### PR TITLE
8211296: Remove HotSpot deprecation warning suppression for Mac/clang

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -3297,16 +3297,6 @@ void os::init(void) {
   Bsd::clock_init();
   initial_time_count = javaTimeNanos();
 
-#ifdef __APPLE__
-  // XXXDARWIN
-  // Work around the unaligned VM callbacks in hotspot's
-  // sharedRuntime. The callbacks don't use SSE2 instructions, and work on
-  // Linux, Solaris, and FreeBSD. On Mac OS X, dyld (rightly so) enforces
-  // alignment when doing symbol lookup. To work around this, we force early
-  // binding of all symbols now, thus binding when alignment is known-good.
-  _dyld_bind_fully_image_containing_address((const void *) &os::init);
-#endif
-
   os::Posix::init();
 }
 

--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -218,8 +218,8 @@ inline int g_isnan(double f) { return isnan(f); }
 
 // Checking for finiteness
 
-inline int g_isfinite(jfloat  f)                 { return finite(f); }
-inline int g_isfinite(jdouble f)                 { return finite(f); }
+inline int g_isfinite(jfloat  f)                 { return isfinite(f); }
+inline int g_isfinite(jdouble f)                 { return isfinite(f); }
 
 
 // Wide characters


### PR DESCRIPTION
Please review the backport of 8211296 to jdk11u-dev.
The first part of patch ( compitejvm.gmk) wasn't needed for jdk11u-dev
This is a prerequest for mac-aarch64 due to finite -> isfinite.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8211296](https://bugs.openjdk.java.net/browse/JDK-8211296): Remove HotSpot deprecation warning suppression for Mac/clang


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/5.diff">https://git.openjdk.java.net/jdk11u-dev/pull/5.diff</a>

</details>
