### PR TITLE
8196092: javax/swing/JComboBox/8032878/bug8032878.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -729,7 +729,6 @@ javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-al
 javax/swing/Action/8133039/bug8133039.java 8196089 windows-all,macosx-all
 javax/swing/JComboBox/6559152/bug6559152.java 8196090 windows-all,macosx-all
 javax/swing/JComboBox/6607130/bug6607130.java 8196091 windows-all
-javax/swing/JComboBox/8032878/bug8032878.java 8196092 windows-all,macosx-all
 javax/swing/JComboBox/8057893/bug8057893.java 8169953 windows-all,macosx-all
 javax/swing/JComboBox/8072767/bug8072767.java 8196093 windows-all,macosx-all
 javax/swing/JComponent/4337267/bug4337267.java 8146451 windows-all
@@ -751,7 +750,6 @@ javax/swing/text/CSSBorder/6796710/bug6796710.java 8196099 windows-all
 javax/swing/text/DefaultCaret/HidingSelection/HidingSelectionTest.java 8194048 windows-all
 javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
 javax/swing/plaf/basic/BasicGraphicsUtils/8132119/bug8132119.java 8196434 linux-all,solaris-all
-javax/swing/JComboBox/8032878/bug8032878.java 8196439 linux-all
 javax/swing/JComboBox/8182031/ComboPopupTest.java 8196465 linux-all,macosx-all
 javax/swing/JFileChooser/6738668/bug6738668.java 8194946 generic-all
 javax/swing/JFileChooser/8021253/bug8021253.java 8169954 windows-all,linux-all,macosx-all

--- a/test/jdk/javax/swing/JComboBox/8032878/bug8032878.java
+++ b/test/jdk/javax/swing/JComboBox/8032878/bug8032878.java
@@ -28,9 +28,6 @@
  * @summary Checks that JComboBox as JTable cell editor processes key events
  *          even where setSurrendersFocusOnKeystroke flag in JTable is false and
  *          that it does not lose the first key press where the flag is true.
- * @library ../../regtesthelpers
- * @build Util
- * @author Alexey Ivanov
  * @run main bug8032878
  */
 
@@ -86,6 +83,7 @@ public class bug8032878 implements Runnable {
 
         frame.pack();
         frame.setVisible(true);
+        frame.setLocationRelativeTo(null);
     }
 
     private void test(final boolean flag) throws Exception {
@@ -93,11 +91,13 @@ public class bug8032878 implements Runnable {
             surrender = flag;
             SwingUtilities.invokeAndWait(this);
 
+            robot.waitForIdle();
+            robot.delay(1000);
             runTest();
             checkResult();
         } finally {
             if (frame != null) {
-                frame.dispose();
+                SwingUtilities.invokeAndWait(() -> frame.dispose());
             }
         }
     }
@@ -105,12 +105,20 @@ public class bug8032878 implements Runnable {
     private void runTest() throws Exception {
         robot.waitForIdle();
         // Select 'one'
-        Util.hitKeys(robot, KeyEvent.VK_TAB);
+        robot.keyPress(KeyEvent.VK_TAB);
+        robot.keyRelease(KeyEvent.VK_TAB);
         robot.waitForIdle();
-        Util.hitKeys(robot, KeyEvent.VK_1);
-        Util.hitKeys(robot, KeyEvent.VK_2);
-        Util.hitKeys(robot, KeyEvent.VK_3);
-        Util.hitKeys(robot, KeyEvent.VK_ENTER);
+        robot.keyPress(KeyEvent.VK_1);
+        robot.keyRelease(KeyEvent.VK_1);
+        robot.waitForIdle();
+        robot.keyPress(KeyEvent.VK_2);
+        robot.keyRelease(KeyEvent.VK_2);
+        robot.waitForIdle();
+        robot.keyPress(KeyEvent.VK_3);
+        robot.keyRelease(KeyEvent.VK_3);
+        robot.waitForIdle();
+        robot.keyPress(KeyEvent.VK_ENTER);
+        robot.keyRelease(KeyEvent.VK_ENTER);
         robot.waitForIdle();
     }
 


### PR DESCRIPTION
I'd like to backport this test fix to 11u too since the same is fixed in 8u for symmetry. The JDK 17 patch didn't apply cleanly due to differences in `ProblemList.txt`. Note that JDK-8196439 refers to the same commit than JDK-8196092 (this bug). So it's fine to remove both listings in ProblemList.txt referring to that test. Thoughts?

Testing: test failed prior the fix, passes after.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8196092](https://bugs.openjdk.java.net/browse/JDK-8196092): javax/swing/JComboBox/8032878/bug8032878.java fails


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/8.diff">https://git.openjdk.java.net/jdk11u-dev/pull/8.diff</a>

</details>
