### PR TITLE
8247469: getSystemCpuLoad() returns -1 on linux when some offline cpus are present and cpusets.effective_cpus is not available

### DIFF
--- a/src/jdk.management/aix/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/aix/native/libmanagement_ext/UnixOperatingSystem.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015 SAP SE. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,13 @@ Java_com_sun_management_internal_OperatingSystemImpl_getSingleCpuLoad0
 
 JNIEXPORT jint JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getHostConfiguredCpuCount0
+(JNIEnv *env, jobject mbean)
+{
+    return -1;
+}
+
+JNIEXPORT jint JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getHostOnlineCpuCount0
 (JNIEnv *env, jobject mbean)
 {
     return -1;

--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -364,3 +364,15 @@ Java_com_sun_management_internal_OperatingSystemImpl_getHostConfiguredCpuCount0
        return -1;
     }
 }
+
+JNIEXPORT jint JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getHostOnlineCpuCount0
+(JNIEnv *env, jobject mbean)
+{
+    int n = sysconf(_SC_NPROCESSORS_ONLN);
+    if (n <= 0) {
+        n = 1;
+    }
+    return n;
+}
+

--- a/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,3 +173,11 @@ Java_com_sun_management_internal_OperatingSystemImpl_getHostConfiguredCpuCount0
 {
     return -1;
 }
+
+JNIEXPORT jint JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getHostOnlineCpuCount0
+(JNIEnv *env, jobject mbean)
+{
+    return -1;
+}
+

--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -158,6 +158,10 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
                     return getSystemCpuLoad0();
                 } else {
                     int[] cpuSet = containerMetrics.getEffectiveCpuSetCpus();
+                    // in case the effectiveCPUSetCpus are not available, attempt to use just cpusets.cpus
+                    if (cpuSet == null || cpuSet.length <= 0) {
+                        cpuSet = containerMetrics.getCpuSetCpus();
+                    }
                     if (cpuSet != null && cpuSet.length > 0) {
                         double systemLoad = 0.0;
                         for (int cpu : cpuSet) {
@@ -182,7 +186,7 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
 
     private boolean isCpuSetSameAsHostCpuSet() {
         if (containerMetrics != null) {
-            return containerMetrics.getCpuSetCpus().length == getHostConfiguredCpuCount0();
+            return containerMetrics.getCpuSetCpus().length == getHostOnlineCpuCount0();
         }
         return false;
     }
@@ -200,6 +204,7 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     private native long getTotalSwapSpaceSize0();
     private native double getSingleCpuLoad0(int cpuNum);
     private native int getHostConfiguredCpuCount0();
+    private native int getHostOnlineCpuCount0();
 
     static {
         initialize0();


### PR DESCRIPTION
Please review this backport for OpenJDK 11u. For one it fixes a bug where wrong cpuload is being reported when there are not all CPUs on the host online, and for two is a preparatory backport for JDK-8265836.

The patch doesn't apply cleanly. The only difference is in context of the if condition in `isCpuSetSameAsHostCpuSet()`. In JDK 17 there is an additional null check for what `containerMetrics.getCpuSetCpus()` returns. This is not needed in 11u since it doesn't have JDK-8231111 (adds cgroups v2 support) which changes `containerMetrics.getCpuSetCpus()` to potentially return null for "not supported". That's not applicable in 11.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8247469](https://bugs.openjdk.java.net/browse/JDK-8247469): getSystemCpuLoad() returns -1 on linux when some offline cpus are present and cpusets.effective_cpus is not available


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/9/head:pull/9` \
`$ git checkout pull/9`

Update a local copy of the PR: \
`$ git checkout pull/9` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/9/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9`

View PR using the GUI difftool: \
`$ git pr show -t 9`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/9.diff">https://git.openjdk.java.net/jdk11u-dev/pull/9.diff</a>

</details>
