### PR TITLE
8265231: (fc) ReadDirect and WriteDirect tests fail after fix for JDK-8264821

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/directio/DirectIOTest.java
+++ b/test/jdk/java/nio/channels/FileChannel/directio/DirectIOTest.java
@@ -48,9 +48,8 @@ import com.sun.nio.file.ExtendedOpenOption;
 public class DirectIOTest {
 
     private static final int BASE_SIZE = 4096;
-    private static long blockSize;
 
-    private static int testWrite(Path p) throws Exception {
+    private static int testWrite(Path p, long blockSize) throws Exception {
         try (FileChannel fc = FileChannel.open(p, StandardOpenOption.WRITE,
              ExtendedOpenOption.DIRECT)) {
             int bs = (int)blockSize;
@@ -68,7 +67,7 @@ public class DirectIOTest {
         }
     }
 
-    private static int testRead(Path p) throws Exception {
+    private static int testRead(Path p, long blockSize) throws Exception {
         try (FileChannel fc = FileChannel.open(p, ExtendedOpenOption.DIRECT)) {
             int bs = (int)blockSize;
             int size = Math.max(BASE_SIZE, bs);
@@ -109,7 +108,7 @@ public class DirectIOTest {
 
     public static void main(String[] args) throws Exception {
         Path p = createTempFile();
-        blockSize = Files.getFileStore(p).getBlockSize();
+        long blockSize = Files.getFileStore(p).getBlockSize();
 
         if (!isDirectIOSupportedByFS(p)) {
             Files.delete(p);
@@ -119,12 +118,12 @@ public class DirectIOTest {
         System.loadLibrary("DirectIO");
 
         try {
-            int size = testWrite(p);
+            int size = testWrite(p, blockSize);
             if (isFileInCache(size, p)) {
                 throw new RuntimeException("DirectIO is not working properly with "
                     + "write. File still exists in cache!");
             }
-            size = testRead(p);
+            size = testRead(p, blockSize);
             if (isFileInCache(size, p)) {
                 throw new RuntimeException("DirectIO is not working properly with "
                     + "read. File still exists in cache!");


### PR DESCRIPTION
I would like to backport this patch to 11u for parity with Oracle 11.0.13.

11u patch has been reviewed: https://mail.openjdk.java.net/pipermail/jdk-updates-dev/2021-May/006348.html and the test passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265231](https://bugs.openjdk.java.net/browse/JDK-8265231): (fc) ReadDirect and WriteDirect tests fail after fix for JDK-8264821


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/13.diff">https://git.openjdk.java.net/jdk11u-dev/pull/13.diff</a>

</details>
