### PR TITLE
8265836: OperatingSystemImpl.getCpuLoad() returns incorrect CPU load inside a container

### DIFF
--- a/src/jdk.management/aix/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/aix/native/libmanagement_ext/UnixOperatingSystem.c
@@ -51,6 +51,13 @@ Java_com_sun_management_internal_OperatingSystemImpl_getSingleCpuLoad0
     return -1.0;
 }
 
+JNIEXPORT jlong JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getHostTotalCpuTicks0
+(JNIEnv *env, jobject mbean)
+{
+    return -1.0;
+}
+
 JNIEXPORT jint JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getHostConfiguredCpuCount0
 (JNIEnv *env, jobject mbean)

--- a/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/linux/native/libmanagement_ext/UnixOperatingSystem.c
@@ -59,6 +59,7 @@ static struct perfbuf {
 } counters;
 
 #define DEC_64 "%"SCNd64
+#define NS_PER_SEC 1000000000
 
 static void next_line(FILE *f) {
     while (fgetc(f) != '\n');
@@ -362,6 +363,31 @@ Java_com_sun_management_internal_OperatingSystemImpl_getHostConfiguredCpuCount0
         return counters.nProcs;
     } else {
        return -1;
+    }
+}
+
+// Return the host cpu ticks since boot in nanoseconds
+JNIEXPORT jlong JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getHostTotalCpuTicks0
+(JNIEnv *env, jobject mbean)
+{
+    if (perfInit() == 0) {
+        if (get_totalticks(-1, &counters.cpuTicks) < 0) {
+            return -1;
+        } else {
+            long ticks_per_sec = sysconf(_SC_CLK_TCK);
+            jlong result = (jlong)counters.cpuTicks.total;
+            if (ticks_per_sec <= NS_PER_SEC) {
+                long scale_factor = NS_PER_SEC/ticks_per_sec;
+                result = result * scale_factor;
+            } else {
+                long scale_factor = ticks_per_sec/NS_PER_SEC;
+                result = result / scale_factor;
+            }
+            return result;
+        }
+    } else {
+        return -1;
     }
 }
 

--- a/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/macosx/native/libmanagement_ext/UnixOperatingSystem.c
@@ -167,6 +167,13 @@ Java_com_sun_management_internal_OperatingSystemImpl_getSingleCpuLoad0
     return -1.0;
 }
 
+JNIEXPORT jlong JNICALL
+Java_com_sun_management_internal_OperatingSystemImpl_getHostTotalCpuTicks0
+(JNIEnv *env, jobject mbean)
+{
+    return -1.0;
+}
+
 JNIEXPORT jint JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getHostConfiguredCpuCount0
 (JNIEnv *env, jobject mbean)

--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -42,6 +42,8 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
 
     private static final int MAX_ATTEMPTS_NUMBER = 10;
     private final Metrics containerMetrics;
+    private long usageTicks = 0; // used for cpu load calculation
+    private long totalTicks = 0; // used for cpu load calculation
 
     OperatingSystemImpl(VMManagement vm) {
         super(vm);
@@ -133,24 +135,56 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
         return getMaxFileDescriptorCount0();
     }
 
+    private double getUsageDividesTotal(long usageTicks, long totalTicks) {
+        // If cpu quota or cpu shares are in effect calculate the cpu load
+        // based on the following formula (similar to how
+        // getCpuLoad0() is being calculated):
+        //
+        //   | usageTicks - usageTicks' |
+        //  ------------------------------
+        //   | totalTicks - totalTicks' |
+        //
+        // where usageTicks' and totalTicks' are historical values
+        // retrieved via an earlier call of this method.
+        //
+        // Total ticks should be scaled to the container effective number
+        // of cpus, if cpu shares are in effect.
+        if (usageTicks < 0 || totalTicks <= 0) {
+            return -1;
+        }
+        long distance = usageTicks - this.usageTicks;
+        this.usageTicks = usageTicks;
+        long totalDistance = totalTicks - this.totalTicks;
+        this.totalTicks = totalTicks;
+
+        double systemLoad = 0.0;
+        if (distance > 0 && totalDistance > 0) {
+            systemLoad = ((double)distance) / totalDistance;
+        }
+        // Ensure the return value is in the range 0.0 -> 1.0
+        systemLoad = Math.max(0.0, systemLoad);
+        systemLoad = Math.min(1.0, systemLoad);
+        return systemLoad;
+    }
+
     public double getSystemCpuLoad() {
         if (containerMetrics != null) {
             long quota = containerMetrics.getCpuQuota();
+            long share = containerMetrics.getCpuShares();
+            long usageNanos = containerMetrics.getCpuUsage();
             if (quota > 0) {
-                long periodLength = containerMetrics.getCpuPeriod();
                 long numPeriods = containerMetrics.getCpuNumPeriods();
-                long usageNanos = containerMetrics.getCpuUsage();
-                if (periodLength > 0 && numPeriods > 0 && usageNanos > 0) {
-                    long elapsedNanos = TimeUnit.MICROSECONDS.toNanos(periodLength * numPeriods);
-                    double systemLoad = (double) usageNanos / elapsedNanos;
-                    // Ensure the return value is in the range 0.0 -> 1.0
-                    systemLoad = Math.max(0.0, systemLoad);
-                    systemLoad = Math.min(1.0, systemLoad);
-                    return systemLoad;
-                }
-                return -1;
+                long quotaNanos = TimeUnit.MICROSECONDS.toNanos(quota * numPeriods);
+                return getUsageDividesTotal(usageNanos, quotaNanos);
+            } else if (share > 0) {
+                long hostTicks = getHostTotalCpuTicks0();
+                int totalCPUs = getHostOnlineCpuCount0();
+                int containerCPUs = getAvailableProcessors();
+                // scale the total host load to the actual container cpus
+                hostTicks = hostTicks * containerCPUs / totalCPUs;
+                return getUsageDividesTotal(usageNanos, hostTicks);
             } else {
-                // If CPU quotas are not active then find the average system load for
+                // If CPU quotas and shares are not active then find the average system load for
                 // all online CPUs that are allowed to run this container.
 
                 // If the cpuset is the same as the host's one there is no need to iterate over each CPU
@@ -205,6 +239,8 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     private native double getSingleCpuLoad0(int cpuNum);
     private native int getHostConfiguredCpuCount0();
     private native int getHostOnlineCpuCount0();
+    // CPU ticks since boot in nanoseconds
+    private native long getHostTotalCpuTicks0();
 
     static {
         initialize0();


### PR DESCRIPTION
JDK-8265836 applies to OpenJDK 11u as well. Patch applies clean. The only difference is in context. JDK head changed method `getCpuLoad()` while the JDK 11u backport changes `getSystemCpuLoad()` as that name hasn't been changed when the OperatingSystemMXBean has been made container aware in 11u.

Testing: Manual using the reproducer of the bug. See the backport bug for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8265836](https://bugs.openjdk.java.net/browse/JDK-8265836): OperatingSystemImpl.getCpuLoad() returns incorrect CPU load inside a container


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/20.diff">https://git.openjdk.java.net/jdk11u-dev/pull/20.diff</a>

</details>
