### PR TITLE
8213137: Remove static initialization of monitor/mutex instances

### DIFF
--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -321,7 +321,6 @@ class JfrThreadSampler : public NonJavaThread {
   int _cur_index;
   const u4 _max_frames;
   volatile bool _disenrolled;
-  static Monitor* _transition_block_lock;
 
   JavaThread* next_thread(ThreadsList* t_list, JavaThread* first_sampled, JavaThread* current);
   void task_stacktrace(JfrSampleType type, JavaThread** last_thread);
@@ -339,11 +338,9 @@ class JfrThreadSampler : public NonJavaThread {
 
  public:
   void run();
-  static Monitor* transition_block() { return _transition_block_lock; }
+  static Monitor* transition_block() { return JfrThreadSampler_lock; }
   static void on_javathread_suspend(JavaThread* thread);
 };
-
-Monitor* JfrThreadSampler::_transition_block_lock = new Monitor(Mutex::leaf, "Trace block", true, Monitor::_safepoint_check_never);
 
 static void clear_transition_block(JavaThread* jt) {
   jt->clear_trace_flag();

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -105,7 +105,7 @@ Monitor* Notify_lock                  = NULL;
 Mutex*   ProfilePrint_lock            = NULL;
 Mutex*   ExceptionCache_lock          = NULL;
 Mutex*   OsrList_lock                 = NULL;
-
+Mutex*   NMethodSweeperStats_lock     = NULL;
 #ifndef PRODUCT
 Mutex*   FullGCALot_lock              = NULL;
 #endif
@@ -139,6 +139,7 @@ Mutex*   JfrStacktrace_lock           = NULL;
 Monitor* JfrMsg_lock                  = NULL;
 Mutex*   JfrBuffer_lock               = NULL;
 Mutex*   JfrStream_lock               = NULL;
+Monitor* JfrThreadSampler_lock        = NULL;
 #endif
 
 #ifndef SUPPORTS_NATIVE_CX8
@@ -148,6 +149,9 @@ Monitor* CodeHeapStateAnalytics_lock  = NULL;
 
 Mutex*   MetaspaceExpand_lock         = NULL;
 Mutex*   ThreadIdTableCreate_lock     = NULL;
+Monitor* ThreadsSMRDelete_lock       = NULL;
+Mutex*   SharedDecoder_lock           = NULL;
+Mutex*   DCmdFactory_lock             = NULL;
 
 #define MAX_NUM_MUTEX 128
 static Monitor * _mutex_array[MAX_NUM_MUTEX];
@@ -241,7 +245,7 @@ void mutex_init() {
   def(JmethodIdCreation_lock       , PaddedMutex  , leaf,        true,  Monitor::_safepoint_check_never);      // used for creating jmethodIDs.
 
   def(SystemDictionary_lock        , PaddedMonitor, leaf,        true,  Monitor::_safepoint_check_always);     // lookups done by VM thread
-  def(SharedDictionary_lock        , PaddedMutex,   leaf,        true,  Monitor::_safepoint_check_always);     // lookups done by VM thread
+  def(SharedDictionary_lock        , PaddedMutex  , leaf,        true,  Monitor::_safepoint_check_always);     // lookups done by VM thread
   def(Module_lock                  , PaddedMutex  , leaf+2,      true,  Monitor::_safepoint_check_always);
   def(InlineCacheBuffer_lock       , PaddedMutex  , leaf,        true,  Monitor::_safepoint_check_always);
   def(VMStatistic_lock             , PaddedMutex  , leaf,        false, Monitor::_safepoint_check_always);
@@ -323,6 +327,7 @@ void mutex_init() {
   def(JfrBuffer_lock               , PaddedMutex  , leaf,        true,  Monitor::_safepoint_check_never);
   def(JfrStream_lock               , PaddedMutex  , leaf+1,      true,  Monitor::_safepoint_check_never);      // ensure to rank lower than 'safepoint'
   def(JfrStacktrace_lock           , PaddedMutex  , special,     true,  Monitor::_safepoint_check_sometimes);
+  def(JfrThreadSampler_lock        , PaddedMonitor, leaf,        true,  Monitor::_safepoint_check_never);
 #endif
 
 #ifndef SUPPORTS_NATIVE_CX8
@@ -331,6 +336,11 @@ void mutex_init() {
 
   def(CodeHeapStateAnalytics_lock  , PaddedMutex  , nonleaf+6,   false, Monitor::_safepoint_check_always);
   def(ThreadIdTableCreate_lock     , PaddedMutex  , leaf,        false, Monitor::_safepoint_check_always);
+
+  def(NMethodSweeperStats_lock     , PaddedMutex  , special,     true,  Monitor::_safepoint_check_sometimes);
+  def(ThreadsSMRDelete_lock        , PaddedMonitor, special,     false, Monitor::_safepoint_check_never);
+  def(SharedDecoder_lock           , PaddedMutex  , native,      false, Monitor::_safepoint_check_never);
+  def(DCmdFactory_lock             , PaddedMutex  , leaf,        true,  Monitor::_safepoint_check_never);
 }
 
 GCMutexLocker::GCMutexLocker(Monitor * mutex) {

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -109,6 +109,7 @@ extern Monitor* Notify_lock;                     // a lock used to synchronize t
 extern Mutex*   ProfilePrint_lock;               // a lock used to serialize the printing of profiles
 extern Mutex*   ExceptionCache_lock;             // a lock used to synchronize exception cache updates
 extern Mutex*   OsrList_lock;                    // a lock used to serialize access to OSR queues
+extern Mutex*   NMethodSweeperStats_lock;        // a lock used to serialize access to sweeper statistics
 
 #ifndef PRODUCT
 extern Mutex*   FullGCALot_lock;                 // a lock to make FullGCALot MT safe
@@ -134,11 +135,15 @@ extern Mutex*   ThreadIdTableCreate_lock;        // Used by ThreadIdTable to laz
 extern Monitor* RedefineClasses_lock;            // locks classes from parallel redefinition
 extern Mutex*   ThreadHeapSampler_lock;          // protects the static data for initialization.
 
+extern Monitor* ThreadsSMRDelete_lock;           // Used by ThreadsSMRSupport to take pressure off the Threads_lock
+extern Mutex*   SharedDecoder_lock;              // serializes access to the decoder during normal (not error reporting) use
+extern Mutex*   DCmdFactory_lock;                // serialize access to DCmdFactory information
 #if INCLUDE_JFR
 extern Mutex*   JfrStacktrace_lock;              // used to guard access to the JFR stacktrace table
 extern Monitor* JfrMsg_lock;                     // protects JFR messaging
 extern Mutex*   JfrBuffer_lock;                  // protects JFR buffer operations
 extern Mutex*   JfrStream_lock;                  // protects JFR stream access
+extern Monitor* JfrThreadSampler_lock;           // used to suspend/resume JFR thread sampler
 #endif
 
 #ifndef SUPPORTS_NATIVE_CX8

--- a/src/hotspot/share/runtime/sweeper.cpp
+++ b/src/hotspot/share/runtime/sweeper.cpp
@@ -160,8 +160,6 @@ Tickspan NMethodSweeper::_total_time_this_sweep;               // Total time thi
 Tickspan NMethodSweeper::_peak_sweep_time;                     // Peak time for a full sweep
 Tickspan NMethodSweeper::_peak_sweep_fraction_time;            // Peak time sweeping one fraction
 
-Monitor* NMethodSweeper::_stat_lock = new Monitor(Mutex::special, "Sweeper::Statistics", true, Monitor::_safepoint_check_sometimes);
-
 class MarkActivationClosure: public CodeBlobClosure {
 public:
   virtual void do_code_blob(CodeBlob* cb) {
@@ -505,7 +503,7 @@ void NMethodSweeper::sweep_code_cache() {
   const Ticks sweep_end_counter = Ticks::now();
   const Tickspan sweep_time = sweep_end_counter - sweep_start_counter;
   {
-    MutexLockerEx mu(_stat_lock, Mutex::_no_safepoint_check_flag);
+    MutexLockerEx mu(NMethodSweeperStats_lock, Mutex::_no_safepoint_check_flag);
     _total_time_sweeping  += sweep_time;
     _total_time_this_sweep += sweep_time;
     _peak_sweep_fraction_time = MAX2(sweep_time, _peak_sweep_fraction_time);

--- a/src/hotspot/share/runtime/sweeper.hpp
+++ b/src/hotspot/share/runtime/sweeper.hpp
@@ -88,8 +88,6 @@ class NMethodSweeper : public AllStatic {
   static Tickspan  _peak_sweep_time;              // Peak time for a full sweep
   static Tickspan  _peak_sweep_fraction_time;     // Peak time sweeping one fraction
 
-  static Monitor*  _stat_lock;
-
   static MethodStateChange process_compiled_method(CompiledMethod *nm);
 
   static void init_sweeper_log() NOT_DEBUG_RETURN;

--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -38,10 +38,6 @@
 #include "utilities/resourceHash.hpp"
 #include "utilities/vmError.hpp"
 
-Monitor*              ThreadsSMRSupport::_delete_lock =
-                          new Monitor(Monitor::special, "Thread_SMR_delete_lock",
-                                      false /* allow_vm_block */,
-                                      Monitor::_safepoint_check_never);
 // The '_cnt', '_max' and '_times" fields are enabled via
 // -XX:+EnableThreadSMRStatistics:
 

--- a/src/hotspot/share/runtime/threadSMR.hpp
+++ b/src/hotspot/share/runtime/threadSMR.hpp
@@ -91,7 +91,8 @@ class ThreadsSMRSupport : AllStatic {
   // The coordination between ThreadsSMRSupport::release_stable_list() and
   // ThreadsSMRSupport::smr_delete() uses the delete_lock in order to
   // reduce the traffic on the Threads_lock.
-  static Monitor*              _delete_lock;
+  static Monitor* delete_lock() { return ThreadsSMRDelete_lock; }
+
   // The '_cnt', '_max' and '_times" fields are enabled via
   // -XX:+EnableThreadSMRStatistics (see thread.cpp for a
   // description about each field):
@@ -121,7 +122,6 @@ class ThreadsSMRSupport : AllStatic {
   static void add_deleted_thread_times(uint add_value);
   static void add_tlh_times(uint add_value);
   static void clear_delete_notify();
-  static Monitor* delete_lock() { return _delete_lock; }
   static bool delete_notify();
   static void free_list(ThreadsList* threads);
   static void inc_deleted_thread_cnt();

--- a/src/hotspot/share/services/diagnosticFramework.cpp
+++ b/src/hotspot/share/services/diagnosticFramework.cpp
@@ -491,11 +491,10 @@ void DCmdFactory::send_notification_internal(TRAPS) {
   }
 }
 
-Mutex* DCmdFactory::_dcmdFactory_lock = new Mutex(Mutex::leaf, "DCmdFactory", true, Monitor::_safepoint_check_never);
 bool DCmdFactory::_send_jmx_notification = false;
 
 DCmdFactory* DCmdFactory::factory(DCmdSource source, const char* name, size_t len) {
-  MutexLockerEx ml(_dcmdFactory_lock, Mutex::_no_safepoint_check_flag);
+  MutexLockerEx ml(DCmdFactory_lock, Mutex::_no_safepoint_check_flag);
   DCmdFactory* factory = _DCmdFactoryList;
   while (factory != NULL) {
     if (strlen(factory->name()) == len &&
@@ -512,7 +511,7 @@ DCmdFactory* DCmdFactory::factory(DCmdSource source, const char* name, size_t le
 }
 
 int DCmdFactory::register_DCmdFactory(DCmdFactory* factory) {
-  MutexLockerEx ml(_dcmdFactory_lock, Mutex::_no_safepoint_check_flag);
+  MutexLockerEx ml(DCmdFactory_lock, Mutex::_no_safepoint_check_flag);
   factory->_next = _DCmdFactoryList;
   _DCmdFactoryList = factory;
   if (_send_jmx_notification && !factory->_hidden
@@ -537,7 +536,7 @@ DCmd* DCmdFactory::create_local_DCmd(DCmdSource source, CmdLine &line,
 }
 
 GrowableArray<const char*>* DCmdFactory::DCmd_list(DCmdSource source) {
-  MutexLockerEx ml(_dcmdFactory_lock, Mutex::_no_safepoint_check_flag);
+  MutexLockerEx ml(DCmdFactory_lock, Mutex::_no_safepoint_check_flag);
   GrowableArray<const char*>* array = new GrowableArray<const char*>();
   DCmdFactory* factory = _DCmdFactoryList;
   while (factory != NULL) {
@@ -550,7 +549,7 @@ GrowableArray<const char*>* DCmdFactory::DCmd_list(DCmdSource source) {
 }
 
 GrowableArray<DCmdInfo*>* DCmdFactory::DCmdInfo_list(DCmdSource source ) {
-  MutexLockerEx ml(_dcmdFactory_lock, Mutex::_no_safepoint_check_flag);
+  MutexLockerEx ml(DCmdFactory_lock, Mutex::_no_safepoint_check_flag);
   GrowableArray<DCmdInfo*>* array = new GrowableArray<DCmdInfo*>();
   DCmdFactory* factory = _DCmdFactoryList;
   while (factory != NULL) {

--- a/src/hotspot/share/services/diagnosticFramework.hpp
+++ b/src/hotspot/share/services/diagnosticFramework.hpp
@@ -344,7 +344,6 @@ public:
 // management.cpp)
 class DCmdFactory: public CHeapObj<mtInternal> {
 private:
-  static Mutex*       _dcmdFactory_lock;
   static bool         _send_jmx_notification;
   static bool         _has_pending_jmx_notification;
   static DCmdFactory* _DCmdFactoryList;

--- a/src/hotspot/share/utilities/decoder.hpp
+++ b/src/hotspot/share/utilities/decoder.hpp
@@ -131,7 +131,6 @@ private:
   static NullDecoder          _do_nothing_decoder;
 
 protected:
-  static Mutex*               _shared_decoder_lock;
   static Mutex* shared_decoder_lock();
 
   friend class DecoderLocker;


### PR DESCRIPTION
We are backporting JDK-8210832: Remove sneaky locking in class Monitor. It has a few dependencies. JDK-8213137: Remove static initialization of monitor/mutex instances is one of them.

The original patch from JDK-8213137 causes conflicts. The conflicts are because a patched file does not exist in jdk11u and git struggled to position changes. The original changes are not changed after resolution of the conflicts.

Testing: Amazon Linux 2, aarch64, tier1 and tier2. Amazon Linux 2, x86_64, tier1 and tier2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8213137](https://bugs.openjdk.java.net/browse/JDK-8213137): Remove static initialization of monitor/mutex instances


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)
 * [Volker Simonis](https://openjdk.java.net/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/21.diff">https://git.openjdk.java.net/jdk11u-dev/pull/21.diff</a>

</details>
