### PR TITLE
8251945: SIGSEGV in PackageEntry::purge_qualified_exports()

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -1045,7 +1045,7 @@ ClassLoaderData* ClassLoaderDataGraph::add_to_graph(Handle loader, bool is_anony
 
   if (!is_anonymous) {
     MutexLocker ml(ClassLoaderDataGraph_lock);
-    cld = java_lang_ClassLoader::loader_data(loader());
+    cld = java_lang_ClassLoader::loader_data_raw(loader());
     if (cld != NULL) {
       return cld;
     }

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -1,5 +1,5 @@
  /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -1050,7 +1050,7 @@ ClassLoaderData* ClassLoaderDataGraph::add_to_graph(Handle loader, bool is_anony
       return cld;
     }
     cld = new ClassLoaderData(loader, is_anonymous);
-    java_lang_ClassLoader::set_loader_data(loader(), cld);
+    java_lang_ClassLoader::release_set_loader_data(loader(), cld);
   } else {
     cld = new ClassLoaderData(loader, is_anonymous);
   }

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -1041,21 +1041,23 @@ bool ClassLoaderDataGraph::_metaspace_oom = false;
 // Add a new class loader data node to the list.  Assign the newly created
 // ClassLoaderData into the java/lang/ClassLoader object as a hidden field
 ClassLoaderData* ClassLoaderDataGraph::add_to_graph(Handle loader, bool is_anonymous) {
+  ClassLoaderData* cld;
+
+  if (!is_anonymous) {
+    MutexLocker ml(ClassLoaderDataGraph_lock);
+    cld = java_lang_ClassLoader::loader_data(loader());
+    if (cld != NULL) {
+      return cld;
+    }
+    cld = new ClassLoaderData(loader, is_anonymous);
+    java_lang_ClassLoader::set_loader_data(loader(), cld);
+  } else {
+    cld = new ClassLoaderData(loader, is_anonymous);
+  }
+
   NoSafepointVerifier no_safepoints; // we mustn't GC until we've installed the
                                      // ClassLoaderData in the graph since the CLD
                                      // contains oops in _handles that must be walked.
-
-  ClassLoaderData* cld = new ClassLoaderData(loader, is_anonymous);
-
-  if (!is_anonymous) {
-    // First, Atomically set it
-    ClassLoaderData* old = java_lang_ClassLoader::cmpxchg_loader_data(cld, loader(), NULL);
-    if (old != NULL) {
-      delete cld;
-      // Returns the data.
-      return old;
-    }
-  }
 
   // We won the race, and therefore the task of adding the data to the list of
   // class loader data

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/classfile/classLoaderData.inline.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ inline ClassLoaderData* ClassLoaderData::class_loader_data_or_null(oop loader) {
   if (loader == NULL) {
     return ClassLoaderData::the_null_class_loader_data();
   }
-  return java_lang_ClassLoader::loader_data(loader);
+  return java_lang_ClassLoader::loader_data_acquire(loader);
 }
 
 inline ClassLoaderData* ClassLoaderData::class_loader_data(oop loader) {
@@ -59,7 +59,7 @@ inline ClassLoaderData *ClassLoaderDataGraph::find_or_create(Handle loader) {
   guarantee(loader() != NULL && oopDesc::is_oop(loader()), "Loader must be oop");
   // Gets the class loader data out of the java/lang/ClassLoader object, if non-null
   // it's already in the loader_data, so no need to add
-  ClassLoaderData* loader_data= java_lang_ClassLoader::loader_data(loader());
+  ClassLoaderData* loader_data= java_lang_ClassLoader::loader_data_acquire(loader());
   if (loader_data) {
      return loader_data;
   }

--- a/src/hotspot/share/classfile/classLoaderStats.cpp
+++ b/src/hotspot/share/classfile/classLoaderStats.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,7 +139,7 @@ void ClassLoaderStatsClosure::print() {
 
 
 void ClassLoaderStatsClosure::addEmptyParents(oop cl) {
-  while (cl != NULL && java_lang_ClassLoader::loader_data(cl) == NULL) {
+  while (cl != NULL && java_lang_ClassLoader::loader_data_acquire(cl) == NULL) {
     // This classloader has not loaded any classes
     ClassLoaderStats** cls_ptr = _stats->get(cl);
     if (cls_ptr == NULL) {

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4020,7 +4020,7 @@ int  java_lang_ClassLoader::name_offset = -1;
 int  java_lang_ClassLoader::nameAndId_offset = -1;
 int  java_lang_ClassLoader::unnamedModule_offset = -1;
 
-ClassLoaderData* java_lang_ClassLoader::loader_data(oop loader) {
+ClassLoaderData* java_lang_ClassLoader::loader_data_acquire(oop loader) {
   assert(loader != NULL && oopDesc::is_oop(loader), "loader must be oop");
   return HeapAccess<MO_ACQUIRE>::load_at(loader, _loader_data_offset);
 }
@@ -4030,7 +4030,7 @@ ClassLoaderData* java_lang_ClassLoader::loader_data_raw(oop loader) {
   return RawAccess<>::load_at(loader, _loader_data_offset);
 }
 
-void java_lang_ClassLoader::set_loader_data(oop loader, ClassLoaderData* new_data) {
+void java_lang_ClassLoader::release_set_loader_data(oop loader, ClassLoaderData* new_data) {
   assert(loader != NULL, "loader must not be NULL");
   assert(oopDesc::is_oop(loader), "loader must be oop");
   HeapAccess<MO_RELEASE>::store_at(loader, _loader_data_offset, new_data);

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4022,13 +4022,18 @@ int  java_lang_ClassLoader::unnamedModule_offset = -1;
 
 ClassLoaderData* java_lang_ClassLoader::loader_data(oop loader) {
   assert(loader != NULL && oopDesc::is_oop(loader), "loader must be oop");
-  return HeapAccess<>::load_at(loader, _loader_data_offset);
+  return HeapAccess<MO_ACQUIRE>::load_at(loader, _loader_data_offset);
+}
+
+ClassLoaderData* java_lang_ClassLoader::loader_data_raw(oop loader) {
+  assert(loader != NULL && oopDesc::is_oop(loader), "loader must be oop");
+  return RawAccess<>::load_at(loader, _loader_data_offset);
 }
 
 void java_lang_ClassLoader::set_loader_data(oop loader, ClassLoaderData* new_data) {
   assert(loader != NULL, "loader must not be NULL");
   assert(oopDesc::is_oop(loader), "loader must be oop");
-  HeapAccess<>::store_at(loader, _loader_data_offset, new_data);
+  HeapAccess<MO_RELEASE>::store_at(loader, _loader_data_offset, new_data);
 }
 
 #define CLASSLOADER_FIELDS_DO(macro) \

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4025,9 +4025,10 @@ ClassLoaderData* java_lang_ClassLoader::loader_data(oop loader) {
   return HeapAccess<>::load_at(loader, _loader_data_offset);
 }
 
-ClassLoaderData* java_lang_ClassLoader::cmpxchg_loader_data(ClassLoaderData* new_data, oop loader, ClassLoaderData* expected_data) {
-  assert(loader != NULL && oopDesc::is_oop(loader), "loader must be oop");
-  return HeapAccess<>::atomic_cmpxchg_at(new_data, loader, _loader_data_offset, expected_data);
+void java_lang_ClassLoader::set_loader_data(oop loader, ClassLoaderData* new_data) {
+  assert(loader != NULL, "loader must not be NULL");
+  assert(oopDesc::is_oop(loader), "loader must be oop");
+  HeapAccess<>::store_at(loader, _loader_data_offset, new_data);
 }
 
 #define CLASSLOADER_FIELDS_DO(macro) \

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1320,9 +1320,9 @@ class java_lang_ClassLoader : AllStatic {
   static void compute_offsets();
   static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;
 
-  static ClassLoaderData* loader_data(oop loader);
+  static ClassLoaderData* loader_data_acquire(oop loader);
   static ClassLoaderData* loader_data_raw(oop loader);
-  static void set_loader_data(oop loader, ClassLoaderData* new_data);
+  static void release_set_loader_data(oop loader, ClassLoaderData* new_data);
 
   static oop parent(oop loader);
   static oop name(oop loader);

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1321,7 +1321,7 @@ class java_lang_ClassLoader : AllStatic {
   static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;
 
   static ClassLoaderData* loader_data(oop loader);
-  static ClassLoaderData* cmpxchg_loader_data(ClassLoaderData* new_data, oop loader, ClassLoaderData* expected_data);
+  static void set_loader_data(oop loader, ClassLoaderData* new_data);
 
   static oop parent(oop loader);
   static oop name(oop loader);

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1321,6 +1321,7 @@ class java_lang_ClassLoader : AllStatic {
   static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;
 
   static ClassLoaderData* loader_data(oop loader);
+  static ClassLoaderData* loader_data_raw(oop loader);
   static void set_loader_data(oop loader, ClassLoaderData* new_data);
 
   static oop parent(oop loader);

--- a/src/hotspot/share/gc/parallel/psCompactionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -183,7 +183,7 @@ void InstanceMirrorKlass::oop_pc_follow_contents(oop obj, ParCompactionManager* 
 void InstanceClassLoaderKlass::oop_pc_follow_contents(oop obj, ParCompactionManager* cm) {
   InstanceKlass::oop_pc_follow_contents(obj, cm);
 
-  ClassLoaderData * const loader_data = java_lang_ClassLoader::loader_data(obj);
+  ClassLoaderData * const loader_data = java_lang_ClassLoader::loader_data_acquire(obj);
   if (loader_data != NULL) {
     cm->follow_class_loader(loader_data);
   }

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -468,9 +468,9 @@ public:
 
   bool do_entry(oop const& key, ClassLoaderStats* const& cls) {
     const ClassLoaderData* this_cld = cls->_class_loader != NULL ?
-      java_lang_ClassLoader::loader_data(cls->_class_loader) : (ClassLoaderData*)NULL;
+      java_lang_ClassLoader::loader_data_acquire(cls->_class_loader) : (ClassLoaderData*)NULL;
     const ClassLoaderData* parent_cld = cls->_parent != NULL ?
-      java_lang_ClassLoader::loader_data(cls->_parent) : (ClassLoaderData*)NULL;
+      java_lang_ClassLoader::loader_data_acquire(cls->_parent) : (ClassLoaderData*)NULL;
     EventClassLoaderStatistics event;
     event.set_classLoader(this_cld);
     event.set_parentClassLoader(parent_cld);

--- a/src/hotspot/share/oops/instanceClassLoaderKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceClassLoaderKlass.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ inline void InstanceClassLoaderKlass::oop_oop_iterate(oop obj, OopClosureType* c
   InstanceKlass::oop_oop_iterate<T>(obj, closure);
 
   if (Devirtualizer::do_metadata(closure)) {
-    ClassLoaderData* cld = java_lang_ClassLoader::loader_data(obj);
+    ClassLoaderData* cld = java_lang_ClassLoader::loader_data_acquire(obj);
     // cld can be null if we have a non-registered class loader.
     if (cld != NULL) {
       Devirtualizer::do_cld(closure, cld);
@@ -61,7 +61,7 @@ inline void InstanceClassLoaderKlass::oop_oop_iterate_bounded(oop obj, OopClosur
 
   if (Devirtualizer::do_metadata(closure)) {
     if (mr.contains(obj)) {
-      ClassLoaderData* cld = java_lang_ClassLoader::loader_data(obj);
+      ClassLoaderData* cld = java_lang_ClassLoader::loader_data_acquire(obj);
       // cld can be null if we have a non-registered class loader.
       if (cld != NULL) {
         Devirtualizer::do_cld(closure, cld);

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1550,7 +1550,7 @@ WB_ENTRY(jlong, WB_AllocateMetaspace(JNIEnv* env, jobject wb, jobject class_load
 
   oop class_loader_oop = JNIHandles::resolve(class_loader);
   ClassLoaderData* cld = class_loader_oop != NULL
-      ? java_lang_ClassLoader::loader_data(class_loader_oop)
+      ? java_lang_ClassLoader::loader_data_acquire(class_loader_oop)
       : ClassLoaderData::the_null_class_loader_data();
 
   void* metadata = MetadataFactory::new_array<u1>(cld, WhiteBox::array_bytes_to_length((size_t)size), thread);
@@ -1561,7 +1561,7 @@ WB_END
 WB_ENTRY(void, WB_FreeMetaspace(JNIEnv* env, jobject wb, jobject class_loader, jlong addr, jlong size))
   oop class_loader_oop = JNIHandles::resolve(class_loader);
   ClassLoaderData* cld = class_loader_oop != NULL
-      ? java_lang_ClassLoader::loader_data(class_loader_oop)
+      ? java_lang_ClassLoader::loader_data_acquire(class_loader_oop)
       : ClassLoaderData::the_null_class_loader_data();
 
   MetadataFactory::free_array(cld, (Array<u1>*)(uintptr_t)addr);

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -147,6 +147,7 @@ Mutex*   UnsafeJlong_lock             = NULL;
 Monitor* CodeHeapStateAnalytics_lock  = NULL;
 
 Mutex*   MetaspaceExpand_lock         = NULL;
+Mutex*   ClassLoaderDataGraph_lock    = NULL;
 Mutex*   ThreadIdTableCreate_lock     = NULL;
 
 #define MAX_NUM_MUTEX 128
@@ -235,6 +236,7 @@ void mutex_init() {
   def(OopMapCacheAlloc_lock        , PaddedMutex  , leaf,        true,  Monitor::_safepoint_check_always);     // used for oop_map_cache allocation.
 
   def(MetaspaceExpand_lock         , PaddedMutex  , leaf-1,      true,  Monitor::_safepoint_check_never);
+  def(ClassLoaderDataGraph_lock    , PaddedMutex  , nonleaf,     true,  Monitor::_safepoint_check_sometimes);
 
   def(Patching_lock                , PaddedMutex  , special,     true,  Monitor::_safepoint_check_never);      // used for safepointing and code patching.
   def(Service_lock                 , PaddedMonitor, special,     true,  Monitor::_safepoint_check_never);      // used for service thread operations

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -236,7 +236,7 @@ void mutex_init() {
   def(OopMapCacheAlloc_lock        , PaddedMutex  , leaf,        true,  Monitor::_safepoint_check_always);     // used for oop_map_cache allocation.
 
   def(MetaspaceExpand_lock         , PaddedMutex  , leaf-1,      true,  Monitor::_safepoint_check_never);
-  def(ClassLoaderDataGraph_lock    , PaddedMutex  , nonleaf,     true,  Monitor::_safepoint_check_sometimes);
+  def(ClassLoaderDataGraph_lock    , PaddedMutex  , nonleaf,     true,  Monitor::_safepoint_check_always);
 
   def(Patching_lock                , PaddedMutex  , special,     true,  Monitor::_safepoint_check_never);      // used for safepointing and code patching.
   def(Service_lock                 , PaddedMonitor, special,     true,  Monitor::_safepoint_check_never);      // used for service thread operations

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -146,7 +146,7 @@ extern Mutex*   UnsafeJlong_lock;                // provides Unsafe atomic updat
 #endif
 
 extern Mutex*   MetaspaceExpand_lock;            // protects Metaspace virtualspace and chunk expansions
-
+extern Mutex*   ClassLoaderDataGraph_lock;       // protects CLDG list, needed for concurrent unloading
 
 extern Monitor* CodeHeapStateAnalytics_lock;     // lock print functions against concurrent analyze functions.
                                                  // Only used locally in PrintCodeCacheLayout processing.

--- a/test/hotspot/jtreg/runtime/8251945/Test.java
+++ b/test/hotspot/jtreg/runtime/8251945/Test.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8251945
+ * @summary Ensure no race on installing class loader data
+ *
+ * @run main/othervm Test
+ */
+import jdk.jfr.Event;
+import java.util.concurrent.BrokenBarrierException;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.OutputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+
+public final class Test
+{
+    private static final int ITERATIONS = Integer.getInteger("iterations", 10000);
+    private volatile ClassLoader nextLoader;
+    
+    public static void main(final String[] args) {
+        new Test().crash();
+    }
+    
+    public void crash() {
+        final byte[] runnableClass = loadBytecode("Test$TestRunnable");
+        final byte[] eventClass = loadBytecode("Test$TestRunnable$RunnableEvent");
+        final int numberOfThreads = Runtime.getRuntime().availableProcessors();
+        if (numberOfThreads < 1) {
+            throw new IllegalStateException("requies more than one thread");
+        }
+        final ExecutorService threadPool = Executors.newFixedThreadPool(numberOfThreads);
+        final CyclicBarrier cyclicBarrier = new CyclicBarrier(numberOfThreads, () -> this.nextLoader = new PredefinedClassLoader(runnableClass, eventClass));
+        for (int i = 0; i < numberOfThreads; ++i) {
+            threadPool.submit(new LoadingRunnable(cyclicBarrier));
+        }
+        threadPool.shutdown();
+    }
+    
+    Runnable loadTestRunnable(final ClassLoader classLoader) {
+        try {
+            return (Runnable)Class.forName("Test$TestRunnable", true, classLoader).asSubclass(Runnable.class).getConstructor((Class<?>[])new Class[0]).newInstance(new Object[0]);
+        }
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException("could not load runnable", e);
+        }
+    }
+    
+    private static byte[] loadBytecode(final String className) {
+        final String resource = toResourceName(className);
+        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        try {
+            final InputStream inputStream = Test.class.getClassLoader().getResourceAsStream(resource);
+            try {
+                inputStream.transferTo(buffer);
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            }
+            catch (Throwable t) {
+                if (inputStream != null) {
+                    try {
+                        inputStream.close();
+                    }
+                    catch (Throwable exception) {
+                        t.addSuppressed(exception);
+                    }
+                }
+                throw t;
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(className, e);
+        }
+        return buffer.toByteArray();
+    }
+    
+    private static String toResourceName(final String className) {
+        return className.replace('.', '/') + ".class";
+    }
+    
+    final class LoadingRunnable implements Runnable
+    {
+        private final CyclicBarrier barrier;
+        
+        LoadingRunnable(final CyclicBarrier barrier) {
+            this.barrier = barrier;
+        }
+        
+        @Override
+        public void run() {
+            int itr = 0;
+            try {
+                while (itr++ < ITERATIONS) {
+                    this.barrier.await();
+                    final Runnable runnable = Test.this.loadTestRunnable(Test.this.nextLoader);
+                    runnable.run();
+                }
+            }
+            catch (InterruptedException | BrokenBarrierException ex) {
+                final Exception e = ex;
+            }
+        }
+    }
+    
+    static final class PredefinedClassLoader extends ClassLoader
+    {
+        private final byte[] runnableClass;
+        private final byte[] eventClass;
+
+        PredefinedClassLoader(final byte[] runnableClass, final byte[] eventClass) {
+            super(null);
+            this.runnableClass = runnableClass;
+            this.eventClass = eventClass;
+        }
+        
+        @Override
+        protected Class<?> loadClass(final String className, final boolean resolve) throws ClassNotFoundException {
+            final Class<?> loadedClass = this.findLoadedClass(className);
+            if (loadedClass != null) {
+                if (resolve) {
+                    this.resolveClass(loadedClass);
+                }
+                return loadedClass;
+            }
+            if (className.equals("Test$TestRunnable")) {
+                return this.loadClassFromByteArray(className, resolve, this.runnableClass);
+            }
+            if (className.equals("Test$TestRunnable$RunnableEvent")) {
+                return this.loadClassFromByteArray(className, resolve, this.eventClass);
+            }
+            return super.loadClass(className, resolve);
+        }
+
+        private Class<?> loadClassFromByteArray(final String className, final boolean resolve, final byte[] byteCode) throws ClassNotFoundException {
+            Class<?> clazz;
+            try {
+                synchronized (getClassLoadingLock(className)) {
+                    clazz = this.defineClass(className, byteCode, 0, byteCode.length);
+                }
+            }
+            catch (LinkageError e) {
+                clazz = this.findLoadedClass(className);
+            }
+            if (resolve) {
+                this.resolveClass(clazz);
+            }
+            return clazz;
+        }
+    }
+
+    public static final class TestRunnable implements Runnable
+    {
+        @Override
+        public void run() {
+            final RunnableEvent event = new RunnableEvent();
+            event.setRunnableClassName("TestRunnable");
+            event.begin();
+            event.end();
+            event.commit();
+        }
+        
+        public static class RunnableEvent extends Event
+        {
+            private String runnableClassName;
+            
+            String getRunnableClassName() {
+                return this.runnableClassName;
+            }
+            
+            void setRunnableClassName(final String operationName) {
+                this.runnableClassName = operationName;
+            }
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/runtime/8251945/Test.java
+++ b/test/hotspot/jtreg/runtime/8251945/Test.java
@@ -44,11 +44,11 @@ public final class Test
 {
     private static final int ITERATIONS = Integer.getInteger("iterations", 10000);
     private volatile ClassLoader nextLoader;
-    
+
     public static void main(final String[] args) {
         new Test().crash();
     }
-    
+
     public void crash() {
         final byte[] runnableClass = loadBytecode("Test$TestRunnable");
         final byte[] eventClass = loadBytecode("Test$TestRunnable$RunnableEvent");
@@ -63,7 +63,7 @@ public final class Test
         }
         threadPool.shutdown();
     }
-    
+
     Runnable loadTestRunnable(final ClassLoader classLoader) {
         try {
             return (Runnable)Class.forName("Test$TestRunnable", true, classLoader).asSubclass(Runnable.class).getConstructor((Class<?>[])new Class[0]).newInstance(new Object[0]);
@@ -72,7 +72,7 @@ public final class Test
             throw new RuntimeException("could not load runnable", e);
         }
     }
-    
+
     private static byte[] loadBytecode(final String className) {
         final String resource = toResourceName(className);
         final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
@@ -101,19 +101,19 @@ public final class Test
         }
         return buffer.toByteArray();
     }
-    
+
     private static String toResourceName(final String className) {
         return className.replace('.', '/') + ".class";
     }
-    
+
     final class LoadingRunnable implements Runnable
     {
         private final CyclicBarrier barrier;
-        
+
         LoadingRunnable(final CyclicBarrier barrier) {
             this.barrier = barrier;
         }
-        
+
         @Override
         public void run() {
             int itr = 0;
@@ -129,7 +129,7 @@ public final class Test
             }
         }
     }
-    
+
     static final class PredefinedClassLoader extends ClassLoader
     {
         private final byte[] runnableClass;
@@ -140,7 +140,7 @@ public final class Test
             this.runnableClass = runnableClass;
             this.eventClass = eventClass;
         }
-        
+
         @Override
         protected Class<?> loadClass(final String className, final boolean resolve) throws ClassNotFoundException {
             final Class<?> loadedClass = this.findLoadedClass(className);
@@ -186,19 +186,18 @@ public final class Test
             event.end();
             event.commit();
         }
-        
+
         public static class RunnableEvent extends Event
         {
             private String runnableClassName;
-            
+
             String getRunnableClassName() {
                 return this.runnableClassName;
             }
-            
+
             void setRunnableClassName(final String operationName) {
                 this.runnableClassName = operationName;
             }
         }
     }
 }
-


### PR DESCRIPTION
I would like to fix the crash in openjdk 11u.

The crash is caused by racy installing new CLD in ClassLoaderDataGraph::add_to_graph().

The method first creates new ClassLoaderData, and in its constructor, it creates unnamed module entry and installs it in java_lang_Module oop.

Then add_to_graph() tries to install newly created CLD to java_lang_ClassLoader oop via CAS. If it loses race, then it deletes new CLD and returns existing one.

But at this point, java_lang_Module oop still points module entry that is already freed.

The fix I am purposing is to borrow ClassLoaderDataGraph_lock from JDK-8210155, but only uses it to prevent racing installing CLD and new CLD is still published via CAS to avoid needing additional patches.

Test:
 - [x] hotspot_runtime
 - [x] hotspot_gc
 - [x] vmTestbase_vm_gc


<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251945](https://bugs.openjdk.java.net/browse/JDK-8251945): SIGSEGV in PackageEntry::purge_qualified_exports()


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/22.diff">https://git.openjdk.java.net/jdk11u-dev/pull/22.diff</a>

</details>
