### PR TITLE
8268523: SIGSEGV in PackageEntry::purge_qualified_exports()

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -1041,21 +1041,23 @@ bool ClassLoaderDataGraph::_metaspace_oom = false;
 // Add a new class loader data node to the list.  Assign the newly created
 // ClassLoaderData into the java/lang/ClassLoader object as a hidden field
 ClassLoaderData* ClassLoaderDataGraph::add_to_graph(Handle loader, bool is_anonymous) {
+  ClassLoaderData* cld;
+
+  if (!is_anonymous) {
+    MutexLocker ml(ClassLoaderDataGraph_lock);
+    cld = java_lang_ClassLoader::loader_data(loader());
+    if (cld != NULL) {
+      return cld;
+    }
+    cld = new ClassLoaderData(loader, is_anonymous);
+    java_lang_ClassLoader::set_loader_data(loader(), cld);
+  } else {
+    cld = new ClassLoaderData(loader, is_anonymous);
+  }
+
   NoSafepointVerifier no_safepoints; // we mustn't GC until we've installed the
                                      // ClassLoaderData in the graph since the CLD
                                      // contains oops in _handles that must be walked.
-
-  ClassLoaderData* cld = new ClassLoaderData(loader, is_anonymous);
-
-  if (!is_anonymous) {
-    // First, Atomically set it
-    ClassLoaderData* old = java_lang_ClassLoader::cmpxchg_loader_data(cld, loader(), NULL);
-    if (old != NULL) {
-      delete cld;
-      // Returns the data.
-      return old;
-    }
-  }
 
   // We won the race, and therefore the task of adding the data to the list of
   // class loader data

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4025,9 +4025,10 @@ ClassLoaderData* java_lang_ClassLoader::loader_data(oop loader) {
   return HeapAccess<>::load_at(loader, _loader_data_offset);
 }
 
-ClassLoaderData* java_lang_ClassLoader::cmpxchg_loader_data(ClassLoaderData* new_data, oop loader, ClassLoaderData* expected_data) {
-  assert(loader != NULL && oopDesc::is_oop(loader), "loader must be oop");
-  return HeapAccess<>::atomic_cmpxchg_at(new_data, loader, _loader_data_offset, expected_data);
+void java_lang_ClassLoader::set_loader_data(oop loader, ClassLoaderData* new_data) {
+  assert(loader != NULL, "loader must not be NULL");
+  assert(oopDesc::is_oop(loader), "loader must be oop");
+  HeapAccess<>::store_at(loader, _loader_data_offset, new_data);
 }
 
 #define CLASSLOADER_FIELDS_DO(macro) \

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1321,7 +1321,7 @@ class java_lang_ClassLoader : AllStatic {
   static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;
 
   static ClassLoaderData* loader_data(oop loader);
-  static ClassLoaderData* cmpxchg_loader_data(ClassLoaderData* new_data, oop loader, ClassLoaderData* expected_data);
+  static void set_loader_data(oop loader, ClassLoaderData* new_data);
 
   static oop parent(oop loader);
   static oop name(oop loader);

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -147,6 +147,7 @@ Mutex*   UnsafeJlong_lock             = NULL;
 Monitor* CodeHeapStateAnalytics_lock  = NULL;
 
 Mutex*   MetaspaceExpand_lock         = NULL;
+Mutex*   ClassLoaderDataGraph_lock    = NULL;
 Mutex*   ThreadIdTableCreate_lock     = NULL;
 
 #define MAX_NUM_MUTEX 128
@@ -235,6 +236,7 @@ void mutex_init() {
   def(OopMapCacheAlloc_lock        , PaddedMutex  , leaf,        true,  Monitor::_safepoint_check_always);     // used for oop_map_cache allocation.
 
   def(MetaspaceExpand_lock         , PaddedMutex  , leaf-1,      true,  Monitor::_safepoint_check_never);
+  def(ClassLoaderDataGraph_lock    , PaddedMutex  , nonleaf,     true,  Monitor::_safepoint_check_sometimes);
 
   def(Patching_lock                , PaddedMutex  , special,     true,  Monitor::_safepoint_check_never);      // used for safepointing and code patching.
   def(Service_lock                 , PaddedMonitor, special,     true,  Monitor::_safepoint_check_never);      // used for service thread operations

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -146,7 +146,7 @@ extern Mutex*   UnsafeJlong_lock;                // provides Unsafe atomic updat
 #endif
 
 extern Mutex*   MetaspaceExpand_lock;            // protects Metaspace virtualspace and chunk expansions
-
+extern Mutex*   ClassLoaderDataGraph_lock;       // protects CLDG list, needed for concurrent unloading
 
 extern Monitor* CodeHeapStateAnalytics_lock;     // lock print functions against concurrent analyze functions.
                                                  // Only used locally in PrintCodeCacheLayout processing.


### PR DESCRIPTION
I would like to fix the crash in openjdk 11u.

The crash is caused by racy installing new CLD in ClassLoaderDataGraph::add_to_graph().

The method first creates new ClassLoaderData, and in its constructor, it creates unnamed module entry and installs it in java_lang_Module oop.

Then add_to_graph() tries to install newly created CLD to java_lang_ClassLoader oop via CAS. If it loses race, then it deletes new CLD and returns existing one.

But at this point, java_lang_Module oop could still point module entry that is already freed.

The fix I am purposing is to borrow ClassLoaderDataGraph_lock from JDK-8210155, but only uses it to prevent racing installing CLD and new CLD is still published via CAS to avoid needing additional patches.

Test:

- [x] hotspot_runtime
- [x] hotspot_gc
- [x] vmTestbase_vm_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268523](https://bugs.openjdk.java.net/browse/JDK-8268523): SIGSEGV in PackageEntry::purge_qualified_exports()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/23.diff">https://git.openjdk.java.net/jdk11u-dev/pull/23.diff</a>

</details>
