### PR TITLE
8253048: AArch64: When CallLeaf, no need to preserve callee-saved registers in caller

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -201,43 +201,43 @@ reg_def R31_H   (  NS,  NS, Op_RegI, 31, r31_sp->as_VMReg()->next());
   reg_def V7_J ( SOC, SOC, Op_RegF,  7, v7->as_VMReg()->next(2) );
   reg_def V7_K ( SOC, SOC, Op_RegF,  7, v7->as_VMReg()->next(3) );
 
-  reg_def V8   ( SOC, SOC, Op_RegF,  8, v8->as_VMReg()          );
-  reg_def V8_H ( SOC, SOC, Op_RegF,  8, v8->as_VMReg()->next()  );
+  reg_def V8   ( SOC, SOE, Op_RegF,  8, v8->as_VMReg()          );
+  reg_def V8_H ( SOC, SOE, Op_RegF,  8, v8->as_VMReg()->next()  );
   reg_def V8_J ( SOC, SOC, Op_RegF,  8, v8->as_VMReg()->next(2) );
   reg_def V8_K ( SOC, SOC, Op_RegF,  8, v8->as_VMReg()->next(3) );
 
-  reg_def V9   ( SOC, SOC, Op_RegF,  9, v9->as_VMReg()          );
-  reg_def V9_H ( SOC, SOC, Op_RegF,  9, v9->as_VMReg()->next()  );
+  reg_def V9   ( SOC, SOE, Op_RegF,  9, v9->as_VMReg()          );
+  reg_def V9_H ( SOC, SOE, Op_RegF,  9, v9->as_VMReg()->next()  );
   reg_def V9_J ( SOC, SOC, Op_RegF,  9, v9->as_VMReg()->next(2) );
   reg_def V9_K ( SOC, SOC, Op_RegF,  9, v9->as_VMReg()->next(3) );
 
-  reg_def V10  ( SOC, SOC, Op_RegF, 10, v10->as_VMReg()         );
-  reg_def V10_H( SOC, SOC, Op_RegF, 10, v10->as_VMReg()->next() );
+  reg_def V10  ( SOC, SOE, Op_RegF, 10, v10->as_VMReg()         );
+  reg_def V10_H( SOC, SOE, Op_RegF, 10, v10->as_VMReg()->next() );
   reg_def V10_J( SOC, SOC, Op_RegF, 10, v10->as_VMReg()->next(2));
   reg_def V10_K( SOC, SOC, Op_RegF, 10, v10->as_VMReg()->next(3));
 
-  reg_def V11  ( SOC, SOC, Op_RegF, 11, v11->as_VMReg()         );
-  reg_def V11_H( SOC, SOC, Op_RegF, 11, v11->as_VMReg()->next() );
+  reg_def V11  ( SOC, SOE, Op_RegF, 11, v11->as_VMReg()         );
+  reg_def V11_H( SOC, SOE, Op_RegF, 11, v11->as_VMReg()->next() );
   reg_def V11_J( SOC, SOC, Op_RegF, 11, v11->as_VMReg()->next(2));
   reg_def V11_K( SOC, SOC, Op_RegF, 11, v11->as_VMReg()->next(3));
 
-  reg_def V12  ( SOC, SOC, Op_RegF, 12, v12->as_VMReg()         );
-  reg_def V12_H( SOC, SOC, Op_RegF, 12, v12->as_VMReg()->next() );
+  reg_def V12  ( SOC, SOE, Op_RegF, 12, v12->as_VMReg()         );
+  reg_def V12_H( SOC, SOE, Op_RegF, 12, v12->as_VMReg()->next() );
   reg_def V12_J( SOC, SOC, Op_RegF, 12, v12->as_VMReg()->next(2));
   reg_def V12_K( SOC, SOC, Op_RegF, 12, v12->as_VMReg()->next(3));
 
-  reg_def V13  ( SOC, SOC, Op_RegF, 13, v13->as_VMReg()         );
-  reg_def V13_H( SOC, SOC, Op_RegF, 13, v13->as_VMReg()->next() );
+  reg_def V13  ( SOC, SOE, Op_RegF, 13, v13->as_VMReg()         );
+  reg_def V13_H( SOC, SOE, Op_RegF, 13, v13->as_VMReg()->next() );
   reg_def V13_J( SOC, SOC, Op_RegF, 13, v13->as_VMReg()->next(2));
   reg_def V13_K( SOC, SOC, Op_RegF, 13, v13->as_VMReg()->next(3));
 
-  reg_def V14  ( SOC, SOC, Op_RegF, 14, v14->as_VMReg()         );
-  reg_def V14_H( SOC, SOC, Op_RegF, 14, v14->as_VMReg()->next() );
+  reg_def V14  ( SOC, SOE, Op_RegF, 14, v14->as_VMReg()         );
+  reg_def V14_H( SOC, SOE, Op_RegF, 14, v14->as_VMReg()->next() );
   reg_def V14_J( SOC, SOC, Op_RegF, 14, v14->as_VMReg()->next(2));
   reg_def V14_K( SOC, SOC, Op_RegF, 14, v14->as_VMReg()->next(3));
 
-  reg_def V15  ( SOC, SOC, Op_RegF, 15, v15->as_VMReg()         );
-  reg_def V15_H( SOC, SOC, Op_RegF, 15, v15->as_VMReg()->next() );
+  reg_def V15  ( SOC, SOE, Op_RegF, 15, v15->as_VMReg()         );
+  reg_def V15_H( SOC, SOE, Op_RegF, 15, v15->as_VMReg()->next() );
   reg_def V15_J( SOC, SOC, Op_RegF, 15, v15->as_VMReg()->next(2));
   reg_def V15_K( SOC, SOC, Op_RegF, 15, v15->as_VMReg()->next(3));
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64_trig.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64_trig.cpp
@@ -360,7 +360,7 @@ void MacroAssembler::generate__ieee754_rem_pio2(address npio2_hw,
       lsr(rscratch1, ix, 20);                      // ix >> 20
       movz(tmp5, 0x4170, 48);
       subw(rscratch1, rscratch1, 1046);            // e0
-      fmovd(v10, tmp5);                            // init two24A value
+      fmovd(v24, tmp5);                            // init two24A value
       subw(jv, ix, rscratch1, LSL, 20);            // ix - (e0<<20)
       lsl(jv, jv, 32);
       subw(rscratch2, rscratch1, 3);
@@ -374,7 +374,7 @@ void MacroAssembler::generate__ieee754_rem_pio2(address npio2_hw,
         sdivw(jv, rscratch2, i);                   // jv = (e0 - 3)/24
         fsubd(v26, v26, v6);
         sub(sp, sp, 560);
-        fmuld(v26, v26, v10);
+        fmuld(v26, v26, v24);
         frintzd(v7, v26);                          // v7 = (double)((int)v26)
         movw(jx, 2); // calculate jx as nx - 1, which is initially 2. Not a part of unrolled loop
         fsubd(v26, v26, v7);
@@ -383,7 +383,7 @@ void MacroAssembler::generate__ieee754_rem_pio2(address npio2_hw,
       block_comment("nx calculation with unrolled while(tx[nx-1]==zeroA) nx--;"); {
         fcmpd(v26, 0.0);                           // if NE then jx == 2. else it's 1 or 0
         add(iqBase, sp, 480);                      // base of iq[]
-        fmuld(v3, v26, v10);
+        fmuld(v3, v26, v24);
         br(NE, NX_SET);
         fcmpd(v7, 0.0);                            // v7 == 0 => jx = 0. Else jx = 1
         csetw(jx, NE);
@@ -839,7 +839,7 @@ void MacroAssembler::generate__kernel_rem_pio2(address two_over_pi, address pio2
           ldrd(v27, post(tmp2, -8));
           fmuld(v29, v17, v18);                            // twon24*z
           frintzd(v29, v29);                               // (double)(int)
-          fmsubd(v28, v10, v29, v18);                      // v28 = z-two24A*fw
+          fmsubd(v28, v24, v29, v18);                      // v28 = z-two24A*fw
           fcvtzdw(tmp1, v28);                              // (int)(z-two24A*fw)
           strw(tmp1, Address(iqBase, i, Address::lsl(2)));
           faddd(v18, v27, v29);
@@ -1000,11 +1000,11 @@ void MacroAssembler::generate__kernel_rem_pio2(address two_over_pi, address pio2
       block_comment("else block of if(z==0.0) {"); {
         bind(RECOMP_CHECK_DONE_NOT_ZERO);
           fmuld(v18, v18, v22);
-          fcmpd(v18, v10);                                   // v10 is stil two24A
+          fcmpd(v18, v24);                                   // v24 is stil two24A
           br(LT, Z_IS_LESS_THAN_TWO24B);
           fmuld(v1, v18, v17);                               // twon24*z
           frintzd(v1, v1);                                   // v1 = (double)(int)(v1)
-          fmaddd(v2, v10, v1, v18);
+          fmaddd(v2, v24, v1, v18);
           fcvtzdw(tmp3, v1);                                 // (int)fw
           fcvtzdw(tmp2, v2);                                 // double to int
           strw(tmp2, Address(iqBase, jz, Address::lsl(2)));


### PR DESCRIPTION
This small patch reduces registers spilling on aarch64. Changes bring the save policy in line with AArch64 ABI.

Original patch require simple adjustments to the context.

Testing: tier1, tier2, opto assembly check.

11u RFR: https://mail.openjdk.java.net/pipermail/jdk-updates-dev/2021-May/006239.html
https://mail.openjdk.java.net/pipermail/jdk-updates-dev/2021-May/006373.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253048](https://bugs.openjdk.java.net/browse/JDK-8253048): AArch64: When CallLeaf, no need to preserve callee-saved registers in caller


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/24.diff">https://git.openjdk.java.net/jdk11u-dev/pull/24.diff</a>

</details>
