### PR TITLE
8250597: G1: Improve inlining around trim_queue

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -165,6 +165,20 @@ private:
 
   inline void do_oop_partial_array(oop* p);
 
+  HeapWord* allocate_copy_slow(InCSetState const state,
+                               InCSetState* dest_state,
+                               oop old,
+                               size_t word_sz,
+                               uint age);
+
+  void undo_allocation(InCSetState dest_state,
+                       HeapWord* obj_ptr,
+                       size_t word_sz);
+
+  inline oop do_copy_to_survivor_space(InCSetState state,
+                                       oop old,
+                                       markOop old_mark);
+
   // This method is applied to the fields of the objects that have just been copied.
   template <class T> inline void do_oop_evac(T* p);
 
@@ -191,20 +205,19 @@ private:
                               oop const old, size_t word_sz, uint age,
                               HeapWord * const obj_ptr) const;
 
+  void trim_queue_to_threshold(uint threshold);
+
   inline bool needs_partial_trimming() const;
-  inline bool is_partially_trimmed() const;
 
-  inline void trim_queue_to_threshold(uint threshold);
 public:
-  oop copy_to_survivor_space(InCSetState const state, oop const obj, markOop const old_mark);
+  oop copy_to_survivor_space(InCSetState state, oop obj, markOop old_mark);
 
-  void trim_queue();
-  void trim_queue_partially();
+  inline void trim_queue();
+  inline void trim_queue_partially();
+  void steal_and_trim_queue(RefToScanQueueSet *task_queues);
 
   Tickspan trim_ticks() const;
   void reset_trim_ticks();
-
-  inline void steal_and_trim_queue(RefToScanQueueSet *task_queues);
 
   // An attempt to evacuate "obj" has failed; take necessary steps.
   oop handle_evacuation_failure_par(oop obj, markOop m);

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
@@ -30,159 +30,32 @@
 #include "oops/access.inline.hpp"
 #include "oops/oop.inline.hpp"
 
-template <class T> void G1ParScanThreadState::do_oop_evac(T* p) {
-  // Reference should not be NULL here as such are never pushed to the task queue.
-  oop obj = RawAccess<IS_NOT_NULL>::oop_load(p);
-
-  // Although we never intentionally push references outside of the collection
-  // set, due to (benign) races in the claim mechanism during RSet scanning more
-  // than one thread might claim the same card. So the same card may be
-  // processed multiple times, and so we might get references into old gen here.
-  // So we need to redo this check.
-  const InCSetState in_cset_state = _g1h->in_cset_state(obj);
-  if (in_cset_state.is_in_cset()) {
-    markOop m = obj->mark_raw();
-    if (m->is_marked()) {
-      obj = (oop) m->decode_pointer();
-    } else {
-      obj = copy_to_survivor_space(in_cset_state, obj, m);
-    }
-    RawAccess<IS_NOT_NULL>::oop_store(p, obj);
-  } else if (in_cset_state.is_humongous()) {
-    _g1h->set_humongous_is_live(obj);
-  } else {
-    assert(in_cset_state.is_default(),
-           "In_cset_state must be NotInCSet here, but is " CSETSTATE_FORMAT, in_cset_state.value());
-  }
-
-  assert(obj != NULL, "Must be");
-  if (!HeapRegion::is_in_same_region(p, obj)) {
-    HeapRegion* from = _g1h->heap_region_containing(p);
-    update_rs(from, p, obj);
-  }
-}
-
 template <class T> inline void G1ParScanThreadState::push_on_queue(T* ref) {
   assert(verify_ref(ref), "sanity");
   _refs->push(ref);
 }
 
-inline void G1ParScanThreadState::do_oop_partial_array(oop* p) {
-  assert(has_partial_array_mask(p), "invariant");
-  oop from_obj = clear_partial_array_mask(p);
-
-  assert(_g1h->is_in_reserved(from_obj), "must be in heap.");
-  assert(from_obj->is_objArray(), "must be obj array");
-  objArrayOop from_obj_array = objArrayOop(from_obj);
-  // The from-space object contains the real length.
-  int length                 = from_obj_array->length();
-
-  assert(from_obj->is_forwarded(), "must be forwarded");
-  oop to_obj                 = from_obj->forwardee();
-  assert(from_obj != to_obj, "should not be chunking self-forwarded objects");
-  objArrayOop to_obj_array   = objArrayOop(to_obj);
-  // We keep track of the next start index in the length field of the
-  // to-space object.
-  int next_index             = to_obj_array->length();
-  assert(0 <= next_index && next_index < length,
-         "invariant, next index: %d, length: %d", next_index, length);
-
-  int start                  = next_index;
-  int end                    = length;
-  int remainder              = end - start;
-  // We'll try not to push a range that's smaller than ParGCArrayScanChunk.
-  if (remainder > 2 * ParGCArrayScanChunk) {
-    end = start + ParGCArrayScanChunk;
-    to_obj_array->set_length(end);
-    // Push the remainder before we process the range in case another
-    // worker has run out of things to do and can steal it.
-    oop* from_obj_p = set_partial_array_mask(from_obj);
-    push_on_queue(from_obj_p);
-  } else {
-    assert(length == end, "sanity");
-    // We'll process the final range for this object. Restore the length
-    // so that the heap remains parsable in case of evacuation failure.
-    to_obj_array->set_length(end);
-  }
-  _scanner.set_region(_g1h->heap_region_containing(to_obj));
-  // Process indexes [start,end). It will also process the header
-  // along with the first chunk (i.e., the chunk with start == 0).
-  // Note that at this point the length field of to_obj_array is not
-  // correct given that we are using it to keep track of the next
-  // start index. oop_iterate_range() (thankfully!) ignores the length
-  // field and only relies on the start / end parameters.  It does
-  // however return the size of the object which will be incorrect. So
-  // we have to ignore it even if we wanted to use it.
-  to_obj_array->oop_iterate_range(&_scanner, start, end);
-}
-
-inline void G1ParScanThreadState::deal_with_reference(oop* ref_to_scan) {
-  if (!has_partial_array_mask(ref_to_scan)) {
-    do_oop_evac(ref_to_scan);
-  } else {
-    do_oop_partial_array(ref_to_scan);
-  }
-}
-
-inline void G1ParScanThreadState::deal_with_reference(narrowOop* ref_to_scan) {
-  assert(!has_partial_array_mask(ref_to_scan), "NarrowOop* elements should never be partial arrays.");
-  do_oop_evac(ref_to_scan);
-}
-
-inline void G1ParScanThreadState::dispatch_reference(StarTask ref) {
-  assert(verify_task(ref), "sanity");
-  if (ref.is_narrow()) {
-    deal_with_reference((narrowOop*)ref);
-  } else {
-    deal_with_reference((oop*)ref);
-  }
-}
-
-void G1ParScanThreadState::steal_and_trim_queue(RefToScanQueueSet *task_queues) {
-  StarTask stolen_task;
-  while (task_queues->steal(_worker_id, &_hash_seed, stolen_task)) {
-    assert(verify_task(stolen_task), "sanity");
-    dispatch_reference(stolen_task);
-
-    // We've just processed a reference and we might have made
-    // available new entries on the queues. So we have to make sure
-    // we drain the queues as necessary.
-    trim_queue();
-  }
-}
-
-inline bool G1ParScanThreadState::needs_partial_trimming() const {
+bool G1ParScanThreadState::needs_partial_trimming() const {
   return !_refs->overflow_empty() || _refs->size() > _stack_trim_upper_threshold;
 }
 
-inline bool G1ParScanThreadState::is_partially_trimmed() const {
-  return _refs->overflow_empty() && _refs->size() <= _stack_trim_lower_threshold;
-}
-
-inline void G1ParScanThreadState::trim_queue_to_threshold(uint threshold) {
-  StarTask ref;
-  // Drain the overflow stack first, so other threads can potentially steal.
-  while (_refs->pop_overflow(ref)) {
-    if (!_refs->try_push_to_taskqueue(ref)) {
-      dispatch_reference(ref);
-    }
-  }
-
-  while (_refs->pop_local(ref, threshold)) {
-    dispatch_reference(ref);
-  }
-}
-
-inline void G1ParScanThreadState::trim_queue_partially() {
+void G1ParScanThreadState::trim_queue_partially() {
   if (!needs_partial_trimming()) {
     return;
   }
 
   const Ticks start = Ticks::now();
-  do {
-    trim_queue_to_threshold(_stack_trim_lower_threshold);
-  } while (!is_partially_trimmed());
+  trim_queue_to_threshold(_stack_trim_lower_threshold);
+  assert(_refs->overflow_empty(), "invariant");
+  assert(_refs->size() <= _stack_trim_lower_threshold, "invariant");
   _trim_ticks += Ticks::now() - start;
+}
+
+void G1ParScanThreadState::trim_queue() {
+  StarTask ref;
+  trim_queue_to_threshold(0);
+  assert(_refs->overflow_empty(), "invariant");
+  assert(_refs->taskqueue_empty(), "invariant");
 }
 
 inline Tickspan G1ParScanThreadState::trim_ticks() const {

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -43,6 +43,10 @@
 #define ATTRIBUTE_ALIGNED(x)
 #endif
 
+#ifndef ATTRIBUTE_FLATTEN
+#define ATTRIBUTE_FLATTEN
+#endif
+
 // This file holds all globally used constants & types, class (forward)
 // declarations and a few frequently used utility functions.
 

--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -271,6 +271,7 @@ inline int wcslen(const jchar* x) { return wcslen((const wchar_t*)x); }
 // Inlining support
 #define NOINLINE     __attribute__ ((noinline))
 #define ALWAYSINLINE inline __attribute__ ((always_inline))
+#define ATTRIBUTE_FLATTEN __attribute__ ((flatten))
 
 // Alignment
 //


### PR DESCRIPTION
This change improves latency with G1 in some cases and makes trim_queue() code structure closer to current mainline.

The original patch does not apply cleanly in particular because of https://bugs.openjdk.java.net/browse/JDK-8200545 . However the refactoring is rather simple because it is a rearrangement of code between functions with compiler hints. It has been reproduced (short description in the next comment).

The change is isolated and is a set of code moves so the risk is low.

Testing: tier1, tier2 on aarch64 and x86_64 in development, the change has been included in Liberica JDK 11u EA for some time.

As an example of performance improvement, Critical-jOPS on Graviton2 raised +1%:+6.2% for 8GB heap.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250597](https://bugs.openjdk.java.net/browse/JDK-8250597): G1: Improve inlining around trim_queue


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/26.diff">https://git.openjdk.java.net/jdk11u-dev/pull/26.diff</a>

</details>
