### PR TITLE
8268127: Shenandoah: Heap size may be too small for region to align to large page size

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -50,11 +50,13 @@ void ShenandoahArguments::initialize() {
 
   FLAG_SET_DEFAULT(ShenandoahVerifyOptoBarriers,     false);
 #endif
-
-  if (UseLargePages && (MaxHeapSize / os::large_page_size()) < ShenandoahHeapRegion::MIN_NUM_REGIONS) {
-    warning("Large pages size (" SIZE_FORMAT "K) is too large to afford page-sized regions, disabling uncommit",
-            os::large_page_size() / K);
-    FLAG_SET_DEFAULT(ShenandoahUncommit, false);
+  if (UseLargePages) {
+    size_t large_page_size = os::large_page_size();
+    if ((align_up(MaxHeapSize, large_page_size) / large_page_size) < ShenandoahHeapRegion::MIN_NUM_REGIONS) {
+      warning("Large pages size (" SIZE_FORMAT "K) is too large to afford page-sized regions, disabling uncommit",
+              os::large_page_size() / K);
+      FLAG_SET_DEFAULT(ShenandoahUncommit, false);
+    }
   }
 
   // Enable NUMA by default. While Shenandoah is not NUMA-aware, enabling NUMA makes

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -462,7 +462,7 @@ size_t ShenandoahHeapRegion::block_size(const HeapWord* p) const {
   }
 }
 
-void ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
+size_t ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
   // Absolute minimums we should not ever break.
   static const size_t MIN_REGION_SIZE = 256*K;
 
@@ -537,14 +537,28 @@ void ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
     region_size = ShenandoahRegionSize;
   }
 
-  // Make sure region size is at least one large page, if enabled.
-  // The heap sizes would be rounded by heap initialization code by
-  // page size, so we need to round up the region size too, to cover
-  // the heap exactly.
+  // Make sure region size and heap size are page aligned.
+  // If large pages are used, we ensure that region size is aligned to large page size if
+  // heap size is large enough to accommodate minimal number of regions. Otherwise, we align
+  // region size to regular page size.
+
+  // Figure out page size to use, and aligns up heap to page size
+  int page_size = os::vm_page_size();
   if (UseLargePages) {
-    region_size = MAX2(region_size, os::large_page_size());
+    size_t large_page_size = os::large_page_size();
+    max_heap_size = align_up(max_heap_size, large_page_size);
+    if ((max_heap_size / align_up(region_size, large_page_size)) >= MIN_NUM_REGIONS) {
+      page_size = (int)large_page_size;
+    } else {
+      // Should have been checked during argument initialization
+      assert(!ShenandoahUncommit, "Uncommit requires region size aligns to large page size");
+    }
+  } else {
+    max_heap_size = align_up(max_heap_size, page_size);
   }
 
+  // Align region size to page size
+  region_size = align_up(region_size, page_size);
   int region_size_log = log2_long((jlong) region_size);
   // Recalculate the region size to make sure it's a power of
   // 2. This means that region_size is the largest power of 2 that's
@@ -614,6 +628,8 @@ void ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
                      byte_size_in_proper_unit(HumongousThresholdBytes), proper_unit_for_byte_size(HumongousThresholdBytes));
   log_info(gc, init)("Max TLAB size: " SIZE_FORMAT "%s",
                      byte_size_in_proper_unit(MaxTLABSizeBytes), proper_unit_for_byte_size(MaxTLABSizeBytes));
+
+  return max_heap_size;
 }
 
 void ShenandoahHeapRegion::do_commit() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -250,7 +250,8 @@ public:
 
   static const size_t MIN_NUM_REGIONS = 10;
 
-  static void setup_sizes(size_t max_heap_size);
+  // Return adjusted max heap size
+  static size_t setup_sizes(size_t max_heap_size);
 
   double empty_time() {
     return _empty_time;


### PR DESCRIPTION
I would like to backport this Shenandoah specific patch to 11u, which allows to fallback to regular pages for regions, if heap size is too small to allow regions to use large pages.

The original patch does not apply cleanly, resolved then manually.

Test:
Manually test to ensure large pages are used. Failed w/o the patch and passed with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268127](https://bugs.openjdk.java.net/browse/JDK-8268127): Shenandoah: Heap size may be too small for region to align to large page size


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - Committer)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/28.diff">https://git.openjdk.java.net/jdk11u-dev/pull/28.diff</a>

</details>
