### PR TITLE
8265773: incorrect jdeps message "jdk8internals" to describe a removed JDK internal API

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Analyzer.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/Analyzer.java
@@ -405,6 +405,14 @@ public class Analyzer {
             }
         }
 
+        /*
+         * Ignore the module name which should not be shown in the output
+         */
+        @Override
+        public String name() {
+            return getName();
+        }
+
         public boolean contains(Location location) {
             String cn = location.getClassName();
             int i = cn.lastIndexOf('.');

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsWriter.java
@@ -312,7 +312,7 @@ public abstract class JdepsWriter {
      * For non-JDK archives, this method returns the file name of the archive.
      */
     String toTag(Archive source, String name, Archive target) {
-        if (source == target || !target.getModule().isNamed()) {
+        if (source == target || !target.getModule().isNamed() || Analyzer.notFound(target)) {
             return target.getName();
         }
 


### PR DESCRIPTION
This is a direct backport of the fix `JDK-8265773: incorrect jdeps message "jdk8internals" to describe a removed JDK internal API` to jdk11u-dev.
The patch applies cleanly.

The fix has been built with the latest jdk11u-dev sources on Ubuntu 18.04 and manually tested with reactor-core-3.4.5.jar  lib.

The jdeps output without the fix is `jdk8internals`:
```
build/linux-x86_64-normal-server-release/jdk/bin/jdeps -s reactor-core-3.4.5.jar 
reactor-core-3.4.5.jar -> jdk8internals
reactor-core-3.4.5.jar -> java.base
reactor-core-3.4.5.jar -> java.logging
reactor-core-3.4.5.jar -> not found
```

and with the fix is `JDK removed internal API`
```
build/linux-x86_64-normal-server-release/jdk/bin/jdeps -s reactor-core-3.4.5.jar 
reactor-core-3.4.5.jar -> JDK removed internal API
reactor-core-3.4.5.jar -> java.base
reactor-core-3.4.5.jar -> java.logging
reactor-core-3.4.5.jar -> not found
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8265773](https://bugs.openjdk.java.net/browse/JDK-8265773): incorrect jdeps message "jdk8internals" to describe a removed JDK internal API


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/32/head:pull/32` \
`$ git checkout pull/32`

Update a local copy of the PR: \
`$ git checkout pull/32` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/32/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32`

View PR using the GUI difftool: \
`$ git pr show -t 32`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/32.diff">https://git.openjdk.java.net/jdk11u-dev/pull/32.diff</a>

</details>
