### PR TITLE
8268771: javadoc -notimestamp option does not work on index.html

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexRedirectWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexRedirectWriter.java
@@ -77,7 +77,7 @@ public class IndexRedirectWriter extends HtmlDocletWriter {
         DocType htmlDocType = DocType.forVersion(configuration.htmlVersion);
         Content htmlComment = contents.newPage;
         Head head = new Head(path, configuration.htmlVersion, configuration.docletVersion)
-                .setTimestamp(true, false)
+                .setTimestamp(!configuration.notimestamp, false)
                 .addDefaultScript(false);
 
         String title = (configuration.windowtitle.length() > 0)


### PR DESCRIPTION
In jdk 14 there was a change which allows conditionally generate timestamp in index.html of javadoc.
It would be nice to have this feature in jdk 11 for supporting reproducible builds

https://github.com/openjdk/jdk14u/commit/2ace3e69e6de678d77719376dad961bdcb0d550e#diff-ac839a98e6e91aa8aba6e1b9efdfc018616306f478fc95bae067dfc44d3667d4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268771](https://bugs.openjdk.java.net/browse/JDK-8268771): javadoc -notimestamp option does not work on index.html


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/33.diff">https://git.openjdk.java.net/jdk11u-dev/pull/33.diff</a>

</details>
