### PR TITLE
8173585: Intrinsify StringLatin1.indexOf(char)

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -15120,18 +15120,38 @@ instruct string_indexof_conUL(iRegP_R1 str1, iRegI_R4 cnt1, iRegP_R3 str2,
   ins_pipe(pipe_class_memory);
 %}
 
-instruct string_indexofU_char(iRegP_R1 str1, iRegI_R2 cnt1, iRegI_R3 ch,
+instruct string_indexof_char(iRegP_R1 str1, iRegI_R2 cnt1, iRegI_R3 ch,
                               iRegI_R0 result, iRegINoSp tmp1, iRegINoSp tmp2,
                               iRegINoSp tmp3, rFlagsReg cr)
 %{
   match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
+  predicate(((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::U);
   effect(USE_KILL str1, USE_KILL cnt1, USE_KILL ch,
          TEMP tmp1, TEMP tmp2, TEMP tmp3, KILL cr);
 
-  format %{ "String IndexOf char[] $str1,$cnt1,$ch -> $result" %}
+  format %{ "StringUTF16 IndexOf char[] $str1,$cnt1,$ch -> $result" %}
 
   ins_encode %{
     __ string_indexof_char($str1$$Register, $cnt1$$Register, $ch$$Register,
+                           $result$$Register, $tmp1$$Register, $tmp2$$Register,
+                           $tmp3$$Register);
+  %}
+  ins_pipe(pipe_class_memory);
+%}
+
+instruct stringL_indexof_char(iRegP_R1 str1, iRegI_R2 cnt1, iRegI_R3 ch,
+                              iRegI_R0 result, iRegINoSp tmp1, iRegINoSp tmp2,
+                              iRegINoSp tmp3, rFlagsReg cr)
+%{
+  match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
+  predicate(((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::L);
+  effect(USE_KILL str1, USE_KILL cnt1, USE_KILL ch,
+         TEMP tmp1, TEMP tmp2, TEMP tmp3, KILL cr);
+
+  format %{ "StringLatin1 IndexOf char[] $str1,$cnt1,$ch -> $result" %}
+
+  ins_encode %{
+    __ stringL_indexof_char($str1$$Register, $cnt1$$Register, $ch$$Register,
                            $result$$Register, $tmp1$$Register, $tmp2$$Register,
                            $tmp3$$Register);
   %}

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4793,6 +4793,70 @@ void MacroAssembler::string_indexof_char(Register str1, Register cnt1,
   BIND(DONE);
 }
 
+void MacroAssembler::stringL_indexof_char(Register str1, Register cnt1,
+                                          Register ch, Register result,
+                                          Register tmp1, Register tmp2, Register tmp3)
+{
+  Label CH1_LOOP, HAS_ZERO, DO1_SHORT, DO1_LOOP, MATCH, NOMATCH, DONE;
+  Register cnt1_neg = cnt1;
+  Register ch1 = rscratch1;
+  Register result_tmp = rscratch2;
+
+  cbz(cnt1, NOMATCH);
+
+  cmp(cnt1, (u1)8);
+  br(LT, DO1_SHORT);
+
+  orr(ch, ch, ch, LSL, 8);
+  orr(ch, ch, ch, LSL, 16);
+  orr(ch, ch, ch, LSL, 32);
+
+  sub(cnt1, cnt1, 8);
+  mov(result_tmp, cnt1);
+  lea(str1, Address(str1, cnt1));
+  sub(cnt1_neg, zr, cnt1);
+
+  mov(tmp3, 0x0101010101010101);
+
+  BIND(CH1_LOOP);
+    ldr(ch1, Address(str1, cnt1_neg));
+    eor(ch1, ch, ch1);
+    sub(tmp1, ch1, tmp3);
+    orr(tmp2, ch1, 0x7f7f7f7f7f7f7f7f);
+    bics(tmp1, tmp1, tmp2);
+    br(NE, HAS_ZERO);
+    adds(cnt1_neg, cnt1_neg, 8);
+    br(LT, CH1_LOOP);
+
+    cmp(cnt1_neg, (u1)8);
+    mov(cnt1_neg, 0);
+    br(LT, CH1_LOOP);
+    b(NOMATCH);
+
+  BIND(HAS_ZERO);
+    rev(tmp1, tmp1);
+    clz(tmp1, tmp1);
+    add(cnt1_neg, cnt1_neg, tmp1, LSR, 3);
+    b(MATCH);
+
+  BIND(DO1_SHORT);
+    mov(result_tmp, cnt1);
+    lea(str1, Address(str1, cnt1));
+    sub(cnt1_neg, zr, cnt1);
+  BIND(DO1_LOOP);
+    ldrb(ch1, Address(str1, cnt1_neg));
+    cmp(ch, ch1);
+    br(EQ, MATCH);
+    adds(cnt1_neg, cnt1_neg, 1);
+    br(LT, DO1_LOOP);
+  BIND(NOMATCH);
+    mov(result, -1);
+    b(DONE);
+  BIND(MATCH);
+    add(result, result_tmp, cnt1_neg);
+  BIND(DONE);
+}
+
 // Compare strings.
 void MacroAssembler::string_compare(Register str1, Register str2,
     Register cnt1, Register cnt2, Register result, Register tmp1, Register tmp2,

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1260,6 +1260,9 @@ public:
   void string_indexof_char(Register str1, Register cnt1,
                            Register ch, Register result,
                            Register tmp1, Register tmp2, Register tmp3);
+  void stringL_indexof_char(Register str1, Register cnt1,
+                            Register ch, Register result,
+                            Register tmp1, Register tmp2, Register tmp3);
   void fast_log(FloatRegister vtmp0, FloatRegister vtmp1, FloatRegister vtmp2,
                 FloatRegister vtmp3, FloatRegister vtmp4, FloatRegister vtmp5,
                 FloatRegister tmpC1, FloatRegister tmpC2, FloatRegister tmpC3,

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -6606,6 +6606,99 @@ void MacroAssembler::string_indexof_char(Register str1, Register cnt1, Register 
   bind(DONE_LABEL);
 } // string_indexof_char
 
+void MacroAssembler::stringL_indexof_char(Register str1, Register cnt1, Register ch, Register result,
+                                          XMMRegister vec1, XMMRegister vec2, XMMRegister vec3, Register tmp) {
+  ShortBranchVerifier sbv(this);
+  assert(UseSSE42Intrinsics, "SSE4.2 intrinsics are required");
+
+  int stride = 16;
+
+  Label FOUND_CHAR, SCAN_TO_CHAR_INIT, SCAN_TO_CHAR_LOOP,
+        SCAN_TO_16_CHAR, SCAN_TO_16_CHAR_LOOP, SCAN_TO_32_CHAR_LOOP,
+        RET_NOT_FOUND, SCAN_TO_16_CHAR_INIT,
+        FOUND_SEQ_CHAR, DONE_LABEL;
+
+  movptr(result, str1);
+  if (UseAVX >= 2) {
+    cmpl(cnt1, stride);
+    jcc(Assembler::less, SCAN_TO_CHAR_INIT);
+    cmpl(cnt1, stride*2);
+    jcc(Assembler::less, SCAN_TO_16_CHAR_INIT);
+    movdl(vec1, ch);
+    vpbroadcastb(vec1, vec1, Assembler::AVX_256bit);
+    vpxor(vec2, vec2);
+    movl(tmp, cnt1);
+    andl(tmp, 0xFFFFFFE0);  //vector count (in chars)
+    andl(cnt1,0x0000001F);  //tail count (in chars)
+
+    bind(SCAN_TO_32_CHAR_LOOP);
+    vmovdqu(vec3, Address(result, 0));
+    vpcmpeqb(vec3, vec3, vec1, Assembler::AVX_256bit);
+    vptest(vec2, vec3);
+    jcc(Assembler::carryClear, FOUND_CHAR);
+    addptr(result, 32);
+    subl(tmp, stride*2);
+    jcc(Assembler::notZero, SCAN_TO_32_CHAR_LOOP);
+    jmp(SCAN_TO_16_CHAR);
+
+    bind(SCAN_TO_16_CHAR_INIT);
+    movdl(vec1, ch);
+    pxor(vec2, vec2);
+    pshufb(vec1, vec2);
+  }
+
+  bind(SCAN_TO_16_CHAR);
+  cmpl(cnt1, stride);
+  jcc(Assembler::less, SCAN_TO_CHAR_INIT);//less than 16 entires left
+  if (UseAVX < 2) {
+    movdl(vec1, ch);
+    pxor(vec2, vec2);
+    pshufb(vec1, vec2);
+  }
+  movl(tmp, cnt1);
+  andl(tmp, 0xFFFFFFF0);  //vector count (in bytes)
+  andl(cnt1,0x0000000F);  //tail count (in bytes)
+
+  bind(SCAN_TO_16_CHAR_LOOP);
+  movdqu(vec3, Address(result, 0));
+  pcmpeqb(vec3, vec1);
+  ptest(vec2, vec3);
+  jcc(Assembler::carryClear, FOUND_CHAR);
+  addptr(result, 16);
+  subl(tmp, stride);
+  jcc(Assembler::notZero, SCAN_TO_16_CHAR_LOOP);//last 16 items...
+
+  bind(SCAN_TO_CHAR_INIT);
+  testl(cnt1, cnt1);
+  jcc(Assembler::zero, RET_NOT_FOUND);
+  bind(SCAN_TO_CHAR_LOOP);
+  load_unsigned_byte(tmp, Address(result, 0));
+  cmpl(ch, tmp);
+  jccb(Assembler::equal, FOUND_SEQ_CHAR);
+  addptr(result, 1);
+  subl(cnt1, 1);
+  jccb(Assembler::zero, RET_NOT_FOUND);
+  jmp(SCAN_TO_CHAR_LOOP);
+
+  bind(RET_NOT_FOUND);
+  movl(result, -1);
+  jmpb(DONE_LABEL);
+
+  bind(FOUND_CHAR);
+  if (UseAVX >= 2) {
+    vpmovmskb(tmp, vec3);
+  } else {
+    pmovmskb(tmp, vec3);
+  }
+  bsfl(ch, tmp);
+  addl(result, ch);
+
+  bind(FOUND_SEQ_CHAR);
+  subptr(result, str1);
+
+  bind(DONE_LABEL);
+} // stringL_indexof_char
+
 // helper function for string_compare
 void MacroAssembler::load_next_elements(Register elem1, Register elem2, Register str1, Register str2,
                                         Address::ScaleFactor scale, Address::ScaleFactor scale1,

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1654,6 +1654,9 @@ public:
   void string_indexof_char(Register str1, Register cnt1, Register ch, Register result,
                            XMMRegister vec1, XMMRegister vec2, XMMRegister vec3, Register tmp);
 
+  void stringL_indexof_char(Register str1, Register cnt1, Register ch, Register result,
+                            XMMRegister vec1, XMMRegister vec2, XMMRegister vec3, Register tmp);
+
   // IndexOf strings.
   // Small strings are loaded through stack if they cross page boundary.
   void string_indexof(Register str1, Register str2,

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -11909,14 +11909,27 @@ instruct string_indexofUL(eDIRegP str1, eDXRegI cnt1, eSIRegP str2, eAXRegI cnt2
   ins_pipe( pipe_slow );
 %}
 
-instruct string_indexofU_char(eDIRegP str1, eDXRegI cnt1, eAXRegI ch,
-                              eBXRegI result, regD vec1, regD vec2, regD vec3, eCXRegI tmp, eFlagsReg cr) %{
-  predicate(UseSSE42Intrinsics);
+instruct string_indexof_char(eDIRegP str1, eDXRegI cnt1, eAXRegI ch,
+                             eBXRegI result, regD vec1, regD vec2, regD vec3, eCXRegI tmp, eFlagsReg cr) %{
+  predicate(UseSSE42Intrinsics && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::U));
   match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
   effect(TEMP vec1, TEMP vec2, TEMP vec3, USE_KILL str1, USE_KILL cnt1, USE_KILL ch, TEMP tmp, KILL cr);
-  format %{ "String IndexOf char[] $str1,$cnt1,$ch -> $result   // KILL all" %}
+  format %{ "StringUTF16 IndexOf char[] $str1,$cnt1,$ch -> $result   // KILL all" %}
   ins_encode %{
     __ string_indexof_char($str1$$Register, $cnt1$$Register, $ch$$Register, $result$$Register,
+                           $vec1$$XMMRegister, $vec2$$XMMRegister, $vec3$$XMMRegister, $tmp$$Register);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct stringL_indexof_char(eDIRegP str1, eDXRegI cnt1, eAXRegI ch,
+                              eBXRegI result, regD vec1, regD vec2, regD vec3, eCXRegI tmp, eFlagsReg cr) %{
+  predicate(UseSSE42Intrinsics && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::L));
+  match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
+  effect(TEMP vec1, TEMP vec2, TEMP vec3, USE_KILL str1, USE_KILL cnt1, USE_KILL ch, TEMP tmp, KILL cr);
+  format %{ "StringLatin1 IndexOf char[] $str1,$cnt1,$ch -> $result   // KILL all" %}
+  ins_encode %{
+    __ stringL_indexof_char($str1$$Register, $cnt1$$Register, $ch$$Register, $result$$Register,
                            $vec1$$XMMRegister, $vec2$$XMMRegister, $vec3$$XMMRegister, $tmp$$Register);
   %}
   ins_pipe( pipe_slow );

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -11508,16 +11508,30 @@ instruct string_indexofUL(rdi_RegP str1, rdx_RegI cnt1, rsi_RegP str2, rax_RegI 
   ins_pipe( pipe_slow );
 %}
 
-instruct string_indexofU_char(rdi_RegP str1, rdx_RegI cnt1, rax_RegI ch,
-                              rbx_RegI result, legVecS vec1, legVecS vec2, legVecS vec3, rcx_RegI tmp, rFlagsReg cr)
+instruct string_indexof_char(rdi_RegP str1, rdx_RegI cnt1, rax_RegI ch,
+                             rbx_RegI result, legVecS vec1, legVecS vec2, legVecS vec3, rcx_RegI tmp, rFlagsReg cr)
 %{
-  predicate(UseSSE42Intrinsics);
+  predicate(UseSSE42Intrinsics && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::U));
   match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
   effect(TEMP vec1, TEMP vec2, TEMP vec3, USE_KILL str1, USE_KILL cnt1, USE_KILL ch, TEMP tmp, KILL cr);
-  format %{ "String IndexOf char[] $str1,$cnt1,$ch -> $result   // KILL all" %}
+  format %{ "StringUTF16 IndexOf char[] $str1,$cnt1,$ch -> $result   // KILL all" %}
   ins_encode %{
     __ string_indexof_char($str1$$Register, $cnt1$$Register, $ch$$Register, $result$$Register,
                            $vec1$$XMMRegister, $vec2$$XMMRegister, $vec3$$XMMRegister, $tmp$$Register);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct stringL_indexof_char(rdi_RegP str1, rdx_RegI cnt1, rax_RegI ch,
+                              rbx_RegI result, legRegD tmp_vec1, legRegD tmp_vec2, legRegD tmp_vec3, rcx_RegI tmp, rFlagsReg cr)
+%{
+  predicate(UseSSE42Intrinsics && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::L));
+  match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
+  effect(TEMP tmp_vec1, TEMP tmp_vec2, TEMP tmp_vec3, USE_KILL str1, USE_KILL cnt1, USE_KILL ch, TEMP tmp, KILL cr);
+  format %{ "StringLatin1 IndexOf char[] $str1,$cnt1,$ch -> $result   // KILL all" %}
+  ins_encode %{
+    __ stringL_indexof_char($str1$$Register, $cnt1$$Register, $ch$$Register, $result$$Register,
+                           $tmp_vec1$$XMMRegister, $tmp_vec2$$XMMRegister, $tmp_vec3$$XMMRegister, $tmp$$Register);
   %}
   ins_pipe( pipe_slow );
 %}

--- a/src/hotspot/share/classfile/vmSymbols.cpp
+++ b/src/hotspot/share/classfile/vmSymbols.cpp
@@ -523,6 +523,7 @@ bool vmIntrinsics::is_disabled_by_flags(vmIntrinsics::ID id) {
     case vmIntrinsics::_indexOfIU:
     case vmIntrinsics::_indexOfIUL:
     case vmIntrinsics::_indexOfU_char:
+    case vmIntrinsics::_indexOfL_char:
     case vmIntrinsics::_compareToL:
     case vmIntrinsics::_compareToU:
     case vmIntrinsics::_compareToLU:
@@ -808,6 +809,7 @@ bool vmIntrinsics::is_disabled_by_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_indexOfIU:
   case vmIntrinsics::_indexOfIUL:
   case vmIntrinsics::_indexOfU_char:
+  case vmIntrinsics::_indexOfL_char:
     if (!SpecialStringIndexOf) return true;
     break;
   case vmIntrinsics::_equalsL:

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -946,6 +946,7 @@
   do_intrinsic(_indexOfIU,                java_lang_StringUTF16, indexOf_name, indexOfI_signature,               F_S)   \
   do_intrinsic(_indexOfIUL,               java_lang_StringUTF16, indexOfUL_name, indexOfI_signature,             F_S)   \
   do_intrinsic(_indexOfU_char,            java_lang_StringUTF16, indexOfChar_name, indexOfChar_signature,        F_S)   \
+  do_intrinsic(_indexOfL_char,            java_lang_StringLatin1,indexOfChar_name, indexOfChar_signature,        F_S)   \
    do_name(     indexOf_name,                                    "indexOf")                                             \
    do_name(     indexOfChar_name,                                "indexOfChar")                                         \
    do_name(     indexOfUL_name,                                  "indexOfLatin1")                                       \

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -496,6 +496,7 @@ bool C2Compiler::is_intrinsic_supported(const methodHandle& method, bool is_virt
   case vmIntrinsics::_indexOfIU:
   case vmIntrinsics::_indexOfIUL:
   case vmIntrinsics::_indexOfU_char:
+  case vmIntrinsics::_indexOfL_char:
   case vmIntrinsics::_toBytesStringU:
   case vmIntrinsics::_getCharsStringU:
   case vmIntrinsics::_getCharStringU:

--- a/src/hotspot/share/opto/intrinsicnode.hpp
+++ b/src/hotspot/share/opto/intrinsicnode.hpp
@@ -47,10 +47,11 @@ class PartialSubtypeCheckNode : public Node {
 // Base class for Ideal nodes used in String intrinsic code.
 class StrIntrinsicNode: public Node {
  public:
-  // Possible encodings of the two parameters passed to the string intrinsic.
+  // Possible encodings of the parameters passed to the string intrinsic.
   // 'L' stands for Latin1 and 'U' stands for UTF16. For example, 'LU' means that
   // the first string is Latin1 encoded and the second string is UTF16 encoded.
-  typedef enum ArgEncoding { LL, LU, UL, UU, none } ArgEnc;
+  // 'L' means that the single string is Latin1 encoded
+  typedef enum ArgEncoding { LL, LU, UL, UU, L, U, none } ArgEnc;
 
  protected:
   // Encoding of strings. Used to select the right version of the intrinsic.

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -217,7 +217,7 @@ class LibraryCallKit : public GraphKit {
   bool inline_string_indexOfI(StrIntrinsicNode::ArgEnc ae);
   Node* make_indexOf_node(Node* src_start, Node* src_count, Node* tgt_start, Node* tgt_count,
                           RegionNode* region, Node* phi, StrIntrinsicNode::ArgEnc ae);
-  bool inline_string_indexOfChar();
+  bool inline_string_indexOfChar(StrIntrinsicNode::ArgEnc ae);
   bool inline_string_equals(StrIntrinsicNode::ArgEnc ae);
   bool inline_string_toBytesU();
   bool inline_string_getCharsU();
@@ -590,7 +590,8 @@ bool LibraryCallKit::try_to_inline(int predicate) {
   case vmIntrinsics::_indexOfIL:                return inline_string_indexOfI(StrIntrinsicNode::LL);
   case vmIntrinsics::_indexOfIU:                return inline_string_indexOfI(StrIntrinsicNode::UU);
   case vmIntrinsics::_indexOfIUL:               return inline_string_indexOfI(StrIntrinsicNode::UL);
-  case vmIntrinsics::_indexOfU_char:            return inline_string_indexOfChar();
+  case vmIntrinsics::_indexOfU_char:            return inline_string_indexOfChar(StrIntrinsicNode::U);
+  case vmIntrinsics::_indexOfL_char:            return inline_string_indexOfChar(StrIntrinsicNode::L);
 
   case vmIntrinsics::_equalsL:                  return inline_string_equals(StrIntrinsicNode::LL);
   case vmIntrinsics::_equalsU:                  return inline_string_equals(StrIntrinsicNode::UU);
@@ -1420,7 +1421,7 @@ Node* LibraryCallKit::make_indexOf_node(Node* src_start, Node* src_count, Node* 
 }
 
 //-----------------------------inline_string_indexOfChar-----------------------
-bool LibraryCallKit::inline_string_indexOfChar() {
+bool LibraryCallKit::inline_string_indexOfChar(StrIntrinsicNode::ArgEnc ae) {
   if (too_many_traps(Deoptimization::Reason_intrinsic)) {
     return false;
   }
@@ -1435,12 +1436,12 @@ bool LibraryCallKit::inline_string_indexOfChar() {
 
   src = must_be_not_null(src, true);
 
-  Node* src_offset = _gvn.transform(new LShiftINode(from_index, intcon(1)));
+  Node* src_offset = ae == StrIntrinsicNode::L ? from_index : _gvn.transform(new LShiftINode(from_index, intcon(1)));
   Node* src_start = array_element_address(src, src_offset, T_BYTE);
   Node* src_count = _gvn.transform(new SubINode(max, from_index));
 
   // Range checks
-  generate_string_range_check(src, src_offset, src_count, true);
+  generate_string_range_check(src, src_offset, src_count, ae == StrIntrinsicNode::U);
   if (stopped()) {
     return true;
   }
@@ -1448,7 +1449,7 @@ bool LibraryCallKit::inline_string_indexOfChar() {
   RegionNode* region = new RegionNode(3);
   Node* phi = new PhiNode(region, TypeInt::INT);
 
-  Node* result = new StrIndexOfCharNode(control(), memory(TypeAryPtr::BYTES), src_start, src_count, tgt, StrIntrinsicNode::none);
+  Node* result = new StrIndexOfCharNode(control(), memory(TypeAryPtr::BYTES), src_start, src_count, tgt, ae);
   C->set_has_split_ifs(true); // Has chance for split-if optimization
   _gvn.transform(result);
 

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -209,6 +209,11 @@ final class StringLatin1 {
             // Note: fromIndex might be near -1>>>1.
             return -1;
         }
+        return indexOfChar(value, ch, fromIndex, max);
+    }
+
+    @HotSpotIntrinsicCandidate
+    private static int indexOfChar(byte[] value, int ch, int fromIndex, int max) {
         byte c = (byte)ch;
         for (int i = fromIndex; i < max; i++) {
             if (value[i] == c) {

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringLatin1IndexOfChar.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringLatin1IndexOfChar.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8173585
+ * @summary Test intrinsification of StringLatin1.indexOf(char). Note that
+ * differing code paths are taken contingent upon the length of the input String.
+ * Hence we must test against differing string lengths in order to validate
+ * correct functionality. We also ensure the strings are long enough to trigger
+ * the looping conditions of the individual code paths.
+ *
+ * Run with varing levels of AVX and SSE support, also without the intrinsic at all
+ *
+ * @library /compiler/patches /test/lib
+ * @run main/othervm -Xbatch -XX:Tier4InvocationThreshold=200 -XX:CompileThreshold=100 compiler.intrinsics.string.TestStringLatin1IndexOfChar
+ * @run main/othervm -Xbatch -XX:Tier4InvocationThreshold=200 -XX:CompileThreshold=100 -XX:+UnlockDiagnosticVMOptions -XX:DisableIntrinsic=_indexOfL_char compiler.intrinsics.string.TestStringLatin1IndexOfChar
+ * @run main/othervm -Xbatch -XX:Tier4InvocationThreshold=200 -XX:CompileThreshold=100 -XX:+IgnoreUnrecognizedVMOptions -XX:UseSSE=0 compiler.intrinsics.string.TestStringLatin1IndexOfChar
+ * @run main/othervm -Xbatch -XX:Tier4InvocationThreshold=200 -XX:CompileThreshold=100 -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=1 compiler.intrinsics.string.TestStringLatin1IndexOfChar
+ * @run main/othervm -Xbatch -XX:Tier4InvocationThreshold=200 -XX:CompileThreshold=100 -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=2 compiler.intrinsics.string.TestStringLatin1IndexOfChar
+ * @run main/othervm -Xbatch -XX:Tier4InvocationThreshold=200 -XX:CompileThreshold=100 -XX:+IgnoreUnrecognizedVMOptions -XX:UseAVX=3 compiler.intrinsics.string.TestStringLatin1IndexOfChar
+ */
+
+package compiler.intrinsics.string;
+
+import jdk.test.lib.Asserts;
+
+public class TestStringLatin1IndexOfChar{
+    private final static int MAX_LENGTH = 2048;//future proof for AVX-512 instructions
+
+    public static void main(String[] args) throws Exception {
+        for (int i = 0; i < 1_000; ++i) {//repeat such that we enter into C2 code...
+            findOneItem();
+            withOffsetTest();
+            testEmpty();
+        }
+    }
+
+    private static void testEmpty(){
+        Asserts.assertEQ("".indexOf('a'), -1);
+    }
+
+    private final static char SEARCH_CHAR = 'z';
+    private final static char INVERLEAVING_CHAR = 'a';
+    private final static char MISSING_CHAR = 'd';
+
+    private static void findOneItem(){
+        //test strings of varying length ensuring that for all lengths one instance of the
+        //search char can be found. We check what happens when the search character is in
+        //each position of the search string (including first and last positions)
+        for(int strLength : new int[]{1, 15, 31, 32, 79}){
+            for(int searchPos = 0; searchPos < strLength; searchPos++){
+                String totest = makeOneItemStringLatin1(strLength, searchPos);
+
+                int intri = totest.indexOf(SEARCH_CHAR);
+                int nonintri = indexOfCharNonIntrinsic(totest, SEARCH_CHAR, 0);
+                Asserts.assertEQ(intri, nonintri);
+            }
+        }
+    }
+
+    private static String makeOneItemStringLatin1(int length, int searchPos){
+        StringBuilder sb = new StringBuilder(length);
+
+        for(int n =0; n < length; n++){
+            sb.append(searchPos==n?SEARCH_CHAR:INVERLEAVING_CHAR);
+        }
+
+        return sb.toString();
+    }
+
+    private static void withOffsetTest(){
+        //progressivly move through string checking indexes and starting offset correctly processed
+        //string is of form azaza, aazaazaa, aaazaaazaaa, etc
+        //we find n s.t. maxlength = (n*3) + 2
+        int maxaInstances = (MAX_LENGTH-2)/3;
+
+        for(int aInstances = 5; aInstances < MAX_LENGTH; aInstances++){
+            String totest = makeWithOffsetStringLatin1(aInstances);
+
+            int startoffset;
+            {
+                int intri = totest.indexOf(SEARCH_CHAR);
+                int nonintri = indexOfCharNonIntrinsic(totest, SEARCH_CHAR, 0);
+
+                Asserts.assertEQ(intri, nonintri);
+                startoffset = intri+1;
+            }
+
+            {
+                int intri = totest.indexOf(SEARCH_CHAR, startoffset);
+                int nonintri = indexOfCharNonIntrinsic(totest, SEARCH_CHAR, startoffset);
+
+                Asserts.assertEQ(intri, nonintri);
+                startoffset = intri+1;
+            }
+
+            Asserts.assertEQ(totest.indexOf(SEARCH_CHAR, startoffset), -1);//only two SEARCH_CHAR per string
+            Asserts.assertEQ(totest.indexOf(MISSING_CHAR), -1);
+        }
+    }
+
+    private static String makeWithOffsetStringLatin1(int aInstances){
+        StringBuilder sb = new StringBuilder((aInstances*3) + 2);
+        for(int n =0; n < aInstances; n++){
+            sb.append(INVERLEAVING_CHAR);
+        }
+
+        sb.append(SEARCH_CHAR);
+
+        for(int n =0; n < aInstances; n++){
+            sb.append(INVERLEAVING_CHAR);
+        }
+
+        sb.append(SEARCH_CHAR);
+
+        for(int n =0; n < aInstances; n++){
+            sb.append(INVERLEAVING_CHAR);
+        }
+        return sb.toString();
+    }
+
+    private static int indexOfCharNonIntrinsic(String value, int ch, int fromIndex) {
+        //non intrinsic version of indexOfChar
+        byte c = (byte)ch;
+        for (int i = fromIndex; i < value.length(); i++) {
+            if (value.charAt(i) == c) {
+               return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/StringIndexOfChar.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringIndexOfChar.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang;
+
+import java.util.Random;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This benchmark can be used to measure performance between StringLatin1 and StringUTF16 in terms of
+ * performance of the indexOf(char) and indexOf(String) methods which are intrinsified.
+ * On x86 the behaviour of the indexOf method is contingent upon the length of the string
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class IndexOfBenchmark {
+    private static final int loops = 100000;
+    private static final Random rng = new Random(1999);
+    private static final int pathCnt = 1000;
+    private static final String [] latn1_short        = new String[pathCnt];
+    private static final String [] latn1_sse4         = new String[pathCnt];
+    private static final String [] latn1_avx2         = new String[pathCnt];
+    private static final String [] latn1_mixedLength  = new String[pathCnt];
+    private static final String [] utf16_short        = new String[pathCnt];
+    private static final String [] utf16_sse4         = new String[pathCnt];
+    private static final String [] utf16_avx2         = new String[pathCnt];
+    private static final String [] utf16_mixedLength  = new String[pathCnt];
+    static {
+        for (int i = 0; i < pathCnt; i++) {
+            latn1_short[i] = makeRndString(false, 15);
+            latn1_sse4[i]  = makeRndString(false, 16);
+            latn1_avx2[i]  = makeRndString(false, 32);
+            utf16_short[i] = makeRndString(true, 7);
+            utf16_sse4[i]  = makeRndString(true, 8);
+            utf16_avx2[i]  = makeRndString(true, 16);
+            latn1_mixedLength[i] = makeRndString(false, rng.nextInt(65));
+            utf16_mixedLength[i] = makeRndString(true, rng.nextInt(65));
+        }
+    }
+
+    private static String makeRndString(boolean isUtf16, int length) {
+        StringBuilder sb = new StringBuilder(length);
+        if(length > 0){
+            sb.append(isUtf16?'☺':'b');
+
+            for (int i = 1; i < length-1; i++) {
+                sb.append((char)('b' + rng.nextInt(26)));
+            }
+
+            sb.append(rng.nextInt(3) >= 1?'a':'b');//66.6% of time 'a' is in string
+        }
+        return sb.toString();
+    }
+
+
+    @Benchmark
+    public static void latin1_mixed_char() {
+        int ret = 0;
+        for (String what : latn1_mixedLength) {
+            ret += what.indexOf('a');
+        }
+    }
+
+    @Benchmark
+    public static void utf16_mixed_char() {
+        int ret = 0;
+        for (String what : utf16_mixedLength) {
+            ret += what.indexOf('a');
+        }
+    }
+
+    @Benchmark
+    public static void latin1_mixed_String() {
+        int ret = 0;
+        for (String what : latn1_mixedLength) {
+            ret += what.indexOf("a");
+        }
+    }
+
+    @Benchmark
+    public static void utf16_mixed_String() {
+        int ret = 0;
+        for (String what : utf16_mixedLength) {
+            ret += what.indexOf("a");
+        }
+    }
+
+    ////////// more detailed code path dependent tests //////////
+
+    @Benchmark
+    public static void latin1_Short_char() {
+        int ret = 0;
+        for (String what : latn1_short) {
+            ret += what.indexOf('a');
+        }
+    }
+
+    @Benchmark
+    public static void latin1_SSE4_char() {
+        int ret = 0;
+        for (String what : latn1_sse4) {
+            ret += what.indexOf('a');
+        }
+    }
+
+    @Benchmark
+    public static void latin1_AVX2_char() {
+        int ret = 0;
+        for (String what : latn1_avx2) {
+            ret += what.indexOf('a');
+        }
+    }
+
+    @Benchmark
+    public static int utf16_Short_char() {
+        int ret = 0;
+        for (String what : utf16_short) {
+            ret += what.indexOf('a');
+        }
+        return ret;
+    }
+
+    @Benchmark
+    public static int utf16_SSE4_char() {
+        int ret = 0;
+        for (String what : utf16_sse4) {
+            ret += what.indexOf('a');
+        }
+        return ret;
+    }
+
+    @Benchmark
+    public static int utf16_AVX2_char() {
+        int ret = 0;
+        for (String what : utf16_avx2) {
+            ret += what.indexOf('a');
+        }
+        return ret;
+    }
+
+    @Benchmark
+    public static int latin1_Short_String() {
+        int ret = 0;
+        for (String what : latn1_short) {
+            ret += what.indexOf("a");
+        }
+        return ret;
+    }
+
+    @Benchmark
+    public static int latin1_SSE4_String() {
+        int ret = 0;
+        for (String what : latn1_sse4) {
+            ret += what.indexOf("a");
+        }
+        return ret;
+    }
+
+    @Benchmark
+    public static int latin1_AVX2_String() {
+        int ret = 0;
+        for (String what : latn1_avx2) {
+            ret += what.indexOf("a");
+        }
+        return ret;
+    }
+
+    @Benchmark
+    public static int utf16_Short_String() {
+        int ret = 0;
+        for (String what : utf16_short) {
+            ret += what.indexOf("a");
+        }
+        return ret;
+    }
+
+    @Benchmark
+    public static int utf16_SSE4_String() {
+        int ret = 0;
+        for (String what : utf16_sse4) {
+            ret += what.indexOf("a");
+        }
+        return ret;
+    }
+
+    @Benchmark
+    public static int utf16_AVX2_String() {
+        int ret = 0;
+        for (String what : utf16_avx2) {
+            ret += what.indexOf("a");
+        }
+        return ret;
+    }
+}


### PR DESCRIPTION
I'd like to backport StringLatin1.indexOf(char) intrinsic. Several issues to backport:

JDK-8173585 - This one, main change.
JDK-8254775 - Microbenchmark compilation fix. Applies on top of JDK-8173585.
JDK-8255274 - fix for PPC.
JDK-8254785 - Graal intrinsics test fix.
JDK-8254782 - Microbenchmark cleanup. Applies on top of JDK-8254775.

Pull requests to be opened for all of them, the ones that depend on earlier changes will be based on appropriate threads and won't be applicable initially.

In this backport the cnahges were reapplied manually because macroAssembler files have old names in 11u and vmIntrinsics.*pp part is vmSymbols.*pp. Hunks contents (intrinsic code etc.) are the same.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8173585](https://bugs.openjdk.java.net/browse/JDK-8173585): Intrinsify StringLatin1.indexOf(char)


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.java.net/census#kdnilsen) (@kdnilsen - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/41.diff">https://git.openjdk.java.net/jdk11u-dev/pull/41.diff</a>

</details>
