### PR TITLE
8223050: JVMCI: findUniqueConcreteMethod() should not use Dependencies::find_unique_concrete_method() for non-virtual methods

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -370,6 +370,9 @@ C2V_VMENTRY(jobject, findUniqueConcreteMethod, (JNIEnv *, jobject, jobject jvmci
   if (method->is_abstract()) {
     return NULL;
   }
+  if (method->can_be_statically_bound()) {
+    THROW_MSG_0(vmSymbols::java_lang_InternalError(), err_msg("Effectively static method %s.%s should be handled in Java code", method->method_holder()->external_name(), method->external_name()));
+  }
 
   methodHandle ucm;
   {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
@@ -228,7 +228,7 @@ final class HotSpotResolvedJavaMethodImpl extends HotSpotMethod implements HotSp
 
     @Override
     public boolean canBeStaticallyBound() {
-        return (isFinal() || isPrivate() || isStatic() || holder.isLeaf()) && isConcrete();
+        return (isFinal() || isPrivate() || isStatic() || holder.isLeaf() || isConstructor()) && isConcrete();
     }
 
     @Override
@@ -392,6 +392,8 @@ final class HotSpotResolvedJavaMethodImpl extends HotSpotMethod implements HotSp
 
     @Override
     public ResolvedJavaMethod uniqueConcreteMethod(HotSpotResolvedObjectType receiver) {
+        assert !canBeStaticallyBound() : this;
+
         if (receiver.isInterface()) {
             // Cannot trust interfaces. Because of:
             // interface I { void foo(); }
@@ -403,6 +405,7 @@ final class HotSpotResolvedJavaMethodImpl extends HotSpotMethod implements HotSp
             // seeing A.foo().
             return null;
         }
+        assert !receiver.isLinked() || isInVirtualMethodTable(receiver);
         if (this.isDefault()) {
             // CHA for default methods doesn't work and may crash the VM
             return null;

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaMethod.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaMethod.java
@@ -214,7 +214,8 @@ public class TestResolvedJavaMethod extends MethodUniverse {
 
     private static boolean canBeStaticallyBound(Member method) {
         int modifiers = method.getModifiers();
-        return (Modifier.isFinal(modifiers) || Modifier.isPrivate(modifiers) || Modifier.isStatic(modifiers) || Modifier.isFinal(method.getDeclaringClass().getModifiers())) &&
+        boolean isConstructor = method instanceof Constructor;
+        return (Modifier.isFinal(modifiers) || Modifier.isPrivate(modifiers) || Modifier.isStatic(modifiers) || Modifier.isFinal(method.getDeclaringClass().getModifiers()) || isConstructor) &&
                         !Modifier.isAbstract(modifiers);
     }
 


### PR DESCRIPTION
Please review this backport of JDK-8223050 related to JVMCI. The JDK 13 patch doesn't apply cleanly. The change in assert in check_unique_method() has been left out since JDK 11u doesn't have [JDK-8223171](https://bugs.openjdk.java.net/browse/JDK-8223171) which introduced this method. It doesn't seem needed to bring that in too. JVMCI_THROW_MSG_NULL doesn't exist in JDK 11u. I've used THROW_MSG_0 instead. Finally, test `TestResolvedJavaMethod.java` needed to account for this change as it would fail otherwise. Note that the test is `@ignored` in HEAD so hasn't been fixed there.

**Testing**

- [x] tier1 on Linux x86_64 (pass)
- [x] `jtreg:test/hotspot/jtreg/compiler/jvmci/` most notably `FindUniqueConcreteMethodTest.java` and `TestResolvedJavaMethod.java`. All pass.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8223050](https://bugs.openjdk.java.net/browse/JDK-8223050): JVMCI: findUniqueConcreteMethod() should not use Dependencies::find_unique_concrete_method() for non-virtual methods


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/48.diff">https://git.openjdk.java.net/jdk11u-dev/pull/48.diff</a>

</details>
