### PR TITLE
8264752: SIGFPE crash with option FlightRecorderOptions:threadbuffersize=30M

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrMemorySizer.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrMemorySizer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@ extern const julong MIN_BUFFER_COUNT;
 extern const julong MIN_GLOBAL_BUFFER_SIZE;
 extern const julong MIN_MEMORY_SIZE;
 extern const julong MIN_THREAD_BUFFER_SIZE;
+extern const julong MAX_GLOBAL_BUFFER_SIZE;
+extern const julong MAX_THREAD_BUFFER_SIZE;
 
 struct JfrMemoryOptions {
   julong memory_size;

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -391,34 +391,41 @@ static julong divide_with_user_unit(Argument& memory_argument, julong value) {
   return value;
 }
 
-template <typename Argument>
-static void log_lower_than_min_value(Argument& memory_argument, julong min_value) {
+static const char higher_than_msg[] = "This value is higher than the maximum size limited ";
+static const char lower_than_msg[] = "This value is lower than the minimum size required ";
+template <typename Argument, bool lower>
+static void log_out_of_range_value(Argument& memory_argument, julong min_value) {
+  const char* msg = lower ? lower_than_msg : higher_than_msg;
   if (memory_argument.value()._size != memory_argument.value()._val) {
     // has multiplier
     log_error(arguments) (
-      "This value is lower than the minimum size required " JULONG_FORMAT "%c",
+      "%s" JULONG_FORMAT "%c", msg,
       divide_with_user_unit(memory_argument, min_value),
       memory_argument.value()._multiplier);
     return;
   }
   log_error(arguments) (
-    "This value is lower than the minimum size required " JULONG_FORMAT,
+    "%s" JULONG_FORMAT, msg,
     divide_with_user_unit(memory_argument, min_value));
 }
 
+static const char default_val_msg[] = "Value default for option ";
+static const char specified_val_msg[] = "Value specified for option ";
 template <typename Argument>
 static void log_set_value(Argument& memory_argument) {
   if (memory_argument.value()._size != memory_argument.value()._val) {
     // has multiplier
     log_error(arguments) (
-      "Value specified for option \"%s\" is " JULONG_FORMAT "%c",
+      "%s\"%s\" is " JULONG_FORMAT "%c",
+      memory_argument.is_set() ? specified_val_msg: default_val_msg,
       memory_argument.name(),
       memory_argument.value()._val,
       memory_argument.value()._multiplier);
     return;
   }
   log_error(arguments) (
-    "Value specified for option \"%s\" is " JULONG_FORMAT,
+    "%s\"%s\" is " JULONG_FORMAT,
+    memory_argument.is_set() ? specified_val_msg: default_val_msg,
     memory_argument.name(), memory_argument.value()._val);
 }
 
@@ -539,6 +546,10 @@ static bool valid_memory_relations(const JfrMemoryOptions& options) {
         return false;
       }
     }
+  } else if (options.thread_buffer_size_configured && options.memory_size_configured) {
+    if (!ensure_first_gteq_second(_dcmd_memorysize, _dcmd_threadbuffersize)) {
+      return false;
+    }
   }
   return true;
 }
@@ -607,7 +618,7 @@ template <typename Argument>
 static bool ensure_gteq(Argument& memory_argument, const jlong value) {
   if ((jlong)memory_argument.value()._size < value) {
     log_set_value(memory_argument);
-    log_lower_than_min_value(memory_argument, value);
+    log_out_of_range_value<Argument, true>(memory_argument, value);
     return false;
   }
   return true;
@@ -638,6 +649,30 @@ static bool ensure_valid_minimum_sizes() {
   return true;
 }
 
+template <typename Argument>
+static bool ensure_lteq(Argument& memory_argument, const jlong value) {
+  if ((jlong)memory_argument.value()._size > value) {
+    log_set_value(memory_argument);
+    log_out_of_range_value<Argument, false>(memory_argument, value);
+    return false;
+  }
+  return true;
+}
+
+static bool ensure_valid_maximum_sizes() {
+  if (_dcmd_globalbuffersize.is_set()) {
+    if (!ensure_lteq(_dcmd_globalbuffersize, MAX_GLOBAL_BUFFER_SIZE)) {
+      return false;
+    }
+  }
+  if (_dcmd_threadbuffersize.is_set()) {
+    if (!ensure_lteq(_dcmd_threadbuffersize, MAX_THREAD_BUFFER_SIZE)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * Starting with the initial set of memory values from the user,
  * sanitize, enforce min/max rules and adjust to a set of consistent options.
@@ -645,7 +680,7 @@ static bool ensure_valid_minimum_sizes() {
  * Adjusted memory sizes will be page aligned.
  */
 bool JfrOptionSet::adjust_memory_options() {
-  if (!ensure_valid_minimum_sizes()) {
+  if (!ensure_valid_minimum_sizes() || !ensure_valid_maximum_sizes()) {
     return false;
   }
   JfrMemoryOptions options;
@@ -654,6 +689,24 @@ bool JfrOptionSet::adjust_memory_options() {
     return false;
   }
   if (!JfrMemorySizer::adjust_options(&options)) {
+    if (options.buffer_count < MIN_BUFFER_COUNT || options.global_buffer_size < options.thread_buffer_size) {
+      log_set_value(_dcmd_memorysize);
+      log_set_value(_dcmd_globalbuffersize);
+      log_error(arguments) ("%s \"%s\" is " JLONG_FORMAT,
+        _dcmd_numglobalbuffers.is_set() ? specified_val_msg: default_val_msg,
+        _dcmd_numglobalbuffers.name(), _dcmd_numglobalbuffers.value());
+      log_set_value(_dcmd_threadbuffersize);
+      if (options.buffer_count < MIN_BUFFER_COUNT) {
+        log_error(arguments) ("numglobalbuffers " JULONG_FORMAT " is less than minimal value " JULONG_FORMAT,
+          options.buffer_count, MIN_BUFFER_COUNT);
+        log_error(arguments) ("Decrease globalbuffersize/threadbuffersize or increase memorysize");
+      } else {
+        log_error(arguments) ("globalbuffersize " JULONG_FORMAT " is less than threadbuffersize" JULONG_FORMAT,
+          options.global_buffer_size, options.thread_buffer_size);
+        log_error(arguments) ("Decrease globalbuffersize or increase memorysize or adjust global/threadbuffersize");
+      }
+      return false;
+    }
     if (!check_for_ambiguity(_dcmd_memorysize, _dcmd_globalbuffersize, _dcmd_numglobalbuffers)) {
       return false;
     }

--- a/test/jdk/jdk/jfr/startupargs/TestBadOptionValues.java
+++ b/test/jdk/jdk/jfr/startupargs/TestBadOptionValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package jdk.jfr.startupargs;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import sun.hotspot.WhiteBox;
 
 /**
  * @test
@@ -39,7 +40,10 @@ import jdk.test.lib.process.ProcessTools;
  *          java.management
  *          jdk.jfr
  *
- * @run main jdk.jfr.startupargs.TestBadOptionValues
+ * @build ClassFileInstaller
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI jdk.jfr.startupargs.TestBadOptionValues
  */
 public class TestBadOptionValues {
 
@@ -120,6 +124,31 @@ public class TestBadOptionValues {
 
         test(START_FLIGHT_RECORDING, "Parsing error memory size value: invalid value",
             "maxsize=");
+
+        // globalbuffersize exceeds limit
+        test(FLIGHT_RECORDER_OPTIONS, "This value is higher than the maximum size limit",
+            "globalbuffersize=4G");
+
+        // threadbuffersize exceeds limit
+        test(FLIGHT_RECORDER_OPTIONS, "This value is higher than the maximum size limit",
+            "threadbuffersize=4G");
+
+        // computed numglobalbuffers smaller than MIN_BUFFER_COUNT
+        test(FLIGHT_RECORDER_OPTIONS, "Decrease globalbuffersize/threadbuffersize or increase memorysize",
+            "memorysize=1m,globalbuffersize=1m");
+
+        // memorysize smaller than threadbuffersize
+        test(FLIGHT_RECORDER_OPTIONS, "The value for option \"threadbuffersize\" should not be larger than the value specified for option \"memorysize\"",
+            "memorysize=1m,threadbuffersize=2m");
+
+        // computed globalbuffersize smaller than threadbuffersize
+        // test is on when vm page isn't larger than 4K, avoiding both buffer sizes align to vm page size
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        long smallPageSize = wb.getVMPageSize();
+        if (smallPageSize <= 4096) {
+            test(FLIGHT_RECORDER_OPTIONS, "Decrease globalbuffersize or increase memorysize or adjust global/threadbuffersize",
+                "memorysize=1m,numglobalbuffers=256");
+        }
 
         test(FLIGHT_RECORDER_OPTIONS, "Parsing error memory size value: invalid value",
             "threadbuffersize=a",

--- a/test/jdk/jdk/jfr/startupargs/TestMemoryOptions.java
+++ b/test/jdk/jdk/jfr/startupargs/TestMemoryOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -641,6 +641,11 @@ public class TestMemoryOptions {
         tc = new TestCase("GlobalBufferSizeTimesGlobalBufferCountEqualToMinMemorySizePositive", false);
         tc.setGlobalBufferSizeTestParam(64, 'k');
         tc.setGlobalBufferCountTestParam(16, 'b');
+        testCases.add(tc);
+
+        // threadbuffersize exceeds default memorysize
+        tc = new TestCase("ThreadBufferSizeExceedMemorySize", false);
+        tc.setThreadBufferSizeTestParam(30, 'm');
         testCases.add(tc);
     }
 


### PR DESCRIPTION
Please help review backport of JDK-8264752 related to JFR.
This backport also includes successive build failure fix JDK-8266206 (for older gcc version).

Applied almost cleanly on jdk11u, except copyright year in license and ClassFileInstaller build/use in test/jdk/jdk/jfr/startupargs/TestBadOptionValues.java.

Tested on Linux X64 tier1/tier2/tier3 release/fastdebug no regression.
New test added in this PR also pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8264752](https://bugs.openjdk.java.net/browse/JDK-8264752): SIGFPE crash with option FlightRecorderOptions:threadbuffersize=30M ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/50.diff">https://git.openjdk.java.net/jdk11u-dev/pull/50.diff</a>

</details>
