### PR TITLE
8267751: (test) jtreg.SkippedException has no serial VersionUID

### DIFF
--- a/test/lib/jtreg/SkippedException.java
+++ b/test/lib/jtreg/SkippedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@ package jtreg;
  * of skipped status.
  */
 public final class SkippedException extends RuntimeException {
+    private static final long serialVersionUID = 1347132660681446077L;
+
     public SkippedException(String s, Throwable t) {
         super(s, t);
     }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8267751](https://bugs.openjdk.java.net/browse/JDK-8267751): (test) jtreg.SkippedException has no serial VersionUID


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/53.diff">https://git.openjdk.java.net/jdk11u-dev/pull/53.diff</a>

</details>
