### PR TITLE
8233989: Create an IPv4 version of java/net/MulticastSocket/SetLoopbackMode.java

### DIFF
--- a/test/jdk/java/net/MulticastSocket/SetLoopbackMode.java
+++ b/test/jdk/java/net/MulticastSocket/SetLoopbackMode.java
@@ -33,7 +33,6 @@
 
 import java.net.*;
 import java.io.IOException;
-import java.util.Enumeration;
 import jdk.test.lib.NetworkConfiguration;
 
 public class SetLoopbackMode {

--- a/test/jdk/java/net/MulticastSocket/SetLoopbackModeIPv4.java
+++ b/test/jdk/java/net/MulticastSocket/SetLoopbackModeIPv4.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4686717
+ * @summary Test MulticastSocket.setLoopbackMode with IPv4 addresses
+ * @library /test/lib
+ * @build jdk.test.lib.NetworkConfiguration
+ *        jdk.test.lib.Platform
+ *        SetLoopbackMode
+ *        SetLoopbackModeIPv4
+ * @run main/othervm -Djava.net.preferIPv4Stack=true SetLoopbackModeIPv4
+ */
+
+import jdk.test.lib.net.IPSupport;
+
+public class SetLoopbackModeIPv4 {
+    public static void main(String[] args) throws Exception {
+        IPSupport.throwSkippedExceptionIfNonOperational();
+        SetLoopbackMode.main(args);
+    }
+}
+
+


### PR DESCRIPTION
I would like to backport this patch to openjdk11u for parity with Oracle 11.0.13.

The original patch applies cleanly.

Test:
- [x]  java/net/MulticastSocket/SetLoopbackMode.java
- [x]  java/net/MulticastSocket/SetLoopbackModeIPv4.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8233989](https://bugs.openjdk.java.net/browse/JDK-8233989): Create an IPv4 version of java/net/MulticastSocket/SetLoopbackMode.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/54.diff">https://git.openjdk.java.net/jdk11u-dev/pull/54.diff</a>

</details>
