### PR TITLE
8263382: java/util/logging/ParentLoggersTest.java failed with "checkLoggers: getLoggerNames() returned unexpected loggers"

### DIFF
--- a/test/jdk/java/util/logging/ParentLoggersTest.java
+++ b/test/jdk/java/util/logging/ParentLoggersTest.java
@@ -29,7 +29,7 @@
  * @author  ss45998
  *
  * @build ParentLoggersTest
- * @run main ParentLoggersTest
+ * @run main/othervm ParentLoggersTest
  */
 
 /*


### PR DESCRIPTION
I would like to backport this patch to openjdk11u for parity with Oracle 11.0.13.

The original patch applies cleanly and test passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8263382](https://bugs.openjdk.java.net/browse/JDK-8263382): java/util/logging/ParentLoggersTest.java failed with "checkLoggers: getLoggerNames() returned unexpected loggers"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/55.diff">https://git.openjdk.java.net/jdk11u-dev/pull/55.diff</a>

</details>
