### PR TITLE
8226533: JVMCI: findUniqueConcreteMethod should handle statically bindable methods directly

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
@@ -602,6 +602,10 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
             // The type isn't known to implement the method.
             return null;
         }
+        if (resolvedMethod.canBeStaticallyBound()) {
+            // No assumptions are required.
+            return new AssumptionResult<>(resolvedMethod);
+        }
 
         ResolvedJavaMethod result = resolvedMethod.uniqueConcreteMethod(this);
         if (result != null) {


### PR DESCRIPTION
Clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8226533](https://bugs.openjdk.java.net/browse/JDK-8226533): JVMCI: findUniqueConcreteMethod should handle statically bindable methods directly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/57.diff">https://git.openjdk.java.net/jdk11u-dev/pull/57.diff</a>

</details>
