### PR TITLE
8231717: Improve performance of charset decoding when charset is always compactable

### DIFF
--- a/make/data/charsetmapping/SingleByte-X.java.template
+++ b/make/data/charsetmapping/SingleByte-X.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class $NAME_CLZ$ extends Charset implements HistoricallyNamedCharset
     }
 
     public CharsetDecoder newDecoder() {
-        return new SingleByte.Decoder(this, b2c, $ASCIICOMPATIBLE$);
+        return new SingleByte.Decoder(this, b2c, $ASCIICOMPATIBLE$, $LATIN1DECODABLE$);
     }
 
     public CharsetEncoder newEncoder() {

--- a/make/jdk/src/classes/build/tools/charsetmapping/SBCS.java
+++ b/make/jdk/src/classes/build/tools/charsetmapping/SBCS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,7 @@ public class SBCS {
         String hisName = cs.hisName;
         String pkgName = cs.pkgName;
         boolean isASCII = cs.isASCII;
+        boolean isLatin1Decodable = true;
 
         StringBuilder b2cSB = new StringBuilder();
         StringBuilder b2cNRSB = new StringBuilder();
@@ -68,6 +69,9 @@ public class SBCS {
             if (c2bIndex[e.cp>>8] == UNMAPPABLE_DECODING) {
                 c2bOff += 0x100;
                 c2bIndex[e.cp>>8] = 1;
+            }
+            if (e.cp > 0xFF) {
+                isLatin1Decodable = false;
             }
         }
 
@@ -177,6 +181,9 @@ public class SBCS {
             }
             if (line.indexOf("$ASCIICOMPATIBLE$") != -1) {
                 line = line.replace("$ASCIICOMPATIBLE$", isASCII ? "true" : "false");
+            }
+            if (line.indexOf("$LATIN1DECODABLE$") != -1) {
+                line = line.replace("$LATIN1DECODABLE$", isLatin1Decodable ? "true" : "false");
             }
             if (line.indexOf("$B2CTABLE$") != -1) {
                 line = line.replace("$B2CTABLE$", b2c);

--- a/src/java.base/share/classes/java/lang/StringCoding.java
+++ b/src/java.base/share/classes/java/lang/StringCoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,6 +191,12 @@ class StringCoding {
                     return result.with(StringLatin1.inflate(ba, off, len), UTF16);
                 }
             }
+            // fastpath for always Latin1 decodable single byte
+            if (COMPACT_STRINGS && cd instanceof ArrayDecoder && ((ArrayDecoder)cd).isLatin1Decodable()) {
+                byte[] dst = new byte[len];
+                ((ArrayDecoder)cd).decodeToLatin1(ba, off, len, dst);
+                return result.with(dst, LATIN1);
+            }
             int en = scale(len, cd.maxCharsPerByte());
             char[] ca = new char[en];
             if (cd instanceof ArrayDecoder) {
@@ -278,6 +284,13 @@ class StringCoding {
             ((ArrayDecoder)cd).isASCIICompatible() && !hasNegatives(ba, off, len)) {
             return decodeLatin1(ba, off, len);
         }
+        // fastpath for always Latin1 decodable single byte
+        if (COMPACT_STRINGS && cd instanceof ArrayDecoder && ((ArrayDecoder)cd).isLatin1Decodable()) {
+            byte[] dst = new byte[len];
+            ((ArrayDecoder)cd).decodeToLatin1(ba, off, len, dst);
+            return new Result().with(dst, LATIN1);
+        }
+
         int en = scale(len, cd.maxCharsPerByte());
         if (len == 0) {
             return new Result().with();

--- a/src/java.base/share/classes/sun/nio/cs/ArrayDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/ArrayDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,9 @@ package sun.nio.cs;
 /*
  * FastPath byte[]->char[] decoder, REPLACE on malformed or
  * unmappable input.
+ *
+ * FastPath encoded byte[]-> "String Latin1 coding" byte[] decoder for use when
+ * charset is always decodable to the internal String Latin1 coding byte[], ie. all mappings <=0xff
  */
 
 public interface ArrayDecoder {
@@ -35,5 +38,15 @@ public interface ArrayDecoder {
 
     default boolean isASCIICompatible() {
         return false;
+    }
+
+    // Is always decodable to internal String Latin1 coding, ie. all mappings <= 0xff
+    default boolean isLatin1Decodable() {
+        return false;
+    }
+
+    // Decode to internal String Latin1 coding byte[] fastpath for when isLatin1Decodable == true
+    default int decodeToLatin1(byte[] src, int sp, int len, byte[] dst) {
+        return 0;
     }
 }

--- a/src/java.base/share/classes/sun/nio/cs/SingleByte.java
+++ b/src/java.base/share/classes/sun/nio/cs/SingleByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,17 +50,27 @@ public class SingleByte
                                       implements ArrayDecoder {
         private final char[] b2c;
         private final boolean isASCIICompatible;
+        private final boolean isLatin1Decodable;
 
         public Decoder(Charset cs, char[] b2c) {
             super(cs, 1.0f, 1.0f);
             this.b2c = b2c;
             this.isASCIICompatible = false;
+            this.isLatin1Decodable = false;
         }
 
         public Decoder(Charset cs, char[] b2c, boolean isASCIICompatible) {
             super(cs, 1.0f, 1.0f);
             this.b2c = b2c;
             this.isASCIICompatible = isASCIICompatible;
+            this.isLatin1Decodable = false;
+        }
+
+        public Decoder(Charset cs, char[] b2c, boolean isASCIICompatible, boolean isLatin1Decodable) {
+            super(cs, 1.0f, 1.0f);
+            this.b2c = b2c;
+            this.isASCIICompatible = isASCIICompatible;
+            this.isLatin1Decodable = isLatin1Decodable;
         }
 
         private CoderResult decodeArrayLoop(ByteBuffer src, CharBuffer dst) {
@@ -125,6 +135,18 @@ public class SingleByte
         }
 
         @Override
+        public int decodeToLatin1(byte[] src, int sp, int len, byte[] dst) {
+            if (len > dst.length)
+                len = dst.length;
+
+            int dp = 0;
+            while (dp < len) {
+                dst[dp++] = (byte)decode(src[sp++]);
+            }
+            return dp;
+        }
+
+        @Override
         public int decode(byte[] src, int sp, int len, char[] dst) {
             if (len > dst.length)
                 len = dst.length;
@@ -142,6 +164,11 @@ public class SingleByte
         @Override
         public boolean isASCIICompatible() {
             return isASCIICompatible;
+        }
+
+        @Override
+        public boolean isLatin1Decodable() {
+            return isLatin1Decodable;
         }
     }
 


### PR DESCRIPTION
This change improves charset decoding for a number of encodings that are "Latin1Decodable". Original patch applies cleanly.

Testing: tier1, tier2, sun/nio/cs on aarch64 and x86.

StrCodingBenchmark benchmark shows improvements for target encodings (IBM037 etc.) on both aarch64 and x86.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8231717](https://bugs.openjdk.java.net/browse/JDK-8231717): Improve performance of charset decoding when charset is always compactable


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/58.diff">https://git.openjdk.java.net/jdk11u-dev/pull/58.diff</a>

</details>
