### PR TITLE
8193214: Incorrect annotations.without.processors warnings with JDK 9

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
@@ -243,15 +243,20 @@ public class JavacProcessingEnvironment implements ProcessingEnvironment, Closea
     }
 
     private Set<String> initPlatformAnnotations() {
-        Set<String> platformAnnotations = new HashSet<>();
-        platformAnnotations.add("java.lang.Deprecated");
-        platformAnnotations.add("java.lang.Override");
-        platformAnnotations.add("java.lang.SuppressWarnings");
-        platformAnnotations.add("java.lang.annotation.Documented");
-        platformAnnotations.add("java.lang.annotation.Inherited");
-        platformAnnotations.add("java.lang.annotation.Retention");
-        platformAnnotations.add("java.lang.annotation.Target");
-        return Collections.unmodifiableSet(platformAnnotations);
+        final String module_prefix =
+            Feature.MODULES.allowedInSource(source) ? "java.base/" : "";
+        return Set.of(module_prefix + "java.lang.Deprecated",
+                      module_prefix + "java.lang.FunctionalInterface",
+                      module_prefix + "java.lang.Override",
+                      module_prefix + "java.lang.SafeVarargs",
+                      module_prefix + "java.lang.SuppressWarnings",
+
+                      module_prefix + "java.lang.annotation.Documented",
+                      module_prefix + "java.lang.annotation.Inherited",
+                      module_prefix + "java.lang.annotation.Native",
+                      module_prefix + "java.lang.annotation.Repeatable",
+                      module_prefix + "java.lang.annotation.Retention",
+                      module_prefix + "java.lang.annotation.Target");
     }
 
     private void initProcessorLoader() {

--- a/test/langtools/tools/javac/processing/warnings/LintProcessing/TestAnnotationsWithoutProcessors.java
+++ b/test/langtools/tools/javac/processing/warnings/LintProcessing/TestAnnotationsWithoutProcessors.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8193214
+ * @summary Verify annotations without processors warning not given for base module annotations.
+ * @library /tools/javac/lib
+ * @modules java.compiler
+ * @build JavacTestingAbstractProcessor TestAnnotationsWithoutProcessors
+ * @compile/ref=empty.out -XDrawDiagnostics -Xlint:processing -processor TestAnnotationsWithoutProcessors --release 8 TestAnnotationsWithoutProcessors.java
+ * @compile/ref=empty.out -XDrawDiagnostics -Xlint:processing -processor TestAnnotationsWithoutProcessors TestAnnotationsWithoutProcessors.java
+ */
+
+import java.lang.annotation.*;
+import java.util.*;
+import javax.annotation.processing.*;
+import javax.lang.model.element.*;
+
+/**
+ * Use various annotations in java.base.
+ */
+@SuppressWarnings("unchecked")
+public class TestAnnotationsWithoutProcessors extends JavacTestingAbstractProcessor {
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        return false;
+    }
+
+    @SafeVarargs
+    @Deprecated
+    public static void main(String... args) {
+        return;
+    }
+
+    @FunctionalInterface
+    interface OneMethod {
+        String method();
+    }
+
+    @Native
+    public double TAU = 2.0 * Math.PI;
+
+    @Documented
+    @Inherited
+    @Repeatable(TestAnnotationTypes.class)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @interface TestAnnotationType {
+    }
+
+    @Documented
+    @Inherited
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    @interface TestAnnotationTypes {
+        TestAnnotationType[] value();
+    }
+}


### PR DESCRIPTION
JDK 9 regression, fixed in JDK 12, but not in JDK 11. Prevents compiling JDK 11 code with -Xlint:processing when annotation processors are enabled. Patch applies cleanly. The only affected code path seems to be Xlint itself, and nothing else. New test fails without the patch, passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8193214](https://bugs.openjdk.java.net/browse/JDK-8193214): Incorrect annotations.without.processors warnings with JDK 9


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/61/head:pull/61` \
`$ git checkout pull/61`

Update a local copy of the PR: \
`$ git checkout pull/61` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/61/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 61`

View PR using the GUI difftool: \
`$ git pr show -t 61`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/61.diff">https://git.openjdk.java.net/jdk11u-dev/pull/61.diff</a>

</details>
