### PR TITLE
8266480: Implicit null check optimization does not update control of hoisted memory operation

### DIFF
--- a/src/hotspot/share/opto/lcm.cpp
+++ b/src/hotspot/share/opto/lcm.cpp
@@ -413,7 +413,8 @@ void PhaseCFG::implicit_null_check(Block* block, Node *proj, Node *val, int allo
 
   // Move the control dependence if it is pinned to not-null block.
   // Don't change it in other cases: NULL or dominating control.
-  if (best->in(0) == not_null_block->head()) {
+  Node* ctrl = best->in(0);
+  if (get_block_for_node(ctrl) == not_null_block) {
     // Set it to control edge of null check.
     best->set_req(0, proj->in(0)->in(0));
   }

--- a/test/hotspot/jtreg/compiler/c2/TestImplicitNullCheckDominance.java
+++ b/test/hotspot/jtreg/compiler/c2/TestImplicitNullCheckDominance.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2;
+
+/**
+ * @test
+ * @bug 8266480
+ * @summary Check correct re-wiring of control edge when hoisting a memory
+ *          operation for an implicit null check.
+ * @run main/othervm -Xbatch
+ *                   compiler.c2.TestImplicitNullCheckDominance
+ */
+public class TestImplicitNullCheckDominance {
+
+    double dFld;
+    int iFld;
+
+    static void test1(TestImplicitNullCheckDominance t, double d) {
+        for (int i = 0; i < 100; i++) {
+            t.dFld = d % 42;
+            t.iFld = 43;
+        }
+    }
+
+    static void test2(TestImplicitNullCheckDominance t) {
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 100; j++) {
+               t.dFld %= 42;
+               t.iFld = 43;
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        TestImplicitNullCheckDominance t = new TestImplicitNullCheckDominance();
+        for (int i = 0; i < 50_000; ++i) {
+            test1(t, i);
+            test2(t);
+        }
+    }
+}


### PR DESCRIPTION
JDK-8266480 should get backported for parity with 11.0.13-oracle. Applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8266480](https://bugs.openjdk.java.net/browse/JDK-8266480): Implicit null check optimization does not update control of hoisted memory operation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/63.diff">https://git.openjdk.java.net/jdk11u-dev/pull/63.diff</a>

</details>
