### PR TITLE
8210959: JShell fails and exits when statement throws an exception whose message contains a '%'.

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -864,7 +864,7 @@ public class JShellTool implements MessageHandler {
      */
     @Override
     public void errormsg(String key, Object... args) {
-        error(messageFormat(key, args));
+        error("%s", messageFormat(key, args));
     }
 
     /**

--- a/test/langtools/jdk/jshell/ToolSimpleTest.java
+++ b/test/langtools/jdk/jshell/ToolSimpleTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8153716 8143955 8151754 8150382 8153920 8156910 8131024 8160089 8153897 8167128 8154513 8170015 8170368 8172102 8172103  8165405 8173073 8173848 8174041 8173916 8174028 8174262 8174797 8177079 8180508 8177466 8172154 8192979 8191842 8198573 8198801 8239536
+ * @bug 8153716 8143955 8151754 8150382 8153920 8156910 8131024 8160089 8153897 8167128 8154513 8170015 8170368 8172102 8172103  8165405 8173073 8173848 8174041 8173916 8174028 8174262 8174797 8177079 8180508 8177466 8172154 8192979 8191842 8198573 8198801 8239536 8210959
  * @summary Simple jshell tool tests
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
@@ -32,8 +32,9 @@
  * @build KullaTesting TestingInputStream
  * @run testng/othervm ToolSimpleTest
  */
-import java.util.Arrays;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
@@ -109,6 +110,20 @@ public class ToolSimpleTest extends ReplToolTesting {
                         "|  dropped method p()"),
                 (a) -> assertCommand(a, "m()",
                         "|  attempted to call method n() which cannot be invoked until method p() is declared")
+        );
+    }
+
+    @Test
+    public void testThrowWithPercent() {
+        test(
+                (a) -> assertCommandCheckOutput(a,
+                        "URI u = new URI(\"http\", null, \"h\", -1, \"a\" + (char)0x04, null, null);", (s) ->
+                                assertTrue(s.contains("URISyntaxException") && !s.contains("JShellTool"),
+                                        "Output: '" + s + "'")),
+                (a) -> assertCommandCheckOutput(a,
+                        "throw new Exception(\"%z\")", (s) ->
+                                assertTrue(s.contains("java.lang.Exception") && !s.contains("UnknownFormatConversionException"),
+                                        "Output: '" + s + "'"))
         );
     }
 


### PR DESCRIPTION
This is unclean backport: there is a minor conflict in `@bug` line in the test. Otherwise it applies cleanly. New test case fails without the patch, passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8210959](https://bugs.openjdk.java.net/browse/JDK-8210959): JShell fails and exits when statement throws an exception whose message contains a '%'.


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/64.diff">https://git.openjdk.java.net/jdk11u-dev/pull/64.diff</a>

</details>
