### PR TITLE
8247421: [TESTBUG] ReturnBlobToWrongHeapTest.java failed allocating blob

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/stress/ReturnBlobToWrongHeapTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/ReturnBlobToWrongHeapTest.java
@@ -64,13 +64,22 @@ public class ReturnBlobToWrongHeapTest {
 
     public static void main(String[] args) {
         if (codeCacheMinBlockLength == 1) {
+            // start with allocating a small block
+            long firstSegmentSizedAddress = 0;
+            firstSegmentSizedAddress = allocate(0);
+            if (firstSegmentSizedAddress == 0) {
+                throw new RuntimeException("Test failed: Failed allocating first segment-sized blob");
+            }
+
             // Fill first code heap with large blobs until allocation fails.
             long address;
             while ((address = allocate((int)largeBlobSize)) != 0) {
             }
 
-            // Allocate segment-sized blocks in first code heap.
-            long lastSegmentSizedAddress = 0; // Address of the last segment-sized blob allocated
+            // Allocate segment-sized blocks in first code heap until it runs out
+            // Remember the last one
+            // Use the pre-allocated one as backup if the code cache is already completely full.
+            long lastSegmentSizedAddress = firstSegmentSizedAddress;
             while ((address = allocate(0)) != 0) {
                 lastSegmentSizedAddress = address;
             }


### PR DESCRIPTION
This fixes the testbug and keeps codebases in sync (I see 11.0.13-oracle). Patch applies cleanly to 11u, passes tier1, passes affected test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8247421](https://bugs.openjdk.java.net/browse/JDK-8247421): [TESTBUG] ReturnBlobToWrongHeapTest.java failed allocating blob


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/65.diff">https://git.openjdk.java.net/jdk11u-dev/pull/65.diff</a>

</details>
