### PR TITLE
8261496: Shenandoah: reconsider pacing updates memory ordering

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -93,7 +93,7 @@ void ShenandoahControlThread::run_service() {
     bool implicit_gc_requested = _gc_requested.is_set() && !is_explicit_gc(_requested_gc_cause);
 
     // This control loop iteration have seen this much allocations.
-    size_t allocs_seen = Atomic::xchg<size_t>(0, &_allocs_seen);
+    size_t allocs_seen = Atomic::xchg<size_t>(0, &_allocs_seen, memory_order_relaxed);
 
     // Check if we have seen a new target for soft max heap size.
     bool soft_max_changed = check_soft_max_changed();
@@ -627,7 +627,7 @@ void ShenandoahControlThread::notify_heap_changed() {
 
 void ShenandoahControlThread::pacing_notify_alloc(size_t words) {
   assert(ShenandoahPacing, "should only call when pacing is enabled");
-  Atomic::add(words, &_allocs_seen);
+  Atomic::add(words, &_allocs_seen, memory_order_relaxed);
 }
 
 void ShenandoahControlThread::set_forced_counters_update(bool value) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.inline.hpp
@@ -53,13 +53,13 @@ inline void ShenandoahPacer::report_internal(size_t words) {
 inline void ShenandoahPacer::report_progress_internal(size_t words) {
   assert(ShenandoahPacing, "Only be here when pacing is enabled");
   STATIC_ASSERT(sizeof(size_t) <= sizeof(intptr_t));
-  Atomic::add((intptr_t)words, &_progress);
+  Atomic::add((intptr_t)words, &_progress, memory_order_relaxed);
 }
 
 inline void ShenandoahPacer::add_budget(size_t words) {
   STATIC_ASSERT(sizeof(size_t) <= sizeof(intptr_t));
   intptr_t inc = (intptr_t) words;
-  intptr_t new_budget = Atomic::add(inc, &_budget);
+  intptr_t new_budget = Atomic::add(inc, &_budget, memory_order_relaxed);
 
   // Was the budget replenished beyond zero? Then all pacing claims
   // are satisfied, notify the waiters. Avoid taking any locks here,


### PR DESCRIPTION
This backport does not apply cleanly, because the `Atomic` parameter orders had changed since [JDK-8234563](https://bugs.openjdk.java.net/browse/JDK-8234563). Passes `hotspot_gc_shenandoah`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261496](https://bugs.openjdk.java.net/browse/JDK-8261496): Shenandoah: reconsider pacing updates memory ordering


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - Committer)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/66.diff">https://git.openjdk.java.net/jdk11u-dev/pull/66.diff</a>

</details>
