### PR TITLE
8265335: Epsilon: Minor typo in EpsilonElasticTLABDecay description

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilon_globals.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilon_globals.hpp
@@ -69,7 +69,7 @@
           "smaller TLABs until policy catches up.")                         \
                                                                             \
   experimental(bool, EpsilonElasticTLABDecay, true,                         \
-          "Use timed decays to shrik TLAB sizes. This conserves memory "    \
+          "Use timed decays to shrink TLAB sizes. This conserves memory "   \
           "for the threads that allocate in bursts of different sizes, "    \
           "for example the small/rare allocations coming after the initial "\
           "large burst.")                                                   \


### PR DESCRIPTION
Unclean backport (although bots think it is clean when fuzzed apply?), since the flags infrastructure changed a bit in later JDKs. Passes `gc/epsilon` tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8265335](https://bugs.openjdk.java.net/browse/JDK-8265335): Epsilon: Minor typo in EpsilonElasticTLABDecay description


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/69.diff">https://git.openjdk.java.net/jdk11u-dev/pull/69.diff</a>

</details>
