### PR TITLE
8267348: Rewrite gc/epsilon/TestClasses.java to use Metaspace with less classes

### DIFF
--- a/test/hotspot/jtreg/gc/epsilon/TestClasses.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestClasses.java
@@ -25,12 +25,12 @@
  * @test TestClasses
  * @key gc
  * @requires vm.gc.Epsilon & !vm.graal.enabled
- * @summary Epsilon is able to allocate a lot of classes
+ * @summary Epsilon is able to allocate a lot of classes, resizing Metaspace
  *
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc
  *
- * @run main/othervm -Xmx128m -XX:MetaspaceSize=1m -XX:MaxMetaspaceSize=64m -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -Xlog:gc+metaspace TestClasses
+ * @run main/othervm -Xmx1g -XX:MetaspaceSize=1m -XX:MaxMetaspaceSize=64m -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -Xlog:gc+metaspace TestClasses
  */
 
 import jdk.internal.org.objectweb.asm.ClassWriter;
@@ -43,14 +43,26 @@ import java.nio.file.*;
 
 public class TestClasses {
 
-  static final int COUNT = 32*1024;
+  static final int CLASSES = 1024;
+  static final int FIELDS = 1024;
 
   static volatile Object sink;
 
   static class MyClassLoader extends ClassLoader {
+    static final String[] FIELD_NAMES;
+    static {
+       FIELD_NAMES = new String[FIELDS];
+       for (int c = 0; c < FIELDS; c++) {
+          FIELD_NAMES[c] = "f" + c;
+       }
+    }
+
     public byte[] createClass(String name) {
       ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
       cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC | Opcodes.ACC_SUPER, name, null, "java/lang/Object", null);
+      for (String fName : FIELD_NAMES) {
+          cw.visitField(Opcodes.ACC_STATIC | Opcodes.ACC_PRIVATE, fName, "J", null, null);
+      }
       return cw.toByteArray();
     }
 
@@ -65,7 +77,7 @@ public class TestClasses {
 
   public static void main(String[] args) throws Exception {
     ClassLoader cl = new MyClassLoader();
-    for (int c = 0; c < COUNT; c++) {
+    for (int c = 0; c < CLASSES; c++) {
       Class<?> clazz = Class.forName("Dummy" + c, true, cl);
       if (clazz.getClassLoader() != cl) {
         throw new IllegalStateException("Should have loaded by target loader");


### PR DESCRIPTION
Unclean backport, because the test is in old package (thus need to drop `gc.epsilon` package). Passes `gc/epsilon`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267348](https://bugs.openjdk.java.net/browse/JDK-8267348): Rewrite gc/epsilon/TestClasses.java to use Metaspace with less classes


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/70.diff">https://git.openjdk.java.net/jdk11u-dev/pull/70.diff</a>

</details>
