### PR TITLE
8227766: CheckUnhandledOops is broken in MemAllocator

### DIFF
--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -324,7 +324,7 @@ oop StringTable::intern(Handle string_or_null_h, jchar* name, int len, TRAPS) {
     return found_string;
   }
   return StringTable::the_table()->do_intern(string_or_null_h, name, len,
-                                             hash, CHECK_NULL);
+                                             hash, THREAD);
 }
 
 class StringTableCreateEntry : public StackObj {

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -377,6 +377,10 @@ oop MemAllocator::allocate() const {
     HeapWord* mem = mem_allocate(allocation);
     if (mem != NULL) {
       obj = initialize(mem);
+    } else {
+      // The unhandled oop detector will poison local variable obj,
+      // so reset it to NULL if mem is NULL.
+      obj = NULL;
     }
   }
   return obj;

--- a/src/hotspot/share/runtime/unhandledOops.cpp
+++ b/src/hotspot/share/runtime/unhandledOops.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,15 +56,15 @@ void UnhandledOops::dump_oops(UnhandledOops *list) {
 
 // For debugging unhandled oop detector _in the debugger_
 // You don't want to turn it on in compiled code here.
-static bool unhandled_oop_print=0;
+static Thread* unhandled_oop_print = NULL;
 
 void UnhandledOops::register_unhandled_oop(oop* op, address pc) {
   if (!_thread->is_in_stack((address)op))
     return;
 
-  _level ++;
-  if (unhandled_oop_print) {
-    for (int i=0; i<_level; i++) tty->print(" ");
+  _level++;
+  if (unhandled_oop_print == _thread) {
+    for (int i=0; i < _level; i++) tty->print(" ");
     tty->print_cr("r " INTPTR_FORMAT, p2i(op));
   }
   UnhandledOopEntry entry(op, pc);
@@ -99,11 +99,11 @@ void UnhandledOops::allow_unhandled_oop(oop* op) {
 void UnhandledOops::unregister_unhandled_oop(oop* op) {
   if (!_thread->is_in_stack((address)op)) return;
 
-  _level --;
-  if (unhandled_oop_print) {
-    for (int i=0; i<_level; i++) tty->print(" ");
+  if (unhandled_oop_print == _thread) {
+    for (int i=0; i < _level; i++) tty->print(" ");
     tty->print_cr("u " INTPTR_FORMAT, p2i(op));
   }
+  _level--;
 
   int i = _oop_list->find_from_end(op, match_oop_entry);
   assert(i!=-1, "oop not in unhandled_oop_list");

--- a/src/hotspot/share/services/gcNotifier.cpp
+++ b/src/hotspot/share/services/gcNotifier.cpp
@@ -159,7 +159,7 @@ static Handle createGcInfo(GCMemoryManager *gcManager, GCStatInfo *gcStatInfo,TR
                           gcInfoklass,
                           vmSymbols::com_sun_management_GcInfo_constructor_signature(),
                           &constructor_args,
-                          CHECK_NH);
+                          THREAD);
 }
 
 void GCNotifier::sendNotification(TRAPS) {

--- a/test/hotspot/jtreg/runtime/CheckUnhandledOops/TestOutOfMemory.java
+++ b/test/hotspot/jtreg/runtime/CheckUnhandledOops/TestOutOfMemory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8227766
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+CheckUnhandledOops -Xmx100m TestOutOfMemory
+ */
+
+public class TestOutOfMemory {
+    public static void main(java.lang.String[] unused) {
+        final int BIG = 0x100000;
+        // Getting OOM breaks the unhandled oop detector
+        try {
+            int[][] X = new int[BIG][];
+            for (int i = 0; i < BIG; i++) {
+                X[i] = new int[BIG];
+                System.out.println("length = " + X.length);
+            }
+         } catch (OutOfMemoryError oom) {
+            System.out.println("OOM expected");
+         }
+    }
+}


### PR DESCRIPTION
This fixes `-XX:+CheckUnhandledOops` verification code.

Additional testing:
 - [x] New test fails without the patch, passes with it
 - [x] Linux x86_64 fastdebug `tier1` with `-XX:+CheckUnhandledOops`
 - [x] Linux x86_64 fastdebug `tier2` with `-XX:+CheckUnhandledOops`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8227766](https://bugs.openjdk.java.net/browse/JDK-8227766): CheckUnhandledOops is broken in MemAllocator


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/73/head:pull/73` \
`$ git checkout pull/73`

Update a local copy of the PR: \
`$ git checkout pull/73` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/73/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 73`

View PR using the GUI difftool: \
`$ git pr show -t 73`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/73.diff">https://git.openjdk.java.net/jdk11u-dev/pull/73.diff</a>

</details>
