### PR TITLE
8268699: Shenandoah: Add test for JDK-8268127

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/options/TestLargePagesWithSmallHeap.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestLargePagesWithSmallHeap.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test id=default
+ * @requires vm.gc.Shenandoah
+ * @bug 8268127
+ * @summary when heap is too small for regions to align to large page size, should fallback to regular page size
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -Xms17m -Xmx17m TestLargePagesWithSmallHeap
+ * @run main/othervm -XX:+UseShenandoahGC         -Xmx17m TestLargePagesWithSmallHeap
+ * @run main/othervm -XX:+UseShenandoahGC -Xms17m         TestLargePagesWithSmallHeap
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -Xms17m -Xmx17m TestLargePagesWithSmallHeap
+ * @run main/othervm -XX:+UseShenandoahGC         -Xmx17m TestLargePagesWithSmallHeap
+ * @run main/othervm -XX:+UseShenandoahGC -Xms17m         TestLargePagesWithSmallHeap
+ */
+
+/*
+ * @test id=lp
+ * @requires vm.gc.Shenandoah
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages -Xms17m -Xmx17m TestLargePagesWithSmallHeap
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages         -Xmx17m TestLargePagesWithSmallHeap
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages -Xms17m         TestLargePagesWithSmallHeap
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages -Xms17m -Xmx17m TestLargePagesWithSmallHeap
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages         -Xmx17m TestLargePagesWithSmallHeap
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages -Xms17m         TestLargePagesWithSmallHeap
+ */
+
+/*
+ * @test id=thp
+ * @requires vm.gc.Shenandoah
+ * @requires os.family == "linux"
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseTransparentHugePages -Xms17m -Xmx17m TestLargePagesWithSmallHeap
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseTransparentHugePages         -Xmx17m TestLargePagesWithSmallHeap
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseTransparentHugePages -Xms17m         TestLargePagesWithSmallHeap
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseTransparentHugePages -Xms17m -Xmx17m TestLargePagesWithSmallHeap
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseTransparentHugePages         -Xmx17m TestLargePagesWithSmallHeap
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseTransparentHugePages -Xms17m         TestLargePagesWithSmallHeap
+ */
+
+public class TestLargePagesWithSmallHeap {
+    public static void main(String[] args) {
+        // Everything is checked on initialization
+    }
+}


### PR DESCRIPTION
I would like to backport this new test to openjdk11u to ensure no regression of JDK-8268127.

Test:

- [x] New test passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268699](https://bugs.openjdk.java.net/browse/JDK-8268699): Shenandoah: Add test for JDK-8268127


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/74.diff">https://git.openjdk.java.net/jdk11u-dev/pull/74.diff</a>

</details>
