### PR TITLE
Backport d812742d687cf6e8748d65552831f60be156c860

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CipherSuite.java
+++ b/src/java.base/share/classes/sun/security/ssl/CipherSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,20 +56,22 @@ enum CipherSuite {
     // the following criteria:
     // 1. Prefer Suite B compliant cipher suites, see RFC6460 (To be
     //    changed later, see below).
-    // 2. Prefer the stronger bulk cipher, in the order of AES_256(GCM),
+    // 2. Prefer forward secrecy cipher suites.
+    // 3. Prefer the stronger bulk cipher, in the order of AES_256(GCM),
     //    AES_128(GCM), AES_256, AES_128, 3DES-EDE.
-    // 3. Prefer the stronger MAC algorithm, in the order of SHA384,
+    // 4. Prefer the stronger MAC algorithm, in the order of SHA384,
     //    SHA256, SHA, MD5.
-    // 4. Prefer the better performance of key exchange and digital
+    // 5. Prefer the better performance of key exchange and digital
     //    signature algorithm, in the order of ECDHE-ECDSA, ECDHE-RSA,
-    //    RSA, ECDH-ECDSA, ECDH-RSA, DHE-RSA, DHE-DSS.
+    //    DHE-RSA, DHE-DSS, ECDH-ECDSA, ECDH-RSA, RSA.
 
-    TLS_AES_128_GCM_SHA256(
-            0x1301, true, "TLS_AES_128_GCM_SHA256",
-            ProtocolVersion.PROTOCOLS_OF_13, B_AES_128_GCM_IV, H_SHA256),
+    // TLS 1.3 cipher suites.
     TLS_AES_256_GCM_SHA384(
             0x1302, true, "TLS_AES_256_GCM_SHA384",
             ProtocolVersion.PROTOCOLS_OF_13, B_AES_256_GCM_IV, H_SHA384),
+    TLS_AES_128_GCM_SHA256(
+            0x1301, true, "TLS_AES_128_GCM_SHA256",
+            ProtocolVersion.PROTOCOLS_OF_13, B_AES_128_GCM_IV, H_SHA256),
     TLS_CHACHA20_POLY1305_SHA256(
             0x1303, true, "TLS_CHACHA20_POLY1305_SHA256",
             ProtocolVersion.PROTOCOLS_OF_13, B_CC20_P1305, H_SHA256),
@@ -101,7 +103,11 @@ enum CipherSuite {
             ProtocolVersion.PROTOCOLS_OF_12,
             K_ECDHE_ECDSA, B_CC20_P1305, M_NULL, H_SHA256),
 
-    // AES_256(GCM)
+    //
+    // Forward screcy cipher suites.
+    //
+
+    // AES_256(GCM) - ECDHE
     TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384(
             0xC030, true, "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "",
             ProtocolVersion.PROTOCOLS_OF_12,
@@ -110,18 +116,14 @@ enum CipherSuite {
             0xCCA8, true, "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256", "",
             ProtocolVersion.PROTOCOLS_OF_12,
             K_ECDHE_RSA, B_CC20_P1305, M_NULL, H_SHA256),
-    TLS_RSA_WITH_AES_256_GCM_SHA384(
-            0x009D, true, "TLS_RSA_WITH_AES_256_GCM_SHA384", "",
+
+    // AES_128(GCM) - ECDHE
+    TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256(
+            0xC02F, true, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "",
             ProtocolVersion.PROTOCOLS_OF_12,
-            K_RSA, B_AES_256_GCM, M_NULL, H_SHA384),
-    TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384(
-            0xC02E, true, "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384", "",
-            ProtocolVersion.PROTOCOLS_OF_12,
-            K_ECDH_ECDSA, B_AES_256_GCM, M_NULL, H_SHA384),
-    TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384(
-            0xC032, true, "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384", "",
-            ProtocolVersion.PROTOCOLS_OF_12,
-            K_ECDH_RSA, B_AES_256_GCM, M_NULL, H_SHA384),
+            K_ECDHE_RSA, B_AES_128_GCM, M_NULL, H_SHA256),
+
+    // AES_256(GCM) - DHE
     TLS_DHE_RSA_WITH_AES_256_GCM_SHA384(
             0x009F, true, "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384", "",
             ProtocolVersion.PROTOCOLS_OF_12,
@@ -135,23 +137,7 @@ enum CipherSuite {
             ProtocolVersion.PROTOCOLS_OF_12,
             K_DHE_DSS, B_AES_256_GCM, M_NULL, H_SHA384),
 
-    // AES_128(GCM)
-    TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256(
-            0xC02F, true, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "",
-            ProtocolVersion.PROTOCOLS_OF_12,
-            K_ECDHE_RSA, B_AES_128_GCM, M_NULL, H_SHA256),
-    TLS_RSA_WITH_AES_128_GCM_SHA256(
-            0x009C, true, "TLS_RSA_WITH_AES_128_GCM_SHA256", "",
-            ProtocolVersion.PROTOCOLS_OF_12,
-            K_RSA, B_AES_128_GCM, M_NULL, H_SHA256),
-    TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256(
-            0xC02D, true, "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256", "",
-            ProtocolVersion.PROTOCOLS_OF_12,
-            K_ECDH_ECDSA, B_AES_128_GCM, M_NULL, H_SHA256),
-    TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256(
-            0xC031, true, "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256", "",
-            ProtocolVersion.PROTOCOLS_OF_12,
-            K_ECDH_RSA, B_AES_128_GCM, M_NULL, H_SHA256),
+    // AES_128(GCM) - DHE
     TLS_DHE_RSA_WITH_AES_128_GCM_SHA256(
             0x009E, true, "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256", "",
             ProtocolVersion.PROTOCOLS_OF_12,
@@ -161,7 +147,7 @@ enum CipherSuite {
             ProtocolVersion.PROTOCOLS_OF_12,
             K_DHE_DSS, B_AES_128_GCM, M_NULL, H_SHA256),
 
-    // AES_256(CBC)
+    // AES_256(CBC) - ECDHE
     TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384(
             0xC024, true, "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384", "",
             ProtocolVersion.PROTOCOLS_OF_12,
@@ -170,18 +156,18 @@ enum CipherSuite {
             0xC028, true, "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384", "",
             ProtocolVersion.PROTOCOLS_OF_12,
             K_ECDHE_RSA, B_AES_256, M_SHA384, H_SHA384),
-    TLS_RSA_WITH_AES_256_CBC_SHA256(
-            0x003D, true, "TLS_RSA_WITH_AES_256_CBC_SHA256", "",
+
+    // AES_128(CBC) - ECDHE
+    TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256(
+            0xC023, true, "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", "",
             ProtocolVersion.PROTOCOLS_OF_12,
-            K_RSA, B_AES_256, M_SHA256, H_SHA256),
-    TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384(
-            0xC026, true, "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384", "",
+            K_ECDHE_ECDSA, B_AES_128, M_SHA256, H_SHA256),
+    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256(
+            0xC027, true, "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", "",
             ProtocolVersion.PROTOCOLS_OF_12,
-            K_ECDH_ECDSA, B_AES_256, M_SHA384, H_SHA384),
-    TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384(
-            0xC02A, true, "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384", "",
-            ProtocolVersion.PROTOCOLS_OF_12,
-            K_ECDH_RSA, B_AES_256, M_SHA384, H_SHA384),
+            K_ECDHE_RSA, B_AES_128, M_SHA256, H_SHA256),
+
+    // AES_256(CBC) - DHE
     TLS_DHE_RSA_WITH_AES_256_CBC_SHA256(
             0x006B, true, "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256", "",
             ProtocolVersion.PROTOCOLS_OF_12,
@@ -191,56 +177,7 @@ enum CipherSuite {
             ProtocolVersion.PROTOCOLS_OF_12,
             K_DHE_DSS, B_AES_256, M_SHA256, H_SHA256),
 
-    TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA(
-            0xC00A, true, "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_ECDHE_ECDSA, B_AES_256, M_SHA, H_SHA256),
-    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA(
-            0xC014, true, "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_ECDHE_RSA, B_AES_256, M_SHA, H_SHA256),
-    TLS_RSA_WITH_AES_256_CBC_SHA(
-            0x0035, true, "TLS_RSA_WITH_AES_256_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_RSA, B_AES_256, M_SHA, H_SHA256),
-    TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA(
-            0xC005, true, "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_ECDH_ECDSA, B_AES_256, M_SHA, H_SHA256),
-    TLS_ECDH_RSA_WITH_AES_256_CBC_SHA(
-            0xC00F, true, "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_ECDH_RSA, B_AES_256, M_SHA, H_SHA256),
-    TLS_DHE_RSA_WITH_AES_256_CBC_SHA(
-            0x0039, true, "TLS_DHE_RSA_WITH_AES_256_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_DHE_RSA, B_AES_256, M_SHA, H_SHA256),
-    TLS_DHE_DSS_WITH_AES_256_CBC_SHA(
-            0x0038, true, "TLS_DHE_DSS_WITH_AES_256_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_DHE_DSS, B_AES_256, M_SHA, H_SHA256),
-
-    // AES_128(CBC)
-    TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256(
-            0xC023, true, "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", "",
-            ProtocolVersion.PROTOCOLS_OF_12,
-            K_ECDHE_ECDSA, B_AES_128, M_SHA256, H_SHA256),
-    TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256(
-            0xC027, true, "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", "",
-            ProtocolVersion.PROTOCOLS_OF_12,
-            K_ECDHE_RSA, B_AES_128, M_SHA256, H_SHA256),
-    TLS_RSA_WITH_AES_128_CBC_SHA256(
-            0x003C, true, "TLS_RSA_WITH_AES_128_CBC_SHA256", "",
-            ProtocolVersion.PROTOCOLS_OF_12,
-            K_RSA, B_AES_128, M_SHA256, H_SHA256),
-    TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256(
-            0xC025, true, "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256", "",
-            ProtocolVersion.PROTOCOLS_OF_12,
-            K_ECDH_ECDSA, B_AES_128, M_SHA256, H_SHA256),
-    TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256(
-            0xC029, true, "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256", "",
-            ProtocolVersion.PROTOCOLS_OF_12,
-            K_ECDH_RSA, B_AES_128, M_SHA256, H_SHA256),
+    // AES_128(CBC) - DHE
     TLS_DHE_RSA_WITH_AES_128_CBC_SHA256(
             0x0067, true, "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256", "",
             ProtocolVersion.PROTOCOLS_OF_12,
@@ -250,6 +187,65 @@ enum CipherSuite {
             ProtocolVersion.PROTOCOLS_OF_12,
             K_DHE_DSS, B_AES_128, M_SHA256, H_SHA256),
 
+    //
+    // not forward screcy cipher suites.
+    //
+
+    // AES_256(GCM)
+    TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384(
+            0xC02E, true, "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384", "",
+            ProtocolVersion.PROTOCOLS_OF_12,
+            K_ECDH_ECDSA, B_AES_256_GCM, M_NULL, H_SHA384),
+    TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384(
+            0xC032, true, "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384", "",
+            ProtocolVersion.PROTOCOLS_OF_12,
+            K_ECDH_RSA, B_AES_256_GCM, M_NULL, H_SHA384),
+
+    // AES_128(GCM)
+    TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256(
+            0xC02D, true, "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256", "",
+            ProtocolVersion.PROTOCOLS_OF_12,
+            K_ECDH_ECDSA, B_AES_128_GCM, M_NULL, H_SHA256),
+    TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256(
+            0xC031, true, "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256", "",
+            ProtocolVersion.PROTOCOLS_OF_12,
+            K_ECDH_RSA, B_AES_128_GCM, M_NULL, H_SHA256),
+
+    // AES_256(CBC)
+    TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384(
+            0xC026, true, "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384", "",
+            ProtocolVersion.PROTOCOLS_OF_12,
+            K_ECDH_ECDSA, B_AES_256, M_SHA384, H_SHA384),
+    TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384(
+            0xC02A, true, "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384", "",
+            ProtocolVersion.PROTOCOLS_OF_12,
+            K_ECDH_RSA, B_AES_256, M_SHA384, H_SHA384),
+
+    // AES_128(CBC)
+    TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256(
+            0xC025, true, "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256", "",
+            ProtocolVersion.PROTOCOLS_OF_12,
+            K_ECDH_ECDSA, B_AES_128, M_SHA256, H_SHA256),
+    TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256(
+            0xC029, true, "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256", "",
+            ProtocolVersion.PROTOCOLS_OF_12,
+            K_ECDH_RSA, B_AES_128, M_SHA256, H_SHA256),
+
+    //
+    // Legacy, used for compatibility
+    //
+
+    // AES_256(CBC) - ECDHE - Using SHA
+    TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA(
+            0xC00A, true, "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_ECDHE_ECDSA, B_AES_256, M_SHA, H_SHA256),
+    TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA(
+            0xC014, true, "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_ECDHE_RSA, B_AES_256, M_SHA, H_SHA256),
+
+    // AES_128(CBC) - ECDHE - using SHA
     TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA(
             0xC009, true, "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", "",
             ProtocolVersion.PROTOCOLS_TO_12,
@@ -258,18 +254,18 @@ enum CipherSuite {
             0xC013, true, "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "",
             ProtocolVersion.PROTOCOLS_TO_12,
             K_ECDHE_RSA, B_AES_128, M_SHA, H_SHA256),
-    TLS_RSA_WITH_AES_128_CBC_SHA(
-            0x002F, true, "TLS_RSA_WITH_AES_128_CBC_SHA", "",
+
+    // AES_256(CBC) - DHE - Using SHA
+    TLS_DHE_RSA_WITH_AES_256_CBC_SHA(
+            0x0039, true, "TLS_DHE_RSA_WITH_AES_256_CBC_SHA", "",
             ProtocolVersion.PROTOCOLS_TO_12,
-            K_RSA, B_AES_128, M_SHA, H_SHA256),
-    TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA(
-            0xC004, true, "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA", "",
+            K_DHE_RSA, B_AES_256, M_SHA, H_SHA256),
+    TLS_DHE_DSS_WITH_AES_256_CBC_SHA(
+            0x0038, true, "TLS_DHE_DSS_WITH_AES_256_CBC_SHA", "",
             ProtocolVersion.PROTOCOLS_TO_12,
-            K_ECDH_ECDSA, B_AES_128, M_SHA, H_SHA256),
-    TLS_ECDH_RSA_WITH_AES_128_CBC_SHA(
-            0xC00E, true, "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_ECDH_RSA, B_AES_128, M_SHA, H_SHA256),
+            K_DHE_DSS, B_AES_256, M_SHA, H_SHA256),
+
+    // AES_128(CBC) - DHE - using SHA
     TLS_DHE_RSA_WITH_AES_128_CBC_SHA(
             0x0033, true, "TLS_DHE_RSA_WITH_AES_128_CBC_SHA", "",
             ProtocolVersion.PROTOCOLS_TO_12,
@@ -279,7 +275,67 @@ enum CipherSuite {
             ProtocolVersion.PROTOCOLS_TO_12,
             K_DHE_DSS, B_AES_128, M_SHA, H_SHA256),
 
-    // 3DES_EDE
+    // AES_256(CBC) - using SHA, not forward screcy
+    TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA(
+            0xC005, true, "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_ECDH_ECDSA, B_AES_256, M_SHA, H_SHA256),
+    TLS_ECDH_RSA_WITH_AES_256_CBC_SHA(
+            0xC00F, true, "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_ECDH_RSA, B_AES_256, M_SHA, H_SHA256),
+
+    // AES_128(CBC) - using SHA, not forward screcy
+    TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA(
+            0xC004, true, "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_ECDH_ECDSA, B_AES_128, M_SHA, H_SHA256),
+    TLS_ECDH_RSA_WITH_AES_128_CBC_SHA(
+            0xC00E, true, "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_ECDH_RSA, B_AES_128, M_SHA, H_SHA256),
+
+    //
+    // deprecated, used for compatibility
+    //
+
+    // RSA, AES_256(GCM)
+    TLS_RSA_WITH_AES_256_GCM_SHA384(
+            0x009D, true, "TLS_RSA_WITH_AES_256_GCM_SHA384", "",
+            ProtocolVersion.PROTOCOLS_OF_12,
+            K_RSA, B_AES_256_GCM, M_NULL, H_SHA384),
+
+    // RSA, AES_128(GCM)
+    TLS_RSA_WITH_AES_128_GCM_SHA256(
+            0x009C, true, "TLS_RSA_WITH_AES_128_GCM_SHA256", "",
+            ProtocolVersion.PROTOCOLS_OF_12,
+            K_RSA, B_AES_128_GCM, M_NULL, H_SHA256),
+
+    // RSA, AES_256(CBC)
+    TLS_RSA_WITH_AES_256_CBC_SHA256(
+            0x003D, true, "TLS_RSA_WITH_AES_256_CBC_SHA256", "",
+            ProtocolVersion.PROTOCOLS_OF_12,
+            K_RSA, B_AES_256, M_SHA256, H_SHA256),
+
+    // RSA, AES_128(CBC)
+    TLS_RSA_WITH_AES_128_CBC_SHA256(
+            0x003C, true, "TLS_RSA_WITH_AES_128_CBC_SHA256", "",
+            ProtocolVersion.PROTOCOLS_OF_12,
+            K_RSA, B_AES_128, M_SHA256, H_SHA256),
+
+    // RSA, AES_256(CBC) - using SHA, not forward screcy
+    TLS_RSA_WITH_AES_256_CBC_SHA(
+            0x0035, true, "TLS_RSA_WITH_AES_256_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_RSA, B_AES_256, M_SHA, H_SHA256),
+
+    // RSA, AES_128(CBC) - using SHA, not forward screcy
+    TLS_RSA_WITH_AES_128_CBC_SHA(
+            0x002F, true, "TLS_RSA_WITH_AES_128_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_RSA, B_AES_128, M_SHA, H_SHA256),
+
+    // 3DES_EDE, forward secrecy.
     TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA(
             0xC008, true, "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA", "",
             ProtocolVersion.PROTOCOLS_TO_12,
@@ -288,19 +344,6 @@ enum CipherSuite {
             0xC012, true, "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", "",
             ProtocolVersion.PROTOCOLS_TO_12,
             K_ECDHE_RSA, B_3DES, M_SHA, H_SHA256),
-    SSL_RSA_WITH_3DES_EDE_CBC_SHA(
-            0x000A, true, "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
-                          "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_RSA, B_3DES, M_SHA, H_SHA256),
-    TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA(
-            0xC003, true, "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_ECDH_ECDSA, B_3DES, M_SHA, H_SHA256),
-    TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA(
-            0xC00D, true, "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA", "",
-            ProtocolVersion.PROTOCOLS_TO_12,
-            K_ECDH_RSA, B_3DES, M_SHA, H_SHA256),
     SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA(
             0x0016, true, "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
                           "TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
@@ -311,6 +354,21 @@ enum CipherSuite {
                           "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
             ProtocolVersion.PROTOCOLS_TO_12,
             K_DHE_DSS, B_3DES, M_SHA, H_SHA256),
+
+    // 3DES_EDE, not forward secrecy.
+    TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA(
+            0xC003, true, "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_ECDH_ECDSA, B_3DES, M_SHA, H_SHA256),
+    TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA(
+            0xC00D, true, "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA", "",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_ECDH_RSA, B_3DES, M_SHA, H_SHA256),
+    SSL_RSA_WITH_3DES_EDE_CBC_SHA(
+            0x000A, true, "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
+                          "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+            ProtocolVersion.PROTOCOLS_TO_12,
+            K_RSA, B_3DES, M_SHA, H_SHA256),
 
     // Renegotiation protection request Signalling Cipher Suite Value (SCSV).
     TLS_EMPTY_RENEGOTIATION_INFO_SCSV(        //  RFC 5746, TLS 1.2 and prior

--- a/test/jdk/javax/net/ssl/sanity/ciphersuites/CheckCipherSuites.java
+++ b/test/jdk/javax/net/ssl/sanity/ciphersuites/CheckCipherSuites.java
@@ -23,9 +23,9 @@
 
 /*
  * @test
- * @bug 4750141 4895631 8217579
+ * @bug 4750141 4895631 8217579 8163326
  * @summary Check enabled and supported ciphersuites are correct
- * @run main CheckCipherSuites default
+ * @run main/othervm CheckCipherSuites default
  * @run main/othervm CheckCipherSuites limited
  */
 
@@ -38,54 +38,97 @@ public class CheckCipherSuites {
     // List of enabled cipher suites when the "crypto.policy" security
     // property is set to "unlimited" (the default value).
     private final static String[] ENABLED_DEFAULT = {
-        "TLS_AES_128_GCM_SHA256",
+        // TLS 1.3 cipher suites
         "TLS_AES_256_GCM_SHA384",
+        "TLS_AES_128_GCM_SHA256",
         "TLS_CHACHA20_POLY1305_SHA256",
+
+        // Suite B compliant cipher suites
         "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+
+        // Not suite B, but we want it to position the suite early
         "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+
+        // AES_256(GCM) - ECDHE - forward screcy
         "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
+
+        // AES_128(GCM) - ECDHE - forward screcy
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+
+        // AES_256(GCM) - DHE - forward screcy
         "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
         "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
         "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
+
+        // AES_128(GCM) - DHE - forward screcy
         "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
+
+        // AES_256(CBC) - ECDHE - forward screcy
         "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
         "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
-        "TLS_RSA_WITH_AES_256_CBC_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
-        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
-        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+
+        // AES_256(CBC) - ECDHE - forward screcy
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
+
+        // AES_256(CBC) - DHE - forward screcy
+        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
+
+        // AES_128(CBC) - DHE - forward screcy
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+
+        // AES_256(GCM) - not forward screcy
+        "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
+
+        // AES_128(GCM) - not forward screcy
+        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
+
+        // AES_256(CBC) - not forward screcy
+        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
+
+        // AES_128(CBC) - not forward screcy
+        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
+
+        // AES_256(CBC) - ECDHE - using SHA
+        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+
+        // AES_128(CBC) - ECDHE - using SHA
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
+
+        // AES_256(CBC) - DHE - using SHA
+        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+
+        // AES_128(CBC) - DHE - using SHA
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+
+        // AES_256(CBC) - using SHA, not forward screcy
+        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
+
+        // AES_128(CBC) - using SHA, not forward screcy
+        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
+        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
+
+        // deprecated
+        "TLS_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_256_CBC_SHA256",
+        "TLS_RSA_WITH_AES_128_CBC_SHA256",
+        "TLS_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_RSA_WITH_AES_128_CBC_SHA",
         "TLS_EMPTY_RENEGOTIATION_INFO_SCSV"
     };
 
@@ -95,79 +138,122 @@ public class CheckCipherSuites {
         "TLS_AES_128_GCM_SHA256",
         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
         "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
+        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_128_CBC_SHA256",
+        "TLS_RSA_WITH_AES_128_CBC_SHA",
         "TLS_EMPTY_RENEGOTIATION_INFO_SCSV"
     };
 
     // List of supported cipher suites when the "crypto.policy" security
     // property is set to "unlimited" (the default value).
     private final static String[] SUPPORTED_DEFAULT = {
-        "TLS_AES_128_GCM_SHA256",
+        // TLS 1.3 cipher suites
         "TLS_AES_256_GCM_SHA384",
+        "TLS_AES_128_GCM_SHA256",
         "TLS_CHACHA20_POLY1305_SHA256",
+
+        // Suite B compliant cipher suites
         "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+
+        // Not suite B, but we want it to position the suite early
         "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+
+        // AES_256(GCM) - ECDHE - forward screcy
         "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
+
+        // AES_128(GCM) - ECDHE - forward screcy
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+
+        // AES_256(GCM) - DHE - forward screcy
         "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
         "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
         "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
+
+        // AES_128(GCM) - DHE - forward screcy
         "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
+
+        // AES_256(CBC) - ECDHE - forward screcy
         "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
         "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
-        "TLS_RSA_WITH_AES_256_CBC_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
-        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
-        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+
+        // AES_256(CBC) - ECDHE - forward screcy
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
+
+        // AES_256(CBC) - DHE - forward screcy
+        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
+
+        // AES_128(CBC) - DHE - forward screcy
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+
+        // AES_256(GCM) - not forward screcy
+        "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
+
+        // AES_128(GCM) - not forward screcy
+        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
+
+        // AES_256(CBC) - not forward screcy
+        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
+
+        // AES_128(CBC) - not forward screcy
+        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
+
+        // AES_256(CBC) - ECDHE - using SHA
+        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+
+        // AES_128(CBC) - ECDHE - using SHA
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
+
+        // AES_256(CBC) - DHE - using SHA
+        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+
+        // AES_128(CBC) - DHE - using SHA
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+
+        // AES_256(CBC) - using SHA, not forward screcy
+        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
+
+        // AES_128(CBC) - using SHA, not forward screcy
+        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
+        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
+
+        // deprecated
+        "TLS_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_256_CBC_SHA256",
+        "TLS_RSA_WITH_AES_128_CBC_SHA256",
+        "TLS_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_RSA_WITH_AES_128_CBC_SHA",
         "TLS_EMPTY_RENEGOTIATION_INFO_SCSV"
     };
 
@@ -177,25 +263,25 @@ public class CheckCipherSuites {
         "TLS_AES_128_GCM_SHA256",
         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
         "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
+        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_128_CBC_SHA256",
+        "TLS_RSA_WITH_AES_128_CBC_SHA",
         "TLS_EMPTY_RENEGOTIATION_INFO_SCSV"
     };
 
@@ -228,7 +314,8 @@ public class CheckCipherSuites {
             throw new Exception("Illegal argument");
         }
 
-        SSLSocketFactory factory = (SSLSocketFactory)SSLSocketFactory.getDefault();
+        SSLSocketFactory factory =
+                (SSLSocketFactory)SSLSocketFactory.getDefault();
         SSLSocket socket = (SSLSocket)factory.createSocket();
         String[] enabled = socket.getEnabledCipherSuites();
 
@@ -257,5 +344,4 @@ public class CheckCipherSuites {
         long end = System.currentTimeMillis();
         System.out.println("Done (" + (end - start) + " ms).");
     }
-
 }

--- a/test/jdk/javax/net/ssl/sanity/ciphersuites/CipherSuitesInOrder.java
+++ b/test/jdk/javax/net/ssl/sanity/ciphersuites/CipherSuitesInOrder.java
@@ -32,7 +32,6 @@
  * @summary Test for ciphersuites order
  * @run main/othervm CipherSuitesInOrder
  */
-
 import java.util.*;
 import javax.net.ssl.*;
 
@@ -41,129 +40,162 @@ public class CipherSuitesInOrder {
     // Supported ciphersuites
     private final static List<String> supportedCipherSuites
             = Arrays.<String>asList(
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
-
-        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
-        "TLS_RSA_WITH_AES_256_CBC_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
-        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
-        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
-
-        "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
-        "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA",
-        "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
-        "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
-
-        "TLS_EMPTY_RENEGOTIATION_INFO_SCSV",
-
-        "TLS_DH_anon_WITH_AES_256_GCM_SHA384",
-        "TLS_DH_anon_WITH_AES_128_GCM_SHA256",
-
-        "TLS_DH_anon_WITH_AES_256_CBC_SHA256",
-        "TLS_ECDH_anon_WITH_AES_256_CBC_SHA",
-        "TLS_DH_anon_WITH_AES_256_CBC_SHA",
-        "TLS_DH_anon_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_anon_WITH_AES_128_CBC_SHA",
-        "TLS_DH_anon_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA",
-        "SSL_DH_anon_WITH_3DES_EDE_CBC_SHA",
-
-        "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
-        "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
-        "SSL_RSA_WITH_RC4_128_SHA",
-        "TLS_ECDH_ECDSA_WITH_RC4_128_SHA",
-        "TLS_ECDH_RSA_WITH_RC4_128_SHA",
-        "SSL_RSA_WITH_RC4_128_MD5",
-        "TLS_ECDH_anon_WITH_RC4_128_SHA",
-        "SSL_DH_anon_WITH_RC4_128_MD5",
-
-        "SSL_RSA_WITH_DES_CBC_SHA",
-        "SSL_DHE_RSA_WITH_DES_CBC_SHA",
-        "SSL_DHE_DSS_WITH_DES_CBC_SHA",
-        "SSL_DH_anon_WITH_DES_CBC_SHA",
-        "SSL_RSA_EXPORT_WITH_DES40_CBC_SHA",
-        "SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA",
-        "SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA",
-        "SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA",
-
-        "SSL_RSA_EXPORT_WITH_RC4_40_MD5",
-        "SSL_DH_anon_EXPORT_WITH_RC4_40_MD5",
-
-        "TLS_RSA_WITH_NULL_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_NULL_SHA",
-        "TLS_ECDHE_RSA_WITH_NULL_SHA",
-        "SSL_RSA_WITH_NULL_SHA",
-        "TLS_ECDH_ECDSA_WITH_NULL_SHA",
-        "TLS_ECDH_RSA_WITH_NULL_SHA",
-        "TLS_ECDH_anon_WITH_NULL_SHA",
-        "SSL_RSA_WITH_NULL_MD5",
-
-        "TLS_KRB5_WITH_3DES_EDE_CBC_SHA",
-        "TLS_KRB5_WITH_3DES_EDE_CBC_MD5",
-        "TLS_KRB5_WITH_RC4_128_SHA",
-        "TLS_KRB5_WITH_RC4_128_MD5",
-        "TLS_KRB5_WITH_DES_CBC_SHA",
-        "TLS_KRB5_WITH_DES_CBC_MD5",
-        "TLS_KRB5_EXPORT_WITH_DES_CBC_40_SHA",
-        "TLS_KRB5_EXPORT_WITH_DES_CBC_40_MD5",
-        "TLS_KRB5_EXPORT_WITH_RC4_40_SHA",
-        "TLS_KRB5_EXPORT_WITH_RC4_40_MD5"
-    );
+                    // TLS 1.3 cipher suites.
+                    "TLS_AES_256_GCM_SHA384",
+                    "TLS_AES_128_GCM_SHA256",
+                    "TLS_CHACHA20_POLY1305_SHA256",
+                    // Suite B compliant cipher suites, see RFC 6460.
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                    // Not suite B, but we want it to position the suite early
+                    //in the list of 1.2 suites.
+                    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+                    //
+                    // Forward secrecy cipher suites.
+                    //
+                    // AES_256(GCM) - ECDHE
+                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+                    // AES_128(GCM) - ECDHE
+                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                    // AES_256(GCM) - DHE
+                    "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+                    "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384",
+                    // AES_128(GCM) - DHE
+                    "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
+                    // AES_256(CBC) - ECDHE
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+                    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+                    // AES_128(CBC) - ECDHE
+                    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+                    // AES_256(CBC) - DHE
+                    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+                    "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
+                    // AES_128(CBC) - DHE
+                    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+                    "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+                    //
+                    // Not forward secret cipher suites.
+                    //
+                    // AES_256(GCM)
+                    "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
+                    // AES_128(GCM)
+                    "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
+                    // AES_256(CBC)
+                    "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
+                    "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
+                    // AES_128(CBC)
+                    "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
+                    "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
+                    //
+                    // Legacy, used for compatibility
+                    //
+                    // AES_256(CBC) - ECDHE - Using SHA
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+                    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+                    // AES_128(CBC) - ECDHE - using SHA
+                    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+                    // AES_256(CBC) - DHE - Using SHA
+                    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+                    "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+                    // AES_128(CBC) - DHE - using SHA
+                    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+                    "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+                    // AES_256(CBC) - using SHA, not forward secrecy
+                    "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
+                    "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
+                    // AES_128(CBC) - using SHA, not forward secrecy
+                    "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
+                    "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
+                    //
+                    // Deprecated, used for compatibility
+                    //
+                    // RSA, AES_256(GCM)
+                    "TLS_RSA_WITH_AES_256_GCM_SHA384",
+                    // RSA, AES_128(GCM)
+                    "TLS_RSA_WITH_AES_128_GCM_SHA256",
+                    // RSA, AES_256(CBC)
+                    "TLS_RSA_WITH_AES_256_CBC_SHA256",
+                    // RSA, AES_128(CBC)
+                    "TLS_RSA_WITH_AES_128_CBC_SHA256",
+                    // RSA, AES_256(CBC) - using SHA, not forward secrecy
+                    "TLS_RSA_WITH_AES_256_CBC_SHA",
+                    // RSA, AES_128(CBC) - using SHA, not forward secrecy
+                    "TLS_RSA_WITH_AES_128_CBC_SHA",
+                    // 3DES_EDE, forward secrecy.
+                    "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+                    "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
+                    "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+                    // 3DES_EDE, not forward secrecy.
+                    "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",
+                    "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA",
+                    "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
+                    // Renegotiation protection request Signalling
+                    // Cipher Suite Value (SCSV).
+                    "TLS_EMPTY_RENEGOTIATION_INFO_SCSV",
+                    // Definition of the Cipher Suites that are supported but not
+                    // enabled by default.
+                    "TLS_DH_anon_WITH_AES_256_GCM_SHA384",
+                    "TLS_DH_anon_WITH_AES_128_GCM_SHA256",
+                    "TLS_DH_anon_WITH_AES_256_CBC_SHA256",
+                    "TLS_ECDH_anon_WITH_AES_256_CBC_SHA",
+                    "TLS_DH_anon_WITH_AES_256_CBC_SHA",
+                    "TLS_DH_anon_WITH_AES_128_CBC_SHA256",
+                    "TLS_ECDH_anon_WITH_AES_128_CBC_SHA",
+                    "TLS_DH_anon_WITH_AES_128_CBC_SHA",
+                    "TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA",
+                    "SSL_DH_anon_WITH_3DES_EDE_CBC_SHA",
+                    // RC4
+                    "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+                    "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+                    "SSL_RSA_WITH_RC4_128_SHA",
+                    "TLS_ECDH_ECDSA_WITH_RC4_128_SHA",
+                    "TLS_ECDH_RSA_WITH_RC4_128_SHA",
+                    "SSL_RSA_WITH_RC4_128_MD5",
+                    "TLS_ECDH_anon_WITH_RC4_128_SHA",
+                    "SSL_DH_anon_WITH_RC4_128_MD5",
+                    // Weak cipher suites obsoleted in TLS 1.2 [RFC 5246]
+                    "SSL_RSA_WITH_DES_CBC_SHA",
+                    "SSL_DHE_RSA_WITH_DES_CBC_SHA",
+                    "SSL_DHE_DSS_WITH_DES_CBC_SHA",
+                    "SSL_DH_anon_WITH_DES_CBC_SHA",
+                    // Weak cipher suites obsoleted in TLS 1.1  [RFC 4346]
+                    "SSL_RSA_EXPORT_WITH_DES40_CBC_SHA",
+                    "SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA",
+                    "SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA",
+                    "SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA",
+                    "SSL_RSA_EXPORT_WITH_RC4_40_MD5",
+                    "SSL_DH_anon_EXPORT_WITH_RC4_40_MD5",
+                    // No traffic encryption cipher suites
+                    "TLS_RSA_WITH_NULL_SHA256",
+                    "TLS_ECDHE_ECDSA_WITH_NULL_SHA",
+                    "TLS_ECDHE_RSA_WITH_NULL_SHA",
+                    "SSL_RSA_WITH_NULL_SHA",
+                    "TLS_ECDH_ECDSA_WITH_NULL_SHA",
+                    "TLS_ECDH_RSA_WITH_NULL_SHA",
+                    "TLS_ECDH_anon_WITH_NULL_SHA",
+                    "SSL_RSA_WITH_NULL_MD5",
+                    // Definition of the cipher suites that are not supported but the names
+                    // are known.
+                    "TLS_AES_128_CCM_SHA256",
+                    "TLS_AES_128_CCM_8_SHA256"
+            );
 
     private final static String[] protocols = {
         "", "SSL", "TLS", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"
     };
 
-
     public static void main(String[] args) throws Exception {
         // show all of the supported cipher suites
         showSuites(supportedCipherSuites.toArray(new String[0]),
-                 "All supported cipher suites");
+                "All supported cipher suites");
 
         for (String protocol : protocols) {
             System.out.println("//");


### PR DESCRIPTION
I'd like to backport JDK-8163326 for parity with Oracle and align the list of cipher suites with other versions.

The original patch applies clean but I had to update test/jdk/javax/net/ssl/sanity/ciphersuites/CipherSuitesInOrder.java test because of the list of ciphers was not updated during JDK-8234728 backport to 11u

sun/security/ssl and javax/net/ssl tests passed successfully