### PR TITLE
8254024: Enhance native libs for AWT and Swing to work with GraalVM Native Image

### DIFF
--- a/src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.h
+++ b/src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ typedef struct {
 typedef mlib_image *(*MlibCreateFP_t)(mlib_type, mlib_s32, mlib_s32,
                                        mlib_s32);
 typedef mlib_image *(*MlibCreateStructFP_t)(mlib_type, mlib_s32, mlib_s32,
-                                             mlib_s32, mlib_s32, void *);
+                                             mlib_s32, mlib_s32, const void *);
 typedef void (*MlibDeleteFP_t)(mlib_image *);
 
 typedef struct {

--- a/src/java.desktop/unix/native/libawt/awt/awt_Mlib.c
+++ b/src/java.desktop/unix/native/libawt/awt/awt_Mlib.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,9 +36,50 @@
 #include "awt_Mlib.h"
 #include "java_awt_image_BufferedImage.h"
 
+#ifdef STATIC_BUILD
+#include "mlib_image.h"
+#endif
+
 static void start_timer(int numsec);
 static void stop_timer(int numsec, int ntimes);
 
+#ifdef STATIC_BUILD
+// Mapping functions to their names for runtime check
+static mlibFnS_t sMlibFnsStatic[] = {
+    {j2d_mlib_ImageConvMxN, "j2d_mlib_ImageConvMxN"},
+    {j2d_mlib_ImageAffine, "j2d_mlib_ImageAffine"},
+    {j2d_mlib_ImageLookUp, "j2d_mlib_ImageLookUp"},
+    {j2d_mlib_ImageConvKernelConvert, "j2d_mlib_ImageConvKernelConvert"},
+};
+
+mlib_status awt_getImagingLib(JNIEnv *env, mlibFnS_t *sMlibFns,
+                              mlibSysFnS_t *sMlibSysFns) {
+    mlibFnS_t *mptr;
+    int i;
+    char *fName;
+    mlibSysFnS_t tempSysFns;
+    mlib_status ret = MLIB_SUCCESS;
+
+    tempSysFns.createFP = j2d_mlib_ImageCreate;
+    tempSysFns.createStructFP = j2d_mlib_ImageCreateStruct;
+    tempSysFns.deleteImageFP = j2d_mlib_ImageDelete;
+    *sMlibSysFns = tempSysFns;
+
+    mptr = sMlibFns;
+    i = 0;
+    while (mptr[i].fname != NULL) {
+        fName = mptr[i].fname;
+        if(strcmp(fName, sMlibFnsStatic[i].fname) == 0) {
+            mptr[i].fptr = sMlibFnsStatic[i].fptr;
+        } else {
+            ret = MLIB_FAILURE;
+        }
+        i++;
+    }
+
+    return ret;
+}
+#else
 /*
  * This is called by awt_ImagingLib.initLib() to figure out if we
  * can use the VIS version of medialib
@@ -136,6 +177,7 @@ mlib_status awt_getImagingLib(JNIEnv *env, mlibFnS_t *sMlibFns,
     }
     return ret;
 }
+#endif
 
 mlib_start_timer awt_setMlibStartTimer() {
     return start_timer;

--- a/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
+++ b/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
@@ -313,6 +313,8 @@ Java_java_awt_TextField_initIDs
 {
 }
 
+#ifndef STATIC_BUILD
+// The same function exists in libawt.a::awt_LoadLibrary.c
 JNIEXPORT jboolean JNICALL AWTIsHeadless() {
 #ifdef HEADLESS
     return JNI_TRUE;
@@ -320,6 +322,7 @@ JNIEXPORT jboolean JNICALL AWTIsHeadless() {
     return JNI_FALSE;
 #endif
 }
+#endif
 
 JNIEXPORT void JNICALL Java_java_awt_Dialog_initIDs (JNIEnv *env, jclass cls)
 {
@@ -848,8 +851,13 @@ Window get_xawt_root_shell(JNIEnv *env) {
  */
 
 JNIEXPORT void JNICALL
-Java_sun_awt_motif_XsessionWMcommand(JNIEnv *env, jobject this,
+#ifdef STATIC_BUILD
+Java_sun_xawt_motif_XsessionWMcommand(JNIEnv *env, jobject this,
     jobject frame, jstring jcommand)
+#else
+Java_sun_awt_motif_XsessionWMcommand(JNIEnv *env, jobject this,
+        jobject frame, jstring jcommand)
+#endif
 {
     const char *command;
     XTextProperty text_prop;
@@ -893,7 +901,11 @@ Java_sun_awt_motif_XsessionWMcommand(JNIEnv *env, jobject this,
  * name.  It's not!  It's just a plain function.
  */
 JNIEXPORT void JNICALL
+#ifdef STATIC_BUILD
+Java_sun_xawt_motif_XsessionWMcommand_New(JNIEnv *env, jobjectArray jarray)
+#else
 Java_sun_awt_motif_XsessionWMcommand_New(JNIEnv *env, jobjectArray jarray)
+#endif
 {
     jsize length;
     char ** array;


### PR DESCRIPTION
This is a Graal VM native-image enable patch. native-image uses static libraries of OpenJDK. For awt libs dynamic symbols shouldn't be used. From a regular, non-static, OpenJDK perspective this should be a no-op. JDK 17 patch applies clean.

Testing: :jdk_desktop tests and linux x86_64 tier 1. No regressions observed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8254024](https://bugs.openjdk.java.net/browse/JDK-8254024): Enhance native libs for AWT and Swing to work with GraalVM Native Image


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/77.diff">https://git.openjdk.java.net/jdk11u-dev/pull/77.diff</a>

</details>
