### PR TITLE
8261297: NMT: Final report should use scale 1

### DIFF
--- a/src/hotspot/share/services/memReporter.hpp
+++ b/src/hotspot/share/services/memReporter.hpp
@@ -39,14 +39,17 @@
 */
 class MemReporterBase : public StackObj {
  private:
-  size_t        _scale;  // report in this scale
-  outputStream* _output; // destination
+  const size_t  _scale;         // report in this scale
+  outputStream* const _output;  // destination
 
  public:
-  MemReporterBase(outputStream* out = NULL, size_t scale = K)
-    : _scale(scale) {
-    _output = (out == NULL) ? tty : out;
-  }
+
+  // Default scale to use if no scale given.
+  static const size_t default_scale = K;
+
+  MemReporterBase(outputStream* out, size_t scale = default_scale) :
+    _scale(scale), _output(out)
+  {}
 
  protected:
   inline outputStream* output() const {
@@ -74,7 +77,6 @@ class MemReporterBase : public StackObj {
   size_t reserved_total(const MallocMemory* malloc, const VirtualMemory* vm) const;
   size_t committed_total(const MallocMemory* malloc, const VirtualMemory* vm) const;
 
-
   // Print summary total, malloc and virtual memory
   void print_total(size_t reserved, size_t committed) const;
   void print_malloc(size_t amount, size_t count, MEMFLAGS flag = mtNone) const;
@@ -100,7 +102,7 @@ class MemSummaryReporter : public MemReporterBase {
  public:
   // This constructor is for normal reporting from a recent baseline.
   MemSummaryReporter(MemBaseline& baseline, outputStream* output,
-    size_t scale = K) : MemReporterBase(output, scale),
+    size_t scale = default_scale) : MemReporterBase(output, scale),
     _malloc_snapshot(baseline.malloc_memory_snapshot()),
     _vm_snapshot(baseline.virtual_memory_snapshot()),
     _instance_class_count(baseline.instance_class_count()),
@@ -125,7 +127,7 @@ class MemDetailReporter : public MemSummaryReporter {
   MemBaseline&   _baseline;
 
  public:
-  MemDetailReporter(MemBaseline& baseline, outputStream* output, size_t scale = K) :
+  MemDetailReporter(MemBaseline& baseline, outputStream* output, size_t scale = default_scale) :
     MemSummaryReporter(baseline, output, scale),
      _baseline(baseline) { }
 
@@ -162,7 +164,7 @@ class MemSummaryDiffReporter : public MemReporterBase {
 
  public:
   MemSummaryDiffReporter(MemBaseline& early_baseline, MemBaseline& current_baseline,
-    outputStream* output, size_t scale = K) : MemReporterBase(output, scale),
+    outputStream* output, size_t scale = default_scale) : MemReporterBase(output, scale),
     _early_baseline(early_baseline), _current_baseline(current_baseline) {
     assert(early_baseline.baseline_type()   != MemBaseline::Not_baselined, "Not baselined");
     assert(current_baseline.baseline_type() != MemBaseline::Not_baselined, "Not baselined");
@@ -201,7 +203,7 @@ class MemSummaryDiffReporter : public MemReporterBase {
 class MemDetailDiffReporter : public MemSummaryDiffReporter {
  public:
   MemDetailDiffReporter(MemBaseline& early_baseline, MemBaseline& current_baseline,
-    outputStream* output, size_t scale = K) :
+    outputStream* output, size_t scale = default_scale) :
     MemSummaryDiffReporter(early_baseline, current_baseline, output, scale) { }
 
   // Generate detail comparison report

--- a/src/hotspot/share/services/memTracker.cpp
+++ b/src/hotspot/share/services/memTracker.cpp
@@ -183,7 +183,14 @@ bool MemTracker::transition_to(NMT_TrackingLevel level) {
   return true;
 }
 
+// Report during error reporting.
+void MemTracker::error_report(outputStream* output) {
+  if (tracking_level() >= NMT_summary) {
+    report(true, output, MemReporterBase::default_scale); // just print summary for error case.
+  }
+}
 
+// Report when handling PrintNMTStatistics before VM shutdown.
 static volatile bool g_final_report_did_run = false;
 void MemTracker::final_report(outputStream* output) {
   // This function is called during both error reporting and normal VM exit.
@@ -194,25 +201,25 @@ void MemTracker::final_report(outputStream* output) {
   if (Atomic::cmpxchg(true, &g_final_report_did_run, false) == false) {
     NMT_TrackingLevel level = tracking_level();
     if (level >= NMT_summary) {
-      report(level == NMT_summary, output);
+      report(level == NMT_summary, output, 1);
     }
   }
 }
 
-void MemTracker::report(bool summary_only, outputStream* output) {
+void MemTracker::report(bool summary_only, outputStream* output, size_t scale) {
  assert(output != NULL, "No output stream");
   MemBaseline baseline;
   if (baseline.baseline(summary_only)) {
     if (summary_only) {
-      MemSummaryReporter rpt(baseline, output);
+      MemSummaryReporter rpt(baseline, output, scale);
       rpt.report();
     } else {
-      MemDetailReporter rpt(baseline, output);
+      MemDetailReporter rpt(baseline, output, scale);
       rpt.report();
       output->print("Metaspace:");
       // The basic metaspace report avoids any locking and should be safe to
       // be called at any time.
-      MetaspaceUtils::print_basic_report(output, K);
+      MetaspaceUtils::print_basic_report(output, scale);
     }
   }
 }

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -279,13 +279,10 @@ class MemTracker : AllStatic {
   // other tools.
   static inline Mutex* query_lock() { return _query_lock; }
 
-  // Make a final report or report for hs_err file.
-  static void error_report(outputStream* output) {
-    if (tracking_level() >= NMT_summary) {
-      report(true, output);  // just print summary for error case.
-    }
-   }
+  // Report during error reporting.
+  static void error_report(outputStream* output);
 
+  // Report when handling PrintNMTStatistics before VM shutdown.
   static void final_report(outputStream* output);
 
   // Stored baseline
@@ -301,7 +298,7 @@ class MemTracker : AllStatic {
 
  private:
   static NMT_TrackingLevel init_tracking_level();
-  static void report(bool summary_only, outputStream* output);
+  static void report(bool summary_only, outputStream* output, size_t scale);
 
  private:
   // Tracking level


### PR DESCRIPTION
Hi all,

this pull request contains a backport of commit 1740de2a from the openjdk/jdk repository.

The commit being backported was authored by Thomas Stuefe on 11 Feb 2021 and was reviewed by Zhengyu Gu.

Patch applies cleanly.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261297](https://bugs.openjdk.java.net/browse/JDK-8261297): NMT: Final report should use scale 1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/80/head:pull/80` \
`$ git checkout pull/80`

Update a local copy of the PR: \
`$ git checkout pull/80` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/80/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 80`

View PR using the GUI difftool: \
`$ git pr show -t 80`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/80.diff">https://git.openjdk.java.net/jdk11u-dev/pull/80.diff</a>

</details>
