### PR TITLE
8261238: NMT should not limit baselining by size threshold

### DIFF
--- a/src/hotspot/share/services/memBaseline.cpp
+++ b/src/hotspot/share/services/memBaseline.cpp
@@ -95,7 +95,7 @@ class MallocAllocationSiteWalker : public MallocSiteWalker {
   }
 
   bool do_malloc_site(const MallocSite* site) {
-    if (site->size() >= MemBaseline::SIZE_THRESHOLD) {
+    if (site->size() > 0) {
       if (_malloc_sites.add(*site) != NULL) {
         _count++;
         return true;
@@ -103,7 +103,7 @@ class MallocAllocationSiteWalker : public MallocSiteWalker {
         return false;  // OOM
       }
     } else {
-      // malloc site does not meet threshold, ignore and continue
+      // Ignore empty sites.
       return true;
     }
   }
@@ -125,15 +125,17 @@ class VirtualMemoryAllocationWalker : public VirtualMemoryWalker {
   VirtualMemoryAllocationWalker() : _count(0) { }
 
   bool do_allocation_site(const ReservedMemoryRegion* rgn)  {
-    if (rgn->size() >= MemBaseline::SIZE_THRESHOLD) {
+    if (rgn->size() > 0) {
       if (_virtual_memory_regions.add(*rgn) != NULL) {
         _count ++;
         return true;
       } else {
         return false;
       }
+    } else {
+      // Ignore empty sites.
+      return true;
     }
-    return true;
   }
 
   LinkedList<ReservedMemoryRegion>* virtual_memory_allocations() {

--- a/src/hotspot/share/services/memBaseline.hpp
+++ b/src/hotspot/share/services/memBaseline.hpp
@@ -43,9 +43,6 @@ typedef LinkedListIterator<ReservedMemoryRegion>         VirtualMemoryAllocation
  */
 class MemBaseline {
  public:
-  enum BaselineThreshold {
-    SIZE_THRESHOLD = K        // Only allocation size over this threshold will be baselined.
-  };
 
   enum BaselineType {
     Not_baselined,


### PR DESCRIPTION
Hi all,

this pull request contains a backport of commit 578a0b3c from the openjdk/jdk repository.

The commit being backported was authored by Thomas Stuefe on 26 Apr 2021 and was reviewed by Zhengyu Gu and Martin Doerr.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261238](https://bugs.openjdk.java.net/browse/JDK-8261238): NMT should not limit baselining by size threshold


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/82.diff">https://git.openjdk.java.net/jdk11u-dev/pull/82.diff</a>

</details>
