### PR TITLE
8230674: Heap dumps should exclude dormant CDS archived objects of unloaded classes

### DIFF
--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -683,6 +683,16 @@ class DumperSupport : AllStatic {
 
   // fixes up the current dump record and writes HPROF_HEAP_DUMP_END record
   static void end_of_dump(DumpWriter* writer);
+
+  static oop mask_dormant_archived_object(oop o) {
+    if (o != NULL && o->klass()->java_mirror() == NULL) {
+      // Ignore this object since the corresponding java mirror is not loaded.
+      // Might be a dormant archive object.
+      return NULL;
+    } else {
+      return o;
+    }
+  }
 };
 
 // write a header of the given type
@@ -758,6 +768,13 @@ void DumperSupport::dump_field_value(DumpWriter* writer, char type, oop obj, int
     case JVM_SIGNATURE_CLASS :
     case JVM_SIGNATURE_ARRAY : {
       oop o = obj->obj_field_access<ON_UNKNOWN_OOP_REF | AS_NO_KEEPALIVE>(offset);
+      if (o != NULL && log_is_enabled(Debug, cds, heap) && mask_dormant_archived_object(o) == NULL) {
+        ResourceMark rm;
+        log_debug(cds, heap)("skipped dormant archived object " INTPTR_FORMAT " (%s) referenced by " INTPTR_FORMAT " (%s)",
+                             p2i(o), o->klass()->external_name(),
+                             p2i(obj), obj->klass()->external_name());
+      }
+      o = mask_dormant_archived_object(o);
       assert(oopDesc::is_oop_or_null(o), "Expected an oop or NULL at " PTR_FORMAT, p2i(o));
       writer->write_objectID(o);
       break;
@@ -955,11 +972,6 @@ void DumperSupport::dump_instance_field_descriptors(DumpWriter* writer, Klass* k
 // creates HPROF_GC_INSTANCE_DUMP record for the given object
 void DumperSupport::dump_instance(DumpWriter* writer, oop o) {
   Klass* k = o->klass();
-  if (k->java_mirror() == NULL) {
-    // Ignoring this object since the corresponding java mirror is not loaded.
-    // Might be a dormant archive object.
-    return;
-  }
 
   writer->write_u1(HPROF_GC_INSTANCE_DUMP);
   writer->write_objectID(o);
@@ -1145,6 +1157,13 @@ void DumperSupport::dump_object_array(DumpWriter* writer, objArrayOop array) {
   // [id]* elements
   for (int index = 0; index < length; index++) {
     oop o = array->obj_at(index);
+    if (o != NULL && log_is_enabled(Debug, cds, heap) && mask_dormant_archived_object(o) == NULL) {
+      ResourceMark rm;
+      log_debug(cds, heap)("skipped dormant archived object " INTPTR_FORMAT " (%s) referenced by " INTPTR_FORMAT " (%s)",
+                           p2i(o), o->klass()->external_name(),
+                           p2i(array), array->klass()->external_name());
+    }
+    o = mask_dormant_archived_object(o);
     writer->write_objectID(o);
   }
 }
@@ -1422,6 +1441,11 @@ void HeapObjectDumper::do_object(oop o) {
     if (!java_lang_Class::is_primitive(o)) {
       return;
     }
+  }
+
+  if (DumperSupport::mask_dormant_archived_object(o) == NULL) {
+    log_debug(cds, heap)("skipped dormant archived object " INTPTR_FORMAT " (%s)", p2i(o), o->klass()->external_name());
+    return;
   }
 
   if (o->is_instance()) {


### PR DESCRIPTION
<!--
Please review the backport of JDK-8230674. Backport was created with the /backport commit command. Original patch applies cleanly.
-->
Please review the backport of JDK-8230674. Backport was created with the /backport commit command. Original patch applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8230674](https://bugs.openjdk.java.net/browse/JDK-8230674): Heap dumps should exclude dormant CDS archived objects of unloaded classes


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/89/head:pull/89` \
`$ git checkout pull/89`

Update a local copy of the PR: \
`$ git checkout pull/89` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/89/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 89`

View PR using the GUI difftool: \
`$ git pr show -t 89`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/89.diff">https://git.openjdk.java.net/jdk11u-dev/pull/89.diff</a>

</details>
