### PR TITLE
8255810: Zero: build fails without JVMTI

### DIFF
--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -563,6 +563,7 @@ static void rewrite_nofast_bytecodes_and_calculate_fingerprints() {
   }
 }
 
+#if INCLUDE_JVMTI
 static void relocate_cached_class_file() {
   for (int i = 0; i < _global_klass_objects->length(); i++) {
     Klass* k = _global_klass_objects->at(i);
@@ -579,6 +580,7 @@ static void relocate_cached_class_file() {
     }
   }
 }
+#endif // INCLUDE_JVMTI
 
 NOT_PRODUCT(
 static void assert_not_anonymous_class(InstanceKlass* k) {
@@ -1435,7 +1437,7 @@ void VM_PopulateDumpSharedSpace::doit() {
   _md_region.pack(&_od_region);
 
   // Relocate the archived class file data into the od region
-  relocate_cached_class_file();
+  JVMTI_ONLY(relocate_cached_class_file();)
   _od_region.pack();
 
   // The 5 core spaces are allocated consecutively mc->rw->ro->md->od, so there total size

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1982,8 +1982,8 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
    declare_integer_type(AccessFlags)  /* FIXME: wrong type (not integer) */\
   declare_toplevel_type(address)      /* FIXME: should this be an integer type? */\
    declare_integer_type(BasicType)   /* FIXME: wrong type (not integer) */\
-  declare_toplevel_type(BreakpointInfo)                                   \
-  declare_toplevel_type(BreakpointInfo*)                                  \
+  JVMTI_ONLY(declare_toplevel_type(BreakpointInfo))                       \
+  JVMTI_ONLY(declare_toplevel_type(BreakpointInfo*))                      \
   declare_toplevel_type(CodeBlob*)                                        \
   declare_toplevel_type(RuntimeBlob*)                                     \
   declare_toplevel_type(CompressedWriteStream*)                           \

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -299,6 +299,7 @@ void JVMTIDataDumpDCmd::execute(DCmdSource source, TRAPS) {
 }
 
 #if INCLUDE_SERVICES
+#if INCLUDE_JVMTI
 JVMTIAgentLoadDCmd::JVMTIAgentLoadDCmd(outputStream* output, bool heap) :
                                        DCmdWithParser(output, heap),
   _libpath("library path", "Absolute path of the JVMTI agent to load.",
@@ -358,6 +359,7 @@ int JVMTIAgentLoadDCmd::num_arguments() {
     return 0;
   }
 }
+#endif // INCLUDE_JVMTI
 #endif // INCLUDE_SERVICES
 
 void PrintSystemPropertiesDCmd::execute(DCmdSource source, TRAPS) {


### PR DESCRIPTION
This is an unclean backport. It differs from upstream version by additionally protecting `relocate_cached_class_file` that stores bytecode for JVMTI use. It was removed later during rewrite in JDK-8218751 (which does not look very backportable, given its bugtail).

Additional testing: 
 - [x] Linux x86_64 Zero fastdebug build without JVMTI
 - [x] Linux x86_64 Zero fastdebug, `runtime/appcds` tests (ignored by jtreg, as CDS is not enabled for Zero) 
 - [x] Linux x86_64 Server fastdebug, `runtime/appcds` tests (still pass)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255810](https://bugs.openjdk.java.net/browse/JDK-8255810): Zero: build fails without JVMTI


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/94/head:pull/94` \
`$ git checkout pull/94`

Update a local copy of the PR: \
`$ git checkout pull/94` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/94/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 94`

View PR using the GUI difftool: \
`$ git pr show -t 94`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/94.diff">https://git.openjdk.java.net/jdk11u-dev/pull/94.diff</a>

</details>
