### PR TITLE
8168304: Make all of DependencyContext_test available in product mode

### DIFF
--- a/src/hotspot/share/code/dependencyContext.cpp
+++ b/src/hotspot/share/code/dependencyContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -246,6 +246,7 @@ void DependencyContext::print_dependent_nmethods(bool verbose) {
     }
   }
 }
+#endif //PRODUCT
 
 bool DependencyContext::is_dependent_nmethod(nmethod* nm) {
   for (nmethodBucket* b = dependencies(); b != NULL; b = b->next()) {
@@ -266,8 +267,6 @@ bool DependencyContext::find_stale_entries() {
   }
   return false;
 }
-
-#endif //PRODUCT
 
 int nmethodBucket::decrement() {
   return Atomic::sub(1, &_count);

--- a/src/hotspot/share/code/dependencyContext.hpp
+++ b/src/hotspot/share/code/dependencyContext.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -147,8 +147,8 @@ class DependencyContext : public StackObj {
 
 #ifndef PRODUCT
   void print_dependent_nmethods(bool verbose);
+#endif //PRODUCT
   bool is_dependent_nmethod(nmethod* nm);
   bool find_stale_entries();
-#endif //PRODUCT
 };
 #endif // SHARE_VM_CODE_DEPENDENCYCONTEXT_HPP

--- a/test/hotspot/gtest/code/test_dependencyContext.cpp
+++ b/test/hotspot/gtest/code/test_dependencyContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,32 +58,30 @@ class TestDependencyContext {
     return ctx.has_stale_entries();
   }
 
-#ifndef PRODUCT
   static bool find_stale_entries(DependencyContext ctx) {
     return ctx.find_stale_entries();
   }
-#endif
 };
 
 static void test_remove_dependent_nmethod(int id, bool delete_immediately) {
   TestDependencyContext c;
   DependencyContext depContext = c.dependencies();
-  NOT_PRODUCT(ASSERT_FALSE(TestDependencyContext::find_stale_entries(depContext)));
+  ASSERT_FALSE(TestDependencyContext::find_stale_entries(depContext));
   ASSERT_FALSE(TestDependencyContext::has_stale_entries(depContext));
 
   nmethod* nm = c._nmethods[id];
   depContext.remove_dependent_nmethod(nm, delete_immediately);
 
   if (!delete_immediately) {
-    NOT_PRODUCT(ASSERT_TRUE(TestDependencyContext::find_stale_entries(depContext)));
+    ASSERT_TRUE(TestDependencyContext::find_stale_entries(depContext));
     ASSERT_TRUE(TestDependencyContext::has_stale_entries(depContext));
-    NOT_PRODUCT(ASSERT_TRUE(depContext.is_dependent_nmethod(nm)));
+    ASSERT_TRUE(depContext.is_dependent_nmethod(nm));
     depContext.expunge_stale_entries();
   }
 
-  NOT_PRODUCT(ASSERT_FALSE(TestDependencyContext::find_stale_entries(depContext)));
+  ASSERT_FALSE(TestDependencyContext::find_stale_entries(depContext));
   ASSERT_FALSE(TestDependencyContext::has_stale_entries(depContext));
-  NOT_PRODUCT(ASSERT_FALSE(depContext.is_dependent_nmethod(nm)));
+  ASSERT_FALSE(depContext.is_dependent_nmethod(nm));
 }
 
 TEST_VM(code, dependency_context) {


### PR DESCRIPTION
Unclean backport, because there is `find_stale_entries` too.

Additional testing: 
 - [x] Affected test on Linux x86_64 fastdebug
 - [x] Affected test on Linux x86_64 release

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8168304](https://bugs.openjdk.java.net/browse/JDK-8168304): Make all of DependencyContext_test available in product mode


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/96.diff">https://git.openjdk.java.net/jdk11u-dev/pull/96.diff</a>

</details>
