### PR TITLE
8224853: CDS address sanitizer errors

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -212,7 +212,7 @@ void java_lang_String::compute_offsets() {
 #if INCLUDE_CDS
 void java_lang_String::serialize_offsets(SerializeClosure* f) {
   STRING_FIELDS_DO(FIELD_SERIALIZE_OFFSET);
-  f->do_u4((u4*)&initialized);
+  f->do_bool(&initialized);
 }
 #endif
 
@@ -1558,7 +1558,7 @@ void java_lang_Class::compute_offsets() {
 
 #if INCLUDE_CDS
 void java_lang_Class::serialize_offsets(SerializeClosure* f) {
-  f->do_u4((u4*)&offsets_computed);
+  f->do_bool(&offsets_computed);
   f->do_u4((u4*)&_init_lock_offset);
 
   CLASS_FIELDS_DO(FIELD_SERIALIZE_OFFSET);

--- a/src/hotspot/share/memory/iterator.hpp
+++ b/src/hotspot/share/memory/iterator.hpp
@@ -317,6 +317,9 @@ public:
   // Read/write the 32-bit unsigned integer pointed to by p.
   virtual void do_u4(u4* p) = 0;
 
+  // Read/write the bool pointed to by p.
+  virtual void do_bool(bool* p) = 0;
+
   // Read/write the region specified.
   virtual void do_region(u_char* start, size_t size) = 0;
 

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -842,6 +842,11 @@ public:
     do_ptr(&ptr);
   }
 
+  void do_bool(bool *p) {
+    void* ptr = (void*)(uintx(*p));
+    do_ptr(&ptr);
+  }
+
   void do_tag(int tag) {
     _dump_region->append_intptr_t((intptr_t)tag);
   }
@@ -2002,6 +2007,11 @@ public:
   void do_u4(u4* p) {
     intptr_t obj = nextPtr();
     *p = (u4)(uintx(obj));
+  }
+
+  void do_bool(bool* p) {
+    intptr_t obj = nextPtr();
+    *p = (bool)(uintx(obj));
   }
 
   void do_tag(int tag) {


### PR DESCRIPTION
This is the unclean backport, because the affected `ReadClosure` and `WriteClosure` moved around for CDS work in later JDKs.

Additional testing: 
 - [x] Linux x86_64 `fastdebug`, `--enable-asan`, `-XX:+DumpSharedSpaces` tests (used to fail, now pass)
 - [x] Linux x86_64 `fastdebug`, `runtime/cds` tests (still pass)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8224853](https://bugs.openjdk.java.net/browse/JDK-8224853): CDS address sanitizer errors


### Reviewers
 * [Jiangli Zhou](https://openjdk.java.net/census#jiangli) (@jianglizhou - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/97/head:pull/97` \
`$ git checkout pull/97`

Update a local copy of the PR: \
`$ git checkout pull/97` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/97/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 97`

View PR using the GUI difftool: \
`$ git pr show -t 97`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/97.diff">https://git.openjdk.java.net/jdk11u-dev/pull/97.diff</a>

</details>
