### PR TITLE
8269847: JDK-8269594 backport breaks 11u builds

### DIFF
--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -1192,7 +1192,7 @@ void ThreadSafepointState::handle_polling_page_exception() {
   if( nm->is_at_poll_return(real_return_addr) ) {
     // See if return type is an oop.
     bool return_oop = nm->method()->is_returning_oop();
-    HandleMark hm(self);
+    HandleMark hm(thread());
     Handle return_value;
     if (return_oop) {
       // The oop result has been saved on the stack together with all


### PR DESCRIPTION
Sorry, I let a bad backport slip through.

Please review this trivial fix to unbreak 11u build.

Test:

- [x] Built on Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269847](https://bugs.openjdk.java.net/browse/JDK-8269847): JDK-8269594 backport breaks 11u builds


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/99/head:pull/99` \
`$ git checkout pull/99`

Update a local copy of the PR: \
`$ git checkout pull/99` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/99/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 99`

View PR using the GUI difftool: \
`$ git pr show -t 99`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/99.diff">https://git.openjdk.java.net/jdk11u-dev/pull/99.diff</a>

</details>
