### PR TITLE
8213922: fix ctw stand-alone build

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/Makefile
+++ b/test/hotspot/jtreg/testlibrary/ctw/Makefile
@@ -45,7 +45,7 @@ SRC_FILES = $(shell find $(SRC_DIR) -name '*.java')
 LIB_FILES = $(shell find $(TESTLIBRARY_DIR)/jdk/test/lib/ \
     $(TESTLIBRARY_DIR)/jdk/test/lib/process \
     $(TESTLIBRARY_DIR)/jdk/test/lib/util \
-    -depth 1 -name '*.java')
+    -maxdepth 1 -name '*.java')
 WB_SRC_FILES = $(shell find $(TESTLIBRARY_DIR)/sun/hotspot -name '*.java')
 EXPORTS=--add-exports java.base/jdk.internal.jimage=ALL-UNNAMED \
 	--add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
@@ -69,7 +69,7 @@ $(DST_DIR):
 	@mkdir -p $@
 
 $(DST_DIR)/ctw.sh: $(DST_DIR)
-	echo '$${JAVA_HOME}/bin/java $${JAVA_OPTIONS} $(EXPORTS) -jar -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:wb.jar -jar ctw.jar $$@' > $@
+	echo '$${JAVA_HOME}/bin/java $${JAVA_OPTIONS} $(EXPORTS) -XX:-UseCounterDecay -Xbatch "-XX:CompileCommand=exclude,java/lang/invoke/MethodHandle.*" -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:wb.jar -jar ctw.jar $$@' > $@
 	chmod a+x $@
 
 $(DST_DIR)/ctw.jar: filelist $(DST_DIR)/wb.jar

--- a/test/hotspot/jtreg/testlibrary/ctw/Makefile
+++ b/test/hotspot/jtreg/testlibrary/ctw/Makefile
@@ -34,48 +34,66 @@ endif
 
 SRC_DIR = src
 BUILD_DIR = build
+DST_DIR = dist
 OUTPUT_DIR = $(BUILD_DIR)/classes
-TESTLIBRARY_DIR = ../../../../test/lib
+TESTLIBRARY_DIR = ../../../../../test/lib
 
 JAVAC = $(JDK_HOME)/bin/javac
 JAR = $(JDK_HOME)/bin/jar
 
-SRC_FILES = $(shell find $(SRC_DIR) $(TESTLIBRARY_DIR)/jdk/test/lib -name '*.java')
+SRC_FILES = $(shell find $(SRC_DIR) -name '*.java')
+LIB_FILES = $(shell find $(TESTLIBRARY_DIR)/jdk/test/lib/ \
+    $(TESTLIBRARY_DIR)/jdk/test/lib/process \
+    $(TESTLIBRARY_DIR)/jdk/test/lib/util \
+    -depth 1 -name '*.java')
 WB_SRC_FILES = $(shell find $(TESTLIBRARY_DIR)/sun/hotspot -name '*.java')
+EXPORTS=--add-exports java.base/jdk.internal.jimage=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.reflect=ALL-UNNAMED \
+	--add-exports java.base/jdk.internal.access=ALL-UNNAMED
 
 MAIN_CLASS = sun.hotspot.tools.ctw.CompileTheWorld
 
 .PHONY: clean cleantmp
 
-all: ctw.jar cleantmp
+all: $(DST_DIR)/ctw.zip cleantmp
 
 clean: cleantmp
-	@rm -rf ctw.jar wb.jar
+	@rm -rf $(DST_DIR)
 
 cleantmp:
 	@rm -rf filelist wb_filelist manifest.mf
 	@rm -rf $(BUILD_DIR)
 
-ctw.jar: filelist wb.jar
-	@mkdir -p $(OUTPUT_DIR)
-	$(JAVAC) --add-exports java.base/jdk.internal.jimage=ALL-UNNAMED \
-		 --add-exports java.base/jdk.internal.misc=ALL-UNNAMED \
-		 --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED \
-		 -sourcepath $(SRC_DIR) -d $(OUTPUT_DIR) -cp wb.jar @filelist
-	$(JAR) --create --file=$@ --main-class $(MAIN_CLASS) -C $(OUTPUT_DIR) .
+$(DST_DIR):
+	@mkdir -p $@
 
-wb.jar: wb_filelist
+$(DST_DIR)/ctw.sh: $(DST_DIR)
+	echo '$${JAVA_HOME}/bin/java $${JAVA_OPTIONS} $(EXPORTS) -jar -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:wb.jar -jar ctw.jar $$@' > $@
+	chmod a+x $@
+
+$(DST_DIR)/ctw.jar: filelist $(DST_DIR)/wb.jar
+	@mkdir -p $(OUTPUT_DIR)
+	$(JAVAC) $(EXPORTS) -sourcepath $(SRC_DIR) -d $(OUTPUT_DIR) -cp $(DST_DIR)/wb.jar @filelist
+	$(JAR) --create --file=$@ --main-class $(MAIN_CLASS) -C $(OUTPUT_DIR) .
+	@rm -rf $(OUTPUT_DIR)
+
+$(DST_DIR)/wb.jar: wb_filelist $(DST_DIR)
 	@mkdir -p $(OUTPUT_DIR)
 	$(JAVAC)  -sourcepath $(TESTLIBRARY_DIR) \
 		-d $(OUTPUT_DIR) \
 		-cp $(OUTPUT_DIR) \
 		@wb_filelist
 	$(JAR) --create --file=$@ -C $(OUTPUT_DIR) .
+	@rm -rf $(OUTPUT_DIR)
+
+$(DST_DIR)/ctw.zip: $(DST_DIR)/ctw.sh $(DST_DIR)/wb.jar $(DST_DIR)/ctw.jar
+	zip -j $@ $?
 
 wb_filelist: $(WB_SRC_FILES)
 	@rm -f $@
 	@echo $(WB_SRC_FILES) > $@
 
-filelist: $(SRC_FILES)
+filelist: $(SRC_FILES) $(LIB_FILES)
 	@rm -f $@
-	@echo $(SRC_FILES) > $@
+	@echo $(SRC_FILES) $(LIB_FILES) > $@


### PR DESCRIPTION
This allows CTW bundle to be built again. Note that it is unclean backport, and it includes the part of "8214917: CTW testlibrary shouldn't ignore errors raised by the library itself" -- which is already quite messy, and would be inconvenient to work in through the regular process.

Additional testing: 
 - [x] Standalone CTW build with JDK 11 now works
 - [x] Sample standalone CTW run with JDK 11 works

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8213922](https://bugs.openjdk.java.net/browse/JDK-8213922): fix ctw stand-alone build


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/101.diff">https://git.openjdk.java.net/jdk11u-dev/pull/101.diff</a>

</details>
