### PR TITLE
8218145: block_if_requested is not proper inlined due to size

### DIFF
--- a/src/hotspot/share/runtime/safepointMechanism.cpp
+++ b/src/hotspot/share/runtime/safepointMechanism.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,6 +80,16 @@ void SafepointMechanism::default_initialize() {
 
     log_info(os)("SafePoint Polling address: " INTPTR_FORMAT, p2i(polling_page));
     os::set_polling_page((address)(polling_page));
+  }
+}
+
+void SafepointMechanism::block_if_requested_slow(JavaThread *thread) {
+  // local poll already checked, if used.
+  if (global_poll()) {
+    SafepointSynchronize::block(thread);
+  }
+  if (uses_thread_local_poll() && thread->has_handshake()) {
+      thread->handshake_process_by_self();
   }
 }
 

--- a/src/hotspot/share/runtime/safepointMechanism.hpp
+++ b/src/hotspot/share/runtime/safepointMechanism.hpp
@@ -49,7 +49,7 @@ class SafepointMechanism : public AllStatic {
   static inline bool local_poll(Thread* thread);
   static inline bool global_poll();
 
-  static inline void block_if_requested_local_poll(JavaThread *thread);
+  static void block_if_requested_slow(JavaThread *thread);
 
   static void default_initialize();
   static void initialize_serialize_page();

--- a/src/hotspot/share/runtime/safepointMechanism.inline.hpp
+++ b/src/hotspot/share/runtime/safepointMechanism.inline.hpp
@@ -55,28 +55,11 @@ bool SafepointMechanism::poll(Thread* thread) {
   }
 }
 
-void SafepointMechanism::block_if_requested_local_poll(JavaThread *thread) {
-  bool armed = local_poll_armed(thread); // load acquire, polling page -> op / global state
-  if(armed) {
-    // We could be armed for either a handshake operation or a safepoint
-    if (global_poll()) {
-      SafepointSynchronize::block(thread);
-    }
-    if (thread->has_handshake()) {
-      thread->handshake_process_by_self();
-    }
-  }
-}
-
 void SafepointMechanism::block_if_requested(JavaThread *thread) {
-  if (uses_thread_local_poll()) {
-    block_if_requested_local_poll(thread);
-  } else {
-    // If we don't have per thread poll this could a handshake or a safepoint
-    if (global_poll()) {
-      SafepointSynchronize::block(thread);
-    }
+  if (uses_thread_local_poll() && !SafepointMechanism::local_poll_armed(thread)) {
+    return;
   }
+  block_if_requested_slow(thread);
 }
 
 void SafepointMechanism::arm_local_poll(JavaThread* thread) {


### PR DESCRIPTION
This small optimization through a trivial refactoring is applicable to 11u. Original patch requires adjustment in a single place: there is initialize_serialize_page() in safepointMechanism.hpp because JDK-8213436 is not backported.

Testing: tier1, tier2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8218145](https://bugs.openjdk.java.net/browse/JDK-8218145): block_if_requested is not proper inlined due to size


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/102/head:pull/102` \
`$ git checkout pull/102`

Update a local copy of the PR: \
`$ git checkout pull/102` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 102`

View PR using the GUI difftool: \
`$ git pr show -t 102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/102.diff">https://git.openjdk.java.net/jdk11u-dev/pull/102.diff</a>

</details>
