### PR TITLE
8252648: Shenandoah: name gang tasks consistently

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -85,7 +85,7 @@ private:
   ShenandoahAllRootScanner* _rp;
 public:
   ShenandoahInitMarkRootsTask(ShenandoahAllRootScanner* rp) :
-    AbstractGangTask("Shenandoah init mark roots task"),
+    AbstractGangTask("Shenandoah Init Mark Roots"),
     _rp(rp) {
   }
 
@@ -127,7 +127,7 @@ private:
   ShenandoahRootUpdater*  _root_updater;
 public:
   ShenandoahUpdateRootsTask(ShenandoahRootUpdater* root_updater) :
-    AbstractGangTask("Shenandoah update roots task"),
+    AbstractGangTask("Shenandoah Update Roots"),
     _root_updater(root_updater) {
   }
 
@@ -149,7 +149,7 @@ private:
 
 public:
   ShenandoahConcurrentMarkingTask(ShenandoahConcurrentMark* cm, ShenandoahTaskTerminator* terminator) :
-    AbstractGangTask("Root Region Scan"), _cm(cm), _terminator(terminator) {
+    AbstractGangTask("Shenandoah Concurrent Mark"), _cm(cm), _terminator(terminator) {
   }
 
   void work(uint worker_id) {
@@ -219,7 +219,7 @@ private:
 
 public:
   ShenandoahFinalMarkingTask(ShenandoahConcurrentMark* cm, ShenandoahTaskTerminator* terminator, bool dedup_string) :
-    AbstractGangTask("Shenandoah Final Marking"), _cm(cm), _terminator(terminator), _dedup_string(dedup_string) {
+    AbstractGangTask("Shenandoah Final Mark"), _cm(cm), _terminator(terminator), _dedup_string(dedup_string) {
   }
 
   void work(uint worker_id) {
@@ -602,7 +602,7 @@ private:
 public:
   ShenandoahRefProcTaskProxy(AbstractRefProcTaskExecutor::ProcessTask& proc_task,
                              ShenandoahTaskTerminator* t) :
-    AbstractGangTask("Process reference objects in parallel"),
+    AbstractGangTask("Shenandoah Process Weak References"),
     _proc_task(proc_task),
     _terminator(t) {
   }
@@ -761,7 +761,7 @@ private:
 
 public:
   ShenandoahPrecleanTask(ReferenceProcessor* rp) :
-          AbstractGangTask("Precleaning task"),
+          AbstractGangTask("Shenandoah Precleaning"),
           _rp(rp) {}
 
   void work(uint worker_id) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -518,7 +518,7 @@ private:
 
 public:
   ShenandoahResetBitmapTask() :
-    AbstractGangTask("Parallel Reset Bitmap Task") {}
+    AbstractGangTask("Shenandoah Reset Bitmap") {}
 
   void work(uint worker_id) {
     ShenandoahHeapRegion* region = _regions.next();
@@ -960,7 +960,7 @@ public:
   ShenandoahEvacuationTask(ShenandoahHeap* sh,
                            ShenandoahCollectionSet* cs,
                            bool concurrent) :
-    AbstractGangTask("Parallel Evacuation Task"),
+    AbstractGangTask("Shenandoah Evacuation"),
     _sh(sh),
     _cs(cs),
     _concurrent(concurrent)
@@ -1078,7 +1078,7 @@ private:
 
 public:
   ShenandoahEvacuateUpdateRootsTask(ShenandoahRootEvacuator* rp) :
-    AbstractGangTask("Shenandoah evacuate and update roots"),
+    AbstractGangTask("Shenandoah Evacuate/Update Roots"),
     _rp(rp) {}
 
   void work(uint worker_id) {
@@ -1355,7 +1355,7 @@ private:
 
 public:
   ShenandoahParallelHeapRegionTask(ShenandoahHeapRegionClosure* blk) :
-          AbstractGangTask("Parallel Region Task"),
+          AbstractGangTask("Shenandoah Parallel Region Operation"),
           _heap(ShenandoahHeap::heap()), _blk(blk), _index(0) {}
 
   void work(uint worker_id) {
@@ -2159,7 +2159,7 @@ private:
   bool _concurrent;
 public:
   ShenandoahUpdateHeapRefsTask(ShenandoahRegionIterator* regions, bool concurrent) :
-    AbstractGangTask("Concurrent Update References Task"),
+    AbstractGangTask("Shenandoah Update References"),
     cl(T()),
     _heap(ShenandoahHeap::heap()),
     _regions(regions),

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkCompact.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkCompact.cpp
@@ -327,7 +327,7 @@ private:
 
 public:
   ShenandoahPrepareForCompactionTask(PreservedMarksSet *preserved_marks, ShenandoahHeapRegionSet **worker_slices) :
-    AbstractGangTask("Shenandoah Prepare For Compaction Task"),
+    AbstractGangTask("Shenandoah Prepare For Compaction"),
     _preserved_marks(preserved_marks),
     _heap(ShenandoahHeap::heap()), _worker_slices(worker_slices) {
   }
@@ -719,7 +719,7 @@ private:
 
 public:
   ShenandoahAdjustPointersTask() :
-    AbstractGangTask("Shenandoah Adjust Pointers Task"),
+    AbstractGangTask("Shenandoah Adjust Pointers"),
     _heap(ShenandoahHeap::heap()) {
   }
 
@@ -741,7 +741,7 @@ private:
   PreservedMarksSet* _preserved_marks;
 public:
   ShenandoahAdjustRootPointersTask(ShenandoahRootAdjuster* rp, PreservedMarksSet* preserved_marks) :
-    AbstractGangTask("Shenandoah Adjust Root Pointers Task"),
+    AbstractGangTask("Shenandoah Adjust Root Pointers"),
     _rp(rp),
     _preserved_marks(preserved_marks) {}
 
@@ -805,7 +805,7 @@ private:
 
 public:
   ShenandoahCompactObjectsTask(ShenandoahHeapRegionSet** worker_slices) :
-    AbstractGangTask("Shenandoah Compact Objects Task"),
+    AbstractGangTask("Shenandoah Compact Objects"),
     _heap(ShenandoahHeap::heap()),
     _worker_slices(worker_slices) {
   }
@@ -953,7 +953,7 @@ private:
 
 public:
   ShenandoahMCResetCompleteBitmapTask() :
-    AbstractGangTask("Parallel Reset Bitmap Task") {
+    AbstractGangTask("Shenandoah Reset Bitmap") {
   }
 
   void work(uint worker_id) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahParallelCleaning.inline.hpp
@@ -35,7 +35,7 @@ ShenandoahParallelWeakRootsCleaningTask<IsAlive, KeepAlive>::ShenandoahParallelW
                                                                                                      IsAlive* is_alive,
                                                                                                      KeepAlive* keep_alive,
                                                                                                      uint num_workers) :
-  AbstractGangTask("Parallel Weak Root Cleaning Task"),
+  AbstractGangTask("Shenandoah Weak Root Cleaning"),
   _phase(phase), _weak_roots(phase, num_workers),
   _is_alive(is_alive), _keep_alive(keep_alive) {
   assert(SafepointSynchronize::is_at_safepoint(), "Must be at a safepoint");

--- a/src/hotspot/share/gc/shenandoah/shenandoahStringDedup.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahStringDedup.cpp
@@ -129,7 +129,7 @@ public:
   ShenandoahStringDedupUnlinkOrOopsDoTask(BoolObjectClosure* is_alive,
                                   OopClosure* keep_alive,
                                   bool allow_resize_and_rehash) :
-    AbstractGangTask("StringDedupUnlinkOrOopsDoTask"),
+    AbstractGangTask("Shenandoah String Dedup Unlink/Process"),
     _cl(is_alive, keep_alive) {
       StringDedup::gc_prologue(allow_resize_and_rehash);
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -411,7 +411,7 @@ public:
                                   ShenandoahRootVerifier* verifier,
                                   const char* label,
                                   ShenandoahVerifier::VerifyOptions options) :
-    AbstractGangTask("Shenandoah Parallel Verifier Reachable Task"),
+    AbstractGangTask("Shenandoah Verifier Reachable Objects"),
     _label(label),
     _verifier(verifier),
     _options(options),
@@ -476,7 +476,7 @@ public:
                                      ShenandoahLivenessData* ld,
                                      const char* label,
                                      ShenandoahVerifier::VerifyOptions options) :
-          AbstractGangTask("Shenandoah Parallel Verifier Marked Region"),
+          AbstractGangTask("Shenandoah Verifier Marked Objects"),
           _label(label),
           _options(options),
           _heap(ShenandoahHeap::heap()),


### PR DESCRIPTION
Unclean backport, because Shenandoah 11u does not have concurrent weak reference processing and concurrent class unloading.

Additional testing:
 - [x] Linux x86_64 fastdebug `hotspot_gc_shenandoah`
 - [x] Inspecting `AbstractGangTask` uses in Shenandoah code

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252648](https://bugs.openjdk.java.net/browse/JDK-8252648): Shenandoah: name gang tasks consistently


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/104/head:pull/104` \
`$ git checkout pull/104`

Update a local copy of the PR: \
`$ git checkout pull/104` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 104`

View PR using the GUI difftool: \
`$ git pr show -t 104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/104.diff">https://git.openjdk.java.net/jdk11u-dev/pull/104.diff</a>

</details>
