### PR TITLE
8263407: SPARC64 detection fails on Athena (SPARC64-X)

### DIFF
--- a/src/hotspot/cpu/sparc/vm_version_sparc.cpp
+++ b/src/hotspot/cpu/sparc/vm_version_sparc.cpp
@@ -160,7 +160,8 @@ void VM_Version::initialize() {
 
   // Use compare and branch instructions if available.
   if (has_cbcond()) {
-    if (FLAG_IS_DEFAULT(UseCBCond)) {
+    // cbcond suspected to cause issues on Athena CPUs
+    if (FLAG_IS_DEFAULT(UseCBCond) && !is_athena()) {
       FLAG_SET_DEFAULT(UseCBCond, true);
     }
   } else if (UseCBCond) {
@@ -218,7 +219,7 @@ void VM_Version::initialize() {
 
   char buf[512];
   jio_snprintf(buf, sizeof(buf),
-               "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s"
+               "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s"
                "%s%s%s%s%s%s%s%s%s" "%s%s%s%s%s%s%s%s%s"
                "%s%s%s%s%s%s%s",
                (has_v9()          ? "v9" : ""),
@@ -228,6 +229,7 @@ void VM_Version::initialize() {
                (has_blk_init()    ? ", blk_init" : ""),
                (has_fmaf()        ? ", fmaf" : ""),
                (has_hpc()         ? ", hpc" : ""),
+               (has_athena()      ? ", athena" : ""),
                (has_ima()         ? ", ima" : ""),
                (has_aes()         ? ", aes" : ""),
                (has_des()         ? ", des" : ""),

--- a/src/hotspot/cpu/sparc/vm_version_sparc.hpp
+++ b/src/hotspot/cpu/sparc/vm_version_sparc.hpp
@@ -42,6 +42,7 @@ protected:
     ISA_FMAF,
     ISA_VIS3,
     ISA_HPC,
+    ISA_FJATHHPC,
     ISA_IMA,
     ISA_AES,
     ISA_DES,
@@ -104,6 +105,7 @@ private:
     ISA_fmaf_msk        = UINT64_C(1) << ISA_FMAF,
     ISA_vis3_msk        = UINT64_C(1) << ISA_VIS3,
     ISA_hpc_msk         = UINT64_C(1) << ISA_HPC,
+    ISA_fjathhpc_msk    = UINT64_C(1) << ISA_FJATHHPC,
     ISA_ima_msk         = UINT64_C(1) << ISA_IMA,
     ISA_aes_msk         = UINT64_C(1) << ISA_AES,
     ISA_des_msk         = UINT64_C(1) << ISA_DES,
@@ -253,6 +255,7 @@ public:
   static bool has_fmaf()         { return (_features & ISA_fmaf_msk) != 0; }
   static bool has_vis3()         { return (_features & ISA_vis3_msk) != 0; }
   static bool has_hpc()          { return (_features & ISA_hpc_msk) != 0; }
+  static bool has_athena()       { return (_features & ISA_fjathhpc_msk) != 0; }
   static bool has_ima()          { return (_features & ISA_ima_msk) != 0; }
   static bool has_aes()          { return (_features & ISA_aes_msk) != 0; }
   static bool has_des()          { return (_features & ISA_des_msk) != 0; }
@@ -304,6 +307,10 @@ public:
   // FIXME: To be removed.
   static bool is_post_niagara()  {
     return (_features & niagara2_msk) == niagara2_msk;
+  }
+
+  static bool is_athena() {
+    return has_athena() || has_athena_plus() || has_athena_plus2();
   }
 
   // Default prefetch block size on SPARC.

--- a/src/hotspot/os_cpu/solaris_sparc/vm_version_solaris_sparc.cpp
+++ b/src/hotspot/os_cpu/solaris_sparc/vm_version_solaris_sparc.cpp
@@ -358,7 +358,7 @@ void VM_Version::platform_features() {
 #endif
 
 #ifndef AV_SPARC_FJATHHPC
-#define AV_SPARC_FJATHHPC     0x00001000 // Fujitsu HPC (Athena) instrs 
+#define AV_SPARC_FJATHHPC     0x00001000 // Fujitsu HPC (Athena) instrs
 #endif
 
   if (av & AV_SPARC_ASI_BLK_INIT) features |= ISA_blk_init_msk;

--- a/src/hotspot/os_cpu/solaris_sparc/vm_version_solaris_sparc.cpp
+++ b/src/hotspot/os_cpu/solaris_sparc/vm_version_solaris_sparc.cpp
@@ -357,10 +357,15 @@ void VM_Version::platform_features() {
 #define AV_SPARC_FMAF         0x00000100 // Fused Multiply-Add
 #endif
 
+#ifndef AV_SPARC_FJATHHPC
+#define AV_SPARC_FJATHHPC     0x00001000 // Fujitsu HPC (Athena) instrs 
+#endif
+
   if (av & AV_SPARC_ASI_BLK_INIT) features |= ISA_blk_init_msk;
   if (av & AV_SPARC_FMAF)         features |= ISA_fmaf_msk;
   if (av & AV_SPARC_VIS3)         features |= ISA_vis3_msk;
   if (av & AV_SPARC_HPC)          features |= ISA_hpc_msk;
+  if (av & AV_SPARC_FJATHHPC)     features |= ISA_fjathhpc_msk;
   if (av & AV_SPARC_IMA)          features |= ISA_ima_msk;
   if (av & AV_SPARC_AES)          features |= ISA_aes_msk;
   if (av & AV_SPARC_DES)          features |= ISA_des_msk;
@@ -460,14 +465,13 @@ void VM_Version::platform_features() {
 
   Sysinfo machine(SI_MACHINE);
 
-  bool is_sun4v = machine.match("sun4v");   // All Oracle SPARC + Fujitsu Athena+/++
+  bool is_sun4v = machine.match("sun4v");   // All Oracle SPARC + Fujitsu Athena(+/++)
   bool is_sun4u = machine.match("sun4u");   // All other Fujitsu
 
-  // Handle Athena+/++ conservatively (simply because we are lacking info.).
+  // Handle Athena(+/++) conservatively (simply because we are lacking info.).
 
-  bool an_athena = has_athena_plus() || has_athena_plus2();
-  bool do_sun4v  = is_sun4v && !an_athena;
-  bool do_sun4u  = is_sun4u ||  an_athena;
+  bool do_sun4v  = is_sun4v && !is_athena();
+  bool do_sun4u  = is_sun4u ||  is_athena();
 
   uint64_t synthetic = 0;
 


### PR DESCRIPTION
Backport of fix  8263407, details of implementation is in thread: 
https://mail.openjdk.java.net/pipermail/jdk-updates-dev/2021-April/005999.html
Was built and run tier1 tests on Solaris machine

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263407](https://bugs.openjdk.java.net/browse/JDK-8263407): SPARC64 detection fails on Athena (SPARC64-X)


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/106.diff">https://git.openjdk.java.net/jdk11u-dev/pull/106.diff</a>

</details>
