### PR TITLE
8256267: Relax compiler/floatingpoint/NaNTest.java for x86_32 and lower -XX:+UseSSE

### DIFF
--- a/test/hotspot/jtreg/compiler/floatingpoint/NaNTest.java
+++ b/test/hotspot/jtreg/compiler/floatingpoint/NaNTest.java
@@ -24,13 +24,23 @@
  * @test
  * @bug 8076373
  * @summary Verify if signaling NaNs are preserved.
+ * @library /test/lib /
  *
- * @run main compiler.floatingpoint.NaNTest
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   compiler.floatingpoint.NaNTest
  */
 
 package compiler.floatingpoint;
 
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
+import sun.hotspot.WhiteBox;
+
 public class NaNTest {
+    static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+
     static void testFloat() {
         int originalValue = 0x7f800001;
         int readBackValue = Float.floatToRawIntBits(Float.intBitsToFloat(originalValue));
@@ -63,11 +73,34 @@ public class NaNTest {
     }
 
     public static void main(String args[]) {
-        System.out.println("### NanTest started");
+        // Some platforms are known to strip signaling NaNs.
+        // The block below can be used to except them.
+        boolean expectStableFloats = true;
+        boolean expectStableDoubles = true;
 
-        testFloat();
-        testDouble();
+        // On x86_32 without relevant SSE-enabled stubs, we are entering
+        // native methods that use FPU instructions, and those strip the
+        // signaling NaNs.
+        if (Platform.isX86()) {
+            int sse = WHITE_BOX.getIntxVMFlag("UseSSE").intValue();
+            expectStableFloats = (sse >= 1);
+            expectStableDoubles = (sse >= 2);
+        }
 
-        System.out.println("### NanTest ended");
+        if (expectStableFloats) {
+           testFloat();
+        } else {
+           System.out.println("Stable floats cannot be expected, skipping");
+        }
+
+        if (expectStableDoubles) {
+           testDouble();
+        } else {
+           System.out.println("Stable doubles cannot be expected, skipping");
+        }
+
+        if (!expectStableFloats && !expectStableDoubles) {
+           throw new SkippedException("No tests were run.");
+        }
     }
 }


### PR DESCRIPTION
Fixes a test x86_32.

Additional testing: 
 - [x] Affected test on x86_32 with `-XX:UseSSE=1`, used to fail, now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8256267](https://bugs.openjdk.java.net/browse/JDK-8256267): Relax compiler/floatingpoint/NaNTest.java for x86_32 and lower -XX:+UseSSE


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/112.diff">https://git.openjdk.java.net/jdk11u-dev/pull/112.diff</a>

</details>
