### PR TITLE
8268360: Missing check for infinite loop during node placement

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3060,6 +3060,7 @@ void PhaseIdealLoop::build_and_optimize(LoopOptsMode mode) {
   if( SplitIfBlocks && do_split_ifs ) {
     visited.Clear();
     split_if_with_blocks( visited, nstack, mode == LoopOptsLastRound );
+    if (C->failing()) return;
     NOT_PRODUCT( if( VerifyLoopOptimizations ) verify(); );
     if (mode == LoopOptsLastRound) {
       C->set_major_progress();

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -3060,7 +3060,6 @@ void PhaseIdealLoop::build_and_optimize(LoopOptsMode mode) {
   if( SplitIfBlocks && do_split_ifs ) {
     visited.Clear();
     split_if_with_blocks( visited, nstack, mode == LoopOptsLastRound );
-    if (C->failing()) return;
     NOT_PRODUCT( if( VerifyLoopOptimizations ) verify(); );
     if (mode == LoopOptsLastRound) {
       C->set_major_progress();

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1076,6 +1076,11 @@ static bool merge_point_safe(Node* region) {
 // For inner loop uses move it to the preheader area.
 Node *PhaseIdealLoop::place_near_use(Node *useblock) const {
   IdealLoopTree *u_loop = get_loop( useblock );
+  if (!u_loop->_head->is_Loop()) {
+    // detected broken graph due to infinite loop
+    C->record_method_not_compilable("infinite loop");
+    return useblock;
+  }
   if (u_loop->_irreducible) {
     return useblock;
   }
@@ -1398,6 +1403,7 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n, bool last_round) {
             // Find control for 'x' next to use but not inside inner loops.
             // For inner loop uses get the preheader area.
             x_ctrl = place_near_use(x_ctrl);
+            if (C->failing()) return;
 
             if (n->is_Load()) {
               // For loads, add a control edge to a CFG node outside of the loop
@@ -1508,6 +1514,7 @@ void PhaseIdealLoop::split_if_with_blocks(VectorSet &visited, Node_Stack &nstack
       if (cnt != 0 && !n->is_Con()) {
         assert(has_node(n), "no dead nodes");
         split_if_with_blocks_post( n, last_round );
+        if (C->failing()) return;
       }
       if (nstack.is_empty()) {
         // Finished all nodes on stack.

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1076,12 +1076,7 @@ static bool merge_point_safe(Node* region) {
 // For inner loop uses move it to the preheader area.
 Node *PhaseIdealLoop::place_near_use(Node *useblock) const {
   IdealLoopTree *u_loop = get_loop( useblock );
-  if (!u_loop->_head->is_Loop()) {
-    // detected broken graph due to infinite loop
-    C->record_method_not_compilable("infinite loop");
-    return useblock;
-  }
-  if (u_loop->_irreducible) {
+  if (u_loop->_irreducible || !u_loop->_head->is_Loop()) {
     return useblock;
   }
   if (u_loop->_child) {
@@ -1403,7 +1398,6 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n, bool last_round) {
             // Find control for 'x' next to use but not inside inner loops.
             // For inner loop uses get the preheader area.
             x_ctrl = place_near_use(x_ctrl);
-            if (C->failing()) return;
 
             if (n->is_Load()) {
               // For loads, add a control edge to a CFG node outside of the loop
@@ -1514,7 +1508,6 @@ void PhaseIdealLoop::split_if_with_blocks(VectorSet &visited, Node_Stack &nstack
       if (cnt != 0 && !n->is_Con()) {
         assert(has_node(n), "no dead nodes");
         split_if_with_blocks_post( n, last_round );
-        if (C->failing()) return;
       }
       if (nstack.is_empty()) {
         // Finished all nodes on stack.

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfLoopNearUsePlacement.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfLoopNearUsePlacement.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8268360
+ * @summary Test node placement when its use is inside infinite loop.
+ * @library /test/lib
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.loopopts.TestInfLoopNearUsePlacement::test
+ *                   compiler.loopopts.TestInfLoopNearUsePlacement
+ */
+
+package compiler.loopopts;
+
+import jdk.test.lib.Utils;
+
+public class TestInfLoopNearUsePlacement {
+
+    static void test() {
+        long loa[] = new long[42];
+
+        try {
+            for (int i = 0; i < 42; i++) {
+                Thread.sleep(1);
+                loa[i] = 42L;
+            }
+        } catch (InterruptedException e) {}
+
+        loa[0] = 1L;
+        // Infinite loop: loop's variable is reset on each iteration
+        for (int i = 0; i < 21; i++) {
+            loa[0] += 1L;
+            i = 1;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Execute test in own thread because it contains an infinite loop
+        Thread thread = new Thread() {
+            public void run() {
+                for (int i = 0; i < 100; ++i) {
+                    test();
+                }
+            }
+        };
+        thread.setDaemon(true);
+        thread.start();
+        // Give thread some time to trigger compilation
+        Thread.sleep(Utils.adjustTimeout(5000));
+    }
+}


### PR DESCRIPTION
11.0.13-oracle has implemented some error detection and bail out (see JBS). The test is publicly available as JDK-8268417. It also fails without the fix in OpenJDK 11u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8268360](https://bugs.openjdk.java.net/browse/JDK-8268360): Missing check for infinite loop during node placement
 * [JDK-8268417](https://bugs.openjdk.java.net/browse/JDK-8268417): Add test from JDK-8268360


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/113/head:pull/113` \
`$ git checkout pull/113`

Update a local copy of the PR: \
`$ git checkout pull/113` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 113`

View PR using the GUI difftool: \
`$ git pr show -t 113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/113.diff">https://git.openjdk.java.net/jdk11u-dev/pull/113.diff</a>

</details>
