### PR TITLE
8217825: Verify @AfterTest is used correctly in WebSocket tests

### DIFF
--- a/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
@@ -29,7 +29,6 @@
  *       WebSocketTest
  */
 
-import org.testng.annotations.AfterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -73,150 +72,150 @@ public class WebSocketTest {
         Support.assertCompletesExceptionally(clazz, stage);
     }
 
-    private DummyWebSocketServer server;
-    private WebSocket webSocket;
-
-    @AfterTest
-    public void cleanup() {
-        System.out.println("AFTER TEST");
-        if (server != null)
-            server.close();
-        if (webSocket != null)
-            webSocket.abort();
-    }
-
     @Test
     public void illegalArgument() throws IOException {
-        server = new DummyWebSocketServer();
-        server.open();
-        webSocket = newBuilder().proxy(NO_PROXY).build()
-                .newWebSocketBuilder()
-                .buildAsync(server.getURI(), new WebSocket.Listener() { })
-                .join();
+        try (var server = new DummyWebSocketServer()) {
+            server.open();
+            var webSocket = newBuilder().proxy(NO_PROXY).build()
+                    .newWebSocketBuilder()
+                    .buildAsync(server.getURI(), new WebSocket.Listener() { })
+                    .join();
+            try {
+                assertFails(IAE, webSocket.sendPing(ByteBuffer.allocate(126)));
+                assertFails(IAE, webSocket.sendPing(ByteBuffer.allocate(127)));
+                assertFails(IAE, webSocket.sendPing(ByteBuffer.allocate(128)));
+                assertFails(IAE, webSocket.sendPing(ByteBuffer.allocate(129)));
+                assertFails(IAE, webSocket.sendPing(ByteBuffer.allocate(256)));
 
-        assertFails(IAE, webSocket.sendPing(ByteBuffer.allocate(126)));
-        assertFails(IAE, webSocket.sendPing(ByteBuffer.allocate(127)));
-        assertFails(IAE, webSocket.sendPing(ByteBuffer.allocate(128)));
-        assertFails(IAE, webSocket.sendPing(ByteBuffer.allocate(129)));
-        assertFails(IAE, webSocket.sendPing(ByteBuffer.allocate(256)));
+                assertFails(IAE, webSocket.sendPong(ByteBuffer.allocate(126)));
+                assertFails(IAE, webSocket.sendPong(ByteBuffer.allocate(127)));
+                assertFails(IAE, webSocket.sendPong(ByteBuffer.allocate(128)));
+                assertFails(IAE, webSocket.sendPong(ByteBuffer.allocate(129)));
+                assertFails(IAE, webSocket.sendPong(ByteBuffer.allocate(256)));
 
-        assertFails(IAE, webSocket.sendPong(ByteBuffer.allocate(126)));
-        assertFails(IAE, webSocket.sendPong(ByteBuffer.allocate(127)));
-        assertFails(IAE, webSocket.sendPong(ByteBuffer.allocate(128)));
-        assertFails(IAE, webSocket.sendPong(ByteBuffer.allocate(129)));
-        assertFails(IAE, webSocket.sendPong(ByteBuffer.allocate(256)));
+                assertFails(IOE, webSocket.sendText(Support.incompleteString(), true));
+                assertFails(IOE, webSocket.sendText(Support.incompleteString(), false));
+                assertFails(IOE, webSocket.sendText(Support.malformedString(), true));
+                assertFails(IOE, webSocket.sendText(Support.malformedString(), false));
 
-        assertFails(IOE, webSocket.sendText(Support.incompleteString(), true));
-        assertFails(IOE, webSocket.sendText(Support.incompleteString(), false));
-        assertFails(IOE, webSocket.sendText(Support.malformedString(), true));
-        assertFails(IOE, webSocket.sendText(Support.malformedString(), false));
+                assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.stringWithNBytes(124)));
+                assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.stringWithNBytes(125)));
+                assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.stringWithNBytes(128)));
+                assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.stringWithNBytes(256)));
+                assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.stringWithNBytes(257)));
+                assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.stringWith2NBytes((123 / 2) + 1)));
+                assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.malformedString()));
+                assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.incompleteString()));
 
-        assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.stringWithNBytes(124)));
-        assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.stringWithNBytes(125)));
-        assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.stringWithNBytes(128)));
-        assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.stringWithNBytes(256)));
-        assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.stringWithNBytes(257)));
-        assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.stringWith2NBytes((123 / 2) + 1)));
-        assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.malformedString()));
-        assertFails(IAE, webSocket.sendClose(NORMAL_CLOSURE, Support.incompleteString()));
+                assertFails(IAE, webSocket.sendClose(-2, "a reason"));
+                assertFails(IAE, webSocket.sendClose(-1, "a reason"));
+                assertFails(IAE, webSocket.sendClose(0, "a reason"));
+                assertFails(IAE, webSocket.sendClose(1, "a reason"));
+                assertFails(IAE, webSocket.sendClose(500, "a reason"));
+                assertFails(IAE, webSocket.sendClose(998, "a reason"));
+                assertFails(IAE, webSocket.sendClose(999, "a reason"));
+                assertFails(IAE, webSocket.sendClose(1002, "a reason"));
+                assertFails(IAE, webSocket.sendClose(1003, "a reason"));
+                assertFails(IAE, webSocket.sendClose(1006, "a reason"));
+                assertFails(IAE, webSocket.sendClose(1007, "a reason"));
+                assertFails(IAE, webSocket.sendClose(1009, "a reason"));
+                assertFails(IAE, webSocket.sendClose(1010, "a reason"));
+                assertFails(IAE, webSocket.sendClose(1012, "a reason"));
+                assertFails(IAE, webSocket.sendClose(1013, "a reason"));
+                assertFails(IAE, webSocket.sendClose(1015, "a reason"));
+                assertFails(IAE, webSocket.sendClose(5000, "a reason"));
+                assertFails(IAE, webSocket.sendClose(32768, "a reason"));
+                assertFails(IAE, webSocket.sendClose(65535, "a reason"));
+                assertFails(IAE, webSocket.sendClose(65536, "a reason"));
+                assertFails(IAE, webSocket.sendClose(Integer.MAX_VALUE, "a reason"));
+                assertFails(IAE, webSocket.sendClose(Integer.MIN_VALUE, "a reason"));
 
-        assertFails(IAE, webSocket.sendClose(-2, "a reason"));
-        assertFails(IAE, webSocket.sendClose(-1, "a reason"));
-        assertFails(IAE, webSocket.sendClose(0, "a reason"));
-        assertFails(IAE, webSocket.sendClose(1, "a reason"));
-        assertFails(IAE, webSocket.sendClose(500, "a reason"));
-        assertFails(IAE, webSocket.sendClose(998, "a reason"));
-        assertFails(IAE, webSocket.sendClose(999, "a reason"));
-        assertFails(IAE, webSocket.sendClose(1002, "a reason"));
-        assertFails(IAE, webSocket.sendClose(1003, "a reason"));
-        assertFails(IAE, webSocket.sendClose(1006, "a reason"));
-        assertFails(IAE, webSocket.sendClose(1007, "a reason"));
-        assertFails(IAE, webSocket.sendClose(1009, "a reason"));
-        assertFails(IAE, webSocket.sendClose(1010, "a reason"));
-        assertFails(IAE, webSocket.sendClose(1012, "a reason"));
-        assertFails(IAE, webSocket.sendClose(1013, "a reason"));
-        assertFails(IAE, webSocket.sendClose(1015, "a reason"));
-        assertFails(IAE, webSocket.sendClose(5000, "a reason"));
-        assertFails(IAE, webSocket.sendClose(32768, "a reason"));
-        assertFails(IAE, webSocket.sendClose(65535, "a reason"));
-        assertFails(IAE, webSocket.sendClose(65536, "a reason"));
-        assertFails(IAE, webSocket.sendClose(Integer.MAX_VALUE, "a reason"));
-        assertFails(IAE, webSocket.sendClose(Integer.MIN_VALUE, "a reason"));
+                assertThrows(IAE, () -> webSocket.request(Integer.MIN_VALUE));
+                assertThrows(IAE, () -> webSocket.request(Long.MIN_VALUE));
+                assertThrows(IAE, () -> webSocket.request(-1));
+                assertThrows(IAE, () -> webSocket.request(0));
 
-        assertThrows(IAE, () -> webSocket.request(Integer.MIN_VALUE));
-        assertThrows(IAE, () -> webSocket.request(Long.MIN_VALUE));
-        assertThrows(IAE, () -> webSocket.request(-1));
-        assertThrows(IAE, () -> webSocket.request(0));
-
-        server.close();
+            } finally {
+                webSocket.abort();
+            }
+        }
     }
 
     @Test
     public void partialBinaryThenText() throws IOException {
-        server = new DummyWebSocketServer();
-        server.open();
-        webSocket = newBuilder().proxy(NO_PROXY).build().newWebSocketBuilder()
-                .buildAsync(server.getURI(), new WebSocket.Listener() { })
-                .join();
-        webSocket.sendBinary(ByteBuffer.allocate(16), false).join();
-        assertFails(ISE, webSocket.sendText("text", false));
-        assertFails(ISE, webSocket.sendText("text", true));
-        // Pings & Pongs are fine
-        webSocket.sendPing(ByteBuffer.allocate(125)).join();
-        webSocket.sendPong(ByteBuffer.allocate(125)).join();
-        server.close();
+        try (var server = new DummyWebSocketServer()) {
+            server.open();
+            var webSocket = newBuilder().proxy(NO_PROXY).build().newWebSocketBuilder()
+                    .buildAsync(server.getURI(), new WebSocket.Listener() { })
+                    .join();
+            try {
+                webSocket.sendBinary(ByteBuffer.allocate(16), false).join();
+                assertFails(ISE, webSocket.sendText("text", false));
+                assertFails(ISE, webSocket.sendText("text", true));
+                // Pings & Pongs are fine
+                webSocket.sendPing(ByteBuffer.allocate(125)).join();
+                webSocket.sendPong(ByteBuffer.allocate(125)).join();
+            } finally {
+                webSocket.abort();
+            }
+        }
     }
 
     @Test
     public void partialTextThenBinary() throws IOException {
-        server = new DummyWebSocketServer();
-        server.open();
-        webSocket = newBuilder().proxy(NO_PROXY).build().newWebSocketBuilder()
-                .buildAsync(server.getURI(), new WebSocket.Listener() { })
-                .join();
-
-        webSocket.sendText("text", false).join();
-        assertFails(ISE, webSocket.sendBinary(ByteBuffer.allocate(16), false));
-        assertFails(ISE, webSocket.sendBinary(ByteBuffer.allocate(16), true));
-        // Pings & Pongs are fine
-        webSocket.sendPing(ByteBuffer.allocate(125)).join();
-        webSocket.sendPong(ByteBuffer.allocate(125)).join();
-        server.close();
+        try (var server = new DummyWebSocketServer()) {
+            server.open();
+            var webSocket = newBuilder().proxy(NO_PROXY).build().newWebSocketBuilder()
+                    .buildAsync(server.getURI(), new WebSocket.Listener() { })
+                    .join();
+            try {
+                webSocket.sendText("text", false).join();
+                assertFails(ISE, webSocket.sendBinary(ByteBuffer.allocate(16), false));
+                assertFails(ISE, webSocket.sendBinary(ByteBuffer.allocate(16), true));
+                // Pings & Pongs are fine
+                webSocket.sendPing(ByteBuffer.allocate(125)).join();
+                webSocket.sendPong(ByteBuffer.allocate(125)).join();
+            } finally {
+                webSocket.abort();
+            }
+        }
     }
 
     @Test
     public void sendMethodsThrowIOE1() throws IOException {
-        server = new DummyWebSocketServer();
-        server.open();
-        webSocket = newBuilder().proxy(NO_PROXY).build()
-                .newWebSocketBuilder()
-                .buildAsync(server.getURI(), new WebSocket.Listener() { })
-                .join();
+        try (var server = new DummyWebSocketServer()) {
+            server.open();
+            var webSocket = newBuilder().proxy(NO_PROXY).build()
+                    .newWebSocketBuilder()
+                    .buildAsync(server.getURI(), new WebSocket.Listener() { })
+                    .join();
+            try {
+                webSocket.sendClose(NORMAL_CLOSURE, "ok").join();
 
-        webSocket.sendClose(NORMAL_CLOSURE, "ok").join();
+                assertFails(IOE, webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok"));
 
-        assertFails(IOE, webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok"));
+                assertFails(IOE, webSocket.sendText("", true));
+                assertFails(IOE, webSocket.sendText("", false));
+                assertFails(IOE, webSocket.sendText("abc", true));
+                assertFails(IOE, webSocket.sendText("abc", false));
+                assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(0), true));
+                assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(0), false));
+                assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(1), true));
+                assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(1), false));
 
-        assertFails(IOE, webSocket.sendText("", true));
-        assertFails(IOE, webSocket.sendText("", false));
-        assertFails(IOE, webSocket.sendText("abc", true));
-        assertFails(IOE, webSocket.sendText("abc", false));
-        assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(0), true));
-        assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(0), false));
-        assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(1), true));
-        assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(1), false));
+                assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(125)));
+                assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(124)));
+                assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(1)));
+                assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(0)));
 
-        assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(125)));
-        assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(124)));
-        assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(1)));
-        assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(0)));
-
-        assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(125)));
-        assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(124)));
-        assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(1)));
-        assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(0)));
-
-        server.close();
+                assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(125)));
+                assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(124)));
+                assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(1)));
+                assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(0)));
+            } finally {
+                webSocket.abort();
+            }
+        }
     }
 
     @DataProvider(name = "sequence")
@@ -251,150 +250,153 @@ public class WebSocketTest {
     public void listenerSequentialOrder(int[] binary, long requestSize)
             throws IOException
     {
+        try (var server = Support.serverWithCannedData(binary)) {
+            server.open();
 
-        server = Support.serverWithCannedData(binary);
-        server.open();
+            CompletableFuture<Void> violation = new CompletableFuture<>();
 
-        CompletableFuture<Void> violation = new CompletableFuture<>();
+            MockListener listener = new MockListener(requestSize) {
 
-        MockListener listener = new MockListener(requestSize) {
+                final AtomicBoolean guard = new AtomicBoolean();
 
-            final AtomicBoolean guard = new AtomicBoolean();
-
-            private <T> T checkRunExclusively(Supplier<T> action) {
-                if (guard.getAndSet(true)) {
-                    violation.completeExceptionally(new RuntimeException());
-                }
-                try {
-                    return action.get();
-                } finally {
-                    if (!guard.getAndSet(false)) {
+                private <T> T checkRunExclusively(Supplier<T> action) {
+                    if (guard.getAndSet(true)) {
                         violation.completeExceptionally(new RuntimeException());
                     }
+                    try {
+                        return action.get();
+                    } finally {
+                        if (!guard.getAndSet(false)) {
+                            violation.completeExceptionally(new RuntimeException());
+                        }
+                    }
                 }
+
+                @Override
+                public void onOpen(WebSocket webSocket) {
+                    checkRunExclusively(() -> {
+                        super.onOpen(webSocket);
+                        return null;
+                    });
+                }
+
+                @Override
+                public CompletionStage<?> onText(WebSocket webSocket,
+                                                 CharSequence data,
+                                                 boolean last) {
+                    return checkRunExclusively(
+                            () -> super.onText(webSocket, data, last));
+                }
+
+                @Override
+                public CompletionStage<?> onBinary(WebSocket webSocket,
+                                                   ByteBuffer data,
+                                                   boolean last) {
+                    return checkRunExclusively(
+                            () -> super.onBinary(webSocket, data, last));
+                }
+
+                @Override
+                public CompletionStage<?> onPing(WebSocket webSocket,
+                                                 ByteBuffer message) {
+                    return checkRunExclusively(
+                            () -> super.onPing(webSocket, message));
+                }
+
+                @Override
+                public CompletionStage<?> onPong(WebSocket webSocket,
+                                                 ByteBuffer message) {
+                    return checkRunExclusively(
+                            () -> super.onPong(webSocket, message));
+                }
+
+                @Override
+                public CompletionStage<?> onClose(WebSocket webSocket,
+                                                  int statusCode,
+                                                  String reason) {
+                    return checkRunExclusively(
+                            () -> super.onClose(webSocket, statusCode, reason));
+                }
+
+                @Override
+                public void onError(WebSocket webSocket, Throwable error) {
+                    checkRunExclusively(() -> {
+                        super.onError(webSocket, error);
+                        return null;
+                    });
+                }
+            };
+
+            var webSocket = newBuilder().proxy(NO_PROXY).build().newWebSocketBuilder()
+                    .buildAsync(server.getURI(), listener)
+                    .join();
+            try {
+                listener.invocations();
+                violation.complete(null); // won't affect if completed exceptionally
+                violation.join();
+            } finally {
+                webSocket.abort();
             }
-
-            @Override
-            public void onOpen(WebSocket webSocket) {
-                checkRunExclusively(() -> {
-                    super.onOpen(webSocket);
-                    return null;
-                });
-            }
-
-            @Override
-            public CompletionStage<?> onText(WebSocket webSocket,
-                                             CharSequence data,
-                                             boolean last) {
-                return checkRunExclusively(
-                        () -> super.onText(webSocket, data, last));
-            }
-
-            @Override
-            public CompletionStage<?> onBinary(WebSocket webSocket,
-                                               ByteBuffer data,
-                                               boolean last) {
-                return checkRunExclusively(
-                        () -> super.onBinary(webSocket, data, last));
-            }
-
-            @Override
-            public CompletionStage<?> onPing(WebSocket webSocket,
-                                             ByteBuffer message) {
-                return checkRunExclusively(
-                        () -> super.onPing(webSocket, message));
-            }
-
-            @Override
-            public CompletionStage<?> onPong(WebSocket webSocket,
-                                             ByteBuffer message) {
-                return checkRunExclusively(
-                        () -> super.onPong(webSocket, message));
-            }
-
-            @Override
-            public CompletionStage<?> onClose(WebSocket webSocket,
-                                              int statusCode,
-                                              String reason) {
-                return checkRunExclusively(
-                        () -> super.onClose(webSocket, statusCode, reason));
-            }
-
-            @Override
-            public void onError(WebSocket webSocket, Throwable error) {
-                checkRunExclusively(() -> {
-                    super.onError(webSocket, error);
-                    return null;
-                });
-            }
-        };
-
-        webSocket = newBuilder().proxy(NO_PROXY).build().newWebSocketBuilder()
-                .buildAsync(server.getURI(), listener)
-                .join();
-
-
-        listener.invocations();
-        violation.complete(null); // won't affect if completed exceptionally
-        violation.join();
-
-        server.close();
+        }
     }
 
     @Test
     public void sendMethodsThrowIOE2() throws Exception {
-        server = Support.serverWithCannedData(0x88, 0x00);
-        server.open();
-        CompletableFuture<Void> onCloseCalled = new CompletableFuture<>();
-        CompletableFuture<Void> canClose = new CompletableFuture<>();
+        try (var server = Support.serverWithCannedData(0x88, 0x00)) {
+            server.open();
 
-        WebSocket.Listener listener = new WebSocket.Listener() {
-            @Override
-            public CompletionStage<?> onClose(WebSocket webSocket,
-                                              int statusCode,
-                                              String reason) {
-                System.out.printf("onClose(%s, '%s')%n", statusCode, reason);
-                onCloseCalled.complete(null);
-                return canClose;
+            CompletableFuture<Void> onCloseCalled = new CompletableFuture<>();
+            CompletableFuture<Void> canClose = new CompletableFuture<>();
+
+            WebSocket.Listener listener = new WebSocket.Listener() {
+                @Override
+                public CompletionStage<?> onClose(WebSocket webSocket,
+                                                  int statusCode,
+                                                  String reason) {
+                    System.out.printf("onClose(%s, '%s')%n", statusCode, reason);
+                    onCloseCalled.complete(null);
+                    return canClose;
+                }
+
+                @Override
+                public void onError(WebSocket webSocket, Throwable error) {
+                    System.out.println("onError(" + error + ")");
+                    onCloseCalled.completeExceptionally(error);
+                }
+            };
+
+            var webSocket = newBuilder().proxy(NO_PROXY).build().newWebSocketBuilder()
+                    .buildAsync(server.getURI(), listener)
+                    .join();
+            try {
+                onCloseCalled.join();      // Wait for onClose to be called
+                canClose.complete(null);   // Signal to the WebSocket it can close the output
+                TimeUnit.SECONDS.sleep(5); // Give canClose some time to reach the WebSocket
+
+                assertFails(IOE, webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok"));
+
+                assertFails(IOE, webSocket.sendText("", true));
+                assertFails(IOE, webSocket.sendText("", false));
+                assertFails(IOE, webSocket.sendText("abc", true));
+                assertFails(IOE, webSocket.sendText("abc", false));
+                assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(0), true));
+                assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(0), false));
+                assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(1), true));
+                assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(1), false));
+
+                assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(125)));
+                assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(124)));
+                assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(1)));
+                assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(0)));
+
+                assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(125)));
+                assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(124)));
+                assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(1)));
+                assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(0)));
+            } finally {
+                webSocket.abort();
             }
-
-            @Override
-            public void onError(WebSocket webSocket, Throwable error) {
-                System.out.println("onError(" + error + ")");
-                onCloseCalled.completeExceptionally(error);
-            }
-        };
-
-        webSocket = newBuilder().proxy(NO_PROXY).build().newWebSocketBuilder()
-                .buildAsync(server.getURI(), listener)
-                .join();
-
-        onCloseCalled.join();      // Wait for onClose to be called
-        canClose.complete(null);   // Signal to the WebSocket it can close the output
-        TimeUnit.SECONDS.sleep(5); // Give canClose some time to reach the WebSocket
-
-        assertFails(IOE, webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "ok"));
-
-        assertFails(IOE, webSocket.sendText("", true));
-        assertFails(IOE, webSocket.sendText("", false));
-        assertFails(IOE, webSocket.sendText("abc", true));
-        assertFails(IOE, webSocket.sendText("abc", false));
-        assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(0), true));
-        assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(0), false));
-        assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(1), true));
-        assertFails(IOE, webSocket.sendBinary(ByteBuffer.allocate(1), false));
-
-        assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(125)));
-        assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(124)));
-        assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(1)));
-        assertFails(IOE, webSocket.sendPing(ByteBuffer.allocate(0)));
-
-        assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(125)));
-        assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(124)));
-        assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(1)));
-        assertFails(IOE, webSocket.sendPong(ByteBuffer.allocate(0)));
-
-        server.close();
+        }
     }
 
     // Used to verify a server requiring Authentication
@@ -458,74 +460,76 @@ public class WebSocketTest {
         };
         CompletableFuture<List<byte[]>> actual = new CompletableFuture<>();
 
-        server = serverSupplier.apply(binary);
-        server.open();
+        try (var server = serverSupplier.apply(binary)) {
+            server.open();
 
-        WebSocket.Listener listener = new WebSocket.Listener() {
+            WebSocket.Listener listener = new WebSocket.Listener() {
 
-            List<byte[]> collectedBytes = new ArrayList<>();
-            ByteBuffer buffer = ByteBuffer.allocate(1024);
+                List<byte[]> collectedBytes = new ArrayList<>();
+                ByteBuffer buffer = ByteBuffer.allocate(1024);
 
-            @Override
-            public CompletionStage<?> onBinary(WebSocket webSocket,
-                                               ByteBuffer message,
-                                               boolean last) {
-                System.out.printf("onBinary(%s, %s)%n", message, last);
-                webSocket.request(1);
+                @Override
+                public CompletionStage<?> onBinary(WebSocket webSocket,
+                                                   ByteBuffer message,
+                                                   boolean last) {
+                    System.out.printf("onBinary(%s, %s)%n", message, last);
+                    webSocket.request(1);
 
-                append(message);
-                if (last) {
-                    buffer.flip();
-                    byte[] bytes = new byte[buffer.remaining()];
-                    buffer.get(bytes);
-                    buffer.clear();
-                    processWholeBinary(bytes);
+                    append(message);
+                    if (last) {
+                        buffer.flip();
+                        byte[] bytes = new byte[buffer.remaining()];
+                        buffer.get(bytes);
+                        buffer.clear();
+                        processWholeBinary(bytes);
+                    }
+                    return null;
                 }
-                return null;
-            }
 
-            private void append(ByteBuffer message) {
-                if (buffer.remaining() < message.remaining()) {
-                    assert message.remaining() > 0;
-                    int cap = (buffer.capacity() + message.remaining()) * 2;
-                    ByteBuffer b = ByteBuffer.allocate(cap);
-                    b.put(buffer.flip());
-                    buffer = b;
+                private void append(ByteBuffer message) {
+                    if (buffer.remaining() < message.remaining()) {
+                        assert message.remaining() > 0;
+                        int cap = (buffer.capacity() + message.remaining()) * 2;
+                        ByteBuffer b = ByteBuffer.allocate(cap);
+                        b.put(buffer.flip());
+                        buffer = b;
+                    }
+                    buffer.put(message);
                 }
-                buffer.put(message);
+
+                private void processWholeBinary(byte[] bytes) {
+                    String stringBytes = new String(bytes, UTF_8);
+                    System.out.println("processWholeBinary: " + stringBytes);
+                    collectedBytes.add(bytes);
+                }
+
+                @Override
+                public CompletionStage<?> onClose(WebSocket webSocket,
+                                                  int statusCode,
+                                                  String reason) {
+                    actual.complete(collectedBytes);
+                    return null;
+                }
+
+                @Override
+                public void onError(WebSocket webSocket, Throwable error) {
+                    actual.completeExceptionally(error);
+                }
+            };
+
+            var webSocket = newBuilder()
+                    .proxy(NO_PROXY)
+                    .authenticator(new WSAuthenticator())
+                    .build().newWebSocketBuilder()
+                    .buildAsync(server.getURI(), listener)
+                    .join();
+            try {
+                List<byte[]> a = actual.join();
+                assertEquals(a, expected);
+            } finally {
+                webSocket.abort();
             }
-
-            private void processWholeBinary(byte[] bytes) {
-                String stringBytes = new String(bytes, UTF_8);
-                System.out.println("processWholeBinary: " + stringBytes);
-                collectedBytes.add(bytes);
-            }
-
-            @Override
-            public CompletionStage<?> onClose(WebSocket webSocket,
-                                              int statusCode,
-                                              String reason) {
-                actual.complete(collectedBytes);
-                return null;
-            }
-
-            @Override
-            public void onError(WebSocket webSocket, Throwable error) {
-                actual.completeExceptionally(error);
-            }
-        };
-
-        webSocket = newBuilder()
-                .proxy(NO_PROXY)
-                .authenticator(new WSAuthenticator())
-                .build().newWebSocketBuilder()
-                .buildAsync(server.getURI(), listener)
-                .join();
-
-        List<byte[]> a = actual.join();
-        assertEquals(a, expected);
-
-        server.close();
+        }
     }
 
     @Test(dataProvider = "servers")
@@ -554,59 +558,61 @@ public class WebSocketTest {
         };
         CompletableFuture<List<String>> actual = new CompletableFuture<>();
 
-        server = serverSupplier.apply(binary);
-        server.open();
+        try (var server = serverSupplier.apply(binary)) {
+            server.open();
 
-        WebSocket.Listener listener = new WebSocket.Listener() {
+            WebSocket.Listener listener = new WebSocket.Listener() {
 
-            List<String> collectedStrings = new ArrayList<>();
-            StringBuilder text = new StringBuilder();
+                List<String> collectedStrings = new ArrayList<>();
+                StringBuilder text = new StringBuilder();
 
-            @Override
-            public CompletionStage<?> onText(WebSocket webSocket,
-                                             CharSequence message,
-                                             boolean last) {
-                System.out.printf("onText(%s, %s)%n", message, last);
-                webSocket.request(1);
-                text.append(message);
-                if (last) {
-                    String str = text.toString();
-                    text.setLength(0);
-                    processWholeText(str);
+                @Override
+                public CompletionStage<?> onText(WebSocket webSocket,
+                                                 CharSequence message,
+                                                 boolean last) {
+                    System.out.printf("onText(%s, %s)%n", message, last);
+                    webSocket.request(1);
+                    text.append(message);
+                    if (last) {
+                        String str = text.toString();
+                        text.setLength(0);
+                        processWholeText(str);
+                    }
+                    return null;
                 }
-                return null;
+
+                private void processWholeText(String string) {
+                    System.out.println(string);
+                    collectedStrings.add(string);
+                }
+
+                @Override
+                public CompletionStage<?> onClose(WebSocket webSocket,
+                                                  int statusCode,
+                                                  String reason) {
+                    actual.complete(collectedStrings);
+                    return null;
+                }
+
+                @Override
+                public void onError(WebSocket webSocket, Throwable error) {
+                    actual.completeExceptionally(error);
+                }
+            };
+
+            var webSocket = newBuilder()
+                    .proxy(NO_PROXY)
+                    .authenticator(new WSAuthenticator())
+                    .build().newWebSocketBuilder()
+                    .buildAsync(server.getURI(), listener)
+                    .join();
+            try {
+                List<String> a = actual.join();
+                assertEquals(a, expected);
+            } finally {
+                webSocket.abort();
             }
-
-            private void processWholeText(String string) {
-                System.out.println(string);
-                collectedStrings.add(string);
-            }
-
-            @Override
-            public CompletionStage<?> onClose(WebSocket webSocket,
-                                              int statusCode,
-                                              String reason) {
-                actual.complete(collectedStrings);
-                return null;
-            }
-
-            @Override
-            public void onError(WebSocket webSocket, Throwable error) {
-                actual.completeExceptionally(error);
-            }
-        };
-
-        webSocket = newBuilder()
-                .proxy(NO_PROXY)
-                .authenticator(new WSAuthenticator())
-                .build().newWebSocketBuilder()
-                .buildAsync(server.getURI(), listener)
-                .join();
-
-        List<String> a = actual.join();
-        assertEquals(a, expected);
-
-        server.close();
+        }
     }
 
     /*
@@ -639,73 +645,75 @@ public class WebSocketTest {
         };
         CompletableFuture<List<String>> actual = new CompletableFuture<>();
 
-        server = serverSupplier.apply(binary);
-        server.open();
+        try (var server = serverSupplier.apply(binary)) {
+            server.open();
 
-        WebSocket.Listener listener = new WebSocket.Listener() {
+            WebSocket.Listener listener = new WebSocket.Listener() {
 
-            List<CharSequence> parts = new ArrayList<>();
-            /*
-             * A CompletableFuture which will complete once the current
-             * message has been fully assembled. Until then the listener
-             * returns this instance for every call.
-             */
-            CompletableFuture<?> currentCf = new CompletableFuture<>();
-            List<String> collected = new ArrayList<>();
+                List<CharSequence> parts = new ArrayList<>();
+                /*
+                 * A CompletableFuture which will complete once the current
+                 * message has been fully assembled. Until then the listener
+                 * returns this instance for every call.
+                 */
+                CompletableFuture<?> currentCf = new CompletableFuture<>();
+                List<String> collected = new ArrayList<>();
 
-            @Override
-            public CompletionStage<?> onText(WebSocket webSocket,
-                                             CharSequence message,
-                                             boolean last) {
-                parts.add(message);
-                if (!last) {
-                    webSocket.request(1);
-                } else {
-                    this.currentCf.thenRun(() -> webSocket.request(1));
-                    CompletableFuture<?> refCf = this.currentCf;
-                    processWholeMessage(new ArrayList<>(parts), refCf);
-                    currentCf = new CompletableFuture<>();
-                    parts.clear();
-                    return refCf;
+                @Override
+                public CompletionStage<?> onText(WebSocket webSocket,
+                                                 CharSequence message,
+                                                 boolean last) {
+                    parts.add(message);
+                    if (!last) {
+                        webSocket.request(1);
+                    } else {
+                        this.currentCf.thenRun(() -> webSocket.request(1));
+                        CompletableFuture<?> refCf = this.currentCf;
+                        processWholeMessage(new ArrayList<>(parts), refCf);
+                        currentCf = new CompletableFuture<>();
+                        parts.clear();
+                        return refCf;
+                    }
+                    return currentCf;
                 }
-                return currentCf;
+
+                @Override
+                public CompletionStage<?> onClose(WebSocket webSocket,
+                                                  int statusCode,
+                                                  String reason) {
+                    actual.complete(collected);
+                    return null;
+                }
+
+                @Override
+                public void onError(WebSocket webSocket, Throwable error) {
+                    actual.completeExceptionally(error);
+                }
+
+                public void processWholeMessage(List<CharSequence> data,
+                                                CompletableFuture<?> cf) {
+                    StringBuilder b = new StringBuilder();
+                    data.forEach(b::append);
+                    String s = b.toString();
+                    System.out.println(s);
+                    cf.complete(null);
+                    collected.add(s);
+                }
+            };
+
+            var webSocket = newBuilder()
+                    .proxy(NO_PROXY)
+                    .authenticator(new WSAuthenticator())
+                    .build().newWebSocketBuilder()
+                    .buildAsync(server.getURI(), listener)
+                    .join();
+            try {
+                List<String> a = actual.join();
+                assertEquals(a, expected);
+            } finally {
+                webSocket.abort();
             }
-
-            @Override
-            public CompletionStage<?> onClose(WebSocket webSocket,
-                                              int statusCode,
-                                              String reason) {
-                actual.complete(collected);
-                return null;
-            }
-
-            @Override
-            public void onError(WebSocket webSocket, Throwable error) {
-                actual.completeExceptionally(error);
-            }
-
-            public void processWholeMessage(List<CharSequence> data,
-                                            CompletableFuture<?> cf) {
-                StringBuilder b = new StringBuilder();
-                data.forEach(b::append);
-                String s = b.toString();
-                System.out.println(s);
-                cf.complete(null);
-                collected.add(s);
-            }
-        };
-
-        webSocket = newBuilder()
-                .proxy(NO_PROXY)
-                .authenticator(new WSAuthenticator())
-                .build().newWebSocketBuilder()
-                .buildAsync(server.getURI(), listener)
-                .join();
-
-        List<String> a = actual.join();
-        assertEquals(a, expected);
-
-        server.close();
+        }
     }
 
     // -- authentication specific tests
@@ -725,6 +733,7 @@ public class WebSocketTest {
                     .newWebSocketBuilder()
                     .buildAsync(server.getURI(), new WebSocket.Listener() { })
                     .join();
+            webSocket.abort();
         }
     }
 
@@ -745,6 +754,7 @@ public class WebSocketTest {
                     .header("Authorization", hv)
                     .buildAsync(server.getURI(), new WebSocket.Listener() { })
                     .join();
+            webSocket.abort();
         }
     }
 
@@ -763,6 +773,7 @@ public class WebSocketTest {
 
             try {
                 var webSocket = cf.join();
+                silentAbort(webSocket);
                 fail("Expected exception not thrown");
             } catch (CompletionException expected) {
                 WebSocketHandshakeException e = (WebSocketHandshakeException)expected.getCause();
@@ -783,7 +794,7 @@ public class WebSocketTest {
 
             Authenticator authenticator = new Authenticator() {
                 @Override protected PasswordAuthentication getPasswordAuthentication() {
-                    return new PasswordAuthentication("BAD"+USERNAME, "".toCharArray());
+                    return new PasswordAuthentication("BAD" + USERNAME, "".toCharArray());
                 }
             };
 
@@ -796,10 +807,16 @@ public class WebSocketTest {
 
             try {
                 var webSocket = cf.join();
+                silentAbort(webSocket);
                 fail("Expected exception not thrown");
             } catch (CompletionException expected) {
                 System.out.println("caught expected exception:" + expected);
             }
         }
+    }
+    private static void silentAbort(WebSocket ws) {
+        try {
+            ws.abort();
+        } catch (Throwable t) { }
     }
 }


### PR DESCRIPTION
Backporting to stabilize the tests and for `11.0.13-oracle` parity. Affected tests still pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8217825](https://bugs.openjdk.java.net/browse/JDK-8217825): Verify @AfterTest is used correctly in WebSocket tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/116.diff">https://git.openjdk.java.net/jdk11u-dev/pull/116.diff</a>

</details>
