### PR TITLE
8270196: [11u] [JVMCI] JavaType.toJavaName() returns incorrect type name for lambdas

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/MetaUtil.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/MetaUtil.java
@@ -64,6 +64,29 @@ public class MetaUtil {
     }
 
     /**
+     * Classes for lambdas can have {@code /} characters that are not package separators. These are
+     * distinguished by being followed by a character that is not a
+     * {@link Character#isJavaIdentifierStart(char)} (e.g.,
+     * "jdk.vm.ci.runtime.test.TypeUniverse$$Lambda$1/869601985").
+     */
+    private static String replacePackageSeparatorsWithDot(String name) {
+        int length = name.length();
+        int i = 0;
+        StringBuilder buf = new StringBuilder(length);
+        while (i < length - 1) {
+            char ch = name.charAt(i);
+            if (ch == '/' && Character.isJavaIdentifierStart(name.charAt(i + 1))) {
+                buf.append('.');
+            } else {
+                buf.append(ch);
+            }
+            i++;
+        }
+        buf.append(name.charAt(length - 1));
+        return buf.toString();
+    }
+
+    /**
      * Converts a type name in internal form to an external form.
      *
      * @param name the internal name to convert
@@ -76,7 +99,7 @@ public class MetaUtil {
     public static String internalNameToJava(String name, boolean qualified, boolean classForNameCompatible) {
         switch (name.charAt(0)) {
             case 'L': {
-                String result = name.substring(1, name.length() - 1).replace('/', '.');
+                String result = replacePackageSeparatorsWithDot(name.substring(1, name.length() - 1));
                 if (!qualified) {
                     final int lastDot = result.lastIndexOf('.');
                     if (lastDot != -1) {
@@ -86,7 +109,7 @@ public class MetaUtil {
                 return result;
             }
             case '[':
-                return classForNameCompatible ? name.replace('/', '.') : internalNameToJava(name.substring(1), qualified, classForNameCompatible) + "[]";
+                return classForNameCompatible ? replacePackageSeparatorsWithDot(name) : internalNameToJava(name.substring(1), qualified, classForNameCompatible) + "[]";
             default:
                 if (name.length() != 1) {
                     throw new IllegalArgumentException("Illegal internal name: " + name);


### PR DESCRIPTION
Please review this partial backport of [JDK-8225810](https://bugs.openjdk.java.net/browse/JDK-8225810) which fixes an issue of returning an incorrect type name for lambda classes. The type name includes a `.` where it should be a `/`. This causes an issue for debuginfo generation in native-image (from Mandrel, which is based on OpenJDK 11u). A regression test for this follows with [JDK-8270184](https://bugs.openjdk.java.net/browse/JDK-8270184).

Backporting the full JVMCI update seems too risky in order to get this simple fix. Thus, the proposal of an OpenJDK 11u specific bug. The change is self-contained to JVMCI.

Testing: test/hotspot/jtreg/compiler/jvmci/ jtreg tests and JVMCI bootstrap test, modified `TestResolvedJavaType.java` from JDK-8270184 (used to fail, now passes).

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270196](https://bugs.openjdk.java.net/browse/JDK-8270196): [11u] [JVMCI] JavaType.toJavaName() returns incorrect type name for lambdas


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/120/head:pull/120` \
`$ git checkout pull/120`

Update a local copy of the PR: \
`$ git checkout pull/120` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 120`

View PR using the GUI difftool: \
`$ git pr show -t 120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/120.diff">https://git.openjdk.java.net/jdk11u-dev/pull/120.diff</a>

</details>
