### PR TITLE
8270306: [TESTBUG] Add smoke test for JVMCI bootstrapping

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/TestBootstrapJVMCIOption.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestBootstrapJVMCIOption.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test TestBootstrapJVMCIOption
+ * @bug 8226533
+ * @summary Ensure that -XX:+BootstrapJVMCI does not trigger an assertion
+ * @requires vm.jvmci
+ * @library /test/lib
+ * @run driver TestBootstrapJVMCIOption
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestBootstrapJVMCIOption {
+    public static void main(String[] args) throws Exception {
+        final ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+UnlockExperimentalVMOptions",
+                "-XX:+EnableJVMCI",
+                "-XX:+UseJVMCICompiler",
+                "-XX:+BootstrapJVMCI",
+                "-XX:+PrintBootstrap",
+                "--version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldContain("Bootstrapping JVMCI");
+        output.shouldContain("methods)");
+        output.shouldHaveExitValue(0);
+    }
+}


### PR DESCRIPTION
Test fails with the undermentioned when fix for 8226533 is reverted (ed48e5cb).

```
----------System.err:(67/7089)----------
 stdout: [Bootstrapping JVMCI.Thread[JVMCI CompilerThread0,9,system]: Compilation of org.graalvm.compiler.phases.common.util.HashSetNodeEventListener.changed(Graph$NodeEvent, Node) failed: org.graalvm.compiler.graph.GraalGraphError: java.lang.InternalError: Effectively static method org.graalvm.compiler.graph.Node.int org.graalvm.compiler.graph.Node.hashCode() should be handled in Java code
    at node: 113|LoadMethod
    at exact jdk.internal.vm.compiler.collections.EconomicMapImpl.getHashIndex(Object):int
    ...
```

The test passes with the fix in place.

The test requires JVMCI implementation compiler to be present,
i.e. it makes sense only in versions before https://openjdk.java.net/jeps/410.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issues
 * [JDK-8270306](https://bugs.openjdk.java.net/browse/JDK-8270306): [TESTBUG] Add smoke test for JVMCI bootstrapping
 * [JDK-8270306](https://bugs.openjdk.java.net/browse/JDK-8270306): [TESTBUG] Add smoke test for JVMCI bootstrapping


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/122/head:pull/122` \
`$ git checkout pull/122`

Update a local copy of the PR: \
`$ git checkout pull/122` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 122`

View PR using the GUI difftool: \
`$ git pr show -t 122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/122.diff">https://git.openjdk.java.net/jdk11u-dev/pull/122.diff</a>

</details>
