### PR TITLE
8267666: Add option to jcmd GC.heap_dump to use existing file

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -3789,9 +3789,7 @@ int os::open(const char *path, int oflag, int mode) {
 // create binary file, rewriting existing file if required
 int os::create_binary_file(const char* path, bool rewrite_existing) {
   int oflags = O_WRONLY | O_CREAT;
-  if (!rewrite_existing) {
-    oflags |= O_EXCL;
-  }
+  oflags |= rewrite_existing ? O_TRUNC : O_EXCL;
   return ::open64(path, oflags, S_IREAD | S_IWRITE);
 }
 

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -3628,9 +3628,7 @@ int os::open(const char *path, int oflag, int mode) {
 // create binary file, rewriting existing file if required
 int os::create_binary_file(const char* path, bool rewrite_existing) {
   int oflags = O_WRONLY | O_CREAT;
-  if (!rewrite_existing) {
-    oflags |= O_EXCL;
-  }
+  oflags |= rewrite_existing ? O_TRUNC : O_EXCL;
   return ::open(path, oflags, S_IREAD | S_IWRITE);
 }
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -5743,9 +5743,7 @@ int os::open(const char *path, int oflag, int mode) {
 // create binary file, rewriting existing file if required
 int os::create_binary_file(const char* path, bool rewrite_existing) {
   int oflags = O_WRONLY | O_CREAT;
-  if (!rewrite_existing) {
-    oflags |= O_EXCL;
-  }
+  oflags |= rewrite_existing ? O_TRUNC : O_EXCL;
   return ::open64(path, oflags, S_IREAD | S_IWRITE);
 }
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4600,9 +4600,7 @@ bool os::dir_is_empty(const char* path) {
 // create binary file, rewriting existing file if required
 int os::create_binary_file(const char* path, bool rewrite_existing) {
   int oflags = _O_CREAT | _O_WRONLY | _O_BINARY;
-  if (!rewrite_existing) {
-    oflags |= _O_EXCL;
-  }
+  oflags |= rewrite_existing ? _O_TRUNC : _O_EXCL;
   return ::open(path, oflags, _S_IREAD | _S_IWRITE);
 }
 

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -506,9 +506,12 @@ HeapDumpDCmd::HeapDumpDCmd(outputStream* output, bool heap) :
                            DCmdWithParser(output, heap),
   _filename("filename","Name of the dump file", "STRING",true),
   _all("-all", "Dump all objects, including unreachable objects",
-       "BOOLEAN", false, "false") {
+       "BOOLEAN", false, "false"),
+  _overwrite("-overwrite", "If specified, the dump file will be overwritten if it exists",
+           "BOOLEAN", false, "false") {
   _dcmdparser.add_dcmd_option(&_all);
   _dcmdparser.add_dcmd_argument(&_filename);
+  _dcmdparser.add_dcmd_option(&_overwrite);
 }
 
 void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
@@ -516,7 +519,7 @@ void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
   // This helps reduces the amount of unreachable objects in the dump
   // and makes it easier to browse.
   HeapDumper dumper(!_all.value() /* request GC if _all is false*/);
-  int res = dumper.dump(_filename.value());
+  int res = dumper.dump(_filename.value(), _overwrite.value());
   if (res == 0) {
     output()->print_cr("Heap dump file created");
   } else {

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -331,6 +331,7 @@ class HeapDumpDCmd : public DCmdWithParser {
 protected:
   DCmdArgument<char*> _filename;
   DCmdArgument<bool>  _all;
+  DCmdArgument<bool> _overwrite;
 public:
   HeapDumpDCmd(outputStream* output, bool heap);
   static const char* name() {

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -406,7 +406,7 @@ class DumpWriter : public StackObj {
   void write_internal(void* s, size_t len);
 
  public:
-  DumpWriter(const char* path);
+  DumpWriter(const char* path, bool overwrite);
   ~DumpWriter();
 
   void close();
@@ -444,7 +444,7 @@ class DumpWriter : public StackObj {
   void write_id(u4 x);
 };
 
-DumpWriter::DumpWriter(const char* path) {
+DumpWriter::DumpWriter(const char* path, bool overwrite) {
   // try to allocate an I/O buffer of io_buffer_size. If there isn't
   // sufficient memory then reduce size until we can allocate something.
   _size = io_buffer_size;
@@ -459,7 +459,7 @@ DumpWriter::DumpWriter(const char* path) {
   _error = NULL;
   _bytes_written = 0L;
   _dump_start = (jlong)-1;
-  _fd = os::create_binary_file(path, false);    // don't replace existing file
+  _fd = os::create_binary_file(path, overwrite);
 
   // if the open failed we record the error
   if (_fd < 0) {
@@ -1935,7 +1935,7 @@ void VM_HeapDumper::dump_stack_traces() {
 }
 
 // dump the heap to given path.
-int HeapDumper::dump(const char* path) {
+int HeapDumper::dump(const char* path, bool overwrite) {
   assert(path != NULL && strlen(path) > 0, "path missing");
 
   // print message in interactive case
@@ -1945,7 +1945,7 @@ int HeapDumper::dump(const char* path) {
   }
 
   // create the dump writer. If the file can be opened then bail
-  DumpWriter writer(path);
+  DumpWriter writer(path, overwrite);
   if (!writer.is_open()) {
     set_error(writer.error());
     if (print_to_tty()) {

--- a/src/hotspot/share/services/heapDumper.hpp
+++ b/src/hotspot/share/services/heapDumper.hpp
@@ -71,7 +71,7 @@ class HeapDumper : public StackObj {
   ~HeapDumper();
 
   // dumps the heap to the specified file, returns 0 if success.
-  int dump(const char* path);
+  int dump(const char* path, bool overwrite = false);
 
   // returns error message (resource allocated), or NULL if no error
   char* error_as_C_string() const;

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpTest.java
@@ -50,13 +50,15 @@ import jdk.test.lib.dcmd.PidJcmdExecutor;
 public class HeapDumpTest {
     protected String heapDumpArgs = "";
 
-    public void run(CommandExecutor executor) throws IOException {
+    public void run(CommandExecutor executor, boolean overwrite) throws IOException {
         File dump = new File("jcmd.gc.heap_dump." + System.currentTimeMillis() + ".hprof");
-        if (dump.exists()) {
+        if (!overwrite && dump.exists()) {
             dump.delete();
+        } else if (overwrite) {
+            dump.createNewFile();
         }
 
-        String cmd = "GC.heap_dump " + heapDumpArgs + " " + dump.getAbsolutePath();
+        String cmd = "GC.heap_dump " + (overwrite ? "-overwrite " : "") + heapDumpArgs + " " + dump.getAbsolutePath();
         executor.execute(cmd);
 
         verifyHeapDump(dump);
@@ -85,7 +87,12 @@ public class HeapDumpTest {
     /* GC.heap_dump is not available over JMX, running jcmd pid executor instead */
     @Test
     public void pid() throws IOException {
-        run(new PidJcmdExecutor());
+        run(new PidJcmdExecutor(), false);
+    }
+
+    @Test
+    public void pidRewrite() throws IOException {
+        run(new PidJcmdExecutor(), true);
     }
 }
 


### PR DESCRIPTION
Backport of the heap dump enhancement. CSR includes update releases.

Patch did not apply cleanly, I had to resolve/modify
src/hotspot/share/services/diagnosticCommand.cpp
src/hotspot/share/services/diagnosticCommand.hpp
src/hotspot/share/services/heapDumper.cpp
src/hotspot/share/services/heapDumper.hpp

Following files do not exist in 11u:
src/hotspot/share/services/heapDumperCompression.cpp
src/hotspot/share/services/heapDumperCompression.hpp
Changes had been made in heapDumper.cpp/heapDumper.hpp

I have built it on linuxx86_64 and verified that the modified test succeeds. Will also run it through SAP's test suite before merging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267666](https://bugs.openjdk.java.net/browse/JDK-8267666): Add option to jcmd GC.heap_dump to use existing file


### Reviewers
 * [Ralf Schmelter](https://openjdk.java.net/census#rschmelter) (@schmelter-sap - no project role)
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/131/head:pull/131` \
`$ git checkout pull/131`

Update a local copy of the PR: \
`$ git checkout pull/131` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 131`

View PR using the GUI difftool: \
`$ git pr show -t 131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/131.diff">https://git.openjdk.java.net/jdk11u-dev/pull/131.diff</a>

</details>
