### PR TITLE
8269668: [aarch64] java.library.path not including /usr/lib64

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -414,7 +414,14 @@ void os::init_system_properties_values() {
 #if defined(AMD64) || (defined(_LP64) && defined(SPARC)) || defined(PPC64) || defined(S390)
   #define DEFAULT_LIBPATH "/usr/lib64:/lib64:/lib:/usr/lib"
 #else
+#if defined(AARCH64)
+  // Use 32-bit locations first for AARCH64 (a 64-bit architecture), since some systems
+  // might not adhere to the FHS and it would be a change in behaviour if we used
+  // DEFAULT_LIBPATH of other 64-bit architectures which prefer the 64-bit paths.
+  #define DEFAULT_LIBPATH "/lib:/usr/lib:/usr/lib64:/lib64"
+#else
   #define DEFAULT_LIBPATH "/lib:/usr/lib"
+#endif // AARCH64
 #endif
 
 // Base path of extensions installed on the system.


### PR DESCRIPTION
Here is a conservative backport of JDK-8269668. The JDK 17 patch was not uses as this would mean a change in behaviour for existing JDK 11u users. Instead, a more conservative patch has been chosen to only add 64-bit paths later in the lookup-chain. I believe this is the best we can do in terms of compatibility with also fixing the bug. Thoughts?

Testing: Builds on aarch64 and inspecting `java -XshowSettings:properties -version` output. Manual test with a reproducer I had. tier1 on Linux x86_64.

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269668](https://bugs.openjdk.java.net/browse/JDK-8269668): [aarch64] java.library.path not including /usr/lib64


### Reviewers
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/133/head:pull/133` \
`$ git checkout pull/133`

Update a local copy of the PR: \
`$ git checkout pull/133` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 133`

View PR using the GUI difftool: \
`$ git pr show -t 133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/133.diff">https://git.openjdk.java.net/jdk11u-dev/pull/133.diff</a>

</details>
