### PR TITLE
8267459: Pasting Unicode characters into JShell does not work.

### DIFF
--- a/test/langtools/jdk/jshell/PasteAndMeasurementsUITest.java
+++ b/test/langtools/jdk/jshell/PasteAndMeasurementsUITest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8182297 8242919
+ * @bug 8182297 8242919 8267459
  * @summary Verify that pasting multi-line snippets works properly.
  * @library /tools/lib
  * @modules
@@ -87,6 +87,20 @@ public class PasteAndMeasurementsUITest extends UITesting {
                             "int i;" +
                             LineReaderImpl.BRACKETED_PASTE_END);
             waitOutput(out,       "int i;");
+        });
+    }
+
+    public void testBracketedPasteNonAscii() throws Exception {
+        Field cons = System.class.getDeclaredField("cons");
+        cons.setAccessible(true);
+        Constructor console = Console.class.getDeclaredConstructor();
+        console.setAccessible(true);
+        cons.set(null, console.newInstance());
+        doRunTest((inputSink, out) -> {
+            inputSink.write(LineReaderImpl.BRACKETED_PASTE_BEGIN +
+                            "int \u010d;" +
+                            LineReaderImpl.BRACKETED_PASTE_END);
+            waitOutput(out,       "int \uffc4\uff8d;"); //UTF-8 encoding of \u010d
         });
     }
 }

--- a/test/langtools/jdk/jshell/UITesting.java
+++ b/test/langtools/jdk/jshell/UITesting.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Locale;
@@ -97,7 +98,7 @@ public class UITesting {
             }
         });
 
-        Writer inputSink = new OutputStreamWriter(input.createOutput()) {
+        Writer inputSink = new OutputStreamWriter(input.createOutput(), StandardCharsets.UTF_8) {
             @Override
             public void write(String str) throws IOException {
                 super.write(str);


### PR DESCRIPTION
Hello

Original bug:
  https://bugs.openjdk.java.net/browse/JDK-8267459
  https://github.com/openjdk/jdk/commit/de6472c44166e57cd440b7bffcfc876585aca7dd
 
Original patch does not apply cleanly to 11u, because [8267459](https://bugs.openjdk.java.net/browse/JDK-8267459) requires following order
 [8241950](https://bugs.openjdk.java.net/browse/JDK-8241950): JShell could support auto-indent
 [8247932](https://bugs.openjdk.java.net/browse/JDK-8247932): JShell crashes when typing text block
 [8247403](https://bugs.openjdk.java.net/browse/JDK-8247403): JShell: No custom input (e.g. from GUI) possible with JavaShellToolBuilder
 [8267459](https://bugs.openjdk.java.net/browse/JDK-8267459): Pasting Unicode characters into JShell does not work

 [8241950](https://bugs.openjdk.java.net/browse/JDK-8241950) and [8247932](https://bugs.openjdk.java.net/browse/JDK-8247932) are enhancement code including "Text Blocks" which is not supported by JDK11.
 [8247403](https://bugs.openjdk.java.net/browse/JDK-8247403) is ported to 11.0.13-oracle.
But I could not recreate [8247403](https://bugs.openjdk.java.net/browse/JDK-8247403) by myself.
So I'd like to just send backport for  [8267459](https://bugs.openjdk.java.net/browse/JDK-8267459).

I need to change test/langtools/jdk/jshell/UITesting.java.
Because following code was added by  [8247403](https://bugs.openjdk.java.net/browse/JDK-8247403).
```
import java.lang.reflect.Field;
```

Testing: tier1 and tier2 were passed
 
Thanks,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8267459](https://bugs.openjdk.java.net/browse/JDK-8267459): Pasting Unicode characters into JShell does not work.


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/139.diff">https://git.openjdk.java.net/jdk11u-dev/pull/139.diff</a>

</details>
