### PR TITLE
8206083: Make tools/javac/api/T6265137.java robust to JDK version changes

### DIFF
--- a/test/langtools/tools/javac/api/T6265137.java
+++ b/test/langtools/tools/javac/api/T6265137.java
@@ -52,7 +52,9 @@ public class T6265137 {
             String srcdir = System.getProperty("test.src");
             Iterable<? extends JavaFileObject> files =
                 fm.getJavaFileObjectsFromFiles(Arrays.asList(new File(srcdir, "T6265137a.java")));
-            javac.getTask(null, fm, dl, Arrays.asList("-target","11"), null, files).call();
+            javac.getTask(null, fm, dl,
+                          Arrays.asList("-target", Integer.toString(Runtime.version().feature())),
+                          null, files).call();
         }
     }
 }


### PR DESCRIPTION
Please review this backport of https://bugs.openjdk.java.net/browse/JDK-8206083. It needed a simple resolve from jdk version 12 which was what the original was based on to jdk version 11 of jdk11u-dev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8206083](https://bugs.openjdk.java.net/browse/JDK-8206083): Make tools/javac/api/T6265137.java robust to JDK version changes


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/142/head:pull/142` \
`$ git checkout pull/142`

Update a local copy of the PR: \
`$ git checkout pull/142` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 142`

View PR using the GUI difftool: \
`$ git pr show -t 142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/142.diff">https://git.openjdk.java.net/jdk11u-dev/pull/142.diff</a>

</details>
