### PR TITLE
8206350: java/util/Locale/bcp47u/SystemPropertyTests.java failed on Mac 10.13 with zh_CN and zh_TW locales.

### DIFF
--- a/test/jdk/java/util/Locale/bcp47u/SystemPropertyTests.java
+++ b/test/jdk/java/util/Locale/bcp47u/SystemPropertyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import org.testng.annotations.Test;
 public class SystemPropertyTests {
 
     private static String LANGPROP = "-Duser.language=en";
+    private static String SCPTPROP = "-Duser.script=";
     private static String CTRYPROP = "-Duser.country=US";
 
     @DataProvider(name="data")
@@ -88,7 +89,7 @@ public class SystemPropertyTests {
     @Test(dataProvider="data")
     public void runTest(String extprop, String defLoc,
                         String defFmtLoc, String defDspLoc) throws Exception {
-        int exitValue = executeTestJava(LANGPROP, CTRYPROP,
+        int exitValue = executeTestJava(LANGPROP, SCPTPROP, CTRYPROP,
                                     extprop, "DefaultLocaleTest", defLoc, defFmtLoc, defDspLoc)
                             .outputTo(System.out)
                             .errorTo(System.out)


### PR DESCRIPTION
Hi all,

this pull request contains a backport of commit https://bugs.openjdk.java.net/browse/JDK-8206350 from the openjdk/jdk repository for parity with Oracle 11.0.13.

The commit being backported was authored by Naoto Sato on 5 Jul 2018 and was reviewed by Roger Riggs.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8206350](https://bugs.openjdk.java.net/browse/JDK-8206350): java/util/Locale/bcp47u/SystemPropertyTests.java failed on Mac 10.13 with zh_CN and zh_TW locales.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/143/head:pull/143` \
`$ git checkout pull/143`

Update a local copy of the PR: \
`$ git checkout pull/143` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 143`

View PR using the GUI difftool: \
`$ git pr show -t 143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/143.diff">https://git.openjdk.java.net/jdk11u-dev/pull/143.diff</a>

</details>
