### PR TITLE
8236671: NullPointerException in JKS keystore

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
@@ -291,7 +291,7 @@ public final class JceKeyStore extends KeyStoreSpi {
                 }
 
             } catch (Exception e) {
-                throw new KeyStoreException(e.getMessage());
+                throw new KeyStoreException(e.getMessage(), e);
             }
         }
     }

--- a/src/java.base/share/classes/sun/security/provider/JavaKeyStore.java
+++ b/src/java.base/share/classes/sun/security/provider/JavaKeyStore.java
@@ -263,6 +263,9 @@ public abstract class JavaKeyStore extends KeyStoreSpi {
         if (!(key instanceof java.security.PrivateKey)) {
             throw new KeyStoreException("Cannot store non-PrivateKeys");
         }
+        if (password == null) {
+            throw new KeyStoreException("password can't be null");
+        }
         try {
             synchronized(entries) {
                 KeyEntry entry = new KeyEntry();

--- a/test/jdk/java/security/KeyStore/TestKeyStoreBasic.java
+++ b/test/jdk/java/security/KeyStore/TestKeyStoreBasic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import java.util.Base64;
 
 /*
  * @test
- * @bug 8048621 8133090 8167371
+ * @bug 8048621 8133090 8167371 8236671
  * @summary Test basic operations with keystores (jks, jceks, pkcs12)
  * @author Yu-Ching Valerie PENG
  */
@@ -180,6 +180,17 @@ public class TestKeyStoreBasic {
 
         // create an empty key store
         ks.load(null, null);
+
+        // unit test - test with null password
+        try {
+            ks.setKeyEntry(ALIAS_HEAD, privateKey, null,
+                new Certificate[] { cert });
+        } catch (KeyStoreException e) {
+            if (!e.getMessage().contains("password can\'t be null")) {
+                throw new RuntimeException("Unexpected message:" + e.getMessage());
+            }
+            // expected
+        }
 
         // store the secret keys
         for (int j = 0; j < numEntries; j++) {


### PR DESCRIPTION
Clean backport of JDK-8236671 (only Copyright year update didn't apply automatically).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236671](https://bugs.openjdk.java.net/browse/JDK-8236671): NullPointerException in JKS keystore


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/144/head:pull/144` \
`$ git checkout pull/144`

Update a local copy of the PR: \
`$ git checkout pull/144` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 144`

View PR using the GUI difftool: \
`$ git pr show -t 144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/144.diff">https://git.openjdk.java.net/jdk11u-dev/pull/144.diff</a>

</details>
