### PR TITLE
8225690: Multiple AttachListener threads can be created

### DIFF
--- a/src/hotspot/os/linux/attachListener_linux.cpp
+++ b/src/hotspot/os/linux/attachListener_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,17 +69,7 @@ class LinuxAttachListener: AllStatic {
   // the file descriptor for the listening socket
   static int _listener;
 
-  static void set_path(char* path) {
-    if (path == NULL) {
-      _has_path = false;
-    } else {
-      strncpy(_path, path, UNIX_PATH_MAX);
-      _path[UNIX_PATH_MAX-1] = '\0';
-      _has_path = true;
-    }
-  }
-
-  static void set_listener(int s)               { _listener = s; }
+  static bool _atexit_registered;
 
   // reads a request from the given connected socket
   static LinuxAttachOperation* read_request(int s);
@@ -91,6 +81,19 @@ class LinuxAttachListener: AllStatic {
   enum {
     ATTACH_ERROR_BADVERSION     = 101           // error codes
   };
+
+  static void set_path(char* path) {
+    if (path == NULL) {
+      _path[0] = '\0';
+      _has_path = false;
+    } else {
+      strncpy(_path, path, UNIX_PATH_MAX);
+      _path[UNIX_PATH_MAX-1] = '\0';
+      _has_path = true;
+    }
+  }
+
+  static void set_listener(int s)               { _listener = s; }
 
   // initialize the listener, returns 0 if okay
   static int init();
@@ -125,6 +128,7 @@ class LinuxAttachOperation: public AttachOperation {
 char LinuxAttachListener::_path[UNIX_PATH_MAX];
 bool LinuxAttachListener::_has_path;
 int LinuxAttachListener::_listener = -1;
+bool LinuxAttachListener::_atexit_registered = false;
 
 // Supporting class to help split a buffer into individual components
 class ArgumentIterator : public StackObj {
@@ -159,16 +163,15 @@ class ArgumentIterator : public StackObj {
 // bound too.
 extern "C" {
   static void listener_cleanup() {
-    static int cleanup_done;
-    if (!cleanup_done) {
-      cleanup_done = 1;
-      int s = LinuxAttachListener::listener();
-      if (s != -1) {
-        ::close(s);
-      }
-      if (LinuxAttachListener::has_path()) {
-        ::unlink(LinuxAttachListener::path());
-      }
+    int s = LinuxAttachListener::listener();
+    if (s != -1) {
+      LinuxAttachListener::set_listener(-1);
+      ::shutdown(s, SHUT_RDWR);
+      ::close(s);
+    }
+    if (LinuxAttachListener::has_path()) {
+      ::unlink(LinuxAttachListener::path());
+      LinuxAttachListener::set_path(NULL);
     }
   }
 }
@@ -181,7 +184,10 @@ int LinuxAttachListener::init() {
   int listener;                      // listener socket (file descriptor)
 
   // register function to cleanup
-  ::atexit(listener_cleanup);
+  if (!_atexit_registered) {
+    _atexit_registered = true;
+    ::atexit(listener_cleanup);
+  }
 
   int n = snprintf(path, UNIX_PATH_MAX, "%s/.java_pid%d",
                    os::get_temp_directory(), os::current_process_id());
@@ -483,6 +489,26 @@ int AttachListener::pd_init() {
   thread->check_and_wait_while_suspended();
 
   return ret_code;
+}
+
+bool AttachListener::check_socket_file() {
+  int ret;
+  struct stat64 st;
+  ret = stat64(LinuxAttachListener::path(), &st);
+  if (ret == -1) { // need to restart attach listener.
+    log_debug(attach)("Socket file %s does not exist - Restart Attach Listener",
+                      LinuxAttachListener::path());
+
+    listener_cleanup();
+
+    // wait to terminate current attach listener instance...
+    while (AttachListener::transit_state(AL_INITIALIZING,
+                                         AL_NOT_INITIALIZED) != AL_NOT_INITIALIZED) {
+      os::naked_yield();
+    }
+    return is_init_trigger();
+  }
+  return false;
 }
 
 // Attach Listener is started lazily except in the case when

--- a/src/hotspot/os/solaris/attachListener_solaris.cpp
+++ b/src/hotspot/os/solaris/attachListener_solaris.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,17 +75,7 @@ class SolarisAttachListener: AllStatic {
   // door descriptor returned by door_create
   static int _door_descriptor;
 
-  static void set_door_path(char* path) {
-    if (path == NULL) {
-      _has_door_path = false;
-    } else {
-      strncpy(_door_path, path, PATH_MAX);
-      _door_path[PATH_MAX] = '\0';      // ensure it's nul terminated
-      _has_door_path = true;
-    }
-  }
-
-  static void set_door_descriptor(int dd)               { _door_descriptor = dd; }
+  static bool _atexit_registered;
 
   // mutex to protect operation list
   static mutex_t _mutex;
@@ -120,6 +110,19 @@ class SolarisAttachListener: AllStatic {
     ATTACH_ERROR_INTERNAL       = 103,
     ATTACH_ERROR_DENIED         = 104
   };
+
+  static void set_door_path(char* path) {
+    if (path == NULL) {
+      _door_path[0] = '\0';
+      _has_door_path = false;
+    } else {
+      strncpy(_door_path, path, PATH_MAX);
+      _door_path[PATH_MAX] = '\0';      // ensure it's nul terminated
+      _has_door_path = true;
+    }
+  }
+
+  static void set_door_descriptor(int dd)               { _door_descriptor = dd; }
 
   // initialize the listener
   static int init();
@@ -169,6 +172,7 @@ class SolarisAttachOperation: public AttachOperation {
 char SolarisAttachListener::_door_path[PATH_MAX+1];
 volatile bool SolarisAttachListener::_has_door_path;
 int SolarisAttachListener::_door_descriptor = -1;
+bool SolarisAttachListener::_atexit_registered = false;
 mutex_t SolarisAttachListener::_mutex;
 sema_t SolarisAttachListener::_wakeup;
 SolarisAttachOperation* SolarisAttachListener::_head = NULL;
@@ -359,18 +363,16 @@ extern "C" {
 // atexit hook to detach the door and remove the file
 extern "C" {
   static void listener_cleanup() {
-    static int cleanup_done;
-    if (!cleanup_done) {
-      cleanup_done = 1;
-      int dd = SolarisAttachListener::door_descriptor();
-      if (dd >= 0) {
-        ::close(dd);
-      }
-      if (SolarisAttachListener::has_door_path()) {
-        char* path = SolarisAttachListener::door_path();
-        ::fdetach(path);
-        ::unlink(path);
-      }
+    int dd = SolarisAttachListener::door_descriptor();
+    if (dd >= 0) {
+      SolarisAttachListener::set_door_descriptor(-1);
+      ::close(dd);
+    }
+    if (SolarisAttachListener::has_door_path()) {
+      char* path = SolarisAttachListener::door_path();
+      ::fdetach(path);
+      ::unlink(path);
+      SolarisAttachListener::set_door_path(NULL);
     }
   }
 }
@@ -382,7 +384,10 @@ int SolarisAttachListener::create_door() {
   int fd, res;
 
   // register exit function
-  ::atexit(listener_cleanup);
+  if (!_atexit_registered) {
+    _atexit_registered = true;
+    ::atexit(listener_cleanup);
+  }
 
   // create the door descriptor
   int dd = ::door_create(enqueue_proc, NULL, 0);
@@ -636,6 +641,26 @@ bool AttachListener::init_at_startup() {
   } else {
     return false;
   }
+}
+
+bool AttachListener::check_socket_file() {
+  int ret;
+  struct stat64 st;
+  ret = stat64(SolarisAttachListener::door_path(), &st);
+  if (ret == -1) { // need to restart attach listener.
+    log_debug(attach)("Door file %s does not exist - Restart Attach Listener",
+                      SolarisAttachListener::door_path());
+
+    listener_cleanup();
+
+    // wait to terminate current attach listener instance...
+    while (AttachListener::transit_state(AL_INITIALIZING,
+                                         AL_NOT_INITIALIZED) != AL_NOT_INITIALIZED) {
+      os::naked_yield();
+    }
+    return is_init_trigger();
+  }
+  return false;
 }
 
 // If the file .attach_pid<pid> exists in the working directory

--- a/src/hotspot/os/windows/attachListener_windows.cpp
+++ b/src/hotspot/os/windows/attachListener_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -385,6 +385,12 @@ void AttachListener::vm_start() {
 
 int AttachListener::pd_init() {
   return Win32AttachListener::init();
+}
+
+// This function is used for Un*x OSes only.
+// We need not to implement it for Windows.
+bool AttachListener::check_socket_file() {
+  return false;
 }
 
 bool AttachListener::init_at_startup() {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -361,8 +361,25 @@ static void signal_thread_entry(JavaThread* thread, TRAPS) {
       case SIGBREAK: {
         // Check if the signal is a trigger to start the Attach Listener - in that
         // case don't print stack traces.
-        if (!DisableAttachMechanism && AttachListener::is_init_trigger()) {
-          continue;
+        if (!DisableAttachMechanism) {
+          // Attempt to transit state to AL_INITIALIZING.
+          AttachListenerState cur_state = AttachListener::transit_state(AL_INITIALIZING, AL_NOT_INITIALIZED);
+          if (cur_state == AL_INITIALIZING) {
+            // Attach Listener has been started to initialize. Ignore this signal.
+            continue;
+          } else if (cur_state == AL_NOT_INITIALIZED) {
+            // Start to initialize.
+            if (!AttachListener::is_init_trigger()) {
+              // Attach Listener could not be started.
+              // So we need to transit the state to AL_NOT_INITIALIZED.
+              AttachListener::set_state(AL_NOT_INITIALIZED);
+            }
+            continue;
+          } else if (AttachListener::check_socket_file()) {
+            // Attach Listener has been started, but unix domain socket file
+            // does not exist. So restart Attach Listener.
+            continue;
+          }
         }
         // Print stack traces
         // Any SIGBREAK operations added here should make sure to flush

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -44,7 +44,7 @@
 #include "utilities/debug.hpp"
 #include "utilities/formatBuffer.hpp"
 
-volatile bool AttachListener::_initialized;
+volatile AttachListenerState AttachListener::_state = AL_NOT_INITIALIZED;
 
 // Implementation of "properties" command.
 //
@@ -348,6 +348,7 @@ static void attach_listener_thread_entry(JavaThread* thread, TRAPS) {
          "Should already be setup");
 
   if (AttachListener::pd_init() != 0) {
+    AttachListener::set_state(AL_NOT_INITIALIZED);
     return;
   }
   AttachListener::set_initialized();
@@ -355,6 +356,7 @@ static void attach_listener_thread_entry(JavaThread* thread, TRAPS) {
   for (;;) {
     AttachOperation* op = AttachListener::dequeue();
     if (op == NULL) {
+      AttachListener::set_state(AL_NOT_INITIALIZED);
       return;   // dequeue failed or shutdown
     }
 
@@ -398,6 +400,8 @@ static void attach_listener_thread_entry(JavaThread* thread, TRAPS) {
     // operation complete - send result and output to client
     op->complete(res, &st);
   }
+
+  ShouldNotReachHere();
 }
 
 bool AttachListener::has_init_error(TRAPS) {
@@ -421,6 +425,7 @@ void AttachListener::init() {
   const char thread_name[] = "Attach Listener";
   Handle string = java_lang_String::create_from_str(thread_name, THREAD);
   if (has_init_error(THREAD)) {
+    set_state(AL_NOT_INITIALIZED);
     return;
   }
 
@@ -432,6 +437,7 @@ void AttachListener::init() {
                        string,
                        THREAD);
   if (has_init_error(THREAD)) {
+    set_state(AL_NOT_INITIALIZED);
     return;
   }
 
@@ -445,6 +451,7 @@ void AttachListener::init() {
                         thread_oop,
                         THREAD);
   if (has_init_error(THREAD)) {
+    set_state(AL_NOT_INITIALIZED);
     return;
   }
 

--- a/src/hotspot/share/services/attachListener.hpp
+++ b/src/hotspot/share/services/attachListener.hpp
@@ -26,6 +26,8 @@
 #define SHARE_VM_SERVICES_ATTACHLISTENER_HPP
 
 #include "memory/allocation.hpp"
+#include "metaprogramming/isRegisteredEnum.hpp"
+#include "runtime/atomic.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
@@ -49,6 +51,14 @@ struct AttachOperationFunctionInfo {
   AttachOperationFunction func;
 };
 
+enum AttachListenerState {
+  AL_NOT_INITIALIZED,
+  AL_INITIALIZING,
+  AL_INITIALIZED
+};
+
+template<> struct IsRegisteredEnum<AttachListenerState> : public TrueType {};
+
 class AttachListener: AllStatic {
  public:
   static void vm_start() NOT_SERVICES_RETURN;
@@ -57,6 +67,9 @@ class AttachListener: AllStatic {
 
   // invoke to perform clean-up tasks when all clients detach
   static void detachall() NOT_SERVICES_RETURN;
+
+  // check unix domain socket file on filesystem
+  static bool check_socket_file() NOT_SERVICES_RETURN_(false);
 
   // indicates if the Attach Listener needs to be created at startup
   static bool init_at_startup() NOT_SERVICES_RETURN_(false);
@@ -67,12 +80,31 @@ class AttachListener: AllStatic {
 #if !INCLUDE_SERVICES
   static bool is_attach_supported()             { return false; }
 #else
+
  private:
-  static volatile bool _initialized;
+  static volatile AttachListenerState _state;
 
  public:
-  static bool is_initialized()                  { return _initialized; }
-  static void set_initialized()                 { _initialized = true; }
+  static void set_state(AttachListenerState new_state) {
+    Atomic::store(new_state, &_state);
+  }
+
+  static AttachListenerState get_state() {
+    return Atomic::load(&_state);
+  }
+
+  static AttachListenerState transit_state(AttachListenerState new_state,
+                                           AttachListenerState cmp_state) {
+    return Atomic::cmpxchg(new_state, &_state, cmp_state);
+  }
+
+  static bool is_initialized() {
+    return Atomic::load(&_state) == AL_INITIALIZED;
+  }
+
+  static void set_initialized() {
+    Atomic::store(AL_INITIALIZED, &_state);
+  }
 
   // indicates if this VM supports attach-on-demand
   static bool is_attach_supported()             { return !DisableAttachMechanism; }

--- a/test/hotspot/jtreg/serviceability/attach/ConcAttachTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/ConcAttachTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8225690
+ * @requires os.family != "windows"
+ * @library /test/lib
+ * @modules jdk.attach/com.sun.tools.attach
+ * @run main ConcAttachTest
+ */
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import com.sun.tools.attach.VirtualMachine;
+import com.sun.tools.attach.AttachNotSupportedException;
+
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class ConcAttachTest implements Runnable {
+
+    private static final int NUM_CONC_REQUESTS = 100;
+
+    private static final int THREAD_POOL_TIMEOUT_IN_SEC = 30;
+
+    private static CountDownLatch latch;
+
+    private static String strPID;
+
+    // Attach to LingeredApp concurrently.
+    public void run() {
+        VirtualMachine vm = null;
+
+        try {
+            latch.countDown();
+            latch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            vm = VirtualMachine.attach(strPID);
+        } catch (AttachNotSupportedException | IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            try {
+                vm.detach();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static void checkAttachListenerThread() throws InterruptedException, IOException {
+        JDKToolLauncher jcmd = JDKToolLauncher.createUsingTestJDK("jcmd");
+        jcmd.addToolArg(strPID);
+        jcmd.addToolArg("Thread.print");
+
+        ProcessBuilder pb = new ProcessBuilder(jcmd.getCommand());
+        Process jcmdProc = pb.start();
+
+        OutputAnalyzer out = new OutputAnalyzer(jcmdProc);
+
+        jcmdProc.waitFor();
+
+        System.out.println(out.getStdout());
+        System.err.println(out.getStderr());
+
+        long numOfAttachListener = out.asLines()
+                                      .stream()
+                                      .filter(l -> l.contains("Attach Listener"))
+                                      .count();
+
+        Asserts.assertEquals(1L, numOfAttachListener, "AttachListener should exist only 1 thread.");
+    }
+
+    public static void main(String... args) throws Exception {
+        LingeredApp app = null;
+        latch = new CountDownLatch(NUM_CONC_REQUESTS);
+        ExecutorService pool = Executors.newFixedThreadPool(NUM_CONC_REQUESTS);
+
+        try {
+            app = LingeredApp.startApp();
+            strPID = Long.toString(app.getPid());
+
+            for (int i = 0; i < NUM_CONC_REQUESTS; i++) {
+                pool.submit(new ConcAttachTest());
+            }
+
+            pool.shutdown();
+            pool.awaitTermination(THREAD_POOL_TIMEOUT_IN_SEC, TimeUnit.SECONDS);
+
+            checkAttachListenerThread();
+        } finally {
+            LingeredApp.stopApp(app);
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/serviceability/attach/RemovingUnixDomainSocketTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/RemovingUnixDomainSocketTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8225193
+ * @requires os.family != "windows"
+ * @library /test/lib
+ * @run main RemovingUnixDomainSocketTest
+ */
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class RemovingUnixDomainSocketTest {
+
+    private static void runJCmd(long pid) throws InterruptedException, IOException {
+        JDKToolLauncher jcmd = JDKToolLauncher.createUsingTestJDK("jcmd");
+        jcmd.addToolArg(Long.toString(pid));
+        jcmd.addToolArg("VM.version");
+
+        ProcessBuilder pb = new ProcessBuilder(jcmd.getCommand());
+        Process jcmdProc = pb.start();
+
+        OutputAnalyzer out = new OutputAnalyzer(jcmdProc);
+
+        jcmdProc.waitFor();
+
+        System.out.println(out.getStdout());
+        System.err.println(out.getStderr());
+
+        out.stderrShouldBeEmpty();
+    }
+
+    public static void main(String... args) throws Exception {
+        LingeredApp app = null;
+        try {
+            app = LingeredApp.startApp();
+
+            // Access to Attach Listener
+            runJCmd(app.getPid());
+
+            // Remove unix domain socket file
+            var sockFile = Path.of(System.getProperty("java.io.tmpdir"),
+                                   ".java_pid" + app.getPid())
+                               .toFile();
+            System.out.println("Remove " + sockFile.toString());
+            sockFile.delete();
+
+            // Access to Attach Listener again
+            runJCmd(app.getPid());
+        } finally {
+            LingeredApp.stopApp(app);
+        }
+    }
+
+}


### PR DESCRIPTION
Clean backport of JDK-8225690.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8225690](https://bugs.openjdk.java.net/browse/JDK-8225690): Multiple AttachListener threads can be created


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/145/head:pull/145` \
`$ git checkout pull/145`

Update a local copy of the PR: \
`$ git checkout pull/145` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 145`

View PR using the GUI difftool: \
`$ git pr show -t 145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/145.diff">https://git.openjdk.java.net/jdk11u-dev/pull/145.diff</a>

</details>
