### PR TITLE
8227815: Minimal VM: set_state is not a member of AttachListener

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -359,11 +359,13 @@ static void signal_thread_entry(JavaThread* thread, TRAPS) {
 
     switch (sig) {
       case SIGBREAK: {
+#if INCLUDE_SERVICES
         // Check if the signal is a trigger to start the Attach Listener - in that
         // case don't print stack traces.
         if (!DisableAttachMechanism && AttachListener::is_init_trigger()) {
           continue;
         }
+#endif
         // Print stack traces
         // Any SIGBREAK operations added here should make sure to flush
         // the output stream (e.g. tty->flush()) after output.  See 4803766.


### PR DESCRIPTION
Clean backport of JDK-8227815. Required for JDK-8225690 backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8227815](https://bugs.openjdk.java.net/browse/JDK-8227815): Minimal VM: set_state is not a member of AttachListener


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/146/head:pull/146` \
`$ git checkout pull/146`

Update a local copy of the PR: \
`$ git checkout pull/146` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 146`

View PR using the GUI difftool: \
`$ git pr show -t 146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/146.diff">https://git.openjdk.java.net/jdk11u-dev/pull/146.diff</a>

</details>
