### PR TITLE
8227738: jvmti/DataDumpRequest/datadumpreq001 failed due to "exit code is 134"

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -370,12 +370,15 @@ static void signal_thread_entry(JavaThread* thread, TRAPS) {
             continue;
           } else if (cur_state == AL_NOT_INITIALIZED) {
             // Start to initialize.
-            if (!AttachListener::is_init_trigger()) {
+            if (AttachListener::is_init_trigger()) {
+              // Attach Listener has been initialized.
+              // Accept subsequent request.
+              continue;
+            } else {
               // Attach Listener could not be started.
               // So we need to transit the state to AL_NOT_INITIALIZED.
               AttachListener::set_state(AL_NOT_INITIALIZED);
             }
-            continue;
           } else if (AttachListener::check_socket_file()) {
             // Attach Listener has been started, but unix domain socket file
             // does not exist. So restart Attach Listener.


### PR DESCRIPTION
Clean backport of JDK-8227738.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8227738](https://bugs.openjdk.java.net/browse/JDK-8227738): jvmti/DataDumpRequest/datadumpreq001 failed due to "exit code is 134"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/152/head:pull/152` \
`$ git checkout pull/152`

Update a local copy of the PR: \
`$ git checkout pull/152` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 152`

View PR using the GUI difftool: \
`$ git pr show -t 152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/152.diff">https://git.openjdk.java.net/jdk11u-dev/pull/152.diff</a>

</details>
