### PR TITLE
8208363: test/jdk/java/lang/Package/PackageFromManifest.java missing module dependencies declaration

### DIFF
--- a/test/jdk/java/lang/Package/PackageFromManifest.java
+++ b/test/jdk/java/lang/Package/PackageFromManifest.java
@@ -29,6 +29,7 @@
  *          same package if multiple jars). Then verify package versioning info
  * @library /lib/testlibrary
  * @library /test/lib
+ * @modules jdk.compiler
  * @run main PackageFromManifest setup test
  * @run main PackageFromManifest runJar test1.jar
  * @run main PackageFromManifest runJar test1.jar test2.jar foo.Foo1


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8208363 from the openjdk/jdk repository.

The commit being backported was authored by Chris Yin on 30 Jul 2018 and was reviewed by Lance Andersen and Mandy Chung.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8208363](https://bugs.openjdk.java.net/browse/JDK-8208363): test/jdk/java/lang/Package/PackageFromManifest.java missing module dependencies declaration


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/159/head:pull/159` \
`$ git checkout pull/159`

Update a local copy of the PR: \
`$ git checkout pull/159` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 159`

View PR using the GUI difftool: \
`$ git pr show -t 159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/159.diff">https://git.openjdk.java.net/jdk11u-dev/pull/159.diff</a>

</details>
