### PR TITLE
8194230: jdk/internal/jrtfs/remote/RemoteRuntimeImageTest.java fails with java.lang.NullPointerException

### DIFF
--- a/test/jdk/jdk/internal/jrtfs/remote/RemoteRuntimeImageTest.java
+++ b/test/jdk/jdk/internal/jrtfs/remote/RemoteRuntimeImageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -55,7 +54,7 @@ public class RemoteRuntimeImageTest {
             return;
         }
 
-        Path jdk8Path = getJdk8Path(jdk8Home);
+        Path jdk8Path = Paths.get(jdk8Home);
         if (!isJdk8(jdk8Path)) {
             System.err.println("This test is only for JDK 8. Skip testing");
             return;
@@ -102,16 +101,14 @@ public class RemoteRuntimeImageTest {
         }
     }
 
-    private static Path getJdk8Path(String jdk8Home) {
-        Path jdk8Path = Paths.get(jdk8Home);
-        // It is possible to point to the path of java executable by ${JT_JAVA}
-        return Files.isDirectory(jdk8Path)? jdk8Path : jdk8Path.getParent().getParent();
-    }
-
-    private static boolean isJdk8(Path jdk8Home) throws FileNotFoundException, IOException {
-        File file = jdk8Home.resolve("release").toFile();
+    private static boolean isJdk8(Path jdk8HomePath) throws IOException {
+        File releaseFile = jdk8HomePath.resolve("release").toFile();
+        if (!releaseFile.exists()) {
+            throw new RuntimeException(releaseFile.getPath() +
+                    " doesn't exist");
+        }
         Properties props = new Properties();
-        try (FileInputStream in = new FileInputStream(file)) {
+        try (FileInputStream in = new FileInputStream(releaseFile)) {
             props.load(in);
         }
 


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8194230 from the openjdk/jdk repository.

The commit being backported was authored by Felix Yang on 14 Aug 2018 and was reviewed by Mandy Chung.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8194230](https://bugs.openjdk.java.net/browse/JDK-8194230): jdk/internal/jrtfs/remote/RemoteRuntimeImageTest.java fails with java.lang.NullPointerException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/160/head:pull/160` \
`$ git checkout pull/160`

Update a local copy of the PR: \
`$ git checkout pull/160` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 160`

View PR using the GUI difftool: \
`$ git pr show -t 160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/160.diff">https://git.openjdk.java.net/jdk11u-dev/pull/160.diff</a>

</details>
