### PR TITLE
8042902: Test java/net/Inet6Address/serialize/Inet6AddressSerializationTest.java fails intermittently

### DIFF
--- a/test/jdk/java/net/Inet6Address/serialize/Inet6AddressSerializationTest.java
+++ b/test/jdk/java/net/Inet6Address/serialize/Inet6AddressSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -192,6 +192,7 @@ public class Inet6AddressSerializationTest {
                     System.err.println("Testing with " + iadr);
                     System.err.println(" scoped iface: "
                             + i6adr.getScopedInterface());
+                    System.err.println(" hostname: " + i6adr.getHostName());
                     testInet6AddressSerialization(i6adr, null);
                 }
             }


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8042902 from the openjdk/jdk repository.

The commit being backported was authored by Chris Yin on 7 Sep 2018 and was reviewed by Chris Hegarty.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8042902](https://bugs.openjdk.java.net/browse/JDK-8042902): Test java/net/Inet6Address/serialize/Inet6AddressSerializationTest.java fails intermittently


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/162/head:pull/162` \
`$ git checkout pull/162`

Update a local copy of the PR: \
`$ git checkout pull/162` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 162`

View PR using the GUI difftool: \
`$ git pr show -t 162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/162.diff">https://git.openjdk.java.net/jdk11u-dev/pull/162.diff</a>

</details>
