### PR TITLE
8269795: C2: Out of bounds array load floats above its range check in loop peeling resulting in SEGV

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -381,35 +381,39 @@ bool IdealLoopTree::policy_peeling( PhaseIdealLoop *phase ) const {
 // If we got the effect of peeling, either by actually peeling or by making
 // a pre-loop which must execute at least once, we can remove all
 // loop-invariant dominated tests in the main body.
-void PhaseIdealLoop::peeled_dom_test_elim( IdealLoopTree *loop, Node_List &old_new ) {
+void PhaseIdealLoop::peeled_dom_test_elim(IdealLoopTree* loop, Node_List& old_new) {
   bool progress = true;
-  while( progress ) {
-    progress = false;           // Reset for next iteration
-    Node *prev = loop->_head->in(LoopNode::LoopBackControl);//loop->tail();
-    Node *test = prev->in(0);
-    while( test != loop->_head ) { // Scan till run off top of loop
-
+  while (progress) {
+    progress = false; // Reset for next iteration
+    Node* prev = loop->_head->in(LoopNode::LoopBackControl); // loop->tail();
+    Node* test = prev->in(0);
+    while (test != loop->_head) { // Scan till run off top of loop
       int p_op = prev->Opcode();
-      if( (p_op == Op_IfFalse || p_op == Op_IfTrue) &&
-          test->is_If() &&      // Test?
-          !test->in(1)->is_Con() && // And not already obvious?
-          // Condition is not a member of this loop?
-          !loop->is_member(get_loop(get_ctrl(test->in(1))))){
+      assert(test != NULL, "test cannot be NULL");
+      Node* test_cond = NULL;
+      if ((p_op == Op_IfFalse || p_op == Op_IfTrue) && test->is_If()) {
+        test_cond = test->in(1);
+      }
+      if (test_cond != NULL && // Test?
+          !test_cond->is_Con() && // And not already obvious?
+          // And condition is not a member of this loop?
+          !loop->is_member(get_loop(get_ctrl(test_cond)))) {
         // Walk loop body looking for instances of this test
-        for( uint i = 0; i < loop->_body.size(); i++ ) {
-          Node *n = loop->_body.at(i);
-          if( n->is_If() && n->in(1) == test->in(1) /*&& n != loop->tail()->in(0)*/ ) {
+        for (uint i = 0; i < loop->_body.size(); i++) {
+          Node* n = loop->_body.at(i);
+          // Check against cached test condition because dominated_by()
+          // replaces the test condition with a constant.
+          if (n->is_If() && n->in(1) == test_cond) {
             // IfNode was dominated by version in peeled loop body
             progress = true;
-            dominated_by( old_new[prev->_idx], n );
+            dominated_by(old_new[prev->_idx], n);
           }
         }
       }
       prev = test;
       test = idom(test);
     } // End of scan tests in loop
-
-  } // End of while( progress )
+  } // End of while (progress)
 }
 
 //------------------------------do_peeling-------------------------------------

--- a/test/hotspot/jtreg/compiler/loopopts/TestPeelingRemoveDominatedTest.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPeelingRemoveDominatedTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key stress
+ * @requires vm.compiler2.enabled
+ * @bug 8269795
+ * @summary PhaseIdealLoop::peeled_dom_test_elim wrongly moves a non-dominated test out of a loop together with control dependent data nodes.
+ *          This results in a crash due to an out of bounds read of an array.
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xcomp -XX:-TieredCompilation -XX:+StressGCM
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestPeelingRemoveDominatedTest compiler.loopopts.TestPeelingRemoveDominatedTest
+ */
+
+package compiler.loopopts;
+
+public class TestPeelingRemoveDominatedTest {
+    public static int N = 400;
+    static boolean bFld = true;
+    static int iArrFld[] = new int[N];
+
+    public static void main(String[] strArr) {
+        TestPeelingRemoveDominatedTest _instance = new TestPeelingRemoveDominatedTest();
+        for (int i = 0; i < 10; i++) {
+            _instance.mainTest();
+        }
+    }
+
+    public void mainTest() {
+        vMeth();
+    }
+
+
+    static void vMeth() {
+        iArrFld[1] = 2;
+        int i6 = 2;
+        while (--i6 > 0) {
+            try {
+                int i3 = (iArrFld[i6 - 1] / 56);
+                iArrFld[1] = (-139 % i3);
+            } catch (ArithmeticException a_e) {
+            }
+            if (bFld) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backport of JDK-8269795. Doesn't apply cleanly because cleanup change JDK-8223142 is not it 11u. Taken new PhaseIdealLoop::peeled_dom_test_elim which includes the cleanup. Removed key "randomness" from test which doesn't work with 11u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269795](https://bugs.openjdk.java.net/browse/JDK-8269795): C2: Out of bounds array load floats above its range check in loop peeling resulting in SEGV


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/166.diff">https://git.openjdk.java.net/jdk11u-dev/pull/166.diff</a>

</details>
