### PR TITLE
8257497: Update keytool to create AKID from the SKID of the issuing certificate as specified by RFC 5280

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1493,12 +1493,39 @@ public final class Main {
                 reqex = (CertificateExtensions)attr.getAttributeValue();
             }
         }
+
+        PublicKey subjectPubKey = req.getSubjectPublicKeyInfo();
+        PublicKey issuerPubKey = signerCert.getPublicKey();
+
+        KeyIdentifier signerSubjectKeyId;
+        if (Arrays.equals(subjectPubKey.getEncoded(), issuerPubKey.getEncoded())) {
+            // No AKID for self-signed cert
+            signerSubjectKeyId = null;
+        } else {
+            X509CertImpl certImpl;
+            if (signerCert instanceof X509CertImpl) {
+                certImpl = (X509CertImpl) signerCert;
+            } else {
+                certImpl = new X509CertImpl(signerCert.getEncoded());
+            }
+
+            // To enforce compliance with RFC 5280 section 4.2.1.1: "Where a key
+            // identifier has been previously established, the CA SHOULD use the
+            // previously established identifier."
+            // Use issuer's SKID to establish the AKID in createV3Extensions() method.
+            signerSubjectKeyId = certImpl.getSubjectKeyId();
+
+            if (signerSubjectKeyId == null) {
+                signerSubjectKeyId = new KeyIdentifier(issuerPubKey);
+            }
+        }
+
         CertificateExtensions ext = createV3Extensions(
                 reqex,
                 null,
                 v3ext,
-                req.getSubjectPublicKeyInfo(),
-                signerCert.getPublicKey());
+                subjectPubKey,
+                signerSubjectKeyId);
         info.set(X509CertInfo.EXTENSIONS, ext);
         X509CertImpl cert = new X509CertImpl(info);
         cert.sign(privateKey, params, sigAlgName, null);
@@ -4204,6 +4231,7 @@ public final class Main {
      * @param extstrs -ext values, Read keytool doc
      * @param pkey the public key for the certificate
      * @param akey the public key for the authority (issuer)
+     * @param aSubjectKeyId the subject key identifier for the authority (issuer)
      * @return the created CertificateExtensions
      */
     private CertificateExtensions createV3Extensions(
@@ -4211,7 +4239,7 @@ public final class Main {
             CertificateExtensions existingEx,
             List <String> extstrs,
             PublicKey pkey,
-            PublicKey akey) throws Exception {
+            KeyIdentifier aSubjectKeyId) throws Exception {
 
         // By design, inside a CertificateExtensions object, all known
         // extensions uses name (say, "BasicConstraints") as key and
@@ -4236,6 +4264,14 @@ public final class Main {
             }
         }
         try {
+            // always non-critical
+            setExt(result, new SubjectKeyIdentifierExtension(
+                    new KeyIdentifier(pkey).getIdentifier()));
+            if (aSubjectKeyId != null) {
+                setExt(result, new AuthorityKeyIdentifierExtension(aSubjectKeyId,
+                        null, null));
+            }
+
             // name{:critical}{=value}
             // Honoring requested extensions
             if (requestedEx != null) {
@@ -4567,13 +4603,6 @@ public final class Main {
                         throw new Exception(rb.getString(
                                 "Unknown.extension.type.") + extstr);
                 }
-            }
-            // always non-critical
-            setExt(result, new SubjectKeyIdentifierExtension(
-                    new KeyIdentifier(pkey).getIdentifier()));
-            if (akey != null && !pkey.equals(akey)) {
-                setExt(result, new AuthorityKeyIdentifierExtension(
-                                new KeyIdentifier(akey), null, null));
             }
         } catch(IOException e) {
             throw new RuntimeException(e);

--- a/test/jdk/sun/security/tools/keytool/CheckCertAKID.java
+++ b/test/jdk/sun/security/tools/keytool/CheckCertAKID.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8257497
+ * @summary Check if issuer's SKID is used to establish the AKID for the subject cert
+ * @library /test/lib
+ * @modules java.base/sun.security.util
+ */
+
+import jdk.test.lib.SecurityTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.io.*;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import sun.security.util.DerValue;
+import jdk.test.lib.KnownOIDs;
+import static jdk.test.lib.KnownOIDs.*;
+
+public class CheckCertAKID {
+
+    static OutputAnalyzer kt(String cmd, String ks) throws Exception {
+        return SecurityTools.keytool("-storepass changeit " + cmd +
+                " -keystore " + ks);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        System.out.println("Generating a root cert with SubjectKeyIdentifier extension");
+        kt("-genkeypair -keyalg rsa -alias ca -dname CN=CA -ext bc:c " +
+                "-ext 2.5.29.14=04:14:00:01:02:03:04:05:06:07:08:09:10:11:12:13:14:15:16:17:18:19",
+                "ks");
+
+        kt("-exportcert -alias ca -rfc -file root.cert", "ks");
+
+        SecurityTools.keytool("-keystore ks -storepass changeit " +
+                "-printcert -file root.cert")
+                .shouldNotContain("AuthorityKeyIdentifier")
+                .shouldContain("SubjectKeyIdentifier")
+                .shouldContain("0000: 00 01 02 03 04 05 06 07   08 09 10 11 12 13 14 15")
+                .shouldContain("0010: 16 17 18 19")
+                .shouldHaveExitValue(0);
+
+        System.out.println("Generating an end entity cert using issuer CA's SKID as its AKID");
+        kt("-genkeypair -keyalg rsa -alias e1 -dname CN=E1", "ks");
+        kt("-certreq -alias e1 -file tmp.req", "ks");
+        kt("-gencert -alias ca -ext san=dns:e1 -infile tmp.req -outfile tmp.cert ",
+                "ks");
+        kt("-importcert -alias e1 -file tmp.cert", "ks");
+
+        byte[] expectedId = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19};
+
+        KeyStore kstore = KeyStore.getInstance(new File("ks"),
+                "changeit".toCharArray());
+        X509Certificate cert = (X509Certificate)kstore.getCertificate("e1");
+        byte[] authorityKeyIdExt = cert.getExtensionValue(
+                KnownOIDs.AuthorityKeyID.value());
+
+        byte[] authorityKeyId = null;
+        if (authorityKeyIdExt == null) {
+            System.out.println("Failed to get AKID extension from the cert");
+            System.exit(1);
+        } else {
+            try {
+                authorityKeyId = new DerValue(authorityKeyIdExt).getOctetString();
+            } catch (IOException e) {
+                System.out.println("Failed to get AKID encoded OctetString in the cert");
+                System.exit(1);
+            }
+        }
+
+        authorityKeyId = Arrays.copyOfRange(authorityKeyId, 4, authorityKeyId.length);
+        if (!Arrays.equals(authorityKeyId, expectedId)) {
+            System.out.println("Failed due to AKID mismatch");
+            System.exit(1);
+        }
+    }
+}


### PR DESCRIPTION
Backport of JDK-8257497. The actual fix applies cleanly. Copyright year update doesn't. The test CheckCertAKID.java uses KnownOIDs which is not part of the JDK in 11u. We're using a copy in the test library instead. Skipped changes in ExtOptionCamelCase.java which belongs to JDK-8231950 which is not in 11u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257497](https://bugs.openjdk.java.net/browse/JDK-8257497): Update keytool to create AKID from the SKID of the issuing certificate as specified by RFC 5280


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/167/head:pull/167` \
`$ git checkout pull/167`

Update a local copy of the PR: \
`$ git checkout pull/167` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 167`

View PR using the GUI difftool: \
`$ git pr show -t 167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/167.diff">https://git.openjdk.java.net/jdk11u-dev/pull/167.diff</a>

</details>
