### PR TITLE
8268775: Password is being converted to String in AccessibleJPasswordField

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JPasswordField.java
+++ b/src/java.desktop/share/classes/javax/swing/JPasswordField.java
@@ -489,20 +489,19 @@ public class JPasswordField extends JTextField {
          * @since 1.6
          */
         public String getAtIndex(int part, int index) {
-           String str = null;
             if (part == AccessibleText.CHARACTER) {
-                str = super.getAtIndex(part, index);
+                return getEchoString(super.getAtIndex(part, index));
             } else {
                 // Treat the text displayed in the JPasswordField
                 // as one word and sentence.
-                char password[] = getPassword();
-                if (password == null ||
-                    index < 0 || index >= password.length) {
+                int length = getDocument().getLength();
+                if (index < 0 || index >= length) {
                     return null;
                 }
-                str = new String(password);
+                char[] password = new char[length];
+                Arrays.fill(password, getEchoChar());
+                return new String(password);
             }
-            return getEchoString(str);
         }
 
         /**
@@ -523,8 +522,7 @@ public class JPasswordField extends JTextField {
          */
         public String getAfterIndex(int part, int index) {
             if (part == AccessibleText.CHARACTER) {
-                String str = super.getAfterIndex(part, index);
-                return getEchoString(str);
+                return getEchoString(super.getAfterIndex(part, index));
             } else {
                 // There is no word or sentence after the text
                 // displayed in the JPasswordField.
@@ -550,8 +548,7 @@ public class JPasswordField extends JTextField {
          */
         public String getBeforeIndex(int part, int index) {
             if (part == AccessibleText.CHARACTER) {
-                String str = super.getBeforeIndex(part, index);
-                return getEchoString(str);
+                return getEchoString(super.getBeforeIndex(part, index));
             } else {
                 // There is no word or sentence before the text
                 // displayed in the JPasswordField.
@@ -606,14 +603,14 @@ public class JPasswordField extends JTextField {
             } else {
                 // Treat the text displayed in the JPasswordField
                 // as one word, sentence, line and attribute run
-                char password[] = getPassword();
-                if (password == null ||
-                    index < 0 || index >= password.length) {
+                int length = getDocument().getLength();
+                if (index < 0 || index >= length) {
                     return null;
                 }
+                char[] password = new char[length];
+                Arrays.fill(password, getEchoChar());
                 String text = new String(password);
-                return new AccessibleTextSequence(0, password.length - 1,
-                                                  getEchoString(text));
+                return new AccessibleTextSequence(0, password.length - 1, text);
             }
         }
 


### PR DESCRIPTION
Backport of JDK-8268775. Doesn't apply cleanly because cleanup JDK-8211300 is not in 11u. Taken new version which includes cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268775](https://bugs.openjdk.java.net/browse/JDK-8268775): Password is being converted to String in AccessibleJPasswordField


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/170/head:pull/170` \
`$ git checkout pull/170`

Update a local copy of the PR: \
`$ git checkout pull/170` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 170`

View PR using the GUI difftool: \
`$ git pr show -t 170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/170.diff">https://git.openjdk.java.net/jdk11u-dev/pull/170.diff</a>

</details>
