### PR TITLE
8226319: Add forgotten test/jdk/java/net/httpclient/BodySubscribersTest.java

### DIFF
--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -1252,7 +1252,7 @@ public interface HttpResponse<T> {
         /**
          * Returns a {@code BodySubscriber} which buffers data before delivering
          * it to the given downstream subscriber. The subscriber guarantees to
-         * deliver {@code buffersize} bytes of data to each invocation of the
+         * deliver {@code bufferSize} bytes of data to each invocation of the
          * downstream's {@link BodySubscriber#onNext(Object) onNext} method,
          * except for the final invocation, just before
          * {@link BodySubscriber#onComplete() onComplete} is invoked. The final

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -84,6 +84,7 @@ public class ResponseSubscribers {
 
         @Override
         public void onSubscribe(Flow.Subscription subscription) {
+            Objects.requireNonNull(subscription);
             if (!subscribed.compareAndSet(false, true)) {
                 subscription.cancel();
             } else {
@@ -94,6 +95,7 @@ public class ResponseSubscribers {
 
         @Override
         public void onNext(List<ByteBuffer> items) {
+            Objects.requireNonNull(items);
             for (ByteBuffer item : items) {
                 byte[] buf = new byte[item.remaining()];
                 item.get(buf);
@@ -104,6 +106,7 @@ public class ResponseSubscribers {
 
         @Override
         public void onError(Throwable throwable) {
+            Objects.requireNonNull(throwable);
             result.completeExceptionally(throwable);
         }
 
@@ -131,6 +134,7 @@ public class ResponseSubscribers {
         private final FilePermission[] filePermissions;
         private final CompletableFuture<Path> result = new MinimalFuture<>();
 
+        private final AtomicBoolean subscribed = new AtomicBoolean();
         private volatile Flow.Subscription subscription;
         private volatile FileChannel out;
 
@@ -170,6 +174,12 @@ public class ResponseSubscribers {
 
         @Override
         public void onSubscribe(Flow.Subscription subscription) {
+            Objects.requireNonNull(subscription);
+            if (!subscribed.compareAndSet(false, true)) {
+                subscription.cancel();
+                return;
+            }
+
             this.subscription = subscription;
             if (System.getSecurityManager() == null) {
                 try {
@@ -411,6 +421,7 @@ public class ResponseSubscribers {
 
         @Override
         public void onSubscribe(Flow.Subscription s) {
+            Objects.requireNonNull(s);
             try {
                 if (!subscribed.compareAndSet(false, true)) {
                     s.cancel();
@@ -539,6 +550,7 @@ public class ResponseSubscribers {
 
         @Override
         public void onSubscribe(Flow.Subscription subscription) {
+            Objects.requireNonNull(subscription);
             if (!subscribed.compareAndSet(false, true)) {
                 subscription.cancel();
             } else {
@@ -553,6 +565,7 @@ public class ResponseSubscribers {
 
         @Override
         public void onError(Throwable throwable) {
+            Objects.requireNonNull(throwable);
             cf.completeExceptionally(throwable);
         }
 
@@ -819,13 +832,21 @@ public class ResponseSubscribers {
             }
         }
 
+        private final AtomicBoolean subscribed = new AtomicBoolean();
+
         @Override
         public void onSubscribe(Flow.Subscription subscription) {
-            subscriptionCF.complete(subscription);
+            Objects.requireNonNull(subscription);
+            if (!subscribed.compareAndSet(false, true)) {
+                subscription.cancel();
+            } else {
+                subscriptionCF.complete(subscription);
+            }
         }
 
         @Override
         public void onNext(List<ByteBuffer> item) {
+            Objects.requireNonNull(item);
             try {
                 // cannot be called before onSubscribe()
                 assert subscriptionCF.isDone();
@@ -853,6 +874,7 @@ public class ResponseSubscribers {
             // onError can be called before request(1), and therefore can
             // be called before subscriberRef is set.
             signalError(throwable);
+            Objects.requireNonNull(throwable);
         }
 
         @Override

--- a/test/jdk/java/net/httpclient/BodySubscribersTest.java
+++ b/test/jdk/java/net/httpclient/BodySubscribersTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Basic test for the standard BodySubscribers default behavior
+ * @bug 8225583
+ * @run testng BodySubscribersTest
+ */
+
+import java.net.http.HttpResponse.BodySubscriber;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.Flow;
+import java.util.function.Supplier;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static java.lang.System.out;
+import static java.net.http.HttpResponse.BodySubscribers.*;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.expectThrows;
+import static org.testng.Assert.fail;
+
+public class BodySubscribersTest {
+
+    static final Class<NullPointerException> NPE = NullPointerException.class;
+
+    // Supplier of BodySubscriber<?>, with a descriptive name
+    static class BSSupplier implements Supplier<BodySubscriber<?>> {
+        private final Supplier<BodySubscriber<?>> supplier;
+        private final String name;
+        private BSSupplier(Supplier<BodySubscriber<?>> supplier, String name) {
+            this.supplier = supplier;
+            this.name = name;
+        }
+        static BSSupplier create(String name, Supplier<BodySubscriber<?>> supplier) {
+            return new BSSupplier(supplier, name);
+        }
+        @Override public BodySubscriber<?> get() { return supplier.get(); }
+        @Override public String toString() { return name; }
+    }
+
+    static class LineSubscriber implements Flow.Subscriber<String> {
+        @Override public void onSubscribe(Flow.Subscription subscription) {  }
+        @Override public void onNext(String item) { fail(); }
+        @Override public void onError(Throwable throwable) { fail(); }
+        @Override public void onComplete() { fail(); }
+    }
+
+    static class BBSubscriber implements Flow.Subscriber<List<ByteBuffer>> {
+        @Override public void onSubscribe(Flow.Subscription subscription) {  }
+        @Override public void onNext(List<ByteBuffer> item) { fail(); }
+        @Override public void onError(Throwable throwable) { fail(); }
+        @Override public void onComplete() { fail(); }
+    }
+
+    @DataProvider(name = "bodySubscriberSuppliers")
+    public Object[][] bodySubscriberSuppliers() { ;
+        List<Supplier<BodySubscriber<?>>> list = List.of(
+            BSSupplier.create("ofByteArray",   () -> ofByteArray()),
+            BSSupplier.create("ofInputStream", () -> ofInputStream()),
+            BSSupplier.create("ofBAConsumer",  () -> ofByteArrayConsumer(ba -> { })),
+            BSSupplier.create("ofLines",       () -> ofLines(UTF_8)),
+            BSSupplier.create("ofPublisher",   () -> ofPublisher()),
+            BSSupplier.create("ofFile",        () -> ofFile(Path.of("f"))),
+            BSSupplier.create("ofFile-opts)",  () -> ofFile(Path.of("f"), CREATE)),
+            BSSupplier.create("ofString",      () -> ofString(UTF_8)),
+            BSSupplier.create("buffering",     () -> buffering(ofByteArray(), 10)),
+            BSSupplier.create("discarding",    () -> discarding()),
+            BSSupplier.create("mapping",       () -> mapping(ofString(UTF_8), s -> s)),
+            BSSupplier.create("replacing",     () -> replacing("hello")),
+            BSSupplier.create("fromSubscriber-1",     () -> fromSubscriber(new BBSubscriber())),
+            BSSupplier.create("fromSubscriber-2",     () -> fromSubscriber(new BBSubscriber(), s -> s)),
+            BSSupplier.create("fromLineSubscriber-1", () -> fromLineSubscriber(new LineSubscriber())),
+            BSSupplier.create("fromLineSubscriber-2", () -> fromLineSubscriber(new LineSubscriber(), s -> s, UTF_8, ","))
+        );
+
+        return list.stream().map(x -> new Object[] { x }).toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "bodySubscriberSuppliers")
+    void nulls(Supplier<BodySubscriber<?>> bodySubscriberSupplier) {
+        BodySubscriber<?> bodySubscriber = bodySubscriberSupplier.get();
+        boolean subscribed = false;
+
+        do {
+            assertNotNull(bodySubscriber.getBody());
+            assertNotNull(bodySubscriber.getBody());
+            assertNotNull(bodySubscriber.getBody());
+            expectThrows(NPE, () -> bodySubscriber.onSubscribe(null));
+            expectThrows(NPE, () -> bodySubscriber.onSubscribe(null));
+            expectThrows(NPE, () -> bodySubscriber.onSubscribe(null));
+
+            expectThrows(NPE, () -> bodySubscriber.onNext(null));
+            expectThrows(NPE, () -> bodySubscriber.onNext(null));
+            expectThrows(NPE, () -> bodySubscriber.onNext(null));
+            expectThrows(NPE, () -> bodySubscriber.onNext(null));
+
+            expectThrows(NPE, () -> bodySubscriber.onError(null));
+            expectThrows(NPE, () -> bodySubscriber.onError(null));
+            expectThrows(NPE, () -> bodySubscriber.onError(null));
+
+            if (!subscribed) {
+                out.println("subscribing");
+                // subscribe the Subscriber and repeat
+                bodySubscriber.onSubscribe(new Flow.Subscription() {
+                    @Override public void request(long n) { /* do nothing */ }
+                    @Override public void cancel() { fail(); }
+                });
+                subscribed = true;
+                continue;
+            }
+            break;
+        } while (true);
+    }
+
+    @Test(dataProvider = "bodySubscriberSuppliers")
+    void subscribeMoreThanOnce(Supplier<BodySubscriber<?>> bodySubscriberSupplier) {
+        BodySubscriber<?> bodySubscriber = bodySubscriberSupplier.get();
+        bodySubscriber.onSubscribe(new Flow.Subscription() {
+            @Override public void request(long n) { /* do nothing */ }
+            @Override public void cancel() { fail(); }
+        });
+
+        for (int i = 0; i < 5; i++) {
+            var subscription = new Flow.Subscription() {
+                volatile boolean cancelled;
+                @Override public void request(long n) { fail(); }
+                @Override public void cancel() { cancelled = true; }
+            };
+            bodySubscriber.onSubscribe(subscription);
+            assertTrue(subscription.cancelled);
+        }
+    }
+}


### PR DESCRIPTION
I would like to backport this patch to 11u. This patch contains missing test from JDK-8225583, which is a Oracle parity backport.

The backport is clean. And the test passes with  JDK-8225583.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8226319](https://bugs.openjdk.java.net/browse/JDK-8226319): Add forgotten test/jdk/java/net/httpclient/BodySubscribersTest.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/175/head:pull/175` \
`$ git checkout pull/175`

Update a local copy of the PR: \
`$ git checkout pull/175` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 175`

View PR using the GUI difftool: \
`$ git pr show -t 175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/175.diff">https://git.openjdk.java.net/jdk11u-dev/pull/175.diff</a>

</details>
