### PR TITLE
8268261: C2: assert(n != __null) failed: Bad immediate dominator info.

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3201,6 +3201,7 @@ bool IdealLoopTree::iteration_split_impl( PhaseIdealLoop *phase, Node_List &old_
       phase->do_peeling(this,old_new);
     } else if (should_unswitch) {
       phase->do_unswitching(this, old_new);
+      return false; // need to recalculate idom data
     }
     return true;
   }
@@ -3219,7 +3220,7 @@ bool IdealLoopTree::iteration_split_impl( PhaseIdealLoop *phase, Node_List &old_
   if (cl->is_normal_loop()) {
     if (should_unswitch) {
       phase->do_unswitching(this, old_new);
-      return true;
+      return false; // need to recalculate idom data
     }
     bool should_maximally_unroll =  policy_maximally_unroll(phase);
     if (should_maximally_unroll) {
@@ -3344,6 +3345,7 @@ bool IdealLoopTree::iteration_split( PhaseIdealLoop *phase, Node_List &old_new )
         }
     } else if (policy_unswitching(phase)) {
       phase->do_unswitching(this, old_new);
+      return false; // need to recalculate idom data
     }
   }
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestIdomAfterLoopUnswitching.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestIdomAfterLoopUnswitching.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8268261
+ * @summary Test idom data after unswitching loop following by full unroll.
+ * @run main/othervm -XX:CompileCommand=compileonly,TestIdomAfterLoopUnswitching::*
+ *                   -Xcomp -XX:-TieredCompilation TestIdomAfterLoopUnswitching
+ */
+
+public class TestIdomAfterLoopUnswitching {
+
+    public static void main(String[] k) {
+        test1();
+        test2();
+    }
+
+    public static void test1() {
+        float h = 0;
+        for (int j = 0; j < 3; ++j) {
+            float k = 9;
+            float[] fla = new float[2];
+            for (int n = 0; n < 5; ++n) {
+                if (j >= 1) {
+                    if (n <= 1) {
+                        h += k;
+                    }
+                }
+            }
+            for (int l12 = 0; l12 < 9; ++l12) {
+                for (int o = 0; o < 1; ++o) {
+                    fla[0] += 1.0f;
+                }
+            }
+        }
+    }
+
+    public static void test2() {
+        float[] fla = new float[1000];
+        for (int i = 0; i < 1000; i++) {
+            for (float fl2 : fla) {
+                fla[100] = 1.0f;
+            }
+        }
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 14; j++) {
+                fla[2] = fla[j];
+            }
+        }
+    }
+}


### PR DESCRIPTION
Not a clean backport due to context different, but easy to resolve manually.

Test:
- [x] New test failed w/o patch and passed with patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268261](https://bugs.openjdk.java.net/browse/JDK-8268261): C2: assert(n != __null) failed: Bad immediate dominator info.


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/179/head:pull/179` \
`$ git checkout pull/179`

Update a local copy of the PR: \
`$ git checkout pull/179` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 179`

View PR using the GUI difftool: \
`$ git pr show -t 179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/179.diff">https://git.openjdk.java.net/jdk11u-dev/pull/179.diff</a>

</details>
