### PR TITLE
8220445: Support for side by side MSVC Toolset versions

### DIFF
--- a/make/autoconf/toolchain_windows.m4
+++ b/make/autoconf/toolchain_windows.m4
@@ -87,6 +87,7 @@ VS_SDK_INSTALLDIR_2017=
 VS_VS_PLATFORM_NAME_2017="v141"
 VS_SDK_PLATFORM_NAME_2017=
 VS_SUPPORTED_2017=true
+VS_TOOLSET_SUPPORTED_2017=true
 
 ################################################################################
 
@@ -177,6 +178,15 @@ AC_DEFUN([TOOLCHAIN_CHECK_POSSIBLE_WIN_SDK_ROOT],
 # build environment and assigns it to VS_ENV_CMD
 AC_DEFUN([TOOLCHAIN_FIND_VISUAL_STUDIO_BAT_FILE],
 [
+  # VS2017 provides the option to install previous minor versions of the MSVC
+  # toolsets. It is not possible to directly download earlier minor versions of
+  # VS2017 and in order to build with a previous minor compiler toolset version,
+  # it is now possible to compile with earlier minor versions by passing
+  # -vcvars_ver=<toolset_version> argument to vcvarsall.bat.
+  AC_ARG_WITH(msvc-toolset-version, [AS_HELP_STRING([--with-msvc-toolset-version],
+      [specific MSVC toolset version to use, passed as -vcvars_ver argument to
+       pass to vcvarsall.bat (Windows only)])])
+
   VS_VERSION="$1"
   eval VS_COMNTOOLS_VAR="\${VS_ENVVAR_${VS_VERSION}}"
   eval VS_COMNTOOLS="\$${VS_COMNTOOLS_VAR}"
@@ -184,6 +194,7 @@ AC_DEFUN([TOOLCHAIN_FIND_VISUAL_STUDIO_BAT_FILE],
   eval VS_EDITIONS="\${VS_EDITIONS_${VS_VERSION}}"
   eval SDK_INSTALL_DIR="\${VS_SDK_INSTALLDIR_${VS_VERSION}}"
   eval VS_ENV_ARGS="\${VS_ENV_ARGS_${VS_VERSION}}"
+  eval VS_TOOLSET_SUPPORTED="\${VS_TOOLSET_SUPPORTED_${VS_VERSION}}"
 
   VS_ENV_CMD=""
 
@@ -240,6 +251,12 @@ AC_DEFUN([TOOLCHAIN_FIND_VISUAL_STUDIO_BAT_FILE],
         [C:/Program Files/$SDK_INSTALL_DIR], [well-known name])
     TOOLCHAIN_CHECK_POSSIBLE_WIN_SDK_ROOT([${VS_VERSION}],
         [C:/Program Files (x86)/$SDK_INSTALL_DIR], [well-known name])
+  fi
+
+  if test "x$VS_TOOLSET_SUPPORTED" != x; then
+    if test "x$with_msvc_toolset_version" != x; then
+      VS_ENV_ARGS="$VS_ENV_ARGS -vcvars_ver=$with_msvc_toolset_version"
+    fi
   fi
 ])
 
@@ -397,6 +414,8 @@ AC_DEFUN([TOOLCHAIN_SETUP_VISUAL_STUDIO_ENV],
           >> $EXTRACT_VC_ENV_BAT_FILE
       $ECHO "$WINPATH_BASH -c 'echo VCINSTALLDIR="'\"$VCINSTALLDIR \" >> set-vs-env.sh' \
           >> $EXTRACT_VC_ENV_BAT_FILE
+      $ECHO "$WINPATH_BASH -c 'echo VCToolsRedistDir="'\"$VCToolsRedistDir \" >> set-vs-env.sh' \
+          >> $EXTRACT_VC_ENV_BAT_FILE
       $ECHO "$WINPATH_BASH -c 'echo WindowsSdkDir="'\"$WindowsSdkDir \" >> set-vs-env.sh' \
           >> $EXTRACT_VC_ENV_BAT_FILE
       $ECHO "$WINPATH_BASH -c 'echo WINDOWSSDKDIR="'\"$WINDOWSSDKDIR \" >> set-vs-env.sh' \
@@ -442,6 +461,7 @@ AC_DEFUN([TOOLCHAIN_SETUP_VISUAL_STUDIO_ENV],
       VS_INCLUDE=`$ECHO "$VS_INCLUDE" | $SED -e 's/\\\\*;* *$//'`
       VS_LIB=`$ECHO "$VS_LIB" | $SED 's/\\\\*;* *$//'`
       VCINSTALLDIR=`$ECHO "$VCINSTALLDIR" | $SED 's/\\\\* *$//'`
+      VCToolsRedistDir=`$ECHO "$VCToolsRedistDir" | $SED 's/\\\\* *$//'`
       WindowsSdkDir=`$ECHO "$WindowsSdkDir" | $SED 's/\\\\* *$//'`
       WINDOWSSDKDIR=`$ECHO "$WINDOWSSDKDIR" | $SED 's/\\\\* *$//'`
       if test -z "$WINDOWSSDKDIR"; then
@@ -561,11 +581,13 @@ AC_DEFUN([TOOLCHAIN_SETUP_MSVC_DLL],
           POSSIBLE_MSVC_DLL="$CYGWIN_VC_INSTALL_DIR/redist/x86/Microsoft.VC${VS_VERSION_INTERNAL}.CRT/$DLL_NAME"
         fi
       else
+        CYGWIN_VC_TOOLS_REDIST_DIR="$VCToolsRedistDir"
+        BASIC_FIXUP_PATH(CYGWIN_VC_TOOLS_REDIST_DIR)
         # Probe: Using well-known location from VS 2017
         if test "x$OPENJDK_TARGET_CPU_BITS" = x64; then
-          POSSIBLE_MSVC_DLL="`ls $CYGWIN_VC_INSTALL_DIR/Redist/MSVC/*/x64/Microsoft.VC${VS_VERSION_INTERNAL}.CRT/$DLL_NAME`"
+          POSSIBLE_MSVC_DLL="`ls $CYGWIN_VC_TOOLS_REDIST_DIR/x64/Microsoft.VC${VS_VERSION_INTERNAL}.CRT/$DLL_NAME`"
         else
-          POSSIBLE_MSVC_DLL="`ls $CYGWIN_VC_INSTALL_DIR/Redist/MSVC/*/x86/Microsoft.VC${VS_VERSION_INTERNAL}.CRT/$DLL_NAME`"
+          POSSIBLE_MSVC_DLL="`ls $CYGWIN_VC_TOOLS_REDIST_DIR/x86/Microsoft.VC${VS_VERSION_INTERNAL}.CRT/$DLL_NAME`"
         fi
       fi
       # In case any of the above finds more than one file, loop over them.


### PR DESCRIPTION
This is a backport of JDK-8220445 Support for side by side MSVC Toolset versions. It is needed to support the GitHub Actions workflow for Windows because it is using the hereby introduced configure option --with-msvc-toolset-version.

The backport did not apply cleanly because JDK-8215445: Enable building for Windows in WSL is missing. I adapted the change to make it fit.

I moved the line
`        $ECHO "$WINPATH_BASH -c 'echo VCToolsRedistDir="'\"$VCToolsRedistDir \" >> set-vs-env.sh' \
            >> $EXTRACT_VC_ENV_BAT_FILE`
to the fitting place and dropped the hunk
`        $ECHO 'echo VCToolsRedistDir="%VCToolsRedistDir% " >> set-vs-env.sh' \
            >> $EXTRACT_VC_ENV_BAT_FILE`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8220445](https://bugs.openjdk.java.net/browse/JDK-8220445): Support for side by side MSVC Toolset versions


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/180/head:pull/180` \
`$ git checkout pull/180`

Update a local copy of the PR: \
`$ git checkout pull/180` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 180`

View PR using the GUI difftool: \
`$ git pr show -t 180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/180.diff">https://git.openjdk.java.net/jdk11u-dev/pull/180.diff</a>

</details>
