### PR TITLE
8263432: javac may report an invalid package/class clash on case insensitive filesystems

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -648,6 +648,10 @@ public class Symtab {
     }
 
     public PackageSymbol lookupPackage(ModuleSymbol msym, Name flatName) {
+        return lookupPackage(msym, flatName, false);
+    }
+
+    private PackageSymbol lookupPackage(ModuleSymbol msym, Name flatName, boolean onlyExisting) {
         Assert.checkNonNull(msym);
 
         if (flatName.isEmpty()) {
@@ -670,7 +674,7 @@ public class Symtab {
 
         pack = getPackage(msym, flatName);
 
-        if (pack != null && pack.exists())
+        if ((pack != null && pack.exists()) || onlyExisting)
             return pack;
 
         boolean dependsOnUnnamed = msym.requires != null &&
@@ -742,7 +746,8 @@ public class Symtab {
      */
     public boolean packageExists(ModuleSymbol msym, Name fullname) {
         Assert.checkNonNull(msym);
-        return lookupPackage(msym, fullname).exists();
+        PackageSymbol pack = lookupPackage(msym, fullname, true);
+        return pack != null && pack.exists();
     }
 
     /** Make a package, given its fully qualified name.

--- a/test/langtools/tools/javac/modules/AnnotationProcessing.java
+++ b/test/langtools/tools/javac/modules/AnnotationProcessing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8133884 8162711 8133896 8172158 8172262 8173636 8175119 8189747
+ * @bug 8133884 8162711 8133896 8172158 8172262 8173636 8175119 8189747 8263432
  * @summary Verify that annotation processing works.
  * @library /tools/lib
  * @modules
@@ -44,6 +44,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -78,6 +79,7 @@ import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.ElementScanner9;
 import javax.tools.Diagnostic.Kind;
 import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaCompiler.CompilationTask;
 import javax.tools.JavaFileManager;
@@ -1549,6 +1551,101 @@ public class AnnotationProcessing extends ModuleTestBase {
         if (!log.equals(expected)) {
             throw new AssertionError("Expected output not found.");
         }
+    }
+
+    @Test
+    public void testClassPhantomPackageClash(Path base) throws Exception {
+        Path classes = base.resolve("classes");
+
+        Files.createDirectories(classes);
+
+        Path src = base.resolve("src");
+
+        tb.writeJavaFiles(src,
+                          "module m {}",
+                          "package api; public class Nested {}",
+                          "package api.nested; public class C {}");
+
+        class TestFileManager extends ForwardingJavaFileManager<JavaFileManager>
+                              implements StandardJavaFileManager {
+
+            public TestFileManager(StandardJavaFileManager fileManager) {
+                super(fileManager);
+            }
+
+            @Override
+            public Iterable<JavaFileObject> list(Location location, String packageName, Set<JavaFileObject.Kind> kinds, boolean recurse) throws IOException {
+                if ("api.Nested".equals(packageName)) {
+                    //simulate case insensitive filesystem:
+                    packageName = "api.nested";
+                }
+                return super.list(location, packageName, kinds, recurse);
+            }
+
+            @Override
+            public void setLocationFromPaths(Location location, Collection<? extends Path> paths) throws IOException {
+                ((StandardJavaFileManager) fileManager).setLocationFromPaths(location, paths);
+            }
+
+            @Override
+            public Iterable<? extends Path> getLocationAsPaths(Location location) {
+                return ((StandardJavaFileManager) fileManager).getLocationAsPaths(location);
+            }
+
+            @Override
+            public Iterable<? extends JavaFileObject> getJavaFileObjectsFromFiles(Iterable<? extends File> files) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Iterable<? extends JavaFileObject> getJavaFileObjects(File... files) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Iterable<? extends JavaFileObject> getJavaFileObjectsFromStrings(Iterable<String> names) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Iterable<? extends JavaFileObject> getJavaFileObjects(String... names) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public void setLocation(Location location, Iterable<? extends File> files) throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Iterable<? extends File> getLocation(Location location) {
+                throw new UnsupportedOperationException();
+            }
+        }
+
+        try (StandardJavaFileManager fm = ToolProvider.getSystemJavaCompiler().getStandardFileManager(null, null, null);
+             JavaFileManager testFM = new TestFileManager(fm)) {
+            new JavacTask(tb)
+                .fileManager(testFM)
+                .options("-processor", NoOpTestAP.class.getName(),
+                         "-sourcepath", src.toString())
+                .outdir(classes)
+                .files(src.resolve("module-info.java"),
+                       src.resolve("api").resolve("Nested.java"))
+                .run()
+                .writeAll()
+                .getOutputLines(OutputKind.STDERR);
+        }
+    }
+
+    @SupportedAnnotationTypes("*")
+    public static final class NoOpTestAP extends AbstractProcessor {
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            return false;
+        }
+
     }
 
     private static void assertNonNull(String msg, Object val) {


### PR DESCRIPTION
Backport of JDK-8263432. Fix applies cleanly except Copyright year update. The test required manual integration and adaptation of imports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263432](https://bugs.openjdk.java.net/browse/JDK-8263432): javac may report an invalid package/class clash on case insensitive filesystems


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/184/head:pull/184` \
`$ git checkout pull/184`

Update a local copy of the PR: \
`$ git checkout pull/184` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 184`

View PR using the GUI difftool: \
`$ git pr show -t 184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/184.diff">https://git.openjdk.java.net/jdk11u-dev/pull/184.diff</a>

</details>
