### PR TITLE
8226871: invalid use of incomplete type class MacroAssembler when building minimal after JDK-8191278

### DIFF
--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "asm/codeBuffer.hpp"
+#include "asm/macroAssembler.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/access.inline.hpp"
 #include "oops/oop.inline.hpp"


### PR DESCRIPTION
This is follow up for 8191278 that fixes build of arm/aarch64 platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #173 must be integrated first

### Issue
 * [JDK-8226871](https://bugs.openjdk.java.net/browse/JDK-8226871): invalid use of incomplete type class MacroAssembler when building minimal after JDK-8191278


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/191/head:pull/191` \
`$ git checkout pull/191`

Update a local copy of the PR: \
`$ git checkout pull/191` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 191`

View PR using the GUI difftool: \
`$ git pr show -t 191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/191.diff">https://git.openjdk.java.net/jdk11u-dev/pull/191.diff</a>

</details>
