### PR TITLE
8268427: Improve AlgorithmConstraints:checkAlgorithm performance

### DIFF
--- a/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/AbstractAlgorithmConstraints.java
@@ -32,6 +32,7 @@ import java.security.Security;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.TreeSet;
 import java.util.List;
 import java.util.Set;
 
@@ -48,7 +49,7 @@ public abstract class AbstractAlgorithmConstraints
     }
 
     // Get algorithm constraints from the specified security property.
-    static List<String> getAlgorithms(String propertyName) {
+    static Set<String> getAlgorithms(String propertyName) {
         String property = AccessController.doPrivileged(
                 new PrivilegedAction<String>() {
                     @Override
@@ -72,38 +73,30 @@ public abstract class AbstractAlgorithmConstraints
 
         // map the disabled algorithms
         if (algorithmsInProperty == null) {
-            return Collections.emptyList();
+            return Collections.emptySet();
         }
-        return new ArrayList<>(Arrays.asList(algorithmsInProperty));
+        Set<String> algorithmsInPropertySet = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        algorithmsInPropertySet.addAll(Arrays.asList(algorithmsInProperty));
+        return algorithmsInPropertySet;
     }
 
-    static boolean checkAlgorithm(List<String> algorithms, String algorithm,
+    static boolean checkAlgorithm(Set<String> algorithms, String algorithm,
             AlgorithmDecomposer decomposer) {
         if (algorithm == null || algorithm.isEmpty()) {
             throw new IllegalArgumentException("No algorithm name specified");
         }
 
-        Set<String> elements = null;
-        for (String item : algorithms) {
-            if (item == null || item.isEmpty()) {
-                continue;
-            }
+        if (algorithms.contains(algorithm)) {
+            return false;
+        }
 
-            // check the full name
-            if (item.equalsIgnoreCase(algorithm)) {
+        // decompose the algorithm into sub-elements
+        Set<String> elements = decomposer.decompose(algorithm);
+
+        // check the element of the elements
+        for (String element : elements) {
+            if (algorithms.contains(element)) {
                 return false;
-            }
-
-            // decompose the algorithm into sub-elements
-            if (elements == null) {
-                elements = decomposer.decompose(algorithm);
-            }
-
-            // check the items of the algorithm
-            for (String element : elements) {
-                if (item.equalsIgnoreCase(element)) {
-                    return false;
-                }
             }
         }
 

--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -85,6 +85,9 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
     private static final String PROPERTY_DISABLED_EC_CURVES =
             "jdk.disabled.namedCurves";
 
+    private static final Pattern INCLUDE_PATTERN = Pattern.compile("include " +
+            PROPERTY_DISABLED_EC_CURVES, Pattern.CASE_INSENSITIVE);
+
     private static class CertPathHolder {
         static final DisabledAlgorithmConstraints CONSTRAINTS =
             new DisabledAlgorithmConstraints(PROPERTY_CERTPATH_DISABLED_ALGS);
@@ -95,7 +98,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
             new DisabledAlgorithmConstraints(PROPERTY_JAR_DISABLED_ALGS);
     }
 
-    private final List<String> disabledAlgorithms;
+    private final Set<String> disabledAlgorithms;
     private final Constraints algorithmConstraints;
 
     public static DisabledAlgorithmConstraints certPathConstraints() {
@@ -130,21 +133,14 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
         disabledAlgorithms = getAlgorithms(propertyName);
 
         // Check for alias
-        int ecindex = -1, i = 0;
         for (String s : disabledAlgorithms) {
-            if (s.regionMatches(true, 0,"include ", 0, 8)) {
-                if (s.regionMatches(true, 8, PROPERTY_DISABLED_EC_CURVES, 0,
-                        PROPERTY_DISABLED_EC_CURVES.length())) {
-                    ecindex = i;
-                    break;
-                }
+            Matcher matcher = INCLUDE_PATTERN.matcher(s);
+            if (matcher.matches()) {
+                disabledAlgorithms.remove(matcher.group());
+                disabledAlgorithms.addAll(
+                        getAlgorithms(PROPERTY_DISABLED_EC_CURVES));
+                break;
             }
-            i++;
-        }
-        if (ecindex > -1) {
-            disabledAlgorithms.remove(ecindex);
-            disabledAlgorithms.addAll(ecindex,
-                    getAlgorithms(PROPERTY_DISABLED_EC_CURVES));
         }
         algorithmConstraints = new Constraints(propertyName, disabledAlgorithms);
     }
@@ -323,8 +319,8 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
                     "denyAfter\\s+(\\d{4})-(\\d{2})-(\\d{2})");
         }
 
-        public Constraints(String propertyName, List<String> constraintArray) {
-            for (String constraintEntry : constraintArray) {
+        public Constraints(String propertyName, Set<String> constraintSet) {
+            for (String constraintEntry : constraintSet) {
                 if (constraintEntry == null || constraintEntry.isEmpty()) {
                     continue;
                 }

--- a/src/java.base/share/classes/sun/security/util/LegacyAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/LegacyAlgorithmConstraints.java
@@ -40,7 +40,7 @@ public class LegacyAlgorithmConstraints extends AbstractAlgorithmConstraints {
     public static final String PROPERTY_TLS_LEGACY_ALGS =
             "jdk.tls.legacyAlgorithms";
 
-    private final List<String> legacyAlgorithms;
+    private final Set<String> legacyAlgorithms;
 
     public LegacyAlgorithmConstraints(String propertyName,
             AlgorithmDecomposer decomposer) {

--- a/test/micro/org/openjdk/bench/java/security/AlgorithmConstraintsPermits.java
+++ b/test/micro/org/openjdk/bench/java/security/AlgorithmConstraintsPermits.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.security;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import sun.security.util.DisabledAlgorithmConstraints;
+
+import java.security.AlgorithmConstraints;
+import java.security.CryptoPrimitive;
+import java.util.concurrent.TimeUnit;
+import java.util.EnumSet;
+import java.util.Set;
+
+import static sun.security.util.DisabledAlgorithmConstraints.PROPERTY_TLS_DISABLED_ALGS;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
+@State(Scope.Thread)
+public class AlgorithmConstraintsPermits {
+
+    AlgorithmConstraints tlsDisabledAlgConstraints;
+    Set<CryptoPrimitive> primitives = EnumSet.of(CryptoPrimitive.KEY_AGREEMENT);
+
+    @Param({"SSLv3", "DES", "NULL", "TLS1.3"})
+    String algorithm;
+
+    @Setup
+    public void setup() {
+        tlsDisabledAlgConstraints = new DisabledAlgorithmConstraints(PROPERTY_TLS_DISABLED_ALGS);
+    }
+
+    @Benchmark
+    public boolean permits() {
+        return tlsDisabledAlgConstraints.permits(primitives, algorithm, null);
+    }
+}
+


### PR DESCRIPTION
A backport of JDK-8233228 to 11u increased the list of disabled algorithms. For TLS the size of the list increased from 9 to 56. `sun.security.util.AbstractAlgorithmConstraints.checkAlgorithm()` uses linear search to check if an algorithm has been disabled. Its execution time significantly increased in the most common case: a checked algorithm is not disabled.

This backport improves `AbstractAlgorithmConstraints.checkAlgorithm()` performance.
Tier1 and tier2 tests pass with the patch.

The patch contains a microbenchmark.
Baseline results before patch:
```
Benchmark                            (algorithm)  Mode  Cnt     Score    Error  Units
AlgorithmConstraintsPermits.permits        SSLv3  avgt   25    17.296 ±  0.282  ns/op
AlgorithmConstraintsPermits.permits          DES  avgt   25   288.010 ±  2.502  ns/op
AlgorithmConstraintsPermits.permits         NULL  avgt   25   459.496 ±  6.160  ns/op
AlgorithmConstraintsPermits.permits       TLS1.3  avgt   25  1361.700 ± 12.871  ns/op
```

Benchmark results after patch:
```
Benchmark                            (algorithm)  Mode  Cnt     Score    Error  Units
AlgorithmConstraintsPermits.permits        SSLv3  avgt   25  119.320 ± 2.572  ns/op
AlgorithmConstraintsPermits.permits          DES  avgt   25   82.259 ± 0.668  ns/op
AlgorithmConstraintsPermits.permits         NULL  avgt   25   57.302 ± 3.611  ns/op
AlgorithmConstraintsPermits.permits       TLS1.3  avgt   25  465.914 ± 2.553  ns/op
```

Before the patch the list of the disabled algorithms has `SSLv3` first, `DES` second, `NULL` 9th and `TLS1.3` not on the list. As `SSLv3` is the first, accesses to it are the fastest. As we get far from the head, the access time increases. `NULL`  had been the last before JDK-8233228. In a case of TLS1.3 the whole list has to be checked.

The patch replaces the list with an ordered set. Despite the increased time for `SSLv3` all other times, especially for permitted algorithms such as `TLS1.3`, significantly decreased.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268427](https://bugs.openjdk.java.net/browse/JDK-8268427): Improve AlgorithmConstraints:checkAlgorithm performance


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/193/head:pull/193` \
`$ git checkout pull/193`

Update a local copy of the PR: \
`$ git checkout pull/193` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 193`

View PR using the GUI difftool: \
`$ git pr show -t 193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/193.diff">https://git.openjdk.java.net/jdk11u-dev/pull/193.diff</a>

</details>
