### PR TITLE
8270893: IndexOutOfBoundsException while reading large TIFF file

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFIFD.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/tiff/TIFFIFD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -323,7 +323,7 @@ public class TIFFIFD extends TIFFDirectory {
                         while (bytesToRead != 0) {
                             int sz = Math.min(bytesToRead, UNIT_SIZE);
                             byte[] unit = new byte[sz];
-                            stream.readFully(unit, bytesRead, sz);
+                            stream.readFully(unit, 0, sz);
                             bufs.add(unit);
                             bytesRead += sz;
                             bytesToRead -= sz;
@@ -459,7 +459,7 @@ public class TIFFIFD extends TIFFDirectory {
                     while (shortsToRead != 0) {
                         int sz = Math.min(shortsToRead, SSHORT_TILE_SIZE);
                         short[] unit = new short[sz];
-                        stream.readFully(unit, shortsRead, sz);
+                        stream.readFully(unit, 0, sz);
                         bufs.add(unit);
                         shortsRead += sz;
                         shortsToRead -= sz;
@@ -490,7 +490,7 @@ public class TIFFIFD extends TIFFDirectory {
                     while (intsToRead != 0) {
                         int sz = Math.min(intsToRead, INT_TILE_SIZE);
                         int[] unit = new int[sz];
-                        stream.readFully(unit, intsToRead, sz);
+                        stream.readFully(unit, 0, sz);
                         bufs.add(unit);
                         intsRead += sz;
                         intsToRead -= sz;
@@ -522,7 +522,7 @@ public class TIFFIFD extends TIFFDirectory {
                     while (srationalsToRead != 0) {
                         int sz = Math.min(srationalsToRead, SRATIONAL_TILE_SIZE);
                         int[] unit = new int[sz * 2];
-                        stream.readFully(unit, (srationalsToRead * 2), (sz * 2));
+                        stream.readFully(unit, 0, (sz * 2));
                         bufs.add(unit);
                         srationalsRead += sz;
                         srationalsToRead -= sz;
@@ -556,7 +556,7 @@ public class TIFFIFD extends TIFFDirectory {
                     while (floatsToRead != 0) {
                         int sz = Math.min(floatsToRead, FLOAT_TILE_SIZE);
                         float[] unit = new float[sz];
-                        stream.readFully(unit, floatsToRead, sz);
+                        stream.readFully(unit, 0, sz);
                         bufs.add(unit);
                         floatsRead += sz;
                         floatsToRead -= sz;
@@ -587,7 +587,7 @@ public class TIFFIFD extends TIFFDirectory {
                     while (doublesToRead != 0) {
                         int sz = Math.min(doublesToRead, DOUBLE_TILE_SIZE);
                         double[] unit = new double[sz];
-                        stream.readFully(unit, doublesToRead, sz);
+                        stream.readFully(unit, 0, sz);
                         bufs.add(unit);
                         doublesRead += sz;
                         doublesToRead -= sz;

--- a/test/jdk/javax/imageio/plugins/tiff/LargeTIFFTagTest.java
+++ b/test/jdk/javax/imageio/plugins/tiff/LargeTIFFTagTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8270893
+ * @summary Ensure that we don't throw IndexOutOfBoundsException when
+ *          we read TIFF tag with content more than 1024000 bytes
+ * @run main LargeTIFFTagTest
+ */
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Iterator;
+
+public class LargeTIFFTagTest {
+    public static void main(String[] args) throws IOException {
+        // TIFF stream length to hold 22 bytes of TIFF header
+        // plus 1024002 bytes of data in one TIFFTag
+        int length = 1024024;
+        byte[] ba = new byte[length];
+        // Little endian TIFF stream with header and only one
+        // IFD entry at offset 22 having count value 1024002.
+        byte[] header = new byte[] { (byte)0x49, (byte) 0x49,
+                (byte)0x2a, (byte)0x00, (byte)0x08, (byte)0x00,
+                (byte)0x00, (byte)0x00, (byte)0x01, (byte)0x00,
+                (byte)0x73, (byte)0x87, (byte)0x07, (byte)0x00,
+                (byte)0x02, (byte)0xA0, (byte)0x0F, (byte)0x00,
+                (byte)0x16, (byte)0x00, (byte)0x00, (byte)0x00};
+        // copy first 22 bytes of TIFF header to byte array
+        for (int i = 0; i < 22; i++) {
+            ba[i] = header[i];
+        }
+        ByteArrayInputStream bais = new ByteArrayInputStream(ba);
+        ImageInputStream stream = ImageIO.createImageInputStream(bais);
+        Iterator<ImageReader> readers = ImageIO.getImageReaders(stream);
+
+        if(readers.hasNext()) {
+            ImageReader reader = readers.next();
+            reader.setInput(stream);
+            try {
+                reader.readAll(0, null);
+            } catch (IllegalArgumentException e) {
+                // do nothing we expect IllegalArgumentException but we
+                // should not throw IndexOutOfBoundsException.
+                System.out.println(e.toString());
+                System.out.println("Caught IllegalArgumentException ignore it");
+            }
+        } else {
+            throw new RuntimeException("No readers available for TIFF format");
+        }
+    }
+}


### PR DESCRIPTION
A clean backport and new test passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270893](https://bugs.openjdk.java.net/browse/JDK-8270893): IndexOutOfBoundsException while reading large TIFF file


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/194/head:pull/194` \
`$ git checkout pull/194`

Update a local copy of the PR: \
`$ git checkout pull/194` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 194`

View PR using the GUI difftool: \
`$ git pr show -t 194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/194.diff">https://git.openjdk.java.net/jdk11u-dev/pull/194.diff</a>

</details>
