### PR TITLE
8212040: Compilation error due to wrong usage of NSPrintJobDispositionValue in mac10.12

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -360,8 +360,7 @@ static void nsPrintInfoToJavaPrinterJob(JNIEnv* env, NSPrintInfo* src, jobject d
     DECLARE_METHOD(jm_setPageRangeAttribute, sjc_CPrinterJob, "setPageRangeAttribute", "(IIZ)V");
     DECLARE_METHOD(jm_setPrintToFile, sjc_CPrinterJob, "setPrintToFile", "(Z)V");
 
-    NSPrintJobDispositionValue jobDisposition = [src jobDisposition];
-    if (jobDisposition == NSPrintSaveJob) {
+    if (src.jobDisposition == NSPrintSaveJob) {
         (*env)->CallVoidMethod(env, dstPrinterJob, jm_setPrintToFile, true);
     } else {
         (*env)->CallVoidMethod(env, dstPrinterJob, jm_setPrintToFile, false);


### PR DESCRIPTION
Backport of JDK-8212040. Manual integration was needed due to JNF removal in the succeeding code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8212040](https://bugs.openjdk.java.net/browse/JDK-8212040): Compilation error due to wrong usage of NSPrintJobDispositionValue in mac10.12


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/195/head:pull/195` \
`$ git checkout pull/195`

Update a local copy of the PR: \
`$ git checkout pull/195` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 195`

View PR using the GUI difftool: \
`$ git pr show -t 195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/195.diff">https://git.openjdk.java.net/jdk11u-dev/pull/195.diff</a>

</details>
