### PR TITLE
8229254: solaris_x64 build fails after JDK-8191278

### DIFF
--- a/src/hotspot/os/solaris/os_solaris.cpp
+++ b/src/hotspot/os/solaris/os_solaris.cpp
@@ -1595,6 +1595,10 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
     char*       name;         // String representation
   } arch_t;
 
+#ifndef EM_AARCH64
+  #define EM_AARCH64    183               /* ARM AARCH64 */
+#endif
+
   static const arch_t arch_array[]={
     {EM_386,         EM_386,     ELFCLASS32, ELFDATA2LSB, (char*)"IA 32"},
     {EM_486,         EM_386,     ELFCLASS32, ELFDATA2LSB, (char*)"IA 32"},

--- a/src/hotspot/os_cpu/solaris_x86/os_solaris_x86.cpp
+++ b/src/hotspot/os_cpu/solaris_x86/os_solaris_x86.cpp
@@ -550,7 +550,7 @@ JVM_handle_solaris_signal(int sig, siginfo_t* info, void* ucVoid,
         if (cb != NULL) {
           CompiledMethod* nm = cb->as_compiled_method_or_null();
           bool is_unsafe_arraycopy = thread->doing_unsafe_access() && UnsafeCopyMemory::contains_pc(pc);
-          if ((nm != NULL && nm->has_unsafe_access()) || is_unsafe_arraycopy)) {
+          if ((nm != NULL && nm->has_unsafe_access()) || is_unsafe_arraycopy) {
             address next_pc = Assembler::locate_next_instruction(pc);
             if (is_unsafe_arraycopy) {
               next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);


### PR DESCRIPTION
This is follow up for 8191278 that fixes solaris_x64 build. Applies cleanly

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #173 must be integrated first

### Issue
 * [JDK-8229254](https://bugs.openjdk.java.net/browse/JDK-8229254): solaris_x64 build fails after JDK-8191278


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/196/head:pull/196` \
`$ git checkout pull/196`

Update a local copy of the PR: \
`$ git checkout pull/196` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 196`

View PR using the GUI difftool: \
`$ git pr show -t 196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/196.diff">https://git.openjdk.java.net/jdk11u-dev/pull/196.diff</a>

</details>
