### PR TITLE
8251377: [macos11] JTabbedPane selected tab text is barely legible

### DIFF
--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
@@ -36,6 +36,16 @@ public final class JRSUIUtils {
 
     static boolean isLeopard = isMacOSXLeopard();
     static boolean isSnowLeopardOrBelow = isMacOSXSnowLeopardOrBelow();
+    static boolean isCatalinaOrAbove = isMacOSXCatalinaOrAbove();
+    static boolean isBigSurOrAbove = isMacOSXBigSurOrAbove();
+
+    public static boolean isMacOSXBigSurOrAbove() {
+        return currentMacOSXVersionMatchesGivenVersionRange(16, true, false, true);
+    }
+
+    static boolean isMacOSXCatalinaOrAbove() {
+        return currentMacOSXVersionMatchesGivenVersionRange(15, true, false, true);
+    }
 
     static boolean isMacOSXLeopard() {
         return isCurrentMacOSXVersion(5);

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaImageFactory.java
@@ -496,4 +496,8 @@ public class AquaImageFactory {
     public static Color getSelectionInactiveForegroundColorUIResource() {
         return new SystemColorProxy(LWCToolkit.getAppleColor(LWCToolkit.INACTIVE_SELECTION_FOREGROUND_COLOR));
     }
+
+    public static Color getSelectedControlColorUIResource() {
+        return new SystemColorProxy(LWCToolkit.getAppleColor(LWCToolkit.SELECTED_CONTROL_TEXT_COLOR));
+    }
 }

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
@@ -307,6 +307,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
         final ColorUIResource selectedTabTitlePressedColor = new ColorUIResource(240, 240, 240);
         final ColorUIResource selectedTabTitleDisabledColor = new ColorUIResource(new Color(1, 1, 1, 0.55f));
         final ColorUIResource selectedTabTitleNormalColor = white;
+        final Color selectedControlTextColor = AquaImageFactory.getSelectedControlColorUIResource();
         final ColorUIResource selectedTabTitleShadowDisabledColor = new ColorUIResource(new Color(0, 0, 0, 0.25f));
         final ColorUIResource selectedTabTitleShadowNormalColor = mediumTranslucentBlack;
         final ColorUIResource nonSelectedTabTitleNormalColor = black;
@@ -848,7 +849,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
             "TabbedPane.tabsOverlapBorder", Boolean.TRUE,
             "TabbedPane.selectedTabTitlePressedColor", selectedTabTitlePressedColor,
             "TabbedPane.selectedTabTitleDisabledColor", selectedTabTitleDisabledColor,
-            "TabbedPane.selectedTabTitleNormalColor", selectedTabTitleNormalColor,
+            "TabbedPane.selectedTabTitleNormalColor", JRSUIUtils.isMacOSXBigSurOrAbove() ? selectedControlTextColor : selectedTabTitleNormalColor,
             "TabbedPane.selectedTabTitleShadowDisabledColor", selectedTabTitleShadowDisabledColor,
             "TabbedPane.selectedTabTitleShadowNormalColor", selectedTabTitleShadowNormalColor,
             "TabbedPane.nonSelectedTabTitleNormalColor", nonSelectedTabTitleNormalColor,

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
@@ -196,14 +196,16 @@ public final class LWCToolkit extends LWToolkit {
     /*
      * System colors with default initial values, overwritten by toolkit if system values differ and are available.
      */
-    private static final int NUM_APPLE_COLORS = 3;
+    private static final int NUM_APPLE_COLORS = 4;
     public static final int KEYBOARD_FOCUS_COLOR = 0;
     public static final int INACTIVE_SELECTION_BACKGROUND_COLOR = 1;
     public static final int INACTIVE_SELECTION_FOREGROUND_COLOR = 2;
+    public static final int SELECTED_CONTROL_TEXT_COLOR = 3;
     private static int[] appleColors = {
         0xFF808080, // keyboardFocusColor = Color.gray;
         0xFFC0C0C0, // secondarySelectedControlColor
         0xFF303030, // controlDarkShadowColor
+        0xFFFFFFFF, // controlTextColor
     };
 
     private native void loadNativeColors(final int[] systemColors, final int[] appleColors);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
@@ -119,6 +119,7 @@ JNI_COCOA_EXIT(env);
     appleColors[sun_lwawt_macosx_LWCToolkit_KEYBOARD_FOCUS_COLOR] =                    [NSColor keyboardFocusIndicatorColor];
     appleColors[sun_lwawt_macosx_LWCToolkit_INACTIVE_SELECTION_BACKGROUND_COLOR] =    [NSColor secondarySelectedControlColor];
     appleColors[sun_lwawt_macosx_LWCToolkit_INACTIVE_SELECTION_FOREGROUND_COLOR] =    [NSColor controlDarkShadowColor];
+    appleColors[sun_lwawt_macosx_LWCToolkit_SELECTED_CONTROL_TEXT_COLOR] =            [NSColor controlTextColor];
 
     for (i = 0; i < sun_lwawt_macosx_LWCToolkit_NUM_APPLE_COLORS; i++) {
         [appleColors[i] retain];


### PR DESCRIPTION
Backport of JDK-8251377. Doesn't apply cleanly because Mac OS version check from JDK-8230869 is not in 11u. I just included the introduction of `isCatalinaOrAbove` and `isBigSurOrAbove` from the latter. Rest applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251377](https://bugs.openjdk.java.net/browse/JDK-8251377): [macos11] JTabbedPane selected tab text is barely legible


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/198/head:pull/198` \
`$ git checkout pull/198`

Update a local copy of the PR: \
`$ git checkout pull/198` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 198`

View PR using the GUI difftool: \
`$ git pr show -t 198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/198.diff">https://git.openjdk.java.net/jdk11u-dev/pull/198.diff</a>

</details>
