### PR TITLE
Allow to process custom RSA private key implementation

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
@@ -468,13 +468,15 @@ enum SignatureScheme {
 
         PrivateKey signingKey = x509Possession.popPrivateKey;
         String keyAlgorithm = signingKey.getAlgorithm();
-        int keySize;
+        int keySize = Integer.MAX_VALUE;
         // Only need to check RSA algorithm at present.
         if (keyAlgorithm.equalsIgnoreCase("RSA") ||
                 keyAlgorithm.equalsIgnoreCase("RSASSA-PSS")) {
             keySize = KeyUtil.getKeySize(signingKey);
-        } else {
-            keySize = Integer.MAX_VALUE;
+            if (keySize  == -1) {
+                // Allow to process custom RSA private key implementation
+                keySize = Integer.MAX_VALUE;
+            }
         }
         for (SignatureScheme ss : schemes) {
             if (ss.isAvailable && (keySize >= ss.minimalKeySize) &&


### PR DESCRIPTION
I customized the signature of the RSA algorithm and customized the privateKey to realize the function of offloading signature (Key less). 
But I need to implement one of the following interfaces in the customized privateKey to enable my private key to be processed: `Length`, `SecretKey`, `RSAKey` , `ECKey`, `DSAKey`, `DHKey`.
 Is it possible to add the logic to allow to process custom RSA private key implementation？
Here is my [commit](https://github.com/Azure/azure-sdk-for-java/pull/23322/commits/8001dcdf83e93837bfb0a4779430cb1a49ce8813) to change my private key.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/202/head:pull/202` \
`$ git checkout pull/202`

Update a local copy of the PR: \
`$ git checkout pull/202` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 202`

View PR using the GUI difftool: \
`$ git pr show -t 202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/202.diff">https://git.openjdk.java.net/jdk11u-dev/pull/202.diff</a>

</details>
