### PR TITLE
8210802: temp files left by tests in jdk/java/net/httpclient

### DIFF
--- a/test/jdk/java/net/httpclient/EchoHandler.java
+++ b/test/jdk/java/net/httpclient/EchoHandler.java
@@ -40,6 +40,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class EchoHandler implements HttpHandler {
+    static final Path CWD = Paths.get(".");
     public EchoHandler() {}
 
     @Override
@@ -53,7 +54,7 @@ public class EchoHandler implements HttpHandler {
             map1.add("X-Hello", "world");
             map1.add("X-Bye", "universe");
             String fixedrequest = map.getFirst("XFixed");
-            File outfile = File.createTempFile("foo", "bar");
+            File outfile = Files.createTempFile(CWD, "foo", "bar").toFile();
             FileOutputStream fos = new FileOutputStream(outfile);
             int count = (int) is.transferTo(fos);
             is.close();


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8210802 from the openjdk/jdk repository.

The commit being backported was authored by Hamlin Li on 18 Sep 2018 and was reviewed by Chris Hegarty and Christoph Langer.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210802](https://bugs.openjdk.java.net/browse/JDK-8210802): temp files left by tests in jdk/java/net/httpclient


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/206/head:pull/206` \
`$ git checkout pull/206`

Update a local copy of the PR: \
`$ git checkout pull/206` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 206`

View PR using the GUI difftool: \
`$ git pr show -t 206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/206.diff">https://git.openjdk.java.net/jdk11u-dev/pull/206.diff</a>

</details>
