### PR TITLE
8251361: Potential race between Logger configuration and GCs in HttpURLConWithProxy test

### DIFF
--- a/test/jdk/java/net/HttpURLConnection/HttpURLConWithProxy.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConWithProxy.java
@@ -45,17 +45,21 @@ import java.util.logging.LogRecord;
 
 public class HttpURLConWithProxy {
 
+    private static Logger logger =
+        Logger.getLogger("sun.net.www.protocol.http.HttpURLConnection");
+
     public static void main(String... arg) {
         // Remove the default nonProxyHosts to use localhost for testing
         System.setProperty("http.nonProxyHosts", "");
 
         System.setProperty("http.proxyHost", "1.1.1.1");
         System.setProperty("http.proxyPort", "1111");
-        String HTTPLOG = "sun.net.www.protocol.http.HttpURLConnection";
-        Logger.getLogger(HTTPLOG).setLevel(Level.ALL);
+
+        // Use the logger to help verify the Proxy was used
+        logger.setLevel(Level.ALL);
         Handler h = new ProxyHandler();
         h.setLevel(Level.ALL);
-        Logger.getLogger(HTTPLOG).addHandler(h);
+        logger.addHandler(h);
 
         ServerSocket ss;
         URL url;


### PR DESCRIPTION
This backport is simple, but it does not apply cleanly to 11u due to context conflict with "8227539: Replace wildcard address with loopback or local host in tests - part 20". It brought `throws Exception` to `main` method. I resolved that conflict by hand.

Additional testing:
 - [x] Affected test still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8251361](https://bugs.openjdk.java.net/browse/JDK-8251361): Potential race between Logger configuration and GCs in HttpURLConWithProxy test


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/208/head:pull/208` \
`$ git checkout pull/208`

Update a local copy of the PR: \
`$ git checkout pull/208` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 208`

View PR using the GUI difftool: \
`$ git pr show -t 208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/208.diff">https://git.openjdk.java.net/jdk11u-dev/pull/208.diff</a>

</details>
