### PR TITLE
8236413: AbstractConnectTimeout should tolerate both NoRouteToHostException and UnresolvedAddressException

### DIFF
--- a/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
+++ b/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.channels.UnresolvedAddressException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -142,11 +143,11 @@ public abstract class AbstractConnectTimeout {
                 long elapsedTime = NANOSECONDS.toMillis(System.nanoTime() - startTime);
                 out.printf("Client: received in %d millis%n", elapsedTime);
                 Throwable t = e.getCause().getCause();  // blocking thread-specific exception
-                if (!(t instanceof NoRouteToHostException)) { // tolerate only NRTHE
+                if (!isAcceptableCause(t)) { // tolerate only NRTHE or UAE
                     e.printStackTrace(out);
                     fail("Unexpected exception:" + e);
                 } else {
-                    out.printf("Caught ConnectException with NoRouteToHostException"
+                    out.printf("Caught ConnectException with "
                             + " cause: %s - skipping%n", t.getCause());
                 }
             }
@@ -194,15 +195,21 @@ public abstract class AbstractConnectTimeout {
                 long elapsedTime = NANOSECONDS.toMillis(System.nanoTime() - startTime);
                 out.printf("Client: received in %d millis%n", elapsedTime);
                 Throwable t = e.getCause();
-                if (t instanceof ConnectException &&
-                        t.getCause() instanceof NoRouteToHostException) { // tolerate only NRTHE
-                    out.printf("Caught ConnectException with NoRouteToHostException"
-                            + " cause: %s - skipping%n", t.getCause());
+                if (t instanceof ConnectException && isAcceptableCause(t.getCause())) {
+                    // tolerate only NRTHE and UAE
+                    out.printf("Caught ConnectException with "
+                            + "cause: %s - skipping%n", t.getCause());
                 } else {
                     assertExceptionTypeAndCause(t);
                 }
             }
         }
+    }
+
+    static boolean isAcceptableCause(Throwable cause) {
+        if (cause instanceof NoRouteToHostException) return true;
+        if (cause instanceof UnresolvedAddressException) return true;
+        return false;
     }
 
     static HttpClient newClient(Duration connectTimeout, ProxySelector proxy) {


### PR DESCRIPTION
Backporting this for `11.0.14-oracle` parity. 

Additional testing:
 - [x] `java/net/httpclient` tests still pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8236413](https://bugs.openjdk.java.net/browse/JDK-8236413): AbstractConnectTimeout should tolerate both NoRouteToHostException and UnresolvedAddressException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/210/head:pull/210` \
`$ git checkout pull/210`

Update a local copy of the PR: \
`$ git checkout pull/210` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 210`

View PR using the GUI difftool: \
`$ git pr show -t 210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/210.diff">https://git.openjdk.java.net/jdk11u-dev/pull/210.diff</a>

</details>
