### PR TITLE
8210669: Some launcher tests assume a pre-JDK 9 run-time image layout

### DIFF
--- a/test/jdk/tools/launcher/ExecutionEnvironment.java
+++ b/test/jdk/tools/launcher/ExecutionEnvironment.java
@@ -241,17 +241,26 @@ public class ExecutionEnvironment extends TestHelper {
      */
     @Test
     void testVmSelection() {
+        boolean haveSomeVM = false;
         if (haveClientVM) {
-            TestResult tr = doExec(javaCmd, "-client", "-version");
-            if (!tr.matches(".*Client VM.*")) {
-                flagError(tr, "the expected vm -client did not launch");
-            }
+            tryVmOption("-client", ".*Client VM.*");
+            haveSomeVM = true;
         }
         if (haveServerVM) {
-            TestResult tr = doExec(javaCmd, "-server", "-version");
-            if (!tr.matches(".*Server VM.*")) {
-                flagError(tr, "the expected vm -server did not launch");
-            }
+            tryVmOption("-server", ".*Server VM.*");
+            haveSomeVM = true;
+        }
+        if (!haveSomeVM) {
+            String msg = "Don't have a known VM";
+            System.err.println(msg);
+            throw new RuntimeException(msg);
+        }
+    }
+
+    private void tryVmOption(String opt, String expected) {
+        TestResult tr = doExec(javaCmd, opt, "-version");
+        if (!tr.matches(expected)) {
+            flagError(tr, "the expected vm " + opt + " did not launch");
         }
     }
 

--- a/test/jdk/tools/launcher/Test7029048.java
+++ b/test/jdk/tools/launcher/Test7029048.java
@@ -59,13 +59,10 @@ public class Test7029048 extends TestHelper {
     private static final File srcLibjvmSo = new File(srcServerDir, LIBJVM);
 
     private static final File dstLibDir = new File("lib");
-    private static final File dstLibArchDir =
-            new File(dstLibDir, getJreArch());
-
-    private static final File dstServerDir = new File(dstLibArchDir, "server");
+    private static final File dstServerDir = new File(dstLibDir, "server");
     private static final File dstServerLibjvm = new File(dstServerDir, LIBJVM);
 
-    private static final File dstClientDir = new File(dstLibArchDir, "client");
+    private static final File dstClientDir = new File(dstLibDir, "client");
     private static final File dstClientLibjvm = new File(dstClientDir, LIBJVM);
 
     private static final Map<String, String> env = new HashMap<>();

--- a/test/jdk/tools/launcher/TestHelper.java
+++ b/test/jdk/tools/launcher/TestHelper.java
@@ -186,8 +186,7 @@ public class TestHelper {
             return jvmFile.exists();
         } else {
             File vmDir = new File(JAVA_LIB, type);
-            File vmArchDir = new File(vmDir, getJreArch());
-            File jvmFile = new File(vmArchDir, LIBJVM);
+            File jvmFile = new File(vmDir, LIBJVM);
             return jvmFile.exists();
         }
     }


### PR DESCRIPTION
Backporting for `11.0.13-oracle` parity.

Additional testing:
 - [x] `tools/launcher/` pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210669](https://bugs.openjdk.java.net/browse/JDK-8210669): Some launcher tests assume a pre-JDK 9 run-time image layout


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/211/head:pull/211` \
`$ git checkout pull/211`

Update a local copy of the PR: \
`$ git checkout pull/211` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 211`

View PR using the GUI difftool: \
`$ git pr show -t 211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/211.diff">https://git.openjdk.java.net/jdk11u-dev/pull/211.diff</a>

</details>
