### PR TITLE
8258703: Incorrect 512-bit vector registers restore on x86_32

### DIFF
--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -315,18 +315,19 @@ void RegisterSaver::restore_live_registers(MacroAssembler* masm, bool restore_ve
   }
 
   if (restore_vectors) {
+    off = additional_frame_bytes - ymm_bytes;
+    // Restore upper half of YMM registers.
+    for (int n = 0; n < num_xmm_regs; n++) {
+      __ vinsertf128_high(as_XMMRegister(n), Address(rsp, n*16+off));
+    }
+
     if (UseAVX > 2) {
       // Restore upper half of ZMM registers.
       for (int n = 0; n < num_xmm_regs; n++) {
         __ vinsertf64x4_high(as_XMMRegister(n), Address(rsp, n*32));
       }
-      __ addptr(rsp, zmm_bytes);
     }
-    // Restore upper half of YMM registers.
-    for (int n = 0; n < num_xmm_regs; n++) {
-      __ vinsertf128_high(as_XMMRegister(n), Address(rsp, n*16));
-    }
-    __ addptr(rsp, ymm_bytes);
+    __ addptr(rsp, additional_frame_bytes);
   }
 
   __ pop_FPU_state();


### PR DESCRIPTION
Currently, there are x86_32 failures in GHA:

```
compiler/runtime/Test7196199.java 
compiler/runtime/safepoints/TestRegisterRestoring.java 
compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
```

This backport is supposed to fix all three of them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8258703](https://bugs.openjdk.java.net/browse/JDK-8258703): Incorrect 512-bit vector registers restore on x86_32


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/214/head:pull/214` \
`$ git checkout pull/214`

Update a local copy of the PR: \
`$ git checkout pull/214` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 214`

View PR using the GUI difftool: \
`$ git pr show -t 214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/214.diff">https://git.openjdk.java.net/jdk11u-dev/pull/214.diff</a>

</details>
