### PR TITLE
8272197: Update 11u GHA workflow with Shenandoah configurations

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -188,6 +188,7 @@ jobs:
           --with-jtreg=${HOME}/jtreg
           --with-default-make-target="product-bundles test-bundles"
           --with-zlib=system
+          --with-jvm-features=shenandoahgc
           --enable-jtreg-failure-handler
         working-directory: jdk
 
@@ -405,6 +406,8 @@ jobs:
         include:
           - flavor: hs x64 build only
             flags: --enable-debug --disable-precompiled-headers
+          - flavor: hs x64 shenandoah build only
+            flags: --enable-debug --disable-precompiled-headers --with-jvm-features=shenandoahgc
           - flavor: hs x64 zero build only
             flags: --enable-debug --disable-precompiled-headers --with-jvm-variants=zero
           - flavor: hs x64 minimal build only
@@ -413,6 +416,10 @@ jobs:
             flags: --with-debug-level=optimized --disable-precompiled-headers
           - flavor: hs aarch64 build only
             flags: --enable-debug --disable-precompiled-headers
+            debian-arch: arm64
+            gnu-arch: aarch64
+          - flavor: hs aarch64 shenandoah build only
+            flags: --enable-debug --disable-precompiled-headers --with-jvm-features=shenandoahgc
             debian-arch: arm64
             gnu-arch: aarch64
           - flavor: hs arm build only
@@ -648,6 +655,7 @@ jobs:
           --with-jtreg=${HOME}/jtreg
           --with-default-make-target="product-bundles test-bundles"
           --with-zlib=system
+          --with-jvm-features=shenandoahgc
           --enable-jtreg-failure-handler
         working-directory: jdk
 
@@ -939,6 +947,7 @@ jobs:
           --with-boot-jdk="$env:BOOT_JDK"
           --with-jtreg="$env:JT_HOME"
           --with-default-make-target="product-bundles test-bundles"
+          --with-jvm-features=shenandoahgc
           --enable-jtreg-failure-handler
         working-directory: jdk
 
@@ -1241,6 +1250,7 @@ jobs:
           --with-jtreg=${HOME}/jtreg
           --with-default-make-target="product-bundles test-bundles"
           --with-zlib=system
+          --with-jvm-features=shenandoahgc
           --enable-jtreg-failure-handler
         working-directory: jdk
 


### PR DESCRIPTION
I have noticed that 11u GHA workflow builds/tests without Shenandoah. This is because Shenandoah is not enabled by default in 11u, in contrast to mainline. Which means the workflow that we have picked from mainline does not enable Shenandoah.

Instead of changing the build defaults for 11u, I suggest we add Shenandoah configs to testing.

Example run:
https://github.com/shipilev/jdk11u-dev/runs/3288861982

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272197](https://bugs.openjdk.java.net/browse/JDK-8272197): Update 11u GHA workflow with Shenandoah configurations


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/216/head:pull/216` \
`$ git checkout pull/216`

Update a local copy of the PR: \
`$ git checkout pull/216` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 216`

View PR using the GUI difftool: \
`$ git pr show -t 216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/216.diff">https://git.openjdk.java.net/jdk11u-dev/pull/216.diff</a>

</details>
