### PR TITLE
8213235: java/nio/channels/SocketChannel/AsyncCloseChannel.java fails with threads that didn't exit

### DIFF
--- a/test/jdk/java/nio/channels/SocketChannel/AsyncCloseChannel.java
+++ b/test/jdk/java/nio/channels/SocketChannel/AsyncCloseChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,13 +24,16 @@
 /* @test
  * @bug 6285901 6501089
  * @summary Check no data is written to wrong socket channel during async closing.
- * @author Xueming Shen
+ * @run main/othervm AsyncCloseChannel
  */
 
-import java.io.*;
-import java.nio.*;
-import java.nio.channels.*;
-import java.net.*;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.SocketChannel;
 
 public class AsyncCloseChannel {
     static volatile boolean failed = false;

--- a/test/jdk/java/nio/channels/SocketChannel/AsyncCloseChannel.java
+++ b/test/jdk/java/nio/channels/SocketChannel/AsyncCloseChannel.java
@@ -24,7 +24,6 @@
 /* @test
  * @bug 6285901 6501089
  * @summary Check no data is written to wrong socket channel during async closing.
- * @run main/othervm AsyncCloseChannel
  */
 
 import java.io.IOException;
@@ -112,7 +111,7 @@ public class AsyncCloseChannel {
                         public void run() {
                             boolean empty = true;
                             try {
-                                for(;;) {
+                                while (keepGoing) {
                                     int c = s.getInputStream().read();
                                     if(c == -1) {
                                         if(!empty)


### PR DESCRIPTION
Backporting to match `11.0.13-oracle`. This backport contains two fixes that are done in lock-step with each other.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8213235](https://bugs.openjdk.java.net/browse/JDK-8213235): java/nio/channels/SocketChannel/AsyncCloseChannel.java fails with threads that didn't exit
 * [JDK-8213576](https://bugs.openjdk.java.net/browse/JDK-8213576): Make test AsyncCloseChannel.java run in othervm


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/218/head:pull/218` \
`$ git checkout pull/218`

Update a local copy of the PR: \
`$ git checkout pull/218` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 218`

View PR using the GUI difftool: \
`$ git pr show -t 218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/218.diff">https://git.openjdk.java.net/jdk11u-dev/pull/218.diff</a>

</details>
