### PR TITLE
8235216: typo in test filename

### DIFF
--- a/test/langtools/tools/javac/file/MultiReleaseJar/MultiReleaseModuleInfoTest.java
+++ b/test/langtools/tools/javac/file/MultiReleaseJar/MultiReleaseModuleInfoTest.java
@@ -29,7 +29,7 @@
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
- * @run main MutliReleaseModuleInfoTest
+ * @run main MultiReleaseModuleInfoTest
  */
 
 import java.nio.file.Paths;
@@ -49,7 +49,7 @@ import toolbox.Task;
 import toolbox.ToolBox;
 
 
-public class MutliReleaseModuleInfoTest {
+public class MultiReleaseModuleInfoTest {
 
     private final String service_mi =
             "module service {\n" +
@@ -82,7 +82,7 @@ public class MutliReleaseModuleInfoTest {
     private final ToolBox tb = new ToolBox();
 
     public static void main(String [] args) throws Exception {
-        new MutliReleaseModuleInfoTest().runTest();
+        new MultiReleaseModuleInfoTest().runTest();
     }
 
     private void runTest() throws Exception {


### PR DESCRIPTION
Clean backport to match `11.0.13-oracle`.

Additional testing:
 - [x] `tools/javac/file` tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8235216](https://bugs.openjdk.java.net/browse/JDK-8235216): typo in test filename


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/219/head:pull/219` \
`$ git checkout pull/219`

Update a local copy of the PR: \
`$ git checkout pull/219` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 219`

View PR using the GUI difftool: \
`$ git pr show -t 219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/219.diff">https://git.openjdk.java.net/jdk11u-dev/pull/219.diff</a>

</details>
