### PR TITLE
JDK-8253947: Implementation: JEP 388: Windows AArch64 Support

### DIFF
--- a/make/autoconf/basics.m4
+++ b/make/autoconf/basics.m4
@@ -673,6 +673,16 @@ AC_DEFUN([BASIC_EVAL_DEVKIT_VARIABLE],
 ])
 
 ###############################################################################
+# Evaluates platform specific overrides for build devkit variables.
+# $1: Name of variable
+AC_DEFUN([BASIC_EVAL_BUILD_DEVKIT_VARIABLE],
+[
+  if test "x[$]$1" = x; then
+    eval $1="\${$1_${OPENJDK_BUILD_CPU}}"
+  fi
+])
+
+###############################################################################
 AC_DEFUN_ONCE([BASIC_SETUP_DEVKIT],
 [
   AC_ARG_WITH([devkit], [AS_HELP_STRING([--with-devkit],

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -705,7 +705,9 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
       $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -DcpuIntel -Di586 -D$FLAGS_CPU_LEGACY_LIB"
     fi
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
-    if test "x$FLAGS_CPU" = xx86_64; then
+    if test "x$FLAGS_CPU" = xaarch64; then
+      $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -D_ARM64_ -Darm64"
+    elif test "x$FLAGS_CPU" = xx86_64; then
       $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -D_AMD64_ -Damd64"
     else
       $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -D_X86_ -Dx86"

--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -188,14 +188,13 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_CPU_DEP],
     fi
 
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
+    if test "x${OPENJDK_$1_CPU_BITS}" = "x32"; then
+      $1_CPU_EXECUTABLE_LDFLAGS="-stack:327680"
+    elif test "x${OPENJDK_$1_CPU_BITS}" = "x64"; then
+      $1_CPU_EXECUTABLE_LDFLAGS="-stack:1048576"
+    fi
     if test "x${OPENJDK_$1_CPU}" = "xx86"; then
       $1_CPU_LDFLAGS="-safeseh"
-      # NOTE: Old build added -machine. Probably not needed.
-      $1_CPU_LDFLAGS_JVM_ONLY="-machine:I386"
-      $1_CPU_EXECUTABLE_LDFLAGS="-stack:327680"
-    else
-      $1_CPU_LDFLAGS_JVM_ONLY="-machine:AMD64"
-      $1_CPU_EXECUTABLE_LDFLAGS="-stack:1048576"
     fi
   fi
 

--- a/make/autoconf/hotspot.m4
+++ b/make/autoconf/hotspot.m4
@@ -221,7 +221,7 @@ AC_DEFUN_ONCE([HOTSPOT_ENABLE_DISABLE_AOT],
 
   if test "x$ENABLE_AOT" = "xtrue"; then
     # Only enable AOT on X64 platforms.
-    if test "x$OPENJDK_TARGET_CPU" = "xx86_64" || test "x$OPENJDK_TARGET_CPU" = "xaarch64" ; then
+    if test "x$OPENJDK_TARGET_CPU" = "xx86_64" || test "x$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" = "xlinux-aarch64" ; then
       if test -e "${TOPDIR}/src/jdk.aot"; then
         if test -e "${TOPDIR}/src/jdk.internal.vm.compiler"; then
           ENABLE_AOT="true"
@@ -240,7 +240,7 @@ AC_DEFUN_ONCE([HOTSPOT_ENABLE_DISABLE_AOT],
     else
       ENABLE_AOT="false"
       if test "x$enable_aot" = "xyes"; then
-        AC_MSG_ERROR([AOT is currently only supported on x86_64 and aarch64. Remove --enable-aot.])
+        AC_MSG_ERROR([AOT is currently only supported on x86_64 and linux-aarch64. Remove --enable-aot.])
       fi
     fi
   fi
@@ -355,7 +355,7 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_FEATURES],
   # Only enable Shenandoah on supported arches, and only if requested
   AC_MSG_CHECKING([if shenandoah can be built])
   if HOTSPOT_CHECK_JVM_FEATURE(shenandoahgc); then
-    if test "x$OPENJDK_TARGET_CPU_ARCH" = "xx86" || test "x$OPENJDK_TARGET_CPU" = "xaarch64" ; then
+    if test "x$OPENJDK_TARGET_CPU_ARCH" = "xx86" || test "x$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" = "xlinux-aarch64" ; then
       AC_MSG_RESULT([yes])
     else
       DISABLED_JVM_FEATURES="$DISABLED_JVM_FEATURES shenandoahgc"
@@ -412,7 +412,7 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_FEATURES],
     # Only enable jvmci on x86_64, sparcv9 and aarch64
     if test "x$OPENJDK_TARGET_CPU" = "xx86_64" || \
        test "x$OPENJDK_TARGET_CPU" = "xsparcv9" || \
-       test "x$OPENJDK_TARGET_CPU" = "xaarch64" ; then
+       test "x$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" = "xlinux-aarch64" ; then
       AC_MSG_RESULT([yes])
       JVM_FEATURES_jvmci="jvmci"
       INCLUDE_JVMCI="true"

--- a/make/autoconf/hotspot.m4
+++ b/make/autoconf/hotspot.m4
@@ -355,7 +355,11 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_FEATURES],
   # Only enable Shenandoah on supported arches, and only if requested
   AC_MSG_CHECKING([if shenandoah can be built])
   if HOTSPOT_CHECK_JVM_FEATURE(shenandoahgc); then
-    if test "x$OPENJDK_TARGET_CPU_ARCH" = "xx86" || test "x$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" = "xlinux-aarch64" ; then
+    if test "x$OPENJDK_TARGET_CPU_ARCH" = "xx86" ; then
+      AC_MSG_RESULT([yes])
+    elif test "x$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" = "xlinux-aarch64" ; then
+      AC_MSG_RESULT([yes])
+    elif test "x$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" = "xwindows-aarch64" ; then
       AC_MSG_RESULT([yes])
     else
       DISABLED_JVM_FEATURES="$DISABLED_JVM_FEATURES shenandoahgc"

--- a/make/autoconf/hotspot.m4
+++ b/make/autoconf/hotspot.m4
@@ -416,6 +416,7 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_FEATURES],
     # Only enable jvmci on x86_64, sparcv9 and aarch64
     if test "x$OPENJDK_TARGET_CPU" = "xx86_64" || \
        test "x$OPENJDK_TARGET_CPU" = "xsparcv9" || \
+       test "x$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" = "xwindows-aarch64" || \
        test "x$OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU" = "xlinux-aarch64" ; then
       AC_MSG_RESULT([yes])
       JVM_FEATURES_jvmci="jvmci"
@@ -447,10 +448,11 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_FEATURES],
       JVM_FEATURES_graal="graal"
       INCLUDE_GRAAL="true"
     else
-      # By default enable graal build on x64 or where AOT is available.
+      # By default enable graal build on x64/aarch64 or where AOT is available.
       # graal build requires jvmci.
       if test "x$JVM_FEATURES_jvmci" = "xjvmci" && \
           (test "x$OPENJDK_TARGET_CPU" = "xx86_64" || \
+           test "x$OPENJDK_TARGET_CPU" = "xaarch64" || \
            test "x$ENABLE_AOT" = "xtrue") ; then
         AC_MSG_RESULT([yes])
         JVM_FEATURES_graal="graal"

--- a/make/autoconf/toolchain_windows.m4
+++ b/make/autoconf/toolchain_windows.m4
@@ -126,11 +126,15 @@ AC_DEFUN([TOOLCHAIN_CHECK_POSSIBLE_VISUAL_STUDIO_ROOT],
 
     if test -d "$VS_BASE"; then
       AC_MSG_NOTICE([Found Visual Studio installation at $VS_BASE using $METHOD])
-      if test "x$OPENJDK_TARGET_CPU_BITS" = x32; then
+      if test "x$OPENJDK_TARGET_CPU" = xx86; then
         VCVARSFILES="vc/bin/vcvars32.bat vc/auxiliary/build/vcvars32.bat"
-      else
+      elif test "x$OPENJDK_TARGET_CPU" = xx86_64; then
         VCVARSFILES="vc/bin/amd64/vcvars64.bat vc/bin/x86_amd64/vcvarsx86_amd64.bat \
             vc/auxiliary/build/vcvarsx86_amd64.bat vc/auxiliary/build/vcvars64.bat"
+      elif test "x$OPENJDK_TARGET_CPU" = xaarch64; then
+        # for host x86-64, target aarch64
+        VCVARSFILES="vc/auxiliary/build/vcvarsamd64_arm64.bat \
+            vc/auxiliary/build/vcvarsx86_arm64.bat"
       fi
 
       for VCVARSFILE in $VCVARSFILES; do
@@ -170,10 +174,12 @@ AC_DEFUN([TOOLCHAIN_CHECK_POSSIBLE_WIN_SDK_ROOT],
       elif test -f "$WIN_SDK_BASE/Bin/SetEnv.Cmd"; then
         AC_MSG_NOTICE([Found Windows SDK installation at $WIN_SDK_BASE using $METHOD])
         VS_ENV_CMD="$WIN_SDK_BASE/Bin/SetEnv.Cmd"
-        if test "x$OPENJDK_TARGET_CPU_BITS" = x32; then
+        if test "x$OPENJDK_TARGET_CPU" = xx86; then
           VS_ENV_ARGS="/x86"
-        else
+        elif test "x$OPENJDK_TARGET_CPU" = xx86_64; then
           VS_ENV_ARGS="/x64"
+        elif test "x$OPENJDK_TARGET_CPU" = xaarch64; then
+          VS_ENV_ARGS="/arm64"
         fi
         # PLATFORM_TOOLSET is used during the compilation of the freetype sources (see
         # 'LIB_BUILD_FREETYPE' in libraries.m4) and must be 'Windows7.1SDK' for Windows7.1SDK
@@ -489,41 +495,7 @@ AC_DEFUN([TOOLCHAIN_SETUP_VISUAL_STUDIO_ENV],
       AC_SUBST(VS_INCLUDE)
       AC_SUBST(VS_LIB)
 
-      # Convert VS_INCLUDE into SYSROOT_CFLAGS
-      OLDIFS="$IFS"
-      IFS=";"
-      for i in $VS_INCLUDE; do
-        ipath=$i
-        # Only process non-empty elements
-        if test "x$ipath" != x; then
-          IFS="$OLDIFS"
-          # Check that directory exists before calling fixup_path
-          testpath=$ipath
-          BASIC_WINDOWS_REWRITE_AS_UNIX_PATH([testpath])
-          if test -d "$testpath"; then
-            BASIC_FIXUP_PATH([ipath])
-            SYSROOT_CFLAGS="$SYSROOT_CFLAGS -I$ipath"
-          fi
-          IFS=";"
-        fi
-      done
-      # Convert VS_LIB into SYSROOT_LDFLAGS
-      for i in $VS_LIB; do
-        libpath=$i
-        # Only process non-empty elements
-        if test "x$libpath" != x; then
-          IFS="$OLDIFS"
-          # Check that directory exists before calling fixup_path
-          testpath=$libpath
-          BASIC_WINDOWS_REWRITE_AS_UNIX_PATH([testpath])
-          if test -d "$testpath"; then
-            BASIC_FIXUP_PATH([libpath])
-            SYSROOT_LDFLAGS="$SYSROOT_LDFLAGS -libpath:$libpath"
-          fi
-          IFS=";"
-        fi
-      done
-      IFS="$OLDIFS"
+      TOOLCHAIN_SETUP_VISUAL_STUDIO_SYSROOT_FLAGS
     fi
   else
     AC_MSG_RESULT([not found])
@@ -560,10 +532,15 @@ AC_DEFUN([TOOLCHAIN_CHECK_POSSIBLE_MSVC_DLL],
         CORRECT_MSVCR_ARCH="PE32+ executable"
       fi
     else
-      if test "x$OPENJDK_TARGET_CPU_BITS" = x32; then
+      if test "x$OPENJDK_TARGET_CPU" = xx86; then
         CORRECT_MSVCR_ARCH=386
-      else
+      elif test "x$OPENJDK_TARGET_CPU" = xx86_64; then
         CORRECT_MSVCR_ARCH=x86-64
+      elif test "x$OPENJDK_TARGET_CPU" = xaarch64; then
+        # The cygwin 'file' command only returns "PE32+ executable (DLL) (console), for MS Windows",
+        # without specifying which architecture it is for specifically. This has been fixed upstream.
+        # https://github.com/file/file/commit/b849b1af098ddd530094bf779b58431395db2e10#diff-ff2eced09e6860de75057dd731d092aeR142
+        CORRECT_MSVCR_ARCH="PE32+ executable"
       fi
     fi
     if $ECHO "$MSVC_DLL_FILETYPE" | $GREP "$CORRECT_MSVCR_ARCH" 2>&1 > /dev/null; then
@@ -583,26 +560,26 @@ AC_DEFUN([TOOLCHAIN_SETUP_MSVC_DLL],
   DLL_NAME="$1"
   MSVC_DLL=
 
+  if test "x$OPENJDK_TARGET_CPU" = xx86; then
+    vs_target_cpu=x86
+  elif test "x$OPENJDK_TARGET_CPU" = xx86_64; then
+    vs_target_cpu=x64
+  elif test "x$OPENJDK_TARGET_CPU" = xaarch64; then
+    vs_target_cpu=arm64
+  fi
+
   if test "x$MSVC_DLL" = x; then
     if test "x$VCINSTALLDIR" != x; then
       CYGWIN_VC_INSTALL_DIR="$VCINSTALLDIR"
       BASIC_FIXUP_PATH(CYGWIN_VC_INSTALL_DIR)
       if test "$VS_VERSION" -lt 2017; then
         # Probe: Using well-known location from Visual Studio 12.0 and older
-        if test "x$OPENJDK_TARGET_CPU_BITS" = x64; then
-          POSSIBLE_MSVC_DLL="$CYGWIN_VC_INSTALL_DIR/redist/x64/Microsoft.VC${VS_VERSION_INTERNAL}.CRT/$DLL_NAME"
-        else
-          POSSIBLE_MSVC_DLL="$CYGWIN_VC_INSTALL_DIR/redist/x86/Microsoft.VC${VS_VERSION_INTERNAL}.CRT/$DLL_NAME"
-        fi
+        POSSIBLE_MSVC_DLL="$CYGWIN_VC_INSTALL_DIR/redist/$vs_target_cpu/Microsoft.VC${VS_VERSION_INTERNAL}.CRT/$DLL_NAME"
       else
         CYGWIN_VC_TOOLS_REDIST_DIR="$VCToolsRedistDir"
         BASIC_FIXUP_PATH(CYGWIN_VC_TOOLS_REDIST_DIR)
         # Probe: Using well-known location from VS 2017 and VS 2019
-        if test "x$OPENJDK_TARGET_CPU_BITS" = x64; then
-          POSSIBLE_MSVC_DLL="`ls $CYGWIN_VC_TOOLS_REDIST_DIR/x64/Microsoft.VC${VS_VERSION_INTERNAL}.CRT/$DLL_NAME`"
-        else
-          POSSIBLE_MSVC_DLL="`ls $CYGWIN_VC_TOOLS_REDIST_DIR/x86/Microsoft.VC${VS_VERSION_INTERNAL}.CRT/$DLL_NAME`"
-        fi
+        POSSIBLE_MSVC_DLL="`ls $CYGWIN_VC_TOOLS_REDIST_DIR/$vs_target_cpu/Microsoft.VC${VS_VERSION_INTERNAL}.CRT/$DLL_NAME`"
       fi
       # In case any of the above finds more than one file, loop over them.
       for possible_msvc_dll in $POSSIBLE_MSVC_DLL; do
@@ -634,13 +611,8 @@ AC_DEFUN([TOOLCHAIN_SETUP_MSVC_DLL],
     if test "x$VS100COMNTOOLS" != x; then
       CYGWIN_VS_TOOLS_DIR="$VS100COMNTOOLS/.."
       BASIC_WINDOWS_REWRITE_AS_UNIX_PATH(CYGWIN_VS_TOOLS_DIR)
-      if test "x$OPENJDK_TARGET_CPU_BITS" = x64; then
-        POSSIBLE_MSVC_DLL=`$FIND "$CYGWIN_VS_TOOLS_DIR" -name $DLL_NAME \
-	    | $GREP -i /x64/ | $HEAD --lines 1`
-      else
-        POSSIBLE_MSVC_DLL=`$FIND "$CYGWIN_VS_TOOLS_DIR" -name $DLL_NAME \
-	    | $GREP -i /x86/ | $HEAD --lines 1`
-      fi
+      POSSIBLE_MSVC_DLL=`$FIND "$CYGWIN_VS_TOOLS_DIR" -name $DLL_NAME \
+        | $GREP -i /$vs_target_cpu/ | $HEAD --lines 1`
       TOOLCHAIN_CHECK_POSSIBLE_MSVC_DLL([$DLL_NAME], [$POSSIBLE_MSVC_DLL],
           [search of VS100COMNTOOLS])
     fi
@@ -650,17 +622,17 @@ AC_DEFUN([TOOLCHAIN_SETUP_MSVC_DLL],
     # Probe: Search wildly in the VCINSTALLDIR. We've probably lost by now.
     # (This was the original behaviour; kept since it might turn something up)
     if test "x$CYGWIN_VC_INSTALL_DIR" != x; then
-      if test "x$OPENJDK_TARGET_CPU_BITS" = x64; then
+      if test "x$OPENJDK_TARGET_CPU" = xx86; then
         POSSIBLE_MSVC_DLL=`$FIND "$CYGWIN_VC_INSTALL_DIR" -name $DLL_NAME \
-	    | $GREP x64 | $HEAD --lines 1`
-      else
-        POSSIBLE_MSVC_DLL=`$FIND "$CYGWIN_VC_INSTALL_DIR" -name $DLL_NAME \
-	    | $GREP x86 | $GREP -v ia64 | $GREP -v x64 | $HEAD --lines 1`
+        | $GREP x86 | $GREP -v ia64 | $GREP -v x64 | $GREP -v arm64 | $HEAD --lines 1`
         if test "x$POSSIBLE_MSVC_DLL" = x; then
           # We're grasping at straws now...
           POSSIBLE_MSVC_DLL=`$FIND "$CYGWIN_VC_INSTALL_DIR" -name $DLL_NAME \
 	      | $HEAD --lines 1`
         fi
+      else
+        POSSIBLE_MSVC_DLL=`$FIND "$CYGWIN_VC_INSTALL_DIR" -name $DLL_NAME \
+          | $GREP $vs_target_cpu | $HEAD --lines 1`
       fi
 
       TOOLCHAIN_CHECK_POSSIBLE_MSVC_DLL([$DLL_NAME], [$POSSIBLE_MSVC_DLL],
@@ -744,8 +716,12 @@ AC_DEFUN([TOOLCHAIN_SETUP_VS_RUNTIME_DLLS],
       CYGWIN_WINDOWSSDKDIR="${WINDOWSSDKDIR}"
       BASIC_FIXUP_PATH([CYGWIN_WINDOWSSDKDIR])
       dll_subdir=$OPENJDK_TARGET_CPU
-      if test "x$dll_subdir" = "xx86_64"; then
+      if test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
+        dll_subdir="arm64"
+      elif test "x$OPENJDK_TARGET_CPU" = "xx86_64"; then
         dll_subdir="x64"
+      elif test "x$OPENJDK_TARGET_CPU" = "xx86"; then
+        dll_subdir="x86"
       fi
       UCRT_DLL_DIR="$CYGWIN_WINDOWSSDKDIR/Redist/ucrt/DLLs/$dll_subdir"
       if test -z "$(ls -d "$UCRT_DLL_DIR/"*.dll 2> /dev/null)"; then
@@ -767,4 +743,50 @@ AC_DEFUN([TOOLCHAIN_SETUP_VS_RUNTIME_DLLS],
     UCRT_DLL_DIR=
   fi
   AC_SUBST(UCRT_DLL_DIR)
+])
+
+# Setup the sysroot flags and add them to global CFLAGS and LDFLAGS so
+# that configure can use them while detecting compilers.
+# TOOLCHAIN_TYPE is available here.
+# Param 1 - Optional prefix to all variables. (e.g BUILD_)
+AC_DEFUN([TOOLCHAIN_SETUP_VISUAL_STUDIO_SYSROOT_FLAGS],
+[
+  # Convert $1VS_INCLUDE into $1SYSROOT_CFLAGS
+  OLDIFS="$IFS"
+  IFS=";"
+  for i in [$]$1VS_INCLUDE; do
+    ipath=$i
+    # Only process non-empty elements
+    if test "x$ipath" != x; then
+      IFS="$OLDIFS"
+      # Check that directory exists before calling fixup_path
+      testpath=$ipath
+      BASIC_WINDOWS_REWRITE_AS_UNIX_PATH([testpath])
+      if test -d "$testpath"; then
+        BASIC_FIXUP_PATH([ipath])
+        $1SYSROOT_CFLAGS="[$]$1SYSROOT_CFLAGS -I$ipath"
+      fi
+      IFS=";"
+    fi
+  done
+  # Convert $1VS_LIB into $1SYSROOT_LDFLAGS
+  for i in [$]$1VS_LIB; do
+    libpath=$i
+    # Only process non-empty elements
+    if test "x$libpath" != x; then
+      IFS="$OLDIFS"
+      # Check that directory exists before calling fixup_path
+      testpath=$libpath
+      BASIC_WINDOWS_REWRITE_AS_UNIX_PATH([testpath])
+      if test -d "$testpath"; then
+        BASIC_FIXUP_PATH([libpath])
+        $1SYSROOT_LDFLAGS="[$]$1SYSROOT_LDFLAGS -libpath:$libpath"
+      fi
+      IFS=";"
+    fi
+  done
+  IFS="$OLDIFS"
+
+  AC_SUBST($1SYSROOT_CFLAGS)
+  AC_SUBST($1SYSROOT_LDFLAGS)
 ])

--- a/make/devkit/createWindowsDevkit2017.sh
+++ b/make/devkit/createWindowsDevkit2017.sh
@@ -89,19 +89,23 @@ if [ ! -d $DEVKIT_ROOT/VC ]; then
     REDIST_SUBDIR="VC/Redist/MSVC/14.12.25810"
     echo "Copying VC..."
     mkdir -p $DEVKIT_ROOT/VC/bin
+    cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/bin/Hostx64/arm64" $DEVKIT_ROOT/VC/bin/
     cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/bin/Hostx64/x64" $DEVKIT_ROOT/VC/bin/
     cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/bin/Hostx86/x86" $DEVKIT_ROOT/VC/bin/
     mkdir -p $DEVKIT_ROOT/VC/lib
+    cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/lib/arm64" $DEVKIT_ROOT/VC/lib/
     cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/lib/x64" $DEVKIT_ROOT/VC/lib/
     cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/lib/x86" $DEVKIT_ROOT/VC/lib/
     cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/include" $DEVKIT_ROOT/VC/
     mkdir -p $DEVKIT_ROOT/VC/atlmfc/lib
+    cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/atlmfc/lib/arm64" $DEVKIT_ROOT/VC/atlmfc/lib/
     cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/atlmfc/lib/x64" $DEVKIT_ROOT/VC/atlmfc/lib/
     cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/atlmfc/lib/x86" $DEVKIT_ROOT/VC/atlmfc/lib/
     cp -r "$VS_INSTALL_DIR/${VC_SUBDIR}/atlmfc/include" $DEVKIT_ROOT/VC/atlmfc/
     mkdir -p $DEVKIT_ROOT/VC/Auxiliary
     cp -r "$VS_INSTALL_DIR/VC/Auxiliary/Build" $DEVKIT_ROOT/VC/Auxiliary/
     mkdir -p $DEVKIT_ROOT/VC/redist
+    cp -r "$VS_INSTALL_DIR/$REDIST_SUBDIR/arm64" $DEVKIT_ROOT/VC/redist/
     cp -r "$VS_INSTALL_DIR/$REDIST_SUBDIR/x64" $DEVKIT_ROOT/VC/redist/
     cp -r "$VS_INSTALL_DIR/$REDIST_SUBDIR/x86" $DEVKIT_ROOT/VC/redist/
 
@@ -111,6 +115,8 @@ if [ ! -d $DEVKIT_ROOT/VC ]; then
     cp $DEVKIT_ROOT/VC/redist/x86/$MSVCP_DLL $DEVKIT_ROOT/VC/bin/x86
     cp $DEVKIT_ROOT/VC/redist/x64/$MSVCR_DLL $DEVKIT_ROOT/VC/bin/x64
     cp $DEVKIT_ROOT/VC/redist/x64/$MSVCP_DLL $DEVKIT_ROOT/VC/bin/x64
+    cp $DEVKIT_ROOT/VC/redist/arm64/$MSVCR_DLL $DEVKIT_ROOT/VC/bin/arm64
+    cp $DEVKIT_ROOT/VC/redist/arm64/$MSVCP_DLL $DEVKIT_ROOT/VC/bin/arm64
 fi
 
 ################################################################################
@@ -128,8 +134,10 @@ if [ ! -d $DEVKIT_ROOT/$SDK_VERSION ]; then
     cp -r "$SDK_INSTALL_DIR/bin/$SDK_FULL_VERSION/x64" $DEVKIT_ROOT/$SDK_VERSION/bin/
     cp -r "$SDK_INSTALL_DIR/bin/$SDK_FULL_VERSION/x86" $DEVKIT_ROOT/$SDK_VERSION/bin/
     mkdir -p $DEVKIT_ROOT/$SDK_VERSION/lib
+    cp -r "$SDK_INSTALL_DIR/lib/$SDK_FULL_VERSION/um/arm64" $DEVKIT_ROOT/$SDK_VERSION/lib/
     cp -r "$SDK_INSTALL_DIR/lib/$SDK_FULL_VERSION/um/x64" $DEVKIT_ROOT/$SDK_VERSION/lib/
     cp -r "$SDK_INSTALL_DIR/lib/$SDK_FULL_VERSION/um/x86" $DEVKIT_ROOT/$SDK_VERSION/lib/
+    cp -r "$SDK_INSTALL_DIR/lib/$SDK_FULL_VERSION/ucrt/arm64" $DEVKIT_ROOT/$SDK_VERSION/lib/
     cp -r "$SDK_INSTALL_DIR/lib/$SDK_FULL_VERSION/ucrt/x64" $DEVKIT_ROOT/$SDK_VERSION/lib/
     cp -r "$SDK_INSTALL_DIR/lib/$SDK_FULL_VERSION/ucrt/x86" $DEVKIT_ROOT/$SDK_VERSION/lib/
     mkdir -p $DEVKIT_ROOT/$SDK_VERSION/Redist
@@ -164,6 +172,13 @@ echo-info "DEVKIT_VS_LIB_x86_64=\"\$DEVKIT_ROOT/VC/lib/x64;\$DEVKIT_ROOT/VC/atlm
 echo-info "DEVKIT_MSVCR_DLL_x86_64=\"\$DEVKIT_ROOT/VC/redist/x64/$MSVCR_DLL\""
 echo-info "DEVKIT_MSVCP_DLL_x86_64=\"\$DEVKIT_ROOT/VC/redist/x64/$MSVCP_DLL\""
 echo-info "DEVKIT_UCRT_DLL_DIR_x86_64=\"\$DEVKIT_ROOT/10/Redist/ucrt/DLLs/x64\""
+echo-info ""
+echo-info "DEVKIT_TOOLCHAIN_PATH_aarch64=\"\$DEVKIT_ROOT/VC/bin/arm64:\$DEVKIT_ROOT/$SDK_VERSION/bin/x64:\$DEVKIT_ROOT/$SDK_VERSION/bin/x86\""
+echo-info "DEVKIT_VS_INCLUDE_aarch64=\"\$DEVKIT_ROOT/VC/include;\$DEVKIT_ROOT/VC/atlmfc/include;\$DEVKIT_ROOT/$SDK_VERSION/include/shared;\$DEVKIT_ROOT/$SDK_VERSION/include/ucrt;\$DEVKIT_ROOT/$SDK_VERSION/include/um;\$DEVKIT_ROOT/$SDK_VERSION/include/winrt\""
+echo-info "DEVKIT_VS_LIB_aarch64=\"\$DEVKIT_ROOT/VC/lib/arm64;\$DEVKIT_ROOT/VC/atlmfc/lib/arm64;\$DEVKIT_ROOT/$SDK_VERSION/lib/arm64\""
+echo-info "DEVKIT_MSVCR_DLL_aarch64=\"\$DEVKIT_ROOT/VC/redist/arm64/$MSVCR_DLL\""
+echo-info "DEVKIT_MSVCP_DLL_aarch64=\"\$DEVKIT_ROOT/VC/redist/arm64/$MSVCP_DLL\""
+echo-info "DEVKIT_UCRT_DLL_DIR_aarch64=\"\$DEVKIT_ROOT/10/Redist/ucrt/DLLs/arm64\""
 
 ################################################################################
 # Copy this script

--- a/make/gensrc/GensrcMisc.gmk
+++ b/make/gensrc/GensrcMisc.gmk
@@ -63,6 +63,12 @@ ifneq ($(filter $(TOOLCHAIN_TYPE), gcc clang), )
   CPP_FLAGS += -x c
 else ifeq ($(TOOLCHAIN_TYPE), microsoft)
   CPP_FLAGS += -nologo
+
+  ifeq ($(OPENJDK_TARGET_CPU),aarch64)
+    # cl.exe does only recognize few file extensions as valid (ex: .c, .h, .cpp), so
+    # make sure *.java.template files are recognized as valid input files
+    CPP_FILEPREFIX = -Tc
+  endif
 endif
 
 # Generate a java source file from a template through the C preprocessor for the
@@ -75,7 +81,7 @@ endif
 define generate-preproc-src
 	$(call MakeDir, $(@D))
 	( $(NAWK) '/@@END_COPYRIGHT@@/{exit}1' $< && \
-	  $(CPP) $(CPP_FLAGS) $(SYSROOT_CFLAGS) $(CFLAGS_JDKLIB) $< \
+	  $(CPP) $(CPP_FLAGS) $(SYSROOT_CFLAGS) $(CFLAGS_JDKLIB) $(CPP_FILEPREFIX) $< \
 	      2> >($(GREP) -v '^$(<F)$$' >&2) \
 	      | $(NAWK) '/@@START_HERE@@/,0' \
 	      |  $(SED) -e 's/@@START_HERE@@/\/\/ AUTOMATICALLY GENERATED FILE - DO NOT EDIT/' \

--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -99,6 +99,13 @@ ifeq ($(call check-jvm-feature, compiler2), true)
     ADLCFLAGS += -DAIX=1
   else ifeq ($(OPENJDK_TARGET_OS), macosx)
     ADLCFLAGS += -D_ALLBSD_SOURCE=1 -D_GNU_SOURCE=1
+  else ifeq ($(OPENJDK_TARGET_OS), windows)
+    ifeq ($(call isTargetCpuBits, 64), true)
+      ADLCFLAGS += -D_WIN64=1
+    endif
+    ifeq ($(HOTSPOT_TARGET_CPU_ARCH), aarch64)
+      ADLCFLAGS += -DR18_RESERVED=1
+    endif
   endif
 
   ifneq ($(OPENJDK_TARGET_OS), windows)

--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -78,6 +78,7 @@ $(eval $(call SetupNativeCompilation, BUILD_GTEST_LIBJVM, \
     DISABLED_WARNINGS_clang := undef switch format-nonliteral \
         tautological-undefined-compare $(BUILD_LIBJVM_DISABLED_WARNINGS_clang), \
     DISABLED_WARNINGS_solstudio := identexpected, \
+    DISABLED_WARNINGS_microsoft := 4146, \
     LDFLAGS := $(JVM_LDFLAGS), \
     LDFLAGS_solaris := -library=stlport4 $(call SET_SHARED_LIBRARY_ORIGIN), \
     LIBS := $(JVM_LIBS), \

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -164,6 +164,7 @@ $(eval $(call SetupNativeCompilation, BUILD_LIBJVM, \
     DISABLED_WARNINGS_solstudio := $(DISABLED_WARNINGS_solstudio), \
     DISABLED_WARNINGS_xlc := 1540-0216 1540-0198 1540-1090 1540-1639 \
         1540-1088 1500-010, \
+    DISABLED_WARNINGS_microsoft := 4146, \
     ASFLAGS := $(JVM_ASFLAGS), \
     LDFLAGS := $(JVM_LDFLAGS), \
     LIBS := $(JVM_LIBS), \

--- a/src/hotspot/cpu/aarch64/aarch64-asmtest.py
+++ b/src/hotspot/cpu/aarch64/aarch64-asmtest.py
@@ -13,6 +13,8 @@ class Register(Operand):
 
     def generate(self):
         self.number = random.randint(0, 30)
+        if self.number == 18:
+            self.number = 17
         return self
 
     def astr(self, prefix):
@@ -37,6 +39,8 @@ class GeneralRegisterOrZr(Register):
 
     def generate(self):
         self.number = random.randint(0, 31)
+        if self.number == 18:
+            self.number = 16
         return self
 
     def astr(self, prefix = ""):
@@ -54,6 +58,8 @@ class GeneralRegisterOrZr(Register):
 class GeneralRegisterOrSp(Register):
     def generate(self):
         self.number = random.randint(0, 31)
+        if self.number == 18:
+            self.number = 15
         return self
 
     def astr(self, prefix = ""):

--- a/src/hotspot/cpu/aarch64/aarch64-asmtest.py
+++ b/src/hotspot/cpu/aarch64/aarch64-asmtest.py
@@ -1,8 +1,8 @@
 import random
 
-AARCH64_AS = "<PATH-TO-AS>"
-AARCH64_OBJDUMP = "<PATH-TO-OBJDUMP>"
-AARCH64_OBJCOPY = "<PATH-TO-OBJCOPY>"
+AARCH64_AS = "as"
+AARCH64_OBJDUMP = "objdump"
+AARCH64_OBJCOPY = "objcopy"
 
 class Operand(object):
 
@@ -348,7 +348,7 @@ class LogicalImmOp(AddSubImmOp):
                   + ', #0x%x' % self.immed)
 
      def cstr(self):
-          return super(AddSubImmOp, self).cstr() + "l);"
+          return super(AddSubImmOp, self).cstr() + "ll);"
     
 class MultiOp():
 

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -9660,7 +9660,7 @@ instruct lshift_ext(iRegLNoSp dst, iRegIorL2I src, immI scale, rFlagsReg cr) %{
   ins_encode %{
     __ sbfiz(as_Register($dst$$reg),
           as_Register($src$$reg),
-          $scale$$constant & 63, MIN(32, (-$scale$$constant) & 63));
+          $scale$$constant & 63, MIN2(32, (int)((-$scale$$constant) & 63)));
   %}
 
   ins_pipe(ialu_reg_shift);

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2055,11 +2055,6 @@ int HandlerImpl::emit_deopt_handler(CodeBuffer& cbuf)
 
 const bool Matcher::match_rule_supported(int opcode) {
 
-  switch (opcode) {
-  default:
-    break;
-  }
-
   if (!has_match_rule(opcode)) {
     return false;
   }

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -110,8 +110,8 @@ reg_def R16     ( SOC, SOC, Op_RegI, 16, r16->as_VMReg()        );
 reg_def R16_H   ( SOC, SOC, Op_RegI, 16, r16->as_VMReg()->next());
 reg_def R17     ( SOC, SOC, Op_RegI, 17, r17->as_VMReg()        );
 reg_def R17_H   ( SOC, SOC, Op_RegI, 17, r17->as_VMReg()->next());
-reg_def R18     ( SOC, SOC, Op_RegI, 18, r18->as_VMReg()        );
-reg_def R18_H   ( SOC, SOC, Op_RegI, 18, r18->as_VMReg()->next());
+reg_def R18     ( SOC, SOC, Op_RegI, 18, r18_reserved->as_VMReg()        );
+reg_def R18_H   ( SOC, SOC, Op_RegI, 18, r18_reserved->as_VMReg()->next());
 reg_def R19     ( SOC, SOE, Op_RegI, 19, r19->as_VMReg()        );
 reg_def R19_H   ( SOC, SOE, Op_RegI, 19, r19->as_VMReg()->next());
 reg_def R20     ( SOC, SOE, Op_RegI, 20, r20->as_VMReg()        ); // caller esp
@@ -352,7 +352,6 @@ alloc_class chunk0(
     R15, R15_H,
     R16, R16_H,
     R17, R17_H,
-    R18, R18_H,
 
     // arg registers
     R0, R0_H,
@@ -375,7 +374,7 @@ alloc_class chunk0(
     R26, R26_H,
 
     // non-allocatable registers
-
+    R18, R18_H, // platform
     R27, R27_H, // heapbase
     R28, R28_H, // thread
     R29, R29_H, // fp
@@ -533,7 +532,10 @@ reg_class no_special_reg32_no_fp(
     R15,
     R16,
     R17,
+#ifndef R18_RESERVED
+    // See comment in register_aarch64.hpp
     R18,
+#endif
     R19,
     R20,
     R21,
@@ -566,7 +568,10 @@ reg_class no_special_reg32_with_fp(
     R15,
     R16,
     R17,
+#ifndef R18_RESERVED
+    // See comment in register_aarch64.hpp
     R18,
+#endif
     R19,
     R20,
     R21,
@@ -602,7 +607,10 @@ reg_class no_special_reg_no_fp(
     R15, R15_H,
     R16, R16_H,
     R17, R17_H,
+#ifndef R18_RESERVED
+    // See comment in register_aarch64.hpp
     R18, R18_H,
+#endif
     R19, R19_H,
     R20, R20_H,
     R21, R21_H,
@@ -635,7 +643,10 @@ reg_class no_special_reg_with_fp(
     R15, R15_H,
     R16, R16_H,
     R17, R17_H,
+#ifndef R18_RESERVED
+    // See comment in register_aarch64.hpp
     R18, R18_H,
+#endif
     R19, R19_H,
     R20, R20_H,
     R21, R21_H,
@@ -775,7 +786,10 @@ reg_class no_special_ptr_reg(
     R15, R15_H,
     R16, R16_H,
     R17, R17_H,
+#ifndef R18_RESERVED
+    // See comment in register_aarch64.hpp
     R18, R18_H,
+#endif
     R19, R19_H,
     R20, R20_H,
     R21, R21_H,
@@ -5419,7 +5433,7 @@ pipeline %{
 attributes %{
   // ARM instructions are of fixed length
   fixed_size_instructions;        // Fixed size instructions TODO does
-  max_instructions_per_bundle = 2;   // A53 = 2, A57 = 4
+  max_instructions_per_bundle = 4;   // A53 = 2, A57 = 4
   // ARM instructions come in 32-bit word units
   instruction_unit_size = 4;         // An instruction is 4 bytes long
   instruction_fetch_unit_size = 64;  // The processor fetches one line

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1615,7 +1615,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   MacroAssembler _masm(&cbuf);
 
   // n.b. frame size includes space for return pc and rfp
-  const long framesize = C->frame_size_in_bytes();
+  const int framesize = C->frame_size_in_bytes();
   assert(framesize%(2*wordSize) == 0, "must preserve 2*wordSize alignment");
 
   // insert a nop at the start of the prolog so we can patch in a
@@ -3005,7 +3005,7 @@ encode %{
         if (con < (address)(uintptr_t)os::vm_page_size()) {
           __ mov(dst_reg, con);
         } else {
-          unsigned long offset;
+          uintptr_t offset;
           __ adrp(dst_reg, con, offset);
           __ add(dst_reg, dst_reg, offset);
         }
@@ -3029,7 +3029,7 @@ encode %{
     MacroAssembler _masm(&cbuf);
     address page = (address)$src$$constant;
     Register dst_reg = as_Register($dst$$reg);
-    unsigned long off;
+    uint64_t off;
     __ adrp(dst_reg, Address(page, relocInfo::poll_type), off);
     assert(off == 0, "assumed offset == 0");
   %}
@@ -4079,7 +4079,7 @@ operand immLoffset16()
 // 32 bit integer valid for add sub immediate
 operand immIAddSub()
 %{
-  predicate(Assembler::operand_valid_for_add_sub_immediate((long)n->get_int()));
+  predicate(Assembler::operand_valid_for_add_sub_immediate((int64_t)n->get_int()));
   match(ConI);
   op_cost(0);
   format %{ %}
@@ -4090,7 +4090,7 @@ operand immIAddSub()
 // TODO -- check this is right when e.g the mask is 0x80000000
 operand immILog()
 %{
-  predicate(Assembler::operand_valid_for_logical_immediate(/*is32*/true, (unsigned long)n->get_int()));
+  predicate(Assembler::operand_valid_for_logical_immediate(/*is32*/true, (uint64_t)n->get_int()));
   match(ConI);
 
   op_cost(0);
@@ -4168,7 +4168,7 @@ operand immLAddSub()
 // 64 bit integer valid for logical immediate
 operand immLLog()
 %{
-  predicate(Assembler::operand_valid_for_logical_immediate(/*is32*/false, (unsigned long)n->get_long()));
+  predicate(Assembler::operand_valid_for_logical_immediate(/*is32*/false, (uint64_t)n->get_long()));
   match(ConL);
   op_cost(0);
   format %{ %}
@@ -10260,6 +10260,9 @@ instruct rShiftL_reg_imm(iRegLNoSp dst, iRegL src1, immI src2) %{
 
 // BEGIN This section of the file is automatically generated. Do not edit --------------
 
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct regL_not_reg(iRegLNoSp dst,
                          iRegL src1, immL_M1 m1,
                          rFlagsReg cr) %{
@@ -10276,6 +10279,9 @@ instruct regL_not_reg(iRegLNoSp dst,
 
   ins_pipe(ialu_reg);
 %}
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct regI_not_reg(iRegINoSp dst,
                          iRegIorL2I src1, immI_M1 m1,
                          rFlagsReg cr) %{
@@ -10293,6 +10299,8 @@ instruct regI_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndI_reg_not_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2, immI_M1 m1,
                          rFlagsReg cr) %{
@@ -10310,6 +10318,8 @@ instruct AndI_reg_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndL_reg_not_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2, immL_M1 m1,
                          rFlagsReg cr) %{
@@ -10327,6 +10337,8 @@ instruct AndL_reg_not_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrI_reg_not_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2, immI_M1 m1,
                          rFlagsReg cr) %{
@@ -10344,6 +10356,8 @@ instruct OrI_reg_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrL_reg_not_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2, immL_M1 m1,
                          rFlagsReg cr) %{
@@ -10361,6 +10375,8 @@ instruct OrL_reg_not_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorI_reg_not_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2, immI_M1 m1,
                          rFlagsReg cr) %{
@@ -10378,6 +10394,8 @@ instruct XorI_reg_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorL_reg_not_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2, immL_M1 m1,
                          rFlagsReg cr) %{
@@ -10395,6 +10413,8 @@ instruct XorL_reg_not_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndI_reg_URShift_not_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, immI_M1 src4, rFlagsReg cr) %{
@@ -10413,6 +10433,8 @@ instruct AndI_reg_URShift_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndL_reg_URShift_not_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, immL_M1 src4, rFlagsReg cr) %{
@@ -10431,6 +10453,8 @@ instruct AndL_reg_URShift_not_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndI_reg_RShift_not_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, immI_M1 src4, rFlagsReg cr) %{
@@ -10449,6 +10473,8 @@ instruct AndI_reg_RShift_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndL_reg_RShift_not_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, immL_M1 src4, rFlagsReg cr) %{
@@ -10467,6 +10493,8 @@ instruct AndL_reg_RShift_not_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndI_reg_LShift_not_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, immI_M1 src4, rFlagsReg cr) %{
@@ -10485,6 +10513,8 @@ instruct AndI_reg_LShift_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndL_reg_LShift_not_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, immL_M1 src4, rFlagsReg cr) %{
@@ -10503,6 +10533,8 @@ instruct AndL_reg_LShift_not_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorI_reg_URShift_not_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, immI_M1 src4, rFlagsReg cr) %{
@@ -10521,6 +10553,8 @@ instruct XorI_reg_URShift_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorL_reg_URShift_not_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, immL_M1 src4, rFlagsReg cr) %{
@@ -10539,6 +10573,8 @@ instruct XorL_reg_URShift_not_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorI_reg_RShift_not_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, immI_M1 src4, rFlagsReg cr) %{
@@ -10557,6 +10593,8 @@ instruct XorI_reg_RShift_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorL_reg_RShift_not_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, immL_M1 src4, rFlagsReg cr) %{
@@ -10575,6 +10613,8 @@ instruct XorL_reg_RShift_not_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorI_reg_LShift_not_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, immI_M1 src4, rFlagsReg cr) %{
@@ -10593,6 +10633,8 @@ instruct XorI_reg_LShift_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorL_reg_LShift_not_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, immL_M1 src4, rFlagsReg cr) %{
@@ -10611,6 +10653,8 @@ instruct XorL_reg_LShift_not_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrI_reg_URShift_not_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, immI_M1 src4, rFlagsReg cr) %{
@@ -10629,6 +10673,8 @@ instruct OrI_reg_URShift_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrL_reg_URShift_not_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, immL_M1 src4, rFlagsReg cr) %{
@@ -10647,6 +10693,8 @@ instruct OrL_reg_URShift_not_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrI_reg_RShift_not_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, immI_M1 src4, rFlagsReg cr) %{
@@ -10665,6 +10713,8 @@ instruct OrI_reg_RShift_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrL_reg_RShift_not_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, immL_M1 src4, rFlagsReg cr) %{
@@ -10683,6 +10733,8 @@ instruct OrL_reg_RShift_not_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrI_reg_LShift_not_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, immI_M1 src4, rFlagsReg cr) %{
@@ -10701,6 +10753,8 @@ instruct OrI_reg_LShift_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrL_reg_LShift_not_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, immL_M1 src4, rFlagsReg cr) %{
@@ -10719,6 +10773,8 @@ instruct OrL_reg_LShift_not_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndI_reg_URShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -10738,6 +10794,8 @@ instruct AndI_reg_URShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndL_reg_URShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -10757,6 +10815,8 @@ instruct AndL_reg_URShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndI_reg_RShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -10776,6 +10836,8 @@ instruct AndI_reg_RShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndL_reg_RShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -10795,6 +10857,8 @@ instruct AndL_reg_RShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndI_reg_LShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -10814,6 +10878,8 @@ instruct AndI_reg_LShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AndL_reg_LShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -10833,6 +10899,8 @@ instruct AndL_reg_LShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorI_reg_URShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -10852,6 +10920,8 @@ instruct XorI_reg_URShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorL_reg_URShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -10871,6 +10941,8 @@ instruct XorL_reg_URShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorI_reg_RShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -10890,6 +10962,8 @@ instruct XorI_reg_RShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorL_reg_RShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -10909,6 +10983,8 @@ instruct XorL_reg_RShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorI_reg_LShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -10928,6 +11004,8 @@ instruct XorI_reg_LShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct XorL_reg_LShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -10947,6 +11025,8 @@ instruct XorL_reg_LShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrI_reg_URShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -10966,6 +11046,8 @@ instruct OrI_reg_URShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrL_reg_URShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -10985,6 +11067,8 @@ instruct OrL_reg_URShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrI_reg_RShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -11004,6 +11088,8 @@ instruct OrI_reg_RShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrL_reg_RShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -11023,6 +11109,8 @@ instruct OrL_reg_RShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrI_reg_LShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -11042,6 +11130,8 @@ instruct OrI_reg_LShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct OrL_reg_LShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -11061,6 +11151,8 @@ instruct OrL_reg_LShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddI_reg_URShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -11080,6 +11172,8 @@ instruct AddI_reg_URShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddL_reg_URShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -11099,6 +11193,8 @@ instruct AddL_reg_URShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddI_reg_RShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -11118,6 +11214,8 @@ instruct AddI_reg_RShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddL_reg_RShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -11137,6 +11235,8 @@ instruct AddL_reg_RShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddI_reg_LShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -11156,6 +11256,8 @@ instruct AddI_reg_LShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddL_reg_LShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -11175,6 +11277,8 @@ instruct AddL_reg_LShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubI_reg_URShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -11194,6 +11298,8 @@ instruct SubI_reg_URShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubL_reg_URShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -11213,6 +11319,8 @@ instruct SubL_reg_URShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubI_reg_RShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -11232,6 +11340,8 @@ instruct SubI_reg_RShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubL_reg_RShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -11251,6 +11361,8 @@ instruct SubL_reg_RShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubI_reg_LShift_reg(iRegINoSp dst,
                          iRegIorL2I src1, iRegIorL2I src2,
                          immI src3, rFlagsReg cr) %{
@@ -11270,6 +11382,8 @@ instruct SubI_reg_LShift_reg(iRegINoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubL_reg_LShift_reg(iRegLNoSp dst,
                          iRegL src1, iRegL src2,
                          immI src3, rFlagsReg cr) %{
@@ -11289,7 +11403,8 @@ instruct SubL_reg_LShift_reg(iRegLNoSp dst,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
-
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
 // Shift Left followed by Shift Right.
 // This idiom is used by the compiler for the i2b bytecode etc.
@@ -11311,6 +11426,9 @@ instruct sbfmL(iRegLNoSp dst, iRegL src, immI lshift_count, immI rshift_count)
   ins_pipe(ialu_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
+
 // Shift Left followed by Shift Right.
 // This idiom is used by the compiler for the i2b bytecode etc.
 instruct sbfmwI(iRegINoSp dst, iRegIorL2I src, immI lshift_count, immI rshift_count)
@@ -11330,6 +11448,9 @@ instruct sbfmwI(iRegINoSp dst, iRegIorL2I src, immI lshift_count, immI rshift_co
 
   ins_pipe(ialu_reg_shift);
 %}
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
 // Shift Left followed by Shift Right.
 // This idiom is used by the compiler for the i2b bytecode etc.
@@ -11351,6 +11472,9 @@ instruct ubfmL(iRegLNoSp dst, iRegL src, immI lshift_count, immI rshift_count)
   ins_pipe(ialu_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
+
 // Shift Left followed by Shift Right.
 // This idiom is used by the compiler for the i2b bytecode etc.
 instruct ubfmwI(iRegINoSp dst, iRegIorL2I src, immI lshift_count, immI rshift_count)
@@ -11370,8 +11494,11 @@ instruct ubfmwI(iRegINoSp dst, iRegIorL2I src, immI lshift_count, immI rshift_co
 
   ins_pipe(ialu_reg_shift);
 %}
+
 // Bitfield extract with shift & mask
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct ubfxwI(iRegINoSp dst, iRegIorL2I src, immI rshift, immI_bitmask mask)
 %{
   match(Set dst (AndI (URShiftI src rshift) mask));
@@ -11382,13 +11509,16 @@ instruct ubfxwI(iRegINoSp dst, iRegIorL2I src, immI rshift, immI_bitmask mask)
   format %{ "ubfxw $dst, $src, $rshift, $mask" %}
   ins_encode %{
     int rshift = $rshift$$constant & 31;
-    long mask = $mask$$constant;
+    intptr_t mask = $mask$$constant;
     int width = exact_log2(mask+1);
     __ ubfxw(as_Register($dst$$reg),
             as_Register($src$$reg), rshift, width);
   %}
   ins_pipe(ialu_reg_shift);
 %}
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct ubfxL(iRegLNoSp dst, iRegL src, immI rshift, immL_bitmask mask)
 %{
   match(Set dst (AndL (URShiftL src rshift) mask));
@@ -11399,13 +11529,17 @@ instruct ubfxL(iRegLNoSp dst, iRegL src, immI rshift, immL_bitmask mask)
   format %{ "ubfx $dst, $src, $rshift, $mask" %}
   ins_encode %{
     int rshift = $rshift$$constant & 63;
-    long mask = $mask$$constant;
+    intptr_t mask = $mask$$constant;
     int width = exact_log2_long(mask+1);
     __ ubfx(as_Register($dst$$reg),
             as_Register($src$$reg), rshift, width);
   %}
   ins_pipe(ialu_reg_shift);
 %}
+
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
 // We can use ubfx when extending an And with a mask when we know mask
 // is positive.  We know that because immI_bitmask guarantees it.
@@ -11419,7 +11553,7 @@ instruct ubfxIConvI2L(iRegLNoSp dst, iRegIorL2I src, immI rshift, immI_bitmask m
   format %{ "ubfx $dst, $src, $rshift, $mask" %}
   ins_encode %{
     int rshift = $rshift$$constant & 31;
-    long mask = $mask$$constant;
+    intptr_t mask = $mask$$constant;
     int width = exact_log2(mask+1);
     __ ubfx(as_Register($dst$$reg),
             as_Register($src$$reg), rshift, width);
@@ -11427,6 +11561,9 @@ instruct ubfxIConvI2L(iRegLNoSp dst, iRegIorL2I src, immI rshift, immI_bitmask m
   ins_pipe(ialu_reg_shift);
 %}
 
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
 // We can use ubfiz when masking by a positive number and then left shifting the result.
 // We know that the mask is positive because immI_bitmask guarantees it.
@@ -11439,13 +11576,16 @@ instruct ubfizwI(iRegINoSp dst, iRegIorL2I src, immI lshift, immI_bitmask mask)
   format %{ "ubfizw $dst, $src, $lshift, $mask" %}
   ins_encode %{
     int lshift = $lshift$$constant & 31;
-    long mask = $mask$$constant;
+    intptr_t mask = $mask$$constant;
     int width = exact_log2(mask+1);
     __ ubfizw(as_Register($dst$$reg),
           as_Register($src$$reg), lshift, width);
   %}
   ins_pipe(ialu_reg_shift);
 %}
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
 // We can use ubfiz when masking by a positive number and then left shifting the result.
 // We know that the mask is positive because immL_bitmask guarantees it.
@@ -11458,13 +11598,16 @@ instruct ubfizL(iRegLNoSp dst, iRegL src, immI lshift, immL_bitmask mask)
   format %{ "ubfiz $dst, $src, $lshift, $mask" %}
   ins_encode %{
     int lshift = $lshift$$constant & 63;
-    long mask = $mask$$constant;
+    intptr_t mask = $mask$$constant;
     int width = exact_log2_long(mask+1);
     __ ubfiz(as_Register($dst$$reg),
           as_Register($src$$reg), lshift, width);
   %}
   ins_pipe(ialu_reg_shift);
 %}
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
 // We can use ubfiz when masking by a positive number and then left shifting the result.
 // We know that the mask is positive because immI_bitmask guarantees it.
@@ -11477,13 +11620,16 @@ instruct ubfizwIConvI2L(iRegLNoSp dst, iRegIorL2I src, immI lshift, immI_bitmask
   format %{ "ubfizw $dst, $src, $lshift, $mask" %}
   ins_encode %{
     int lshift = $lshift$$constant & 31;
-    long mask = $mask$$constant;
+    intptr_t mask = $mask$$constant;
     int width = exact_log2(mask+1);
     __ ubfizw(as_Register($dst$$reg),
           as_Register($src$$reg), lshift, width);
   %}
   ins_pipe(ialu_reg_shift);
 %}
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
 // We can use ubfiz when masking by a positive number and then left shifting the result.
 // We know that the mask is positive because immL_bitmask guarantees it.
@@ -11496,7 +11642,7 @@ instruct ubfizLConvL2I(iRegINoSp dst, iRegL src, immI lshift, immL_positive_bitm
   format %{ "ubfiz $dst, $src, $lshift, $mask" %}
   ins_encode %{
     int lshift = $lshift$$constant & 63;
-    long mask = $mask$$constant;
+    intptr_t mask = $mask$$constant;
     int width = exact_log2_long(mask+1);
     __ ubfiz(as_Register($dst$$reg),
           as_Register($src$$reg), lshift, width);
@@ -11504,6 +11650,9 @@ instruct ubfizLConvL2I(iRegINoSp dst, iRegL src, immI lshift, immL_positive_bitm
   ins_pipe(ialu_reg_shift);
 %}
 
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
 // If there is a convert I to L block between and AndI and a LShiftL, we can also match ubfiz
 instruct ubfizIConvI2L(iRegLNoSp dst, iRegIorL2I src, immI lshift, immI_bitmask mask)
@@ -11515,7 +11664,7 @@ instruct ubfizIConvI2L(iRegLNoSp dst, iRegIorL2I src, immI lshift, immI_bitmask 
   format %{ "ubfiz $dst, $src, $lshift, $mask" %}
   ins_encode %{
     int lshift = $lshift$$constant & 63;
-    long mask = $mask$$constant;
+    intptr_t mask = $mask$$constant;
     int width = exact_log2(mask+1);
     __ ubfiz(as_Register($dst$$reg),
              as_Register($src$$reg), lshift, width);
@@ -11533,7 +11682,7 @@ instruct ubfizLConvL2Ix(iRegINoSp dst, iRegL src, immI lshift, immL_positive_bit
   format %{ "ubfiz $dst, $src, $lshift, $mask" %}
   ins_encode %{
     int lshift = $lshift$$constant & 31;
-    long mask = $mask$$constant;
+    intptr_t mask = $mask$$constant;
     int width = exact_log2(mask+1);
     __ ubfiz(as_Register($dst$$reg),
              as_Register($src$$reg), lshift, width);
@@ -11553,8 +11702,10 @@ instruct ubfizIConvI2LAndI(iRegLNoSp dst, iRegI src, immI_bitmask msk)
   ins_pipe(ialu_reg_shift);
 %}
 
-// Rotations
 
+// Rotations
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct extrOrL(iRegLNoSp dst, iRegL src1, iRegL src2, immI lshift, immI rshift, rFlagsReg cr)
 %{
   match(Set dst (OrL (LShiftL src1 lshift) (URShiftL src2 rshift)));
@@ -11570,6 +11721,9 @@ instruct extrOrL(iRegLNoSp dst, iRegL src1, iRegL src2, immI lshift, immI rshift
   ins_pipe(ialu_reg_reg_extr);
 %}
 
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct extrOrI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI lshift, immI rshift, rFlagsReg cr)
 %{
   match(Set dst (OrI (LShiftI src1 lshift) (URShiftI src2 rshift)));
@@ -11585,6 +11739,9 @@ instruct extrOrI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI lshift, i
   ins_pipe(ialu_reg_reg_extr);
 %}
 
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct extrAddL(iRegLNoSp dst, iRegL src1, iRegL src2, immI lshift, immI rshift, rFlagsReg cr)
 %{
   match(Set dst (AddL (LShiftL src1 lshift) (URShiftL src2 rshift)));
@@ -11600,6 +11757,9 @@ instruct extrAddL(iRegLNoSp dst, iRegL src1, iRegL src2, immI lshift, immI rshif
   ins_pipe(ialu_reg_reg_extr);
 %}
 
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct extrAddI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI lshift, immI rshift, rFlagsReg cr)
 %{
   match(Set dst (AddI (LShiftI src1 lshift) (URShiftI src2 rshift)));
@@ -11616,8 +11776,10 @@ instruct extrAddI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI lshift, 
 %}
 
 
-// rol expander
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
+// rol expander
 instruct rolL_rReg(iRegLNoSp dst, iRegL src, iRegI shift, rFlagsReg cr)
 %{
   effect(DEF dst, USE src, USE shift);
@@ -11632,8 +11794,10 @@ instruct rolL_rReg(iRegLNoSp dst, iRegL src, iRegI shift, rFlagsReg cr)
   ins_pipe(ialu_reg_reg_vshift);
 %}
 
-// rol expander
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
+// rol expander
 instruct rolI_rReg(iRegINoSp dst, iRegI src, iRegI shift, rFlagsReg cr)
 %{
   effect(DEF dst, USE src, USE shift);
@@ -11648,6 +11812,8 @@ instruct rolI_rReg(iRegINoSp dst, iRegI src, iRegI shift, rFlagsReg cr)
   ins_pipe(ialu_reg_reg_vshift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct rolL_rReg_Var_C_64(iRegLNoSp dst, iRegL src, iRegI shift, immI_64 c_64, rFlagsReg cr)
 %{
   match(Set dst (OrL (LShiftL src shift) (URShiftL src (SubI c_64 shift))));
@@ -11657,6 +11823,8 @@ instruct rolL_rReg_Var_C_64(iRegLNoSp dst, iRegL src, iRegI shift, immI_64 c_64,
   %}
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct rolL_rReg_Var_C0(iRegLNoSp dst, iRegL src, iRegI shift, immI0 c0, rFlagsReg cr)
 %{
   match(Set dst (OrL (LShiftL src shift) (URShiftL src (SubI c0 shift))));
@@ -11666,6 +11834,8 @@ instruct rolL_rReg_Var_C0(iRegLNoSp dst, iRegL src, iRegI shift, immI0 c0, rFlag
   %}
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct rolI_rReg_Var_C_32(iRegINoSp dst, iRegI src, iRegI shift, immI_32 c_32, rFlagsReg cr)
 %{
   match(Set dst (OrI (LShiftI src shift) (URShiftI src (SubI c_32 shift))));
@@ -11675,6 +11845,8 @@ instruct rolI_rReg_Var_C_32(iRegINoSp dst, iRegI src, iRegI shift, immI_32 c_32,
   %}
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct rolI_rReg_Var_C0(iRegINoSp dst, iRegI src, iRegI shift, immI0 c0, rFlagsReg cr)
 %{
   match(Set dst (OrI (LShiftI src shift) (URShiftI src (SubI c0 shift))));
@@ -11684,8 +11856,10 @@ instruct rolI_rReg_Var_C0(iRegINoSp dst, iRegI src, iRegI shift, immI0 c0, rFlag
   %}
 %}
 
-// ror expander
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
+// ror expander
 instruct rorL_rReg(iRegLNoSp dst, iRegL src, iRegI shift, rFlagsReg cr)
 %{
   effect(DEF dst, USE src, USE shift);
@@ -11699,8 +11873,10 @@ instruct rorL_rReg(iRegLNoSp dst, iRegL src, iRegI shift, rFlagsReg cr)
   ins_pipe(ialu_reg_reg_vshift);
 %}
 
-// ror expander
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
+// ror expander
 instruct rorI_rReg(iRegINoSp dst, iRegI src, iRegI shift, rFlagsReg cr)
 %{
   effect(DEF dst, USE src, USE shift);
@@ -11714,6 +11890,8 @@ instruct rorI_rReg(iRegINoSp dst, iRegI src, iRegI shift, rFlagsReg cr)
   ins_pipe(ialu_reg_reg_vshift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct rorL_rReg_Var_C_64(iRegLNoSp dst, iRegL src, iRegI shift, immI_64 c_64, rFlagsReg cr)
 %{
   match(Set dst (OrL (URShiftL src shift) (LShiftL src (SubI c_64 shift))));
@@ -11723,6 +11901,8 @@ instruct rorL_rReg_Var_C_64(iRegLNoSp dst, iRegL src, iRegI shift, immI_64 c_64,
   %}
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct rorL_rReg_Var_C0(iRegLNoSp dst, iRegL src, iRegI shift, immI0 c0, rFlagsReg cr)
 %{
   match(Set dst (OrL (URShiftL src shift) (LShiftL src (SubI c0 shift))));
@@ -11732,6 +11912,8 @@ instruct rorL_rReg_Var_C0(iRegLNoSp dst, iRegL src, iRegI shift, immI0 c0, rFlag
   %}
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct rorI_rReg_Var_C_32(iRegINoSp dst, iRegI src, iRegI shift, immI_32 c_32, rFlagsReg cr)
 %{
   match(Set dst (OrI (URShiftI src shift) (LShiftI src (SubI c_32 shift))));
@@ -11741,6 +11923,8 @@ instruct rorI_rReg_Var_C_32(iRegINoSp dst, iRegI src, iRegI shift, immI_32 c_32,
   %}
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct rorI_rReg_Var_C0(iRegINoSp dst, iRegI src, iRegI shift, immI0 c0, rFlagsReg cr)
 %{
   match(Set dst (OrI (URShiftI src shift) (LShiftI src (SubI c0 shift))));
@@ -11750,8 +11934,11 @@ instruct rorI_rReg_Var_C0(iRegINoSp dst, iRegI src, iRegI shift, immI0 c0, rFlag
   %}
 %}
 
+
 // Add/subtract (extended)
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtI(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (ConvI2L src2)));
@@ -11763,8 +11950,10 @@ instruct AddExtI(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, rFlagsReg cr)
             as_Register($src2$$reg), ext::sxtw);
    %}
   ins_pipe(ialu_reg_reg);
-%};
+%}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtI(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, rFlagsReg cr)
 %{
   match(Set dst (SubL src1 (ConvI2L src2)));
@@ -11776,9 +11965,10 @@ instruct SubExtI(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, rFlagsReg cr)
             as_Register($src2$$reg), ext::sxtw);
    %}
   ins_pipe(ialu_reg_reg);
-%};
+%}
 
-
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtI_sxth(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_16 lshift, immI_16 rshift, rFlagsReg cr)
 %{
   match(Set dst (AddI src1 (RShiftI (LShiftI src2 lshift) rshift)));
@@ -11792,6 +11982,8 @@ instruct AddExtI_sxth(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_16 l
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtI_sxtb(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_24 lshift, immI_24 rshift, rFlagsReg cr)
 %{
   match(Set dst (AddI src1 (RShiftI (LShiftI src2 lshift) rshift)));
@@ -11805,6 +11997,8 @@ instruct AddExtI_sxtb(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_24 l
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtI_uxtb(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_24 lshift, immI_24 rshift, rFlagsReg cr)
 %{
   match(Set dst (AddI src1 (URShiftI (LShiftI src2 lshift) rshift)));
@@ -11818,6 +12012,8 @@ instruct AddExtI_uxtb(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_24 l
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtL_sxth(iRegLNoSp dst, iRegL src1, iRegL src2, immI_48 lshift, immI_48 rshift, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (RShiftL (LShiftL src2 lshift) rshift)));
@@ -11831,6 +12027,8 @@ instruct AddExtL_sxth(iRegLNoSp dst, iRegL src1, iRegL src2, immI_48 lshift, imm
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtL_sxtw(iRegLNoSp dst, iRegL src1, iRegL src2, immI_32 lshift, immI_32 rshift, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (RShiftL (LShiftL src2 lshift) rshift)));
@@ -11844,6 +12042,8 @@ instruct AddExtL_sxtw(iRegLNoSp dst, iRegL src1, iRegL src2, immI_32 lshift, imm
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtL_sxtb(iRegLNoSp dst, iRegL src1, iRegL src2, immI_56 lshift, immI_56 rshift, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (RShiftL (LShiftL src2 lshift) rshift)));
@@ -11857,6 +12057,8 @@ instruct AddExtL_sxtb(iRegLNoSp dst, iRegL src1, iRegL src2, immI_56 lshift, imm
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtL_uxtb(iRegLNoSp dst, iRegL src1, iRegL src2, immI_56 lshift, immI_56 rshift, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (URShiftL (LShiftL src2 lshift) rshift)));
@@ -11870,7 +12072,8 @@ instruct AddExtL_uxtb(iRegLNoSp dst, iRegL src1, iRegL src2, immI_56 lshift, imm
   ins_pipe(ialu_reg_reg);
 %}
 
-
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtI_uxtb_and(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_255 mask, rFlagsReg cr)
 %{
   match(Set dst (AddI src1 (AndI src2 mask)));
@@ -11884,6 +12087,8 @@ instruct AddExtI_uxtb_and(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtI_uxth_and(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_65535 mask, rFlagsReg cr)
 %{
   match(Set dst (AddI src1 (AndI src2 mask)));
@@ -11897,6 +12102,8 @@ instruct AddExtI_uxth_and(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtL_uxtb_and(iRegLNoSp dst, iRegL src1, iRegL src2, immL_255 mask, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (AndL src2 mask)));
@@ -11910,6 +12117,8 @@ instruct AddExtL_uxtb_and(iRegLNoSp dst, iRegL src1, iRegL src2, immL_255 mask, 
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtL_uxth_and(iRegLNoSp dst, iRegL src1, iRegL src2, immL_65535 mask, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (AndL src2 mask)));
@@ -11923,6 +12132,8 @@ instruct AddExtL_uxth_and(iRegLNoSp dst, iRegL src1, iRegL src2, immL_65535 mask
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtL_uxtw_and(iRegLNoSp dst, iRegL src1, iRegL src2, immL_4294967295 mask, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (AndL src2 mask)));
@@ -11936,6 +12147,8 @@ instruct AddExtL_uxtw_and(iRegLNoSp dst, iRegL src1, iRegL src2, immL_4294967295
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtI_uxtb_and(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_255 mask, rFlagsReg cr)
 %{
   match(Set dst (SubI src1 (AndI src2 mask)));
@@ -11949,6 +12162,8 @@ instruct SubExtI_uxtb_and(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtI_uxth_and(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_65535 mask, rFlagsReg cr)
 %{
   match(Set dst (SubI src1 (AndI src2 mask)));
@@ -11962,6 +12177,8 @@ instruct SubExtI_uxth_and(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtL_uxtb_and(iRegLNoSp dst, iRegL src1, iRegL src2, immL_255 mask, rFlagsReg cr)
 %{
   match(Set dst (SubL src1 (AndL src2 mask)));
@@ -11975,6 +12192,8 @@ instruct SubExtL_uxtb_and(iRegLNoSp dst, iRegL src1, iRegL src2, immL_255 mask, 
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtL_uxth_and(iRegLNoSp dst, iRegL src1, iRegL src2, immL_65535 mask, rFlagsReg cr)
 %{
   match(Set dst (SubL src1 (AndL src2 mask)));
@@ -11988,6 +12207,8 @@ instruct SubExtL_uxth_and(iRegLNoSp dst, iRegL src1, iRegL src2, immL_65535 mask
   ins_pipe(ialu_reg_reg);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtL_uxtw_and(iRegLNoSp dst, iRegL src1, iRegL src2, immL_4294967295 mask, rFlagsReg cr)
 %{
   match(Set dst (SubL src1 (AndL src2 mask)));
@@ -12002,6 +12223,8 @@ instruct SubExtL_uxtw_and(iRegLNoSp dst, iRegL src1, iRegL src2, immL_4294967295
 %}
 
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtL_sxtb_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immIExt lshift2, immI_56 lshift1, immI_56 rshift1, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (LShiftL (RShiftL (LShiftL src2 lshift1) rshift1) lshift2)));
@@ -12015,6 +12238,8 @@ instruct AddExtL_sxtb_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immIExt lshif
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtL_sxth_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immIExt lshift2, immI_48 lshift1, immI_48 rshift1, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (LShiftL (RShiftL (LShiftL src2 lshift1) rshift1) lshift2)));
@@ -12028,6 +12253,8 @@ instruct AddExtL_sxth_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immIExt lshif
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtL_sxtw_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immIExt lshift2, immI_32 lshift1, immI_32 rshift1, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (LShiftL (RShiftL (LShiftL src2 lshift1) rshift1) lshift2)));
@@ -12041,6 +12268,8 @@ instruct AddExtL_sxtw_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immIExt lshif
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtL_sxtb_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immIExt lshift2, immI_56 lshift1, immI_56 rshift1, rFlagsReg cr)
 %{
   match(Set dst (SubL src1 (LShiftL (RShiftL (LShiftL src2 lshift1) rshift1) lshift2)));
@@ -12054,6 +12283,8 @@ instruct SubExtL_sxtb_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immIExt lshif
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtL_sxth_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immIExt lshift2, immI_48 lshift1, immI_48 rshift1, rFlagsReg cr)
 %{
   match(Set dst (SubL src1 (LShiftL (RShiftL (LShiftL src2 lshift1) rshift1) lshift2)));
@@ -12067,6 +12298,8 @@ instruct SubExtL_sxth_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immIExt lshif
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtL_sxtw_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immIExt lshift2, immI_32 lshift1, immI_32 rshift1, rFlagsReg cr)
 %{
   match(Set dst (SubL src1 (LShiftL (RShiftL (LShiftL src2 lshift1) rshift1) lshift2)));
@@ -12080,6 +12313,8 @@ instruct SubExtL_sxtw_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immIExt lshif
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtI_sxtb_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immIExt lshift2, immI_24 lshift1, immI_24 rshift1, rFlagsReg cr)
 %{
   match(Set dst (AddI src1 (LShiftI (RShiftI (LShiftI src2 lshift1) rshift1) lshift2)));
@@ -12093,6 +12328,8 @@ instruct AddExtI_sxtb_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, imm
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtI_sxth_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immIExt lshift2, immI_16 lshift1, immI_16 rshift1, rFlagsReg cr)
 %{
   match(Set dst (AddI src1 (LShiftI (RShiftI (LShiftI src2 lshift1) rshift1) lshift2)));
@@ -12106,6 +12343,8 @@ instruct AddExtI_sxth_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, imm
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtI_sxtb_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immIExt lshift2, immI_24 lshift1, immI_24 rshift1, rFlagsReg cr)
 %{
   match(Set dst (SubI src1 (LShiftI (RShiftI (LShiftI src2 lshift1) rshift1) lshift2)));
@@ -12119,6 +12358,8 @@ instruct SubExtI_sxtb_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, imm
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtI_sxth_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immIExt lshift2, immI_16 lshift1, immI_16 rshift1, rFlagsReg cr)
 %{
   match(Set dst (SubI src1 (LShiftI (RShiftI (LShiftI src2 lshift1) rshift1) lshift2)));
@@ -12132,7 +12373,8 @@ instruct SubExtI_sxth_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, imm
   ins_pipe(ialu_reg_reg_shift);
 %}
 
-
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtI_shift(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (LShiftL (ConvI2L src2) lshift)));
@@ -12144,8 +12386,10 @@ instruct AddExtI_shift(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immIExt lshif
             as_Register($src2$$reg), ext::sxtw, ($lshift$$constant));
    %}
   ins_pipe(ialu_reg_reg_shift);
-%};
+%}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtI_shift(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst (SubL src1 (LShiftL (ConvI2L src2) lshift)));
@@ -12157,9 +12401,10 @@ instruct SubExtI_shift(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immIExt lshif
             as_Register($src2$$reg), ext::sxtw, ($lshift$$constant));
    %}
   ins_pipe(ialu_reg_reg_shift);
-%};
+%}
 
-
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtL_uxtb_and_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immL_255 mask, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (LShiftL (AndL src2 mask) lshift)));
@@ -12173,6 +12418,8 @@ instruct AddExtL_uxtb_and_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immL_255 
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtL_uxth_and_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immL_65535 mask, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (LShiftL (AndL src2 mask) lshift)));
@@ -12186,6 +12433,8 @@ instruct AddExtL_uxth_and_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immL_6553
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtL_uxtw_and_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immL_4294967295 mask, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst (AddL src1 (LShiftL (AndL src2 mask) lshift)));
@@ -12199,6 +12448,8 @@ instruct AddExtL_uxtw_and_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immL_4294
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtL_uxtb_and_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immL_255 mask, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst (SubL src1 (LShiftL (AndL src2 mask) lshift)));
@@ -12212,6 +12463,8 @@ instruct SubExtL_uxtb_and_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immL_255 
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtL_uxth_and_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immL_65535 mask, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst (SubL src1 (LShiftL (AndL src2 mask) lshift)));
@@ -12225,6 +12478,8 @@ instruct SubExtL_uxth_and_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immL_6553
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtL_uxtw_and_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immL_4294967295 mask, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst (SubL src1 (LShiftL (AndL src2 mask) lshift)));
@@ -12238,6 +12493,8 @@ instruct SubExtL_uxtw_and_shift(iRegLNoSp dst, iRegL src1, iRegL src2, immL_4294
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtI_uxtb_and_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_255 mask, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst (AddI src1 (LShiftI (AndI src2 mask) lshift)));
@@ -12251,6 +12508,8 @@ instruct AddExtI_uxtb_and_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct AddExtI_uxth_and_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_65535 mask, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst (AddI src1 (LShiftI (AndI src2 mask) lshift)));
@@ -12264,6 +12523,8 @@ instruct AddExtI_uxth_and_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtI_uxtb_and_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_255 mask, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst (SubI src1 (LShiftI (AndI src2 mask) lshift)));
@@ -12277,6 +12538,8 @@ instruct SubExtI_uxtb_and_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2,
   ins_pipe(ialu_reg_reg_shift);
 %}
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct SubExtI_uxth_and_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2, immI_65535 mask, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst (SubI src1 (LShiftI (AndI src2 mask) lshift)));
@@ -12289,7 +12552,11 @@ instruct SubExtI_uxth_and_shift(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2,
    %}
   ins_pipe(ialu_reg_reg_shift);
 %}
+
+
+
 // END This section of the file is automatically generated. Do not edit --------------
+
 
 // ============================================================================
 // Floating Point Arithmetic Instructions
@@ -12830,7 +13097,7 @@ instruct andI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immILog src2, rFlagsReg cr
   ins_encode %{
     __ andw(as_Register($dst$$reg),
             as_Register($src1$$reg),
-            (unsigned long)($src2$$constant));
+            (uint64_t)($src2$$constant));
   %}
 
   ins_pipe(ialu_reg_imm);
@@ -12862,7 +13129,7 @@ instruct orI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immILog src2) %{
   ins_encode %{
     __ orrw(as_Register($dst$$reg),
             as_Register($src1$$reg),
-            (unsigned long)($src2$$constant));
+            (uint64_t)($src2$$constant));
   %}
 
   ins_pipe(ialu_reg_imm);
@@ -12894,7 +13161,7 @@ instruct xorI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immILog src2) %{
   ins_encode %{
     __ eorw(as_Register($dst$$reg),
             as_Register($src1$$reg),
-            (unsigned long)($src2$$constant));
+            (uint64_t)($src2$$constant));
   %}
 
   ins_pipe(ialu_reg_imm);
@@ -12927,7 +13194,7 @@ instruct andL_reg_imm(iRegLNoSp dst, iRegL src1, immLLog src2, rFlagsReg cr) %{
   ins_encode %{
     __ andr(as_Register($dst$$reg),
             as_Register($src1$$reg),
-            (unsigned long)($src2$$constant));
+            (uint64_t)($src2$$constant));
   %}
 
   ins_pipe(ialu_reg_imm);
@@ -12959,7 +13226,7 @@ instruct orL_reg_imm(iRegLNoSp dst, iRegL src1, immLLog src2) %{
   ins_encode %{
     __ orr(as_Register($dst$$reg),
            as_Register($src1$$reg),
-           (unsigned long)($src2$$constant));
+           (uint64_t)($src2$$constant));
   %}
 
   ins_pipe(ialu_reg_imm);
@@ -12991,7 +13258,7 @@ instruct xorL_reg_imm(iRegLNoSp dst, iRegL src1, immLLog src2) %{
   ins_encode %{
     __ eor(as_Register($dst$$reg),
            as_Register($src1$$reg),
-           (unsigned long)($src2$$constant));
+           (uint64_t)($src2$$constant));
   %}
 
   ins_pipe(ialu_reg_imm);

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2968,7 +2968,7 @@ encode %{
 
   enc_class aarch64_enc_movw_imm(iRegI dst, immI src) %{
     MacroAssembler _masm(&cbuf);
-    u_int32_t con = (u_int32_t)$src$$constant;
+    uint32_t con = (uint32_t)$src$$constant;
     Register dst_reg = as_Register($dst$$reg);
     if (con == 0) {
       __ movw(dst_reg, zr);
@@ -2980,7 +2980,7 @@ encode %{
   enc_class aarch64_enc_mov_imm(iRegL dst, immL src) %{
     MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
-    u_int64_t con = (u_int64_t)$src$$constant;
+    uint64_t con = (uint64_t)$src$$constant;
     if (con == 0) {
       __ mov(dst_reg, zr);
     } else {
@@ -3022,7 +3022,7 @@ encode %{
   enc_class aarch64_enc_mov_p1(iRegP dst, immP_1 src) %{
     MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
-    __ mov(dst_reg, (u_int64_t)1);
+    __ mov(dst_reg, (uint64_t)1);
   %}
 
   enc_class aarch64_enc_mov_poll_page(iRegP dst, immPollPage src) %{
@@ -3156,7 +3156,7 @@ encode %{
   enc_class aarch64_enc_cmpw_imm(iRegI src1, immI src2) %{
     MacroAssembler _masm(&cbuf);
     Register reg1 = as_Register($src1$$reg);
-    u_int32_t val = (u_int32_t)$src2$$constant;
+    uint32_t val = (uint32_t)$src2$$constant;
     __ movw(rscratch1, val);
     __ cmpw(reg1, rscratch1);
   %}
@@ -3178,7 +3178,7 @@ encode %{
       __ adds(zr, reg, -val);
     } else {
     // aargh, Long.MIN_VALUE is a special case
-      __ orr(rscratch1, zr, (u_int64_t)val);
+      __ orr(rscratch1, zr, (uint64_t)val);
       __ subs(zr, reg, rscratch1);
     }
   %}
@@ -3186,7 +3186,7 @@ encode %{
   enc_class aarch64_enc_cmp_imm(iRegL src1, immL src2) %{
     MacroAssembler _masm(&cbuf);
     Register reg1 = as_Register($src1$$reg);
-    u_int64_t val = (u_int64_t)$src2$$constant;
+    uint64_t val = (uint64_t)$src2$$constant;
     __ mov(rscratch1, val);
     __ cmp(reg1, rscratch1);
   %}
@@ -13444,8 +13444,8 @@ instruct clearArray_reg_reg(iRegL_R11 cnt, iRegP_R10 base, Universe dummy, rFlag
 
 instruct clearArray_imm_reg(immL cnt, iRegP_R10 base, Universe dummy, rFlagsReg cr)
 %{
-  predicate((u_int64_t)n->in(2)->get_long()
-            < (u_int64_t)(BlockZeroingLowLimit >> LogBytesPerWord));
+  predicate((uint64_t)n->in(2)->get_long()
+            < (uint64_t)(BlockZeroingLowLimit >> LogBytesPerWord));
   match(Set dummy (ClearArray cnt base));
   effect(USE_KILL base);
 
@@ -13453,7 +13453,7 @@ instruct clearArray_imm_reg(immL cnt, iRegP_R10 base, Universe dummy, rFlagsReg 
   format %{ "ClearArray $cnt, $base" %}
 
   ins_encode %{
-    __ zero_words($base$$Register, (u_int64_t)$cnt$$constant);
+    __ zero_words($base$$Register, (uint64_t)$cnt$$constant);
   %}
 
   ins_pipe(pipe_class_memory);

--- a/src/hotspot/cpu/aarch64/aarch64_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_ad.m4
@@ -1,4 +1,4 @@
-dnl Copyright (c) 2014, Red Hat Inc. All rights reserved.
+dnl Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
 dnl DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 dnl
 dnl This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,12 @@ dnl
 dnl Process this file with m4 aarch64_ad.m4 to generate the arithmetic
 dnl and shift patterns patterns used in aarch64.ad.
 dnl
-// BEGIN This section of the file is automatically generated. Do not edit --------------
 dnl
 define(`ORL2I', `ifelse($1,I,orL2I)')
 dnl
 define(`BASE_SHIFT_INSN',
-`
+`// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct $2$1_reg_$4_reg(iReg$1NoSp dst,
                          iReg$1`'ORL2I($1) src1, iReg$1`'ORL2I($1) src2,
                          immI src3, rFlagsReg cr) %{
@@ -46,9 +46,11 @@ instruct $2$1_reg_$4_reg(iReg$1NoSp dst,
   %}
 
   ins_pipe(ialu_reg_reg_shift);
-%}')dnl
+%}
+')dnl
 define(`BASE_INVERTED_INSN',
-`
+`// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct $2$1_reg_not_reg(iReg$1NoSp dst,
                          iReg$1`'ORL2I($1) src1, iReg$1`'ORL2I($1) src2, imm$1_M1 m1,
                          rFlagsReg cr) %{
@@ -68,9 +70,11 @@ dnl into this canonical form.
   %}
 
   ins_pipe(ialu_reg_reg);
-%}')dnl
+%}
+')dnl
 define(`INVERTED_SHIFT_INSN',
-`
+`// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct $2$1_reg_$4_not_reg(iReg$1NoSp dst,
                          iReg$1`'ORL2I($1) src1, iReg$1`'ORL2I($1) src2,
                          immI src3, imm$1_M1 src4, rFlagsReg cr) %{
@@ -91,9 +95,12 @@ dnl into this canonical form.
   %}
 
   ins_pipe(ialu_reg_reg_shift);
-%}')dnl
+%}
+')dnl
 define(`NOT_INSN',
-`instruct reg$1_not_reg(iReg$1NoSp dst,
+`// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
+instruct reg$1_not_reg(iReg$1NoSp dst,
                          iReg$1`'ORL2I($1) src1, imm$1_M1 m1,
                          rFlagsReg cr) %{
   match(Set dst (Xor$1 src1 m1));
@@ -108,7 +115,8 @@ define(`NOT_INSN',
   %}
 
   ins_pipe(ialu_reg);
-%}')dnl
+%}
+')dnl
 dnl
 define(`BOTH_SHIFT_INSNS',
 `BASE_SHIFT_INSN(I, $1, ifelse($2,andr,andw,$2w), $3, $4)
@@ -120,7 +128,7 @@ BASE_INVERTED_INSN(L, $1, $2, $3, $4)')dnl
 dnl
 define(`BOTH_INVERTED_SHIFT_INSNS',
 `INVERTED_SHIFT_INSN(I, $1, $2w, $3, $4, ~0, int)
-INVERTED_SHIFT_INSN(L, $1, $2, $3, $4, ~0l, long)')dnl
+INVERTED_SHIFT_INSN(L, $1, $2, $3, $4, ~0l, jlong)')dnl
 dnl
 define(`ALL_SHIFT_KINDS',
 `BOTH_SHIFT_INSNS($1, $2, URShift, LSR)
@@ -147,8 +155,10 @@ ALL_SHIFT_KINDS(Add, add)
 ALL_SHIFT_KINDS(Sub, sub)
 dnl
 dnl EXTEND mode, rshift_op, src, lshift_count, rshift_count
-define(`EXTEND', `($2$1 (LShift$1 $3 $4) $5)')
-define(`BFM_INSN',`
+define(`EXTEND', `($2$1 (LShift$1 $3 $4) $5)') dnl
+define(`BFM_INSN',`// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
+
 // Shift Left followed by Shift Right.
 // This idiom is used by the compiler for the i2b bytecode etc.
 instruct $4$1(iReg$1NoSp dst, iReg$1`'ORL2I($1) src, immI lshift_count, immI rshift_count)
@@ -167,7 +177,8 @@ instruct $4$1(iReg$1NoSp dst, iReg$1`'ORL2I($1) src, immI lshift_count, immI rsh
   %}
 
   ins_pipe(ialu_reg_shift);
-%}')
+%}
+')
 BFM_INSN(L, 63, RShift, sbfm)
 BFM_INSN(I, 31, RShift, sbfmw)
 BFM_INSN(L, 63, URShift, ubfm)
@@ -175,7 +186,9 @@ BFM_INSN(I, 31, URShift, ubfmw)
 dnl
 // Bitfield extract with shift & mask
 define(`BFX_INSN',
-`instruct $3$1(iReg$1NoSp dst, iReg$1`'ORL2I($1) src, immI rshift, imm$1_bitmask mask)
+`// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
+instruct $3$1(iReg$1NoSp dst, iReg$1`'ORL2I($1) src, immI rshift, imm$1_bitmask mask)
 %{
   match(Set dst (And$1 ($2$1 src rshift) mask));
   // Make sure we are not going to exceed what $3 can do.
@@ -185,15 +198,19 @@ define(`BFX_INSN',
   format %{ "$3 $dst, $src, $rshift, $mask" %}
   ins_encode %{
     int rshift = $rshift$$constant & $4;
-    long mask = $mask$$constant;
+    intptr_t mask = $mask$$constant;
     int width = exact_log2$6(mask+1);
     __ $3(as_Register($dst$$reg),
             as_Register($src$$reg), rshift, width);
   %}
   ins_pipe(ialu_reg_shift);
-%}')
+%}
+')
 BFX_INSN(I, URShift, ubfxw, 31, int)
 BFX_INSN(L, URShift, ubfx,  63, long, _long)
+
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
 // We can use ubfx when extending an And with a mask when we know mask
 // is positive.  We know that because immI_bitmask guarantees it.
@@ -207,7 +224,7 @@ instruct ubfxIConvI2L(iRegLNoSp dst, iRegIorL2I src, immI rshift, immI_bitmask m
   format %{ "ubfx $dst, $src, $rshift, $mask" %}
   ins_encode %{
     int rshift = $rshift$$constant & 31;
-    long mask = $mask$$constant;
+    intptr_t mask = $mask$$constant;
     int width = exact_log2(mask+1);
     __ ubfx(as_Register($dst$$reg),
             as_Register($src$$reg), rshift, width);
@@ -215,7 +232,10 @@ instruct ubfxIConvI2L(iRegLNoSp dst, iRegIorL2I src, immI rshift, immI_bitmask m
   ins_pipe(ialu_reg_shift);
 %}
 
-define(`UBFIZ_INSN', `// We can use ubfiz when masking by a positive number and then left shifting the result.
+define(`UBFIZ_INSN', `// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
+
+// We can use ubfiz when masking by a positive number and then left shifting the result.
 // We know that the mask is positive because imm$1_bitmask guarantees it.
 instruct $3$1$8(iReg$2NoSp dst, iReg$1`'ORL2I($1) src, immI lshift, $7 mask)
 %{
@@ -230,7 +250,7 @@ instruct $3$1$8(iReg$2NoSp dst, iReg$1`'ORL2I($1) src, immI lshift, $7 mask)
   format %{ "$3 $dst, $src, $lshift, $mask" %}
   ins_encode %{
     int lshift = $lshift$$constant & $4;
-    long mask = $mask$$constant;
+    intptr_t mask = $mask$$constant;
     int width = $6(mask+1);
     __ $3(as_Register($dst$$reg),
           as_Register($src$$reg), lshift, width);
@@ -243,6 +263,9 @@ UBFIZ_INSN(L, L, ubfiz,  63, long, exact_log2_long, immL_bitmask)
 UBFIZ_INSN(I, L, ubfizw, 31, int,  exact_log2,      immI_bitmask,           ConvI2L)
 UBFIZ_INSN(L, I, ubfiz,  63, long, exact_log2_long, immL_positive_bitmaskI, ConvL2I)
 
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
+
 define(`BFX1_INSN', `// If there is a convert $1 to $2 block between and And$1 and a LShift$2, we can also match ubfiz
 instruct ubfiz$1Conv$3$9(iReg$2NoSp dst, iReg$1`'ORL2I($1) src, immI lshift, $8 mask)
 %{
@@ -253,7 +276,7 @@ instruct ubfiz$1Conv$3$9(iReg$2NoSp dst, iReg$1`'ORL2I($1) src, immI lshift, $8 
   format %{ "ubfiz $dst, $src, $lshift, $mask" %}
   ins_encode %{
     int lshift = $lshift$$constant & $6;
-    long mask = $mask$$constant;
+    intptr_t mask = $mask$$constant;
     int width = exact_log2(mask+1);
     __ ubfiz(as_Register($dst$$reg),
              as_Register($src$$reg), lshift, width);
@@ -275,10 +298,12 @@ instruct ubfizIConvI2LAndI(iRegLNoSp dst, iRegI src, immI_bitmask msk)
   ins_pipe(ialu_reg_shift);
 %}
 
-// Rotations
 
-define(`EXTRACT_INSN',
-`instruct extr$3$1(iReg$1NoSp dst, iReg$1`'ORL2I($1) src1, iReg$1`'ORL2I($1) src2, immI lshift, immI rshift, rFlagsReg cr)
+// Rotations dnl
+define(`EXTRACT_INSN',`
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
+instruct extr$3$1(iReg$1NoSp dst, iReg$1`'ORL2I($1) src1, iReg$1`'ORL2I($1) src2, immI lshift, immI rshift, rFlagsReg cr)
 %{
   match(Set dst ($3$1 (LShift$1 src1 lshift) (URShift$1 src2 rshift)));
   predicate(0 == (((n->in(1)->in(2)->get_int() & $2) + (n->in(2)->in(2)->get_int() & $2)) & $2));
@@ -297,9 +322,10 @@ EXTRACT_INSN(L, 63, Or, extr)
 EXTRACT_INSN(I, 31, Or, extrw)
 EXTRACT_INSN(L, 63, Add, extr)
 EXTRACT_INSN(I, 31, Add, extrw)
-define(`ROL_EXPAND', `
-// $2 expander
+define(`ROL_EXPAND', `// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
+// $2 expander
 instruct $2$1_rReg(iReg$1NoSp dst, iReg$1 src, iRegI shift, rFlagsReg cr)
 %{
   effect(DEF dst, USE src, USE shift);
@@ -312,10 +338,12 @@ instruct $2$1_rReg(iReg$1NoSp dst, iReg$1 src, iRegI shift, rFlagsReg cr)
             rscratch1);
     %}
   ins_pipe(ialu_reg_reg_vshift);
-%}')dnl
-define(`ROR_EXPAND', `
-// $2 expander
+%}
+')
+define(`ROR_EXPAND', `// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 
+// $2 expander
 instruct $2$1_rReg(iReg$1NoSp dst, iReg$1 src, iRegI shift, rFlagsReg cr)
 %{
   effect(DEF dst, USE src, USE shift);
@@ -327,8 +355,10 @@ instruct $2$1_rReg(iReg$1NoSp dst, iReg$1 src, iRegI shift, rFlagsReg cr)
             as_Register($shift$$reg));
     %}
   ins_pipe(ialu_reg_reg_vshift);
-%}')dnl
-define(ROL_INSN, `
+%}
+')dnl
+define(ROL_INSN, `// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct $3$1_rReg_Var_C$2(iReg$1NoSp dst, iReg$1 src, iRegI shift, immI$2 c$2, rFlagsReg cr)
 %{
   match(Set dst (Or$1 (LShift$1 src shift) (URShift$1 src (SubI c$2 shift))));
@@ -336,8 +366,10 @@ instruct $3$1_rReg_Var_C$2(iReg$1NoSp dst, iReg$1 src, iRegI shift, immI$2 c$2, 
   expand %{
     $3$1_rReg(dst, src, shift, cr);
   %}
-%}')dnl
-define(ROR_INSN, `
+%}
+')dnl
+define(ROR_INSN, `// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct $3$1_rReg_Var_C$2(iReg$1NoSp dst, iReg$1 src, iRegI shift, immI$2 c$2, rFlagsReg cr)
 %{
   match(Set dst (Or$1 (URShift$1 src shift) (LShift$1 src (SubI c$2 shift))));
@@ -345,7 +377,8 @@ instruct $3$1_rReg_Var_C$2(iReg$1NoSp dst, iReg$1 src, iRegI shift, immI$2 c$2, 
   expand %{
     $3$1_rReg(dst, src, shift, cr);
   %}
-%}')dnl
+%}
+')dnl
 ROL_EXPAND(L, rol, rorv)
 ROL_EXPAND(I, rol, rorvw)
 ROL_INSN(L, _64, rol)
@@ -362,6 +395,8 @@ ROR_INSN(I, 0, ror)
 // Add/subtract (extended)
 dnl ADD_SUB_EXTENDED(mode, size, add node, shift node, insn, shift type, wordsize
 define(`ADD_SUB_CONV', `
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct $3Ext$1(iReg$2NoSp dst, iReg$2`'ORL2I($2) src1, iReg$1`'ORL2I($1) src2, rFlagsReg cr)
 %{
   match(Set dst ($3$2 src1 (ConvI2L src2)));
@@ -374,10 +409,12 @@ instruct $3Ext$1(iReg$2NoSp dst, iReg$2`'ORL2I($2) src1, iReg$1`'ORL2I($1) src2,
    %}
   ins_pipe(ialu_reg_reg);
 %}')dnl
-ADD_SUB_CONV(I,L,Add,add,sxtw);
-ADD_SUB_CONV(I,L,Sub,sub,sxtw);
+ADD_SUB_CONV(I,L,Add,add,sxtw)
+ADD_SUB_CONV(I,L,Sub,sub,sxtw)
 dnl
 define(`ADD_SUB_EXTENDED', `
+// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct $3Ext$1_$6(iReg$1NoSp dst, iReg$1`'ORL2I($1) src1, iReg$1`'ORL2I($1) src2, immI_`'eval($7-$2) lshift, immI_`'eval($7-$2) rshift, rFlagsReg cr)
 %{
   match(Set dst ($3$1 src1 EXTEND($1, $4, src2, lshift, rshift)));
@@ -389,7 +426,7 @@ instruct $3Ext$1_$6(iReg$1NoSp dst, iReg$1`'ORL2I($1) src1, iReg$1`'ORL2I($1) sr
             as_Register($src2$$reg), ext::$6);
    %}
   ins_pipe(ialu_reg_reg);
-%}')
+%}')dnl
 ADD_SUB_EXTENDED(I,16,Add,RShift,add,sxth,32)
 ADD_SUB_EXTENDED(I,8,Add,RShift,add,sxtb,32)
 ADD_SUB_EXTENDED(I,8,Add,URShift,add,uxtb,32)
@@ -399,7 +436,8 @@ ADD_SUB_EXTENDED(L,8,Add,RShift,add,sxtb,64)
 ADD_SUB_EXTENDED(L,8,Add,URShift,add,uxtb,64)
 dnl
 dnl ADD_SUB_ZERO_EXTEND(mode, size, add node, insn, shift type)
-define(`ADD_SUB_ZERO_EXTEND', `
+define(`ADD_SUB_ZERO_EXTEND', `// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct $3Ext$1_$5_and(iReg$1NoSp dst, iReg$1`'ORL2I($1) src1, iReg$1`'ORL2I($1) src2, imm$1_$2 mask, rFlagsReg cr)
 %{
   match(Set dst ($3$1 src1 (And$1 src2 mask)));
@@ -411,7 +449,8 @@ instruct $3Ext$1_$5_and(iReg$1NoSp dst, iReg$1`'ORL2I($1) src1, iReg$1`'ORL2I($1
             as_Register($src2$$reg), ext::$5);
    %}
   ins_pipe(ialu_reg_reg);
-%}')
+%}
+')
 dnl
 ADD_SUB_ZERO_EXTEND(I,255,Add,addw,uxtb)
 ADD_SUB_ZERO_EXTEND(I,65535,Add,addw,uxth)
@@ -426,7 +465,8 @@ ADD_SUB_ZERO_EXTEND(L,65535,Sub,sub,uxth)
 ADD_SUB_ZERO_EXTEND(L,4294967295,Sub,sub,uxtw)
 dnl
 dnl ADD_SUB_ZERO_EXTEND_SHIFT(mode, size, add node, insn, ext type)
-define(`ADD_SUB_EXTENDED_SHIFT', `
+define(`ADD_SUB_EXTENDED_SHIFT', `// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct $3Ext$1_$6_shift(iReg$1NoSp dst, iReg$1`'ORL2I($1) src1, iReg$1`'ORL2I($1) src2, immIExt lshift2, immI_`'eval($7-$2) lshift1, immI_`'eval($7-$2) rshift1, rFlagsReg cr)
 %{
   match(Set dst ($3$1 src1 (LShift$1 EXTEND($1, $4, src2, lshift1, rshift1) lshift2)));
@@ -438,7 +478,8 @@ instruct $3Ext$1_$6_shift(iReg$1NoSp dst, iReg$1`'ORL2I($1) src1, iReg$1`'ORL2I(
             as_Register($src2$$reg), ext::$6, ($lshift2$$constant));
    %}
   ins_pipe(ialu_reg_reg_shift);
-%}')
+%}
+')
 dnl                   $1 $2 $3   $4   $5   $6  $7
 ADD_SUB_EXTENDED_SHIFT(L,8,Add,RShift,add,sxtb,64)
 ADD_SUB_EXTENDED_SHIFT(L,16,Add,RShift,add,sxth,64)
@@ -455,7 +496,8 @@ ADD_SUB_EXTENDED_SHIFT(I,8,Sub,RShift,subw,sxtb,32)
 ADD_SUB_EXTENDED_SHIFT(I,16,Sub,RShift,subw,sxth,32)
 dnl
 dnl ADD_SUB_CONV_SHIFT(mode, add node, insn, ext type)
-define(`ADD_SUB_CONV_SHIFT', `
+define(`ADD_SUB_CONV_SHIFT', `// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct $2ExtI_shift(iReg$1NoSp dst, iReg$1`'ORL2I($1) src1, iRegIorL2I src2, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst ($2$1 src1 (LShiftL (ConvI2L src2) lshift)));
@@ -467,13 +509,14 @@ instruct $2ExtI_shift(iReg$1NoSp dst, iReg$1`'ORL2I($1) src1, iRegIorL2I src2, i
             as_Register($src2$$reg), ext::$4, ($lshift$$constant));
    %}
   ins_pipe(ialu_reg_reg_shift);
-%}')
-dnl
-ADD_SUB_CONV_SHIFT(L,Add,add,sxtw);
-ADD_SUB_CONV_SHIFT(L,Sub,sub,sxtw);
+%}
+')dnl
+ADD_SUB_CONV_SHIFT(L,Add,add,sxtw)
+ADD_SUB_CONV_SHIFT(L,Sub,sub,sxtw)
 dnl
 dnl ADD_SUB_ZERO_EXTEND(mode, size, add node, insn, ext type)
-define(`ADD_SUB_ZERO_EXTEND_SHIFT', `
+define(`ADD_SUB_ZERO_EXTEND_SHIFT', `// This pattern is automatically generated from aarch64_ad.m4
+// DO NOT EDIT ANYTHING IN THIS SECTION OF THE FILE
 instruct $3Ext$1_$5_and_shift(iReg$1NoSp dst, iReg$1`'ORL2I($1) src1, iReg$1`'ORL2I($1) src2, imm$1_$2 mask, immIExt lshift, rFlagsReg cr)
 %{
   match(Set dst ($3$1 src1 (LShift$1 (And$1 src2 mask) lshift)));
@@ -485,8 +528,8 @@ instruct $3Ext$1_$5_and_shift(iReg$1NoSp dst, iReg$1`'ORL2I($1) src1, iReg$1`'OR
             as_Register($src2$$reg), ext::$5, ($lshift$$constant));
    %}
   ins_pipe(ialu_reg_reg_shift);
-%}')
-dnl
+%}
+')dnl
 dnl                       $1 $2  $3  $4  $5
 ADD_SUB_ZERO_EXTEND_SHIFT(L,255,Add,add,uxtb)
 ADD_SUB_ZERO_EXTEND_SHIFT(L,65535,Add,add,uxth)
@@ -502,4 +545,4 @@ dnl
 ADD_SUB_ZERO_EXTEND_SHIFT(I,255,Sub,subw,uxtb)
 ADD_SUB_ZERO_EXTEND_SHIFT(I,65535,Sub,subw,uxth)
 dnl
-// END This section of the file is automatically generated. Do not edit --------------
+

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -1517,7 +1517,7 @@ void Address::lea(MacroAssembler *as, Register r) const {
       break;
   }
   case base_plus_offset_reg: {
-    __ add(r, _base, _index, _ext.op(), MAX(_ext.shift(), 0));
+    __ add(r, _base, _index, _ext.op(), MAX2(_ext.shift(), 0));
     break;
   }
   case literal: {

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -31,7 +31,7 @@
 #include "interpreter/interpreter.hpp"
 
 #ifndef PRODUCT
-const unsigned long Assembler::asm_bp = 0x00007fffee09ac88;
+const uintptr_t Assembler::asm_bp = 0x00007fffee09ac88;
 #endif
 
 #include "compiler/disassembler.hpp"
@@ -1493,7 +1493,7 @@ extern "C" {
       Disassembler::decode((address)start, (address)start + len);
   }
 
-  JNIEXPORT void das1(unsigned long insn) {
+  JNIEXPORT void das1(uintptr_t insn) {
     das(insn, 1);
   }
 }
@@ -1532,7 +1532,7 @@ void Address::lea(MacroAssembler *as, Register r) const {
   }
 }
 
-void Assembler::adrp(Register reg1, const Address &dest, unsigned long &byte_offset) {
+void Assembler::adrp(Register reg1, const Address &dest, uintptr_t &byte_offset) {
   ShouldNotReachHere();
 }
 
@@ -1541,7 +1541,7 @@ void Assembler::adrp(Register reg1, const Address &dest, unsigned long &byte_off
 #define starti Instruction_aarch64 do_not_use(this); set_current(&do_not_use)
 
   void Assembler::adr(Register Rd, address adr) {
-    long offset = adr - pc();
+    intptr_t offset = adr - pc();
     int offset_lo = offset & 3;
     offset >>= 2;
     starti;
@@ -1552,7 +1552,7 @@ void Assembler::adrp(Register reg1, const Address &dest, unsigned long &byte_off
   void Assembler::_adrp(Register Rd, address adr) {
     uint64_t pc_page = (uint64_t)pc() >> 12;
     uint64_t adr_page = (uint64_t)adr >> 12;
-    long offset = adr_page - pc_page;
+    intptr_t offset = adr_page - pc_page;
     int offset_lo = offset & 3;
     offset >>= 2;
     starti;
@@ -1701,9 +1701,9 @@ void Assembler::add_sub_immediate(Register Rd, Register Rn, unsigned uimm, int o
   srf(Rn, 5);
 }
 
-bool Assembler::operand_valid_for_add_sub_immediate(long imm) {
+bool Assembler::operand_valid_for_add_sub_immediate(int64_t imm) {
   bool shift = false;
-  unsigned long uimm = uabs(imm);
+  uint64_t uimm = (uint64_t)uabs(imm);
   if (uimm < (1 << 12))
     return true;
   if (uimm < (1 << 24)

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -96,662 +96,662 @@ void entry(CodeBuffer *cb) {
     __ bind(back);
 
 // ArithOp
-    __ add(r15, r12, r16, Assembler::LSR, 30);         //        add        x15, x12, x16, LSR #30
-    __ sub(r1, r15, r3, Assembler::LSR, 32);           //        sub        x1, x15, x3, LSR #32
-    __ adds(r13, r25, r5, Assembler::LSL, 13);         //        adds        x13, x25, x5, LSL #13
-    __ subs(r22, r28, r6, Assembler::ASR, 17);         //        subs        x22, x28, x6, ASR #17
-    __ addw(r0, r9, r22, Assembler::ASR, 6);           //        add        w0, w9, w22, ASR #6
-    __ subw(r19, r3, r25, Assembler::LSL, 21);         //        sub        w19, w3, w25, LSL #21
-    __ addsw(r4, r19, r11, Assembler::LSL, 20);        //        adds        w4, w19, w11, LSL #20
-    __ subsw(r24, r7, r19, Assembler::ASR, 0);         //        subs        w24, w7, w19, ASR #0
-    __ andr(r30, r7, r11, Assembler::LSL, 48);         //        and        x30, x7, x11, LSL #48
-    __ orr(r24, r8, r15, Assembler::LSL, 12);          //        orr        x24, x8, x15, LSL #12
-    __ eor(r17, r9, r23, Assembler::LSL, 1);           //        eor        x17, x9, x23, LSL #1
-    __ ands(r14, r11, r4, Assembler::LSR, 55);         //        ands        x14, x11, x4, LSR #55
-    __ andw(r19, r7, r12, Assembler::LSR, 17);         //        and        w19, w7, w12, LSR #17
-    __ orrw(r19, r27, r11, Assembler::ASR, 28);        //        orr        w19, w27, w11, ASR #28
-    __ eorw(r30, r3, r22, Assembler::LSR, 31);         //        eor        w30, w3, w22, LSR #31
-    __ andsw(r19, r26, r28, Assembler::ASR, 0);        //        ands        w19, w26, w28, ASR #0
-    __ bic(r29, r6, r26, Assembler::LSL, 51);          //        bic        x29, x6, x26, LSL #51
-    __ orn(r26, r27, r17, Assembler::LSL, 35);         //        orn        x26, x27, x17, LSL #35
-    __ eon(r21, r4, r14, Assembler::LSL, 5);           //        eon        x21, x4, x14, LSL #5
-    __ bics(r2, r15, r0, Assembler::ASR, 5);           //        bics        x2, x15, x0, ASR #5
-    __ bicw(r2, r7, r2, Assembler::LSL, 29);           //        bic        w2, w7, w2, LSL #29
-    __ ornw(r24, r12, r21, Assembler::LSR, 5);         //        orn        w24, w12, w21, LSR #5
-    __ eonw(r30, r15, r19, Assembler::LSL, 2);         //        eon        w30, w15, w19, LSL #2
-    __ bicsw(r30, r23, r17, Assembler::ASR, 28);       //        bics        w30, w23, w17, ASR #28
+    __ add(r15, r0, r24, Assembler::LSL, 59);          // add x15, x0, x24, LSL #59
+    __ sub(r17, r22, r22, Assembler::ASR, 13);         // sub x17, x22, x22, ASR #13
+    __ adds(r10, r26, r28, Assembler::LSL, 57);        // adds  x10, x26, x28, LSL #57
+    __ subs(r25, r16, r24, Assembler::LSL, 18);        // subs  x25, x16, x24, LSL #18
+    __ addw(r8, r5, r28, Assembler::LSL, 7);           // add w8, w5, w28, LSL #7
+    __ subw(r8, r28, r1, Assembler::ASR, 28);          // sub w8, w28, w1, ASR #28
+    __ addsw(r12, r2, r1, Assembler::LSL, 0);          // adds  w12, w2, w1, LSL #0
+    __ subsw(r23, r5, r17, Assembler::LSR, 25);        // subs  w23, w5, w17, LSR #25
+    __ andr(r21, r12, r13, Assembler::LSL, 21);        // and x21, x12, x13, LSL #21
+    __ orr(r21, r15, r23, Assembler::ASR, 36);         // orr x21, x15, x23, ASR #36
+    __ eor(r22, r24, r27, Assembler::ASR, 48);         // eor x22, x24, x27, ASR #48
+    __ ands(r22, r15, r2, Assembler::ASR, 52);         // ands  x22, x15, x2, ASR #52
+    __ andw(r1, r17, r24, Assembler::ASR, 3);          // and w1, w17, w24, ASR #3
+    __ orrw(r5, r2, r6, Assembler::ASR, 11);           // orr w5, w2, w6, ASR #11
+    __ eorw(r23, r1, r5, Assembler::LSR, 12);          // eor w23, w1, w5, LSR #12
+    __ andsw(r0, r12, r14, Assembler::ASR, 20);        // ands  w0, w12, w14, ASR #20
+    __ bic(r1, r6, r2, Assembler::LSR, 7);             // bic x1, x6, x2, LSR #7
+    __ orn(r30, r8, r4, Assembler::LSL, 47);           // orn x30, x8, x4, LSL #47
+    __ eon(r17, r22, r20, Assembler::ASR, 53);         // eon x17, x22, x20, ASR #53
+    __ bics(r29, r15, r5, Assembler::ASR, 36);         // bics  x29, x15, x5, ASR #36
+    __ bicw(r30, r23, r29, Assembler::LSR, 27);        // bic w30, w23, w29, LSR #27
+    __ ornw(r12, r29, r2, Assembler::LSL, 20);         // orn w12, w29, w2, LSL #20
+    __ eonw(r7, r12, r6, Assembler::ASR, 4);           // eon w7, w12, w6, ASR #4
+    __ bicsw(r16, r13, r7, Assembler::ASR, 21);        // bics  w16, w13, w7, ASR #21
 
 // AddSubImmOp
-    __ addw(r4, r20, 660u);                            //        add        w4, w20, #660
-    __ addsw(r2, r10, 710u);                           //        adds        w2, w10, #710
-    __ subw(r19, r26, 244u);                           //        sub        w19, w26, #244
-    __ subsw(r28, r13, 73u);                           //        subs        w28, w13, #73
-    __ add(r2, r30, 862u);                             //        add        x2, x30, #862
-    __ adds(r27, r16, 574u);                           //        adds        x27, x16, #574
-    __ sub(r22, r9, 589u);                             //        sub        x22, x9, #589
-    __ subs(r4, r1, 698u);                             //        subs        x4, x1, #698
+    __ addw(r5, r17, 726u);                            // add w5, w17, #726
+    __ addsw(r10, r16, 347u);                          // adds  w10, w16, #347
+    __ subw(r26, r5, 978u);                            // sub w26, w5, #978
+    __ subsw(r21, r24, 689u);                          // subs  w21, w24, #689
+    __ add(r10, r16, 987u);                            // add x10, x16, #987
+    __ adds(r15, r15, 665u);                           // adds  x15, x15, #665
+    __ sub(r24, r20, 39u);                             // sub x24, x20, #39
+    __ subs(r10, r13, 76u);                            // subs  x10, x13, #76
 
 // LogicalImmOp
-    __ andw(r28, r19, 4294709247ul);                   //        and        w28, w19, #0xfffc0fff
-    __ orrw(r27, r5, 536870910ul);                     //        orr        w27, w5, #0x1ffffffe
-    __ eorw(r30, r20, 4294840319ul);                   //        eor        w30, w20, #0xfffe0fff
-    __ andsw(r22, r26, 4294959615ul);                  //        ands        w22, w26, #0xffffe1ff
-    __ andr(r5, r7, 4194300ul);                        //        and        x5, x7, #0x3ffffc
-    __ orr(r13, r7, 18014398509481728ul);              //        orr        x13, x7, #0x3fffffffffff00
-    __ eor(r7, r9, 18442240474082197503ul);            //        eor        x7, x9, #0xfff0000000003fff
-    __ ands(r3, r0, 18374686479671656447ul);           //        ands        x3, x0, #0xff00000000007fff
+    __ andw(r7, r19, 8388600ull);                      // and w7, w19, #0x7ffff8
+    __ orrw(r5, r17, 4026535935ull);                   // orr w5, w17, #0xf0000fff
+    __ eorw(r16, r28, 4186112ull);                     // eor w16, w28, #0x3fe000
+    __ andsw(r14, r24, 7168ull);                       // ands  w14, w24, #0x1c00
+    __ andr(r14, r27, 18446744073709543551ull);        // and x14, x27, #0xffffffffffffe07f
+    __ orr(r12, r11, 576456354256912384ull);           // orr x12, x11, #0x7fffc0000000000
+    __ eor(r2, r0, 18437736874454811647ull);           // eor x2, x0, #0xffe00000000003ff
+    __ ands(r13, r20, 18446744073642573823ull);        // ands  x13, x20, #0xfffffffffc01ffff
 
 // AbsOp
-    __ b(__ pc());                                     //        b        .
-    __ b(back);                                        //        b        back
-    __ b(forth);                                       //        b        forth
-    __ bl(__ pc());                                    //        bl        .
-    __ bl(back);                                       //        bl        back
-    __ bl(forth);                                      //        bl        forth
+    __ b(__ pc());                                     // b .
+    __ b(back);                                        // b back
+    __ b(forth);                                       // b forth
+    __ bl(__ pc());                                    // bl  .
+    __ bl(back);                                       // bl  back
+    __ bl(forth);                                      // bl  forth
 
 // RegAndAbsOp
-    __ cbzw(r16, __ pc());                             //        cbz        w16, .
-    __ cbzw(r16, back);                                //        cbz        w16, back
-    __ cbzw(r16, forth);                               //        cbz        w16, forth
-    __ cbnzw(r19, __ pc());                            //        cbnz        w19, .
-    __ cbnzw(r19, back);                               //        cbnz        w19, back
-    __ cbnzw(r19, forth);                              //        cbnz        w19, forth
-    __ cbz(r5, __ pc());                               //        cbz        x5, .
-    __ cbz(r5, back);                                  //        cbz        x5, back
-    __ cbz(r5, forth);                                 //        cbz        x5, forth
-    __ cbnz(r4, __ pc());                              //        cbnz        x4, .
-    __ cbnz(r4, back);                                 //        cbnz        x4, back
-    __ cbnz(r4, forth);                                //        cbnz        x4, forth
-    __ adr(r27, __ pc());                              //        adr        x27, .
-    __ adr(r27, back);                                 //        adr        x27, back
-    __ adr(r27, forth);                                //        adr        x27, forth
-    __ _adrp(r16, __ pc());                            //        adrp        x16, .
+    __ cbzw(r15, __ pc());                             // cbz w15, .
+    __ cbzw(r15, back);                                // cbz w15, back
+    __ cbzw(r15, forth);                               // cbz w15, forth
+    __ cbnzw(r28, __ pc());                            // cbnz  w28, .
+    __ cbnzw(r28, back);                               // cbnz  w28, back
+    __ cbnzw(r28, forth);                              // cbnz  w28, forth
+    __ cbz(r27, __ pc());                              // cbz x27, .
+    __ cbz(r27, back);                                 // cbz x27, back
+    __ cbz(r27, forth);                                // cbz x27, forth
+    __ cbnz(r0, __ pc());                              // cbnz  x0, .
+    __ cbnz(r0, back);                                 // cbnz  x0, back
+    __ cbnz(r0, forth);                                // cbnz  x0, forth
+    __ adr(r13, __ pc());                              // adr x13, .
+    __ adr(r13, back);                                 // adr x13, back
+    __ adr(r13, forth);                                // adr x13, forth
+    __ _adrp(r3, __ pc());                             // adrp  x3, .
 
 // RegImmAbsOp
-    __ tbz(r28, 8, __ pc());                           //        tbz        x28, #8, .
-    __ tbz(r28, 8, back);                              //        tbz        x28, #8, back
-    __ tbz(r28, 8, forth);                             //        tbz        x28, #8, forth
-    __ tbnz(r1, 1, __ pc());                           //        tbnz        x1, #1, .
-    __ tbnz(r1, 1, back);                              //        tbnz        x1, #1, back
-    __ tbnz(r1, 1, forth);                             //        tbnz        x1, #1, forth
+    __ tbz(r21, 7, __ pc());                           // tbz x21, #7, .
+    __ tbz(r21, 7, back);                              // tbz x21, #7, back
+    __ tbz(r21, 7, forth);                             // tbz x21, #7, forth
+    __ tbnz(r15, 9, __ pc());                          // tbnz  x15, #9, .
+    __ tbnz(r15, 9, back);                             // tbnz  x15, #9, back
+    __ tbnz(r15, 9, forth);                            // tbnz  x15, #9, forth
 
 // MoveWideImmOp
-    __ movnw(r20, 8639, 16);                           //        movn        w20, #8639, lsl 16
-    __ movzw(r7, 25835, 0);                            //        movz        w7, #25835, lsl 0
-    __ movkw(r17, 7261, 0);                            //        movk        w17, #7261, lsl 0
-    __ movn(r14, 2097, 32);                            //        movn        x14, #2097, lsl 32
-    __ movz(r9, 16082, 0);                             //        movz        x9, #16082, lsl 0
-    __ movk(r19, 13962, 16);                           //        movk        x19, #13962, lsl 16
+    __ movnw(r14, 2655, 16);                           // movn  w14, #2655, lsl 16
+    __ movzw(r17, 7642, 0);                            // movz  w17, #7642, lsl 0
+    __ movkw(r27, 11381, 0);                           // movk  w27, #11381, lsl 0
+    __ movn(r1, 19524, 32);                            // movn  x1, #19524, lsl 32
+    __ movz(r20, 21126, 16);                           // movz  x20, #21126, lsl 16
+    __ movk(r20, 32462, 16);                           // movk  x20, #32462, lsl 16
 
 // BitfieldOp
-    __ sbfm(r9, r22, 6, 22);                           //        sbfm        x9, x22, #6, #22
-    __ bfmw(r19, r0, 11, 0);                           //        bfm        w19, w0, #11, #0
-    __ ubfmw(r10, r19, 11, 19);                        //        ubfm        w10, w19, #11, #19
-    __ sbfm(r4, r15, 5, 17);                           //        sbfm        x4, x15, #5, #17
-    __ bfm(r3, r5, 19, 28);                            //        bfm        x3, x5, #19, #28
-    __ ubfm(r12, r28, 17, 2);                          //        ubfm        x12, x28, #17, #2
+    __ sbfm(r13, r2, 28, 20);                          // sbfm  x13, x2, #28, #20
+    __ bfmw(r16, r20, 19, 15);                         // bfm w16, w20, #19, #15
+    __ ubfmw(r11, r11, 9, 6);                          // ubfm  w11, w11, #9, #6
+    __ sbfm(r2, r4, 25, 21);                           // sbfm  x2, x4, #25, #21
+    __ bfm(r13, r16, 2, 19);                           // bfm x13, x16, #2, #19
+    __ ubfm(r8, r25, 8, 5);                            // ubfm  x8, x25, #8, #5
 
 // ExtractOp
-    __ extrw(r15, r0, r22, 3);                         //        extr        w15, w0, w22, #3
-    __ extr(r6, r14, r14, 55);                         //        extr        x6, x14, x14, #55
+    __ extrw(r29, r27, r10, 14);                       // extr  w29, w27, w10, #14
+    __ extr(r6, r20, r6, 24);                          // extr  x6, x20, x6, #24
 
 // CondBranchOp
-    __ br(Assembler::EQ, __ pc());                     //        b.EQ        .
-    __ br(Assembler::EQ, back);                        //        b.EQ        back
-    __ br(Assembler::EQ, forth);                       //        b.EQ        forth
-    __ br(Assembler::NE, __ pc());                     //        b.NE        .
-    __ br(Assembler::NE, back);                        //        b.NE        back
-    __ br(Assembler::NE, forth);                       //        b.NE        forth
-    __ br(Assembler::HS, __ pc());                     //        b.HS        .
-    __ br(Assembler::HS, back);                        //        b.HS        back
-    __ br(Assembler::HS, forth);                       //        b.HS        forth
-    __ br(Assembler::CS, __ pc());                     //        b.CS        .
-    __ br(Assembler::CS, back);                        //        b.CS        back
-    __ br(Assembler::CS, forth);                       //        b.CS        forth
-    __ br(Assembler::LO, __ pc());                     //        b.LO        .
-    __ br(Assembler::LO, back);                        //        b.LO        back
-    __ br(Assembler::LO, forth);                       //        b.LO        forth
-    __ br(Assembler::CC, __ pc());                     //        b.CC        .
-    __ br(Assembler::CC, back);                        //        b.CC        back
-    __ br(Assembler::CC, forth);                       //        b.CC        forth
-    __ br(Assembler::MI, __ pc());                     //        b.MI        .
-    __ br(Assembler::MI, back);                        //        b.MI        back
-    __ br(Assembler::MI, forth);                       //        b.MI        forth
-    __ br(Assembler::PL, __ pc());                     //        b.PL        .
-    __ br(Assembler::PL, back);                        //        b.PL        back
-    __ br(Assembler::PL, forth);                       //        b.PL        forth
-    __ br(Assembler::VS, __ pc());                     //        b.VS        .
-    __ br(Assembler::VS, back);                        //        b.VS        back
-    __ br(Assembler::VS, forth);                       //        b.VS        forth
-    __ br(Assembler::VC, __ pc());                     //        b.VC        .
-    __ br(Assembler::VC, back);                        //        b.VC        back
-    __ br(Assembler::VC, forth);                       //        b.VC        forth
-    __ br(Assembler::HI, __ pc());                     //        b.HI        .
-    __ br(Assembler::HI, back);                        //        b.HI        back
-    __ br(Assembler::HI, forth);                       //        b.HI        forth
-    __ br(Assembler::LS, __ pc());                     //        b.LS        .
-    __ br(Assembler::LS, back);                        //        b.LS        back
-    __ br(Assembler::LS, forth);                       //        b.LS        forth
-    __ br(Assembler::GE, __ pc());                     //        b.GE        .
-    __ br(Assembler::GE, back);                        //        b.GE        back
-    __ br(Assembler::GE, forth);                       //        b.GE        forth
-    __ br(Assembler::LT, __ pc());                     //        b.LT        .
-    __ br(Assembler::LT, back);                        //        b.LT        back
-    __ br(Assembler::LT, forth);                       //        b.LT        forth
-    __ br(Assembler::GT, __ pc());                     //        b.GT        .
-    __ br(Assembler::GT, back);                        //        b.GT        back
-    __ br(Assembler::GT, forth);                       //        b.GT        forth
-    __ br(Assembler::LE, __ pc());                     //        b.LE        .
-    __ br(Assembler::LE, back);                        //        b.LE        back
-    __ br(Assembler::LE, forth);                       //        b.LE        forth
-    __ br(Assembler::AL, __ pc());                     //        b.AL        .
-    __ br(Assembler::AL, back);                        //        b.AL        back
-    __ br(Assembler::AL, forth);                       //        b.AL        forth
-    __ br(Assembler::NV, __ pc());                     //        b.NV        .
-    __ br(Assembler::NV, back);                        //        b.NV        back
-    __ br(Assembler::NV, forth);                       //        b.NV        forth
+    __ br(Assembler::EQ, __ pc());                     // b.EQ  .
+    __ br(Assembler::EQ, back);                        // b.EQ  back
+    __ br(Assembler::EQ, forth);                       // b.EQ  forth
+    __ br(Assembler::NE, __ pc());                     // b.NE  .
+    __ br(Assembler::NE, back);                        // b.NE  back
+    __ br(Assembler::NE, forth);                       // b.NE  forth
+    __ br(Assembler::HS, __ pc());                     // b.HS  .
+    __ br(Assembler::HS, back);                        // b.HS  back
+    __ br(Assembler::HS, forth);                       // b.HS  forth
+    __ br(Assembler::CS, __ pc());                     // b.CS  .
+    __ br(Assembler::CS, back);                        // b.CS  back
+    __ br(Assembler::CS, forth);                       // b.CS  forth
+    __ br(Assembler::LO, __ pc());                     // b.LO  .
+    __ br(Assembler::LO, back);                        // b.LO  back
+    __ br(Assembler::LO, forth);                       // b.LO  forth
+    __ br(Assembler::CC, __ pc());                     // b.CC  .
+    __ br(Assembler::CC, back);                        // b.CC  back
+    __ br(Assembler::CC, forth);                       // b.CC  forth
+    __ br(Assembler::MI, __ pc());                     // b.MI  .
+    __ br(Assembler::MI, back);                        // b.MI  back
+    __ br(Assembler::MI, forth);                       // b.MI  forth
+    __ br(Assembler::PL, __ pc());                     // b.PL  .
+    __ br(Assembler::PL, back);                        // b.PL  back
+    __ br(Assembler::PL, forth);                       // b.PL  forth
+    __ br(Assembler::VS, __ pc());                     // b.VS  .
+    __ br(Assembler::VS, back);                        // b.VS  back
+    __ br(Assembler::VS, forth);                       // b.VS  forth
+    __ br(Assembler::VC, __ pc());                     // b.VC  .
+    __ br(Assembler::VC, back);                        // b.VC  back
+    __ br(Assembler::VC, forth);                       // b.VC  forth
+    __ br(Assembler::HI, __ pc());                     // b.HI  .
+    __ br(Assembler::HI, back);                        // b.HI  back
+    __ br(Assembler::HI, forth);                       // b.HI  forth
+    __ br(Assembler::LS, __ pc());                     // b.LS  .
+    __ br(Assembler::LS, back);                        // b.LS  back
+    __ br(Assembler::LS, forth);                       // b.LS  forth
+    __ br(Assembler::GE, __ pc());                     // b.GE  .
+    __ br(Assembler::GE, back);                        // b.GE  back
+    __ br(Assembler::GE, forth);                       // b.GE  forth
+    __ br(Assembler::LT, __ pc());                     // b.LT  .
+    __ br(Assembler::LT, back);                        // b.LT  back
+    __ br(Assembler::LT, forth);                       // b.LT  forth
+    __ br(Assembler::GT, __ pc());                     // b.GT  .
+    __ br(Assembler::GT, back);                        // b.GT  back
+    __ br(Assembler::GT, forth);                       // b.GT  forth
+    __ br(Assembler::LE, __ pc());                     // b.LE  .
+    __ br(Assembler::LE, back);                        // b.LE  back
+    __ br(Assembler::LE, forth);                       // b.LE  forth
+    __ br(Assembler::AL, __ pc());                     // b.AL  .
+    __ br(Assembler::AL, back);                        // b.AL  back
+    __ br(Assembler::AL, forth);                       // b.AL  forth
+    __ br(Assembler::NV, __ pc());                     // b.NV  .
+    __ br(Assembler::NV, back);                        // b.NV  back
+    __ br(Assembler::NV, forth);                       // b.NV  forth
 
 // ImmOp
-    __ svc(22064);                                     //        svc        #22064
-    __ hvc(533);                                       //        hvc        #533
-    __ smc(9942);                                      //        smc        #9942
-    __ brk(4714);                                      //        brk        #4714
-    __ hlt(4302);                                      //        hlt        #4302
+    __ svc(26948);                                     // svc #26948
+    __ hvc(29998);                                     // hvc #29998
+    __ smc(10437);                                     // smc #10437
+    __ brk(30290);                                     // brk #30290
+    __ hlt(20851);                                     // hlt #20851
 
 // Op
-    __ nop();                                          //        nop
-    __ eret();                                         //        eret
-    __ drps();                                         //        drps
-    __ isb();                                          //        isb
+    __ nop();                                          // nop
+    __ eret();                                         // eret
+    __ drps();                                         // drps
+    __ isb();                                          // isb
 
 // SystemOp
-    __ dsb(Assembler::OSH);                            //        dsb        OSH
-    __ dmb(Assembler::NSHLD);                          //        dmb        NSHLD
+    __ dsb(Assembler::LD);                             // dsb LD
+    __ dmb(Assembler::ISH);                            // dmb ISH
 
 // OneRegOp
-    __ br(r20);                                        //        br        x20
-    __ blr(r2);                                        //        blr        x2
+    __ br(r9);                                         // br  x9
+    __ blr(r9);                                        // blr x9
 
 // LoadStoreExclusiveOp
-    __ stxr(r18, r23, r0);                             //        stxr        w18, x23, [x0]
-    __ stlxr(r30, r5, r22);                            //        stlxr        w30, x5, [x22]
-    __ ldxr(r5, r8);                                   //        ldxr        x5, [x8]
-    __ ldaxr(r20, r16);                                //        ldaxr        x20, [x16]
-    __ stlr(r6, r11);                                  //        stlr        x6, [x11]
-    __ ldar(r6, r27);                                  //        ldar        x6, [x27]
+    __ stxr(r2, r29, r11);                             // stxr  w2, x29, [x11]
+    __ stlxr(r22, r5, r28);                            // stlxr w22, x5, [x28]
+    __ ldxr(r14, r20);                                 // ldxr  x14, [x20]
+    __ ldaxr(r29, r19);                                // ldaxr x29, [x19]
+    __ stlr(r6, r21);                                  // stlr  x6, [x21]
+    __ ldar(r19, r3);                                  // ldar  x19, [x3]
 
 // LoadStoreExclusiveOp
-    __ stxrw(r10, r17, r5);                            //        stxr        w10, w17, [x5]
-    __ stlxrw(r22, r9, r12);                           //        stlxr        w22, w9, [x12]
-    __ ldxrw(r27, r8);                                 //        ldxr        w27, [x8]
-    __ ldaxrw(r23, r2);                                //        ldaxr        w23, [x2]
-    __ stlrw(r26, r29);                                //        stlr        w26, [x29]
-    __ ldarw(r13, r10);                                //        ldar        w13, [x10]
+    __ stxrw(r12, r3, r27);                            // stxr  w12, w3, [x27]
+    __ stlxrw(r17, r26, r15);                          // stlxr w17, w26, [x15]
+    __ ldxrw(r13, r14);                                // ldxr  w13, [x14]
+    __ ldaxrw(r12, r26);                               // ldaxr w12, [x26]
+    __ stlrw(r8, r17);                                 // stlr  w8, [x17]
+    __ ldarw(r21, r30);                                // ldar  w21, [x30]
 
 // LoadStoreExclusiveOp
-    __ stxrh(r25, r28, r27);                           //        stxrh        w25, w28, [x27]
-    __ stlxrh(r29, r22, r12);                          //        stlxrh        w29, w22, [x12]
-    __ ldxrh(r22, r28);                                //        ldxrh        w22, [x28]
-    __ ldaxrh(r3, r30);                                //        ldaxrh        w3, [x30]
-    __ stlrh(r24, r15);                                //        stlrh        w24, [x15]
-    __ ldarh(r27, r26);                                //        ldarh        w27, [x26]
+    __ stxrh(r0, r15, r11);                            // stxrh w0, w15, [x11]
+    __ stlxrh(r17, r20, r1);                           // stlxrh  w17, w20, [x1]
+    __ ldxrh(r29, r8);                                 // ldxrh w29, [x8]
+    __ ldaxrh(r17, r12);                               // ldaxrh  w17, [x12]
+    __ stlrh(r11, r4);                                 // stlrh w11, [x4]
+    __ ldarh(r16, r4);                                 // ldarh w16, [x4]
 
 // LoadStoreExclusiveOp
-    __ stxrb(r11, r10, r19);                           //        stxrb        w11, w10, [x19]
-    __ stlxrb(r23, r27, r22);                          //        stlxrb        w23, w27, [x22]
-    __ ldxrb(r24, r16);                                //        ldxrb        w24, [x16]
-    __ ldaxrb(r24, r1);                                //        ldaxrb        w24, [x1]
-    __ stlrb(r5, r29);                                 //        stlrb        w5, [x29]
-    __ ldarb(r24, r16);                                //        ldarb        w24, [x16]
+    __ stxrb(r14, r5, r4);                             // stxrb w14, w5, [x4]
+    __ stlxrb(r27, r17, r16);                          // stlxrb  w27, w17, [x16]
+    __ ldxrb(r6, r27);                                 // ldxrb w6, [x27]
+    __ ldaxrb(r27, r24);                               // ldaxrb  w27, [x24]
+    __ stlrb(r10, r20);                                // stlrb w10, [x20]
+    __ ldarb(r9, r26);                                 // ldarb w9, [x26]
 
 // LoadStoreExclusiveOp
-    __ ldxp(r25, r24, r17);                            //        ldxp        x25, x24, [x17]
-    __ ldaxp(r22, r12, r19);                           //        ldaxp        x22, x12, [x19]
-    __ stxp(r0, r26, r21, r25);                        //        stxp        w0, x26, x21, [x25]
-    __ stlxp(r1, r6, r11, r5);                         //        stlxp        w1, x6, x11, [x5]
+    __ ldxp(r5, r30, r28);                             // ldxp  x5, x30, [x28]
+    __ ldaxp(r10, r9, r19);                            // ldaxp x10, x9, [x19]
+    __ stxp(r11, r16, r21, r12);                       // stxp  w11, x16, x21, [x12]
+    __ stlxp(r10, r20, r23, r4);                       // stlxp w10, x20, x23, [x4]
 
 // LoadStoreExclusiveOp
-    __ ldxpw(r13, r14, r4);                            //        ldxp        w13, w14, [x4]
-    __ ldaxpw(r17, r2, r6);                            //        ldaxp        w17, w2, [x6]
-    __ stxpw(r15, r3, r9, r18);                        //        stxp        w15, w3, w9, [x18]
-    __ stlxpw(r18, r17, r4, r9);                       //        stlxp        w18, w17, w4, [x9]
+    __ ldxpw(r22, r1, r0);                             // ldxp  w22, w1, [x0]
+    __ ldaxpw(r3, r1, r8);                             // ldaxp w3, w1, [x8]
+    __ stxpw(r0, r9, r23, r30);                        // stxp  w0, w9, w23, [x30]
+    __ stlxpw(r23, r0, r17, r11);                      // stlxp w23, w0, w17, [x11]
 
 // base_plus_unscaled_offset
 // LoadStoreOp
-    __ str(r23, Address(r21, -49));                    //        str        x23, [x21, -49]
-    __ strw(r21, Address(r2, 63));                     //        str        w21, [x2, 63]
-    __ strb(r27, Address(r28, 11));                    //        strb        w27, [x28, 11]
-    __ strh(r29, Address(r15, -13));                   //        strh        w29, [x15, -13]
-    __ ldr(r14, Address(r30, -45));                    //        ldr        x14, [x30, -45]
-    __ ldrw(r29, Address(r28, 53));                    //        ldr        w29, [x28, 53]
-    __ ldrb(r20, Address(r26, 7));                     //        ldrb        w20, [x26, 7]
-    __ ldrh(r25, Address(r2, -50));                    //        ldrh        w25, [x2, -50]
-    __ ldrsb(r3, Address(r10, -15));                   //        ldrsb        x3, [x10, -15]
-    __ ldrsh(r14, Address(r15, 19));                   //        ldrsh        x14, [x15, 19]
-    __ ldrshw(r29, Address(r11, -5));                  //        ldrsh        w29, [x11, -5]
-    __ ldrsw(r15, Address(r5, -71));                   //        ldrsw        x15, [x5, -71]
-    __ ldrd(v19, Address(r12, 3));                     //        ldr        d19, [x12, 3]
-    __ ldrs(v12, Address(r27, 42));                    //        ldr        s12, [x27, 42]
-    __ strd(v22, Address(r28, 125));                   //        str        d22, [x28, 125]
-    __ strs(v24, Address(r15, -20));                   //        str        s24, [x15, -20]
+    __ str(r6, Address(r10, -31));                     // str x6, [x10, -31]
+    __ strw(r7, Address(r0, -5));                      // str w7, [x0, -5]
+    __ strb(r5, Address(r16, -13));                    // strb  w5, [x16, -13]
+    __ strh(r30, Address(r19, 31));                    // strh  w30, [x19, 31]
+    __ ldr(r16, Address(r9, 119));                     // ldr x16, [x9, 119]
+    __ ldrw(r8, Address(r16, 59));                     // ldr w8, [x16, 59]
+    __ ldrb(r10, Address(r12, -7));                    // ldrb  w10, [x12, -7]
+    __ ldrh(r14, Address(r9, -38));                    // ldrh  w14, [x9, -38]
+    __ ldrsb(r24, Address(r30, -8));                   // ldrsb x24, [x30, -8]
+    __ ldrsh(r7, Address(r4, 23));                     // ldrsh x7, [x4, 23]
+    __ ldrshw(r17, Address(r14, -39));                 // ldrsh w17, [x14, -39]
+    __ ldrsw(r11, Address(r27, -31));                  // ldrsw x11, [x27, -31]
+    __ ldrd(v12, Address(r7, 65));                     // ldr d12, [x7, 65]
+    __ ldrs(v0, Address(r16, -2));                     // ldr s0, [x16, -2]
+    __ strd(v13, Address(r23, -161));                  // str d13, [x23, -161]
+    __ strs(v21, Address(r3, -62));                    // str s21, [x3, -62]
 
 // pre
 // LoadStoreOp
-    __ str(r8, Address(__ pre(r28, -24)));             //        str        x8, [x28, -24]!
-    __ strw(r6, Address(__ pre(r15, 37)));             //        str        w6, [x15, 37]!
-    __ strb(r7, Address(__ pre(r1, 7)));               //        strb        w7, [x1, 7]!
-    __ strh(r0, Address(__ pre(r17, 30)));             //        strh        w0, [x17, 30]!
-    __ ldr(r25, Address(__ pre(r29, 84)));             //        ldr        x25, [x29, 84]!
-    __ ldrw(r26, Address(__ pre(r20, -52)));           //        ldr        w26, [x20, -52]!
-    __ ldrb(r26, Address(__ pre(r29, -25)));           //        ldrb        w26, [x29, -25]!
-    __ ldrh(r4, Address(__ pre(r25, 26)));             //        ldrh        w4, [x25, 26]!
-    __ ldrsb(r28, Address(__ pre(r8, -21)));           //        ldrsb        x28, [x8, -21]!
-    __ ldrsh(r17, Address(__ pre(r14, -6)));           //        ldrsh        x17, [x14, -6]!
-    __ ldrshw(r28, Address(__ pre(r23, 10)));          //        ldrsh        w28, [x23, 10]!
-    __ ldrsw(r30, Address(__ pre(r27, -64)));          //        ldrsw        x30, [x27, -64]!
-    __ ldrd(v20, Address(__ pre(r30, -242)));          //        ldr        d20, [x30, -242]!
-    __ ldrs(v17, Address(__ pre(r27, 20)));            //        ldr        s17, [x27, 20]!
-    __ strd(v7, Address(__ pre(r3, 17)));              //        str        d7, [x3, 17]!
-    __ strs(v13, Address(__ pre(r11, -16)));           //        str        s13, [x11, -16]!
+    __ str(r2, Address(__ pre(r5, 100)));              // str x2, [x5, 100]!
+    __ strw(r9, Address(__ pre(r1, -92)));             // str w9, [x1, -92]!
+    __ strb(r27, Address(__ pre(r30, -5)));            // strb  w27, [x30, -5]!
+    __ strh(r27, Address(__ pre(r15, 12)));            // strh  w27, [x15, 12]!
+    __ ldr(r4, Address(__ pre(r17, -212)));            // ldr x4, [x17, -212]!
+    __ ldrw(r21, Address(__ pre(r23, 30)));            // ldr w21, [x23, 30]!
+    __ ldrb(r13, Address(__ pre(r17, -7)));            // ldrb  w13, [x17, -7]!
+    __ ldrh(r25, Address(__ pre(r0, -50)));            // ldrh  w25, [x0, -50]!
+    __ ldrsb(r1, Address(__ pre(r21, -21)));           // ldrsb x1, [x21, -21]!
+    __ ldrsh(r28, Address(__ pre(r21, -54)));          // ldrsh x28, [x21, -54]!
+    __ ldrshw(r11, Address(__ pre(r4, 2)));            // ldrsh w11, [x4, 2]!
+    __ ldrsw(r17, Address(__ pre(r9, 61)));            // ldrsw x17, [x9, 61]!
+    __ ldrd(v29, Address(__ pre(r19, 39)));            // ldr d29, [x19, 39]!
+    __ ldrs(v22, Address(__ pre(r22, -85)));           // ldr s22, [x22, -85]!
+    __ strd(v9, Address(__ pre(r25, -225)));           // str d9, [x25, -225]!
+    __ strs(v9, Address(__ pre(r2, -15)));             // str s9, [x2, -15]!
 
 // post
 // LoadStoreOp
-    __ str(r6, Address(__ post(r9, -61)));             //        str        x6, [x9], -61
-    __ strw(r16, Address(__ post(r5, -29)));           //        str        w16, [x5], -29
-    __ strb(r29, Address(__ post(r29, 15)));           //        strb        w29, [x29], 15
-    __ strh(r4, Address(__ post(r20, 18)));            //        strh        w4, [x20], 18
-    __ ldr(r19, Address(__ post(r18, 46)));            //        ldr        x19, [x18], 46
-    __ ldrw(r22, Address(__ post(r2, 23)));            //        ldr        w22, [x2], 23
-    __ ldrb(r7, Address(__ post(r3, -30)));            //        ldrb        w7, [x3], -30
-    __ ldrh(r11, Address(__ post(r12, -29)));          //        ldrh        w11, [x12], -29
-    __ ldrsb(r8, Address(__ post(r6, -29)));           //        ldrsb        x8, [x6], -29
-    __ ldrsh(r24, Address(__ post(r23, 4)));           //        ldrsh        x24, [x23], 4
-    __ ldrshw(r17, Address(__ post(r16, 0)));          //        ldrsh        w17, [x16], 0
-    __ ldrsw(r0, Address(__ post(r20, -8)));           //        ldrsw        x0, [x20], -8
-    __ ldrd(v20, Address(__ post(r2, -126)));          //        ldr        d20, [x2], -126
-    __ ldrs(v19, Address(__ post(r30, -104)));         //        ldr        s19, [x30], -104
-    __ strd(v4, Address(__ post(r17, 118)));           //        str        d4, [x17], 118
-    __ strs(v21, Address(__ post(r19, -112)));         //        str        s21, [x19], -112
+    __ str(r13, Address(__ post(r23, -66)));           // str x13, [x23], -66
+    __ strw(r17, Address(__ post(r16, 10)));           // str w17, [x16], 10
+    __ strb(r1, Address(__ post(r14, -32)));           // strb  w1, [x14], -32
+    __ strh(r17, Address(__ post(r0, 6)));             // strh  w17, [x0], 6
+    __ ldr(r27, Address(__ post(r25, -172)));          // ldr x27, [x25], -172
+    __ ldrw(r13, Address(__ post(r25, -38)));          // ldr w13, [x25], -38
+    __ ldrb(r11, Address(__ post(r25, -29)));          // ldrb  w11, [x25], -29
+    __ ldrh(r30, Address(__ post(r5, 20)));            // ldrh  w30, [x5], 20
+    __ ldrsb(r9, Address(__ post(r7, -7)));            // ldrsb x9, [x7], -7
+    __ ldrsh(r0, Address(__ post(r3, -62)));           // ldrsh x0, [x3], -62
+    __ ldrshw(r7, Address(__ post(r14, 31)));          // ldrsh w7, [x14], 31
+    __ ldrsw(r17, Address(__ post(r27, 39)));          // ldrsw x17, [x27], 39
+    __ ldrd(v17, Address(__ post(r4, -235)));          // ldr d17, [x4], -235
+    __ ldrs(v26, Address(__ post(r21, 34)));           // ldr s26, [x21], 34
+    __ strd(v5, Address(__ post(r17, -57)));           // str d5, [x17], -57
+    __ strs(v13, Address(__ post(r13, -109)));         // str s13, [x13], -109
 
 // base_plus_reg
 // LoadStoreOp
-    __ str(r26, Address(r2, r19, Address::lsl(3)));    //        str        x26, [x2, x19, lsl #3]
-    __ strw(r9, Address(r0, r15, Address::sxtw(2)));   //        str        w9, [x0, w15, sxtw #2]
-    __ strb(r26, Address(r12, r1, Address::lsl(0)));   //        strb        w26, [x12, x1, lsl #0]
-    __ strh(r21, Address(r11, r10, Address::lsl(1)));  //        strh        w21, [x11, x10, lsl #1]
-    __ ldr(r16, Address(r23, r16, Address::sxtx(0)));  //        ldr        x16, [x23, x16, sxtx #0]
-    __ ldrw(r10, Address(r11, r17, Address::sxtw(2))); //        ldr        w10, [x11, w17, sxtw #2]
-    __ ldrb(r13, Address(r23, r11, Address::lsl(0)));  //        ldrb        w13, [x23, x11, lsl #0]
-    __ ldrh(r27, Address(r4, r21, Address::lsl(0)));   //        ldrh        w27, [x4, x21, lsl #0]
-    __ ldrsb(r26, Address(r8, r15, Address::sxtw(0))); //        ldrsb        x26, [x8, w15, sxtw #0]
-    __ ldrsh(r21, Address(r10, r2, Address::sxtw(0))); //        ldrsh        x21, [x10, w2, sxtw #0]
-    __ ldrshw(r8, Address(r30, r14, Address::lsl(0))); //        ldrsh        w8, [x30, x14, lsl #0]
-    __ ldrsw(r29, Address(r14, r20, Address::sxtx(2))); //        ldrsw        x29, [x14, x20, sxtx #2]
-    __ ldrd(v30, Address(r27, r22, Address::sxtx(0))); //        ldr        d30, [x27, x22, sxtx #0]
-    __ ldrs(v13, Address(r9, r22, Address::lsl(0)));   //        ldr        s13, [x9, x22, lsl #0]
-    __ strd(v8, Address(r25, r17, Address::sxtw(3)));  //        str        d8, [x25, w17, sxtw #3]
-    __ strs(v1, Address(r24, r5, Address::uxtw(2)));   //        str        s1, [x24, w5, uxtw #2]
+    __ str(r6, Address(r16, r4, Address::sxtw(3)));    // str x6, [x16, w4, sxtw #3]
+    __ strw(r9, Address(r24, r20, Address::sxtw(2)));  // str w9, [x24, w20, sxtw #2]
+    __ strb(r3, Address(r29, r3, Address::lsl(0)));    // strb  w3, [x29, x3, lsl #0]
+    __ strh(r10, Address(r17, r30, Address::lsl(0)));  // strh  w10, [x17, x30, lsl #0]
+    __ ldr(r27, Address(r11, r7, Address::uxtw(0)));   // ldr x27, [x11, w7, uxtw #0]
+    __ ldrw(r14, Address(r15, r25, Address::uxtw(0))); // ldr w14, [x15, w25, uxtw #0]
+    __ ldrb(r24, Address(r14, r19, Address::lsl(0)));  // ldrb  w24, [x14, x19, lsl #0]
+    __ ldrh(r16, Address(r0, r6, Address::sxtw(0)));   // ldrh  w16, [x0, w6, sxtw #0]
+    __ ldrsb(r10, Address(r12, r12, Address::sxtw(0))); //  ldrsb x10, [x12, w12, sxtw #0]
+    __ ldrsh(r26, Address(r12, r16, Address::uxtw(0))); //  ldrsh x26, [x12, w16, uxtw #0]
+    __ ldrshw(r26, Address(r0, r14, Address::lsl(1))); // ldrsh w26, [x0, x14, lsl #1]
+    __ ldrsw(r17, Address(r11, r27, Address::sxtx(2))); //  ldrsw x17, [x11, x27, sxtx #2]
+    __ ldrd(v3, Address(r0, r19, Address::sxtw(3)));   // ldr d3, [x0, w19, sxtw #3]
+    __ ldrs(v26, Address(r15, r9, Address::lsl(2)));   // ldr s26, [x15, x9, lsl #2]
+    __ strd(v11, Address(r13, r16, Address::sxtx(0))); // str d11, [x13, x16, sxtx #0]
+    __ strs(v26, Address(r19, r21, Address::uxtw(2))); // str s26, [x19, w21, uxtw #2]
 
 // base_plus_scaled_offset
 // LoadStoreOp
-    __ str(r10, Address(r21, 14496));                  //        str        x10, [x21, 14496]
-    __ strw(r18, Address(r29, 7228));                  //        str        w18, [x29, 7228]
-    __ strb(r23, Address(r3, 2018));                   //        strb        w23, [x3, 2018]
-    __ strh(r28, Address(r11, 3428));                  //        strh        w28, [x11, 3428]
-    __ ldr(r24, Address(r26, 14376));                  //        ldr        x24, [x26, 14376]
-    __ ldrw(r21, Address(r2, 6972));                   //        ldr        w21, [x2, 6972]
-    __ ldrb(r4, Address(r5, 1848));                    //        ldrb        w4, [x5, 1848]
-    __ ldrh(r14, Address(r14, 3112));                  //        ldrh        w14, [x14, 3112]
-    __ ldrsb(r4, Address(r27, 1959));                  //        ldrsb        x4, [x27, 1959]
-    __ ldrsh(r4, Address(r27, 3226));                  //        ldrsh        x4, [x27, 3226]
-    __ ldrshw(r10, Address(r28, 3286));                //        ldrsh        w10, [x28, 3286]
-    __ ldrsw(r10, Address(r17, 7912));                 //        ldrsw        x10, [x17, 7912]
-    __ ldrd(v13, Address(r28, 13400));                 //        ldr        d13, [x28, 13400]
-    __ ldrs(v24, Address(r3, 7596));                   //        ldr        s24, [x3, 7596]
-    __ strd(v2, Address(r12, 15360));                  //        str        d2, [x12, 15360]
-    __ strs(v17, Address(r1, 6492));                   //        str        s17, [x1, 6492]
+    __ str(r8, Address(r21, 12552));                   // str x8, [x21, 12552]
+    __ strw(r10, Address(r27, 6380));                  // str w10, [x27, 6380]
+    __ strb(r27, Address(r14, 1733));                  // strb  w27, [x14, 1733]
+    __ strh(r16, Address(r7, 3424));                   // strh  w16, [x7, 3424]
+    __ ldr(r27, Address(r9, 12520));                   // ldr x27, [x9, 12520]
+    __ ldrw(r24, Address(r10, 6680));                  // ldr w24, [x10, 6680]
+    __ ldrb(r24, Address(r24, 1743));                  // ldrb  w24, [x24, 1743]
+    __ ldrh(r20, Address(r5, 3072));                   // ldrh  w20, [x5, 3072]
+    __ ldrsb(r17, Address(r4, 1570));                  // ldrsb x17, [x4, 1570]
+    __ ldrsh(r14, Address(r13, 3392));                 // ldrsh x14, [x13, 3392]
+    __ ldrshw(r10, Address(r25, 3722));                // ldrsh w10, [x25, 3722]
+    __ ldrsw(r2, Address(r26, 6160));                  // ldrsw x2, [x26, 6160]
+    __ ldrd(v26, Address(r14, 14912));                 // ldr d26, [x14, 14912]
+    __ ldrs(v28, Address(r4, 7804));                   // ldr s28, [x4, 7804]
+    __ strd(v14, Address(r19, 13984));                 // str d14, [x19, 13984]
+    __ strs(v23, Address(r28, 6364));                  // str s23, [x28, 6364]
 
 // pcrel
 // LoadStoreOp
-    __ ldr(r16, __ pc());                              //        ldr        x16, .
-    __ ldrw(r13, __ pc());                             //        ldr        w13, .
+    __ ldr(r8, forth);                                 // ldr x8, forth
+    __ ldrw(r17, back);                                // ldr w17, back
 
 // LoadStoreOp
-    __ prfm(Address(r18, -127));                       //        prfm        PLDL1KEEP, [x18, -127]
+    __ prfm(Address(r4, -175));                        // prfm  PLDL1KEEP, [x4, -175]
 
 // LoadStoreOp
-    __ prfm(back);                                     //        prfm        PLDL1KEEP, back
+    __ prfm(__ pc());                                  // prfm  PLDL1KEEP, .
 
 // LoadStoreOp
-    __ prfm(Address(r20, r2, Address::lsl(3)));        //        prfm        PLDL1KEEP, [x20, x2, lsl #3]
+    __ prfm(Address(r8, r4, Address::sxtw(0)));        // prfm  PLDL1KEEP, [x8, w4, sxtw #0]
 
 // LoadStoreOp
-    __ prfm(Address(r9, 13808));                       //        prfm        PLDL1KEEP, [x9, 13808]
+    __ prfm(Address(r12, 13248));                      // prfm  PLDL1KEEP, [x12, 13248]
 
 // AddSubCarryOp
-    __ adcw(r8, r23, r2);                              //        adc        w8, w23, w2
-    __ adcsw(r24, r3, r19);                            //        adcs        w24, w3, w19
-    __ sbcw(r22, r24, r29);                            //        sbc        w22, w24, w29
-    __ sbcsw(r12, r27, r3);                            //        sbcs        w12, w27, w3
-    __ adc(r11, r23, r1);                              //        adc        x11, x23, x1
-    __ adcs(r29, r5, r23);                             //        adcs        x29, x5, x23
-    __ sbc(r9, r25, r12);                              //        sbc        x9, x25, x12
-    __ sbcs(r12, r0, r22);                             //        sbcs        x12, x0, x22
+    __ adcw(r20, r27, r21);                            // adc w20, w27, w21
+    __ adcsw(r7, r17, r6);                             // adcs  w7, w17, w6
+    __ sbcw(r5, r6, r25);                              // sbc w5, w6, w25
+    __ sbcsw(r30, r11, r14);                           // sbcs  w30, w11, w14
+    __ adc(r3, r17, r11);                              // adc x3, x17, x11
+    __ adcs(r25, r10, r17);                            // adcs  x25, x10, x17
+    __ sbc(r7, r16, r23);                              // sbc x7, x16, x23
+    __ sbcs(r4, r10, r5);                              // sbcs  x4, x10, x5
 
 // AddSubExtendedOp
-    __ addw(r26, r12, r3, ext::uxtw, 1);               //        add        w26, w12, w3, uxtw #1
-    __ addsw(r20, r16, r18, ext::sxtb, 2);             //        adds        w20, w16, w18, sxtb #2
-    __ sub(r30, r30, r7, ext::uxtw, 2);                //        sub        x30, x30, x7, uxtw #2
-    __ subsw(r11, r21, r2, ext::uxth, 3);              //        subs        w11, w21, w2, uxth #3
-    __ add(r2, r26, r1, ext::uxtw, 2);                 //        add        x2, x26, x1, uxtw #2
-    __ adds(r18, r29, r20, ext::sxth, 1);              //        adds        x18, x29, x20, sxth #1
-    __ sub(r14, r16, r4, ext::uxtw, 4);                //        sub        x14, x16, x4, uxtw #4
-    __ subs(r0, r17, r23, ext::sxtb, 3);               //        subs        x0, x17, x23, sxtb #3
+    __ addw(r9, r30, r9, ext::uxtx, 4);                // add w9, w30, w9, uxtx #4
+    __ addsw(r0, r5, r16, ext::sxth, 2);               // adds  w0, w5, w16, sxth #2
+    __ sub(r15, r29, r27, ext::sxtb, 2);               // sub x15, x29, x27, sxtb #2
+    __ subsw(r11, r9, r1, ext::sxtx, 4);               // subs  w11, w9, w1, sxtx #4
+    __ add(r2, r24, r6, ext::uxtw, 3);                 // add x2, x24, x6, uxtw #3
+    __ adds(r19, r6, r26, ext::uxtx, 4);               // adds  x19, x6, x26, uxtx #4
+    __ sub(r8, r26, r25, ext::sxtx, 3);                // sub x8, x26, x25, sxtx #3
+    __ subs(r26, r20, r9, ext::uxth, 4);               // subs  x26, x20, x9, uxth #4
 
 // ConditionalCompareOp
-    __ ccmnw(r20, r22, 3u, Assembler::PL);             //        ccmn        w20, w22, #3, PL
-    __ ccmpw(r25, r2, 1u, Assembler::EQ);              //        ccmp        w25, w2, #1, EQ
-    __ ccmn(r18, r24, 7u, Assembler::GT);              //        ccmn        x18, x24, #7, GT
-    __ ccmp(r8, r13, 6u, Assembler::PL);               //        ccmp        x8, x13, #6, PL
+    __ ccmnw(r13, r26, 7u, Assembler::MI);             // ccmn  w13, w26, #7, MI
+    __ ccmpw(r8, r20, 15u, Assembler::LO);             // ccmp  w8, w20, #15, LO
+    __ ccmn(r22, r3, 8u, Assembler::EQ);               // ccmn  x22, x3, #8, EQ
+    __ ccmp(r2, r24, 10u, Assembler::GE);              // ccmp  x2, x24, #10, GE
 
 // ConditionalCompareImmedOp
-    __ ccmnw(r9, 2, 4, Assembler::VS);                 //        ccmn        w9, #2, #4, VS
-    __ ccmpw(r2, 27, 7, Assembler::EQ);                //        ccmp        w2, #27, #7, EQ
-    __ ccmn(r16, 1, 2, Assembler::CC);                 //        ccmn        x16, #1, #2, CC
-    __ ccmp(r17, 31, 3, Assembler::LT);                //        ccmp        x17, #31, #3, LT
+    __ ccmnw(r8, 16, 13, Assembler::MI);               // ccmn  w8, #16, #13, MI
+    __ ccmpw(r16, 12, 1, Assembler::EQ);               // ccmp  w16, #12, #1, EQ
+    __ ccmn(r15, 31, 3, Assembler::VC);                // ccmn  x15, #31, #3, VC
+    __ ccmp(r23, 12, 15, Assembler::EQ);               // ccmp  x23, #12, #15, EQ
 
 // ConditionalSelectOp
-    __ cselw(r23, r27, r23, Assembler::LS);            //        csel        w23, w27, w23, LS
-    __ csincw(r10, r0, r6, Assembler::VS);             //        csinc        w10, w0, w6, VS
-    __ csinvw(r11, r0, r9, Assembler::CC);             //        csinv        w11, w0, w9, CC
-    __ csnegw(r17, r27, r18, Assembler::LO);           //        csneg        w17, w27, w18, LO
-    __ csel(r12, r16, r11, Assembler::VC);             //        csel        x12, x16, x11, VC
-    __ csinc(r6, r28, r6, Assembler::HI);              //        csinc        x6, x28, x6, HI
-    __ csinv(r13, r27, r26, Assembler::VC);            //        csinv        x13, x27, x26, VC
-    __ csneg(r29, r22, r18, Assembler::PL);            //        csneg        x29, x22, x18, PL
+    __ cselw(r14, r7, r26, Assembler::LO);             // csel  w14, w7, w26, LO
+    __ csincw(r3, r27, r30, Assembler::LE);            // csinc w3, w27, w30, LE
+    __ csinvw(r11, r21, r23, Assembler::EQ);           // csinv w11, w21, w23, EQ
+    __ csnegw(r26, r30, r21, Assembler::GT);           // csneg w26, w30, w21, GT
+    __ csel(r28, r26, r13, Assembler::HI);             // csel  x28, x26, x13, HI
+    __ csinc(r17, r3, r16, Assembler::LS);             // csinc x17, x3, x16, LS
+    __ csinv(r11, r5, r3, Assembler::HI);              // csinv x11, x5, x3, HI
+    __ csneg(r1, r3, r19, Assembler::GT);              // csneg x1, x3, x19, GT
 
 // TwoRegOp
-    __ rbitw(r12, r19);                                //        rbit        w12, w19
-    __ rev16w(r23, r18);                               //        rev16        w23, w18
-    __ revw(r9, r28);                                  //        rev        w9, w28
-    __ clzw(r2, r19);                                  //        clz        w2, w19
-    __ clsw(r25, r29);                                 //        cls        w25, w29
-    __ rbit(r4, r23);                                  //        rbit        x4, x23
-    __ rev16(r29, r18);                                //        rev16        x29, x18
-    __ rev32(r7, r8);                                  //        rev32        x7, x8
-    __ rev(r13, r17);                                  //        rev        x13, x17
-    __ clz(r17, r0);                                   //        clz        x17, x0
-    __ cls(r18, r26);                                  //        cls        x18, x26
+    __ rbitw(r0, r9);                                  // rbit  w0, w9
+    __ rev16w(r26, r14);                               // rev16 w26, w14
+    __ revw(r13, r17);                                 // rev w13, w17
+    __ clzw(r11, r20);                                 // clz w11, w20
+    __ clsw(r28, r17);                                 // cls w28, w17
+    __ rbit(r13, r4);                                  // rbit  x13, x4
+    __ rev16(r1, r30);                                 // rev16 x1, x30
+    __ rev32(r13, r14);                                // rev32 x13, x14
+    __ rev(r5, r8);                                    // rev x5, x8
+    __ clz(r2, r25);                                   // clz x2, x25
+    __ cls(r20, r8);                                   // cls x20, x8
 
 // ThreeRegOp
-    __ udivw(r11, r12, r16);                           //        udiv        w11, w12, w16
-    __ sdivw(r4, r9, r7);                              //        sdiv        w4, w9, w7
-    __ lslvw(r12, r7, r16);                            //        lslv        w12, w7, w16
-    __ lsrvw(r19, r16, r23);                           //        lsrv        w19, w16, w23
-    __ asrvw(r7, r4, r6);                              //        asrv        w7, w4, w6
-    __ rorvw(r21, r20, r23);                           //        rorv        w21, w20, w23
-    __ udiv(r16, r12, r28);                            //        udiv        x16, x12, x28
-    __ sdiv(r4, r12, r13);                             //        sdiv        x4, x12, x13
-    __ lslv(r9, r13, r7);                              //        lslv        x9, x13, x7
-    __ lsrv(r28, r27, r15);                            //        lsrv        x28, x27, x15
-    __ asrv(r20, r30, r14);                            //        asrv        x20, x30, x14
-    __ rorv(r14, r18, r30);                            //        rorv        x14, x18, x30
-    __ umulh(r3, r11, r7);                             //        umulh        x3, x11, x7
-    __ smulh(r23, r20, r24);                           //        smulh        x23, x20, x24
+    __ udivw(r21, r25, r27);                           // udiv  w21, w25, w27
+    __ sdivw(r13, r10, r16);                           // sdiv  w13, w10, w16
+    __ lslvw(r28, r1, r17);                            // lslv  w28, w1, w17
+    __ lsrvw(r25, r23, r10);                           // lsrv  w25, w23, w10
+    __ asrvw(r7, r3, r7);                              // asrv  w7, w3, w7
+    __ rorvw(r14, r30, r14);                           // rorv  w14, w30, w14
+    __ udiv(r12, r22, r15);                            // udiv  x12, x22, x15
+    __ sdiv(r2, r25, r13);                             // sdiv  x2, x25, x13
+    __ lslv(r7, r23, r21);                             // lslv  x7, x23, x21
+    __ lsrv(r11, r12, r0);                             // lsrv  x11, x12, x0
+    __ asrv(r30, r9, r28);                             // asrv  x30, x9, x28
+    __ rorv(r13, r5, r22);                             // rorv  x13, x5, x22
+    __ umulh(r5, r21, r4);                             // umulh x5, x21, x4
+    __ smulh(r17, r2, r7);                             // smulh x17, x2, x7
 
 // FourRegMulOp
-    __ maddw(r2, r5, r21, r9);                         //        madd        w2, w5, w21, w9
-    __ msubw(r24, r24, r4, r8);                        //        msub        w24, w24, w4, w8
-    __ madd(r11, r12, r15, r19);                       //        madd        x11, x12, x15, x19
-    __ msub(r29, r25, r12, r25);                       //        msub        x29, x25, x12, x25
-    __ smaddl(r17, r11, r12, r22);                     //        smaddl        x17, w11, w12, x22
-    __ smsubl(r28, r3, r20, r18);                      //        smsubl        x28, w3, w20, x18
-    __ umaddl(r7, r4, r28, r26);                       //        umaddl        x7, w4, w28, x26
-    __ umsubl(r22, r10, r17, r5);                      //        umsubl        x22, w10, w17, x5
+    __ maddw(r12, r12, r17, r12);                      // madd  w12, w12, w17, w12
+    __ msubw(r30, r15, r1, r27);                       // msub  w30, w15, w1, w27
+    __ madd(r2, r19, r17, r29);                        // madd  x2, x19, x17, x29
+    __ msub(r4, r23, r3, r30);                         // msub  x4, x23, x3, x30
+    __ smaddl(r15, r23, r17, r15);                     // smaddl  x15, w23, w17, x15
+    __ smsubl(r27, r12, r1, r13);                      // smsubl  x27, w12, w1, x13
+    __ umaddl(r6, r13, r12, r17);                      // umaddl  x6, w13, w12, x17
+    __ umsubl(r25, r1, r6, r10);                       // umsubl  x25, w1, w6, x10
 
 // ThreeRegFloatOp
-    __ fmuls(v17, v3, v17);                            //        fmul        s17, s3, s17
-    __ fdivs(v11, v17, v6);                            //        fdiv        s11, s17, s6
-    __ fadds(v29, v7, v9);                             //        fadd        s29, s7, s9
-    __ fsubs(v7, v12, v19);                            //        fsub        s7, s12, s19
-    __ fmuls(v0, v23, v3);                             //        fmul        s0, s23, s3
-    __ fmuld(v26, v3, v21);                            //        fmul        d26, d3, d21
-    __ fdivd(v0, v19, v5);                             //        fdiv        d0, d19, d5
-    __ faddd(v0, v26, v9);                             //        fadd        d0, d26, d9
-    __ fsubd(v25, v21, v21);                           //        fsub        d25, d21, d21
-    __ fmuld(v16, v13, v19);                           //        fmul        d16, d13, d19
+    __ fmuls(v17, v3, v4);                             // fmul  s17, s3, s4
+    __ fdivs(v16, v5, v21);                            // fdiv  s16, s5, s21
+    __ fadds(v3, v27, v17);                            // fadd  s3, s27, s17
+    __ fsubs(v25, v10, v15);                           // fsub  s25, s10, s15
+    __ fmuls(v10, v17, v0);                            // fmul  s10, s17, s0
+    __ fmuld(v28, v26, v3);                            // fmul  d28, d26, d3
+    __ fdivd(v4, v0, v27);                             // fdiv  d4, d0, d27
+    __ faddd(v28, v14, v2);                            // fadd  d28, d14, d2
+    __ fsubd(v12, v26, v23);                           // fsub  d12, d26, d23
+    __ fmuld(v15, v30, v1);                            // fmul  d15, d30, d1
 
 // FourRegFloatOp
-    __ fmadds(v29, v18, v0, v16);                      //        fmadd        s29, s18, s0, s16
-    __ fmsubs(v23, v13, v29, v5);                      //        fmsub        s23, s13, s29, s5
-    __ fnmadds(v9, v7, v10, v14);                      //        fnmadd        s9, s7, s10, s14
-    __ fnmadds(v25, v28, v15, v23);                    //        fnmadd        s25, s28, s15, s23
-    __ fmaddd(v6, v13, v21, v17);                      //        fmadd        d6, d13, d21, d17
-    __ fmsubd(v3, v21, v2, v7);                        //        fmsub        d3, d21, d2, d7
-    __ fnmaddd(v10, v25, v5, v17);                     //        fnmadd        d10, d25, d5, d17
-    __ fnmaddd(v14, v14, v20, v18);                    //        fnmadd        d14, d14, d20, d18
+    __ fmadds(v4, v5, v5, v13);                        // fmadd s4, s5, s5, s13
+    __ fmsubs(v21, v13, v28, v1);                      // fmsub s21, s13, s28, s1
+    __ fnmadds(v17, v3, v29, v7);                      // fnmadd  s17, s3, s29, s7
+    __ fnmadds(v23, v25, v29, v26);                    // fnmadd  s23, s25, s29, s26
+    __ fmaddd(v14, v7, v30, v26);                      // fmadd d14, d7, d30, d26
+    __ fmsubd(v22, v7, v10, v9);                       // fmsub d22, d7, d10, d9
+    __ fnmaddd(v7, v7, v14, v9);                       // fnmadd  d7, d7, d14, d9
+    __ fnmaddd(v14, v24, v15, v24);                    // fnmadd  d14, d24, d15, d24
 
 // TwoRegFloatOp
-    __ fmovs(v15, v2);                                 //        fmov        s15, s2
-    __ fabss(v18, v7);                                 //        fabs        s18, s7
-    __ fnegs(v3, v6);                                  //        fneg        s3, s6
-    __ fsqrts(v12, v1);                                //        fsqrt        s12, s1
-    __ fcvts(v9, v0);                                  //        fcvt        d9, s0
-    __ fmovd(v4, v5);                                  //        fmov        d4, d5
-    __ fabsd(v3, v15);                                 //        fabs        d3, d15
-    __ fnegd(v17, v25);                                //        fneg        d17, d25
-    __ fsqrtd(v12, v24);                               //        fsqrt        d12, d24
-    __ fcvtd(v21, v5);                                 //        fcvt        s21, d5
+    __ fmovs(v22, v2);                                 // fmov  s22, s2
+    __ fabss(v0, v3);                                  // fabs  s0, s3
+    __ fnegs(v9, v17);                                 // fneg  s9, s17
+    __ fsqrts(v24, v11);                               // fsqrt s24, s11
+    __ fcvts(v15, v25);                                // fcvt  d15, s25
+    __ fmovd(v4, v3);                                  // fmov  d4, d3
+    __ fabsd(v26, v22);                                // fabs  d26, d22
+    __ fnegd(v30, v19);                                // fneg  d30, d19
+    __ fsqrtd(v12, v14);                               // fsqrt d12, d14
+    __ fcvtd(v17, v7);                                 // fcvt  s17, d7
 
 // FloatConvertOp
-    __ fcvtzsw(r4, v21);                               //        fcvtzs        w4, s21
-    __ fcvtzs(r27, v3);                                //        fcvtzs        x27, s3
-    __ fcvtzdw(r29, v8);                               //        fcvtzs        w29, d8
-    __ fcvtzd(r9, v21);                                //        fcvtzs        x9, d21
-    __ scvtfws(v20, r29);                              //        scvtf        s20, w29
-    __ scvtfs(v7, r8);                                 //        scvtf        s7, x8
-    __ scvtfwd(v12, r21);                              //        scvtf        d12, w21
-    __ scvtfd(v16, r21);                               //        scvtf        d16, x21
-    __ fmovs(r18, v5);                                 //        fmov        w18, s5
-    __ fmovd(r25, v8);                                 //        fmov        x25, d8
-    __ fmovs(v18, r26);                                //        fmov        s18, w26
-    __ fmovd(v0, r11);                                 //        fmov        d0, x11
+    __ fcvtzsw(r24, v14);                              // fcvtzs  w24, s14
+    __ fcvtzs(r13, v26);                               // fcvtzs  x13, s26
+    __ fcvtzdw(r2, v1);                                // fcvtzs  w2, d1
+    __ fcvtzd(r5, v11);                                // fcvtzs  x5, d11
+    __ scvtfws(v14, r19);                              // scvtf s14, w19
+    __ scvtfs(v1, r22);                                // scvtf s1, x22
+    __ scvtfwd(v27, r17);                              // scvtf d27, w17
+    __ scvtfd(v22, r9);                                // scvtf d22, x9
+    __ fmovs(r14, v3);                                 // fmov  w14, s3
+    __ fmovd(r12, v17);                                // fmov  x12, d17
+    __ fmovs(v8, r27);                                 // fmov  s8, w27
+    __ fmovd(v29, r28);                                // fmov  d29, x28
 
 // TwoRegFloatOp
-    __ fcmps(v16, v6);                                 //        fcmp        s16, s6
-    __ fcmpd(v16, v29);                                //        fcmp        d16, d29
-    __ fcmps(v30, 0.0);                                //        fcmp        s30, #0.0
-    __ fcmpd(v9, 0.0);                                 //        fcmp        d9, #0.0
+    __ fcmps(v0, v30);                                 // fcmp  s0, s30
+    __ fcmpd(v12, v9);                                 // fcmp  d12, d9
+    __ fcmps(v10, 0.0);                                // fcmp  s10, #0.0
+    __ fcmpd(v25, 0.0);                                // fcmp  d25, #0.0
 
 // LoadStorePairOp
-    __ stpw(r27, r4, Address(r12, -16));               //        stp        w27, w4, [x12, #-16]
-    __ ldpw(r3, r9, Address(r10, 80));                 //        ldp        w3, w9, [x10, #80]
-    __ ldpsw(r16, r3, Address(r3, 64));                //        ldpsw        x16, x3, [x3, #64]
-    __ stp(r10, r28, Address(r19, -192));              //        stp        x10, x28, [x19, #-192]
-    __ ldp(r19, r18, Address(r7, -192));               //        ldp        x19, x18, [x7, #-192]
+    __ stpw(r8, r30, Address(r27, -144));              // stp w8, w30, [x27, #-144]
+    __ ldpw(r21, r19, Address(r24, 80));               // ldp w21, w19, [x24, #80]
+    __ ldpsw(r16, r27, Address(r2, -240));             // ldpsw x16, x27, [x2, #-240]
+    __ stp(r21, r5, Address(r6, -128));                // stp x21, x5, [x6, #-128]
+    __ ldp(r29, r25, Address(r28, -32));               // ldp x29, x25, [x28, #-32]
 
 // LoadStorePairOp
-    __ stpw(r10, r16, Address(__ pre(r30, 16)));       //        stp        w10, w16, [x30, #16]!
-    __ ldpw(r2, r4, Address(__ pre(r18, -240)));       //        ldp        w2, w4, [x18, #-240]!
-    __ ldpsw(r24, r19, Address(__ pre(r13, 48)));      //        ldpsw        x24, x19, [x13, #48]!
-    __ stp(r17, r0, Address(__ pre(r24, 0)));          //        stp        x17, x0, [x24, #0]!
-    __ ldp(r14, r26, Address(__ pre(r3, -192)));       //        ldp        x14, x26, [x3, #-192]!
+    __ stpw(r8, r13, Address(__ pre(r0, 128)));        // stp w8, w13, [x0, #128]!
+    __ ldpw(r25, r20, Address(__ pre(r1, -160)));      // ldp w25, w20, [x1, #-160]!
+    __ ldpsw(r14, r24, Address(__ pre(r22, -32)));     // ldpsw x14, x24, [x22, #-32]!
+    __ stp(r17, r1, Address(__ pre(r6, 80)));          // stp x17, x1, [x6, #80]!
+    __ ldp(r21, r17, Address(__ pre(r25, -64)));       // ldp x21, x17, [x25, #-64]!
 
 // LoadStorePairOp
-    __ stpw(r22, r1, Address(__ post(r0, 80)));        //        stp        w22, w1, [x0], #80
-    __ ldpw(r18, r10, Address(__ post(r0, -16)));      //        ldp        w18, w10, [x0], #-16
-    __ ldpsw(r24, r24, Address(__ post(r22, -16)));    //        ldpsw        x24, x24, [x22], #-16
-    __ stp(r12, r12, Address(__ post(r4, 80)));        //        stp        x12, x12, [x4], #80
-    __ ldp(r4, r9, Address(__ post(r19, -240)));       //        ldp        x4, x9, [x19], #-240
+    __ stpw(r17, r21, Address(__ post(r20, -128)));    // stp w17, w21, [x20], #-128
+    __ ldpw(r28, r28, Address(__ post(r2, 64)));       // ldp w28, w28, [x2], #64
+    __ ldpsw(r19, r30, Address(__ post(r10, -256)));   // ldpsw x19, x30, [x10], #-256
+    __ stp(r17, r15, Address(__ post(r17, -16)));      // stp x17, x15, [x17], #-16
+    __ ldp(r17, r0, Address(__ post(r25, -32)));       // ldp x17, x0, [x25], #-32
 
 // LoadStorePairOp
-    __ stnpw(r18, r26, Address(r6, -224));             //        stnp        w18, w26, [x6, #-224]
-    __ ldnpw(r21, r20, Address(r1, 112));              //        ldnp        w21, w20, [x1, #112]
-    __ stnp(r25, r29, Address(r20, -224));             //        stnp        x25, x29, [x20, #-224]
-    __ ldnp(r1, r5, Address(r23, 112));                //        ldnp        x1, x5, [x23, #112]
+    __ stnpw(r14, r5, Address(r24, -32));              // stnp  w14, w5, [x24, #-32]
+    __ ldnpw(r23, r19, Address(r1, 112));              // ldnp  w23, w19, [x1, #112]
+    __ stnp(r11, r6, Address(r14, 64));                // stnp  x11, x6, [x14, #64]
+    __ ldnp(r2, r11, Address(r27, -224));              // ldnp  x2, x11, [x27, #-224]
 
 // LdStSIMDOp
-    __ ld1(v4, __ T8B, Address(r20));                  //        ld1        {v4.8B}, [x20]
-    __ ld1(v24, v25, __ T16B, Address(__ post(r10, 32))); //        ld1        {v24.16B, v25.16B}, [x10], 32
-    __ ld1(v24, v25, v26, __ T1D, Address(__ post(r6, r15))); //        ld1        {v24.1D, v25.1D, v26.1D}, [x6], x15
-    __ ld1(v3, v4, v5, v6, __ T8H, Address(__ post(r4, 64))); //        ld1        {v3.8H, v4.8H, v5.8H, v6.8H}, [x4], 64
-    __ ld1r(v2, __ T8B, Address(r6));                  //        ld1r        {v2.8B}, [x6]
-    __ ld1r(v13, __ T4S, Address(__ post(r14, 4)));    //        ld1r        {v13.4S}, [x14], 4
-    __ ld1r(v15, __ T1D, Address(__ post(r21, r24)));  //        ld1r        {v15.1D}, [x21], x24
-    __ ld2(v9, v10, __ T2D, Address(r21));             //        ld2        {v9.2D, v10.2D}, [x21]
-    __ ld2(v29, v30, __ T4H, Address(__ post(r21, 16))); //        ld2        {v29.4H, v30.4H}, [x21], 16
-    __ ld2r(v8, v9, __ T16B, Address(r14));            //        ld2r        {v8.16B, v9.16B}, [x14]
-    __ ld2r(v7, v8, __ T2S, Address(__ post(r20, 8))); //        ld2r        {v7.2S, v8.2S}, [x20], 8
-    __ ld2r(v28, v29, __ T2D, Address(__ post(r3, r3))); //        ld2r        {v28.2D, v29.2D}, [x3], x3
-    __ ld3(v27, v28, v29, __ T4S, Address(__ post(r11, r29))); //        ld3        {v27.4S, v28.4S, v29.4S}, [x11], x29
-    __ ld3(v16, v17, v18, __ T2S, Address(r10));       //        ld3        {v16.2S, v17.2S, v18.2S}, [x10]
-    __ ld3r(v21, v22, v23, __ T8H, Address(r12));      //        ld3r        {v21.8H, v22.8H, v23.8H}, [x12]
-    __ ld3r(v4, v5, v6, __ T4S, Address(__ post(r29, 12))); //        ld3r        {v4.4S, v5.4S, v6.4S}, [x29], 12
-    __ ld3r(v24, v25, v26, __ T1D, Address(__ post(r9, r19))); //        ld3r        {v24.1D, v25.1D, v26.1D}, [x9], x19
-    __ ld4(v10, v11, v12, v13, __ T8H, Address(__ post(r3, 64))); //        ld4        {v10.8H, v11.8H, v12.8H, v13.8H}, [x3], 64
-    __ ld4(v27, v28, v29, v30, __ T8B, Address(__ post(r28, r9))); //        ld4        {v27.8B, v28.8B, v29.8B, v30.8B}, [x28], x9
-    __ ld4r(v21, v22, v23, v24, __ T8B, Address(r30)); //        ld4r        {v21.8B, v22.8B, v23.8B, v24.8B}, [x30]
-    __ ld4r(v23, v24, v25, v26, __ T4H, Address(__ post(r14, 8))); //        ld4r        {v23.4H, v24.4H, v25.4H, v26.4H}, [x14], 8
-    __ ld4r(v4, v5, v6, v7, __ T2S, Address(__ post(r13, r20))); //        ld4r        {v4.2S, v5.2S, v6.2S, v7.2S}, [x13], x20
+    __ ld1(v16, __ T8B, Address(r17));                 // ld1 {v16.8B}, [x17]
+    __ ld1(v29, v30, __ T16B, Address(__ post(r9, 32))); // ld1 {v29.16B, v30.16B}, [x9], 32
+    __ ld1(v30, v31, v0, __ T1D, Address(__ post(r24, r21))); //  ld1 {v30.1D, v31.1D, v0.1D}, [x24], x21
+    __ ld1(v0, v1, v2, v3, __ T8H, Address(__ post(r2, 64))); //  ld1 {v0.8H, v1.8H, v2.8H, v3.8H}, [x2], 64
+    __ ld1r(v20, __ T8B, Address(r9));                 // ld1r  {v20.8B}, [x9]
+    __ ld1r(v17, __ T4S, Address(__ post(r0, 4)));     // ld1r  {v17.4S}, [x0], 4
+    __ ld1r(v21, __ T1D, Address(__ post(r22, r26)));  // ld1r  {v21.1D}, [x22], x26
+    __ ld2(v19, v20, __ T2D, Address(r25));            // ld2 {v19.2D, v20.2D}, [x25]
+    __ ld2(v10, v11, __ T4H, Address(__ post(r5, 16))); //  ld2 {v10.4H, v11.4H}, [x5], 16
+    __ ld2r(v10, v11, __ T16B, Address(r24));          // ld2r  {v10.16B, v11.16B}, [x24]
+    __ ld2r(v13, v14, __ T2S, Address(__ post(r29, 8))); // ld2r  {v13.2S, v14.2S}, [x29], 8
+    __ ld2r(v22, v23, __ T2D, Address(__ post(r28, r2))); //  ld2r  {v22.2D, v23.2D}, [x28], x2
+    __ ld3(v30, v31, v0, __ T4S, Address(__ post(r4, r11))); // ld3 {v30.4S, v31.4S, v0.4S}, [x4], x11
+    __ ld3(v29, v30, v31, __ T2S, Address(r0));        // ld3 {v29.2S, v30.2S, v31.2S}, [x0]
+    __ ld3r(v23, v24, v25, __ T8H, Address(r27));      // ld3r  {v23.8H, v24.8H, v25.8H}, [x27]
+    __ ld3r(v3, v4, v5, __ T4S, Address(__ post(r10, 12))); //  ld3r  {v3.4S, v4.4S, v5.4S}, [x10], 12
+    __ ld3r(v19, v20, v21, __ T1D, Address(__ post(r14, r22))); //  ld3r  {v19.1D, v20.1D, v21.1D}, [x14], x22
+    __ ld4(v14, v15, v16, v17, __ T8H, Address(__ post(r0, 64))); //  ld4 {v14.8H, v15.8H, v16.8H, v17.8H}, [x0], 64
+    __ ld4(v30, v31, v0, v1, __ T8B, Address(__ post(r22, r25))); //  ld4 {v30.8B, v31.8B, v0.8B, v1.8B}, [x22], x25
+    __ ld4r(v25, v26, v27, v28, __ T8B, Address(r0));  // ld4r  {v25.8B, v26.8B, v27.8B, v28.8B}, [x0]
+    __ ld4r(v10, v11, v12, v13, __ T4H, Address(__ post(r8, 8))); //  ld4r  {v10.4H, v11.4H, v12.4H, v13.4H}, [x8], 8
+    __ ld4r(v1, v2, v3, v4, __ T2S, Address(__ post(r6, r28))); //  ld4r  {v1.2S, v2.2S, v3.2S, v4.2S}, [x6], x28
 
 // SpecialCases
-    __ ccmn(zr, zr, 3u, Assembler::LE);                //        ccmn        xzr, xzr, #3, LE
-    __ ccmnw(zr, zr, 5u, Assembler::EQ);               //        ccmn        wzr, wzr, #5, EQ
-    __ ccmp(zr, 1, 4u, Assembler::NE);                 //        ccmp        xzr, 1, #4, NE
-    __ ccmpw(zr, 2, 2, Assembler::GT);                 //        ccmp        wzr, 2, #2, GT
-    __ extr(zr, zr, zr, 0);                            //        extr        xzr, xzr, xzr, 0
-    __ stlxp(r0, zr, zr, sp);                          //        stlxp        w0, xzr, xzr, [sp]
-    __ stlxpw(r2, zr, zr, r3);                         //        stlxp        w2, wzr, wzr, [x3]
-    __ stxp(r4, zr, zr, r5);                           //        stxp        w4, xzr, xzr, [x5]
-    __ stxpw(r6, zr, zr, sp);                          //        stxp        w6, wzr, wzr, [sp]
-    __ dup(v0, __ T16B, zr);                           //        dup        v0.16b, wzr
-    __ mov(v1, __ T1D, 0, zr);                         //        mov        v1.d[0], xzr
-    __ mov(v1, __ T2S, 1, zr);                         //        mov        v1.s[1], wzr
-    __ mov(v1, __ T4H, 2, zr);                         //        mov        v1.h[2], wzr
-    __ mov(v1, __ T8B, 3, zr);                         //        mov        v1.b[3], wzr
-    __ ld1(v31, v0, __ T2D, Address(__ post(r1, r0))); //        ld1        {v31.2d, v0.2d}, [x1], x0
+    __ ccmn(zr, zr, 3u, Assembler::LE);                // ccmn  xzr, xzr, #3, LE
+    __ ccmnw(zr, zr, 5u, Assembler::EQ);               // ccmn  wzr, wzr, #5, EQ
+    __ ccmp(zr, 1, 4u, Assembler::NE);                 // ccmp  xzr, 1, #4, NE
+    __ ccmpw(zr, 2, 2, Assembler::GT);                 // ccmp  wzr, 2, #2, GT
+    __ extr(zr, zr, zr, 0);                            // extr  xzr, xzr, xzr, 0
+    __ stlxp(r0, zr, zr, sp);                          // stlxp w0, xzr, xzr, [sp]
+    __ stlxpw(r2, zr, zr, r3);                         // stlxp w2, wzr, wzr, [x3]
+    __ stxp(r4, zr, zr, r5);                           // stxp  w4, xzr, xzr, [x5]
+    __ stxpw(r6, zr, zr, sp);                          // stxp  w6, wzr, wzr, [sp]
+    __ dup(v0, __ T16B, zr);                           // dup v0.16b, wzr
+    __ mov(v1, __ T1D, 0, zr);                         // mov v1.d[0], xzr
+    __ mov(v1, __ T2S, 1, zr);                         // mov v1.s[1], wzr
+    __ mov(v1, __ T4H, 2, zr);                         // mov v1.h[2], wzr
+    __ mov(v1, __ T8B, 3, zr);                         // mov v1.b[3], wzr
+    __ ld1(v31, v0, __ T2D, Address(__ post(r1, r0))); // ld1 {v31.2d, v0.2d}, [x1], x0
 
 // FloatImmediateOp
-    __ fmovd(v0, 2.0);                                 //        fmov d0, #2.0
-    __ fmovd(v0, 2.125);                               //        fmov d0, #2.125
-    __ fmovd(v0, 4.0);                                 //        fmov d0, #4.0
-    __ fmovd(v0, 4.25);                                //        fmov d0, #4.25
-    __ fmovd(v0, 8.0);                                 //        fmov d0, #8.0
-    __ fmovd(v0, 8.5);                                 //        fmov d0, #8.5
-    __ fmovd(v0, 16.0);                                //        fmov d0, #16.0
-    __ fmovd(v0, 17.0);                                //        fmov d0, #17.0
-    __ fmovd(v0, 0.125);                               //        fmov d0, #0.125
-    __ fmovd(v0, 0.1328125);                           //        fmov d0, #0.1328125
-    __ fmovd(v0, 0.25);                                //        fmov d0, #0.25
-    __ fmovd(v0, 0.265625);                            //        fmov d0, #0.265625
-    __ fmovd(v0, 0.5);                                 //        fmov d0, #0.5
-    __ fmovd(v0, 0.53125);                             //        fmov d0, #0.53125
-    __ fmovd(v0, 1.0);                                 //        fmov d0, #1.0
-    __ fmovd(v0, 1.0625);                              //        fmov d0, #1.0625
-    __ fmovd(v0, -2.0);                                //        fmov d0, #-2.0
-    __ fmovd(v0, -2.125);                              //        fmov d0, #-2.125
-    __ fmovd(v0, -4.0);                                //        fmov d0, #-4.0
-    __ fmovd(v0, -4.25);                               //        fmov d0, #-4.25
-    __ fmovd(v0, -8.0);                                //        fmov d0, #-8.0
-    __ fmovd(v0, -8.5);                                //        fmov d0, #-8.5
-    __ fmovd(v0, -16.0);                               //        fmov d0, #-16.0
-    __ fmovd(v0, -17.0);                               //        fmov d0, #-17.0
-    __ fmovd(v0, -0.125);                              //        fmov d0, #-0.125
-    __ fmovd(v0, -0.1328125);                          //        fmov d0, #-0.1328125
-    __ fmovd(v0, -0.25);                               //        fmov d0, #-0.25
-    __ fmovd(v0, -0.265625);                           //        fmov d0, #-0.265625
-    __ fmovd(v0, -0.5);                                //        fmov d0, #-0.5
-    __ fmovd(v0, -0.53125);                            //        fmov d0, #-0.53125
-    __ fmovd(v0, -1.0);                                //        fmov d0, #-1.0
-    __ fmovd(v0, -1.0625);                             //        fmov d0, #-1.0625
+    __ fmovd(v0, 2.0);                                 // fmov d0, #2.0
+    __ fmovd(v0, 2.125);                               // fmov d0, #2.125
+    __ fmovd(v0, 4.0);                                 // fmov d0, #4.0
+    __ fmovd(v0, 4.25);                                // fmov d0, #4.25
+    __ fmovd(v0, 8.0);                                 // fmov d0, #8.0
+    __ fmovd(v0, 8.5);                                 // fmov d0, #8.5
+    __ fmovd(v0, 16.0);                                // fmov d0, #16.0
+    __ fmovd(v0, 17.0);                                // fmov d0, #17.0
+    __ fmovd(v0, 0.125);                               // fmov d0, #0.125
+    __ fmovd(v0, 0.1328125);                           // fmov d0, #0.1328125
+    __ fmovd(v0, 0.25);                                // fmov d0, #0.25
+    __ fmovd(v0, 0.265625);                            // fmov d0, #0.265625
+    __ fmovd(v0, 0.5);                                 // fmov d0, #0.5
+    __ fmovd(v0, 0.53125);                             // fmov d0, #0.53125
+    __ fmovd(v0, 1.0);                                 // fmov d0, #1.0
+    __ fmovd(v0, 1.0625);                              // fmov d0, #1.0625
+    __ fmovd(v0, -2.0);                                // fmov d0, #-2.0
+    __ fmovd(v0, -2.125);                              // fmov d0, #-2.125
+    __ fmovd(v0, -4.0);                                // fmov d0, #-4.0
+    __ fmovd(v0, -4.25);                               // fmov d0, #-4.25
+    __ fmovd(v0, -8.0);                                // fmov d0, #-8.0
+    __ fmovd(v0, -8.5);                                // fmov d0, #-8.5
+    __ fmovd(v0, -16.0);                               // fmov d0, #-16.0
+    __ fmovd(v0, -17.0);                               // fmov d0, #-17.0
+    __ fmovd(v0, -0.125);                              // fmov d0, #-0.125
+    __ fmovd(v0, -0.1328125);                          // fmov d0, #-0.1328125
+    __ fmovd(v0, -0.25);                               // fmov d0, #-0.25
+    __ fmovd(v0, -0.265625);                           // fmov d0, #-0.265625
+    __ fmovd(v0, -0.5);                                // fmov d0, #-0.5
+    __ fmovd(v0, -0.53125);                            // fmov d0, #-0.53125
+    __ fmovd(v0, -1.0);                                // fmov d0, #-1.0
+    __ fmovd(v0, -1.0625);                             // fmov d0, #-1.0625
 
 // LSEOp
-    __ swp(Assembler::xword, r21, r5, r24);            //        swp        x21, x5, [x24]
-    __ ldadd(Assembler::xword, r13, r13, r15);         //        ldadd        x13, x13, [x15]
-    __ ldbic(Assembler::xword, r22, r19, r26);         //        ldclr        x22, x19, [x26]
-    __ ldeor(Assembler::xword, r25, r10, r26);         //        ldeor        x25, x10, [x26]
-    __ ldorr(Assembler::xword, r5, r27, r15);          //        ldset        x5, x27, [x15]
-    __ ldsmin(Assembler::xword, r19, r5, r11);         //        ldsmin        x19, x5, [x11]
-    __ ldsmax(Assembler::xword, r26, r0, r4);          //        ldsmax        x26, x0, [x4]
-    __ ldumin(Assembler::xword, r22, r23, r30);        //        ldumin        x22, x23, [x30]
-    __ ldumax(Assembler::xword, r18, r28, r8);         //        ldumax        x18, x28, [x8]
+    __ swp(Assembler::xword, r16, r20, r15);           // swp x16, x20, [x15]
+    __ ldadd(Assembler::xword, r2, r7, r28);           // ldadd x2, x7, [x28]
+    __ ldbic(Assembler::xword, r20, r10, r25);         // ldclr x20, x10, [x25]
+    __ ldeor(Assembler::xword, r22, r11, r2);          // ldeor x22, x11, [x2]
+    __ ldorr(Assembler::xword, r1, r10, r19);          // ldset x1, x10, [x19]
+    __ ldsmin(Assembler::xword, r14, r21, r3);         // ldsmin  x14, x21, [x3]
+    __ ldsmax(Assembler::xword, r28, r27, r13);        // ldsmax  x28, x27, [x13]
+    __ ldumin(Assembler::xword, r17, r30, r21);        // ldumin  x17, x30, [x21]
+    __ ldumax(Assembler::xword, r27, r16, r29);        // ldumax  x27, x16, [x29]
 
 // LSEOp
-    __ swpa(Assembler::xword, r13, r29, r27);          //        swpa        x13, x29, [x27]
-    __ ldadda(Assembler::xword, r11, r5, r13);         //        ldadda        x11, x5, [x13]
-    __ ldbica(Assembler::xword, r1, r24, r21);         //        ldclra        x1, x24, [x21]
-    __ ldeora(Assembler::xword, r27, r17, r24);        //        ldeora        x27, x17, [x24]
-    __ ldorra(Assembler::xword, r18, r30, r5);         //        ldseta        x18, x30, [x5]
-    __ ldsmina(Assembler::xword, r7, r22, r25);        //        ldsmina        x7, x22, [x25]
-    __ ldsmaxa(Assembler::xword, r4, r26, r19);        //        ldsmaxa        x4, x26, [x19]
-    __ ldumina(Assembler::xword, r6, r30, r3);         //        ldumina        x6, x30, [x3]
-    __ ldumaxa(Assembler::xword, r24, r23, r5);        //        ldumaxa        x24, x23, [x5]
+    __ swpa(Assembler::xword, r30, r9, r0);            // swpa  x30, x9, [x0]
+    __ ldadda(Assembler::xword, r28, r27, r28);        // ldadda  x28, x27, [x28]
+    __ ldbica(Assembler::xword, r21, r25, r10);        // ldclra  x21, x25, [x10]
+    __ ldeora(Assembler::xword, zr, r20, r15);         // ldeora  xzr, x20, [x15]
+    __ ldorra(Assembler::xword, r1, r25, r14);         // ldseta  x1, x25, [x14]
+    __ ldsmina(Assembler::xword, r21, r26, r29);       // ldsmina x21, x26, [x29]
+    __ ldsmaxa(Assembler::xword, r8, r29, r25);        // ldsmaxa x8, x29, [x25]
+    __ ldumina(Assembler::xword, r13, r2, r25);        // ldumina x13, x2, [x25]
+    __ ldumaxa(Assembler::xword, r15, r23, r0);        // ldumaxa x15, x23, [x0]
 
 // LSEOp
-    __ swpal(Assembler::xword, r24, r18, r28);         //        swpal        x24, x18, [x28]
-    __ ldaddal(Assembler::xword, r19, zr, r7);         //        ldaddal        x19, xzr, [x7]
-    __ ldbical(Assembler::xword, r13, r6, r28);        //        ldclral        x13, x6, [x28]
-    __ ldeoral(Assembler::xword, r8, r15, r21);        //        ldeoral        x8, x15, [x21]
-    __ ldorral(Assembler::xword, r2, r13, r1);         //        ldsetal        x2, x13, [x1]
-    __ ldsminal(Assembler::xword, r17, r29, r25);      //        ldsminal        x17, x29, [x25]
-    __ ldsmaxal(Assembler::xword, r25, r18, r14);      //        ldsmaxal        x25, x18, [x14]
-    __ lduminal(Assembler::xword, zr, r6, r27);        //        lduminal        xzr, x6, [x27]
-    __ ldumaxal(Assembler::xword, r16, r5, r15);       //        ldumaxal        x16, x5, [x15]
+    __ swpal(Assembler::xword, r3, r1, r2);            // swpal x3, x1, [x2]
+    __ ldaddal(Assembler::xword, r28, r3, r20);        // ldaddal x28, x3, [x20]
+    __ ldbical(Assembler::xword, r14, zr, r14);        // ldclral x14, xzr, [x14]
+    __ ldeoral(Assembler::xword, r7, r28, r2);         // ldeoral x7, x28, [x2]
+    __ ldorral(Assembler::xword, r0, r11, r5);         // ldsetal x0, x11, [x5]
+    __ ldsminal(Assembler::xword, r11, r14, r20);      // ldsminal  x11, x14, [x20]
+    __ ldsmaxal(Assembler::xword, zr, r4, r2);         // ldsmaxal  xzr, x4, [x2]
+    __ lduminal(Assembler::xword, r26, r0, r22);       // lduminal  x26, x0, [x22]
+    __ ldumaxal(Assembler::xword, r17, r1, r13);       // ldumaxal  x17, x1, [x13]
 
 // LSEOp
-    __ swpl(Assembler::xword, r11, r18, r3);           //        swpl        x11, x18, [x3]
-    __ ldaddl(Assembler::xword, r26, r20, r2);         //        ldaddl        x26, x20, [x2]
-    __ ldbicl(Assembler::xword, r11, r4, r11);         //        ldclrl        x11, x4, [x11]
-    __ ldeorl(Assembler::xword, r30, r19, r23);        //        ldeorl        x30, x19, [x23]
-    __ ldorrl(Assembler::xword, r3, r15, r14);         //        ldsetl        x3, x15, [x14]
-    __ ldsminl(Assembler::xword, r30, r22, r20);       //        ldsminl        x30, x22, [x20]
-    __ ldsmaxl(Assembler::xword, r7, r5, r24);         //        ldsmaxl        x7, x5, [x24]
-    __ lduminl(Assembler::xword, r23, r16, r15);       //        lduminl        x23, x16, [x15]
-    __ ldumaxl(Assembler::xword, r11, r19, r0);        //        ldumaxl        x11, x19, [x0]
+    __ swpl(Assembler::xword, r23, r26, r20);          // swpl  x23, x26, [x20]
+    __ ldaddl(Assembler::xword, r14, r11, r12);        // ldaddl  x14, x11, [x12]
+    __ ldbicl(Assembler::xword, r12, zr, r15);         // ldclrl  x12, xzr, [x15]
+    __ ldeorl(Assembler::xword, r27, r14, r8);         // ldeorl  x27, x14, [x8]
+    __ ldorrl(Assembler::xword, r10, r30, r25);        // ldsetl  x10, x30, [x25]
+    __ ldsminl(Assembler::xword, r22, r7, r16);        // ldsminl x22, x7, [x16]
+    __ ldsmaxl(Assembler::xword, r1, r16, r8);         // ldsmaxl x1, x16, [x8]
+    __ lduminl(Assembler::xword, r1, r1, r26);         // lduminl x1, x1, [x26]
+    __ ldumaxl(Assembler::xword, r0, r23, r15);        // ldumaxl x0, x23, [x15]
 
 // LSEOp
-    __ swp(Assembler::word, r28, r28, r1);             //        swp        w28, w28, [x1]
-    __ ldadd(Assembler::word, r11, r21, r12);          //        ldadd        w11, w21, [x12]
-    __ ldbic(Assembler::word, r29, r0, r18);           //        ldclr        w29, w0, [x18]
-    __ ldeor(Assembler::word, r5, r0, r25);            //        ldeor        w5, w0, [x25]
-    __ ldorr(Assembler::word, r14, r0, r26);           //        ldset        w14, w0, [x26]
-    __ ldsmin(Assembler::word, r28, r18, r29);         //        ldsmin        w28, w18, [x29]
-    __ ldsmax(Assembler::word, r15, r1, r29);          //        ldsmax        w15, w1, [x29]
-    __ ldumin(Assembler::word, r8, r26, r28);          //        ldumin        w8, w26, [x28]
-    __ ldumax(Assembler::word, r17, r14, r4);          //        ldumax        w17, w14, [x4]
+    __ swp(Assembler::word, r11, r16, r8);             // swp w11, w16, [x8]
+    __ ldadd(Assembler::word, r1, r7, r14);            // ldadd w1, w7, [x14]
+    __ ldbic(Assembler::word, r16, zr, r9);            // ldclr w16, wzr, [x9]
+    __ ldeor(Assembler::word, r22, r6, r13);           // ldeor w22, w6, [x13]
+    __ ldorr(Assembler::word, r11, r13, r4);           // ldset w11, w13, [x4]
+    __ ldsmin(Assembler::word, r16, r22, r0);          // ldsmin  w16, w22, [x0]
+    __ ldsmax(Assembler::word, r28, zr, r10);          // ldsmax  w28, wzr, [x10]
+    __ ldumin(Assembler::word, r16, r5, r8);           // ldumin  w16, w5, [x8]
+    __ ldumax(Assembler::word, r26, r20, r15);         // ldumax  w26, w20, [x15]
 
 // LSEOp
-    __ swpa(Assembler::word, r24, r25, r1);            //        swpa        w24, w25, [x1]
-    __ ldadda(Assembler::word, r10, r17, r17);         //        ldadda        w10, w17, [x17]
-    __ ldbica(Assembler::word, r29, r20, r21);         //        ldclra        w29, w20, [x21]
-    __ ldeora(Assembler::word, r29, r9, r12);          //        ldeora        w29, w9, [x12]
-    __ ldorra(Assembler::word, r11, r6, r5);           //        ldseta        w11, w6, [x5]
-    __ ldsmina(Assembler::word, r21, r7, r21);         //        ldsmina        w21, w7, [x21]
-    __ ldsmaxa(Assembler::word, r10, r23, r12);        //        ldsmaxa        w10, w23, [x12]
-    __ ldumina(Assembler::word, r21, r5, r10);         //        ldumina        w21, w5, [x10]
-    __ ldumaxa(Assembler::word, r30, r20, r18);        //        ldumaxa        w30, w20, [x18]
+    __ swpa(Assembler::word, r27, r6, r16);            // swpa  w27, w6, [x16]
+    __ ldadda(Assembler::word, zr, zr, r2);            // ldadda  wzr, wzr, [x2]
+    __ ldbica(Assembler::word, r24, r28, r8);          // ldclra  w24, w28, [x8]
+    __ ldeora(Assembler::word, r15, r9, r23);          // ldeora  w15, w9, [x23]
+    __ ldorra(Assembler::word, r26, r2, r7);           // ldseta  w26, w2, [x7]
+    __ ldsmina(Assembler::word, r3, r17, r15);         // ldsmina w3, w17, [x15]
+    __ ldsmaxa(Assembler::word, r19, r5, r21);         // ldsmaxa w19, w5, [x21]
+    __ ldumina(Assembler::word, r7, r26, r12);         // ldumina w7, w26, [x12]
+    __ ldumaxa(Assembler::word, r12, r7, r29);         // ldumaxa w12, w7, [x29]
 
 // LSEOp
-    __ swpal(Assembler::word, r13, r23, r5);           //        swpal        w13, w23, [x5]
-    __ ldaddal(Assembler::word, r15, r24, r5);         //        ldaddal        w15, w24, [x5]
-    __ ldbical(Assembler::word, r9, r10, r25);         //        ldclral        w9, w10, [x25]
-    __ ldeoral(Assembler::word, r20, r17, r17);        //        ldeoral        w20, w17, [x17]
-    __ ldorral(Assembler::word, r12, r18, r30);        //        ldsetal        w12, w18, [x30]
-    __ ldsminal(Assembler::word, r3, r3, r25);         //        ldsminal        w3, w3, [x25]
-    __ ldsmaxal(Assembler::word, r26, r25, r10);       //        ldsmaxal        w26, w25, [x10]
-    __ lduminal(Assembler::word, r2, r11, sp);         //        lduminal        w2, w11, [sp]
-    __ ldumaxal(Assembler::word, r7, r2, r5);          //        ldumaxal        w7, w2, [x5]
+    __ swpal(Assembler::word, r9, r8, r20);            // swpal w9, w8, [x20]
+    __ ldaddal(Assembler::word, r8, zr, r30);          // ldaddal w8, wzr, [x30]
+    __ ldbical(Assembler::word, r0, r6, r12);          // ldclral w0, w6, [x12]
+    __ ldeoral(Assembler::word, r17, r23, r2);         // ldeoral w17, w23, [x2]
+    __ ldorral(Assembler::word, r0, r30, r1);          // ldsetal w0, w30, [x1]
+    __ ldsminal(Assembler::word, r22, r3, r15);        // ldsminal  w22, w3, [x15]
+    __ ldsmaxal(Assembler::word, r25, r21, r13);       // ldsmaxal  w25, w21, [x13]
+    __ lduminal(Assembler::word, r13, r24, r27);       // lduminal  w13, w24, [x27]
+    __ ldumaxal(Assembler::word, r20, r3, r11);        // ldumaxal  w20, w3, [x11]
 
 // LSEOp
-    __ swpl(Assembler::word, r0, r7, r20);             //        swpl        w0, w7, [x20]
-    __ ldaddl(Assembler::word, r5, zr, r2);            //        ldaddl        w5, wzr, [x2]
-    __ ldbicl(Assembler::word, r27, r25, r27);         //        ldclrl        w27, w25, [x27]
-    __ ldeorl(Assembler::word, r30, r24, r26);         //        ldeorl        w30, w24, [x26]
-    __ ldorrl(Assembler::word, r15, r2, r22);          //        ldsetl        w15, w2, [x22]
-    __ ldsminl(Assembler::word, r0, r3, sp);           //        ldsminl        w0, w3, [sp]
-    __ ldsmaxl(Assembler::word, r15, r20, r10);        //        ldsmaxl        w15, w20, [x10]
-    __ lduminl(Assembler::word, r22, r21, r14);        //        lduminl        w22, w21, [x14]
-    __ ldumaxl(Assembler::word, r6, r30, r2);          //        ldumaxl        w6, w30, [x2]
+    __ swpl(Assembler::word, r3, r13, r21);            // swpl  w3, w13, [x21]
+    __ ldaddl(Assembler::word, r26, r15, r26);         // ldaddl  w26, w15, [x26]
+    __ ldbicl(Assembler::word, r9, r19, r2);           // ldclrl  w9, w19, [x2]
+    __ ldeorl(Assembler::word, r24, r29, r7);          // ldeorl  w24, w29, [x7]
+    __ ldorrl(Assembler::word, r29, r25, r15);         // ldsetl  w29, w25, [x15]
+    __ ldsminl(Assembler::word, r11, r30, r7);         // ldsminl w11, w30, [x7]
+    __ ldsmaxl(Assembler::word, r11, r2, r6);          // ldsmaxl w11, w2, [x6]
+    __ lduminl(Assembler::word, r16, r11, r14);        // lduminl w16, w11, [x14]
+    __ ldumaxl(Assembler::word, r5, r8, r11);          // ldumaxl w5, w8, [x11]
 
     __ bind(forth);
 
@@ -762,567 +762,567 @@ aarch64ops.o:     file format elf64-littleaarch64
 Disassembly of section .text:
 
 0000000000000000 <back>:
-   0:        8b50798f         add        x15, x12, x16, lsr #30
-   4:        cb4381e1         sub        x1, x15, x3, lsr #32
-   8:        ab05372d         adds        x13, x25, x5, lsl #13
-   c:        eb864796         subs        x22, x28, x6, asr #17
-  10:        0b961920         add        w0, w9, w22, asr #6
-  14:        4b195473         sub        w19, w3, w25, lsl #21
-  18:        2b0b5264         adds        w4, w19, w11, lsl #20
-  1c:        6b9300f8         subs        w24, w7, w19, asr #0
-  20:        8a0bc0fe         and        x30, x7, x11, lsl #48
-  24:        aa0f3118         orr        x24, x8, x15, lsl #12
-  28:        ca170531         eor        x17, x9, x23, lsl #1
-  2c:        ea44dd6e         ands        x14, x11, x4, lsr #55
-  30:        0a4c44f3         and        w19, w7, w12, lsr #17
-  34:        2a8b7373         orr        w19, w27, w11, asr #28
-  38:        4a567c7e         eor        w30, w3, w22, lsr #31
-  3c:        6a9c0353         ands        w19, w26, w28, asr #0
-  40:        8a3accdd         bic        x29, x6, x26, lsl #51
-  44:        aa318f7a         orn        x26, x27, x17, lsl #35
-  48:        ca2e1495         eon        x21, x4, x14, lsl #5
-  4c:        eaa015e2         bics        x2, x15, x0, asr #5
-  50:        0a2274e2         bic        w2, w7, w2, lsl #29
-  54:        2a751598         orn        w24, w12, w21, lsr #5
-  58:        4a3309fe         eon        w30, w15, w19, lsl #2
-  5c:        6ab172fe         bics        w30, w23, w17, asr #28
-  60:        110a5284         add        w4, w20, #0x294
-  64:        310b1942         adds        w2, w10, #0x2c6
-  68:        5103d353         sub        w19, w26, #0xf4
-  6c:        710125bc         subs        w28, w13, #0x49
-  70:        910d7bc2         add        x2, x30, #0x35e
-  74:        b108fa1b         adds        x27, x16, #0x23e
-  78:        d1093536         sub        x22, x9, #0x24d
-  7c:        f10ae824         subs        x4, x1, #0x2ba
-  80:        120e667c         and        w28, w19, #0xfffc0fff
-  84:        321f6cbb         orr        w27, w5, #0x1ffffffe
-  88:        520f6a9e         eor        w30, w20, #0xfffe0fff
-  8c:        72136f56         ands        w22, w26, #0xffffe1ff
-  90:        927e4ce5         and        x5, x7, #0x3ffffc
-  94:        b278b4ed         orr        x13, x7, #0x3fffffffffff00
-  98:        d24c6527         eor        x7, x9, #0xfff0000000003fff
-  9c:        f2485803         ands        x3, x0, #0xff00000000007fff
-  a0:        14000000         b        a0 <back+0xa0>
-  a4:        17ffffd7         b        0 <back>
-  a8:        140001ee         b        860 <forth>
-  ac:        94000000         bl        ac <back+0xac>
-  b0:        97ffffd4         bl        0 <back>
-  b4:        940001eb         bl        860 <forth>
-  b8:        34000010         cbz        w16, b8 <back+0xb8>
-  bc:        34fffa30         cbz        w16, 0 <back>
-  c0:        34003d10         cbz        w16, 860 <forth>
-  c4:        35000013         cbnz        w19, c4 <back+0xc4>
-  c8:        35fff9d3         cbnz        w19, 0 <back>
-  cc:        35003cb3         cbnz        w19, 860 <forth>
-  d0:        b4000005         cbz        x5, d0 <back+0xd0>
-  d4:        b4fff965         cbz        x5, 0 <back>
-  d8:        b4003c45         cbz        x5, 860 <forth>
-  dc:        b5000004         cbnz        x4, dc <back+0xdc>
-  e0:        b5fff904         cbnz        x4, 0 <back>
-  e4:        b5003be4         cbnz        x4, 860 <forth>
-  e8:        1000001b         adr        x27, e8 <back+0xe8>
-  ec:        10fff8bb         adr        x27, 0 <back>
-  f0:        10003b9b         adr        x27, 860 <forth>
-  f4:        90000010         adrp        x16, 0 <back>
-  f8:        3640001c         tbz        w28, #8, f8 <back+0xf8>
-  fc:        3647f83c         tbz        w28, #8, 0 <back>
- 100:        36403b1c         tbz        w28, #8, 860 <forth>
- 104:        37080001         tbnz        w1, #1, 104 <back+0x104>
- 108:        370ff7c1         tbnz        w1, #1, 0 <back>
- 10c:        37083aa1         tbnz        w1, #1, 860 <forth>
- 110:        12a437f4         mov        w20, #0xde40ffff                    // #-566165505
- 114:        528c9d67         mov        w7, #0x64eb                        // #25835
- 118:        72838bb1         movk        w17, #0x1c5d
- 11c:        92c1062e         mov        x14, #0xfffff7ceffffffff            // #-9006546419713
- 120:        d287da49         mov        x9, #0x3ed2                        // #16082
- 124:        f2a6d153         movk        x19, #0x368a, lsl #16
- 128:        93465ac9         sbfx        x9, x22, #6, #17
- 12c:        330b0013         bfi        w19, w0, #21, #1
- 130:        530b4e6a         ubfx        w10, w19, #11, #9
- 134:        934545e4         sbfx        x4, x15, #5, #13
- 138:        b35370a3         bfxil        x3, x5, #19, #10
- 13c:        d3510b8c         ubfiz        x12, x28, #47, #3
- 140:        13960c0f         extr        w15, w0, w22, #3
- 144:        93ceddc6         ror        x6, x14, #55
- 148:        54000000         b.eq        148 <back+0x148>  // b.none
- 14c:        54fff5a0         b.eq        0 <back>  // b.none
- 150:        54003880         b.eq        860 <forth>  // b.none
- 154:        54000001         b.ne        154 <back+0x154>  // b.any
- 158:        54fff541         b.ne        0 <back>  // b.any
- 15c:        54003821         b.ne        860 <forth>  // b.any
- 160:        54000002         b.cs        160 <back+0x160>  // b.hs, b.nlast
- 164:        54fff4e2         b.cs        0 <back>  // b.hs, b.nlast
- 168:        540037c2         b.cs        860 <forth>  // b.hs, b.nlast
- 16c:        54000002         b.cs        16c <back+0x16c>  // b.hs, b.nlast
- 170:        54fff482         b.cs        0 <back>  // b.hs, b.nlast
- 174:        54003762         b.cs        860 <forth>  // b.hs, b.nlast
- 178:        54000003         b.cc        178 <back+0x178>  // b.lo, b.ul, b.last
- 17c:        54fff423         b.cc        0 <back>  // b.lo, b.ul, b.last
- 180:        54003703         b.cc        860 <forth>  // b.lo, b.ul, b.last
- 184:        54000003         b.cc        184 <back+0x184>  // b.lo, b.ul, b.last
- 188:        54fff3c3         b.cc        0 <back>  // b.lo, b.ul, b.last
- 18c:        540036a3         b.cc        860 <forth>  // b.lo, b.ul, b.last
- 190:        54000004         b.mi        190 <back+0x190>  // b.first
- 194:        54fff364         b.mi        0 <back>  // b.first
- 198:        54003644         b.mi        860 <forth>  // b.first
- 19c:        54000005         b.pl        19c <back+0x19c>  // b.nfrst
- 1a0:        54fff305         b.pl        0 <back>  // b.nfrst
- 1a4:        540035e5         b.pl        860 <forth>  // b.nfrst
- 1a8:        54000006         b.vs        1a8 <back+0x1a8>
- 1ac:        54fff2a6         b.vs        0 <back>
- 1b0:        54003586         b.vs        860 <forth>
- 1b4:        54000007         b.vc        1b4 <back+0x1b4>
- 1b8:        54fff247         b.vc        0 <back>
- 1bc:        54003527         b.vc        860 <forth>
- 1c0:        54000008         b.hi        1c0 <back+0x1c0>  // b.pmore
- 1c4:        54fff1e8         b.hi        0 <back>  // b.pmore
- 1c8:        540034c8         b.hi        860 <forth>  // b.pmore
- 1cc:        54000009         b.ls        1cc <back+0x1cc>  // b.plast
- 1d0:        54fff189         b.ls        0 <back>  // b.plast
- 1d4:        54003469         b.ls        860 <forth>  // b.plast
- 1d8:        5400000a         b.ge        1d8 <back+0x1d8>  // b.tcont
- 1dc:        54fff12a         b.ge        0 <back>  // b.tcont
- 1e0:        5400340a         b.ge        860 <forth>  // b.tcont
- 1e4:        5400000b         b.lt        1e4 <back+0x1e4>  // b.tstop
- 1e8:        54fff0cb         b.lt        0 <back>  // b.tstop
- 1ec:        540033ab         b.lt        860 <forth>  // b.tstop
- 1f0:        5400000c         b.gt        1f0 <back+0x1f0>
- 1f4:        54fff06c         b.gt        0 <back>
- 1f8:        5400334c         b.gt        860 <forth>
- 1fc:        5400000d         b.le        1fc <back+0x1fc>
- 200:        54fff00d         b.le        0 <back>
- 204:        540032ed         b.le        860 <forth>
- 208:        5400000e         b.al        208 <back+0x208>
- 20c:        54ffefae         b.al        0 <back>
- 210:        5400328e         b.al        860 <forth>
- 214:        5400000f         b.nv        214 <back+0x214>
- 218:        54ffef4f         b.nv        0 <back>
- 21c:        5400322f         b.nv        860 <forth>
- 220:        d40ac601         svc        #0x5630
- 224:        d40042a2         hvc        #0x215
- 228:        d404dac3         smc        #0x26d6
- 22c:        d4224d40         brk        #0x126a
- 230:        d44219c0         hlt        #0x10ce
- 234:        d503201f         nop
- 238:        d69f03e0         eret
- 23c:        d6bf03e0         drps
- 240:        d5033fdf         isb
- 244:        d503339f         dsb        osh
- 248:        d50335bf         dmb        nshld
- 24c:        d61f0280         br        x20
- 250:        d63f0040         blr        x2
- 254:        c8127c17         stxr        w18, x23, [x0]
- 258:        c81efec5         stlxr        w30, x5, [x22]
- 25c:        c85f7d05         ldxr        x5, [x8]
- 260:        c85ffe14         ldaxr        x20, [x16]
- 264:        c89ffd66         stlr        x6, [x11]
- 268:        c8dfff66         ldar        x6, [x27]
- 26c:        880a7cb1         stxr        w10, w17, [x5]
- 270:        8816fd89         stlxr        w22, w9, [x12]
- 274:        885f7d1b         ldxr        w27, [x8]
- 278:        885ffc57         ldaxr        w23, [x2]
- 27c:        889fffba         stlr        w26, [x29]
- 280:        88dffd4d         ldar        w13, [x10]
- 284:        48197f7c         stxrh        w25, w28, [x27]
- 288:        481dfd96         stlxrh        w29, w22, [x12]
- 28c:        485f7f96         ldxrh        w22, [x28]
- 290:        485fffc3         ldaxrh        w3, [x30]
- 294:        489ffdf8         stlrh        w24, [x15]
- 298:        48dfff5b         ldarh        w27, [x26]
- 29c:        080b7e6a         stxrb        w11, w10, [x19]
- 2a0:        0817fedb         stlxrb        w23, w27, [x22]
- 2a4:        085f7e18         ldxrb        w24, [x16]
- 2a8:        085ffc38         ldaxrb        w24, [x1]
- 2ac:        089fffa5         stlrb        w5, [x29]
- 2b0:        08dffe18         ldarb        w24, [x16]
- 2b4:        c87f6239         ldxp        x25, x24, [x17]
- 2b8:        c87fb276         ldaxp        x22, x12, [x19]
- 2bc:        c820573a         stxp        w0, x26, x21, [x25]
- 2c0:        c821aca6         stlxp        w1, x6, x11, [x5]
- 2c4:        887f388d         ldxp        w13, w14, [x4]
- 2c8:        887f88d1         ldaxp        w17, w2, [x6]
- 2cc:        882f2643         stxp        w15, w3, w9, [x18]
- 2d0:        88329131         stlxp        w18, w17, w4, [x9]
- 2d4:        f81cf2b7         stur        x23, [x21, #-49]
- 2d8:        b803f055         stur        w21, [x2, #63]
- 2dc:        39002f9b         strb        w27, [x28, #11]
- 2e0:        781f31fd         sturh        w29, [x15, #-13]
- 2e4:        f85d33ce         ldur        x14, [x30, #-45]
- 2e8:        b843539d         ldur        w29, [x28, #53]
- 2ec:        39401f54         ldrb        w20, [x26, #7]
- 2f0:        785ce059         ldurh        w25, [x2, #-50]
- 2f4:        389f1143         ldursb        x3, [x10, #-15]
- 2f8:        788131ee         ldursh        x14, [x15, #19]
- 2fc:        78dfb17d         ldursh        w29, [x11, #-5]
- 300:        b89b90af         ldursw        x15, [x5, #-71]
- 304:        fc403193         ldur        d19, [x12, #3]
- 308:        bc42a36c         ldur        s12, [x27, #42]
- 30c:        fc07d396         stur        d22, [x28, #125]
- 310:        bc1ec1f8         stur        s24, [x15, #-20]
- 314:        f81e8f88         str        x8, [x28, #-24]!
- 318:        b8025de6         str        w6, [x15, #37]!
- 31c:        38007c27         strb        w7, [x1, #7]!
- 320:        7801ee20         strh        w0, [x17, #30]!
- 324:        f8454fb9         ldr        x25, [x29, #84]!
- 328:        b85cce9a         ldr        w26, [x20, #-52]!
- 32c:        385e7fba         ldrb        w26, [x29, #-25]!
- 330:        7841af24         ldrh        w4, [x25, #26]!
- 334:        389ebd1c         ldrsb        x28, [x8, #-21]!
- 338:        789fadd1         ldrsh        x17, [x14, #-6]!
- 33c:        78c0aefc         ldrsh        w28, [x23, #10]!
- 340:        b89c0f7e         ldrsw        x30, [x27, #-64]!
- 344:        fc50efd4         ldr        d20, [x30, #-242]!
- 348:        bc414f71         ldr        s17, [x27, #20]!
- 34c:        fc011c67         str        d7, [x3, #17]!
- 350:        bc1f0d6d         str        s13, [x11, #-16]!
- 354:        f81c3526         str        x6, [x9], #-61
- 358:        b81e34b0         str        w16, [x5], #-29
- 35c:        3800f7bd         strb        w29, [x29], #15
- 360:        78012684         strh        w4, [x20], #18
- 364:        f842e653         ldr        x19, [x18], #46
- 368:        b8417456         ldr        w22, [x2], #23
- 36c:        385e2467         ldrb        w7, [x3], #-30
- 370:        785e358b         ldrh        w11, [x12], #-29
- 374:        389e34c8         ldrsb        x8, [x6], #-29
- 378:        788046f8         ldrsh        x24, [x23], #4
- 37c:        78c00611         ldrsh        w17, [x16], #0
- 380:        b89f8680         ldrsw        x0, [x20], #-8
- 384:        fc582454         ldr        d20, [x2], #-126
- 388:        bc5987d3         ldr        s19, [x30], #-104
- 38c:        fc076624         str        d4, [x17], #118
- 390:        bc190675         str        s21, [x19], #-112
- 394:        f833785a         str        x26, [x2, x19, lsl #3]
- 398:        b82fd809         str        w9, [x0, w15, sxtw #2]
- 39c:        3821799a         strb        w26, [x12, x1, lsl #0]
- 3a0:        782a7975         strh        w21, [x11, x10, lsl #1]
- 3a4:        f870eaf0         ldr        x16, [x23, x16, sxtx]
- 3a8:        b871d96a         ldr        w10, [x11, w17, sxtw #2]
- 3ac:        386b7aed         ldrb        w13, [x23, x11, lsl #0]
- 3b0:        7875689b         ldrh        w27, [x4, x21]
- 3b4:        38afd91a         ldrsb        x26, [x8, w15, sxtw #0]
- 3b8:        78a2c955         ldrsh        x21, [x10, w2, sxtw]
- 3bc:        78ee6bc8         ldrsh        w8, [x30, x14]
- 3c0:        b8b4f9dd         ldrsw        x29, [x14, x20, sxtx #2]
- 3c4:        fc76eb7e         ldr        d30, [x27, x22, sxtx]
- 3c8:        bc76692d         ldr        s13, [x9, x22]
- 3cc:        fc31db28         str        d8, [x25, w17, sxtw #3]
- 3d0:        bc255b01         str        s1, [x24, w5, uxtw #2]
- 3d4:        f91c52aa         str        x10, [x21, #14496]
- 3d8:        b91c3fb2         str        w18, [x29, #7228]
- 3dc:        391f8877         strb        w23, [x3, #2018]
- 3e0:        791ac97c         strh        w28, [x11, #3428]
- 3e4:        f95c1758         ldr        x24, [x26, #14376]
- 3e8:        b95b3c55         ldr        w21, [x2, #6972]
- 3ec:        395ce0a4         ldrb        w4, [x5, #1848]
- 3f0:        795851ce         ldrh        w14, [x14, #3112]
- 3f4:        399e9f64         ldrsb        x4, [x27, #1959]
- 3f8:        79993764         ldrsh        x4, [x27, #3226]
- 3fc:        79d9af8a         ldrsh        w10, [x28, #3286]
- 400:        b99eea2a         ldrsw        x10, [x17, #7912]
- 404:        fd5a2f8d         ldr        d13, [x28, #13400]
- 408:        bd5dac78         ldr        s24, [x3, #7596]
- 40c:        fd1e0182         str        d2, [x12, #15360]
- 410:        bd195c31         str        s17, [x1, #6492]
- 414:        58000010         ldr        x16, 414 <back+0x414>
- 418:        1800000d         ldr        w13, 418 <back+0x418>
- 41c:        f8981240         prfum        pldl1keep, [x18, #-127]
- 420:        d8ffdf00         prfm        pldl1keep, 0 <back>
- 424:        f8a27a80         prfm        pldl1keep, [x20, x2, lsl #3]
- 428:        f99af920         prfm        pldl1keep, [x9, #13808]
- 42c:        1a0202e8         adc        w8, w23, w2
- 430:        3a130078         adcs        w24, w3, w19
- 434:        5a1d0316         sbc        w22, w24, w29
- 438:        7a03036c         sbcs        w12, w27, w3
- 43c:        9a0102eb         adc        x11, x23, x1
- 440:        ba1700bd         adcs        x29, x5, x23
- 444:        da0c0329         sbc        x9, x25, x12
- 448:        fa16000c         sbcs        x12, x0, x22
- 44c:        0b23459a         add        w26, w12, w3, uxtw #1
- 450:        2b328a14         adds        w20, w16, w18, sxtb #2
- 454:        cb274bde         sub        x30, x30, w7, uxtw #2
- 458:        6b222eab         subs        w11, w21, w2, uxth #3
- 45c:        8b214b42         add        x2, x26, w1, uxtw #2
- 460:        ab34a7b2         adds        x18, x29, w20, sxth #1
- 464:        cb24520e         sub        x14, x16, w4, uxtw #4
- 468:        eb378e20         subs        x0, x17, w23, sxtb #3
- 46c:        3a565283         ccmn        w20, w22, #0x3, pl  // pl = nfrst
- 470:        7a420321         ccmp        w25, w2, #0x1, eq  // eq = none
- 474:        ba58c247         ccmn        x18, x24, #0x7, gt
- 478:        fa4d5106         ccmp        x8, x13, #0x6, pl  // pl = nfrst
- 47c:        3a426924         ccmn        w9, #0x2, #0x4, vs
- 480:        7a5b0847         ccmp        w2, #0x1b, #0x7, eq  // eq = none
- 484:        ba413a02         ccmn        x16, #0x1, #0x2, cc  // cc = lo, ul, last
- 488:        fa5fba23         ccmp        x17, #0x1f, #0x3, lt  // lt = tstop
- 48c:        1a979377         csel        w23, w27, w23, ls  // ls = plast
- 490:        1a86640a         csinc        w10, w0, w6, vs
- 494:        5a89300b         csinv        w11, w0, w9, cc  // cc = lo, ul, last
- 498:        5a923771         csneg        w17, w27, w18, cc  // cc = lo, ul, last
- 49c:        9a8b720c         csel        x12, x16, x11, vc
- 4a0:        9a868786         csinc        x6, x28, x6, hi  // hi = pmore
- 4a4:        da9a736d         csinv        x13, x27, x26, vc
- 4a8:        da9256dd         csneg        x29, x22, x18, pl  // pl = nfrst
- 4ac:        5ac0026c         rbit        w12, w19
- 4b0:        5ac00657         rev16        w23, w18
- 4b4:        5ac00b89         rev        w9, w28
- 4b8:        5ac01262         clz        w2, w19
- 4bc:        5ac017b9         cls        w25, w29
- 4c0:        dac002e4         rbit        x4, x23
- 4c4:        dac0065d         rev16        x29, x18
- 4c8:        dac00907         rev32        x7, x8
- 4cc:        dac00e2d         rev        x13, x17
- 4d0:        dac01011         clz        x17, x0
- 4d4:        dac01752         cls        x18, x26
- 4d8:        1ad0098b         udiv        w11, w12, w16
- 4dc:        1ac70d24         sdiv        w4, w9, w7
- 4e0:        1ad020ec         lsl        w12, w7, w16
- 4e4:        1ad72613         lsr        w19, w16, w23
- 4e8:        1ac62887         asr        w7, w4, w6
- 4ec:        1ad72e95         ror        w21, w20, w23
- 4f0:        9adc0990         udiv        x16, x12, x28
- 4f4:        9acd0d84         sdiv        x4, x12, x13
- 4f8:        9ac721a9         lsl        x9, x13, x7
- 4fc:        9acf277c         lsr        x28, x27, x15
- 500:        9ace2bd4         asr        x20, x30, x14
- 504:        9ade2e4e         ror        x14, x18, x30
- 508:        9bc77d63         umulh        x3, x11, x7
- 50c:        9b587e97         smulh        x23, x20, x24
- 510:        1b1524a2         madd        w2, w5, w21, w9
- 514:        1b04a318         msub        w24, w24, w4, w8
- 518:        9b0f4d8b         madd        x11, x12, x15, x19
- 51c:        9b0ce73d         msub        x29, x25, x12, x25
- 520:        9b2c5971         smaddl        x17, w11, w12, x22
- 524:        9b34c87c         smsubl        x28, w3, w20, x18
- 528:        9bbc6887         umaddl        x7, w4, w28, x26
- 52c:        9bb19556         umsubl        x22, w10, w17, x5
- 530:        1e310871         fmul        s17, s3, s17
- 534:        1e261a2b         fdiv        s11, s17, s6
- 538:        1e2928fd         fadd        s29, s7, s9
- 53c:        1e333987         fsub        s7, s12, s19
- 540:        1e230ae0         fmul        s0, s23, s3
- 544:        1e75087a         fmul        d26, d3, d21
- 548:        1e651a60         fdiv        d0, d19, d5
- 54c:        1e692b40         fadd        d0, d26, d9
- 550:        1e753ab9         fsub        d25, d21, d21
- 554:        1e7309b0         fmul        d16, d13, d19
- 558:        1f00425d         fmadd        s29, s18, s0, s16
- 55c:        1f1d95b7         fmsub        s23, s13, s29, s5
- 560:        1f2a38e9         fnmadd        s9, s7, s10, s14
- 564:        1f2f5f99         fnmadd        s25, s28, s15, s23
- 568:        1f5545a6         fmadd        d6, d13, d21, d17
- 56c:        1f429ea3         fmsub        d3, d21, d2, d7
- 570:        1f65472a         fnmadd        d10, d25, d5, d17
- 574:        1f7449ce         fnmadd        d14, d14, d20, d18
- 578:        1e20404f         fmov        s15, s2
- 57c:        1e20c0f2         fabs        s18, s7
- 580:        1e2140c3         fneg        s3, s6
- 584:        1e21c02c         fsqrt        s12, s1
- 588:        1e22c009         fcvt        d9, s0
- 58c:        1e6040a4         fmov        d4, d5
- 590:        1e60c1e3         fabs        d3, d15
- 594:        1e614331         fneg        d17, d25
- 598:        1e61c30c         fsqrt        d12, d24
- 59c:        1e6240b5         fcvt        s21, d5
- 5a0:        1e3802a4         fcvtzs        w4, s21
- 5a4:        9e38007b         fcvtzs        x27, s3
- 5a8:        1e78011d         fcvtzs        w29, d8
- 5ac:        9e7802a9         fcvtzs        x9, d21
- 5b0:        1e2203b4         scvtf        s20, w29
- 5b4:        9e220107         scvtf        s7, x8
- 5b8:        1e6202ac         scvtf        d12, w21
- 5bc:        9e6202b0         scvtf        d16, x21
- 5c0:        1e2600b2         fmov        w18, s5
- 5c4:        9e660119         fmov        x25, d8
- 5c8:        1e270352         fmov        s18, w26
- 5cc:        9e670160         fmov        d0, x11
- 5d0:        1e262200         fcmp        s16, s6
- 5d4:        1e7d2200         fcmp        d16, d29
- 5d8:        1e2023c8         fcmp        s30, #0.0
- 5dc:        1e602128         fcmp        d9, #0.0
- 5e0:        293e119b         stp        w27, w4, [x12, #-16]
- 5e4:        294a2543         ldp        w3, w9, [x10, #80]
- 5e8:        69480c70         ldpsw        x16, x3, [x3, #64]
- 5ec:        a934726a         stp        x10, x28, [x19, #-192]
- 5f0:        a97448f3         ldp        x19, x18, [x7, #-192]
- 5f4:        298243ca         stp        w10, w16, [x30, #16]!
- 5f8:        29e21242         ldp        w2, w4, [x18, #-240]!
- 5fc:        69c64db8         ldpsw        x24, x19, [x13, #48]!
- 600:        a9800311         stp        x17, x0, [x24, #0]!
- 604:        a9f4686e         ldp        x14, x26, [x3, #-192]!
- 608:        288a0416         stp        w22, w1, [x0], #80
- 60c:        28fe2812         ldp        w18, w10, [x0], #-16
- 610:        68fe62d8         .inst        0x68fe62d8 ; undefined
- 614:        a885308c         stp        x12, x12, [x4], #80
- 618:        a8f12664         ldp        x4, x9, [x19], #-240
- 61c:        282468d2         stnp        w18, w26, [x6, #-224]
- 620:        284e5035         ldnp        w21, w20, [x1, #112]
- 624:        a8327699         stnp        x25, x29, [x20, #-224]
- 628:        a84716e1         ldnp        x1, x5, [x23, #112]
- 62c:        0c407284         ld1        {v4.8b}, [x20]
- 630:        4cdfa158         ld1        {v24.16b, v25.16b}, [x10], #32
- 634:        0ccf6cd8         ld1        {v24.1d-v26.1d}, [x6], x15
- 638:        4cdf2483         ld1        {v3.8h-v6.8h}, [x4], #64
- 63c:        0d40c0c2         ld1r        {v2.8b}, [x6]
- 640:        4ddfc9cd         ld1r        {v13.4s}, [x14], #4
- 644:        0dd8ceaf         ld1r        {v15.1d}, [x21], x24
- 648:        4c408ea9         ld2        {v9.2d, v10.2d}, [x21]
- 64c:        0cdf86bd         ld2        {v29.4h, v30.4h}, [x21], #16
- 650:        4d60c1c8         ld2r        {v8.16b, v9.16b}, [x14]
- 654:        0dffca87         ld2r        {v7.2s, v8.2s}, [x20], #8
- 658:        4de3cc7c         ld2r        {v28.2d, v29.2d}, [x3], x3
- 65c:        4cdd497b         ld3        {v27.4s-v29.4s}, [x11], x29
- 660:        0c404950         ld3        {v16.2s-v18.2s}, [x10]
- 664:        4d40e595         ld3r        {v21.8h-v23.8h}, [x12]
- 668:        4ddfeba4         ld3r        {v4.4s-v6.4s}, [x29], #12
- 66c:        0dd3ed38         ld3r        {v24.1d-v26.1d}, [x9], x19
- 670:        4cdf046a         ld4        {v10.8h-v13.8h}, [x3], #64
- 674:        0cc9039b         ld4        {v27.8b-v30.8b}, [x28], x9
- 678:        0d60e3d5         ld4r        {v21.8b-v24.8b}, [x30]
- 67c:        0dffe5d7         ld4r        {v23.4h-v26.4h}, [x14], #8
- 680:        0df4e9a4         ld4r        {v4.2s-v7.2s}, [x13], x20
- 684:        ba5fd3e3         ccmn        xzr, xzr, #0x3, le
- 688:        3a5f03e5         ccmn        wzr, wzr, #0x5, eq  // eq = none
- 68c:        fa411be4         ccmp        xzr, #0x1, #0x4, ne  // ne = any
- 690:        7a42cbe2         ccmp        wzr, #0x2, #0x2, gt
- 694:        93df03ff         ror        xzr, xzr, #0
- 698:        c820ffff         stlxp        w0, xzr, xzr, [sp]
- 69c:        8822fc7f         stlxp        w2, wzr, wzr, [x3]
- 6a0:        c8247cbf         stxp        w4, xzr, xzr, [x5]
- 6a4:        88267fff         stxp        w6, wzr, wzr, [sp]
- 6a8:        4e010fe0         dup        v0.16b, wzr
- 6ac:        4e081fe1         mov        v1.d[0], xzr
- 6b0:        4e0c1fe1         mov        v1.s[1], wzr
- 6b4:        4e0a1fe1         mov        v1.h[2], wzr
- 6b8:        4e071fe1         mov        v1.b[3], wzr
- 6bc:        4cc0ac3f         ld1        {v31.2d, v0.2d}, [x1], x0
- 6c0:        1e601000         fmov        d0, #2.000000000000000000e+00
- 6c4:        1e603000         fmov        d0, #2.125000000000000000e+00
- 6c8:        1e621000         fmov        d0, #4.000000000000000000e+00
- 6cc:        1e623000         fmov        d0, #4.250000000000000000e+00
- 6d0:        1e641000         fmov        d0, #8.000000000000000000e+00
- 6d4:        1e643000         fmov        d0, #8.500000000000000000e+00
- 6d8:        1e661000         fmov        d0, #1.600000000000000000e+01
- 6dc:        1e663000         fmov        d0, #1.700000000000000000e+01
- 6e0:        1e681000         fmov        d0, #1.250000000000000000e-01
- 6e4:        1e683000         fmov        d0, #1.328125000000000000e-01
- 6e8:        1e6a1000         fmov        d0, #2.500000000000000000e-01
- 6ec:        1e6a3000         fmov        d0, #2.656250000000000000e-01
- 6f0:        1e6c1000         fmov        d0, #5.000000000000000000e-01
- 6f4:        1e6c3000         fmov        d0, #5.312500000000000000e-01
- 6f8:        1e6e1000         fmov        d0, #1.000000000000000000e+00
- 6fc:        1e6e3000         fmov        d0, #1.062500000000000000e+00
- 700:        1e701000         fmov        d0, #-2.000000000000000000e+00
- 704:        1e703000         fmov        d0, #-2.125000000000000000e+00
- 708:        1e721000         fmov        d0, #-4.000000000000000000e+00
- 70c:        1e723000         fmov        d0, #-4.250000000000000000e+00
- 710:        1e741000         fmov        d0, #-8.000000000000000000e+00
- 714:        1e743000         fmov        d0, #-8.500000000000000000e+00
- 718:        1e761000         fmov        d0, #-1.600000000000000000e+01
- 71c:        1e763000         fmov        d0, #-1.700000000000000000e+01
- 720:        1e781000         fmov        d0, #-1.250000000000000000e-01
- 724:        1e783000         fmov        d0, #-1.328125000000000000e-01
- 728:        1e7a1000         fmov        d0, #-2.500000000000000000e-01
- 72c:        1e7a3000         fmov        d0, #-2.656250000000000000e-01
- 730:        1e7c1000         fmov        d0, #-5.000000000000000000e-01
- 734:        1e7c3000         fmov        d0, #-5.312500000000000000e-01
- 738:        1e7e1000         fmov        d0, #-1.000000000000000000e+00
- 73c:        1e7e3000         fmov        d0, #-1.062500000000000000e+00
- 740:        f8358305         swp        x21, x5, [x24]
- 744:        f82d01ed         ldadd        x13, x13, [x15]
- 748:        f8361353         ldclr        x22, x19, [x26]
- 74c:        f839234a         ldeor        x25, x10, [x26]
- 750:        f82531fb         ldset        x5, x27, [x15]
- 754:        f8335165         ldsmin        x19, x5, [x11]
- 758:        f83a4080         ldsmax        x26, x0, [x4]
- 75c:        f83673d7         ldumin        x22, x23, [x30]
- 760:        f832611c         ldumax        x18, x28, [x8]
- 764:        f8ad837d         swpa        x13, x29, [x27]
- 768:        f8ab01a5         ldadda        x11, x5, [x13]
- 76c:        f8a112b8         ldclra        x1, x24, [x21]
- 770:        f8bb2311         ldeora        x27, x17, [x24]
- 774:        f8b230be         ldseta        x18, x30, [x5]
- 778:        f8a75336         ldsmina        x7, x22, [x25]
- 77c:        f8a4427a         ldsmaxa        x4, x26, [x19]
- 780:        f8a6707e         ldumina        x6, x30, [x3]
- 784:        f8b860b7         ldumaxa        x24, x23, [x5]
- 788:        f8f88392         swpal        x24, x18, [x28]
- 78c:        f8f300ff         ldaddal        x19, xzr, [x7]
- 790:        f8ed1386         ldclral        x13, x6, [x28]
- 794:        f8e822af         ldeoral        x8, x15, [x21]
- 798:        f8e2302d         ldsetal        x2, x13, [x1]
- 79c:        f8f1533d         ldsminal        x17, x29, [x25]
- 7a0:        f8f941d2         ldsmaxal        x25, x18, [x14]
- 7a4:        f8ff7366         lduminal        xzr, x6, [x27]
- 7a8:        f8f061e5         ldumaxal        x16, x5, [x15]
- 7ac:        f86b8072         swpl        x11, x18, [x3]
- 7b0:        f87a0054         ldaddl        x26, x20, [x2]
- 7b4:        f86b1164         ldclrl        x11, x4, [x11]
- 7b8:        f87e22f3         ldeorl        x30, x19, [x23]
- 7bc:        f86331cf         ldsetl        x3, x15, [x14]
- 7c0:        f87e5296         ldsminl        x30, x22, [x20]
- 7c4:        f8674305         ldsmaxl        x7, x5, [x24]
- 7c8:        f87771f0         lduminl        x23, x16, [x15]
- 7cc:        f86b6013         ldumaxl        x11, x19, [x0]
- 7d0:        b83c803c         swp        w28, w28, [x1]
- 7d4:        b82b0195         ldadd        w11, w21, [x12]
- 7d8:        b83d1240         ldclr        w29, w0, [x18]
- 7dc:        b8252320         ldeor        w5, w0, [x25]
- 7e0:        b82e3340         ldset        w14, w0, [x26]
- 7e4:        b83c53b2         ldsmin        w28, w18, [x29]
- 7e8:        b82f43a1         ldsmax        w15, w1, [x29]
- 7ec:        b828739a         ldumin        w8, w26, [x28]
- 7f0:        b831608e         ldumax        w17, w14, [x4]
- 7f4:        b8b88039         swpa        w24, w25, [x1]
- 7f8:        b8aa0231         ldadda        w10, w17, [x17]
- 7fc:        b8bd12b4         ldclra        w29, w20, [x21]
- 800:        b8bd2189         ldeora        w29, w9, [x12]
- 804:        b8ab30a6         ldseta        w11, w6, [x5]
- 808:        b8b552a7         ldsmina        w21, w7, [x21]
- 80c:        b8aa4197         ldsmaxa        w10, w23, [x12]
- 810:        b8b57145         ldumina        w21, w5, [x10]
- 814:        b8be6254         ldumaxa        w30, w20, [x18]
- 818:        b8ed80b7         swpal        w13, w23, [x5]
- 81c:        b8ef00b8         ldaddal        w15, w24, [x5]
- 820:        b8e9132a         ldclral        w9, w10, [x25]
- 824:        b8f42231         ldeoral        w20, w17, [x17]
- 828:        b8ec33d2         ldsetal        w12, w18, [x30]
- 82c:        b8e35323         ldsminal        w3, w3, [x25]
- 830:        b8fa4159         ldsmaxal        w26, w25, [x10]
- 834:        b8e273eb         lduminal        w2, w11, [sp]
- 838:        b8e760a2         ldumaxal        w7, w2, [x5]
- 83c:        b8608287         swpl        w0, w7, [x20]
- 840:        b865005f         staddl        w5, [x2]
- 844:        b87b1379         ldclrl        w27, w25, [x27]
- 848:        b87e2358         ldeorl        w30, w24, [x26]
- 84c:        b86f32c2         ldsetl        w15, w2, [x22]
- 850:        b86053e3         ldsminl        w0, w3, [sp]
- 854:        b86f4154         ldsmaxl        w15, w20, [x10]
- 858:        b87671d5         lduminl        w22, w21, [x14]
- 85c:        b866605e         ldumaxl        w6, w30, [x2]
+   0: 8b18ec0f  add x15, x0, x24, lsl #59
+   4: cb9636d1  sub x17, x22, x22, asr #13
+   8: ab1ce74a  adds  x10, x26, x28, lsl #57
+   c: eb184a19  subs  x25, x16, x24, lsl #18
+  10: 0b1c1ca8  add w8, w5, w28, lsl #7
+  14: 4b817388  sub w8, w28, w1, asr #28
+  18: 2b01004c  adds  w12, w2, w1
+  1c: 6b5164b7  subs  w23, w5, w17, lsr #25
+  20: 8a0d5595  and x21, x12, x13, lsl #21
+  24: aa9791f5  orr x21, x15, x23, asr #36
+  28: ca9bc316  eor x22, x24, x27, asr #48
+  2c: ea82d1f6  ands  x22, x15, x2, asr #52
+  30: 0a980e21  and w1, w17, w24, asr #3
+  34: 2a862c45  orr w5, w2, w6, asr #11
+  38: 4a453037  eor w23, w1, w5, lsr #12
+  3c: 6a8e5180  ands  w0, w12, w14, asr #20
+  40: 8a621cc1  bic x1, x6, x2, lsr #7
+  44: aa24bd1e  orn x30, x8, x4, lsl #47
+  48: cab4d6d1  eon x17, x22, x20, asr #53
+  4c: eaa591fd  bics  x29, x15, x5, asr #36
+  50: 0a7d6efe  bic w30, w23, w29, lsr #27
+  54: 2a2253ac  orn w12, w29, w2, lsl #20
+  58: 4aa61187  eon w7, w12, w6, asr #4
+  5c: 6aa755b0  bics  w16, w13, w7, asr #21
+  60: 110b5a25  add w5, w17, #0x2d6
+  64: 31056e0a  adds  w10, w16, #0x15b
+  68: 510f48ba  sub w26, w5, #0x3d2
+  6c: 710ac715  subs  w21, w24, #0x2b1
+  70: 910f6e0a  add x10, x16, #0x3db
+  74: b10a65ef  adds  x15, x15, #0x299
+  78: d1009e98  sub x24, x20, #0x27
+  7c: f10131aa  subs  x10, x13, #0x4c
+  80: 121d4e67  and w7, w19, #0x7ffff8
+  84: 32043e25  orr w5, w17, #0xf0000fff
+  88: 52132390  eor w16, w28, #0x3fe000
+  8c: 72160b0e  ands  w14, w24, #0x1c00
+  90: 9273e76e  and x14, x27, #0xffffffffffffe07f
+  94: b256416c  orr x12, x11, #0x7fffc0000000000
+  98: d24b5002  eor x2, x0, #0xffe00000000003ff
+  9c: f266da8d  ands  x13, x20, #0xfffffffffc01ffff
+  a0: 14000000  b a0 <back+0xa0>
+  a4: 17ffffd7  b 0 <back>
+  a8: 140001ee  b 860 <forth>
+  ac: 94000000  bl  ac <back+0xac>
+  b0: 97ffffd4  bl  0 <back>
+  b4: 940001eb  bl  860 <forth>
+  b8: 3400000f  cbz w15, b8 <back+0xb8>
+  bc: 34fffa2f  cbz w15, 0 <back>
+  c0: 34003d0f  cbz w15, 860 <forth>
+  c4: 3500001c  cbnz  w28, c4 <back+0xc4>
+  c8: 35fff9dc  cbnz  w28, 0 <back>
+  cc: 35003cbc  cbnz  w28, 860 <forth>
+  d0: b400001b  cbz x27, d0 <back+0xd0>
+  d4: b4fff97b  cbz x27, 0 <back>
+  d8: b4003c5b  cbz x27, 860 <forth>
+  dc: b5000000  cbnz  x0, dc <back+0xdc>
+  e0: b5fff900  cbnz  x0, 0 <back>
+  e4: b5003be0  cbnz  x0, 860 <forth>
+  e8: 1000000d  adr x13, e8 <back+0xe8>
+  ec: 10fff8ad  adr x13, 0 <back>
+  f0: 10003b8d  adr x13, 860 <forth>
+  f4: 90000003  adrp  x3, 0 <back>
+  f8: 36380015  tbz w21, #7, f8 <back+0xf8>
+  fc: 363ff835  tbz w21, #7, 0 <back>
+ 100: 36383b15  tbz w21, #7, 860 <forth>
+ 104: 3748000f  tbnz  w15, #9, 104 <back+0x104>
+ 108: 374ff7cf  tbnz  w15, #9, 0 <back>
+ 10c: 37483aaf  tbnz  w15, #9, 860 <forth>
+ 110: 12a14bee  mov w14, #0xf5a0ffff              // #-173998081
+ 114: 5283bb51  mov w17, #0x1dda                  // #7642
+ 118: 72858ebb  movk  w27, #0x2c75
+ 11c: 92c98881  mov x1, #0xffffb3bbffffffff     // #-83854941487105
+ 120: d2aa50d4  mov x20, #0x52860000              // #1384513536
+ 124: f2afd9d4  movk  x20, #0x7ece, lsl #16
+ 128: 935c504d  sbfiz x13, x2, #36, #21
+ 12c: 33133e90  bfi w16, w20, #13, #16
+ 130: 5309196b  ubfiz w11, w11, #23, #7
+ 134: 93595482  sbfiz x2, x4, #39, #22
+ 138: b3424e0d  bfxil x13, x16, #2, #18
+ 13c: d3481728  ubfiz x8, x25, #56, #6
+ 140: 138a3b7d  extr  w29, w27, w10, #14
+ 144: 93c66286  extr  x6, x20, x6, #24
+ 148: 54000000  b.eq  148 <back+0x148>  // b.none
+ 14c: 54fff5a0  b.eq  0 <back>  // b.none
+ 150: 54003880  b.eq  860 <forth>  // b.none
+ 154: 54000001  b.ne  154 <back+0x154>  // b.any
+ 158: 54fff541  b.ne  0 <back>  // b.any
+ 15c: 54003821  b.ne  860 <forth>  // b.any
+ 160: 54000002  b.cs  160 <back+0x160>  // b.hs, b.nlast
+ 164: 54fff4e2  b.cs  0 <back>  // b.hs, b.nlast
+ 168: 540037c2  b.cs  860 <forth>  // b.hs, b.nlast
+ 16c: 54000002  b.cs  16c <back+0x16c>  // b.hs, b.nlast
+ 170: 54fff482  b.cs  0 <back>  // b.hs, b.nlast
+ 174: 54003762  b.cs  860 <forth>  // b.hs, b.nlast
+ 178: 54000003  b.cc  178 <back+0x178>  // b.lo, b.ul, b.last
+ 17c: 54fff423  b.cc  0 <back>  // b.lo, b.ul, b.last
+ 180: 54003703  b.cc  860 <forth>  // b.lo, b.ul, b.last
+ 184: 54000003  b.cc  184 <back+0x184>  // b.lo, b.ul, b.last
+ 188: 54fff3c3  b.cc  0 <back>  // b.lo, b.ul, b.last
+ 18c: 540036a3  b.cc  860 <forth>  // b.lo, b.ul, b.last
+ 190: 54000004  b.mi  190 <back+0x190>  // b.first
+ 194: 54fff364  b.mi  0 <back>  // b.first
+ 198: 54003644  b.mi  860 <forth>  // b.first
+ 19c: 54000005  b.pl  19c <back+0x19c>  // b.nfrst
+ 1a0: 54fff305  b.pl  0 <back>  // b.nfrst
+ 1a4: 540035e5  b.pl  860 <forth>  // b.nfrst
+ 1a8: 54000006  b.vs  1a8 <back+0x1a8>
+ 1ac: 54fff2a6  b.vs  0 <back>
+ 1b0: 54003586  b.vs  860 <forth>
+ 1b4: 54000007  b.vc  1b4 <back+0x1b4>
+ 1b8: 54fff247  b.vc  0 <back>
+ 1bc: 54003527  b.vc  860 <forth>
+ 1c0: 54000008  b.hi  1c0 <back+0x1c0>  // b.pmore
+ 1c4: 54fff1e8  b.hi  0 <back>  // b.pmore
+ 1c8: 540034c8  b.hi  860 <forth>  // b.pmore
+ 1cc: 54000009  b.ls  1cc <back+0x1cc>  // b.plast
+ 1d0: 54fff189  b.ls  0 <back>  // b.plast
+ 1d4: 54003469  b.ls  860 <forth>  // b.plast
+ 1d8: 5400000a  b.ge  1d8 <back+0x1d8>  // b.tcont
+ 1dc: 54fff12a  b.ge  0 <back>  // b.tcont
+ 1e0: 5400340a  b.ge  860 <forth>  // b.tcont
+ 1e4: 5400000b  b.lt  1e4 <back+0x1e4>  // b.tstop
+ 1e8: 54fff0cb  b.lt  0 <back>  // b.tstop
+ 1ec: 540033ab  b.lt  860 <forth>  // b.tstop
+ 1f0: 5400000c  b.gt  1f0 <back+0x1f0>
+ 1f4: 54fff06c  b.gt  0 <back>
+ 1f8: 5400334c  b.gt  860 <forth>
+ 1fc: 5400000d  b.le  1fc <back+0x1fc>
+ 200: 54fff00d  b.le  0 <back>
+ 204: 540032ed  b.le  860 <forth>
+ 208: 5400000e  b.al  208 <back+0x208>
+ 20c: 54ffefae  b.al  0 <back>
+ 210: 5400328e  b.al  860 <forth>
+ 214: 5400000f  b.nv  214 <back+0x214>
+ 218: 54ffef4f  b.nv  0 <back>
+ 21c: 5400322f  b.nv  860 <forth>
+ 220: d40d2881  svc #0x6944
+ 224: d40ea5c2  hvc #0x752e
+ 228: d40518a3  smc #0x28c5
+ 22c: d42eca40  brk #0x7652
+ 230: d44a2e60  hlt #0x5173
+ 234: d503201f  nop
+ 238: d69f03e0  eret
+ 23c: d6bf03e0  drps
+ 240: d5033fdf  isb
+ 244: d5033d9f  dsb ld
+ 248: d5033bbf  dmb ish
+ 24c: d61f0120  br  x9
+ 250: d63f0120  blr x9
+ 254: c8027d7d  stxr  w2, x29, [x11]
+ 258: c816ff85  stlxr w22, x5, [x28]
+ 25c: c85f7e8e  ldxr  x14, [x20]
+ 260: c85ffe7d  ldaxr x29, [x19]
+ 264: c89ffea6  stlr  x6, [x21]
+ 268: c8dffc73  ldar  x19, [x3]
+ 26c: 880c7f63  stxr  w12, w3, [x27]
+ 270: 8811fdfa  stlxr w17, w26, [x15]
+ 274: 885f7dcd  ldxr  w13, [x14]
+ 278: 885fff4c  ldaxr w12, [x26]
+ 27c: 889ffe28  stlr  w8, [x17]
+ 280: 88dfffd5  ldar  w21, [x30]
+ 284: 48007d6f  stxrh w0, w15, [x11]
+ 288: 4811fc34  stlxrh  w17, w20, [x1]
+ 28c: 485f7d1d  ldxrh w29, [x8]
+ 290: 485ffd91  ldaxrh  w17, [x12]
+ 294: 489ffc8b  stlrh w11, [x4]
+ 298: 48dffc90  ldarh w16, [x4]
+ 29c: 080e7c85  stxrb w14, w5, [x4]
+ 2a0: 081bfe11  stlxrb  w27, w17, [x16]
+ 2a4: 085f7f66  ldxrb w6, [x27]
+ 2a8: 085fff1b  ldaxrb  w27, [x24]
+ 2ac: 089ffe8a  stlrb w10, [x20]
+ 2b0: 08dfff49  ldarb w9, [x26]
+ 2b4: c87f7b85  ldxp  x5, x30, [x28]
+ 2b8: c87fa66a  ldaxp x10, x9, [x19]
+ 2bc: c82b5590  stxp  w11, x16, x21, [x12]
+ 2c0: c82adc94  stlxp w10, x20, x23, [x4]
+ 2c4: 887f0416  ldxp  w22, w1, [x0]
+ 2c8: 887f8503  ldaxp w3, w1, [x8]
+ 2cc: 88205fc9  stxp  w0, w9, w23, [x30]
+ 2d0: 8837c560  stlxp w23, w0, w17, [x11]
+ 2d4: f81e1146  stur  x6, [x10, #-31]
+ 2d8: b81fb007  stur  w7, [x0, #-5]
+ 2dc: 381f3205  sturb w5, [x16, #-13]
+ 2e0: 7801f27e  sturh w30, [x19, #31]
+ 2e4: f8477130  ldur  x16, [x9, #119]
+ 2e8: b843b208  ldur  w8, [x16, #59]
+ 2ec: 385f918a  ldurb w10, [x12, #-7]
+ 2f0: 785da12e  ldurh w14, [x9, #-38]
+ 2f4: 389f83d8  ldursb  x24, [x30, #-8]
+ 2f8: 78817087  ldursh  x7, [x4, #23]
+ 2fc: 78dd91d1  ldursh  w17, [x14, #-39]
+ 300: b89e136b  ldursw  x11, [x27, #-31]
+ 304: fc4410ec  ldur  d12, [x7, #65]
+ 308: bc5fe200  ldur  s0, [x16, #-2]
+ 30c: fc15f2ed  stur  d13, [x23, #-161]
+ 310: bc1c2075  stur  s21, [x3, #-62]
+ 314: f8064ca2  str x2, [x5, #100]!
+ 318: b81a4c29  str w9, [x1, #-92]!
+ 31c: 381fbfdb  strb  w27, [x30, #-5]!
+ 320: 7800cdfb  strh  w27, [x15, #12]!
+ 324: f852ce24  ldr x4, [x17, #-212]!
+ 328: b841eef5  ldr w21, [x23, #30]!
+ 32c: 385f9e2d  ldrb  w13, [x17, #-7]!
+ 330: 785cec19  ldrh  w25, [x0, #-50]!
+ 334: 389ebea1  ldrsb x1, [x21, #-21]!
+ 338: 789caebc  ldrsh x28, [x21, #-54]!
+ 33c: 78c02c8b  ldrsh w11, [x4, #2]!
+ 340: b883dd31  ldrsw x17, [x9, #61]!
+ 344: fc427e7d  ldr d29, [x19, #39]!
+ 348: bc5abed6  ldr s22, [x22, #-85]!
+ 34c: fc11ff29  str d9, [x25, #-225]!
+ 350: bc1f1c49  str s9, [x2, #-15]!
+ 354: f81be6ed  str x13, [x23], #-66
+ 358: b800a611  str w17, [x16], #10
+ 35c: 381e05c1  strb  w1, [x14], #-32
+ 360: 78006411  strh  w17, [x0], #6
+ 364: f855473b  ldr x27, [x25], #-172
+ 368: b85da72d  ldr w13, [x25], #-38
+ 36c: 385e372b  ldrb  w11, [x25], #-29
+ 370: 784144be  ldrh  w30, [x5], #20
+ 374: 389f94e9  ldrsb x9, [x7], #-7
+ 378: 789c2460  ldrsh x0, [x3], #-62
+ 37c: 78c1f5c7  ldrsh w7, [x14], #31
+ 380: b8827771  ldrsw x17, [x27], #39
+ 384: fc515491  ldr d17, [x4], #-235
+ 388: bc4226ba  ldr s26, [x21], #34
+ 38c: fc1c7625  str d5, [x17], #-57
+ 390: bc1935ad  str s13, [x13], #-109
+ 394: f824da06  str x6, [x16, w4, sxtw #3]
+ 398: b834db09  str w9, [x24, w20, sxtw #2]
+ 39c: 38237ba3  strb  w3, [x29, x3, lsl #0]
+ 3a0: 783e6a2a  strh  w10, [x17, x30]
+ 3a4: f867497b  ldr x27, [x11, w7, uxtw]
+ 3a8: b87949ee  ldr w14, [x15, w25, uxtw]
+ 3ac: 387379d8  ldrb  w24, [x14, x19, lsl #0]
+ 3b0: 7866c810  ldrh  w16, [x0, w6, sxtw]
+ 3b4: 38acd98a  ldrsb x10, [x12, w12, sxtw #0]
+ 3b8: 78b0499a  ldrsh x26, [x12, w16, uxtw]
+ 3bc: 78ee781a  ldrsh w26, [x0, x14, lsl #1]
+ 3c0: b8bbf971  ldrsw x17, [x11, x27, sxtx #2]
+ 3c4: fc73d803  ldr d3, [x0, w19, sxtw #3]
+ 3c8: bc6979fa  ldr s26, [x15, x9, lsl #2]
+ 3cc: fc30e9ab  str d11, [x13, x16, sxtx]
+ 3d0: bc355a7a  str s26, [x19, w21, uxtw #2]
+ 3d4: f91886a8  str x8, [x21, #12552]
+ 3d8: b918ef6a  str w10, [x27, #6380]
+ 3dc: 391b15db  strb  w27, [x14, #1733]
+ 3e0: 791ac0f0  strh  w16, [x7, #3424]
+ 3e4: f958753b  ldr x27, [x9, #12520]
+ 3e8: b95a1958  ldr w24, [x10, #6680]
+ 3ec: 395b3f18  ldrb  w24, [x24, #1743]
+ 3f0: 795800b4  ldrh  w20, [x5, #3072]
+ 3f4: 39988891  ldrsb x17, [x4, #1570]
+ 3f8: 799a81ae  ldrsh x14, [x13, #3392]
+ 3fc: 79dd172a  ldrsh w10, [x25, #3722]
+ 400: b9981342  ldrsw x2, [x26, #6160]
+ 404: fd5d21da  ldr d26, [x14, #14912]
+ 408: bd5e7c9c  ldr s28, [x4, #7804]
+ 40c: fd1b526e  str d14, [x19, #13984]
+ 410: bd18df97  str s23, [x28, #6364]
+ 414: 58002268  ldr x8, 860 <forth>
+ 418: 18ffdf51  ldr w17, 0 <back>
+ 41c: f8951080  prfum pldl1keep, [x4, #-175]
+ 420: d8000000  prfm  pldl1keep, 420 <back+0x420>
+ 424: f8a4c900  prfm  pldl1keep, [x8, w4, sxtw]
+ 428: f999e180  prfm  pldl1keep, [x12, #13248]
+ 42c: 1a150374  adc w20, w27, w21
+ 430: 3a060227  adcs  w7, w17, w6
+ 434: 5a1900c5  sbc w5, w6, w25
+ 438: 7a0e017e  sbcs  w30, w11, w14
+ 43c: 9a0b0223  adc x3, x17, x11
+ 440: ba110159  adcs  x25, x10, x17
+ 444: da170207  sbc x7, x16, x23
+ 448: fa050144  sbcs  x4, x10, x5
+ 44c: 0b2973c9  add w9, w30, w9, uxtx #4
+ 450: 2b30a8a0  adds  w0, w5, w16, sxth #2
+ 454: cb3b8baf  sub x15, x29, w27, sxtb #2
+ 458: 6b21f12b  subs  w11, w9, w1, sxtx #4
+ 45c: 8b264f02  add x2, x24, w6, uxtw #3
+ 460: ab3a70d3  adds  x19, x6, x26, uxtx #4
+ 464: cb39ef48  sub x8, x26, x25, sxtx #3
+ 468: eb29329a  subs  x26, x20, w9, uxth #4
+ 46c: 3a5a41a7  ccmn  w13, w26, #0x7, mi  // mi = first
+ 470: 7a54310f  ccmp  w8, w20, #0xf, cc  // cc = lo, ul, last
+ 474: ba4302c8  ccmn  x22, x3, #0x8, eq  // eq = none
+ 478: fa58a04a  ccmp  x2, x24, #0xa, ge  // ge = tcont
+ 47c: 3a50490d  ccmn  w8, #0x10, #0xd, mi  // mi = first
+ 480: 7a4c0a01  ccmp  w16, #0xc, #0x1, eq  // eq = none
+ 484: ba5f79e3  ccmn  x15, #0x1f, #0x3, vc
+ 488: fa4c0aef  ccmp  x23, #0xc, #0xf, eq  // eq = none
+ 48c: 1a9a30ee  csel  w14, w7, w26, cc  // cc = lo, ul, last
+ 490: 1a9ed763  csinc w3, w27, w30, le
+ 494: 5a9702ab  csinv w11, w21, w23, eq  // eq = none
+ 498: 5a95c7da  csneg w26, w30, w21, gt
+ 49c: 9a8d835c  csel  x28, x26, x13, hi  // hi = pmore
+ 4a0: 9a909471  csinc x17, x3, x16, ls  // ls = plast
+ 4a4: da8380ab  csinv x11, x5, x3, hi  // hi = pmore
+ 4a8: da93c461  csneg x1, x3, x19, gt
+ 4ac: 5ac00120  rbit  w0, w9
+ 4b0: 5ac005da  rev16 w26, w14
+ 4b4: 5ac00a2d  rev w13, w17
+ 4b8: 5ac0128b  clz w11, w20
+ 4bc: 5ac0163c  cls w28, w17
+ 4c0: dac0008d  rbit  x13, x4
+ 4c4: dac007c1  rev16 x1, x30
+ 4c8: dac009cd  rev32 x13, x14
+ 4cc: dac00d05  rev x5, x8
+ 4d0: dac01322  clz x2, x25
+ 4d4: dac01514  cls x20, x8
+ 4d8: 1adb0b35  udiv  w21, w25, w27
+ 4dc: 1ad00d4d  sdiv  w13, w10, w16
+ 4e0: 1ad1203c  lsl w28, w1, w17
+ 4e4: 1aca26f9  lsr w25, w23, w10
+ 4e8: 1ac72867  asr w7, w3, w7
+ 4ec: 1ace2fce  ror w14, w30, w14
+ 4f0: 9acf0acc  udiv  x12, x22, x15
+ 4f4: 9acd0f22  sdiv  x2, x25, x13
+ 4f8: 9ad522e7  lsl x7, x23, x21
+ 4fc: 9ac0258b  lsr x11, x12, x0
+ 500: 9adc293e  asr x30, x9, x28
+ 504: 9ad62cad  ror x13, x5, x22
+ 508: 9bc47ea5  umulh x5, x21, x4
+ 50c: 9b477c51  smulh x17, x2, x7
+ 510: 1b11318c  madd  w12, w12, w17, w12
+ 514: 1b01edfe  msub  w30, w15, w1, w27
+ 518: 9b117662  madd  x2, x19, x17, x29
+ 51c: 9b03fae4  msub  x4, x23, x3, x30
+ 520: 9b313eef  smaddl  x15, w23, w17, x15
+ 524: 9b21b59b  smsubl  x27, w12, w1, x13
+ 528: 9bac45a6  umaddl  x6, w13, w12, x17
+ 52c: 9ba6a839  umsubl  x25, w1, w6, x10
+ 530: 1e240871  fmul  s17, s3, s4
+ 534: 1e3518b0  fdiv  s16, s5, s21
+ 538: 1e312b63  fadd  s3, s27, s17
+ 53c: 1e2f3959  fsub  s25, s10, s15
+ 540: 1e200a2a  fmul  s10, s17, s0
+ 544: 1e630b5c  fmul  d28, d26, d3
+ 548: 1e7b1804  fdiv  d4, d0, d27
+ 54c: 1e6229dc  fadd  d28, d14, d2
+ 550: 1e773b4c  fsub  d12, d26, d23
+ 554: 1e610bcf  fmul  d15, d30, d1
+ 558: 1f0534a4  fmadd s4, s5, s5, s13
+ 55c: 1f1c85b5  fmsub s21, s13, s28, s1
+ 560: 1f3d1c71  fnmadd  s17, s3, s29, s7
+ 564: 1f3d6b37  fnmadd  s23, s25, s29, s26
+ 568: 1f5e68ee  fmadd d14, d7, d30, d26
+ 56c: 1f4aa4f6  fmsub d22, d7, d10, d9
+ 570: 1f6e24e7  fnmadd  d7, d7, d14, d9
+ 574: 1f6f630e  fnmadd  d14, d24, d15, d24
+ 578: 1e204056  fmov  s22, s2
+ 57c: 1e20c060  fabs  s0, s3
+ 580: 1e214229  fneg  s9, s17
+ 584: 1e21c178  fsqrt s24, s11
+ 588: 1e22c32f  fcvt  d15, s25
+ 58c: 1e604064  fmov  d4, d3
+ 590: 1e60c2da  fabs  d26, d22
+ 594: 1e61427e  fneg  d30, d19
+ 598: 1e61c1cc  fsqrt d12, d14
+ 59c: 1e6240f1  fcvt  s17, d7
+ 5a0: 1e3801d8  fcvtzs  w24, s14
+ 5a4: 9e38034d  fcvtzs  x13, s26
+ 5a8: 1e780022  fcvtzs  w2, d1
+ 5ac: 9e780165  fcvtzs  x5, d11
+ 5b0: 1e22026e  scvtf s14, w19
+ 5b4: 9e2202c1  scvtf s1, x22
+ 5b8: 1e62023b  scvtf d27, w17
+ 5bc: 9e620136  scvtf d22, x9
+ 5c0: 1e26006e  fmov  w14, s3
+ 5c4: 9e66022c  fmov  x12, d17
+ 5c8: 1e270368  fmov  s8, w27
+ 5cc: 9e67039d  fmov  d29, x28
+ 5d0: 1e3e2000  fcmp  s0, s30
+ 5d4: 1e692180  fcmp  d12, d9
+ 5d8: 1e202148  fcmp  s10, #0.0
+ 5dc: 1e602328  fcmp  d25, #0.0
+ 5e0: 292e7b68  stp w8, w30, [x27, #-144]
+ 5e4: 294a4f15  ldp w21, w19, [x24, #80]
+ 5e8: 69626c50  ldpsw x16, x27, [x2, #-240]
+ 5ec: a93814d5  stp x21, x5, [x6, #-128]
+ 5f0: a97e679d  ldp x29, x25, [x28, #-32]
+ 5f4: 29903408  stp w8, w13, [x0, #128]!
+ 5f8: 29ec5039  ldp w25, w20, [x1, #-160]!
+ 5fc: 69fc62ce  ldpsw x14, x24, [x22, #-32]!
+ 600: a98504d1  stp x17, x1, [x6, #80]!
+ 604: a9fc4735  ldp x21, x17, [x25, #-64]!
+ 608: 28b05691  stp w17, w21, [x20], #-128
+ 60c: 28c8705c  ldp w28, w28, [x2], #64
+ 610: 68e07953  ldpsw x19, x30, [x10], #-256
+ 614: a8bf3e31  stp x17, x15, [x17], #-16
+ 618: a8fe0331  ldp x17, x0, [x25], #-32
+ 61c: 283c170e  stnp  w14, w5, [x24, #-32]
+ 620: 284e4c37  ldnp  w23, w19, [x1, #112]
+ 624: a80419cb  stnp  x11, x6, [x14, #64]
+ 628: a8722f62  ldnp  x2, x11, [x27, #-224]
+ 62c: 0c407230  ld1 {v16.8b}, [x17]
+ 630: 4cdfa13d  ld1 {v29.16b, v30.16b}, [x9], #32
+ 634: 0cd56f1e  ld1 {v30.1d, v31.1d, v0.1d}, [x24], x21
+ 638: 4cdf2440  ld1 {v0.8h-v3.8h}, [x2], #64
+ 63c: 0d40c134  ld1r  {v20.8b}, [x9]
+ 640: 4ddfc811  ld1r  {v17.4s}, [x0], #4
+ 644: 0ddaced5  ld1r  {v21.1d}, [x22], x26
+ 648: 4c408f33  ld2 {v19.2d, v20.2d}, [x25]
+ 64c: 0cdf84aa  ld2 {v10.4h, v11.4h}, [x5], #16
+ 650: 4d60c30a  ld2r  {v10.16b, v11.16b}, [x24]
+ 654: 0dffcbad  ld2r  {v13.2s, v14.2s}, [x29], #8
+ 658: 4de2cf96  ld2r  {v22.2d, v23.2d}, [x28], x2
+ 65c: 4ccb489e  ld3 {v30.4s, v31.4s, v0.4s}, [x4], x11
+ 660: 0c40481d  ld3 {v29.2s-v31.2s}, [x0]
+ 664: 4d40e777  ld3r  {v23.8h-v25.8h}, [x27]
+ 668: 4ddfe943  ld3r  {v3.4s-v5.4s}, [x10], #12
+ 66c: 0dd6edd3  ld3r  {v19.1d-v21.1d}, [x14], x22
+ 670: 4cdf040e  ld4 {v14.8h-v17.8h}, [x0], #64
+ 674: 0cd902de  ld4 {v30.8b, v31.8b, v0.8b, v1.8b}, [x22], x25
+ 678: 0d60e019  ld4r  {v25.8b-v28.8b}, [x0]
+ 67c: 0dffe50a  ld4r  {v10.4h-v13.4h}, [x8], #8
+ 680: 0dfce8c1  ld4r  {v1.2s-v4.2s}, [x6], x28
+ 684: ba5fd3e3  ccmn  xzr, xzr, #0x3, le
+ 688: 3a5f03e5  ccmn  wzr, wzr, #0x5, eq  // eq = none
+ 68c: fa411be4  ccmp  xzr, #0x1, #0x4, ne  // ne = any
+ 690: 7a42cbe2  ccmp  wzr, #0x2, #0x2, gt
+ 694: 93df03ff  ror xzr, xzr, #0
+ 698: c820ffff  stlxp w0, xzr, xzr, [sp]
+ 69c: 8822fc7f  stlxp w2, wzr, wzr, [x3]
+ 6a0: c8247cbf  stxp  w4, xzr, xzr, [x5]
+ 6a4: 88267fff  stxp  w6, wzr, wzr, [sp]
+ 6a8: 4e010fe0  dup v0.16b, wzr
+ 6ac: 4e081fe1  mov v1.d[0], xzr
+ 6b0: 4e0c1fe1  mov v1.s[1], wzr
+ 6b4: 4e0a1fe1  mov v1.h[2], wzr
+ 6b8: 4e071fe1  mov v1.b[3], wzr
+ 6bc: 4cc0ac3f  ld1 {v31.2d, v0.2d}, [x1], x0
+ 6c0: 1e601000  fmov  d0, #2.000000000000000000e+00
+ 6c4: 1e603000  fmov  d0, #2.125000000000000000e+00
+ 6c8: 1e621000  fmov  d0, #4.000000000000000000e+00
+ 6cc: 1e623000  fmov  d0, #4.250000000000000000e+00
+ 6d0: 1e641000  fmov  d0, #8.000000000000000000e+00
+ 6d4: 1e643000  fmov  d0, #8.500000000000000000e+00
+ 6d8: 1e661000  fmov  d0, #1.600000000000000000e+01
+ 6dc: 1e663000  fmov  d0, #1.700000000000000000e+01
+ 6e0: 1e681000  fmov  d0, #1.250000000000000000e-01
+ 6e4: 1e683000  fmov  d0, #1.328125000000000000e-01
+ 6e8: 1e6a1000  fmov  d0, #2.500000000000000000e-01
+ 6ec: 1e6a3000  fmov  d0, #2.656250000000000000e-01
+ 6f0: 1e6c1000  fmov  d0, #5.000000000000000000e-01
+ 6f4: 1e6c3000  fmov  d0, #5.312500000000000000e-01
+ 6f8: 1e6e1000  fmov  d0, #1.000000000000000000e+00
+ 6fc: 1e6e3000  fmov  d0, #1.062500000000000000e+00
+ 700: 1e701000  fmov  d0, #-2.000000000000000000e+00
+ 704: 1e703000  fmov  d0, #-2.125000000000000000e+00
+ 708: 1e721000  fmov  d0, #-4.000000000000000000e+00
+ 70c: 1e723000  fmov  d0, #-4.250000000000000000e+00
+ 710: 1e741000  fmov  d0, #-8.000000000000000000e+00
+ 714: 1e743000  fmov  d0, #-8.500000000000000000e+00
+ 718: 1e761000  fmov  d0, #-1.600000000000000000e+01
+ 71c: 1e763000  fmov  d0, #-1.700000000000000000e+01
+ 720: 1e781000  fmov  d0, #-1.250000000000000000e-01
+ 724: 1e783000  fmov  d0, #-1.328125000000000000e-01
+ 728: 1e7a1000  fmov  d0, #-2.500000000000000000e-01
+ 72c: 1e7a3000  fmov  d0, #-2.656250000000000000e-01
+ 730: 1e7c1000  fmov  d0, #-5.000000000000000000e-01
+ 734: 1e7c3000  fmov  d0, #-5.312500000000000000e-01
+ 738: 1e7e1000  fmov  d0, #-1.000000000000000000e+00
+ 73c: 1e7e3000  fmov  d0, #-1.062500000000000000e+00
+ 740: f83081f4  swp x16, x20, [x15]
+ 744: f8220387  ldadd x2, x7, [x28]
+ 748: f834132a  ldclr x20, x10, [x25]
+ 74c: f836204b  ldeor x22, x11, [x2]
+ 750: f821326a  ldset x1, x10, [x19]
+ 754: f82e5075  ldsmin  x14, x21, [x3]
+ 758: f83c41bb  ldsmax  x28, x27, [x13]
+ 75c: f83172be  ldumin  x17, x30, [x21]
+ 760: f83b63b0  ldumax  x27, x16, [x29]
+ 764: f8be8009  swpa  x30, x9, [x0]
+ 768: f8bc039b  ldadda  x28, x27, [x28]
+ 76c: f8b51159  ldclra  x21, x25, [x10]
+ 770: f8bf21f4  ldeora  xzr, x20, [x15]
+ 774: f8a131d9  ldseta  x1, x25, [x14]
+ 778: f8b553ba  ldsmina x21, x26, [x29]
+ 77c: f8a8433d  ldsmaxa x8, x29, [x25]
+ 780: f8ad7322  ldumina x13, x2, [x25]
+ 784: f8af6017  ldumaxa x15, x23, [x0]
+ 788: f8e38041  swpal x3, x1, [x2]
+ 78c: f8fc0283  ldaddal x28, x3, [x20]
+ 790: f8ee11df  ldclral x14, xzr, [x14]
+ 794: f8e7205c  ldeoral x7, x28, [x2]
+ 798: f8e030ab  ldsetal x0, x11, [x5]
+ 79c: f8eb528e  ldsminal  x11, x14, [x20]
+ 7a0: f8ff4044  ldsmaxal  xzr, x4, [x2]
+ 7a4: f8fa72c0  lduminal  x26, x0, [x22]
+ 7a8: f8f161a1  ldumaxal  x17, x1, [x13]
+ 7ac: f877829a  swpl  x23, x26, [x20]
+ 7b0: f86e018b  ldaddl  x14, x11, [x12]
+ 7b4: f86c11ff  stclrl  x12, [x15]
+ 7b8: f87b210e  ldeorl  x27, x14, [x8]
+ 7bc: f86a333e  ldsetl  x10, x30, [x25]
+ 7c0: f8765207  ldsminl x22, x7, [x16]
+ 7c4: f8614110  ldsmaxl x1, x16, [x8]
+ 7c8: f8617341  lduminl x1, x1, [x26]
+ 7cc: f86061f7  ldumaxl x0, x23, [x15]
+ 7d0: b82b8110  swp w11, w16, [x8]
+ 7d4: b82101c7  ldadd w1, w7, [x14]
+ 7d8: b830113f  stclr w16, [x9]
+ 7dc: b83621a6  ldeor w22, w6, [x13]
+ 7e0: b82b308d  ldset w11, w13, [x4]
+ 7e4: b8305016  ldsmin  w16, w22, [x0]
+ 7e8: b83c415f  stsmax  w28, [x10]
+ 7ec: b8307105  ldumin  w16, w5, [x8]
+ 7f0: b83a61f4  ldumax  w26, w20, [x15]
+ 7f4: b8bb8206  swpa  w27, w6, [x16]
+ 7f8: b8bf005f  ldadda  wzr, wzr, [x2]
+ 7fc: b8b8111c  ldclra  w24, w28, [x8]
+ 800: b8af22e9  ldeora  w15, w9, [x23]
+ 804: b8ba30e2  ldseta  w26, w2, [x7]
+ 808: b8a351f1  ldsmina w3, w17, [x15]
+ 80c: b8b342a5  ldsmaxa w19, w5, [x21]
+ 810: b8a7719a  ldumina w7, w26, [x12]
+ 814: b8ac63a7  ldumaxa w12, w7, [x29]
+ 818: b8e98288  swpal w9, w8, [x20]
+ 81c: b8e803df  ldaddal w8, wzr, [x30]
+ 820: b8e01186  ldclral w0, w6, [x12]
+ 824: b8f12057  ldeoral w17, w23, [x2]
+ 828: b8e0303e  ldsetal w0, w30, [x1]
+ 82c: b8f651e3  ldsminal  w22, w3, [x15]
+ 830: b8f941b5  ldsmaxal  w25, w21, [x13]
+ 834: b8ed7378  lduminal  w13, w24, [x27]
+ 838: b8f46163  ldumaxal  w20, w3, [x11]
+ 83c: b86382ad  swpl  w3, w13, [x21]
+ 840: b87a034f  ldaddl  w26, w15, [x26]
+ 844: b8691053  ldclrl  w9, w19, [x2]
+ 848: b87820fd  ldeorl  w24, w29, [x7]
+ 84c: b87d31f9  ldsetl  w29, w25, [x15]
+ 850: b86b50fe  ldsminl w11, w30, [x7]
+ 854: b86b40c2  ldsmaxl w11, w2, [x6]
+ 858: b87071cb  lduminl w16, w11, [x14]
+ 85c: b8656168  ldumaxl w5, w8, [x11]
  */
 
   static const unsigned int insns[] =
   {
-    0x8b50798f,     0xcb4381e1,     0xab05372d,     0xeb864796,
-    0x0b961920,     0x4b195473,     0x2b0b5264,     0x6b9300f8,
-    0x8a0bc0fe,     0xaa0f3118,     0xca170531,     0xea44dd6e,
-    0x0a4c44f3,     0x2a8b7373,     0x4a567c7e,     0x6a9c0353,
-    0x8a3accdd,     0xaa318f7a,     0xca2e1495,     0xeaa015e2,
-    0x0a2274e2,     0x2a751598,     0x4a3309fe,     0x6ab172fe,
-    0x110a5284,     0x310b1942,     0x5103d353,     0x710125bc,
-    0x910d7bc2,     0xb108fa1b,     0xd1093536,     0xf10ae824,
-    0x120e667c,     0x321f6cbb,     0x520f6a9e,     0x72136f56,
-    0x927e4ce5,     0xb278b4ed,     0xd24c6527,     0xf2485803,
+    0x8b18ec0f,     0xcb9636d1,     0xab1ce74a,     0xeb184a19,
+    0x0b1c1ca8,     0x4b817388,     0x2b01004c,     0x6b5164b7,
+    0x8a0d5595,     0xaa9791f5,     0xca9bc316,     0xea82d1f6,
+    0x0a980e21,     0x2a862c45,     0x4a453037,     0x6a8e5180,
+    0x8a621cc1,     0xaa24bd1e,     0xcab4d6d1,     0xeaa591fd,
+    0x0a7d6efe,     0x2a2253ac,     0x4aa61187,     0x6aa755b0,
+    0x110b5a25,     0x31056e0a,     0x510f48ba,     0x710ac715,
+    0x910f6e0a,     0xb10a65ef,     0xd1009e98,     0xf10131aa,
+    0x121d4e67,     0x32043e25,     0x52132390,     0x72160b0e,
+    0x9273e76e,     0xb256416c,     0xd24b5002,     0xf266da8d,
     0x14000000,     0x17ffffd7,     0x140001ee,     0x94000000,
-    0x97ffffd4,     0x940001eb,     0x34000010,     0x34fffa30,
-    0x34003d10,     0x35000013,     0x35fff9d3,     0x35003cb3,
-    0xb4000005,     0xb4fff965,     0xb4003c45,     0xb5000004,
-    0xb5fff904,     0xb5003be4,     0x1000001b,     0x10fff8bb,
-    0x10003b9b,     0x90000010,     0x3640001c,     0x3647f83c,
-    0x36403b1c,     0x37080001,     0x370ff7c1,     0x37083aa1,
-    0x12a437f4,     0x528c9d67,     0x72838bb1,     0x92c1062e,
-    0xd287da49,     0xf2a6d153,     0x93465ac9,     0x330b0013,
-    0x530b4e6a,     0x934545e4,     0xb35370a3,     0xd3510b8c,
-    0x13960c0f,     0x93ceddc6,     0x54000000,     0x54fff5a0,
+    0x97ffffd4,     0x940001eb,     0x3400000f,     0x34fffa2f,
+    0x34003d0f,     0x3500001c,     0x35fff9dc,     0x35003cbc,
+    0xb400001b,     0xb4fff97b,     0xb4003c5b,     0xb5000000,
+    0xb5fff900,     0xb5003be0,     0x1000000d,     0x10fff8ad,
+    0x10003b8d,     0x90000003,     0x36380015,     0x363ff835,
+    0x36383b15,     0x3748000f,     0x374ff7cf,     0x37483aaf,
+    0x12a14bee,     0x5283bb51,     0x72858ebb,     0x92c98881,
+    0xd2aa50d4,     0xf2afd9d4,     0x935c504d,     0x33133e90,
+    0x5309196b,     0x93595482,     0xb3424e0d,     0xd3481728,
+    0x138a3b7d,     0x93c66286,     0x54000000,     0x54fff5a0,
     0x54003880,     0x54000001,     0x54fff541,     0x54003821,
     0x54000002,     0x54fff4e2,     0x540037c2,     0x54000002,
     0x54fff482,     0x54003762,     0x54000003,     0x54fff423,
@@ -1336,77 +1336,77 @@ Disassembly of section .text:
     0x5400000c,     0x54fff06c,     0x5400334c,     0x5400000d,
     0x54fff00d,     0x540032ed,     0x5400000e,     0x54ffefae,
     0x5400328e,     0x5400000f,     0x54ffef4f,     0x5400322f,
-    0xd40ac601,     0xd40042a2,     0xd404dac3,     0xd4224d40,
-    0xd44219c0,     0xd503201f,     0xd69f03e0,     0xd6bf03e0,
-    0xd5033fdf,     0xd503339f,     0xd50335bf,     0xd61f0280,
-    0xd63f0040,     0xc8127c17,     0xc81efec5,     0xc85f7d05,
-    0xc85ffe14,     0xc89ffd66,     0xc8dfff66,     0x880a7cb1,
-    0x8816fd89,     0x885f7d1b,     0x885ffc57,     0x889fffba,
-    0x88dffd4d,     0x48197f7c,     0x481dfd96,     0x485f7f96,
-    0x485fffc3,     0x489ffdf8,     0x48dfff5b,     0x080b7e6a,
-    0x0817fedb,     0x085f7e18,     0x085ffc38,     0x089fffa5,
-    0x08dffe18,     0xc87f6239,     0xc87fb276,     0xc820573a,
-    0xc821aca6,     0x887f388d,     0x887f88d1,     0x882f2643,
-    0x88329131,     0xf81cf2b7,     0xb803f055,     0x39002f9b,
-    0x781f31fd,     0xf85d33ce,     0xb843539d,     0x39401f54,
-    0x785ce059,     0x389f1143,     0x788131ee,     0x78dfb17d,
-    0xb89b90af,     0xfc403193,     0xbc42a36c,     0xfc07d396,
-    0xbc1ec1f8,     0xf81e8f88,     0xb8025de6,     0x38007c27,
-    0x7801ee20,     0xf8454fb9,     0xb85cce9a,     0x385e7fba,
-    0x7841af24,     0x389ebd1c,     0x789fadd1,     0x78c0aefc,
-    0xb89c0f7e,     0xfc50efd4,     0xbc414f71,     0xfc011c67,
-    0xbc1f0d6d,     0xf81c3526,     0xb81e34b0,     0x3800f7bd,
-    0x78012684,     0xf842e653,     0xb8417456,     0x385e2467,
-    0x785e358b,     0x389e34c8,     0x788046f8,     0x78c00611,
-    0xb89f8680,     0xfc582454,     0xbc5987d3,     0xfc076624,
-    0xbc190675,     0xf833785a,     0xb82fd809,     0x3821799a,
-    0x782a7975,     0xf870eaf0,     0xb871d96a,     0x386b7aed,
-    0x7875689b,     0x38afd91a,     0x78a2c955,     0x78ee6bc8,
-    0xb8b4f9dd,     0xfc76eb7e,     0xbc76692d,     0xfc31db28,
-    0xbc255b01,     0xf91c52aa,     0xb91c3fb2,     0x391f8877,
-    0x791ac97c,     0xf95c1758,     0xb95b3c55,     0x395ce0a4,
-    0x795851ce,     0x399e9f64,     0x79993764,     0x79d9af8a,
-    0xb99eea2a,     0xfd5a2f8d,     0xbd5dac78,     0xfd1e0182,
-    0xbd195c31,     0x58000010,     0x1800000d,     0xf8981240,
-    0xd8ffdf00,     0xf8a27a80,     0xf99af920,     0x1a0202e8,
-    0x3a130078,     0x5a1d0316,     0x7a03036c,     0x9a0102eb,
-    0xba1700bd,     0xda0c0329,     0xfa16000c,     0x0b23459a,
-    0x2b328a14,     0xcb274bde,     0x6b222eab,     0x8b214b42,
-    0xab34a7b2,     0xcb24520e,     0xeb378e20,     0x3a565283,
-    0x7a420321,     0xba58c247,     0xfa4d5106,     0x3a426924,
-    0x7a5b0847,     0xba413a02,     0xfa5fba23,     0x1a979377,
-    0x1a86640a,     0x5a89300b,     0x5a923771,     0x9a8b720c,
-    0x9a868786,     0xda9a736d,     0xda9256dd,     0x5ac0026c,
-    0x5ac00657,     0x5ac00b89,     0x5ac01262,     0x5ac017b9,
-    0xdac002e4,     0xdac0065d,     0xdac00907,     0xdac00e2d,
-    0xdac01011,     0xdac01752,     0x1ad0098b,     0x1ac70d24,
-    0x1ad020ec,     0x1ad72613,     0x1ac62887,     0x1ad72e95,
-    0x9adc0990,     0x9acd0d84,     0x9ac721a9,     0x9acf277c,
-    0x9ace2bd4,     0x9ade2e4e,     0x9bc77d63,     0x9b587e97,
-    0x1b1524a2,     0x1b04a318,     0x9b0f4d8b,     0x9b0ce73d,
-    0x9b2c5971,     0x9b34c87c,     0x9bbc6887,     0x9bb19556,
-    0x1e310871,     0x1e261a2b,     0x1e2928fd,     0x1e333987,
-    0x1e230ae0,     0x1e75087a,     0x1e651a60,     0x1e692b40,
-    0x1e753ab9,     0x1e7309b0,     0x1f00425d,     0x1f1d95b7,
-    0x1f2a38e9,     0x1f2f5f99,     0x1f5545a6,     0x1f429ea3,
-    0x1f65472a,     0x1f7449ce,     0x1e20404f,     0x1e20c0f2,
-    0x1e2140c3,     0x1e21c02c,     0x1e22c009,     0x1e6040a4,
-    0x1e60c1e3,     0x1e614331,     0x1e61c30c,     0x1e6240b5,
-    0x1e3802a4,     0x9e38007b,     0x1e78011d,     0x9e7802a9,
-    0x1e2203b4,     0x9e220107,     0x1e6202ac,     0x9e6202b0,
-    0x1e2600b2,     0x9e660119,     0x1e270352,     0x9e670160,
-    0x1e262200,     0x1e7d2200,     0x1e2023c8,     0x1e602128,
-    0x293e119b,     0x294a2543,     0x69480c70,     0xa934726a,
-    0xa97448f3,     0x298243ca,     0x29e21242,     0x69c64db8,
-    0xa9800311,     0xa9f4686e,     0x288a0416,     0x28fe2812,
-    0x68fe62d8,     0xa885308c,     0xa8f12664,     0x282468d2,
-    0x284e5035,     0xa8327699,     0xa84716e1,     0x0c407284,
-    0x4cdfa158,     0x0ccf6cd8,     0x4cdf2483,     0x0d40c0c2,
-    0x4ddfc9cd,     0x0dd8ceaf,     0x4c408ea9,     0x0cdf86bd,
-    0x4d60c1c8,     0x0dffca87,     0x4de3cc7c,     0x4cdd497b,
-    0x0c404950,     0x4d40e595,     0x4ddfeba4,     0x0dd3ed38,
-    0x4cdf046a,     0x0cc9039b,     0x0d60e3d5,     0x0dffe5d7,
-    0x0df4e9a4,     0xba5fd3e3,     0x3a5f03e5,     0xfa411be4,
+    0xd40d2881,     0xd40ea5c2,     0xd40518a3,     0xd42eca40,
+    0xd44a2e60,     0xd503201f,     0xd69f03e0,     0xd6bf03e0,
+    0xd5033fdf,     0xd5033d9f,     0xd5033bbf,     0xd61f0120,
+    0xd63f0120,     0xc8027d7d,     0xc816ff85,     0xc85f7e8e,
+    0xc85ffe7d,     0xc89ffea6,     0xc8dffc73,     0x880c7f63,
+    0x8811fdfa,     0x885f7dcd,     0x885fff4c,     0x889ffe28,
+    0x88dfffd5,     0x48007d6f,     0x4811fc34,     0x485f7d1d,
+    0x485ffd91,     0x489ffc8b,     0x48dffc90,     0x080e7c85,
+    0x081bfe11,     0x085f7f66,     0x085fff1b,     0x089ffe8a,
+    0x08dfff49,     0xc87f7b85,     0xc87fa66a,     0xc82b5590,
+    0xc82adc94,     0x887f0416,     0x887f8503,     0x88205fc9,
+    0x8837c560,     0xf81e1146,     0xb81fb007,     0x381f3205,
+    0x7801f27e,     0xf8477130,     0xb843b208,     0x385f918a,
+    0x785da12e,     0x389f83d8,     0x78817087,     0x78dd91d1,
+    0xb89e136b,     0xfc4410ec,     0xbc5fe200,     0xfc15f2ed,
+    0xbc1c2075,     0xf8064ca2,     0xb81a4c29,     0x381fbfdb,
+    0x7800cdfb,     0xf852ce24,     0xb841eef5,     0x385f9e2d,
+    0x785cec19,     0x389ebea1,     0x789caebc,     0x78c02c8b,
+    0xb883dd31,     0xfc427e7d,     0xbc5abed6,     0xfc11ff29,
+    0xbc1f1c49,     0xf81be6ed,     0xb800a611,     0x381e05c1,
+    0x78006411,     0xf855473b,     0xb85da72d,     0x385e372b,
+    0x784144be,     0x389f94e9,     0x789c2460,     0x78c1f5c7,
+    0xb8827771,     0xfc515491,     0xbc4226ba,     0xfc1c7625,
+    0xbc1935ad,     0xf824da06,     0xb834db09,     0x38237ba3,
+    0x783e6a2a,     0xf867497b,     0xb87949ee,     0x387379d8,
+    0x7866c810,     0x38acd98a,     0x78b0499a,     0x78ee781a,
+    0xb8bbf971,     0xfc73d803,     0xbc6979fa,     0xfc30e9ab,
+    0xbc355a7a,     0xf91886a8,     0xb918ef6a,     0x391b15db,
+    0x791ac0f0,     0xf958753b,     0xb95a1958,     0x395b3f18,
+    0x795800b4,     0x39988891,     0x799a81ae,     0x79dd172a,
+    0xb9981342,     0xfd5d21da,     0xbd5e7c9c,     0xfd1b526e,
+    0xbd18df97,     0x58002268,     0x18ffdf51,     0xf8951080,
+    0xd8000000,     0xf8a4c900,     0xf999e180,     0x1a150374,
+    0x3a060227,     0x5a1900c5,     0x7a0e017e,     0x9a0b0223,
+    0xba110159,     0xda170207,     0xfa050144,     0x0b2973c9,
+    0x2b30a8a0,     0xcb3b8baf,     0x6b21f12b,     0x8b264f02,
+    0xab3a70d3,     0xcb39ef48,     0xeb29329a,     0x3a5a41a7,
+    0x7a54310f,     0xba4302c8,     0xfa58a04a,     0x3a50490d,
+    0x7a4c0a01,     0xba5f79e3,     0xfa4c0aef,     0x1a9a30ee,
+    0x1a9ed763,     0x5a9702ab,     0x5a95c7da,     0x9a8d835c,
+    0x9a909471,     0xda8380ab,     0xda93c461,     0x5ac00120,
+    0x5ac005da,     0x5ac00a2d,     0x5ac0128b,     0x5ac0163c,
+    0xdac0008d,     0xdac007c1,     0xdac009cd,     0xdac00d05,
+    0xdac01322,     0xdac01514,     0x1adb0b35,     0x1ad00d4d,
+    0x1ad1203c,     0x1aca26f9,     0x1ac72867,     0x1ace2fce,
+    0x9acf0acc,     0x9acd0f22,     0x9ad522e7,     0x9ac0258b,
+    0x9adc293e,     0x9ad62cad,     0x9bc47ea5,     0x9b477c51,
+    0x1b11318c,     0x1b01edfe,     0x9b117662,     0x9b03fae4,
+    0x9b313eef,     0x9b21b59b,     0x9bac45a6,     0x9ba6a839,
+    0x1e240871,     0x1e3518b0,     0x1e312b63,     0x1e2f3959,
+    0x1e200a2a,     0x1e630b5c,     0x1e7b1804,     0x1e6229dc,
+    0x1e773b4c,     0x1e610bcf,     0x1f0534a4,     0x1f1c85b5,
+    0x1f3d1c71,     0x1f3d6b37,     0x1f5e68ee,     0x1f4aa4f6,
+    0x1f6e24e7,     0x1f6f630e,     0x1e204056,     0x1e20c060,
+    0x1e214229,     0x1e21c178,     0x1e22c32f,     0x1e604064,
+    0x1e60c2da,     0x1e61427e,     0x1e61c1cc,     0x1e6240f1,
+    0x1e3801d8,     0x9e38034d,     0x1e780022,     0x9e780165,
+    0x1e22026e,     0x9e2202c1,     0x1e62023b,     0x9e620136,
+    0x1e26006e,     0x9e66022c,     0x1e270368,     0x9e67039d,
+    0x1e3e2000,     0x1e692180,     0x1e202148,     0x1e602328,
+    0x292e7b68,     0x294a4f15,     0x69626c50,     0xa93814d5,
+    0xa97e679d,     0x29903408,     0x29ec5039,     0x69fc62ce,
+    0xa98504d1,     0xa9fc4735,     0x28b05691,     0x28c8705c,
+    0x68e07953,     0xa8bf3e31,     0xa8fe0331,     0x283c170e,
+    0x284e4c37,     0xa80419cb,     0xa8722f62,     0x0c407230,
+    0x4cdfa13d,     0x0cd56f1e,     0x4cdf2440,     0x0d40c134,
+    0x4ddfc811,     0x0ddaced5,     0x4c408f33,     0x0cdf84aa,
+    0x4d60c30a,     0x0dffcbad,     0x4de2cf96,     0x4ccb489e,
+    0x0c40481d,     0x4d40e777,     0x4ddfe943,     0x0dd6edd3,
+    0x4cdf040e,     0x0cd902de,     0x0d60e019,     0x0dffe50a,
+    0x0dfce8c1,     0xba5fd3e3,     0x3a5f03e5,     0xfa411be4,
     0x7a42cbe2,     0x93df03ff,     0xc820ffff,     0x8822fc7f,
     0xc8247cbf,     0x88267fff,     0x4e010fe0,     0x4e081fe1,
     0x4e0c1fe1,     0x4e0a1fe1,     0x4e071fe1,     0x4cc0ac3f,
@@ -1418,24 +1418,24 @@ Disassembly of section .text:
     0x1e741000,     0x1e743000,     0x1e761000,     0x1e763000,
     0x1e781000,     0x1e783000,     0x1e7a1000,     0x1e7a3000,
     0x1e7c1000,     0x1e7c3000,     0x1e7e1000,     0x1e7e3000,
-    0xf8358305,     0xf82d01ed,     0xf8361353,     0xf839234a,
-    0xf82531fb,     0xf8335165,     0xf83a4080,     0xf83673d7,
-    0xf832611c,     0xf8ad837d,     0xf8ab01a5,     0xf8a112b8,
-    0xf8bb2311,     0xf8b230be,     0xf8a75336,     0xf8a4427a,
-    0xf8a6707e,     0xf8b860b7,     0xf8f88392,     0xf8f300ff,
-    0xf8ed1386,     0xf8e822af,     0xf8e2302d,     0xf8f1533d,
-    0xf8f941d2,     0xf8ff7366,     0xf8f061e5,     0xf86b8072,
-    0xf87a0054,     0xf86b1164,     0xf87e22f3,     0xf86331cf,
-    0xf87e5296,     0xf8674305,     0xf87771f0,     0xf86b6013,
-    0xb83c803c,     0xb82b0195,     0xb83d1240,     0xb8252320,
-    0xb82e3340,     0xb83c53b2,     0xb82f43a1,     0xb828739a,
-    0xb831608e,     0xb8b88039,     0xb8aa0231,     0xb8bd12b4,
-    0xb8bd2189,     0xb8ab30a6,     0xb8b552a7,     0xb8aa4197,
-    0xb8b57145,     0xb8be6254,     0xb8ed80b7,     0xb8ef00b8,
-    0xb8e9132a,     0xb8f42231,     0xb8ec33d2,     0xb8e35323,
-    0xb8fa4159,     0xb8e273eb,     0xb8e760a2,     0xb8608287,
-    0xb865005f,     0xb87b1379,     0xb87e2358,     0xb86f32c2,
-    0xb86053e3,     0xb86f4154,     0xb87671d5,     0xb866605e,
+    0xf83081f4,     0xf8220387,     0xf834132a,     0xf836204b,
+    0xf821326a,     0xf82e5075,     0xf83c41bb,     0xf83172be,
+    0xf83b63b0,     0xf8be8009,     0xf8bc039b,     0xf8b51159,
+    0xf8bf21f4,     0xf8a131d9,     0xf8b553ba,     0xf8a8433d,
+    0xf8ad7322,     0xf8af6017,     0xf8e38041,     0xf8fc0283,
+    0xf8ee11df,     0xf8e7205c,     0xf8e030ab,     0xf8eb528e,
+    0xf8ff4044,     0xf8fa72c0,     0xf8f161a1,     0xf877829a,
+    0xf86e018b,     0xf86c11ff,     0xf87b210e,     0xf86a333e,
+    0xf8765207,     0xf8614110,     0xf8617341,     0xf86061f7,
+    0xb82b8110,     0xb82101c7,     0xb830113f,     0xb83621a6,
+    0xb82b308d,     0xb8305016,     0xb83c415f,     0xb8307105,
+    0xb83a61f4,     0xb8bb8206,     0xb8bf005f,     0xb8b8111c,
+    0xb8af22e9,     0xb8ba30e2,     0xb8a351f1,     0xb8b342a5,
+    0xb8a7719a,     0xb8ac63a7,     0xb8e98288,     0xb8e803df,
+    0xb8e01186,     0xb8f12057,     0xb8e0303e,     0xb8f651e3,
+    0xb8f941b5,     0xb8ed7378,     0xb8f46163,     0xb86382ad,
+    0xb87a034f,     0xb8691053,     0xb87820fd,     0xb87d31f9,
+    0xb86b50fe,     0xb86b40c2,     0xb87071cb,     0xb8656168,
 
   };
 // END  Generated code -- do not edit
@@ -1783,4 +1783,8 @@ static float unpack(unsigned value) {
   };
   ival = fp_immediate_for_encoding(value, 0);
   return val;
+}
+
+address Assembler::locate_next_instruction(address inst) {
+  return inst + Assembler::instruction_size;
 }

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -199,7 +199,7 @@ public:
     return extend(uval, msb - lsb);
   }
 
-  static void patch(address a, int msb, int lsb, unsigned long val) {
+  static void patch(address a, int msb, int lsb, uint64_t val) {
     int nbits = msb - lsb + 1;
     guarantee(val < (1U << nbits), "Field too big for insn");
     assert_cond(msb >= lsb);
@@ -212,9 +212,9 @@ public:
     *(unsigned *)a = target;
   }
 
-  static void spatch(address a, int msb, int lsb, long val) {
+  static void spatch(address a, int msb, int lsb, int64_t val) {
     int nbits = msb - lsb + 1;
-    long chk = val >> (nbits - 1);
+    int64_t chk = val >> (nbits - 1);
     guarantee (chk == -1 || chk == 0, "Field too big for insn");
     unsigned uval = val;
     unsigned mask = checked_cast<unsigned>(right_n_bits(nbits));
@@ -245,9 +245,9 @@ public:
     f(val, bit, bit);
   }
 
-  void sf(long val, int msb, int lsb) {
+  void sf(int64_t val, int msb, int lsb) {
     int nbits = msb - lsb + 1;
-    long chk = val >> (nbits - 1);
+    int64_t chk = val >> (nbits - 1);
     guarantee (chk == -1 || chk == 0, "Field too big for insn");
     unsigned uval = val;
     unsigned mask = checked_cast<unsigned>(right_n_bits(nbits));
@@ -357,7 +357,7 @@ class Address {
  private:
   Register _base;
   Register _index;
-  long _offset;
+  int64_t _offset;
   enum mode _mode;
   extend _ext;
 
@@ -380,9 +380,9 @@ class Address {
     : _base(r), _index(noreg), _offset(0), _mode(base_plus_offset), _target(0) { }
   Address(Register r, int o)
     : _base(r), _index(noreg), _offset(o), _mode(base_plus_offset), _target(0) { }
-  Address(Register r, long o)
+  Address(Register r, int64_t o)
     : _base(r), _index(noreg), _offset(o), _mode(base_plus_offset), _target(0) { }
-  Address(Register r, unsigned long o)
+  Address(Register r, uint64_t o)
     : _base(r), _index(noreg), _offset(o), _mode(base_plus_offset), _target(0) { }
 #ifdef ASSERT
   Address(Register r, ByteSize disp)
@@ -422,7 +422,7 @@ class Address {
               "wrong mode");
     return _base;
   }
-  long offset() const {
+  int64_t offset() const {
     return _offset;
   }
   Register index() const {
@@ -608,10 +608,10 @@ typedef enum {
 class Assembler : public AbstractAssembler {
 
 #ifndef PRODUCT
-  static const unsigned long asm_bp;
+  static const uintptr_t asm_bp;
 
   void emit_long(jint x) {
-    if ((unsigned long)pc() == asm_bp)
+    if ((uintptr_t)pc() == asm_bp)
       asm volatile ("nop");
     AbstractAssembler::emit_int32(x);
   }
@@ -654,7 +654,7 @@ public:
   void f(unsigned val, int msb) {
     current->f(val, msb, msb);
   }
-  void sf(long val, int msb, int lsb) {
+  void sf(int64_t val, int msb, int lsb) {
     current->sf(val, msb, lsb);
   }
   void rf(Register reg, int lsb) {
@@ -704,7 +704,7 @@ public:
     wrap_label(Rd, L, &Assembler::_adrp);
   }
 
-  void adrp(Register Rd, const Address &dest, unsigned long &offset);
+  void adrp(Register Rd, const Address &dest, uint64_t &offset);
 
 #undef INSN
 
@@ -830,7 +830,7 @@ public:
   // architecture.  In debug mode we shrink it in order to test
   // trampolines, but not so small that branches in the interpreter
   // are out of range.
-  static const unsigned long branch_range = NOT_DEBUG(128 * M) DEBUG_ONLY(2 * M);
+  static const uint64_t branch_range = NOT_DEBUG(128 * M) DEBUG_ONLY(2 * M);
 
   static bool reachable_from_branch_at(address branch, address target) {
     return uabs(target - branch) < branch_range;
@@ -840,7 +840,7 @@ public:
 #define INSN(NAME, opcode)                                              \
   void NAME(address dest) {                                             \
     starti;                                                             \
-    long offset = (dest - pc()) >> 2;                                   \
+    int64_t offset = (dest - pc()) >> 2;                                \
     DEBUG_ONLY(assert(reachable_from_branch_at(pc(), dest), "debug only")); \
     f(opcode, 31), f(0b00101, 30, 26), sf(offset, 25, 0);               \
   }                                                                     \
@@ -857,7 +857,7 @@ public:
   // Compare & branch (immediate)
 #define INSN(NAME, opcode)                              \
   void NAME(Register Rt, address dest) {                \
-    long offset = (dest - pc()) >> 2;                   \
+    int64_t offset = (dest - pc()) >> 2;                \
     starti;                                             \
     f(opcode, 31, 24), sf(offset, 23, 5), rf(Rt, 0);    \
   }                                                     \
@@ -875,7 +875,7 @@ public:
   // Test & branch (immediate)
 #define INSN(NAME, opcode)                                              \
   void NAME(Register Rt, int bitpos, address dest) {                    \
-    long offset = (dest - pc()) >> 2;                                   \
+    int64_t offset = (dest - pc()) >> 2;                                \
     int b5 = bitpos >> 5;                                               \
     bitpos &= 0x1f;                                                     \
     starti;                                                             \
@@ -896,7 +896,7 @@ public:
     {EQ, NE, HS, CS=HS, LO, CC=LO, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE, AL, NV};
 
   void br(Condition  cond, address dest) {
-    long offset = (dest - pc()) >> 2;
+    int64_t offset = (dest - pc()) >> 2;
     starti;
     f(0b0101010, 31, 25), f(0, 24), sf(offset, 23, 5), f(0, 4), f(cond, 3, 0);
   }
@@ -1275,7 +1275,7 @@ public:
   // Load register (literal)
 #define INSN(NAME, opc, V)                                              \
   void NAME(Register Rt, address dest) {                                \
-    long offset = (dest - pc()) >> 2;                                   \
+    int64_t offset = (dest - pc()) >> 2;                                \
     starti;                                                             \
     f(opc, 31, 30), f(0b011, 29, 27), f(V, 26), f(0b00, 25, 24),        \
       sf(offset, 23, 5);                                                \
@@ -1300,7 +1300,7 @@ public:
 
 #define INSN(NAME, opc, V)                                              \
   void NAME(FloatRegister Rt, address dest) {                           \
-    long offset = (dest - pc()) >> 2;                                   \
+    int64_t offset = (dest - pc()) >> 2;                                \
     starti;                                                             \
     f(opc, 31, 30), f(0b011, 29, 27), f(V, 26), f(0b00, 25, 24),        \
       sf(offset, 23, 5);                                                \
@@ -1315,7 +1315,7 @@ public:
 
 #define INSN(NAME, opc, V)                                              \
   void NAME(address dest, prfop op = PLDL1KEEP) {                       \
-    long offset = (dest - pc()) >> 2;                                   \
+    int64_t offset = (dest - pc()) >> 2;                                \
     starti;                                                             \
     f(opc, 31, 30), f(0b011, 29, 27), f(V, 26), f(0b00, 25, 24),        \
       sf(offset, 23, 5);                                                \
@@ -1391,7 +1391,7 @@ public:
       assert(size == 0b10 || size == 0b11, "bad operand size in ldr");
       assert(op == 0b01, "literal form can only be used with loads");
       f(size & 0b01, 31, 30), f(0b011, 29, 27), f(0b00, 25, 24);
-      long offset = (adr.target() - pc()) >> 2;
+      int64_t offset = (adr.target() - pc()) >> 2;
       sf(offset, 23, 5);
       code_section()->relocate(pc(), adr.rspec());
       return;
@@ -2693,7 +2693,7 @@ void ext(FloatRegister Vd, SIMD_Arrangement T, FloatRegister Vn, FloatRegister V
   virtual void bang_stack_with_offset(int offset);
 
   static bool operand_valid_for_logical_immediate(bool is32, uint64_t imm);
-  static bool operand_valid_for_add_sub_immediate(long imm);
+  static bool operand_valid_for_add_sub_immediate(int64_t imm);
   static bool operand_valid_for_float_immediate(double imm);
 
   void emit_data64(jlong data, relocInfo::relocType rtype, int format = 0);

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -28,6 +28,19 @@
 
 #include "asm/register.hpp"
 
+#ifdef __GNUC__
+
+// __nop needs volatile so that compiler doesn't optimize it away
+#define NOP() asm volatile ("nop");
+
+#elif defined(_MSC_VER)
+
+// Use MSVC instrinsic: https://docs.microsoft.com/en-us/cpp/intrinsics/arm64-intrinsics?view=vs-2019#I
+#define NOP() __nop();
+
+#endif
+
+
 // definitions of various symbolic names for machine registers
 
 // First intercalls between C and Java which use 8 general registers
@@ -612,7 +625,7 @@ class Assembler : public AbstractAssembler {
 
   void emit_long(jint x) {
     if ((uintptr_t)pc() == asm_bp)
-      asm volatile ("nop");
+      NOP();
     AbstractAssembler::emit_int32(x);
   }
 #else
@@ -643,6 +656,8 @@ public:
   Address post(Register base, Register idx) {
     return Address(Post(base, idx));
   }
+
+  static address locate_next_instruction(address inst);
 
   Instruction_aarch64* current;
 
@@ -1511,6 +1526,11 @@ public:
   INSN(bicsw, 0, 0b11, 1);
 
 #undef INSN
+
+#ifdef _WIN64
+// In MSVC, `mvn` is defined as a macro and it affects compilation
+#undef mvn
+#endif
 
   // Aliases for short forms of orn
 void mvn(Register Rd, Register Rm,

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -214,7 +214,7 @@ public:
 
   static void patch(address a, int msb, int lsb, uint64_t val) {
     int nbits = msb - lsb + 1;
-    guarantee(val < (1U << nbits), "Field too big for insn");
+    guarantee(val < (1ULL << nbits), "Field too big for insn");
     assert_cond(msb >= lsb);
     unsigned mask = checked_cast<unsigned>(right_n_bits(nbits));
     val <<= lsb;
@@ -430,8 +430,8 @@ class Address {
   }
 
   Register base() const {
-    guarantee((_mode == base_plus_offset | _mode == base_plus_offset_reg
-               | _mode == post | _mode == post_reg),
+    guarantee((_mode == base_plus_offset || _mode == base_plus_offset_reg
+               || _mode == post || _mode == post_reg),
               "wrong mode");
     return _base;
   }

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.inline.hpp
@@ -32,7 +32,7 @@
 
 
 inline bool Address::offset_ok_for_immed(int64_t offset, uint shift) {
-  uint mask = (1 << shift) - 1;
+  unsigned mask = (1 << shift) - 1;
   if (offset < 0 || (offset & mask) != 0) {
     // Unscaled signed offset, encoded in a signed imm9 field.
     return Assembler::is_simm9(offset);

--- a/src/hotspot/cpu/aarch64/c1_Defs_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_Defs_aarch64.hpp
@@ -44,13 +44,13 @@ enum {
   pd_nof_cpu_regs_frame_map = RegisterImpl::number_of_registers,       // number of registers used during code emission
   pd_nof_fpu_regs_frame_map = FloatRegisterImpl::number_of_registers,  // number of registers used during code emission
 
-  pd_nof_caller_save_cpu_regs_frame_map = 19 - 2,  // number of registers killed by calls
+  pd_nof_caller_save_cpu_regs_frame_map = 19 - 2 /* rscratch1 and rscratch2 */ R18_RESERVED_ONLY(- 1),  // number of registers killed by calls
   pd_nof_caller_save_fpu_regs_frame_map = 32,  // number of registers killed by calls
 
-  pd_first_callee_saved_reg = 19 - 2,
-  pd_last_callee_saved_reg = 26 - 2,
+  pd_first_callee_saved_reg = 19 - 2 /* rscratch1 and rscratch2 */ R18_RESERVED_ONLY(- 1),
+  pd_last_callee_saved_reg = 26 - 2 /* rscratch1 and rscratch2 */ R18_RESERVED_ONLY(- 1),
 
-  pd_last_allocatable_cpu_reg = 16,
+  pd_last_allocatable_cpu_reg = 16 R18_RESERVED_ONLY(- 1),
 
   pd_nof_cpu_regs_reg_alloc
     = pd_last_allocatable_cpu_reg + 1,  // number of registers that are visible to register allocator
@@ -60,9 +60,9 @@ enum {
   pd_nof_fpu_regs_linearscan = pd_nof_fpu_regs_frame_map, // number of registers visible to linear scan
   pd_nof_xmm_regs_linearscan = 0, // like sparc we don't have any of these
   pd_first_cpu_reg = 0,
-  pd_last_cpu_reg = 16,
+  pd_last_cpu_reg = 16 R18_RESERVED_ONLY(- 1),
   pd_first_byte_reg = 0,
-  pd_last_byte_reg = 16,
+  pd_last_byte_reg = 16 R18_RESERVED_ONLY(- 1),
   pd_first_fpu_reg = pd_nof_cpu_regs_frame_map,
   pd_last_fpu_reg =  pd_first_fpu_reg + 31,
 

--- a/src/hotspot/cpu/aarch64/c1_FpuStackSim_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_FpuStackSim_aarch64.cpp
@@ -28,3 +28,4 @@
 //--------------------------------------------------------
 
 // No FPU stack on AARCH64
+#include "precompiled.hpp"

--- a/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.cpp
@@ -181,7 +181,10 @@ void FrameMap::initialize() {
   map_register(i, r15); r15_opr = LIR_OprFact::single_cpu(i); i++;
   map_register(i, r16); r16_opr = LIR_OprFact::single_cpu(i); i++;
   map_register(i, r17); r17_opr = LIR_OprFact::single_cpu(i); i++;
-  map_register(i, r18); r18_opr = LIR_OprFact::single_cpu(i); i++;
+#ifndef R18_RESERVED
+  // See comment in register_aarch64.hpp
+  map_register(i, r18_reserved); r18_opr = LIR_OprFact::single_cpu(i); i++;
+#endif
   map_register(i, r19); r19_opr = LIR_OprFact::single_cpu(i); i++;
   map_register(i, r20); r20_opr = LIR_OprFact::single_cpu(i); i++;
   map_register(i, r21); r21_opr = LIR_OprFact::single_cpu(i); i++;
@@ -198,6 +201,11 @@ void FrameMap::initialize() {
   map_register(i, r31_sp); sp_opr = LIR_OprFact::single_cpu(i); i++; // sp
   map_register(i, r8); r8_opr = LIR_OprFact::single_cpu(i); i++;   // rscratch1
   map_register(i, r9); r9_opr = LIR_OprFact::single_cpu(i); i++;   // rscratch2
+
+#ifdef R18_RESERVED
+  // See comment in register_aarch64.hpp
+  map_register(i, r18_reserved); r18_opr = LIR_OprFact::single_cpu(i); i++;
+#endif
 
   rscratch1_opr = r8_opr;
   rscratch2_opr = r9_opr;
@@ -227,7 +235,10 @@ void FrameMap::initialize() {
   _caller_save_cpu_regs[13] = r15_opr;
   _caller_save_cpu_regs[14] = r16_opr;
   _caller_save_cpu_regs[15] = r17_opr;
+#ifndef R18_RESERVED
+  // See comment in register_aarch64.hpp
   _caller_save_cpu_regs[16] = r18_opr;
+#endif
 
   for (int i = 0; i < 8; i++) {
     _caller_save_fpu_regs[i] = LIR_OprFact::single_fpu(i);
@@ -253,7 +264,7 @@ void FrameMap::initialize() {
   r15_oop_opr = as_oop_opr(r15);
   r16_oop_opr = as_oop_opr(r16);
   r17_oop_opr = as_oop_opr(r17);
-  r18_oop_opr = as_oop_opr(r18);
+  r18_oop_opr = as_oop_opr(r18_reserved);
   r19_oop_opr = as_oop_opr(r19);
   r20_oop_opr = as_oop_opr(r20);
   r21_oop_opr = as_oop_opr(r21);

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -2314,7 +2314,6 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
   assert(default_type != NULL && default_type->is_array_klass() && default_type->is_loaded(), "must be true at this point");
 
   int elem_size = type2aelembytes(basic_type);
-  int shift_amount;
   int scale = exact_log2(elem_size);
 
   Address src_length_addr = Address(src, arrayOopDesc::length_offset_in_bytes());

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1378,7 +1378,7 @@ void LIR_Assembler::emit_typecheck_helper(LIR_OpTypeCheck *op, Label* success, L
     __ load_klass(klass_RInfo, obj);
     if (k->is_loaded()) {
       // See if we get an immediate positive hit
-      __ ldr(rscratch1, Address(klass_RInfo, long(k->super_check_offset())));
+      __ ldr(rscratch1, Address(klass_RInfo, int64_t(k->super_check_offset())));
       __ cmp(k_RInfo, rscratch1);
       if ((juint)in_bytes(Klass::secondary_super_cache_offset()) != k->super_check_offset()) {
         __ br(Assembler::NE, *failure_target);
@@ -2704,7 +2704,7 @@ void LIR_Assembler::emit_updatecrc32(LIR_OpUpdateCRC32* op) {
   Register res = op->result_opr()->as_register();
 
   assert_different_registers(val, crc, res);
-  unsigned long offset;
+  uint64_t offset;
   __ adrp(res, ExternalAddress(StubRoutines::crc_table_addr()), offset);
   if (offset) __ add(res, res, offset);
 

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -2042,7 +2042,7 @@ void LIR_Assembler::comp_fl2i(LIR_Code code, LIR_Opr left, LIR_Opr right, LIR_Op
   } else if (code == lir_cmp_l2i) {
     Label done;
     __ cmp(left->as_register_lo(), right->as_register_lo());
-    __ mov(dst->as_register(), (u_int64_t)-1L);
+    __ mov(dst->as_register(), (uint64_t)-1L);
     __ br(Assembler::LT, done);
     __ csinc(dst->as_register(), zr, zr, Assembler::EQ);
     __ bind(done);

--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -290,7 +290,7 @@ void LIRGenerator::cmp_reg_mem(LIR_Condition condition, LIR_Opr reg, LIR_Opr bas
 }
 
 
-bool LIRGenerator::strength_reduce_multiply(LIR_Opr left, int c, LIR_Opr result, LIR_Opr tmp) {
+bool LIRGenerator::strength_reduce_multiply(LIR_Opr left, jint c, LIR_Opr result, LIR_Opr tmp) {
 
   if (is_power_of_2(c - 1)) {
     __ shift_left(left, exact_log2(c - 1), tmp);

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -683,10 +683,10 @@ intptr_t* frame::real_fp() const {
            p[frame::name##_offset], #name);                             \
   }
 
-static __thread uintptr_t nextfp;
-static __thread uintptr_t nextpc;
-static __thread uintptr_t nextsp;
-static __thread RegisterMap *reg_map;
+static THREAD_LOCAL_DECL uintptr_t nextfp;
+static THREAD_LOCAL_DECL uintptr_t nextpc;
+static THREAD_LOCAL_DECL uintptr_t nextsp;
+static THREAD_LOCAL_DECL RegisterMap *reg_map;
 
 static void printbc(Method *m, intptr_t bcx) {
   const char *name;

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -678,14 +678,14 @@ intptr_t* frame::real_fp() const {
 
 #define DESCRIBE_FP_OFFSET(name)                                        \
   {                                                                     \
-    unsigned long *p = (unsigned long *)fp;                             \
-    printf("0x%016lx 0x%016lx %s\n", (unsigned long)(p + frame::name##_offset), \
+    uintptr_t *p = (uintptr_t *)fp;                                     \
+    printf("0x%016lx 0x%016lx %s\n", (uintptr_t)(p + frame::name##_offset), \
            p[frame::name##_offset], #name);                             \
   }
 
-static __thread unsigned long nextfp;
-static __thread unsigned long nextpc;
-static __thread unsigned long nextsp;
+static __thread uintptr_t nextfp;
+static __thread uintptr_t nextpc;
+static __thread uintptr_t nextsp;
 static __thread RegisterMap *reg_map;
 
 static void printbc(Method *m, intptr_t bcx) {
@@ -704,7 +704,7 @@ static void printbc(Method *m, intptr_t bcx) {
   printf("%s : %s ==> %s\n", m->name_and_sig_as_C_string(), buf, name);
 }
 
-void internal_pf(unsigned long sp, unsigned long fp, unsigned long pc, unsigned long bcx) {
+void internal_pf(uintptr_t sp, uintptr_t fp, uintptr_t pc, uintptr_t bcx) {
   if (! fp)
     return;
 
@@ -718,7 +718,7 @@ void internal_pf(unsigned long sp, unsigned long fp, unsigned long pc, unsigned 
   DESCRIBE_FP_OFFSET(interpreter_frame_locals);
   DESCRIBE_FP_OFFSET(interpreter_frame_bcp);
   DESCRIBE_FP_OFFSET(interpreter_frame_initial_sp);
-  unsigned long *p = (unsigned long *)fp;
+  uintptr_t *p = (uintptr_t *)fp;
 
   // We want to see all frames, native and Java.  For compiled and
   // interpreted frames we have special information that allows us to
@@ -728,16 +728,16 @@ void internal_pf(unsigned long sp, unsigned long fp, unsigned long pc, unsigned 
   if (this_frame.is_compiled_frame() ||
       this_frame.is_interpreted_frame()) {
     frame sender = this_frame.sender(reg_map);
-    nextfp = (unsigned long)sender.fp();
-    nextpc = (unsigned long)sender.pc();
-    nextsp = (unsigned long)sender.unextended_sp();
+    nextfp = (uintptr_t)sender.fp();
+    nextpc = (uintptr_t)sender.pc();
+    nextsp = (uintptr_t)sender.unextended_sp();
   } else {
     nextfp = p[frame::link_offset];
     nextpc = p[frame::return_addr_offset];
-    nextsp = (unsigned long)&p[frame::sender_sp_offset];
+    nextsp = (uintptr_t)&p[frame::sender_sp_offset];
   }
 
-  if (bcx == -1ul)
+  if (bcx == -1ULL)
     bcx = p[frame::interpreter_frame_bcp_offset];
 
   if (Interpreter::contains((address)pc)) {
@@ -771,8 +771,8 @@ extern "C" void npf() {
   internal_pf (nextsp, nextfp, nextpc, -1);
 }
 
-extern "C" void pf(unsigned long sp, unsigned long fp, unsigned long pc,
-                   unsigned long bcx, unsigned long thread) {
+extern "C" void pf(uintptr_t sp, uintptr_t fp, uintptr_t pc,
+                   uintptr_t bcx, uintptr_t thread) {
   if (!reg_map) {
     reg_map = NEW_C_HEAP_OBJ(RegisterMap, mtNone);
     ::new (reg_map) RegisterMap((JavaThread*)thread, false);
@@ -791,9 +791,9 @@ extern "C" void pf(unsigned long sp, unsigned long fp, unsigned long pc,
 // support for printing out where we are in a Java method
 // needs to be passed current fp and bcp register values
 // prints method name, bc index and bytecode name
-extern "C" void pm(unsigned long fp, unsigned long bcx) {
+extern "C" void pm(uintptr_t fp, uintptr_t bcx) {
   DESCRIBE_FP_OFFSET(interpreter_frame_method);
-  unsigned long *p = (unsigned long *)fp;
+  uintptr_t *p = (uintptr_t *)fp;
   Method* m = (Method*)p[frame::interpreter_frame_method_offset];
   printbc(m, bcx);
 }

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -676,11 +676,12 @@ intptr_t* frame::real_fp() const {
 
 #undef DESCRIBE_FP_OFFSET
 
-#define DESCRIBE_FP_OFFSET(name)                                        \
-  {                                                                     \
-    uintptr_t *p = (uintptr_t *)fp;                                     \
-    printf("0x%016lx 0x%016lx %s\n", (uintptr_t)(p + frame::name##_offset), \
-           p[frame::name##_offset], #name);                             \
+#define DESCRIBE_FP_OFFSET(name)                     \
+  {                                                  \
+    uintptr_t *p = (uintptr_t *)fp;                  \
+    printf(INTPTR_FORMAT " " INTPTR_FORMAT " %s\n",  \
+           (uintptr_t)(p + frame::name##_offset),    \
+           p[frame::name##_offset], #name);          \
   }
 
 static THREAD_LOCAL_DECL uintptr_t nextfp;

--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
@@ -172,7 +172,7 @@ void BarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register obj,
     Label retry;
     __ bind(retry);
     {
-      unsigned long offset;
+      uint64_t offset;
       __ adrp(rscratch1, ExternalAddress((address) Universe::heap()->end_addr()), offset);
       __ ldr(heap_end, Address(rscratch1, offset));
     }
@@ -181,7 +181,7 @@ void BarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register obj,
 
     // Get the current top of the heap
     {
-      unsigned long offset;
+      uint64_t offset;
       __ adrp(rscratch1, heap_top, offset);
       // Use add() here after ARDP, rather than lea().
       // lea() does not generate anything if its offset is zero.

--- a/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
@@ -53,4 +53,13 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 
 #define THREAD_LOCAL_POLL
 
+#if defined(_WIN64)
+#define R18_RESERVED
+#define R18_RESERVED_ONLY(code) code
+#define NOT_R18_RESERVED(code)
+#else
+#define R18_RESERVED_ONLY(code)
+#define NOT_R18_RESERVED(code) code
+#endif
+
 #endif // CPU_AARCH64_VM_GLOBALDEFINITIONS_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/icache_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/icache_aarch64.hpp
@@ -26,19 +26,6 @@
 #ifndef CPU_AARCH64_VM_ICACHE_AARCH64_HPP
 #define CPU_AARCH64_VM_ICACHE_AARCH64_HPP
 
-// Interface for updating the instruction cache.  Whenever the VM
-// modifies code, part of the processor instruction cache potentially
-// has to be flushed.
-
-class ICache : public AbstractICache {
- public:
-  static void initialize();
-  static void invalidate_word(address addr) {
-    __clear_cache((char *)addr, (char *)(addr + 3));
-  }
-  static void invalidate_range(address start, int nbytes) {
-    __clear_cache((char *)start, (char *)(start + nbytes));
-  }
-};
+#include OS_CPU_HEADER(icache)
 
 #endif // CPU_AARCH64_VM_ICACHE_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -24,6 +24,9 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+
+#include "precompiled.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "immediate_aarch64.hpp"
 
 // there are at most 2^13 possible logical immediate encodings
@@ -244,7 +247,10 @@ int expandLogicalImmediate(uint32_t immN, uint32_t immr,
 
 // constructor to initialise the lookup tables
 
-static void initLITables() __attribute__ ((constructor));
+static void initLITables();
+// Use an empty struct with a construtor as MSVC doesn't support `__attribute__ ((constructor))`
+// See https://stackoverflow.com/questions/1113409/attribute-constructor-equivalent-in-vc
+static struct initLITables_t { initLITables_t(void) { initLITables(); } } _initLITables;
 static void initLITables()
 {
   li_table_entry_count = 0;

--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <stdlib.h>
+#include <stdint.h>
 #include "immediate_aarch64.hpp"
 
 // there are at most 2^13 possible logical immediate encodings
@@ -34,14 +35,14 @@ static int li_table_entry_count;
 // for forward lookup we just use a direct array lookup
 // and assume that the cient has supplied a valid encoding
 // table[encoding] = immediate
-static u_int64_t LITable[LI_TABLE_SIZE];
+static uint64_t LITable[LI_TABLE_SIZE];
 
 // for reverse lookup we need a sparse map so we store a table of
 // immediate and encoding pairs sorted by immediate value
 
 struct li_pair {
-  u_int64_t immediate;
-  u_int32_t encoding;
+  uint64_t immediate;
+  uint32_t encoding;
 };
 
 static struct li_pair InverseLITable[LI_TABLE_SIZE];
@@ -63,9 +64,9 @@ int compare_immediate_pair(const void *i1, const void *i2)
 // helper functions used by expandLogicalImmediate
 
 // for i = 1, ... N result<i-1> = 1 other bits are zero
-static inline u_int64_t ones(int N)
+static inline uint64_t ones(int N)
 {
-  return (N == 64 ? (u_int64_t)-1UL : ((1UL << N) - 1));
+  return (N == 64 ? (uint64_t)-1UL : ((1UL << N) - 1));
 }
 
 /*
@@ -73,49 +74,49 @@ static inline u_int64_t ones(int N)
  */
 
 // 32 bit mask with bits [hi,...,lo] set
-static inline u_int32_t mask32(int hi = 31, int lo = 0)
+static inline uint32_t mask32(int hi = 31, int lo = 0)
 {
   int nbits = (hi + 1) - lo;
   return ((1 << nbits) - 1) << lo;
 }
 
-static inline u_int64_t mask64(int hi = 63, int lo = 0)
+static inline uint64_t mask64(int hi = 63, int lo = 0)
 {
   int nbits = (hi + 1) - lo;
   return ((1L << nbits) - 1) << lo;
 }
 
 // pick bits [hi,...,lo] from val
-static inline u_int32_t pick32(u_int32_t val, int hi = 31, int lo = 0)
+static inline uint32_t pick32(uint32_t val, int hi = 31, int lo = 0)
 {
   return (val & mask32(hi, lo));
 }
 
 // pick bits [hi,...,lo] from val
-static inline u_int64_t pick64(u_int64_t val, int hi = 31, int lo = 0)
+static inline uint64_t pick64(uint64_t val, int hi = 31, int lo = 0)
 {
   return (val & mask64(hi, lo));
 }
 
 // mask [hi,lo] and shift down to start at bit 0
-static inline u_int32_t pickbits32(u_int32_t val, int hi = 31, int lo = 0)
+static inline uint32_t pickbits32(uint32_t val, int hi = 31, int lo = 0)
 {
   return (pick32(val, hi, lo) >> lo);
 }
 
 // mask [hi,lo] and shift down to start at bit 0
-static inline u_int64_t pickbits64(u_int64_t val, int hi = 63, int lo = 0)
+static inline uint64_t pickbits64(uint64_t val, int hi = 63, int lo = 0)
 {
   return (pick64(val, hi, lo) >> lo);
 }
 
 // result<0> to val<N>
-static inline u_int64_t pickbit(u_int64_t val, int N)
+static inline uint64_t pickbit(uint64_t val, int N)
 {
   return pickbits64(val, N, N);
 }
 
-static inline u_int32_t uimm(u_int32_t val, int hi, int lo)
+static inline uint32_t uimm(uint32_t val, int hi, int lo)
 {
   return pickbits32(val, hi, lo);
 }
@@ -123,11 +124,11 @@ static inline u_int32_t uimm(u_int32_t val, int hi, int lo)
 // SPEC bits(M*N) Replicate(bits(M) x, integer N);
 // this is just an educated guess
 
-u_int64_t replicate(u_int64_t bits, int nbits, int count)
+uint64_t replicate(uint64_t bits, int nbits, int count)
 {
-  u_int64_t result = 0;
+  uint64_t result = 0;
   // nbits may be 64 in which case we want mask to be -1
-  u_int64_t mask = ones(nbits);
+  uint64_t mask = ones(nbits);
   for (int i = 0; i < count ; i++) {
     result <<= nbits;
     result |= (bits & mask);
@@ -140,24 +141,24 @@ u_int64_t replicate(u_int64_t bits, int nbits, int count)
 // encoding must be treated as an UNALLOC instruction
 
 // construct a 32 bit immediate value for a logical immediate operation
-int expandLogicalImmediate(u_int32_t immN, u_int32_t immr,
-                            u_int32_t imms, u_int64_t &bimm)
+int expandLogicalImmediate(uint32_t immN, uint32_t immr,
+                            uint32_t imms, uint64_t &bimm)
 {
-  int len;                  // ought to be <= 6
-  u_int32_t levels;         // 6 bits
-  u_int32_t tmask_and;      // 6 bits
-  u_int32_t wmask_and;      // 6 bits
-  u_int32_t tmask_or;       // 6 bits
-  u_int32_t wmask_or;       // 6 bits
-  u_int64_t imm64;          // 64 bits
-  u_int64_t tmask, wmask;   // 64 bits
-  u_int32_t S, R, diff;     // 6 bits?
+  int len;                 // ought to be <= 6
+  uint32_t levels;         // 6 bits
+  uint32_t tmask_and;      // 6 bits
+  uint32_t wmask_and;      // 6 bits
+  uint32_t tmask_or;       // 6 bits
+  uint32_t wmask_or;       // 6 bits
+  uint64_t imm64;          // 64 bits
+  uint64_t tmask, wmask;   // 64 bits
+  uint32_t S, R, diff;     // 6 bits?
 
   if (immN == 1) {
     len = 6; // looks like 7 given the spec above but this cannot be!
   } else {
     len = 0;
-    u_int32_t val = (~imms & 0x3f);
+    uint32_t val = (~imms & 0x3f);
     for (int i = 5; i > 0; i--) {
       if (val & (1 << i)) {
         len = i;
@@ -170,7 +171,7 @@ int expandLogicalImmediate(u_int32_t immN, u_int32_t immr,
     // for valid inputs leading 1s in immr must be less than leading
     // zeros in imms
     int len2 = 0;                   // ought to be < len
-    u_int32_t val2 = (~immr & 0x3f);
+    uint32_t val2 = (~immr & 0x3f);
     for (int i = 5; i > 0; i--) {
       if (!(val2 & (1 << i))) {
         len2 = i;
@@ -199,12 +200,12 @@ int expandLogicalImmediate(u_int32_t immN, u_int32_t immr,
 
   for (int i = 0; i < 6; i++) {
     int nbits = 1 << i;
-    u_int64_t and_bit = pickbit(tmask_and, i);
-    u_int64_t or_bit = pickbit(tmask_or, i);
-    u_int64_t and_bits_sub = replicate(and_bit, 1, nbits);
-    u_int64_t or_bits_sub = replicate(or_bit, 1, nbits);
-    u_int64_t and_bits_top = (and_bits_sub << nbits) | ones(nbits);
-    u_int64_t or_bits_top = (0 << nbits) | or_bits_sub;
+    uint64_t and_bit = pickbit(tmask_and, i);
+    uint64_t or_bit = pickbit(tmask_or, i);
+    uint64_t and_bits_sub = replicate(and_bit, 1, nbits);
+    uint64_t or_bits_sub = replicate(or_bit, 1, nbits);
+    uint64_t and_bits_top = (and_bits_sub << nbits) | ones(nbits);
+    uint64_t or_bits_top = (0 << nbits) | or_bits_sub;
 
     tmask = ((tmask
               & (replicate(and_bits_top, 2 * nbits, 32 / nbits)))
@@ -218,12 +219,12 @@ int expandLogicalImmediate(u_int32_t immN, u_int32_t immr,
 
   for (int i = 0; i < 6; i++) {
     int nbits = 1 << i;
-    u_int64_t and_bit = pickbit(wmask_and, i);
-    u_int64_t or_bit = pickbit(wmask_or, i);
-    u_int64_t and_bits_sub = replicate(and_bit, 1, nbits);
-    u_int64_t or_bits_sub = replicate(or_bit, 1, nbits);
-    u_int64_t and_bits_top = (ones(nbits) << nbits) | and_bits_sub;
-    u_int64_t or_bits_top = (or_bits_sub << nbits) | 0;
+    uint64_t and_bit = pickbit(wmask_and, i);
+    uint64_t or_bit = pickbit(wmask_or, i);
+    uint64_t and_bits_sub = replicate(and_bit, 1, nbits);
+    uint64_t or_bits_sub = replicate(or_bit, 1, nbits);
+    uint64_t and_bits_top = (ones(nbits) << nbits) | and_bits_sub;
+    uint64_t or_bits_top = (or_bits_sub << nbits) | 0;
 
     wmask = ((wmask
               & (replicate(and_bits_top, 2 * nbits, 32 / nbits)))
@@ -248,9 +249,9 @@ static void initLITables()
 {
   li_table_entry_count = 0;
   for (unsigned index = 0; index < LI_TABLE_SIZE; index++) {
-    u_int32_t N = uimm(index, 12, 12);
-    u_int32_t immr = uimm(index, 11, 6);
-    u_int32_t imms = uimm(index, 5, 0);
+    uint32_t N = uimm(index, 12, 12);
+    uint32_t immr = uimm(index, 11, 6);
+    uint32_t imms = uimm(index, 5, 0);
     if (expandLogicalImmediate(N, immr, imms, LITable[index])) {
       InverseLITable[li_table_entry_count].immediate = LITable[index];
       InverseLITable[li_table_entry_count].encoding = index;
@@ -264,12 +265,12 @@ static void initLITables()
 
 // public APIs provided for logical immediate lookup and reverse lookup
 
-u_int64_t logical_immediate_for_encoding(u_int32_t encoding)
+uint64_t logical_immediate_for_encoding(uint32_t encoding)
 {
   return LITable[encoding];
 }
 
-u_int32_t encoding_for_logical_immediate(u_int64_t immediate)
+uint32_t encoding_for_logical_immediate(uint64_t immediate)
 {
   struct li_pair pair;
   struct li_pair *result;
@@ -293,15 +294,15 @@ u_int32_t encoding_for_logical_immediate(u_int64_t immediate)
 // fpimm[3:0] = fraction (assuming leading 1)
 // i.e. F = s * 1.f * 2^(e - b)
 
-u_int64_t fp_immediate_for_encoding(u_int32_t imm8, int is_dp)
+uint64_t fp_immediate_for_encoding(uint32_t imm8, int is_dp)
 {
   union {
     float fpval;
     double dpval;
-    u_int64_t val;
+    uint64_t val;
   };
 
-  u_int32_t s, e, f;
+  uint32_t s, e, f;
   s = (imm8 >> 7 ) & 0x1;
   e = (imm8 >> 4) & 0x7;
   f = imm8 & 0xf;
@@ -329,7 +330,7 @@ u_int64_t fp_immediate_for_encoding(u_int32_t imm8, int is_dp)
   return val;
 }
 
-u_int32_t encoding_for_fp_immediate(float immediate)
+uint32_t encoding_for_fp_immediate(float immediate)
 {
   // given a float which is of the form
   //
@@ -341,10 +342,10 @@ u_int32_t encoding_for_fp_immediate(float immediate)
 
   union {
     float fpval;
-    u_int32_t val;
+    uint32_t val;
   };
   fpval = immediate;
-  u_int32_t s, r, f, res;
+  uint32_t s, r, f, res;
   // sign bit is 31
   s = (val >> 31) & 0x1;
   // exponent is bits 30-23 but we only want the bottom 3 bits

--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ int compare_immediate_pair(const void *i1, const void *i2)
 // for i = 1, ... N result<i-1> = 1 other bits are zero
 static inline uint64_t ones(int N)
 {
-  return (N == 64 ? (uint64_t)-1UL : ((1UL << N) - 1));
+  return (N == 64 ? -1ULL : (1ULL << N) - 1);
 }
 
 /*

--- a/src/hotspot/cpu/aarch64/immediate_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.hpp
@@ -46,9 +46,9 @@
  * encoding then a map lookup will return 0xffffffff.
  */
 
-u_int64_t logical_immediate_for_encoding(u_int32_t encoding);
-u_int32_t encoding_for_logical_immediate(u_int64_t immediate);
-u_int64_t fp_immediate_for_encoding(u_int32_t imm8, int is_dp);
-u_int32_t encoding_for_fp_immediate(float immediate);
+uint64_t logical_immediate_for_encoding(uint32_t encoding);
+uint32_t encoding_for_logical_immediate(uint64_t immediate);
+uint64_t fp_immediate_for_encoding(uint32_t imm8, int is_dp);
+uint32_t encoding_for_fp_immediate(float immediate);
 
 #endif // _IMMEDIATE_H

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,7 +168,7 @@ void InterpreterMacroAssembler::get_unsigned_2_byte_index_at_bcp(
 }
 
 void InterpreterMacroAssembler::get_dispatch() {
-  unsigned long offset;
+  uint64_t offset;
   adrp(rdispatch, ExternalAddress((address)Interpreter::dispatch_table()), offset);
   lea(rdispatch, Address(rdispatch, offset));
 }
@@ -759,7 +759,7 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg)
     // copy
     mov(rscratch1, sp);
     sub(swap_reg, swap_reg, rscratch1);
-    ands(swap_reg, swap_reg, (unsigned long)(7 - os::vm_page_size()));
+    ands(swap_reg, swap_reg, (uint64_t)(7 - os::vm_page_size()));
 
     // Save the test result, for recursive case, the result is zero
     str(swap_reg, Address(lock_reg, mark_offset));

--- a/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,7 +347,7 @@ class SlowSignatureHandler
 
     if (_num_fp_args < Argument::n_float_register_parameters_c) {
       *_fp_args++ = from_obj;
-      *_fp_identifiers |= (1 << _num_fp_args); // mark as double
+      *_fp_identifiers |= (1ull << _num_fp_args); // mark as double
       _num_fp_args++;
     } else {
       *_to++ = from_obj;
@@ -383,7 +383,7 @@ IRT_ENTRY(address,
 
   // handle arguments
   SlowSignatureHandler ssh(m, (address)from, to);
-  ssh.iterate(UCONST64(-1));
+  ssh.iterate((uint64_t)CONST64(-1));
 
   // return result handler
   return Interpreter::result_handler(m->result_type());

--- a/src/hotspot/cpu/aarch64/jniFastGetField_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jniFastGetField_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2004, 2017, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
 
   Label slow;
 
-  unsigned long offset;
+  uint64_t offset;
   __ adrp(rcounter_addr,
           SafepointSynchronize::safepoint_counter_addr(), offset);
   Address safepoint_counter_addr(rcounter_addr, offset);

--- a/src/hotspot/cpu/aarch64/jvmciCodeInstaller_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jvmciCodeInstaller_aarch64.cpp
@@ -21,6 +21,7 @@
  * questions.
  */
 
+#include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
 #include "jvmci/jvmciCodeInstaller.hpp"
 #include "jvmci/jvmciRuntime.hpp"

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5812,10 +5812,14 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
 // by the call to JavaThread::aarch64_get_thread_helper() or, indeed,
 // the call setup code.
 //
-// aarch64_get_thread_helper() clobbers only r0, r1, and flags.
+// On Linux, aarch64_get_thread_helper() clobbers only r0, r1, and flags.
+// On other systems, the helper is a usual C function.
 //
 void MacroAssembler::get_thread(Register dst) {
-  RegSet saved_regs = RegSet::range(r0, r1) + lr - dst;
+  RegSet saved_regs =
+    LINUX_ONLY(RegSet::range(r0, r1)  + lr - dst)
+    NOT_LINUX (RegSet::range(r0, r17) + lr - dst);
+
   push(saved_regs, sp);
 
   mov(lr, CAST_FROM_FN_PTR(address, JavaThread::aarch64_get_thread_helper));

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -70,8 +70,8 @@
 // Return the total length (in bytes) of the instructions.
 int MacroAssembler::pd_patch_instruction_size(address branch, address target) {
   int instructions = 1;
-  assert((uint64_t)target < (1ul << 48), "48-bit overflow in address constant");
-  long offset = (target - branch) >> 2;
+  assert((uint64_t)target < (1ull << 48), "48-bit overflow in address constant");
+  intptr_t offset = (target - branch) >> 2;
   unsigned insn = *(unsigned*)branch;
   if ((Instruction_aarch64::extract(insn, 29, 24) & 0b111011) == 0b011000) {
     // Load register (literal)
@@ -134,9 +134,9 @@ int MacroAssembler::pd_patch_instruction_size(address branch, address target) {
                      Instruction_aarch64::extract(insn2, 4, 0)) {
         // movk #imm16<<32
         Instruction_aarch64::patch(branch + 4, 20, 5, (uint64_t)target >> 32);
-        long dest = ((long)target & 0xffffffffL) | ((long)branch & 0xffff00000000L);
-        long pc_page = (long)branch >> 12;
-        long adr_page = (long)dest >> 12;
+        uintptr_t dest = ((uintptr_t)target & 0xffffffffULL) | ((uintptr_t)branch & 0xffff00000000ULL);
+        uintptr_t pc_page = (uintptr_t)branch >> 12;
+        uintptr_t adr_page = (uintptr_t)dest >> 12;
         offset = adr_page - pc_page;
         instructions = 2;
       }
@@ -205,7 +205,7 @@ int MacroAssembler::patch_narrow_klass(address insn_addr, narrowKlass n) {
 }
 
 address MacroAssembler::target_addr_for_insn(address insn_addr, unsigned insn) {
-  long offset = 0;
+  intptr_t offset = 0;
   if ((Instruction_aarch64::extract(insn, 29, 24) & 0b011011) == 0b00011000) {
     // Load register (literal)
     offset = Instruction_aarch64::sextract(insn, 23, 5);
@@ -297,7 +297,7 @@ void MacroAssembler::safepoint_poll(Label& slow_path) {
     ldr(rscratch1, Address(rthread, Thread::polling_page_offset()));
     tbnz(rscratch1, exact_log2(SafepointMechanism::poll_bit()), slow_path);
   } else {
-    unsigned long offset;
+    uint64_t offset;
     adrp(rscratch1, ExternalAddress(SafepointSynchronize::address_of_state()), offset);
     ldrw(rscratch1, Address(rscratch1, offset));
     assert(SafepointSynchronize::_not_synchronized == 0, "rewrite this code");
@@ -405,7 +405,7 @@ void MacroAssembler::far_call(Address entry, CodeBuffer *cbuf, Register tmp) {
   assert(CodeCache::find_blob(entry.target()) != NULL,
          "destination of far call not found in code cache");
   if (far_branches()) {
-    unsigned long offset;
+    uintptr_t offset;
     // We can use ADRP here because we know that the total size of
     // the code cache cannot exceed 2Gb.
     adrp(tmp, entry, offset);
@@ -423,7 +423,7 @@ void MacroAssembler::far_jump(Address entry, CodeBuffer *cbuf, Register tmp) {
   assert(CodeCache::find_blob(entry.target()) != NULL,
          "destination of far call not found in code cache");
   if (far_branches()) {
-    unsigned long offset;
+    uintptr_t offset;
     // We can use ADRP here because we know that the total size of
     // the code cache cannot exceed 2Gb.
     adrp(tmp, entry, offset);
@@ -847,7 +847,7 @@ void MacroAssembler::c2bool(Register x) {
 address MacroAssembler::ic_call(address entry, jint method_index) {
   RelocationHolder rh = virtual_call_Relocation::spec(pc(), method_index);
   // address const_ptr = long_constant((jlong)Universe::non_oop_word());
-  // unsigned long offset;
+  // uintptr_t offset;
   // ldr_constant(rscratch2, const_ptr);
   movptr(rscratch2, (uintptr_t)Universe::non_oop_word());
   return trampoline_call(Address(entry, rh));
@@ -1700,7 +1700,7 @@ void MacroAssembler::mov_immediate32(Register dst, uint32_t imm32)
 // not actually be used: you must use the Address that is returned.
 // It is up to you to ensure that the shift provided matches the size
 // of your data.
-Address MacroAssembler::form_address(Register Rd, Register base, long byte_offset, int shift) {
+Address MacroAssembler::form_address(Register Rd, Register base, int64_t byte_offset, int shift) {
   if (Address::offset_ok_for_immed(byte_offset, shift))
     // It fits; no need for any heroics
     return Address(base, byte_offset);
@@ -1715,8 +1715,8 @@ Address MacroAssembler::form_address(Register Rd, Register base, long byte_offse
 
   // See if we can do this with two 12-bit offsets
   {
-    unsigned long word_offset = byte_offset >> shift;
-    unsigned long masked_offset = word_offset & 0xfff000;
+    uint64_t word_offset = byte_offset >> shift;
+    uint64_t masked_offset = word_offset & 0xfff000;
     if (Address::offset_ok_for_immed(word_offset - masked_offset)
         && Assembler::operand_valid_for_add_sub_immediate(masked_offset << shift)) {
       add(Rd, base, masked_offset << shift);
@@ -1957,7 +1957,7 @@ void MacroAssembler::decrement(Register reg, int value)
   if (value < (1 << 12)) { sub(reg, reg, value); return; }
   /* else */ {
     assert(reg != rscratch2, "invalid dst for register decrement");
-    mov(rscratch2, (unsigned long)value);
+    mov(rscratch2, (uint64_t)value);
     sub(reg, reg, rscratch2);
   }
 }
@@ -2638,19 +2638,19 @@ Address MacroAssembler::spill_address(int size, int offset, Register tmp)
 // Returns true if it is, else false.
 bool MacroAssembler::merge_alignment_check(Register base,
                                            size_t size,
-                                           long cur_offset,
-                                           long prev_offset) const {
+                                           int64_t cur_offset,
+                                           int64_t prev_offset) const {
   if (AvoidUnalignedAccesses) {
     if (base == sp) {
       // Checks whether low offset if aligned to pair of registers.
-      long pair_mask = size * 2 - 1;
-      long offset = prev_offset > cur_offset ? cur_offset : prev_offset;
+      int64_t pair_mask = size * 2 - 1;
+      int64_t offset = prev_offset > cur_offset ? cur_offset : prev_offset;
       return (offset & pair_mask) == 0;
     } else { // If base is not sp, we can't guarantee the access is aligned.
       return false;
     }
   } else {
-    long mask = size - 1;
+    int64_t mask = size - 1;
     // Load/store pair instruction only supports element size aligned offset.
     return (cur_offset & mask) == 0 && (prev_offset & mask) == 0;
   }
@@ -2683,8 +2683,8 @@ bool MacroAssembler::ldst_can_merge(Register rt,
     return false;
   }
 
-  long max_offset = 63 * prev_size_in_bytes;
-  long min_offset = -64 * prev_size_in_bytes;
+  int64_t max_offset = 63 * prev_size_in_bytes;
+  int64_t min_offset = -64 * prev_size_in_bytes;
 
   assert(prev_ldst->is_not_pre_post_index(), "pre-index or post-index is not supported to be merged.");
 
@@ -2693,8 +2693,8 @@ bool MacroAssembler::ldst_can_merge(Register rt,
     return false;
   }
 
-  long cur_offset = adr.offset();
-  long prev_offset = prev_ldst->offset();
+  int64_t cur_offset = adr.offset();
+  int64_t prev_offset = prev_ldst->offset();
   size_t diff = abs(cur_offset - prev_offset);
   if (diff != prev_size_in_bytes) {
     return false;
@@ -2711,7 +2711,7 @@ bool MacroAssembler::ldst_can_merge(Register rt,
     return false;
   }
 
-  long low_offset = prev_offset > cur_offset ? cur_offset : prev_offset;
+  int64_t low_offset = prev_offset > cur_offset ? cur_offset : prev_offset;
   // Offset range must be in ldp/stp instruction's range.
   if (low_offset > max_offset || low_offset < min_offset) {
     return false;
@@ -2736,7 +2736,7 @@ void MacroAssembler::merge_ldst(Register rt,
   address prev = pc() - NativeInstruction::instruction_size;
   NativeLdSt* prev_ldst = NativeLdSt_at(prev);
 
-  long offset;
+  int64_t offset;
 
   if (adr.offset() < prev_ldst->offset()) {
     offset = adr.offset();
@@ -3282,7 +3282,7 @@ void MacroAssembler::kernel_crc32(Register crc, Register buf, Register len,
         Register table0, Register table1, Register table2, Register table3,
         Register tmp, Register tmp2, Register tmp3) {
   Label L_by16, L_by16_loop, L_by4, L_by4_loop, L_by1, L_by1_loop, L_exit;
-  unsigned long offset;
+  uint64_t offset;
 
   if (UseCRC32) {
       kernel_crc32_using_crc32(crc, buf, len, table0, table1, table2, table3);
@@ -3584,7 +3584,7 @@ void MacroAssembler::kernel_crc32c(Register crc, Register buf, Register len,
 SkipIfEqual::SkipIfEqual(
     MacroAssembler* masm, const bool* flag_addr, bool value) {
   _masm = masm;
-  unsigned long offset;
+  uint64_t offset;
   _masm->adrp(rscratch1, ExternalAddress((address)flag_addr), offset);
   _masm->ldrb(rscratch1, Address(rscratch1, offset));
   _masm->cbzw(rscratch1, _label);
@@ -3613,7 +3613,7 @@ void MacroAssembler::addptr(const Address &dst, int32_t src) {
 }
 
 void MacroAssembler::cmpptr(Register src1, Address src2) {
-  unsigned long offset;
+  uint64_t offset;
   adrp(rscratch1, src2, offset);
   ldr(rscratch1, Address(rscratch1, offset));
   cmp(src1, rscratch1);
@@ -4199,7 +4199,7 @@ void MacroAssembler::get_polling_page(Register dest, address page, relocInfo::re
   if (SafepointMechanism::uses_thread_local_poll()) {
     ldr(dest, Address(rthread, Thread::polling_page_offset()));
   } else {
-    unsigned long off;
+    uint64_t off;
     adrp(dest, Address(page, rtype), off);
     assert(off == 0, "polling page must be page aligned");
   }
@@ -4221,13 +4221,13 @@ address MacroAssembler::read_polling_page(Register r, relocInfo::relocType rtype
   return inst_mark();
 }
 
-void MacroAssembler::adrp(Register reg1, const Address &dest, unsigned long &byte_offset) {
+void MacroAssembler::adrp(Register reg1, const Address &dest, uint64_t &byte_offset) {
   relocInfo::relocType rtype = dest.rspec().reloc()->type();
-  unsigned long low_page = (unsigned long)CodeCache::low_bound() >> 12;
-  unsigned long high_page = (unsigned long)(CodeCache::high_bound()-1) >> 12;
-  unsigned long dest_page = (unsigned long)dest.target() >> 12;
-  long offset_low = dest_page - low_page;
-  long offset_high = dest_page - high_page;
+  uint64_t low_page = (uint64_t)CodeCache::low_bound() >> 12;
+  uint64_t high_page = (uint64_t)(CodeCache::high_bound()-1) >> 12;
+  uint64_t dest_page = (uint64_t)dest.target() >> 12;
+  int64_t offset_low = dest_page - low_page;
+  int64_t offset_high = dest_page - high_page;
 
   assert(is_valid_AArch64_address(dest.target()), "bad address");
   assert(dest.getMode() == Address::literal, "ADRP must be applied to a literal address");
@@ -4239,14 +4239,14 @@ void MacroAssembler::adrp(Register reg1, const Address &dest, unsigned long &byt
   if (offset_high >= -(1<<20) && offset_low < (1<<20)) {
     _adrp(reg1, dest.target());
   } else {
-    unsigned long target = (unsigned long)dest.target();
-    unsigned long adrp_target
-      = (target & 0xffffffffUL) | ((unsigned long)pc() & 0xffff00000000UL);
+    uint64_t target = (uint64_t)dest.target();
+    uint64_t adrp_target
+      = (target & 0xffffffffULL) | ((uint64_t)pc() & 0xffff00000000ULL);
 
     _adrp(reg1, (address)adrp_target);
     movk(reg1, target >> 32, 32);
   }
-  byte_offset = (unsigned long)dest.target() & 0xfff;
+  byte_offset = (uint64_t)dest.target() & 0xfff;
 }
 
 void MacroAssembler::load_byte_map_base(Register reg) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -93,7 +93,7 @@ int MacroAssembler::pd_patch_instruction_size(address branch, address target) {
     offset = target-branch;
     int shift = Instruction_aarch64::extract(insn, 31, 31);
     if (shift) {
-      u_int64_t dest = (u_int64_t)target;
+      uint64_t dest = (uint64_t)target;
       uint64_t pc_page = (uint64_t)branch >> 12;
       uint64_t adr_page = (uint64_t)target >> 12;
       unsigned offset_lo = dest & 0xfff;
@@ -146,7 +146,7 @@ int MacroAssembler::pd_patch_instruction_size(address branch, address target) {
     Instruction_aarch64::spatch(branch, 23, 5, offset);
     Instruction_aarch64::patch(branch, 30, 29, offset_lo);
   } else if (Instruction_aarch64::extract(insn, 31, 21) == 0b11010010100) {
-    u_int64_t dest = (u_int64_t)target;
+    uint64_t dest = (uint64_t)target;
     // Move wide constant
     assert(nativeInstruction_at(branch+4)->is_movk(), "wrong insns in patch");
     assert(nativeInstruction_at(branch+8)->is_movk(), "wrong insns in patch");
@@ -272,13 +272,13 @@ address MacroAssembler::target_addr_for_insn(address insn_addr, unsigned insn) {
       ShouldNotReachHere();
     }
   } else if (Instruction_aarch64::extract(insn, 31, 23) == 0b110100101) {
-    u_int32_t *insns = (u_int32_t *)insn_addr;
+    uint32_t *insns = (uint32_t *)insn_addr;
     // Move wide constant: movz, movk, movk.  See movptr().
     assert(nativeInstruction_at(insns+1)->is_movk(), "wrong insns in patch");
     assert(nativeInstruction_at(insns+2)->is_movk(), "wrong insns in patch");
-    return address(u_int64_t(Instruction_aarch64::extract(insns[0], 20, 5))
-                   + (u_int64_t(Instruction_aarch64::extract(insns[1], 20, 5)) << 16)
-                   + (u_int64_t(Instruction_aarch64::extract(insns[2], 20, 5)) << 32));
+    return address(uint64_t(Instruction_aarch64::extract(insns[0], 20, 5))
+                   + (uint64_t(Instruction_aarch64::extract(insns[1], 20, 5)) << 16)
+                   + (uint64_t(Instruction_aarch64::extract(insns[2], 20, 5)) << 32));
   } else if (Instruction_aarch64::extract(insn, 31, 22) == 0b1011100101 &&
              Instruction_aarch64::extract(insn, 4, 0) == 0b11111) {
     return 0;
@@ -1480,7 +1480,7 @@ void MacroAssembler::null_check(Register reg, int offset) {
 
 void MacroAssembler::mov(Register r, Address dest) {
   code_section()->relocate(pc(), dest.rspec());
-  u_int64_t imm64 = (u_int64_t)dest.target();
+  uint64_t imm64 = (uint64_t)dest.target();
   movptr(r, imm64);
 }
 
@@ -1513,20 +1513,20 @@ void MacroAssembler::movptr(Register r, uintptr_t imm64) {
 //   imm32 == hex abcdefgh  T2S:  Vd = abcdefghabcdefgh
 //   imm32 == hex abcdefgh  T4S:  Vd = abcdefghabcdefghabcdefghabcdefgh
 //   T1D/T2D: invalid
-void MacroAssembler::mov(FloatRegister Vd, SIMD_Arrangement T, u_int32_t imm32) {
+void MacroAssembler::mov(FloatRegister Vd, SIMD_Arrangement T, uint32_t imm32) {
   assert(T != T1D && T != T2D, "invalid arrangement");
   if (T == T8B || T == T16B) {
     assert((imm32 & ~0xff) == 0, "extraneous bits in unsigned imm32 (T8B/T16B)");
     movi(Vd, T, imm32 & 0xff, 0);
     return;
   }
-  u_int32_t nimm32 = ~imm32;
+  uint32_t nimm32 = ~imm32;
   if (T == T4H || T == T8H) {
     assert((imm32  & ~0xffff) == 0, "extraneous bits in unsigned imm32 (T4H/T8H)");
     imm32 &= 0xffff;
     nimm32 &= 0xffff;
   }
-  u_int32_t x = imm32;
+  uint32_t x = imm32;
   int movi_cnt = 0;
   int movn_cnt = 0;
   while (x) { if (x & 0xff) movi_cnt++; x >>= 8; }
@@ -1550,7 +1550,7 @@ void MacroAssembler::mov(FloatRegister Vd, SIMD_Arrangement T, u_int32_t imm32) 
   }
 }
 
-void MacroAssembler::mov_immediate64(Register dst, u_int64_t imm64)
+void MacroAssembler::mov_immediate64(Register dst, uint64_t imm64)
 {
 #ifndef PRODUCT
   {
@@ -1564,7 +1564,7 @@ void MacroAssembler::mov_immediate64(Register dst, u_int64_t imm64)
   } else {
     // we can use a combination of MOVZ or MOVN with
     // MOVK to build up the constant
-    u_int64_t imm_h[4];
+    uint64_t imm_h[4];
     int zero_count = 0;
     int neg_count = 0;
     int i;
@@ -1585,7 +1585,7 @@ void MacroAssembler::mov_immediate64(Register dst, u_int64_t imm64)
     } else if (zero_count == 3) {
       for (i = 0; i < 4; i++) {
         if (imm_h[i] != 0L) {
-          movz(dst, (u_int32_t)imm_h[i], (i << 4));
+          movz(dst, (uint32_t)imm_h[i], (i << 4));
           break;
         }
       }
@@ -1593,7 +1593,7 @@ void MacroAssembler::mov_immediate64(Register dst, u_int64_t imm64)
       // one MOVN will do
       for (int i = 0; i < 4; i++) {
         if (imm_h[i] != 0xffffL) {
-          movn(dst, (u_int32_t)imm_h[i] ^ 0xffffL, (i << 4));
+          movn(dst, (uint32_t)imm_h[i] ^ 0xffffL, (i << 4));
           break;
         }
       }
@@ -1601,69 +1601,69 @@ void MacroAssembler::mov_immediate64(Register dst, u_int64_t imm64)
       // one MOVZ and one MOVK will do
       for (i = 0; i < 3; i++) {
         if (imm_h[i] != 0L) {
-          movz(dst, (u_int32_t)imm_h[i], (i << 4));
+          movz(dst, (uint32_t)imm_h[i], (i << 4));
           i++;
           break;
         }
       }
       for (;i < 4; i++) {
         if (imm_h[i] != 0L) {
-          movk(dst, (u_int32_t)imm_h[i], (i << 4));
+          movk(dst, (uint32_t)imm_h[i], (i << 4));
         }
       }
     } else if (neg_count == 2) {
       // one MOVN and one MOVK will do
       for (i = 0; i < 4; i++) {
         if (imm_h[i] != 0xffffL) {
-          movn(dst, (u_int32_t)imm_h[i] ^ 0xffffL, (i << 4));
+          movn(dst, (uint32_t)imm_h[i] ^ 0xffffL, (i << 4));
           i++;
           break;
         }
       }
       for (;i < 4; i++) {
         if (imm_h[i] != 0xffffL) {
-          movk(dst, (u_int32_t)imm_h[i], (i << 4));
+          movk(dst, (uint32_t)imm_h[i], (i << 4));
         }
       }
     } else if (zero_count == 1) {
       // one MOVZ and two MOVKs will do
       for (i = 0; i < 4; i++) {
         if (imm_h[i] != 0L) {
-          movz(dst, (u_int32_t)imm_h[i], (i << 4));
+          movz(dst, (uint32_t)imm_h[i], (i << 4));
           i++;
           break;
         }
       }
       for (;i < 4; i++) {
         if (imm_h[i] != 0x0L) {
-          movk(dst, (u_int32_t)imm_h[i], (i << 4));
+          movk(dst, (uint32_t)imm_h[i], (i << 4));
         }
       }
     } else if (neg_count == 1) {
       // one MOVN and two MOVKs will do
       for (i = 0; i < 4; i++) {
         if (imm_h[i] != 0xffffL) {
-          movn(dst, (u_int32_t)imm_h[i] ^ 0xffffL, (i << 4));
+          movn(dst, (uint32_t)imm_h[i] ^ 0xffffL, (i << 4));
           i++;
           break;
         }
       }
       for (;i < 4; i++) {
         if (imm_h[i] != 0xffffL) {
-          movk(dst, (u_int32_t)imm_h[i], (i << 4));
+          movk(dst, (uint32_t)imm_h[i], (i << 4));
         }
       }
     } else {
       // use a MOVZ and 3 MOVKs (makes it easier to debug)
-      movz(dst, (u_int32_t)imm_h[0], 0);
+      movz(dst, (uint32_t)imm_h[0], 0);
       for (i = 1; i < 4; i++) {
-        movk(dst, (u_int32_t)imm_h[i], (i << 4));
+        movk(dst, (uint32_t)imm_h[i], (i << 4));
       }
     }
   }
 }
 
-void MacroAssembler::mov_immediate32(Register dst, u_int32_t imm32)
+void MacroAssembler::mov_immediate32(Register dst, uint32_t imm32)
 {
 #ifndef PRODUCT
     {
@@ -1677,7 +1677,7 @@ void MacroAssembler::mov_immediate32(Register dst, u_int32_t imm32)
   } else {
     // we can use MOVZ, MOVN or two calls to MOVK to build up the
     // constant
-    u_int32_t imm_h[2];
+    uint32_t imm_h[2];
     imm_h[0] = imm32 & 0xffff;
     imm_h[1] = ((imm32 >> 16) & 0xffff);
     if (imm_h[0] == 0) {
@@ -5441,7 +5441,7 @@ address MacroAssembler::zero_words(Register ptr, Register cnt)
 // base:         Address of a buffer to be zeroed, 8 bytes aligned.
 // cnt:          Immediate count in HeapWords.
 #define SmallArraySize (18 * BytesPerLong)
-void MacroAssembler::zero_words(Register base, u_int64_t cnt)
+void MacroAssembler::zero_words(Register base, uint64_t cnt)
 {
   BLOCK_COMMENT("zero_words {");
   int i = cnt & 1;  // store any odd word to start

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1496,7 +1496,7 @@ void MacroAssembler::movptr(Register r, uintptr_t imm64) {
     block_comment(buffer);
   }
 #endif
-  assert(imm64 < (1ul << 48), "48-bit overflow in address constant");
+  assert(imm64 < (1ull << 48), "48-bit overflow in address constant");
   movz(r, imm64 & 0xffff);
   imm64 >>= 16;
   movk(r, imm64 & 0xffff, 16);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1492,7 +1492,7 @@ void MacroAssembler::movptr(Register r, uintptr_t imm64) {
 #ifndef PRODUCT
   {
     char buffer[64];
-    snprintf(buffer, sizeof(buffer), "0x%"PRIX64, imm64);
+    snprintf(buffer, sizeof(buffer), PTR64_FORMAT, imm64);
     block_comment(buffer);
   }
 #endif
@@ -1555,7 +1555,7 @@ void MacroAssembler::mov_immediate64(Register dst, uint64_t imm64)
 #ifndef PRODUCT
   {
     char buffer[64];
-    snprintf(buffer, sizeof(buffer), "0x%"PRIX64, imm64);
+    snprintf(buffer, sizeof(buffer), PTR64_FORMAT, imm64);
     block_comment(buffer);
   }
 #endif
@@ -1668,7 +1668,7 @@ void MacroAssembler::mov_immediate32(Register dst, uint32_t imm32)
 #ifndef PRODUCT
     {
       char buffer[64];
-      snprintf(buffer, sizeof(buffer), "0x%"PRIX32, imm32);
+      snprintf(buffer, sizeof(buffer), PTR32_FORMAT, imm32);
       block_comment(buffer);
     }
 #endif
@@ -2544,9 +2544,17 @@ void MacroAssembler::debug64(char* msg, int64_t pc, int64_t regs[])
   }
 }
 
+RegSet MacroAssembler::call_clobbered_registers() {
+  RegSet regs = RegSet::range(r0, r17) - RegSet::of(rscratch1, rscratch2);
+#ifndef R18_RESERVED
+  regs += r18_reserved;
+#endif
+  return regs;
+}
+
 void MacroAssembler::push_call_clobbered_registers() {
   int step = 4 * wordSize;
-  push(RegSet::range(r0, r18) - RegSet::of(rscratch1, rscratch2), sp);
+  push(call_clobbered_registers() - RegSet::of(rscratch1, rscratch2), sp);
   sub(sp, sp, step);
   mov(rscratch1, -step);
   // Push v0-v7, v16-v31.
@@ -2566,7 +2574,7 @@ void MacroAssembler::pop_call_clobbered_registers() {
           as_FloatRegister(i+3), T1D, Address(post(sp, 4 * wordSize)));
   }
 
-  pop(RegSet::range(r0, r18) - RegSet::of(rscratch1, rscratch2), sp);
+  pop(call_clobbered_registers() - RegSet::of(rscratch1, rscratch2), sp);
 }
 
 void MacroAssembler::push_CPU_state(bool save_vectors) {
@@ -4798,7 +4806,7 @@ void MacroAssembler::string_compare(Register str1, Register str2,
     Register cnt1, Register cnt2, Register result, Register tmp1, Register tmp2,
     FloatRegister vtmp1, FloatRegister vtmp2, FloatRegister vtmp3, int ae) {
   Label DONE, SHORT_LOOP, SHORT_STRING, SHORT_LAST, TAIL, STUB,
-      DIFFERENCE, NEXT_WORD, SHORT_LOOP_TAIL, SHORT_LAST2, SHORT_LAST_INIT,
+      DIFF, NEXT_WORD, SHORT_LOOP_TAIL, SHORT_LAST2, SHORT_LAST_INIT,
       SHORT_LOOP_START, TAIL_CHECK;
 
   const int STUB_THRESHOLD = 64 + 8;
@@ -4885,7 +4893,7 @@ void MacroAssembler::string_compare(Register str1, Register str2,
     adds(cnt2, cnt2, isUL ? 4 : 8);
     br(GE, TAIL);
     eor(rscratch2, tmp1, tmp2);
-    cbnz(rscratch2, DIFFERENCE);
+    cbnz(rscratch2, DIFF);
     // main loop
     bind(NEXT_WORD);
     if (str1_isL == str2_isL) {
@@ -4911,10 +4919,10 @@ void MacroAssembler::string_compare(Register str1, Register str2,
 
     eor(rscratch2, tmp1, tmp2);
     cbz(rscratch2, NEXT_WORD);
-    b(DIFFERENCE);
+    b(DIFF);
     bind(TAIL);
     eor(rscratch2, tmp1, tmp2);
-    cbnz(rscratch2, DIFFERENCE);
+    cbnz(rscratch2, DIFF);
     // Last longword.  In the case where length == 4 we compare the
     // same longword twice, but that's still faster than another
     // conditional branch.
@@ -4938,7 +4946,7 @@ void MacroAssembler::string_compare(Register str1, Register str2,
 
     // Find the first different characters in the longwords and
     // compute their difference.
-    bind(DIFFERENCE);
+    bind(DIFF);
     rev(rscratch2, rscratch2);
     clz(rscratch2, rscratch2);
     andr(rscratch2, rscratch2, isLL ? -8 : -16);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1832,7 +1832,7 @@ bool MacroAssembler::try_merge_ldst(Register rt, const Address &adr, size_t size
     return true;
   } else {
     assert(size_in_bytes == 8 || size_in_bytes == 4, "only 8 bytes or 4 bytes load/store is supported.");
-    const unsigned mask = size_in_bytes - 1;
+    const uint64_t mask = size_in_bytes - 1;
     if (adr.getMode() == Address::base_plus_offset &&
         (adr.offset() & mask) == 0) { // only supports base_plus_offset.
       code()->set_last_insn(pc());
@@ -2760,7 +2760,7 @@ void MacroAssembler::merge_ldst(Register rt,
   // Overwrite previous generated binary.
   code_section()->set_end(prev);
 
-  const int sz = prev_ldst->size_in_bytes();
+  const size_t sz = prev_ldst->size_in_bytes();
   assert(sz == 8 || sz == 4, "only supports 64/32bit merging.");
   if (!is_store) {
     BLOCK_COMMENT("merged ldr pair");

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -185,7 +185,15 @@ class MacroAssembler: public Assembler {
     mov(rscratch2, call_site);
   }
 
+// Microsoft's MSVC team thinks that the __FUNCSIG__ is approximately (sympathy for calling conventions) equivalent to __PRETTY_FUNCTION__
+// Also, from Clang patch: "It is very similar to GCC's PRETTY_FUNCTION, except it prints the calling convention."
+// https://reviews.llvm.org/D3311
+
+#ifdef _WIN64
+#define call_Unimplemented() _call_Unimplemented((address)__FUNCSIG__)
+#else
 #define call_Unimplemented() _call_Unimplemented((address)__PRETTY_FUNCTION__)
+#endif
 
   // aliases defined in AARCH64 spec
 
@@ -460,6 +468,8 @@ public:
   void push(RegSet regs, Register stack) { if (regs.bits()) push(regs.bits(), stack); }
   void pop(RegSet regs, Register stack) { if (regs.bits()) pop(regs.bits(), stack); }
 
+  static RegSet call_clobbered_registers();
+
   // Push and pop everything that might be clobbered by a native
   // runtime call except rscratch1 and rscratch2.  (They are always
   // scratch, so we don't have to protect them.)  Only save the lower
@@ -514,10 +524,10 @@ public:
 
   // Generalized Test Bit And Branch, including a "far" variety which
   // spans more than 32KiB.
-  void tbr(Condition cond, Register Rt, int bitpos, Label &dest, bool far = false) {
+  void tbr(Condition cond, Register Rt, int bitpos, Label &dest, bool isfar = false) {
     assert(cond == EQ || cond == NE, "must be");
 
-    if (far)
+    if (isfar)
       cond = ~cond;
 
     void (Assembler::* branch)(Register Rt, int bitpos, Label &L);
@@ -526,7 +536,7 @@ public:
     else
       branch = &Assembler::tbnz;
 
-    if (far) {
+    if (isfar) {
       Label L;
       (this->*branch)(Rt, bitpos, L);
       b(dest);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -448,8 +448,8 @@ class MacroAssembler: public Assembler {
   // first two private routines for loading 32 bit or 64 bit constants
 private:
 
-  void mov_immediate64(Register dst, u_int64_t imm64);
-  void mov_immediate32(Register dst, u_int32_t imm32);
+  void mov_immediate64(Register dst, uint64_t imm64);
+  void mov_immediate32(Register dst, uint32_t imm32);
 
   int push(unsigned int bitset, Register stack);
   int pop(unsigned int bitset, Register stack);
@@ -472,22 +472,22 @@ public:
 
   inline void mov(Register dst, address addr)
   {
-    mov_immediate64(dst, (u_int64_t)addr);
+    mov_immediate64(dst, (uint64_t)addr);
   }
 
-  inline void mov(Register dst, u_int64_t imm64)
+  inline void mov(Register dst, uint64_t imm64)
   {
     mov_immediate64(dst, imm64);
   }
 
-  inline void movw(Register dst, u_int32_t imm32)
+  inline void movw(Register dst, uint32_t imm32)
   {
     mov_immediate32(dst, imm32);
   }
 
   inline void mov(Register dst, long l)
   {
-    mov(dst, (u_int64_t)l);
+    mov(dst, (uint64_t)l);
   }
 
   inline void mov(Register dst, int i)
@@ -504,7 +504,7 @@ public:
 
   void movptr(Register r, uintptr_t imm64);
 
-  void mov(FloatRegister Vd, SIMD_Arrangement T, u_int32_t imm32);
+  void mov(FloatRegister Vd, SIMD_Arrangement T, uint32_t imm32);
 
   void mov(FloatRegister Vd, SIMD_Arrangement T, FloatRegister Vn) {
     orr(Vd, T, Vn, Vn);
@@ -1232,7 +1232,7 @@ public:
                      int elem_size);
 
   void fill_words(Register base, Register cnt, Register value);
-  void zero_words(Register base, u_int64_t cnt);
+  void zero_words(Register base, uint64_t cnt);
   address zero_words(Register ptr, Register cnt);
   void zero_dcache_blocks(Register base, Register cnt);
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -88,7 +88,7 @@ class MacroAssembler: public Assembler {
       = (operand_valid_for_logical_immediate(false /*is32*/,
                                              (uint64_t)Universe::narrow_klass_base())
          && ((uint64_t)Universe::narrow_klass_base()
-             > (1UL << log2_intptr(Universe::narrow_klass_range()))));
+             > (1ULL << log2_intptr(Universe::narrow_klass_range()))));
   }
 
  // These routines should emit JVMTI PopFrame and ForceEarlyReturn handling code.

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -485,14 +485,14 @@ public:
     mov_immediate32(dst, imm32);
   }
 
-  inline void mov(Register dst, long l)
+  inline void mov(Register dst, int64_t l)
   {
     mov(dst, (uint64_t)l);
   }
 
   inline void mov(Register dst, int i)
   {
-    mov(dst, (long)i);
+    mov(dst, (int64_t)i);
   }
 
   void mov(Register dst, RegisterOrConstant src) {
@@ -1160,7 +1160,7 @@ public:
   void sub(Register Rd, Register Rn, RegisterOrConstant decrement);
   void subw(Register Rd, Register Rn, RegisterOrConstant decrement);
 
-  void adrp(Register reg1, const Address &dest, unsigned long &byte_offset);
+  void adrp(Register reg1, const Address &dest, uint64_t &byte_offset);
 
   void tableswitch(Register index, jint lowbound, jint highbound,
                    Label &jumptable, Label &jumptable_end, int stride = 1) {
@@ -1177,7 +1177,7 @@ public:
   // actually be used: you must use the Address that is returned.  It
   // is up to you to ensure that the shift provided matches the size
   // of your data.
-  Address form_address(Register Rd, Register base, long byte_offset, int shift);
+  Address form_address(Register Rd, Register base, int64_t byte_offset, int shift);
 
   // Return true iff an address is within the 48-bit AArch64 address
   // space.
@@ -1202,7 +1202,7 @@ public:
     if (NearCpool) {
       ldr(dest, const_addr);
     } else {
-      unsigned long offset;
+      uint64_t offset;
       adrp(dest, InternalAddress(const_addr.target()), offset);
       ldr(dest, Address(dest, offset));
     }
@@ -1314,7 +1314,7 @@ private:
   // Uses rscratch2 if the address is not directly reachable
   Address spill_address(int size, int offset, Register tmp=rscratch2);
 
-  bool merge_alignment_check(Register base, size_t size, long cur_offset, long prev_offset) const;
+  bool merge_alignment_check(Register base, size_t size, int64_t cur_offset, int64_t prev_offset) const;
 
   // Check whether two loads/stores can be merged into ldp/stp.
   bool ldst_can_merge(Register rx, const Address &adr, size_t cur_size_in_bytes, bool is_store) const;

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64_log.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64_log.cpp
@@ -260,9 +260,9 @@ void MacroAssembler::fast_log(FloatRegister vtmp0, FloatRegister vtmp1,
                               Register tmp4, Register tmp5) {
   Label DONE, CHECK_CORNER_CASES, SMALL_VALUE, MAIN,
       CHECKED_CORNER_CASES, RETURN_MINF_OR_NAN;
-  const long INF_OR_NAN_PREFIX = 0x7FF0;
-  const long MINF_OR_MNAN_PREFIX = 0xFFF0;
-  const long ONE_PREFIX = 0x3FF0;
+  const int64_t INF_OR_NAN_PREFIX = 0x7FF0;
+  const int64_t MINF_OR_MNAN_PREFIX = 0xFFF0;
+  const int64_t ONE_PREFIX = 0x3FF0;
     movz(tmp2, ONE_PREFIX, 48);
     movz(tmp4, 0x0010, 48);
     fmovd(rscratch1, v0); // rscratch1 = AS_LONG_BITS(X)

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64_log.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64_log.cpp
@@ -65,7 +65,7 @@
 
 // Table with p(r) polynomial coefficients
 // and table representation of logarithm values (hi and low parts)
-__attribute__ ((aligned(64))) juint _L_tbl[] =
+ATTRIBUTE_ALIGNED(64) juint _L_tbl[] =
 {
     // coefficients of p(r) polynomial:
     // _coeff[]

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64_trig.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64_trig.cpp
@@ -689,7 +689,7 @@ void MacroAssembler::generate__kernel_rem_pio2(address two_over_pi, address pio2
       RECOMP_FOR1_CHECK;
   Register tmp2 = r1, n = r2, jv = r4, tmp5 = r5, jx = r6,
       tmp3 = r7, iqBase = r10, ih = r11, tmp4 = r12, tmp1 = r13,
-      jz = r14, j = r15, twoOverPiBase = r16, i = r17, qBase = r18;
+      jz = r14, j = r15, twoOverPiBase = r16, i = r17, qBase = r19;
     // jp = jk == init_jk[prec] = init_jk[2] == {2,3,4,6}[2] == 4
     // jx = nx - 1
     lea(twoOverPiBase, ExternalAddress(two_over_pi));
@@ -1421,6 +1421,12 @@ void MacroAssembler::generate_dsin_dcos(bool isCos, address npio2_hw,
   Label DONE, ARG_REDUCTION, TINY_X, RETURN_SIN, EARLY_CASE;
   Register X = r0, absX = r1, n = r2, ix = r3;
   FloatRegister y0 = v4, y1 = v5;
+
+  enter();
+  // r19 is used in TemplateInterpreterGenerator::generate_math_entry
+  RegSet saved_regs = RegSet::of(r19);
+  push (saved_regs, sp);
+
     block_comment("check |x| ~< pi/4, NaN, Inf and |x| < 2**-27 cases"); {
       fmovd(X, v0);
       mov(rscratch2, 0x3e400000);
@@ -1438,14 +1444,14 @@ void MacroAssembler::generate_dsin_dcos(bool isCos, address npio2_hw,
       // Set last bit unconditionally to make it NaN
       orr(r10, r10, 1);
       fmovd(v0, r10);
-      ret(lr);
+      b(DONE);
     }
   block_comment("kernel_sin/kernel_cos: if(ix<0x3e400000) {<fast return>}"); {
     bind(TINY_X);
       if (isCos) {
         fmovd(v0, 1.0);
       }
-      ret(lr);
+      b(DONE);
   }
   bind(ARG_REDUCTION); /* argument reduction needed */
     block_comment("n = __ieee754_rem_pio2(x,y);"); {
@@ -1465,7 +1471,7 @@ void MacroAssembler::generate_dsin_dcos(bool isCos, address npio2_hw,
         tbz(n, 1, DONE);
       }
       fnegd(v0, v0);
-      ret(lr);
+      b(DONE);
     bind(RETURN_SIN);
       generate_kernel_sin(y0, true, dsin_coef);
       if (isCos) {
@@ -1474,7 +1480,7 @@ void MacroAssembler::generate_dsin_dcos(bool isCos, address npio2_hw,
         tbz(n, 1, DONE);
       }
       fnegd(v0, v0);
-      ret(lr);
+      b(DONE);
     }
   bind(EARLY_CASE);
     eor(y1, T8B, y1, y1);
@@ -1484,5 +1490,7 @@ void MacroAssembler::generate_dsin_dcos(bool isCos, address npio2_hw,
       generate_kernel_sin(v0, false, dsin_coef);
     }
   bind(DONE);
+    pop(saved_regs, sp);
+    leave();
     ret(lr);
 }

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64_trig.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64_trig.cpp
@@ -201,9 +201,9 @@
 // NOTE: fpu registers are actively reused. See comments in code about their usage
 void MacroAssembler::generate__ieee754_rem_pio2(address npio2_hw,
     address two_over_pi, address pio2) {
-  const long PIO2_1t = 0x3DD0B4611A626331UL;
-  const long PIO2_2  = 0x3DD0B4611A600000UL;
-  const long PIO2_2t = 0x3BA3198A2E037073UL;
+  const int64_t PIO2_1t = 0x3DD0B4611A626331ULL;
+  const int64_t PIO2_2  = 0x3DD0B4611A600000ULL;
+  const int64_t PIO2_2t = 0x3BA3198A2E037073ULL;
   Label X_IS_NEGATIVE, X_IS_MEDIUM_OR_LARGE, X_IS_POSITIVE_LONG_PI, LARGE_ELSE,
       REDUCTION_DONE, X_IS_MEDIUM_BRANCH_DONE, X_IS_LARGE, NX_SET,
       X_IS_NEGATIVE_LONG_PI;

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2018, Red Hat Inc. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -301,7 +301,7 @@ void NativeMovRegMem::set_offset(int x) {
   unsigned insn = *(unsigned*)pc;
   if (maybe_cpool_ref(pc)) {
     address addr = MacroAssembler::target_addr_for_insn(pc);
-    *(long*)addr = x;
+    *(int64_t*)addr = x;
   } else {
     MacroAssembler::pd_patch_instruction(pc, (address)intptr_t(x));
     ICache::invalidate_range(instruction_address(), instruction_size);

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -681,7 +681,7 @@ public:
       return 0;
     }
   }
-  size_t size_in_bytes() { return 1 << size(); }
+  size_t size_in_bytes() { return 1ULL << size(); }
   bool is_not_pre_post_index() { return (is_ldst_ur() || is_ldst_unsigned_offset()); }
   bool is_load() {
     assert(Instruction_aarch64::extract(uint_at(0), 23, 22) == 0b01 ||

--- a/src/hotspot/cpu/aarch64/register_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/register_aarch64.cpp
@@ -38,7 +38,7 @@ const char* RegisterImpl::name() const {
     "c_rarg0", "c_rarg1", "c_rarg2", "c_rarg3", "c_rarg4", "c_rarg5", "c_rarg6", "c_rarg7",
     "rscratch1", "rscratch2",
     "r10", "r11", "r12", "r13", "r14", "r15", "r16",
-    "r17", "r18", "r19",
+    "r17", "r18_tls", "r19",
     "resp", "rdispatch", "rbcp", "r23", "rlocals", "rmonitors", "rcpool", "rheapbase",
     "rthread", "rfp", "lr", "sp"
   };

--- a/src/hotspot/cpu/aarch64/register_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/register_aarch64.hpp
@@ -91,7 +91,18 @@ CONSTANT_REGISTER_DECLARATION(Register, r14,  (14));
 CONSTANT_REGISTER_DECLARATION(Register, r15,  (15));
 CONSTANT_REGISTER_DECLARATION(Register, r16,  (16));
 CONSTANT_REGISTER_DECLARATION(Register, r17,  (17));
-CONSTANT_REGISTER_DECLARATION(Register, r18,  (18));
+
+// In the ABI for Windows+AArch64 the register r18 is used to store the pointer
+// to the current thread's TEB (where TLS variables are stored). We could
+// carefully save and restore r18 at key places, however Win32 Structured
+// Exception Handling (SEH) is using TLS to unwind the stack. If r18 is used
+// for any other purpose at the time of an exception happening, SEH would not
+// be able to unwind the stack properly and most likely crash.
+//
+// It's easier to avoid allocating r18 altogether.
+//
+// See https://docs.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions?view=vs-2019#integer-registers
+CONSTANT_REGISTER_DECLARATION(Register, r18_reserved,  (18));
 CONSTANT_REGISTER_DECLARATION(Register, r19,  (19));
 CONSTANT_REGISTER_DECLARATION(Register, r20,  (20));
 CONSTANT_REGISTER_DECLARATION(Register, r21,  (21));
@@ -207,6 +218,8 @@ class ConcreteRegisterImpl : public AbstractRegisterImpl {
   static const int max_fpr;
 };
 
+class RegSetIterator;
+
 // A set of registers
 class RegSet {
   uint32_t _bitset;
@@ -231,6 +244,11 @@ public:
 
   RegSet &operator+=(const RegSet aSet) {
     *this = *this + aSet;
+    return *this;
+  }
+
+  RegSet &operator-=(const RegSet aSet) {
+    *this = *this - aSet;
     return *this;
   }
 
@@ -260,6 +278,49 @@ public:
   }
 
   uint32_t bits() const { return _bitset; }
+
+private:
+
+  Register first() {
+    uint32_t first = _bitset & -_bitset;
+    return first ? as_Register(exact_log2(first)) : noreg;
+  }
+
+public:
+
+  friend class RegSetIterator;
+
+  RegSetIterator begin();
 };
+
+class RegSetIterator {
+  RegSet _regs;
+
+public:
+  RegSetIterator(RegSet x): _regs(x) {}
+  RegSetIterator(const RegSetIterator& mit) : _regs(mit._regs) {}
+
+  RegSetIterator& operator++() {
+    Register r = _regs.first();
+    if (r != noreg)
+      _regs -= r;
+    return *this;
+  }
+
+  bool operator==(const RegSetIterator& rhs) const {
+    return _regs.bits() == rhs._regs.bits();
+  }
+  bool operator!=(const RegSetIterator& rhs) const {
+    return ! (rhs == *this);
+  }
+
+  Register operator*() {
+    return _regs.first();
+  }
+};
+
+inline RegSetIterator RegSet::begin() {
+  return RegSetIterator(*this);
+}
 
 #endif // CPU_AARCH64_VM_REGISTER_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/register_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/register_aarch64.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2000, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ class RegisterImpl: public AbstractRegisterImpl {
 
   // Return the bit which represents this register.  This is intended
   // to be ORed into a bitmask: for usage see class RegSet below.
-  unsigned long bit(bool should_set = true) const { return should_set ? 1 << encoding() : 0; }
+  uint64_t bit(bool should_set = true) const { return should_set ? 1 << encoding() : 0; }
 };
 
 // The integer registers of the aarch64 architecture

--- a/src/hotspot/cpu/aarch64/register_definitions_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/register_definitions_aarch64.cpp
@@ -50,7 +50,7 @@ REGISTER_DEFINITION(Register, r14);
 REGISTER_DEFINITION(Register, r15);
 REGISTER_DEFINITION(Register, r16);
 REGISTER_DEFINITION(Register, r17);
-REGISTER_DEFINITION(Register, r18);
+REGISTER_DEFINITION(Register, r18_reserved); // see comment in register_aarch64.hpp
 REGISTER_DEFINITION(Register, r19);
 REGISTER_DEFINITION(Register, r20);
 REGISTER_DEFINITION(Register, r21);

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -398,7 +398,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
     // 3    8 T_BOOL
     // -    0 return address
     //
-    // However to make thing extra confusing. Because we can fit a long/double in
+    // However to make thing extra confusing. Because we can fit a Java long/double in
     // a single slot on a 64 bt vm and it would be silly to break them up, the interpreter
     // leaves one slot empty and only stores to a single slot. In this case the
     // slot that is occupied is the T_VOID slot. See I said it was confusing.
@@ -431,7 +431,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
           __ str(rscratch1, Address(sp, next_off));
 #ifdef ASSERT
           // Overwrite the unused slot with known junk
-          __ mov(rscratch1, 0xdeadffffdeadaaaaul);
+          __ mov(rscratch1, (uint64_t)0xdeadffffdeadaaaaull);
           __ str(rscratch1, Address(sp, st_off));
 #endif /* ASSERT */
         } else {
@@ -448,10 +448,10 @@ static void gen_c2i_adapter(MacroAssembler *masm,
         // Two VMREgs|OptoRegs can be T_OBJECT, T_ADDRESS, T_DOUBLE, T_LONG
         // T_DOUBLE and T_LONG use two slots in the interpreter
         if ( sig_bt[i] == T_LONG || sig_bt[i] == T_DOUBLE) {
-          // long/double in gpr
+          // jlong/double in gpr
 #ifdef ASSERT
           // Overwrite the unused slot with known junk
-          __ mov(rscratch1, 0xdeadffffdeadaaabul);
+          __ mov(rscratch1, (uint64_t)0xdeadffffdeadaaabull);
           __ str(rscratch1, Address(sp, st_off));
 #endif /* ASSERT */
           __ str(r, Address(sp, next_off));
@@ -467,7 +467,7 @@ static void gen_c2i_adapter(MacroAssembler *masm,
       } else {
 #ifdef ASSERT
         // Overwrite the unused slot with known junk
-        __ mov(rscratch1, 0xdeadffffdeadaaacul);
+        __ mov(rscratch1, (uint64_t)0xdeadffffdeadaaacull);
         __ str(rscratch1, Address(sp, st_off));
 #endif /* ASSERT */
         __ strd(r_1->as_FloatRegister(), Address(sp, next_off));
@@ -1675,7 +1675,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   Label dtrace_method_entry, dtrace_method_entry_done;
   {
-    unsigned long offset;
+    uint64_t offset;
     __ adrp(rscratch1, ExternalAddress((address)&DTraceMethodProbes), offset);
     __ ldrb(rscratch1, Address(rscratch1, offset));
     __ cbnzw(rscratch1, dtrace_method_entry);
@@ -1900,7 +1900,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   Label dtrace_method_exit, dtrace_method_exit_done;
   {
-    unsigned long offset;
+    uint64_t offset;
     __ adrp(rscratch1, ExternalAddress((address)&DTraceMethodProbes), offset);
     __ ldrb(rscratch1, Address(rscratch1, offset));
     __ cbnzw(rscratch1, dtrace_method_exit);

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1474,7 +1474,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // Generate stack overflow check
   if (UseStackBanging) {
-    __ bang_stack_with_offset(JavaThread::stack_shadow_zone_size());
+    __ bang_stack_with_offset((int)JavaThread::stack_shadow_zone_size());
   } else {
     Unimplemented();
   }
@@ -2422,7 +2422,7 @@ void SharedRuntime::generate_deopt_blob() {
   __ sub(sp, sp, r19);
 
   // Push interpreter frames in a loop
-  __ mov(rscratch1, (address)0xDEADDEAD);        // Make a recognizable pattern
+  __ mov(rscratch1, (uint64_t)0xDEADDEAD);        // Make a recognizable pattern
   __ mov(rscratch2, rscratch1);
   Label loop;
   __ bind(loop);

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -1073,7 +1073,7 @@ class StubGenerator: public StubCodeGenerator {
     Label copy4, copy8, copy16, copy32, copy80, copy128, copy_big, finish;
     const Register t2 = r5, t3 = r6, t4 = r7, t5 = r8;
     const Register t6 = r9, t7 = r10, t8 = r11, t9 = r12;
-    const Register send = r17, dend = r18;
+    const Register send = r17, dend = r16;
 
     if (PrefetchCopyIntervalInBytes > 0)
       __ prfm(Address(s, 0), PLDL1KEEP);
@@ -1286,11 +1286,15 @@ class StubGenerator: public StubCodeGenerator {
 
   void clobber_registers() {
 #ifdef ASSERT
+    RegSet clobbered
+      = MacroAssembler::call_clobbered_registers() - rscratch1;
     __ mov(rscratch1, (uint64_t)0xdeadbeef);
     __ orr(rscratch1, rscratch1, rscratch1, Assembler::LSL, 32);
-    for (Register r = r3; r <= r18; r++)
-      if (r != rscratch1) __ mov(r, rscratch1);
+    for (RegSetIterator it = clobbered.begin(); *it != noreg; ++it) {
+      __ mov(*it, rscratch1);
+    }
 #endif
+
   }
 
   // Scan over array at a for count oops, verifying each one.
@@ -1713,10 +1717,10 @@ class StubGenerator: public StubCodeGenerator {
     RegSet wb_pre_saved_regs = RegSet::range(c_rarg0, c_rarg4);
     RegSet wb_post_saved_regs = RegSet::of(count);
 
-    // Registers used as temps (r18, r19, r20 are save-on-entry)
+    // Registers used as temps (r19, r20, r21, r22 are save-on-entry)
+    const Register copied_oop  = r22;       // actual oop copied
     const Register count_save  = r21;       // orig elementscount
     const Register start_to    = r20;       // destination array start address
-    const Register copied_oop  = r18;       // actual oop copied
     const Register r19_klass   = r19;       // oop._klass
 
     //---------------------------------------------------------------
@@ -1753,8 +1757,7 @@ class StubGenerator: public StubCodeGenerator {
 
      // Empty array:  Nothing to do.
     __ cbz(count, L_done);
-
-    __ push(RegSet::of(r18, r19, r20, r21), sp);
+    __ push(RegSet::of(r19, r20, r21, r22), sp);
 
 #ifdef ASSERT
     BLOCK_COMMENT("assert consistent ckoff/ckval");
@@ -1823,7 +1826,7 @@ class StubGenerator: public StubCodeGenerator {
     bs->arraycopy_epilogue(_masm, decorators, is_oop, start_to, count_save, rscratch1, wb_post_saved_regs);
 
     __ bind(L_done_pop);
-    __ pop(RegSet::of(r18, r19, r20, r21), sp);
+    __ pop(RegSet::of(r19, r20, r21, r22), sp);
     inc_counter_np(SharedRuntime::_checkcast_array_copy_ctr);
 
     __ bind(L_done);
@@ -1999,7 +2002,7 @@ class StubGenerator: public StubCodeGenerator {
     // registers used as temp
     const Register scratch_length    = r16; // elements count to copy
     const Register scratch_src_klass = r17; // array klass
-    const Register lh                = r18; // layout helper
+    const Register lh                = r15; // layout helper
 
     //  if (length < 0) return -1;
     __ movw(scratch_length, length);        // length (elements count, 32-bits value)
@@ -2070,7 +2073,7 @@ class StubGenerator: public StubCodeGenerator {
     //
 
     const Register rscratch1_offset = rscratch1;    // array offset
-    const Register r18_elsize = lh; // element size
+    const Register r15_elsize = lh; // element size
 
     __ ubfx(rscratch1_offset, lh, Klass::_lh_header_size_shift,
            exact_log2(Klass::_lh_header_size_mask+1));   // array_offset
@@ -2091,8 +2094,8 @@ class StubGenerator: public StubCodeGenerator {
     // The possible values of elsize are 0-3, i.e. exact_log2(element
     // size in bytes).  We do a simple bitwise binary search.
   __ BIND(L_copy_bytes);
-    __ tbnz(r18_elsize, 1, L_copy_ints);
-    __ tbnz(r18_elsize, 0, L_copy_shorts);
+    __ tbnz(r15_elsize, 1, L_copy_ints);
+    __ tbnz(r15_elsize, 0, L_copy_shorts);
     __ lea(from, Address(src, src_pos));// src_addr
     __ lea(to,   Address(dst, dst_pos));// dst_addr
     __ movw(count, scratch_length); // length
@@ -2105,7 +2108,7 @@ class StubGenerator: public StubCodeGenerator {
     __ b(RuntimeAddress(short_copy_entry));
 
   __ BIND(L_copy_ints);
-    __ tbnz(r18_elsize, 0, L_copy_longs);
+    __ tbnz(r15_elsize, 0, L_copy_longs);
     __ lea(from, Address(src, src_pos, Address::lsl(2)));// src_addr
     __ lea(to,   Address(dst, dst_pos, Address::lsl(2)));// dst_addr
     __ movw(count, scratch_length); // length
@@ -2116,8 +2119,8 @@ class StubGenerator: public StubCodeGenerator {
     {
       BLOCK_COMMENT("assert long copy {");
       Label L;
-      __ andw(lh, lh, Klass::_lh_log2_element_size_mask); // lh -> r18_elsize
-      __ cmpw(r18_elsize, LogBytesPerLong);
+      __ andw(lh, lh, Klass::_lh_log2_element_size_mask); // lh -> r15_elsize
+      __ cmpw(r15_elsize, LogBytesPerLong);
       __ br(Assembler::EQ, L);
       __ stop("must be long copy, but elsize is wrong");
       __ bind(L);
@@ -2135,8 +2138,8 @@ class StubGenerator: public StubCodeGenerator {
 
     Label L_plain_copy, L_checkcast_copy;
     //  test array classes for subtyping
-    __ load_klass(r18, dst);
-    __ cmp(scratch_src_klass, r18); // usual case is exact equality
+    __ load_klass(r15, dst);
+    __ cmp(scratch_src_klass, r15); // usual case is exact equality
     __ br(Assembler::NE, L_checkcast_copy);
 
     // Identically typed arrays can be copied without element-wise checks.
@@ -2152,17 +2155,17 @@ class StubGenerator: public StubCodeGenerator {
     __ b(RuntimeAddress(oop_copy_entry));
 
   __ BIND(L_checkcast_copy);
-    // live at this point:  scratch_src_klass, scratch_length, r18 (dst_klass)
+    // live at this point:  scratch_src_klass, scratch_length, r15 (dst_klass)
     {
       // Before looking at dst.length, make sure dst is also an objArray.
-      __ ldrw(rscratch1, Address(r18, lh_offset));
+      __ ldrw(rscratch1, Address(r15, lh_offset));
       __ movw(rscratch2, objArray_lh);
       __ eorw(rscratch1, rscratch1, rscratch2);
       __ cbnzw(rscratch1, L_failed);
 
       // It is safe to examine both src.length and dst.length.
       arraycopy_range_checks(src, src_pos, dst, dst_pos, scratch_length,
-                             r18, L_failed);
+                             r15, L_failed);
 
       __ load_klass(dst_klass, dst); // reload
 
@@ -5115,42 +5118,42 @@ class StubGenerator: public StubCodeGenerator {
 
       // Register allocation
 
-      Register reg = c_rarg0;
-      Pa_base = reg;       // Argument registers
+      RegSetIterator regs = (RegSet::range(r0, r26) - r18_reserved).begin();
+      Pa_base = *regs;       // Argument registers
       if (squaring)
         Pb_base = Pa_base;
       else
-        Pb_base = ++reg;
-      Pn_base = ++reg;
-      Rlen= ++reg;
-      inv = ++reg;
-      Pm_base = ++reg;
+        Pb_base = *++regs;
+      Pn_base = *++regs;
+      Rlen= *++regs;
+      inv = *++regs;
+      Pm_base = *++regs;
 
                           // Working registers:
-      Ra =  ++reg;        // The current digit of a, b, n, and m.
-      Rb =  ++reg;
-      Rm =  ++reg;
-      Rn =  ++reg;
+      Ra =  *++regs;        // The current digit of a, b, n, and m.
+      Rb =  *++regs;
+      Rm =  *++regs;
+      Rn =  *++regs;
 
-      Pa =  ++reg;        // Pointers to the current/next digit of a, b, n, and m.
-      Pb =  ++reg;
-      Pm =  ++reg;
-      Pn =  ++reg;
+      Pa =  *++regs;        // Pointers to the current/next digit of a, b, n, and m.
+      Pb =  *++regs;
+      Pm =  *++regs;
+      Pn =  *++regs;
 
-      t0 =  ++reg;        // Three registers which form a
-      t1 =  ++reg;        // triple-precision accumuator.
-      t2 =  ++reg;
+      t0 =  *++regs;        // Three registers which form a
+      t1 =  *++regs;        // triple-precision accumuator.
+      t2 =  *++regs;
 
-      Ri =  ++reg;        // Inner and outer loop indexes.
-      Rj =  ++reg;
+      Ri =  *++regs;        // Inner and outer loop indexes.
+      Rj =  *++regs;
 
-      Rhi_ab = ++reg;     // Product registers: low and high parts
-      Rlo_ab = ++reg;     // of a*b and m*n.
-      Rhi_mn = ++reg;
-      Rlo_mn = ++reg;
+      Rhi_ab = *++regs;     // Product registers: low and high parts
+      Rlo_ab = *++regs;     // of a*b and m*n.
+      Rhi_mn = *++regs;
+      Rlo_mn = *++regs;
 
       // r19 and up are callee-saved.
-      _toSave = RegSet::range(r19, reg) + Pm_base;
+      _toSave = RegSet::range(r19, *regs) + Pm_base;
     }
 
   private:

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -3243,8 +3243,8 @@ class StubGenerator: public StubCodeGenerator {
 
     // Max number of bytes we can process before having to take the mod
     // 0x15B0 is 5552 in decimal, the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1
-    unsigned long BASE = 0xfff1;
-    unsigned long NMAX = 0x15B0;
+    uint64_t BASE = 0xfff1;
+    uint64_t NMAX = 0x15B0;
 
     __ mov(base, BASE);
     __ mov(nmax, NMAX);
@@ -5607,12 +5607,12 @@ class StubGenerator: public StubCodeGenerator {
     // In C, approximately:
 
     // void
-    // montgomery_multiply(unsigned long Pa_base[], unsigned long Pb_base[],
-    //                     unsigned long Pn_base[], unsigned long Pm_base[],
-    //                     unsigned long inv, int len) {
-    //   unsigned long t0 = 0, t1 = 0, t2 = 0; // Triple-precision accumulator
-    //   unsigned long *Pa, *Pb, *Pn, *Pm;
-    //   unsigned long Ra, Rb, Rn, Rm;
+    // montgomery_multiply(julong Pa_base[], julong Pb_base[],
+    //                     julong Pn_base[], julong Pm_base[],
+    //                     julong inv, int len) {
+    //   julong t0 = 0, t1 = 0, t2 = 0; // Triple-precision accumulator
+    //   julong *Pa, *Pb, *Pn, *Pm;
+    //   julong Ra, Rb, Rn, Rm;
 
     //   int i;
 
@@ -5820,11 +5820,11 @@ class StubGenerator: public StubCodeGenerator {
     // In C, approximately:
 
     // void
-    // montgomery_square(unsigned long Pa_base[], unsigned long Pn_base[],
-    //                   unsigned long Pm_base[], unsigned long inv, int len) {
-    //   unsigned long t0 = 0, t1 = 0, t2 = 0; // Triple-precision accumulator
-    //   unsigned long *Pa, *Pb, *Pn, *Pm;
-    //   unsigned long Ra, Rb, Rn, Rm;
+    // montgomery_square(julong Pa_base[], julong Pn_base[],
+    //                   julong Pm_base[], julong inv, int len) {
+    //   julong t0 = 0, t1 = 0, t2 = 0; // Triple-precision accumulator
+    //   julong *Pa, *Pb, *Pn, *Pm;
+    //   julong Ra, Rb, Rn, Rm;
 
     //   int i;
 

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -1299,14 +1299,14 @@ class StubGenerator: public StubCodeGenerator {
 
   // Scan over array at a for count oops, verifying each one.
   // Preserves a and count, clobbers rscratch1 and rscratch2.
-  void verify_oop_array (size_t size, Register a, Register count, Register temp) {
+  void verify_oop_array (int size, Register a, Register count, Register temp) {
     Label loop, end;
     __ mov(rscratch1, a);
     __ mov(rscratch2, zr);
     __ bind(loop);
     __ cmp(rscratch2, count);
     __ br(Assembler::HS, end);
-    if (size == (size_t)wordSize) {
+    if (size == wordSize) {
       __ ldr(temp, Address(a, rscratch2, Address::lsl(exact_log2(size))));
       __ verify_oop(temp);
     } else {
@@ -1337,7 +1337,7 @@ class StubGenerator: public StubCodeGenerator {
   //   disjoint_int_copy_entry is set to the no-overlap entry point
   //   used by generate_conjoint_int_oop_copy().
   //
-  address generate_disjoint_copy(size_t size, bool aligned, bool is_oop, address *entry,
+  address generate_disjoint_copy(int size, bool aligned, bool is_oop, address *entry,
                                   const char *name, bool dest_uninitialized = false) {
     Register s = c_rarg0, d = c_rarg1, count = c_rarg2;
     RegSet saved_reg = RegSet::of(s, d, count);
@@ -1398,7 +1398,7 @@ class StubGenerator: public StubCodeGenerator {
   // the hardware handle it.  The two dwords within qwords that span
   // cache line boundaries will still be loaded and stored atomically.
   //
-  address generate_conjoint_copy(size_t size, bool aligned, bool is_oop, address nooverlap_target,
+  address generate_conjoint_copy(int size, bool aligned, bool is_oop, address nooverlap_target,
                                  address *entry, const char *name,
                                  bool dest_uninitialized = false) {
     Register s = c_rarg0, d = c_rarg1, count = c_rarg2;
@@ -1644,7 +1644,7 @@ class StubGenerator: public StubCodeGenerator {
   address generate_disjoint_oop_copy(bool aligned, address *entry,
                                      const char *name, bool dest_uninitialized) {
     const bool is_oop = true;
-    const size_t size = UseCompressedOops ? sizeof (jint) : sizeof (jlong);
+    const int size = UseCompressedOops ? sizeof (jint) : sizeof (jlong);
     return generate_disjoint_copy(size, aligned, is_oop, entry, name, dest_uninitialized);
   }
 
@@ -1662,7 +1662,7 @@ class StubGenerator: public StubCodeGenerator {
                                      address nooverlap_target, address *entry,
                                      const char *name, bool dest_uninitialized) {
     const bool is_oop = true;
-    const size_t size = UseCompressedOops ? sizeof (jint) : sizeof (jlong);
+    const int size = UseCompressedOops ? sizeof (jint) : sizeof (jlong);
     return generate_conjoint_copy(size, aligned, is_oop, nooverlap_target, entry,
                                   name, dest_uninitialized);
   }

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -683,7 +683,6 @@ class StubGenerator: public StubCodeGenerator {
     int unit = wordSize * direction;
     int bias = (UseSIMDForMemoryOps ? 4:2) * wordSize;
 
-    int offset;
     const Register t0 = r3, t1 = r4, t2 = r5, t3 = r6,
       t4 = r7, t5 = r10, t6 = r11, t7 = r12;
     const Register stride = r13;

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -4020,7 +4020,7 @@ class StubGenerator: public StubCodeGenerator {
     FloatRegister vtmpZ = v0, vtmp = v1, vtmp3 = v2;
     RegSet spilled_regs = RegSet::of(tmp3, tmp4);
 
-    int prefetchLoopExitCondition = MAX(64, SoftwarePrefetchHintDistance/2);
+    int prefetchLoopExitCondition = MAX2(64, SoftwarePrefetchHintDistance/2);
 
     __ eor(vtmpZ, __ T16B, vtmpZ, vtmpZ);
     // cnt2 == amount of characters left to compare
@@ -4136,7 +4136,7 @@ class StubGenerator: public StubCodeGenerator {
         DIFF_LAST_POSITION, DIFF_LAST_POSITION2;
     // exit from large loop when less than 64 bytes left to read or we're about
     // to prefetch memory behind array border
-    int largeLoopExitCondition = MAX(64, SoftwarePrefetchHintDistance)/(isLL ? 1 : 2);
+    int largeLoopExitCondition = MAX2(64, SoftwarePrefetchHintDistance)/(isLL ? 1 : 2);
     // cnt1/cnt2 contains amount of characters to compare. cnt1 can be re-used
     // update cnt2 counter with already loaded 8 bytes
     __ sub(cnt2, cnt2, wordSize/(isLL ? 1 : 2));
@@ -4561,7 +4561,7 @@ class StubGenerator: public StubCodeGenerator {
     address entry = __ pc();
     Label LOOP, LOOP_START, LOOP_PRFM, LOOP_PRFM_START, DONE;
     Register src = r0, dst = r1, len = r2, octetCounter = r3;
-    const int large_loop_threshold = MAX(64, SoftwarePrefetchHintDistance)/8 + 4;
+    const int large_loop_threshold = MAX2(64, SoftwarePrefetchHintDistance)/8 + 4;
 
     // do one more 8-byte read to have address 16-byte aligned in most cases
     // also use single store instruction

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
@@ -61,7 +61,7 @@ bool StubRoutines::aarch64::_completed = false;
 /**
  *  crc_table[] from jdk/src/share/native/java/util/zip/zlib-1.2.5/crc32.h
  */
-juint StubRoutines::aarch64::_crc_table[] ATTRIBUTE_ALIGNED(4096) =
+ATTRIBUTE_ALIGNED(4096) juint StubRoutines::aarch64::_crc_table[] =
 {
     // Table 0
     0x00000000UL, 0x77073096UL, 0xee0e612cUL, 0x990951baUL, 0x076dc419UL,
@@ -288,11 +288,11 @@ juint StubRoutines::aarch64::_crc_table[] ATTRIBUTE_ALIGNED(4096) =
 };
 
 // Accumulation coefficients for adler32 upper 16 bits
-jubyte StubRoutines::aarch64::_adler_table[] __attribute__ ((aligned(64))) = {
+ATTRIBUTE_ALIGNED(64) jubyte StubRoutines::aarch64::_adler_table[] = {
     16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1
 };
 
-juint StubRoutines::aarch64::_npio2_hw[] __attribute__ ((aligned(64))) = {
+ATTRIBUTE_ALIGNED(64) juint StubRoutines::aarch64::_npio2_hw[] = {
     // first, various coefficient values: 0.5, invpio2, pio2_1, pio2_1t, pio2_2,
     // pio2_2t, pio2_3, pio2_3t
     // This is a small optimization wich keeping double[8] values in int[] table
@@ -324,7 +324,7 @@ juint StubRoutines::aarch64::_npio2_hw[] __attribute__ ((aligned(64))) = {
 
 // Coefficients for sin(x) polynomial approximation: S1..S6.
 // See kernel_sin comments in macroAssembler_aarch64_trig.cpp for details
-jdouble StubRoutines::aarch64::_dsin_coef[] __attribute__ ((aligned(64))) = {
+ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::aarch64::_dsin_coef[] = {
     -1.66666666666666324348e-01, // 0xBFC5555555555549
      8.33333333332248946124e-03, // 0x3F8111111110F8A6
     -1.98412698298579493134e-04, // 0xBF2A01A019C161D5
@@ -335,7 +335,7 @@ jdouble StubRoutines::aarch64::_dsin_coef[] __attribute__ ((aligned(64))) = {
 
 // Coefficients for cos(x) polynomial approximation: C1..C6.
 // See kernel_cos comments in macroAssembler_aarch64_trig.cpp for details
-jdouble StubRoutines::aarch64::_dcos_coef[] __attribute__ ((aligned(64))) = {
+ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::aarch64::_dcos_coef[] = {
      4.16666666666666019037e-02, // c0x3FA555555555554C
     -1.38888888888741095749e-03, // 0xBF56C16C16C15177
      2.48015872894767294178e-05, // 0x3EFA01A019CB1590
@@ -350,7 +350,7 @@ jdouble StubRoutines::aarch64::_dcos_coef[] __attribute__ ((aligned(64))) = {
 // Converted to double to avoid unnecessary conversion in code
 // NOTE: table looks like original int table: {0xA2F983, 0x6E4E44,...} with
 //       only (double) conversion added
-jdouble StubRoutines::aarch64::_two_over_pi[] __attribute__ ((aligned(64))) = {
+ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::aarch64::_two_over_pi[] = {
   (double)0xA2F983, (double)0x6E4E44, (double)0x1529FC, (double)0x2757D1, (double)0xF534DD, (double)0xC0DB62,
   (double)0x95993C, (double)0x439041, (double)0xFE5163, (double)0xABDEBB, (double)0xC561B7, (double)0x246E3A,
   (double)0x424DD2, (double)0xE00649, (double)0x2EEA09, (double)0xD1921C, (double)0xFE1DEB, (double)0x1CB129,
@@ -365,7 +365,7 @@ jdouble StubRoutines::aarch64::_two_over_pi[] __attribute__ ((aligned(64))) = {
 };
 
 // Pi over 2 value
-jdouble StubRoutines::aarch64::_pio2[] __attribute__ ((aligned(64))) = {
+ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::aarch64::_pio2[] = {
   1.57079625129699707031e+00, // 0x3FF921FB40000000
   7.54978941586159635335e-08, // 0x3E74442D00000000
   5.39030252995776476554e-15, // 0x3CF8469880000000

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2019, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1003,7 +1003,7 @@ address TemplateInterpreterGenerator::generate_CRC32_update_entry() {
     __ ldrw(val, Address(esp, 0));              // byte value
     __ ldrw(crc, Address(esp, wordSize));       // Initial CRC
 
-    unsigned long offset;
+    uint64_t offset;
     __ adrp(tbl, ExternalAddress(StubRoutines::crc_table_addr()), offset);
     __ add(tbl, tbl, offset);
 

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1125,7 +1125,7 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
   // an interpreter frame with greater than a page of locals, so each page
   // needs to be checked.  Only true for non-native.
   if (UseStackBanging) {
-    const int n_shadow_pages = JavaThread::stack_shadow_zone_size() / os::vm_page_size();
+    const int n_shadow_pages = (int)(JavaThread::stack_shadow_zone_size() / os::vm_page_size());
     const int start_page = native_call ? n_shadow_pages : 1;
     const int page_size = os::vm_page_size();
     for (int pages = start_page; pages <= n_shadow_pages ; pages++) {

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1595,9 +1595,6 @@ address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized) {
 
   // Make room for locals
   __ sub(rscratch1, esp, r3, ext::uxtx, 3);
-
-  // Padding between locals and fixed part of activation frame to ensure
-  // SP is always 16-byte aligned.
   __ andr(sp, rscratch1, -16);
 
   // r3 - # of additional locals

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1594,22 +1594,29 @@ address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized) {
   __ sub(rlocals, rlocals, wordSize);
 
   // Make room for locals
-  __ sub(rscratch1, esp, r3, ext::uxtx, 3);
-  __ andr(sp, rscratch1, -16);
+  __ mov(rscratch1, esp);
 
   // r3 - # of additional locals
   // allocate space for locals
   // explicitly initialize locals
+  // Initializing memory allocated for locals in the same direction as
+  // the stack grows to ensure page initialization order according
+  // to windows-aarch64 stack page growth requirement (see
+  // https://docs.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions?view=msvc-160#stack)
   {
     Label exit, loop;
     __ ands(zr, r3, r3);
     __ br(Assembler::LE, exit); // do nothing if r3 <= 0
     __ bind(loop);
-    __ str(zr, Address(__ post(rscratch1, wordSize)));
+    __ str(zr, Address(__ pre(rscratch1, -wordSize))); // initialize the additional locals
     __ sub(r3, r3, 1); // until everything initialized
     __ cbnz(r3, loop);
     __ bind(exit);
   }
+
+  // Padding between locals and fixed part of activation frame to ensure
+  // SP is always 16-byte aligned.
+  __ andr(sp, rscratch1, -16);
 
   // And the base dispatch table
   __ get_dispatch();

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -1705,7 +1705,7 @@ void TemplateTable::lcmp()
   Label done;
   __ pop_l(r1);
   __ cmp(r1, r0);
-  __ mov(r0, (u_int64_t)-1L);
+  __ mov(r0, (uint64_t)-1L);
   __ br(Assembler::LT, done);
   // __ mov(r0, 1UL);
   // __ csel(r0, r0, zr, Assembler::NE);
@@ -1729,7 +1729,7 @@ void TemplateTable::float_cmp(bool is_float, int unordered_result)
   if (unordered_result < 0) {
     // we want -1 for unordered or less than, 0 for equal and 1 for
     // greater than.
-    __ mov(r0, (u_int64_t)-1L);
+    __ mov(r0, (uint64_t)-1L);
     // for FP LT tests less than or unordered
     __ br(Assembler::LT, done);
     // install 0 for EQ otherwise 1

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -24,42 +24,15 @@
  */
 
 #include "precompiled.hpp"
-#include "asm/macroAssembler.hpp"
-#include "asm/macroAssembler.inline.hpp"
-#include "memory/resourceArea.hpp"
+#include "runtime/arguments.hpp"
+#include "runtime/globals_extension.hpp"
 #include "runtime/java.hpp"
-#include "runtime/stubCodeGenerator.hpp"
+#include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
+#include "utilities/formatBuffer.hpp"
 #include "utilities/macros.hpp"
 
 #include OS_HEADER_INLINE(os)
-
-#include <sys/auxv.h>
-#include <asm/hwcap.h>
-
-#ifndef HWCAP_AES
-#define HWCAP_AES   (1<<3)
-#endif
-
-#ifndef HWCAP_PMULL
-#define HWCAP_PMULL (1<<4)
-#endif
-
-#ifndef HWCAP_SHA1
-#define HWCAP_SHA1  (1<<5)
-#endif
-
-#ifndef HWCAP_SHA2
-#define HWCAP_SHA2  (1<<6)
-#endif
-
-#ifndef HWCAP_CRC32
-#define HWCAP_CRC32 (1<<7)
-#endif
-
-#ifndef HWCAP_ATOMICS
-#define HWCAP_ATOMICS (1<<8)
-#endif
 
 int VM_Version::_cpu;
 int VM_Version::_model;
@@ -67,57 +40,19 @@ int VM_Version::_model2;
 int VM_Version::_variant;
 int VM_Version::_revision;
 int VM_Version::_stepping;
-VM_Version::PsrInfo VM_Version::_psr_info   = { 0, };
 
-static BufferBlob* stub_blob;
-static const int stub_size = 550;
+int VM_Version::_zva_length;
+int VM_Version::_dcache_line_size;
+int VM_Version::_icache_line_size;
 
-extern "C" {
-  typedef void (*getPsrInfo_stub_t)(void*);
-}
-static getPsrInfo_stub_t getPsrInfo_stub = NULL;
-
-
-class VM_Version_StubGenerator: public StubCodeGenerator {
- public:
-
-  VM_Version_StubGenerator(CodeBuffer *c) : StubCodeGenerator(c) {}
-
-  address generate_getPsrInfo() {
-    StubCodeMark mark(this, "VM_Version", "getPsrInfo_stub");
-#   define __ _masm->
-    address start = __ pc();
-
-    // void getPsrInfo(VM_Version::PsrInfo* psr_info);
-
-    address entry = __ pc();
-
-    __ enter();
-
-    __ get_dczid_el0(rscratch1);
-    __ strw(rscratch1, Address(c_rarg0, in_bytes(VM_Version::dczid_el0_offset())));
-
-    __ get_ctr_el0(rscratch1);
-    __ strw(rscratch1, Address(c_rarg0, in_bytes(VM_Version::ctr_el0_offset())));
-
-    __ leave();
-    __ ret(lr);
-
-#   undef __
-
-    return start;
-  }
-};
-
-
-void VM_Version::get_processor_features() {
+void VM_Version::initialize() {
   _supports_cx8 = true;
   _supports_atomic_getset4 = true;
   _supports_atomic_getadd4 = true;
   _supports_atomic_getset8 = true;
   _supports_atomic_getadd8 = true;
 
-  getPsrInfo_stub(&_psr_info);
+  get_os_cpu_info();
 
   int dcache_line = VM_Version::dcache_line_size();
 
@@ -161,34 +96,6 @@ void VM_Version::get_processor_features() {
 
   if (FLAG_IS_DEFAULT(ContendedPaddingWidth) && (dcache_line > ContendedPaddingWidth)) {
     ContendedPaddingWidth = dcache_line;
-  }
-
-  unsigned long auxv = getauxval(AT_HWCAP);
-
-  char buf[512];
-
-  _features = auxv;
-
-  int cpu_lines = 0;
-  if (FILE *f = fopen("/proc/cpuinfo", "r")) {
-    char buf[128], *p;
-    while (fgets(buf, sizeof (buf), f) != NULL) {
-      if ((p = strchr(buf, ':')) != NULL) {
-        long v = strtol(p+1, NULL, 0);
-        if (strncmp(buf, "CPU implementer", sizeof "CPU implementer" - 1) == 0) {
-          _cpu = v;
-          cpu_lines++;
-        } else if (strncmp(buf, "CPU variant", sizeof "CPU variant" - 1) == 0) {
-          _variant = v;
-        } else if (strncmp(buf, "CPU part", sizeof "CPU part" - 1) == 0) {
-          if (_model != v)  _model2 = _model;
-          _model = v;
-        } else if (strncmp(buf, "CPU revision", sizeof "CPU revision" - 1) == 0) {
-          _revision = v;
-        }
-      }
-    }
-    fclose(f);
   }
 
   // Enable vendor specific features
@@ -256,27 +163,28 @@ void VM_Version::get_processor_features() {
   }
 
   if (_cpu == CPU_ARM && (_model == 0xd07 || _model2 == 0xd07)) _features |= CPU_STXR_PREFETCH;
-  // If an olde style /proc/cpuinfo (cpu_lines == 1) then if _model is an A57 (0xd07)
+  // If an olde style /proc/cpuinfo (cores == 1) then if _model is an A57 (0xd07)
   // we assume the worst and assume we could be on a big little system and have
   // undisclosed A53 cores which we could be swapped to at any stage
-  if (_cpu == CPU_ARM && cpu_lines == 1 && _model == 0xd07) _features |= CPU_A53MAC;
+  if (_cpu == CPU_ARM && os::processor_count() == 1 && _model == 0xd07) _features |= CPU_A53MAC;
 
+  char buf[512];
   sprintf(buf, "0x%02x:0x%x:0x%03x:%d", _cpu, _variant, _model, _revision);
   if (_model2) sprintf(buf+strlen(buf), "(0x%03x)", _model2);
-  if (auxv & HWCAP_ASIMD) strcat(buf, ", simd");
-  if (auxv & HWCAP_CRC32) strcat(buf, ", crc");
-  if (auxv & HWCAP_AES)   strcat(buf, ", aes");
-  if (auxv & HWCAP_SHA1)  strcat(buf, ", sha1");
-  if (auxv & HWCAP_SHA2)  strcat(buf, ", sha256");
-  if (auxv & HWCAP_ATOMICS) strcat(buf, ", lse");
+  if (_features & CPU_ASIMD) strcat(buf, ", simd");
+  if (_features & CPU_CRC32) strcat(buf, ", crc");
+  if (_features & CPU_AES)   strcat(buf, ", aes");
+  if (_features & CPU_SHA1)  strcat(buf, ", sha1");
+  if (_features & CPU_SHA2)  strcat(buf, ", sha256");
+  if (_features & CPU_LSE) strcat(buf, ", lse");
 
   _features_string = os::strdup(buf);
 
   if (FLAG_IS_DEFAULT(UseCRC32)) {
-    UseCRC32 = (auxv & HWCAP_CRC32) != 0;
+    UseCRC32 = (_features & CPU_CRC32) != 0;
   }
 
-  if (UseCRC32 && (auxv & HWCAP_CRC32) == 0) {
+  if (UseCRC32 && (_features & CPU_CRC32) == 0) {
     warning("UseCRC32 specified, but not supported on this CPU");
     FLAG_SET_DEFAULT(UseCRC32, false);
   }
@@ -290,7 +198,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
   }
 
-  if (auxv & HWCAP_ATOMICS) {
+  if (_features & CPU_LSE) {
     if (FLAG_IS_DEFAULT(UseLSE))
       FLAG_SET_DEFAULT(UseLSE, true);
   } else {
@@ -300,7 +208,7 @@ void VM_Version::get_processor_features() {
     }
   }
 
-  if (auxv & HWCAP_AES) {
+  if (_features & CPU_AES) {
     UseAES = UseAES || FLAG_IS_DEFAULT(UseAES);
     UseAESIntrinsics =
         UseAESIntrinsics || (UseAES && FLAG_IS_DEFAULT(UseAESIntrinsics));
@@ -328,7 +236,7 @@ void VM_Version::get_processor_features() {
     UseCRC32Intrinsics = true;
   }
 
-  if (auxv & HWCAP_CRC32) {
+  if (_features & CPU_CRC32) {
     if (FLAG_IS_DEFAULT(UseCRC32CIntrinsics)) {
       FLAG_SET_DEFAULT(UseCRC32CIntrinsics, true);
     }
@@ -341,7 +249,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseFMA, true);
   }
 
-  if (auxv & (HWCAP_SHA1 | HWCAP_SHA2)) {
+  if (_features & (CPU_SHA1 | CPU_SHA2)) {
     if (FLAG_IS_DEFAULT(UseSHA)) {
       FLAG_SET_DEFAULT(UseSHA, true);
     }
@@ -350,7 +258,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA, false);
   }
 
-  if (UseSHA && (auxv & HWCAP_SHA1)) {
+  if (UseSHA && (_features & CPU_SHA1)) {
     if (FLAG_IS_DEFAULT(UseSHA1Intrinsics)) {
       FLAG_SET_DEFAULT(UseSHA1Intrinsics, true);
     }
@@ -359,7 +267,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA1Intrinsics, false);
   }
 
-  if (UseSHA && (auxv & HWCAP_SHA2)) {
+  if (UseSHA && (_features & CPU_SHA2)) {
     if (FLAG_IS_DEFAULT(UseSHA256Intrinsics)) {
       FLAG_SET_DEFAULT(UseSHA256Intrinsics, true);
     }
@@ -377,7 +285,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseSHA, false);
   }
 
-  if (auxv & HWCAP_PMULL) {
+  if (_features & CPU_PMULL) {
     if (FLAG_IS_DEFAULT(UseGHASHIntrinsics)) {
       FLAG_SET_DEFAULT(UseGHASHIntrinsics, true);
     }
@@ -439,22 +347,6 @@ void VM_Version::get_processor_features() {
     OptoScheduling = true;
   }
 #endif
-}
-
-void VM_Version::initialize() {
-  ResourceMark rm;
-
-  stub_blob = BufferBlob::create("getPsrInfo_stub", stub_size);
-  if (stub_blob == NULL) {
-    vm_exit_during_initialization("Unable to allocate getPsrInfo_stub");
-  }
-
-  CodeBuffer c(stub_blob);
-  VM_Version_StubGenerator g(&c);
-  getPsrInfo_stub = CAST_TO_FN_PTR(getPsrInfo_stub_t,
-                                   g.generate_getPsrInfo());
-
-  get_processor_features();
 
   UNSUPPORTED_OPTION(CriticalJNINatives);
 }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -41,12 +41,12 @@ protected:
   static int _revision;
   static int _stepping;
 
-  struct PsrInfo {
-    uint32_t dczid_el0;
-    uint32_t ctr_el0;
-  };
-  static PsrInfo _psr_info;
-  static void get_processor_features();
+  static int _zva_length;
+  static int _dcache_line_size;
+  static int _icache_line_size;
+
+  // Read additional info using OS-specific interfaces
+  static void get_os_cpu_info();
 
 public:
   // Initialization
@@ -91,6 +91,7 @@ public:
     CPU_SHA2         = (1<<6),
     CPU_CRC32        = (1<<7),
     CPU_LSE          = (1<<8),
+    // flags above must follow Linux HWCAP
     CPU_STXR_PREFETCH= (1 << 29),
     CPU_A53MAC       = (1 << 30),
     CPU_DMB_ATOMICS  = (1 << 31),
@@ -101,24 +102,15 @@ public:
   static int cpu_model2()                     { return _model2; }
   static int cpu_variant()                    { return _variant; }
   static int cpu_revision()                   { return _revision; }
-  static ByteSize dczid_el0_offset() { return byte_offset_of(PsrInfo, dczid_el0); }
-  static ByteSize ctr_el0_offset()   { return byte_offset_of(PsrInfo, ctr_el0); }
-  static bool is_zva_enabled() {
-    // Check the DZP bit (bit 4) of dczid_el0 is zero
-    // and block size (bit 0~3) is not zero.
-    return ((_psr_info.dczid_el0 & 0x10) == 0 &&
-            (_psr_info.dczid_el0 & 0xf) != 0);
-  }
+
+  static bool is_zva_enabled() { return 0 <= _zva_length; }
   static int zva_length() {
     assert(is_zva_enabled(), "ZVA not available");
-    return 4 << (_psr_info.dczid_el0 & 0xf);
+    return _zva_length;
   }
-  static int icache_line_size() {
-    return (1 << (_psr_info.ctr_el0 & 0x0f)) * 4;
-  }
-  static int dcache_line_size() {
-    return (1 << ((_psr_info.ctr_el0 >> 16) & 0x0f)) * 4;
-  }
+
+  static int icache_line_size() { return _icache_line_size; }
+  static int dcache_line_size() { return _dcache_line_size; }
 };
 
 #endif // CPU_AARCH64_VM_VM_VERSION_AARCH64_HPP

--- a/src/hotspot/cpu/aarch64/vm_version_ext_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_ext_aarch64.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "precompiled.hpp"
 #include "memory/allocation.hpp"
 #include "memory/allocation.inline.hpp"
 #include "runtime/os.inline.hpp"

--- a/src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp
@@ -436,7 +436,7 @@ void LIRGenerator::cmp_reg_mem(LIR_Condition condition, LIR_Opr reg, LIR_Opr bas
 }
 
 
-bool LIRGenerator::strength_reduce_multiply(LIR_Opr left, int c, LIR_Opr result, LIR_Opr tmp) {
+bool LIRGenerator::strength_reduce_multiply(LIR_Opr left, jint c, LIR_Opr result, LIR_Opr tmp) {
   assert(left != result, "should be different registers");
   if (is_power_of_2(c + 1)) {
 #ifdef AARCH64

--- a/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
@@ -289,7 +289,7 @@ void LIRGenerator::cmp_reg_mem(LIR_Condition condition, LIR_Opr reg, LIR_Opr bas
 }
 
 
-bool LIRGenerator::strength_reduce_multiply(LIR_Opr left, int c, LIR_Opr result, LIR_Opr tmp) {
+bool LIRGenerator::strength_reduce_multiply(LIR_Opr left, jint c, LIR_Opr result, LIR_Opr tmp) {
   assert(left != result, "should be different registers");
   if (is_power_of_2(c + 1)) {
     __ shift_left(left, log2_int(c + 1), result);

--- a/src/hotspot/cpu/s390/c1_LIRGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRGenerator_s390.cpp
@@ -223,7 +223,7 @@ void LIRGenerator::cmp_reg_mem(LIR_Condition condition, LIR_Opr reg, LIR_Opr bas
   __ cmp_reg_mem(condition, reg, new LIR_Address(base, disp, type), info);
 }
 
-bool LIRGenerator::strength_reduce_multiply(LIR_Opr left, int c, LIR_Opr result, LIR_Opr tmp) {
+bool LIRGenerator::strength_reduce_multiply(LIR_Opr left, jint c, LIR_Opr result, LIR_Opr tmp) {
   if (tmp->is_valid()) {
     if (is_power_of_2(c + 1)) {
       __ move(left, tmp);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2359,7 +2359,8 @@ bool os::win32::get_frame_at_stack_banging_point(JavaThread* thread,
 JNIEXPORT
 LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
   if (InterceptOSException) return EXCEPTION_CONTINUE_SEARCH;
-  DWORD exception_code = exceptionInfo->ExceptionRecord->ExceptionCode;
+  PEXCEPTION_RECORD exception_record = exceptionInfo->ExceptionRecord;
+  DWORD exception_code = exception_record->ExceptionCode;
 #ifdef _M_AMD64
   address pc = (address) exceptionInfo->ContextRecord->Rip;
 #else
@@ -2378,9 +2379,8 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
   // This is safe to do because we have a new/unique ExceptionInformation
   // code for this condition.
   if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
-    PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
-    int exception_subcode = (int) exceptionRecord->ExceptionInformation[0];
-    address addr = (address) exceptionRecord->ExceptionInformation[1];
+    int exception_subcode = (int) exception_record->ExceptionInformation[0];
+    address addr = (address) exception_record->ExceptionInformation[1];
 
     if (exception_subcode == EXCEPTION_INFO_EXEC_VIOLATION) {
       int page_size = os::vm_page_size();
@@ -2444,7 +2444,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 
       // Last unguard failed or not unguarding
       tty->print_raw_cr("Execution protection violation");
-      report_error(t, exception_code, addr, exceptionInfo->ExceptionRecord,
+      report_error(t, exception_code, addr, exception_record,
                    exceptionInfo->ContextRecord);
       return EXCEPTION_CONTINUE_SEARCH;
     }
@@ -2458,8 +2458,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
   if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
     if (t != NULL && t->is_Java_thread()) {
       JavaThread* thread = (JavaThread*) t;
-      PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
-      address addr = (address) exceptionRecord->ExceptionInformation[1];
+      address addr = (address) exception_record->ExceptionInformation[1];
       if (os::is_memory_serialize_page(thread, addr)) {
         // Block current thread until the memory serialize page permission restored.
         os::block_on_serialize_page_trap();
@@ -2477,14 +2476,14 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
   if (t != NULL && t->is_Java_thread()) {
     JavaThread* thread = (JavaThread*) t;
     bool in_java = thread->thread_state() == _thread_in_Java;
+    bool in_native = thread->thread_state() == _thread_in_native;
+    bool in_vm = thread->thread_state() == _thread_in_vm;
 
     // Handle potential stack overflows up front.
     if (exception_code == EXCEPTION_STACK_OVERFLOW) {
       if (thread->stack_guards_enabled()) {
         if (in_java) {
           frame fr;
-          PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
-          address addr = (address) exceptionRecord->ExceptionInformation[1];
           if (os::win32::get_frame_at_stack_banging_point(thread, exceptionInfo, pc, &fr)) {
             assert(fr.is_java_frame(), "Must be a Java frame");
             SharedRuntime::look_for_reserved_stack_annotated_method(thread, fr);
@@ -2493,7 +2492,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
         // Yellow zone violation.  The o/s has unprotected the first yellow
         // zone page for us.  Note:  must call disable_stack_yellow_zone to
         // update the enabled status, even if the zone contains only one page.
-        assert(thread->thread_state() != _thread_in_vm, "Undersized StackShadowPages");
+        assert(!in_vm, "Undersized StackShadowPages");
         thread->disable_stack_yellow_reserved_zone();
         // If not in java code, return and hope for the best.
         return in_java
@@ -2503,15 +2502,14 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
         // Fatal red zone violation.
         thread->disable_stack_red_zone();
         tty->print_raw_cr("An unrecoverable stack overflow has occurred.");
-        report_error(t, exception_code, pc, exceptionInfo->ExceptionRecord,
+        report_error(t, exception_code, pc, exception_record,
                       exceptionInfo->ContextRecord);
         return EXCEPTION_CONTINUE_SEARCH;
       }
     } else if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
-      // Either stack overflow or null pointer exception.
       if (in_java) {
-        PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
-        address addr = (address) exceptionRecord->ExceptionInformation[1];
+        // Either stack overflow or null pointer exception.
+        address addr = (address) exception_record->ExceptionInformation[1];
         address stack_end = thread->stack_end();
         if (addr < stack_end && addr >= stack_end - os::vm_page_size()) {
           // Stack overflow.
@@ -2530,47 +2528,38 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
             return Handle_Exception(exceptionInfo, stub);
           }
         }
-        {
 #ifdef _WIN64
-          // If it's a legal stack address map the entire region in
-          //
-          PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
-          address addr = (address) exceptionRecord->ExceptionInformation[1];
-          if (addr > thread->stack_reserved_zone_base() && addr < thread->stack_base()) {
-            addr = (address)((uintptr_t)addr &
-                             (~((uintptr_t)os::vm_page_size() - (uintptr_t)1)));
-            os::commit_memory((char *)addr, thread->stack_base() - addr,
-                              !ExecMem);
-            return EXCEPTION_CONTINUE_EXECUTION;
-          } else
-#endif
-          {
-            // Null pointer exception.
-            if (!MacroAssembler::needs_explicit_null_check((intptr_t)addr)) {
-              address stub = SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime::IMPLICIT_NULL);
-              if (stub != NULL) return Handle_Exception(exceptionInfo, stub);
-            }
-            report_error(t, exception_code, pc, exceptionInfo->ExceptionRecord,
-                         exceptionInfo->ContextRecord);
-            return EXCEPTION_CONTINUE_SEARCH;
-          }
+        // If it's a legal stack address map the entire region in
+        if (addr > thread->stack_reserved_zone_base() && addr < thread->stack_base()) {
+          addr = (address)((uintptr_t)addr &
+                            (~((uintptr_t)os::vm_page_size() - (uintptr_t)1)));
+          os::commit_memory((char *)addr, thread->stack_base() - addr,
+                            !ExecMem);
+          return EXCEPTION_CONTINUE_EXECUTION;
         }
+#endif
+        // Null pointer exception.
+        if (!MacroAssembler::needs_explicit_null_check((intptr_t)addr)) {
+          address stub = SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime::IMPLICIT_NULL);
+          if (stub != NULL) return Handle_Exception(exceptionInfo, stub);
+        }
+        report_error(t, exception_code, pc, exception_record,
+                      exceptionInfo->ContextRecord);
+        return EXCEPTION_CONTINUE_SEARCH;
       }
 
 #ifdef _WIN64
       // Special care for fast JNI field accessors.
       // jni_fast_Get<Primitive>Field can trap at certain pc's if a GC kicks
       // in and the heap gets shrunk before the field access.
-      if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
-        address addr = JNI_FastGetField::find_slowcase_pc(pc);
-        if (addr != (address)-1) {
-          return Handle_Exception(exceptionInfo, addr);
-        }
+      address slowcase_pc = JNI_FastGetField::find_slowcase_pc(pc);
+      if (slowcase_pc != (address)-1) {
+        return Handle_Exception(exceptionInfo, slowcase_pc);
       }
 #endif
 
       // Stack overflow or null pointer exception in native code.
-      report_error(t, exception_code, pc, exceptionInfo->ExceptionRecord,
+      report_error(t, exception_code, pc, exception_record,
                    exceptionInfo->ContextRecord);
       return EXCEPTION_CONTINUE_SEARCH;
     } // /EXCEPTION_ACCESS_VIOLATION
@@ -2583,8 +2572,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
         CodeBlob* cb = CodeCache::find_blob_unsafe(pc);
         nm = (cb != NULL) ? cb->as_compiled_method_or_null() : NULL;
       }
-      if ((thread->thread_state() == _thread_in_vm &&
-          thread->doing_unsafe_access()) ||
+      if ((in_vm && thread->doing_unsafe_access()) ||
           (nm != NULL && nm->has_unsafe_access())) {
         return Handle_Exception(exceptionInfo, SharedRuntime::handle_unsafe_access(thread, (address)Assembler::locate_next_instruction(pc)));
       }
@@ -2600,16 +2588,14 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 
       } // switch
     }
-    if (((thread->thread_state() == _thread_in_Java) ||
-         (thread->thread_state() == _thread_in_native)) &&
-         exception_code != EXCEPTION_UNCAUGHT_CXX_EXCEPTION) {
+    if ((in_java || in_native) && exception_code != EXCEPTION_UNCAUGHT_CXX_EXCEPTION) {
       LONG result=Handle_FLT_Exception(exceptionInfo);
       if (result==EXCEPTION_CONTINUE_EXECUTION) return result;
     }
   }
 
   if (exception_code != EXCEPTION_BREAKPOINT) {
-    report_error(t, exception_code, pc, exceptionInfo->ExceptionRecord,
+    report_error(t, exception_code, pc, exception_record,
                  exceptionInfo->ContextRecord);
   }
   return EXCEPTION_CONTINUE_SEARCH;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -31,6 +31,7 @@
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "code/icBuffer.hpp"
+#include "code/nativeInst.hpp"
 #include "code/vtableStubs.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/disassembler.hpp"
@@ -120,10 +121,17 @@ static FILETIME process_exit_time;
 static FILETIME process_user_time;
 static FILETIME process_kernel_time;
 
-#ifdef _M_AMD64
+#if defined(_M_ARM64)
+  #define __CPU__ aarch64
+#elif defined(_M_AMD64)
   #define __CPU__ amd64
 #else
   #define __CPU__ i486
+#endif
+
+#if defined(USE_VECTORED_EXCEPTION_HANDLING)
+PVOID  topLevelVectoredExceptionHandler = NULL;
+LPTOP_LEVEL_EXCEPTION_FILTER previousUnhandledExceptionFilter = NULL;
 #endif
 
 // save DLL module handle, used by GetModuleFileName
@@ -144,6 +152,12 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved) {
     if (ForceTimeHighResolution) {
       timeEndPeriod(1L);
     }
+#if defined(USE_VECTORED_EXCEPTION_HANDLING)
+    if (topLevelVectoredExceptionHandler != NULL) {
+      RemoveVectoredExceptionHandler(topLevelVectoredExceptionHandler);
+      topLevelVectoredExceptionHandler = NULL;
+    }
+#endif
     break;
   default:
     break;
@@ -454,6 +468,12 @@ static unsigned __stdcall thread_native_entry(Thread* thread) {
 
   log_info(os, thread)("Thread is alive (tid: " UINTX_FORMAT ").", os::current_thread_id());
 
+#ifdef USE_VECTORED_EXCEPTION_HANDLING
+  // Any exception is caught by the Vectored Exception Handler, so VM can
+  // generate error dump when an exception occurred in non-Java thread
+  // (e.g. VM thread).
+  thread->call_run();
+#else
   // Install a win32 structured exception handler around every thread created
   // by VM, so VM can generate error dump when an exception occurred in non-
   // Java thread (e.g. VM thread).
@@ -463,6 +483,7 @@ static unsigned __stdcall thread_native_entry(Thread* thread) {
                                      (_EXCEPTION_POINTERS*)_exception_info())) {
     // Nothing to do.
   }
+#endif
 
   // Note: at this point the thread object may already have deleted itself.
   // Do not dereference it from here on out.
@@ -1426,15 +1447,18 @@ void * os::dll_load(const char *name, char *ebuf, int ebuflen) {
 
   static const arch_t arch_array[] = {
     {IMAGE_FILE_MACHINE_I386,      (char*)"IA 32"},
-    {IMAGE_FILE_MACHINE_AMD64,     (char*)"AMD 64"}
+    {IMAGE_FILE_MACHINE_AMD64,     (char*)"AMD 64"},
+    {IMAGE_FILE_MACHINE_ARM64,     (char*)"ARM 64"}
   };
-#if (defined _M_AMD64)
+#if (defined _M_ARM64)
+  static const uint16_t running_arch = IMAGE_FILE_MACHINE_ARM64;
+#elif (defined _M_AMD64)
   static const uint16_t running_arch = IMAGE_FILE_MACHINE_AMD64;
 #elif (defined _M_IX86)
   static const uint16_t running_arch = IMAGE_FILE_MACHINE_I386;
 #else
   #error Method os::dll_load requires that one of following \
-         is defined :_M_AMD64 or _M_IX86
+         is defined :_M_AMD64 or _M_IX86 or _M_ARM64
 #endif
 
 
@@ -1729,7 +1753,8 @@ void os::win32::print_windows_version(outputStream* st) {
   SYSTEM_INFO si;
   ZeroMemory(&si, sizeof(SYSTEM_INFO));
   GetNativeSystemInfo(&si);
-  if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64) {
+  if ((si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64) ||
+      (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64)) {
     st->print(" , 64 bit");
   }
 
@@ -2141,6 +2166,8 @@ LONG Handle_Exception(struct _EXCEPTION_POINTERS* exceptionInfo,
   #define PC_NAME Rip
 #elif defined(_M_IX86)
   #define PC_NAME Eip
+#elif defined(_M_ARM64)
+  #define PC_NAME Pc
 #else
   #error unknown architecture
 #endif
@@ -2235,7 +2262,17 @@ const char* os::exception_name(int exception_code, char *buf, size_t size) {
 LONG Handle_IDiv_Exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
   // handle exception caused by idiv; should only happen for -MinInt/-1
   // (division by zero is handled explicitly)
-#ifdef  _M_AMD64
+#if defined(_M_ARM64)
+  PCONTEXT ctx = exceptionInfo->ContextRecord;
+  address pc = (address)ctx->Sp;
+  assert(pc[0] == 0x83, "not an sdiv opcode"); //Fixme did i get the right opcode?
+  assert(ctx->X4 == min_jint, "unexpected idiv exception");
+  // set correct result values and continue after idiv instruction
+  ctx->Pc = (uint64_t)pc + 4;        // idiv reg, reg, reg  is 4 bytes
+  ctx->X4 = (uint64_t)min_jint;      // result
+  ctx->X5 = (uint64_t)0;             // remainder
+  // Continue the execution
+#elif defined(_M_AMD64)
   PCONTEXT ctx = exceptionInfo->ContextRecord;
   address pc = (address)ctx->Rip;
   assert(pc[0] >= Assembler::REX && pc[0] <= Assembler::REX_WRXB && pc[1] == 0xF7 || pc[0] == 0xF7, "not an idiv opcode");
@@ -2266,6 +2303,7 @@ LONG Handle_IDiv_Exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
   return EXCEPTION_CONTINUE_EXECUTION;
 }
 
+#if defined(_M_AMD64) || defined(_M_IX86)
 //-----------------------------------------------------------------------------
 LONG WINAPI Handle_FLT_Exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
   PCONTEXT ctx = exceptionInfo->ContextRecord;
@@ -2311,6 +2349,7 @@ LONG WINAPI Handle_FLT_Exception(struct _EXCEPTION_POINTERS* exceptionInfo) {
 
   return EXCEPTION_CONTINUE_SEARCH;
 }
+#endif
 
 static inline void report_error(Thread* t, DWORD exception_code,
                                 address addr, void* siginfo, void* context) {
@@ -2320,48 +2359,15 @@ static inline void report_error(Thread* t, DWORD exception_code,
   // somewhere where we can find it in the minidump.
 }
 
-bool os::win32::get_frame_at_stack_banging_point(JavaThread* thread,
-        struct _EXCEPTION_POINTERS* exceptionInfo, address pc, frame* fr) {
-  PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
-  address addr = (address) exceptionRecord->ExceptionInformation[1];
-  if (Interpreter::contains(pc)) {
-    *fr = os::fetch_frame_from_context((void*)exceptionInfo->ContextRecord);
-    if (!fr->is_first_java_frame()) {
-      // get_frame_at_stack_banging_point() is only called when we
-      // have well defined stacks so java_sender() calls do not need
-      // to assert safe_for_sender() first.
-      *fr = fr->java_sender();
-    }
-  } else {
-    // more complex code with compiled code
-    assert(!Interpreter::contains(pc), "Interpreted methods should have been handled above");
-    CodeBlob* cb = CodeCache::find_blob(pc);
-    if (cb == NULL || !cb->is_nmethod() || cb->is_frame_complete_at(pc)) {
-      // Not sure where the pc points to, fallback to default
-      // stack overflow handling
-      return false;
-    } else {
-      *fr = os::fetch_frame_from_context((void*)exceptionInfo->ContextRecord);
-      // in compiled code, the stack banging is performed just after the return pc
-      // has been pushed on the stack
-      *fr = frame(fr->sp() + 1, fr->fp(), (address)*(fr->sp()));
-      if (!fr->is_java_frame()) {
-        // See java_sender() comment above.
-        *fr = fr->java_sender();
-      }
-    }
-  }
-  assert(fr->is_java_frame(), "Safety check");
-  return true;
-}
-
 //-----------------------------------------------------------------------------
 JNIEXPORT
 LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
   if (InterceptOSException) return EXCEPTION_CONTINUE_SEARCH;
   PEXCEPTION_RECORD exception_record = exceptionInfo->ExceptionRecord;
   DWORD exception_code = exception_record->ExceptionCode;
-#ifdef _M_AMD64
+#if defined(_M_ARM64)
+  address pc = (address) exceptionInfo->ContextRecord->Pc;
+#elif defined(_M_AMD64)
   address pc = (address) exceptionInfo->ContextRecord->Rip;
 #else
   address pc = (address) exceptionInfo->ContextRecord->Eip;
@@ -2444,8 +2450,10 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 
       // Last unguard failed or not unguarding
       tty->print_raw_cr("Execution protection violation");
+#if !defined(USE_VECTORED_EXCEPTION_HANDLING)
       report_error(t, exception_code, addr, exception_record,
                    exceptionInfo->ContextRecord);
+#endif
       return EXCEPTION_CONTINUE_SEARCH;
     }
   }
@@ -2467,11 +2475,13 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
     }
   }
 
+#if defined(_M_AMD64) || defined(_M_IX86)
   if ((exception_code == EXCEPTION_ACCESS_VIOLATION) &&
       VM_Version::is_cpuinfo_segv_addr(pc)) {
     // Verify that OS save/restore AVX registers.
     return Handle_Exception(exceptionInfo, VM_Version::cpuinfo_cont_addr());
   }
+#endif
 
   if (t != NULL && t->is_Java_thread()) {
     JavaThread* thread = (JavaThread*) t;
@@ -2502,8 +2512,10 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
         // Fatal red zone violation.
         thread->disable_stack_red_zone();
         tty->print_raw_cr("An unrecoverable stack overflow has occurred.");
+#if !defined(USE_VECTORED_EXCEPTION_HANDLING)
         report_error(t, exception_code, pc, exception_record,
                       exceptionInfo->ContextRecord);
+#endif
         return EXCEPTION_CONTINUE_SEARCH;
       }
     } else if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
@@ -2559,8 +2571,10 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 #endif
 
       // Stack overflow or null pointer exception in native code.
+#if !defined(USE_VECTORED_EXCEPTION_HANDLING)
       report_error(t, exception_code, pc, exception_record,
                    exceptionInfo->ContextRecord);
+#endif
       return EXCEPTION_CONTINUE_SEARCH;
     } // /EXCEPTION_ACCESS_VIOLATION
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -2578,6 +2592,19 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
       }
     }
 
+#ifdef _M_ARM64
+    if (in_java &&
+        (exception_code == EXCEPTION_ILLEGAL_INSTRUCTION ||
+          exception_code == EXCEPTION_ILLEGAL_INSTRUCTION_2)) {
+      if (nativeInstruction_at(pc)->is_sigill_zombie_not_entrant()) {
+        if (TraceTraps) {
+          tty->print_cr("trap: zombie_not_entrant");
+        }
+        return Handle_Exception(exceptionInfo, SharedRuntime::get_handle_wrong_method_stub());
+      }
+    }
+#endif
+
     if (in_java) {
       switch (exception_code) {
       case EXCEPTION_INT_DIVIDE_BY_ZERO:
@@ -2588,18 +2615,74 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 
       } // switch
     }
+
+#if defined(_M_AMD64) || defined(_M_IX86)
     if ((in_java || in_native) && exception_code != EXCEPTION_UNCAUGHT_CXX_EXCEPTION) {
       LONG result=Handle_FLT_Exception(exceptionInfo);
       if (result==EXCEPTION_CONTINUE_EXECUTION) return result;
     }
+#endif
   }
 
+#if !defined(USE_VECTORED_EXCEPTION_HANDLING)
   if (exception_code != EXCEPTION_BREAKPOINT) {
     report_error(t, exception_code, pc, exception_record,
                  exceptionInfo->ContextRecord);
   }
+#endif
   return EXCEPTION_CONTINUE_SEARCH;
 }
+
+#if defined(USE_VECTORED_EXCEPTION_HANDLING)
+LONG WINAPI topLevelVectoredExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
+  PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
+#if defined(_M_ARM64)
+  address pc = (address) exceptionInfo->ContextRecord->Pc;
+#elif defined(_M_AMD64)
+  address pc = (address) exceptionInfo->ContextRecord->Rip;
+#else
+  address pc = (address) exceptionInfo->ContextRecord->Eip;
+#endif
+
+  // Fast path for code part of the code cache
+  if (CodeCache::low_bound() <= pc && pc < CodeCache::high_bound()) {
+    return topLevelExceptionFilter(exceptionInfo);
+  }
+
+  // Handle the case where we get an implicit exception in AOT generated
+  // code.  AOT DLL's loaded are not registered for structured exceptions.
+  // If the exception occurred in the codeCache or AOT code, pass control
+  // to our normal exception handler.
+  CodeBlob* cb = CodeCache::find_blob(pc);
+  if (cb != NULL) {
+    return topLevelExceptionFilter(exceptionInfo);
+  }
+
+  return EXCEPTION_CONTINUE_SEARCH;
+}
+#endif
+
+#if defined(USE_VECTORED_EXCEPTION_HANDLING)
+LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
+  if (InterceptOSException) goto exit;
+  DWORD exception_code = exceptionInfo->ExceptionRecord->ExceptionCode;
+#if defined(_M_ARM64)
+  address pc = (address)exceptionInfo->ContextRecord->Pc;
+#elif defined(_M_AMD64)
+  address pc = (address) exceptionInfo->ContextRecord->Rip;
+#else
+  address pc = (address) exceptionInfo->ContextRecord->Eip;
+#endif
+  Thread* t = Thread::current_or_null_safe();
+
+  if (exception_code != EXCEPTION_BREAKPOINT) {
+    report_error(t, exception_code, pc, exceptionInfo->ExceptionRecord,
+                exceptionInfo->ContextRecord);
+  }
+exit:
+  return previousUnhandledExceptionFilter ? previousUnhandledExceptionFilter(exceptionInfo) : EXCEPTION_CONTINUE_SEARCH;
+}
+#endif
 
 #ifndef _WIN64
 // Special care for fast JNI accessors.
@@ -3449,7 +3532,12 @@ char* os::non_memory_address_word() {
   // Must never look like an address returned by reserve_memory,
   // even in its subfields (as defined by the CPU immediate fields,
   // if the CPU splits constants across multiple instructions).
+#ifdef _M_ARM64
+  // AArch64 has a maximum addressable space of 48-bits
+  return (char*)((1ull << 48) - 1);
+#else
   return (char*)-1;
+#endif
 }
 
 #define MAX_ERROR_COUNT 100
@@ -4122,6 +4210,11 @@ static jint initSock();
 // this is called _after_ the global arguments have been parsed
 jint os::init_2(void) {
   // Setup Windows Exceptions
+
+#if defined(USE_VECTORED_EXCEPTION_HANDLING)
+  topLevelVectoredExceptionHandler = AddVectoredExceptionHandler(1, topLevelVectoredExceptionFilter);
+  previousUnhandledExceptionFilter = SetUnhandledExceptionFilter(topLevelUnhandledExceptionFilter);
+#endif
 
   // for debugging float code generation bugs
   if (ForceFloatExceptions) {
@@ -5495,7 +5588,7 @@ int os::raw_send(int fd, char* buf, size_t nBytes, uint flags) {
 // WINDOWS CONTEXT Flags for THREAD_SAMPLING
 #if defined(IA32)
   #define sampling_context_flags (CONTEXT_FULL | CONTEXT_FLOATING_POINT | CONTEXT_EXTENDED_REGISTERS)
-#elif defined (AMD64)
+#elif defined(AMD64) || defined(_M_ARM64)
   #define sampling_context_flags (CONTEXT_FULL | CONTEXT_FLOATING_POINT)
 #endif
 

--- a/src/hotspot/os/windows/threadCritical_windows.cpp
+++ b/src/hotspot/os/windows/threadCritical_windows.cpp
@@ -35,10 +35,10 @@
 // See threadCritical.hpp for details of this class.
 //
 
-static bool initialized = false;
-static volatile int lock_count = -1;
+static INIT_ONCE initialized = INIT_ONCE_STATIC_INIT;
+static int lock_count = 0;
 static HANDLE lock_event;
-static DWORD lock_owner = -1;
+static DWORD lock_owner = 0;
 
 //
 // Note that Microsoft's critical region code contains a race
@@ -51,48 +51,36 @@ static DWORD lock_owner = -1;
 // and found them ~30 times slower than the critical region code.
 //
 
-ThreadCritical::ThreadCritical() {
-  DWORD current_thread = GetCurrentThreadId();
+static BOOL WINAPI initialize(PINIT_ONCE InitOnce, PVOID Parameter, PVOID *Context) {
+  lock_event = CreateEvent(NULL, false, true, NULL);
+  assert(lock_event != NULL, "unexpected return value from CreateEvent");
+  return true;
+}
 
+ThreadCritical::ThreadCritical() {
+  InitOnceExecuteOnce(&initialized, &initialize, NULL, NULL);
+
+  DWORD current_thread = GetCurrentThreadId();
   if (lock_owner != current_thread) {
     // Grab the lock before doing anything.
-    while (Atomic::cmpxchg(0, &lock_count, -1) != -1) {
-      if (initialized) {
-        DWORD ret = WaitForSingleObject(lock_event,  INFINITE);
-        assert(ret == WAIT_OBJECT_0, "unexpected return value from WaitForSingleObject");
-      }
-    }
-
-    // Make sure the event object is allocated.
-    if (!initialized) {
-      // Locking will not work correctly unless this is autoreset.
-      lock_event = CreateEvent(NULL, false, false, NULL);
-      initialized = true;
-    }
-
-    assert(lock_owner == -1, "Lock acquired illegally.");
+    DWORD ret = WaitForSingleObject(lock_event,  INFINITE);
+    assert(ret == WAIT_OBJECT_0, "unexpected return value from WaitForSingleObject");
     lock_owner = current_thread;
-  } else {
-    // Atomicity isn't required. Bump the recursion count.
-    lock_count++;
   }
-
-  assert(lock_owner == GetCurrentThreadId(), "Lock acquired illegally.");
+  // Atomicity isn't required. Bump the recursion count.
+  lock_count++;
 }
 
 ThreadCritical::~ThreadCritical() {
   assert(lock_owner == GetCurrentThreadId(), "unlock attempt by wrong thread");
   assert(lock_count >= 0, "Attempt to unlock when already unlocked");
 
+  lock_count--;
   if (lock_count == 0) {
     // We're going to unlock
-    lock_owner = -1;
-    lock_count = -1;
+    lock_owner = 0;
     // No lost wakeups, lock_event stays signaled until reset.
     DWORD ret = SetEvent(lock_event);
     assert(ret != 0, "unexpected return value from SetEvent");
-  } else {
-    // Just unwinding a recursive lock;
-    lock_count--;
   }
 }

--- a/src/hotspot/os_cpu/linux_aarch64/icache_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/icache_linux_aarch64.hpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_LINUX_AARCH64_ICACHE_AARCH64_HPP
+#define OS_CPU_LINUX_AARCH64_ICACHE_AARCH64_HPP
+
+// Interface for updating the instruction cache.  Whenever the VM
+// modifies code, part of the processor instruction cache potentially
+// has to be flushed.
+
+class ICache : public AbstractICache {
+ public:
+  static void initialize();
+  static void invalidate_word(address addr) {
+    __builtin___clear_cache((char *)addr, (char *)(addr + 4));
+  }
+  static void invalidate_range(address start, int nbytes) {
+    __builtin___clear_cache((char *)start, (char *)(start + nbytes));
+  }
+};
+
+#endif // OS_CPU_LINUX_AARCH64_ICACHE_AARCH64_HPP

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -27,3 +27,94 @@
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
 
+#include <asm/hwcap.h>
+#include <sys/auxv.h>
+#include <sys/prctl.h>
+
+#ifndef HWCAP_AES
+#define HWCAP_AES   (1<<3)
+#endif
+
+#ifndef HWCAP_PMULL
+#define HWCAP_PMULL (1<<4)
+#endif
+
+#ifndef HWCAP_SHA1
+#define HWCAP_SHA1  (1<<5)
+#endif
+
+#ifndef HWCAP_SHA2
+#define HWCAP_SHA2  (1<<6)
+#endif
+
+#ifndef HWCAP_CRC32
+#define HWCAP_CRC32 (1<<7)
+#endif
+
+#ifndef HWCAP_ATOMICS
+#define HWCAP_ATOMICS (1<<8)
+#endif
+
+void VM_Version::get_os_cpu_info() {
+
+  uint64_t auxv = getauxval(AT_HWCAP);
+
+  STATIC_ASSERT(CPU_FP      == HWCAP_FP);
+  STATIC_ASSERT(CPU_ASIMD   == HWCAP_ASIMD);
+  STATIC_ASSERT(CPU_EVTSTRM == HWCAP_EVTSTRM);
+  STATIC_ASSERT(CPU_AES     == HWCAP_AES);
+  STATIC_ASSERT(CPU_PMULL   == HWCAP_PMULL);
+  STATIC_ASSERT(CPU_SHA1    == HWCAP_SHA1);
+  STATIC_ASSERT(CPU_SHA2    == HWCAP_SHA2);
+  STATIC_ASSERT(CPU_CRC32   == HWCAP_CRC32);
+  STATIC_ASSERT(CPU_LSE     == HWCAP_ATOMICS);
+  _features = auxv & (
+      HWCAP_FP      |
+      HWCAP_ASIMD   |
+      HWCAP_EVTSTRM |
+      HWCAP_AES     |
+      HWCAP_PMULL   |
+      HWCAP_SHA1    |
+      HWCAP_SHA2    |
+      HWCAP_CRC32   |
+      HWCAP_ATOMICS);
+
+  uint64_t ctr_el0;
+  uint64_t dczid_el0;
+  __asm__ (
+    "mrs %0, CTR_EL0\n"
+    "mrs %1, DCZID_EL0\n"
+    : "=r"(ctr_el0), "=r"(dczid_el0)
+  );
+
+  _icache_line_size = (1 << (ctr_el0 & 0x0f)) * 4;
+  _dcache_line_size = (1 << ((ctr_el0 >> 16) & 0x0f)) * 4;
+
+  if (!(dczid_el0 & 0x10)) {
+    _zva_length = 4 << (dczid_el0 & 0xf);
+  }
+
+  int cpu_lines = 0;
+  if (FILE *f = fopen("/proc/cpuinfo", "r")) {
+    // need a large buffer as the flags line may include lots of text
+    char buf[1024], *p;
+    while (fgets(buf, sizeof (buf), f) != NULL) {
+      if ((p = strchr(buf, ':')) != NULL) {
+        long v = strtol(p+1, NULL, 0);
+        if (strncmp(buf, "CPU implementer", sizeof "CPU implementer" - 1) == 0) {
+          _cpu = v;
+          cpu_lines++;
+        } else if (strncmp(buf, "CPU variant", sizeof "CPU variant" - 1) == 0) {
+          _variant = v;
+        } else if (strncmp(buf, "CPU part", sizeof "CPU part" - 1) == 0) {
+          if (_model != v)  _model2 = _model;
+          _model = v;
+        } else if (strncmp(buf, "CPU revision", sizeof "CPU revision" - 1) == 0) {
+          _revision = v;
+        }
+      }
+    }
+    fclose(f);
+  }
+  guarantee(cpu_lines == os::processor_count(), "core count should be consistent");
+}

--- a/src/hotspot/os_cpu/windows_aarch64/assembler_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/assembler_windows_aarch64.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// nothing required here
+#include "precompiled.hpp"

--- a/src/hotspot/os_cpu/windows_aarch64/atomic_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/atomic_windows_aarch64.hpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_WINDOWS_AARCH64_ATOMIC_WINDOWS_AARCH64_HPP
+#define OS_CPU_WINDOWS_AARCH64_ATOMIC_WINDOWS_AARCH64_HPP
+
+#include <intrin.h>
+#include "runtime/os.hpp"
+#include "runtime/vm_version.hpp"
+
+
+// As per atomic.hpp all read-modify-write operations have to provide two-way
+// barriers semantics. The memory_order parameter is ignored - we always provide
+// the strongest/most-conservative ordering
+//
+// For AARCH64 we add explicit barriers in the stubs.
+
+template<size_t byte_size>
+struct Atomic::PlatformAdd
+  : Atomic::AddAndFetch<Atomic::PlatformAdd<byte_size> >
+{
+  template<typename I, typename D>
+  D add_and_fetch(I add_value, D volatile* dest, atomic_memory_order order) const;
+};
+
+// The Interlocked* APIs only take long and will not accept __int32. That is
+// acceptable on Windows, since long is a 32-bits integer type.
+
+#define DEFINE_INTRINSIC_ADD(IntrinsicName, IntrinsicType)                \
+  template<>                                                              \
+  template<typename I, typename D>                                        \
+  inline D Atomic::PlatformAdd<sizeof(IntrinsicType)>::add_and_fetch(I add_value, \
+                                                                     D volatile* dest, \
+                                                                     atomic_memory_order order) const { \
+    STATIC_ASSERT(sizeof(IntrinsicType) == sizeof(D));                    \
+    return PrimitiveConversions::cast<D>(                                 \
+      IntrinsicName(reinterpret_cast<IntrinsicType volatile *>(dest),     \
+                    PrimitiveConversions::cast<IntrinsicType>(add_value))); \
+  }
+
+DEFINE_INTRINSIC_ADD(InterlockedAdd,   long)
+DEFINE_INTRINSIC_ADD(InterlockedAdd64, __int64)
+
+#undef DEFINE_INTRINSIC_ADD
+
+#define DEFINE_INTRINSIC_XCHG(IntrinsicName, IntrinsicType)               \
+  template<>                                                              \
+  template<typename T>                                                    \
+  inline T Atomic::PlatformXchg<sizeof(IntrinsicType)>::operator()(T exchange_value, \
+                                                                   T volatile* dest, \
+                                                                   atomic_memory_order order) const { \
+    STATIC_ASSERT(sizeof(IntrinsicType) == sizeof(T));                    \
+    return PrimitiveConversions::cast<T>(                                 \
+      IntrinsicName(reinterpret_cast<IntrinsicType volatile *>(dest),     \
+                    PrimitiveConversions::cast<IntrinsicType>(exchange_value))); \
+  }
+
+DEFINE_INTRINSIC_XCHG(InterlockedExchange,   long)
+DEFINE_INTRINSIC_XCHG(InterlockedExchange64, __int64)
+
+#undef DEFINE_INTRINSIC_XCHG
+
+// Note: the order of the parameters is different between
+// Atomic::PlatformCmpxchg<*>::operator() and the
+// InterlockedCompareExchange* API.
+
+#define DEFINE_INTRINSIC_CMPXCHG(IntrinsicName, IntrinsicType)            \
+  template<>                                                              \
+  template<typename T>                                                    \
+  inline T Atomic::PlatformCmpxchg<sizeof(IntrinsicType)>::operator()(T exchange_value, \
+                                                                      T volatile* dest, \
+                                                                      T compare_value, \
+                                                                      atomic_memory_order order) const { \
+    STATIC_ASSERT(sizeof(IntrinsicType) == sizeof(T));                    \
+    return PrimitiveConversions::cast<T>(                                 \
+      IntrinsicName(reinterpret_cast<IntrinsicType volatile *>(dest),     \
+                    PrimitiveConversions::cast<IntrinsicType>(exchange_value), \
+                    PrimitiveConversions::cast<IntrinsicType>(compare_value))); \
+  }
+
+DEFINE_INTRINSIC_CMPXCHG(_InterlockedCompareExchange8, char) // Use the intrinsic as InterlockedCompareExchange8 does not exist
+DEFINE_INTRINSIC_CMPXCHG(InterlockedCompareExchange,   long)
+DEFINE_INTRINSIC_CMPXCHG(InterlockedCompareExchange64, __int64)
+
+#undef DEFINE_INTRINSIC_CMPXCHG
+
+#endif // OS_CPU_WINDOWS_AARCH64_ATOMIC_WINDOWS_AARCH64_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/bytes_windows_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/bytes_windows_aarch64.inline.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_WINDOWS_AARCH64_BYTES_WINDOWS_AARCH64_INLINE_HPP
+#define OS_CPU_WINDOWS_AARCH64_BYTES_WINDOWS_AARCH64_INLINE_HPP
+
+#include <stdlib.h>
+
+// Efficient swapping of data bytes from Java byte
+// ordering to native byte ordering and vice versa.
+inline u2   Bytes::swap_u2(u2 x) {
+  return _byteswap_ushort(x);
+}
+
+inline u4   Bytes::swap_u4(u4 x) {
+  return _byteswap_ulong(x);
+}
+
+inline u8 Bytes::swap_u8(u8 x) {
+  return _byteswap_uint64(x);
+}
+
+#pragma warning(default: 4035) // Enable warning 4035: no return value
+
+#endif // OS_CPU_WINDOWS_AARCH64_BYTES_WINDOWS_AARCH64_INLINE_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/copy_windows_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/copy_windows_aarch64.inline.hpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_WINDOWS_AARCH64_COPY_WINDOWS_AARCH64_INLINE_HPP
+#define OS_CPU_WINDOWS_AARCH64_COPY_WINDOWS_AARCH64_INLINE_HPP
+
+#include <string.h>
+
+static void pd_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
+  (void)memmove(to, from, count * HeapWordSize);
+}
+
+static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
+  switch (count) {
+  case 8:  to[7] = from[7];
+  case 7:  to[6] = from[6];
+  case 6:  to[5] = from[5];
+  case 5:  to[4] = from[4];
+  case 4:  to[3] = from[3];
+  case 3:  to[2] = from[2];
+  case 2:  to[1] = from[1];
+  case 1:  to[0] = from[0];
+  case 0:  break;
+  default:
+    (void)memcpy(to, from, count * HeapWordSize);
+    break;
+  }
+}
+
+static void pd_disjoint_words_atomic(const HeapWord* from, HeapWord* to, size_t count) {
+  switch (count) {
+  case 8:  to[7] = from[7];
+  case 7:  to[6] = from[6];
+  case 6:  to[5] = from[5];
+  case 5:  to[4] = from[4];
+  case 4:  to[3] = from[3];
+  case 3:  to[2] = from[2];
+  case 2:  to[1] = from[1];
+  case 1:  to[0] = from[0];
+  case 0:  break;
+  default: while (count-- > 0) {
+             *to++ = *from++;
+           }
+           break;
+  }
+}
+
+static void pd_aligned_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
+ // pd_conjoint_words(from, to, count);
+  (void)memmove(to, from, count * HeapWordSize);
+}
+
+static void pd_aligned_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
+  pd_disjoint_words(from, to, count);
+}
+
+static void pd_conjoint_bytes(const void* from, void* to, size_t count) {
+  (void)memmove(to, from, count);
+}
+
+static void pd_conjoint_bytes_atomic(const void* from, void* to, size_t count) {
+  pd_conjoint_bytes(from, to, count);
+}
+
+static void pd_conjoint_jshorts_atomic(const jshort* from, jshort* to, size_t count) {
+  if (from > to) {
+    while (count-- > 0) {
+      // Copy forwards
+      *to++ = *from++;
+    }
+  } else {
+    from += count - 1;
+    to   += count - 1;
+    while (count-- > 0) {
+      // Copy backwards
+      *to-- = *from--;
+    }
+  }
+}
+
+static void pd_conjoint_jints_atomic(const jint* from, jint* to, size_t count) {
+  if (from > to) {
+    while (count-- > 0) {
+      // Copy forwards
+      *to++ = *from++;
+    }
+  } else {
+    from += count - 1;
+    to   += count - 1;
+    while (count-- > 0) {
+      // Copy backwards
+      *to-- = *from--;
+    }
+  }
+}
+
+static void pd_conjoint_jlongs_atomic(const jlong* from, jlong* to, size_t count) {
+  pd_conjoint_oops_atomic((const oop*)from, (oop*)to, count);
+}
+
+static void pd_conjoint_oops_atomic(const oop* from, oop* to, size_t count) {
+ if (from > to) {
+    while (count-- > 0) {
+      // Copy forwards
+      *to++ = *from++;
+    }
+  } else {
+    from += count - 1;
+    to   += count - 1;
+    while (count-- > 0) {
+      // Copy backwards
+      *to-- = *from--;
+    }
+  }
+}
+
+static void pd_arrayof_conjoint_bytes(const HeapWord* from, HeapWord* to, size_t count) {
+  pd_conjoint_bytes_atomic(from, to, count);
+}
+
+static void pd_arrayof_conjoint_jshorts(const HeapWord* from, HeapWord* to, size_t count) {
+  pd_conjoint_jshorts_atomic((const jshort*)from, (jshort*)to, count);
+}
+
+static void pd_arrayof_conjoint_jints(const HeapWord* from, HeapWord* to, size_t count) {
+  pd_conjoint_jints_atomic((const jint*)from, (jint*)to, count);
+}
+
+static void pd_arrayof_conjoint_jlongs(const HeapWord* from, HeapWord* to, size_t count) {
+  pd_conjoint_jlongs_atomic((const jlong*)from, (jlong*)to, count);
+}
+
+static void pd_arrayof_conjoint_oops(const HeapWord* from, HeapWord* to, size_t count) {
+ pd_conjoint_oops_atomic((const oop*)from, (oop*)to, count);
+}
+
+#endif // OS_CPU_WINDOWS_AARCH64_COPY_WINDOWS_AARCH64_INLINE_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/globals_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/globals_windows_aarch64.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_WINDOWS_AARCH64_GLOBALS_WINDOWS_AARCH64_HPP
+#define OS_CPU_WINDOWS_AARCH64_GLOBALS_WINDOWS_AARCH64_HPP
+
+// Sets the default values for platform dependent flags used by the runtime system.
+// (see globals.hpp)
+
+define_pd_global(bool, DontYieldALot,            false);
+
+// Default stack size on Windows is determined by the executable (java.exe
+// has a default value of 320K/1MB [32bit/64bit]). Depending on Windows version, changing
+// ThreadStackSize to non-zero may have significant impact on memory usage.
+// See comments in os_windows.cpp.
+define_pd_global(intx, ThreadStackSize,          0); // 0 => use system default
+define_pd_global(intx, VMThreadStackSize,        0);
+
+#ifdef ASSERT
+define_pd_global(intx, CompilerThreadStackSize,  1024);
+#else
+define_pd_global(intx, CompilerThreadStackSize,  0);
+#endif
+
+define_pd_global(uintx,JVMInvokeMethodSlack,     8192);
+
+// Used on 64 bit platforms for UseCompressedOops base address
+define_pd_global(uintx,HeapBaseMinAddress,       2*G);
+#endif // OS_CPU_WINDOWS_AARCH64_GLOBALS_WINDOWS_AARCH64_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/icache_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/icache_windows_aarch64.hpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_WINDOWS_AARCH64_ICACHE_AARCH64_HPP
+#define OS_CPU_WINDOWS_AARCH64_ICACHE_AARCH64_HPP
+
+// Interface for updating the instruction cache.  Whenever the VM
+// modifies code, part of the processor instruction cache potentially
+// has to be flushed.
+
+class ICache : public AbstractICache {
+ public:
+  static void initialize();
+  static void invalidate_word(address addr) {
+    invalidate_range(addr, 4);
+  }
+  static void invalidate_range(address start, int nbytes) {
+    FlushInstructionCache((HANDLE)GetCurrentProcess(), start, (SIZE_T)(nbytes));
+  }
+};
+
+#endif // OS_CPU_WINDOWS_AARCH64_ICACHE_AARCH64_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/orderAccess_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/orderAccess_windows_aarch64.hpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_WINDOWS_AARCH64_ORDERACCESS_WINDOWS_AARCH64_HPP
+#define OS_CPU_WINDOWS_AARCH64_ORDERACCESS_WINDOWS_AARCH64_HPP
+
+// Included in orderAccess.hpp header file.
+#include <atomic>
+using std::atomic_thread_fence;
+#include <intrin.h>
+#include "vm_version_aarch64.hpp"
+#include "runtime/vm_version.hpp"
+
+// Implementation of class OrderAccess.
+
+inline void OrderAccess::loadload()   { acquire(); }
+inline void OrderAccess::storestore() { release(); }
+inline void OrderAccess::loadstore()  { acquire(); }
+inline void OrderAccess::storeload()  { fence(); }
+
+#define READ_MEM_BARRIER atomic_thread_fence(std::memory_order_acquire);
+#define WRITE_MEM_BARRIER atomic_thread_fence(std::memory_order_release);
+#define FULL_MEM_BARRIER atomic_thread_fence(std::memory_order_seq_cst);
+
+inline void OrderAccess::acquire() {
+  READ_MEM_BARRIER;
+}
+
+inline void OrderAccess::release() {
+  WRITE_MEM_BARRIER;
+}
+
+inline void OrderAccess::fence() {
+  FULL_MEM_BARRIER;
+}
+
+#endif // OS_CPU_WINDOWS_AARCH64_ORDERACCESS_WINDOWS_AARCH64_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.cpp
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "jvm.h"
+#include "asm/macroAssembler.hpp"
+#include "classfile/classLoader.hpp"
+#include "classfile/systemDictionary.hpp"
+#include "classfile/vmSymbols.hpp"
+#include "code/codeCache.hpp"
+#include "code/icBuffer.hpp"
+#include "code/vtableStubs.hpp"
+#include "code/nativeInst.hpp"
+#include "interpreter/interpreter.hpp"
+#include "memory/allocation.inline.hpp"
+#include "prims/jniFastGetField.hpp"
+#include "prims/jvm_misc.hpp"
+#include "runtime/arguments.hpp"
+#include "runtime/frame.inline.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/java.hpp"
+#include "runtime/javaCalls.hpp"
+#include "runtime/mutexLocker.hpp"
+#include "runtime/osThread.hpp"
+#include "runtime/sharedRuntime.hpp"
+#include "runtime/stubRoutines.hpp"
+#include "runtime/thread.inline.hpp"
+#include "runtime/timer.hpp"
+#include "unwind_windows_aarch64.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/events.hpp"
+#include "utilities/vmError.hpp"
+
+
+// put OS-includes here
+# include <sys/types.h>
+# include <signal.h>
+# include <errno.h>
+# include <stdlib.h>
+# include <stdio.h>
+# include <intrin.h>
+
+void os::os_exception_wrapper(java_call_t f, JavaValue* value, const methodHandle& method, JavaCallArguments* args, Thread* thread) {
+  f(value, method, args, thread);
+}
+
+#pragma warning(disable: 4172)
+
+// Returns an estimate of the current stack pointer. Result must be guaranteed
+// to point into the calling threads stack, and be no lower than the current
+// stack pointer.
+address os::current_stack_pointer() {
+  int dummy;
+  address sp = (address)&dummy;
+  return sp;
+}
+
+#pragma warning(default: 4172)
+
+ExtendedPC os::fetch_frame_from_context(const void* ucVoid,
+                    intptr_t** ret_sp, intptr_t** ret_fp) {
+  ExtendedPC  epc;
+  CONTEXT* uc = (CONTEXT*)ucVoid;
+
+  if (uc != NULL) {
+    epc = ExtendedPC((address)uc->Pc);
+    if (ret_sp) *ret_sp = (intptr_t*)uc->Sp;
+    if (ret_fp) *ret_fp = (intptr_t*)uc->Fp;
+  } else {
+    // construct empty ExtendedPC for return value checking
+    epc = NULL;
+    if (ret_sp) *ret_sp = (intptr_t *)NULL;
+    if (ret_fp) *ret_fp = (intptr_t *)NULL;
+  }
+  return epc;
+}
+
+frame os::fetch_frame_from_context(const void* ucVoid) {
+  intptr_t* sp;
+  intptr_t* fp;
+  ExtendedPC epc = fetch_frame_from_context(ucVoid, &sp, &fp);
+  return frame(sp, fp, epc.pc());
+}
+
+bool os::win32::get_frame_at_stack_banging_point(JavaThread* thread,
+        struct _EXCEPTION_POINTERS* exceptionInfo, address pc, frame* fr) {
+  PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
+  address addr = (address) exceptionRecord->ExceptionInformation[1];
+  if (Interpreter::contains(pc)) {
+    *fr = os::fetch_frame_from_context((void*)exceptionInfo->ContextRecord);
+    if (!fr->is_first_java_frame()) {
+      // get_frame_at_stack_banging_point() is only called when we
+      // have well defined stacks so java_sender() calls do not need
+      // to assert safe_for_sender() first.
+      *fr = fr->java_sender();
+    }
+  } else {
+    // more complex code with compiled code
+    assert(!Interpreter::contains(pc), "Interpreted methods should have been handled above");
+    CodeBlob* cb = CodeCache::find_blob(pc);
+    if (cb == NULL || !cb->is_nmethod() || cb->is_frame_complete_at(pc)) {
+      // Not sure where the pc points to, fallback to default
+      // stack overflow handling
+      return false;
+    } else {
+      // In compiled code, the stack banging is performed before LR
+      // has been saved in the frame.  LR is live, and SP and FP
+      // belong to the caller.
+      intptr_t* fp = (intptr_t*)exceptionInfo->ContextRecord->Fp;
+      intptr_t* sp = (intptr_t*)exceptionInfo->ContextRecord->Sp;
+      address pc = (address)(exceptionInfo->ContextRecord->Lr
+                         - NativeInstruction::instruction_size);
+      *fr = frame(sp, fp, pc);
+      if (!fr->is_java_frame()) {
+        assert(fr->safe_for_sender(thread), "Safety check");
+        assert(!fr->is_first_frame(), "Safety check");
+        *fr = fr->java_sender();
+      }
+    }
+  }
+  assert(fr->is_java_frame(), "Safety check");
+  return true;
+}
+
+// By default, gcc always saves frame pointer rfp on this stack. This
+// may get turned off by -fomit-frame-pointer.
+frame os::get_sender_for_C_frame(frame* fr) {
+  return frame(fr->link(), fr->link(), fr->sender_pc());
+}
+
+frame os::current_frame() {
+  typedef intptr_t*      get_fp_func           ();
+  get_fp_func* func = CAST_TO_FN_PTR(get_fp_func*,
+                                     StubRoutines::aarch64::get_previous_fp_entry());
+  if (func == NULL) return frame();
+  intptr_t* fp = (*func)();
+  if (fp == NULL) {
+    return frame();
+  }
+
+  frame myframe((intptr_t*)os::current_stack_pointer(),
+                (intptr_t*)fp,
+                CAST_FROM_FN_PTR(address, os::current_frame));
+  if (os::is_first_C_frame(&myframe)) {
+
+    // stack is not walkable
+    return frame();
+  } else {
+    return os::get_sender_for_C_frame(&myframe);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// thread stack
+
+// Minimum usable stack sizes required to get to user code. Space for
+// HotSpot guard pages is added later.
+
+/////////////////////////////////////////////////////////////////////////////
+// helper functions for fatal error handler
+
+void os::print_context(outputStream *st, const void *context) {
+  if (context == NULL) return;
+
+  const CONTEXT* uc = (const CONTEXT*)context;
+
+  st->print_cr("Registers:");
+
+  st->print(  "X0 =" INTPTR_FORMAT, uc->X0);
+  st->print(", X1 =" INTPTR_FORMAT, uc->X1);
+  st->print(", X2 =" INTPTR_FORMAT, uc->X2);
+  st->print(", X3 =" INTPTR_FORMAT, uc->X3);
+  st->cr();
+  st->print(  "X4 =" INTPTR_FORMAT, uc->X4);
+  st->print(", X5 =" INTPTR_FORMAT, uc->X5);
+  st->print(", X6 =" INTPTR_FORMAT, uc->X6);
+  st->print(", X7 =" INTPTR_FORMAT, uc->X7);
+  st->cr();
+  st->print(  "X8 =" INTPTR_FORMAT, uc->X8);
+  st->print(", X9 =" INTPTR_FORMAT, uc->X9);
+  st->print(", X10=" INTPTR_FORMAT, uc->X10);
+  st->print(", X11=" INTPTR_FORMAT, uc->X11);
+  st->cr();
+  st->print(  "X12=" INTPTR_FORMAT, uc->X12);
+  st->print(", X13=" INTPTR_FORMAT, uc->X13);
+  st->print(", X14=" INTPTR_FORMAT, uc->X14);
+  st->print(", X15=" INTPTR_FORMAT, uc->X15);
+  st->cr();
+  st->print(  "X16=" INTPTR_FORMAT, uc->X16);
+  st->print(", X17=" INTPTR_FORMAT, uc->X17);
+  st->print(", X18=" INTPTR_FORMAT, uc->X18);
+  st->print(", X19=" INTPTR_FORMAT, uc->X19);
+  st->cr();
+  st->print(", X20=" INTPTR_FORMAT, uc->X20);
+  st->print(", X21=" INTPTR_FORMAT, uc->X21);
+  st->print(", X22=" INTPTR_FORMAT, uc->X22);
+  st->print(", X23=" INTPTR_FORMAT, uc->X23);
+  st->cr();
+  st->print(", X24=" INTPTR_FORMAT, uc->X24);
+  st->print(", X25=" INTPTR_FORMAT, uc->X25);
+  st->print(", X26=" INTPTR_FORMAT, uc->X26);
+  st->print(", X27=" INTPTR_FORMAT, uc->X27);
+  st->print(", X28=" INTPTR_FORMAT, uc->X28);
+  st->cr();
+  st->cr();
+
+  intptr_t *sp = (intptr_t *)uc->Sp;
+  st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", sp);
+  print_hex_dump(st, (address)sp, (address)(sp + 32), sizeof(intptr_t));
+  st->cr();
+
+  // Note: it may be unsafe to inspect memory near pc. For example, pc may
+  // point to garbage if entry point in an nmethod is corrupted. Leave
+  // this at the end, and hope for the best.
+  address pc = (address)uc->Pc;
+  st->print_cr("Instructions: (pc=" PTR_FORMAT ")", pc);
+  print_hex_dump(st, pc - 32, pc + 32, sizeof(char));
+  st->cr();
+
+}
+
+void os::print_register_info(outputStream *st, const void *context) {
+ if (context == NULL) return;
+
+  const CONTEXT* uc = (const CONTEXT*)context;
+
+  st->print_cr("Register to memory mapping:");
+  st->cr();
+  // this is only for the "general purpose" registers
+  st->print(" X0="); print_location(st, uc->X0);
+  st->print(" X1="); print_location(st, uc->X1);
+  st->print(" X2="); print_location(st, uc->X2);
+  st->print(" X3="); print_location(st, uc->X3);
+  st->cr();
+  st->print(" X4="); print_location(st, uc->X4);
+  st->print(" X5="); print_location(st, uc->X5);
+  st->print(" X6="); print_location(st, uc->X6);
+  st->print(" X7="); print_location(st, uc->X7);
+  st->cr();
+  st->print(" X8="); print_location(st, uc->X8);
+  st->print(" X9="); print_location(st, uc->X9);
+  st->print("X10="); print_location(st, uc->X10);
+  st->print("X11="); print_location(st, uc->X11);
+  st->cr();
+  st->print("X12="); print_location(st, uc->X12);
+  st->print("X13="); print_location(st, uc->X13);
+  st->print("X14="); print_location(st, uc->X14);
+  st->print("X15="); print_location(st, uc->X15);
+  st->cr();
+  st->print("X16="); print_location(st, uc->X16);
+  st->print("X17="); print_location(st, uc->X17);
+  st->print("X18="); print_location(st, uc->X18);
+  st->print("X19="); print_location(st, uc->X19);
+  st->cr();
+  st->print("X20="); print_location(st, uc->X20);
+  st->print("X21="); print_location(st, uc->X21);
+  st->print("X22="); print_location(st, uc->X22);
+  st->print("X23="); print_location(st, uc->X23);
+  st->cr();
+  st->print("X24="); print_location(st, uc->X24);
+  st->print("X25="); print_location(st, uc->X25);
+  st->print("X26="); print_location(st, uc->X26);
+  st->print("X27="); print_location(st, uc->X27);
+  st->print("X28="); print_location(st, uc->X28);
+
+  st->cr();
+}
+
+void os::setup_fpu() {
+}
+
+bool os::supports_sse() {
+  return true;
+}
+
+#ifndef PRODUCT
+void os::verify_stack_alignment() {
+  assert(((intptr_t)os::current_stack_pointer() & (StackAlignmentInBytes-1)) == 0, "incorrect stack alignment");
+}
+#endif
+
+int os::extra_bang_size_in_bytes() {
+  // AArch64 does not require the additional stack bang.
+  return 0;
+}
+
+extern "C" {
+  int SpinPause() {
+    return 0;
+  }
+};

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_WINDOWS_AARCH64_OS_WINDOWS_AARCH64_HPP
+#define OS_CPU_WINDOWS_AARCH64_OS_WINDOWS_AARCH64_HPP
+
+  static void setup_fpu();
+  static bool supports_sse();
+
+  static bool      register_code_area(char *low, char *high) {
+    // Using Vectored Exception Handling
+    return true;
+  }
+
+#endif // OS_CPU_WINDOWS_AARCH64_OS_WINDOWS_AARCH64_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/os_windows_aarch64.inline.hpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_WINDOWS_AARCH64_OS_WINDOWS_AARCH64_INLINE_HPP
+#define OS_CPU_WINDOWS_AARCH64_OS_WINDOWS_AARCH64_INLINE_HPP
+
+#include "runtime/os.hpp"
+
+#endif // OS_CPU_WINDOWS_AARCH64_OS_WINDOWS_AARCH64_INLINE_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/pauth_windows_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/pauth_windows_aarch64.inline.hpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_WINDOWS_AARCH64_PAUTH_WINDOWS_AARCH64_INLINE_HPP
+#define OS_CPU_WINDOWS_AARCH64_PAUTH_WINDOWS_AARCH64_INLINE_HPP
+
+inline address pauth_strip_pointer(address ptr) {
+  // No PAC support in windows as of yet.
+  return ptr;
+}
+
+#endif // OS_CPU_WINDOWS_AARCH64_PAUTH_WINDOWS_AARCH64_INLINE_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/prefetch_windows_aarch64.inline.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/prefetch_windows_aarch64.inline.hpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_WINDOWS_AARCH64_PREFETCH_WINDOWS_AARCH64_INLINE_HPP
+#define OS_CPU_WINDOWS_AARCH64_PREFETCH_WINDOWS_AARCH64_INLINE_HPP
+
+#include "runtime/prefetch.hpp"
+
+
+inline void Prefetch::read (void *loc, intx interval) {
+}
+
+inline void Prefetch::write(void *loc, intx interval) {
+}
+
+#endif // OS_CPU_WINDOWS_AARCH64_PREFETCH_WINDOWS_AARCH64_INLINE_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/thread_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/thread_windows_aarch64.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "memory/metaspaceShared.hpp"
+#include "runtime/frame.inline.hpp"
+#include "runtime/thread.inline.hpp"
+
+frame JavaThread::pd_last_frame() {
+  assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
+  vmassert(_anchor.last_Java_pc() != NULL, "not walkable");
+  return frame(_anchor.last_Java_sp(), _anchor.last_Java_fp(), _anchor.last_Java_pc());
+}
+
+// For Forte Analyzer AsyncGetCallTrace profiling support - thread is
+// currently interrupted by SIGPROF
+bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
+  void* ucontext, bool isInJava) {
+
+  assert(Thread::current() == this, "caller must be current thread");
+  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+}
+
+bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
+  return pd_get_top_frame(fr_addr, ucontext, isInJava);
+}
+
+bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava) {
+
+  assert(this->is_Java_thread(), "must be JavaThread");
+
+  JavaThread* jt = (JavaThread *)this;
+
+  // If we have a last_Java_frame, then we should use it even if
+  // isInJava == true.  It should be more reliable than CONTEXT info.
+  if (jt->has_last_Java_frame() && jt->frame_anchor()->walkable()) {
+    *fr_addr = jt->pd_last_frame();
+    return true;
+  }
+
+  // At this point, we don't have a last_Java_frame, so
+  // we try to glean some information out of the CONTEXT
+  // if we were running Java code when SIGPROF came in.
+  if (isInJava) {
+    frame ret_frame = os::fetch_frame_from_context(ucontext);
+    if (ret_frame.pc() == NULL || ret_frame.sp() == NULL ) {
+      // CONTEXT wasn't useful
+      return false;
+    }
+
+    if (MetaspaceShared::is_in_trampoline_frame(ret_frame.pc())) {
+      // In the middle of a trampoline call. Bail out for safety.
+      // This happens rarely so shouldn't affect profiling.
+      return false;
+    }
+
+    if (!ret_frame.safe_for_sender(jt)) {
+#if COMPILER2_OR_JVMCI
+      // C2 and JVMCI use ebp as a general register see if NULL fp helps
+      frame ret_frame2(ret_frame.sp(), NULL, ret_frame.pc());
+      if (!ret_frame2.safe_for_sender(jt)) {
+        // nothing else to try if the frame isn't good
+        return false;
+      }
+      ret_frame = ret_frame2;
+#else
+      // nothing else to try if the frame isn't good
+      return false;
+#endif // COMPILER2_OR_JVMCI
+    }
+    *fr_addr = ret_frame;
+    return true;
+  }
+
+  // nothing else to try
+  return false;
+}
+
+void JavaThread::cache_global_variables() { }

--- a/src/hotspot/os_cpu/windows_aarch64/thread_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/thread_windows_aarch64.hpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_WINDOWS_AARCH64_THREAD_WINDOWS_AARCH64_HPP
+#define OS_CPU_WINDOWS_AARCH64_THREAD_WINDOWS_AARCH64_HPP
+
+ private:
+
+#ifdef ASSERT
+  // spill stack holds N callee-save registers at each Java call and
+  // grows downwards towards limit
+  // we need limit to check we have space for a spill and base so we
+  // can identify all live spill frames at GC (eventually)
+  address          _spill_stack;
+  address          _spill_stack_base;
+  address          _spill_stack_limit;
+#endif // ASSERT
+
+  void pd_initialize() {
+    _anchor.clear();
+  }
+
+  frame pd_last_frame();
+
+ public:
+  // Mutators are highly dangerous....
+  intptr_t* last_Java_fp()                       { return _anchor.last_Java_fp(); }
+  void  set_last_Java_fp(intptr_t* fp)           { _anchor.set_last_Java_fp(fp);   }
+
+  void set_base_of_stack_pointer(intptr_t* base_sp)  {}
+
+  static ByteSize last_Java_fp_offset()          {
+    return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::last_Java_fp_offset();
+  }
+
+  intptr_t* base_of_stack_pointer()              { return NULL; }
+  void record_base_of_stack_pointer()            {}
+
+  bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
+    bool isInJava);
+
+  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava);
+private:
+  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
+public:
+
+  static Thread *aarch64_get_thread_helper() {
+     return Thread::current();
+  }
+
+ public:
+  // These routines are only used on cpu architectures that
+  // have separate register stacks (Itanium).
+  static bool register_stack_overflow() { return false; }
+  static void enable_register_stack_guard() {}
+  static void disable_register_stack_guard() {}
+
+#endif // OS_CPU_WINDOWS_AARCH64_THREAD_WINDOWS_AARCH64_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/unwind_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/unwind_windows_aarch64.hpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_WINDOWS_AARCH64_UNWIND_WINDOWS_AARCH64_HPP
+#define OS_CPU_WINDOWS_AARCH64_UNWIND_WINDOWS_AARCH64_HPP
+
+
+typedef unsigned char UBYTE;
+
+#if _MSC_VER < 1700
+
+/* Not needed for VS2012 compiler, comes from winnt.h. */
+#define UNW_FLAG_EHANDLER  0x01
+#define UNW_FLAG_UHANDLER  0x02
+#define UNW_FLAG_CHAININFO 0x04
+
+#endif
+
+// See https://docs.microsoft.com/en-us/cpp/build/arm64-exception-handling#xdata-records
+typedef struct _UNWIND_INFO_EH_ONLY {
+    DWORD FunctionLength : 18;
+    DWORD Version        : 2;
+    DWORD X              : 1; // = 1
+    DWORD E              : 1; // = 1
+    DWORD EpilogCount    : 5; // = 0
+    DWORD CodeWords      : 5; // = 1
+    DWORD UnwindCode0    : 8;
+    DWORD UnwindCode1    : 8;
+    DWORD UnwindCode2    : 8;
+    DWORD UnwindCode3    : 8;
+    DWORD ExceptionHandler;
+} UNWIND_INFO_EH_ONLY, *PUNWIND_INFO_EH_ONLY;
+
+/*
+typedef struct _RUNTIME_FUNCTION {
+    DWORD BeginAddress;
+    union {
+        DWORD UnwindData;
+        struct {
+            DWORD Flag : 2;
+            DWORD FunctionLength : 11;
+            DWORD RegF : 3;
+            DWORD RegI : 4;
+            DWORD H : 1;
+            DWORD CR : 2;
+            DWORD FrameSize : 9;
+        } DUMMYSTRUCTNAME;
+    } DUMMYUNIONNAME;
+} RUNTIME_FUNCTION, *PRUNTIME_FUNCTION;
+*/
+
+#if _MSC_VER < 1700
+
+/* Not needed for VS2012 compiler, comes from winnt.h. */
+typedef struct _DISPATCHER_CONTEXT {
+    ULONG64 ControlPc;
+    ULONG64 ImageBase;
+    PRUNTIME_FUNCTION FunctionEntry;
+    ULONG64 EstablisherFrame;
+    ULONG64 TargetIp;
+    PCONTEXT ContextRecord;
+//    PEXCEPTION_ROUTINE LanguageHandler;
+    char * LanguageHandler; // double dependency problem
+    PVOID HandlerData;
+} DISPATCHER_CONTEXT, *PDISPATCHER_CONTEXT;
+
+#endif
+
+#if _MSC_VER < 1500
+
+/* Not needed for VS2008 compiler, comes from winnt.h. */
+typedef EXCEPTION_DISPOSITION (*PEXCEPTION_ROUTINE) (
+    IN PEXCEPTION_RECORD ExceptionRecord,
+    IN ULONG64 EstablisherFrame,
+    IN OUT PCONTEXT ContextRecord,
+    IN OUT PDISPATCHER_CONTEXT DispatcherContext
+);
+
+#endif
+
+#endif // OS_CPU_WINDOWS_AARCH64_UNWIND_WINDOWS_AARCH64_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/vmStructs_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vmStructs_windows_aarch64.hpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_CPU_WINDOWS_AARCH64_VMSTRUCTS_WINDOWS_AARCH64_HPP
+#define OS_CPU_WINDOWS_AARCH64_VMSTRUCTS_WINDOWS_AARCH64_HPP
+
+// These are the OS and CPU-specific fields, types and integer
+// constants required by the Serviceability Agent. This file is
+// referenced by vmStructs.cpp.
+
+#define VM_STRUCTS_OS_CPU(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field, nonproduct_nonstatic_field, c2_nonstatic_field, unchecked_c1_static_field, unchecked_c2_static_field) \
+                                                                                                                                     \
+  /******************************/                                                                                                   \
+  /* Threads (NOTE: incomplete) */                                                                                                   \
+  /******************************/                                                                                                   \
+                                                                                                                                     \
+  nonstatic_field(OSThread,                    _thread_id,                                    OSThread::thread_id_t)                 \
+  unchecked_nonstatic_field(OSThread,          _thread_handle,                                sizeof(HANDLE)) /* NOTE: no type */
+
+#define VM_TYPES_OS_CPU(declare_type, declare_toplevel_type, declare_oop_type, declare_integer_type, declare_unsigned_integer_type, declare_c1_toplevel_type, declare_c2_type, declare_c2_toplevel_type) \
+                                                                          \
+  declare_unsigned_integer_type(OSThread::thread_id_t)
+
+#define VM_INT_CONSTANTS_OS_CPU(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant)
+
+#define VM_LONG_CONSTANTS_OS_CPU(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant)
+
+#endif // OS_CPU_WINDOWS_AARCH64_VMSTRUCTS_WINDOWS_AARCH64_HPP

--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "runtime/os.hpp"
+#include "runtime/vm_version.hpp"
+
+void VM_Version::get_os_cpu_info() {
+
+  if (IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE))   _features |= CPU_CRC32;
+  if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE))  _features |= CPU_AES | CPU_SHA1 | CPU_SHA2;
+  if (IsProcessorFeaturePresent(PF_ARM_VFP_32_REGISTERS_AVAILABLE))        _features |= CPU_ASIMD;
+  // No check for CPU_PMULL
+
+  __int64 dczid_el0 = _ReadStatusReg(0x5807 /* ARM64_DCZID_EL0 */);
+
+  if (!(dczid_el0 & 0x10)) {
+    _zva_length = 4 << (dczid_el0 & 0xf);
+  }
+
+  {
+    PSYSTEM_LOGICAL_PROCESSOR_INFORMATION buffer = NULL;
+    DWORD returnLength = 0;
+
+    // See https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getlogicalprocessorinformation
+    GetLogicalProcessorInformation(NULL, &returnLength);
+    assert(GetLastError() == ERROR_INSUFFICIENT_BUFFER, "Unexpected return from GetLogicalProcessorInformation");
+
+    buffer = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION)os::malloc(returnLength, mtInternal);
+    BOOL rc = GetLogicalProcessorInformation(buffer, &returnLength);
+    assert(rc, "Unexpected return from GetLogicalProcessorInformation");
+
+    _icache_line_size = _dcache_line_size = -1;
+    for (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION ptr = buffer; ptr < buffer + returnLength / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION); ptr++) {
+      switch (ptr->Relationship) {
+      case RelationCache:
+        // Cache data is in ptr->Cache, one CACHE_DESCRIPTOR structure for each cache.
+        PCACHE_DESCRIPTOR Cache = &ptr->Cache;
+        if (Cache->Level == 1) {
+            _icache_line_size = _dcache_line_size = Cache->LineSize;
+        }
+        break;
+      }
+    }
+    os::free(buffer);
+  }
+
+  {
+    char* buf = ::getenv("PROCESSOR_IDENTIFIER");
+    if (buf && strstr(buf, "Ampere(TM)") != NULL) {
+      _cpu = CPU_AMCC;
+    } else if (buf && strstr(buf, "Cavium Inc.") != NULL) {
+      _cpu = CPU_CAVIUM;
+    } else {
+      log_info(os)("VM_Version: unknown CPU model");
+    }
+
+    if (_cpu) {
+      SYSTEM_INFO si;
+      GetSystemInfo(&si);
+      _model = si.wProcessorLevel;
+      _variant = si.wProcessorRevision / 0xFF;
+      _revision = si.wProcessorRevision & 0xFF;
+    }
+  }
+}

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -488,6 +488,41 @@ address os::current_stack_pointer() {
 }
 #endif
 
+bool os::win32::get_frame_at_stack_banging_point(JavaThread* thread,
+        struct _EXCEPTION_POINTERS* exceptionInfo, address pc, frame* fr) {
+  PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
+  address addr = (address) exceptionRecord->ExceptionInformation[1];
+  if (Interpreter::contains(pc)) {
+    *fr = os::fetch_frame_from_context((void*)exceptionInfo->ContextRecord);
+    if (!fr->is_first_java_frame()) {
+      // get_frame_at_stack_banging_point() is only called when we
+      // have well defined stacks so java_sender() calls do not need
+      // to assert safe_for_sender() first.
+      *fr = fr->java_sender();
+    }
+  } else {
+    // more complex code with compiled code
+    assert(!Interpreter::contains(pc), "Interpreted methods should have been handled above");
+    CodeBlob* cb = CodeCache::find_blob(pc);
+    if (cb == NULL || !cb->is_nmethod() || cb->is_frame_complete_at(pc)) {
+      // Not sure where the pc points to, fallback to default
+      // stack overflow handling
+      return false;
+    } else {
+      // in compiled code, the stack banging is performed just after the return pc
+      // has been pushed on the stack
+      intptr_t* fp = (intptr_t*)exceptionInfo->ContextRecord->REG_FP;
+      intptr_t* sp = (intptr_t*)exceptionInfo->ContextRecord->REG_SP;
+      *fr = frame(sp + 1, fp, (address)*sp);
+      if (!fr->is_java_frame()) {
+        // See java_sender() comment above.
+        *fr = fr->java_sender();
+      }
+    }
+  }
+  assert(fr->is_java_frame(), "Safety check");
+  return true;
+}
 
 #ifndef AMD64
 intptr_t* _get_previous_fp() {

--- a/src/hotspot/os_cpu/windows_x86/thread_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/thread_windows_x86.cpp
@@ -63,33 +63,22 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava)
   // we try to glean some information out of the CONTEXT
   // if we were running Java code when SIGPROF came in.
   if (isInJava) {
-    CONTEXT* uc = (CONTEXT*)ucontext;
-
-#ifdef AMD64
-    intptr_t* ret_fp = (intptr_t*) uc->Rbp;
-    intptr_t* ret_sp = (intptr_t*) uc->Rsp;
-    ExtendedPC addr = ExtendedPC((address)uc->Rip);
-#else
-    intptr_t* ret_fp = (intptr_t*) uc->Ebp;
-    intptr_t* ret_sp = (intptr_t*) uc->Esp;
-    ExtendedPC addr = ExtendedPC((address)uc->Eip);
-#endif // AMD64
-    if (addr.pc() == NULL || ret_sp == NULL ) {
+    frame ret_frame = os::fetch_frame_from_context(ucontext);
+    if (ret_frame.pc() == NULL || ret_frame.sp() == NULL ) {
       // CONTEXT wasn't useful
       return false;
     }
 
-    if (MetaspaceShared::is_in_trampoline_frame(addr.pc())) {
+    if (MetaspaceShared::is_in_trampoline_frame(ret_frame.pc())) {
       // In the middle of a trampoline call. Bail out for safety.
       // This happens rarely so shouldn't affect profiling.
       return false;
     }
 
-    frame ret_frame(ret_sp, ret_fp, addr.pc());
     if (!ret_frame.safe_for_sender(jt)) {
 #if COMPILER2_OR_JVMCI
       // C2 and JVMCI use ebp as a general register see if NULL fp helps
-      frame ret_frame2(ret_sp, NULL, addr.pc());
+      frame ret_frame2(ret_frame.sp(), NULL, ret_frame.pc());
       if (!ret_frame2.safe_for_sender(jt)) {
         // nothing else to try if the frame isn't good
         return false;

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -97,7 +97,7 @@
 
 static jint CurrentVersion = JNI_VERSION_10;
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(USE_VECTORED_EXCEPTION_HANDLING)
 extern LONG WINAPI topLevelExceptionFilter(_EXCEPTION_POINTERS* );
 #endif
 
@@ -4093,11 +4093,11 @@ static jint JNI_CreateJavaVM_inner(JavaVM **vm, void **penv, void *args) {
 _JNI_IMPORT_OR_EXPORT_ jint JNICALL JNI_CreateJavaVM(JavaVM **vm, void **penv, void *args) {
   jint result = JNI_ERR;
   // On Windows, let CreateJavaVM run with SEH protection
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(USE_VECTORED_EXCEPTION_HANDLING)
   __try {
 #endif
     result = JNI_CreateJavaVM_inner(vm, penv, args);
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(USE_VECTORED_EXCEPTION_HANDLING)
   } __except(topLevelExceptionFilter((_EXCEPTION_POINTERS*)_exception_info())) {
     // Nothing to do.
   }
@@ -4165,11 +4165,11 @@ static jint JNICALL jni_DestroyJavaVM_inner(JavaVM *vm) {
 jint JNICALL jni_DestroyJavaVM(JavaVM *vm) {
   jint result = JNI_ERR;
   // On Windows, we need SEH protection
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(USE_VECTORED_EXCEPTION_HANDLING)
   __try {
 #endif
     result = jni_DestroyJavaVM_inner(vm);
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(USE_VECTORED_EXCEPTION_HANDLING)
   } __except(topLevelExceptionFilter((_EXCEPTION_POINTERS*)_exception_info())) {
     // Nothing to do.
   }

--- a/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_visCPP.hpp
@@ -172,4 +172,8 @@ inline int g_isfinite(jdouble f)                 { return _finite(f); }
 // Alignment
 #define ATTRIBUTE_ALIGNED(x) __declspec(align(x))
 
+#ifdef _M_ARM64
+#define USE_VECTORED_EXCEPTION_HANDLING
+#endif
+
 #endif // SHARE_VM_UTILITIES_GLOBALDEFINITIONS_VISCPP_HPP

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -576,6 +576,8 @@ GetJavaProperties(JNIEnv* env)
         sprops.os_arch = "amd64";
 #elif _X86_
         sprops.os_arch = "x86";
+#elif defined(_M_ARM64)
+        sprops.os_arch = "aarch64";
 #else
         sprops.os_arch = "unknown";
 #endif

--- a/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
+++ b/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
 #include <stdio.h>
 #include <windows.h>
 #include <cstdlib>
-#include <chrono>
 #include <cstring>
 
 #ifdef __cplusplus
@@ -72,11 +71,13 @@ void finalizeFileLogger() {
     }
 }
 
-auto getTimeStamp() -> long long {
-    using namespace std::chrono;
-    auto timeNow = duration_cast<milliseconds>(steady_clock::now().time_since_epoch());
-
-    return timeNow.count();
+unsigned long long getTimeStamp() {
+    FILETIME ft;
+    ULARGE_INTEGER uli;
+    GetSystemTimeAsFileTime(&ft);
+    uli.LowPart = ft.dwLowDateTime;
+    uli.HighPart = ft.dwHighDateTime;
+    return (uli.QuadPart / 10000ULL) - 11644473600000ULL; // Rebase Epoch from 1601 to 1970
 }
 
 /**

--- a/src/jdk.attach/windows/classes/sun/tools/attach/AttachProviderImpl.java
+++ b/src/jdk.attach/windows/classes/sun/tools/attach/AttachProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public class AttachProviderImpl extends HotSpotAttachProvider {
                 "This provider is not supported on this version of Windows");
         }
         String arch = System.getProperty("os.arch");
-        if (!arch.equals("x86") && !arch.equals("amd64")) {
+        if (!arch.equals("x86") && !arch.equals("amd64") && !arch.equals("aarch64")) {
             throw new RuntimeException(
                 "This provider is not supported on this processor architecture");
         }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
@@ -555,8 +555,10 @@ public class HotSpotAgent {
             machDesc = new MachineDescriptionIntelX86();
         } else if (cpu.equals("amd64")) {
             machDesc = new MachineDescriptionAMD64();
+        } else if (cpu.equals("aarch64")) {
+            machDesc = new MachineDescriptionAArch64();
         } else {
-            throw new DebuggerException("Win32 supported under x86 and amd64 only");
+            throw new DebuggerException("Win32 supported under x86, amd64 and aarch64 only");
         }
 
         // Note we do not use a cache for the local debugger in server

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgDebuggerLocal.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/WindbgDebuggerLocal.java
@@ -28,8 +28,10 @@ import java.io.*;
 import java.net.*;
 import java.util.*;
 import sun.jvm.hotspot.debugger.*;
+import sun.jvm.hotspot.debugger.aarch64.*;
 import sun.jvm.hotspot.debugger.amd64.*;
 import sun.jvm.hotspot.debugger.x86.*;
+import sun.jvm.hotspot.debugger.windbg.aarch64.*;
 import sun.jvm.hotspot.debugger.windbg.amd64.*;
 import sun.jvm.hotspot.debugger.windbg.x86.*;
 import sun.jvm.hotspot.debugger.win32.coff.*;
@@ -113,6 +115,8 @@ public class WindbgDebuggerLocal extends DebuggerBase implements WindbgDebugger 
        threadFactory = new WindbgX86ThreadFactory(this);
     } else if (cpu.equals("amd64")) {
        threadFactory = new WindbgAMD64ThreadFactory(this);
+    } else if (cpu.equals("aarch64")) {
+      threadFactory = new WindbgAARCH64ThreadFactory(this);
     }
 
     if (useCache) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64Thread.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package sun.jvm.hotspot.debugger.windbg.aarch64;
+
+import sun.jvm.hotspot.debugger.*;
+import sun.jvm.hotspot.debugger.aarch64.*;
+import sun.jvm.hotspot.debugger.windbg.*;
+
+class WindbgAARCH64Thread implements ThreadProxy {
+  private WindbgDebugger debugger;
+  private long           sysId;
+  private boolean        gotID;
+  private long           id;
+
+  // The address argument must be the address of the OSThread::_thread_id
+  WindbgAARCH64Thread(WindbgDebugger debugger, Address addr) {
+    this.debugger = debugger;
+    this.sysId    = (long)addr.getCIntegerAt(0, 4, true);
+    gotID         = false;
+  }
+
+  WindbgAARCH64Thread(WindbgDebugger debugger, long sysId) {
+    this.debugger = debugger;
+    this.sysId    = sysId;
+    gotID         = false;
+  }
+
+  public ThreadContext getContext() throws IllegalThreadStateException {
+    long[] data = debugger.getThreadIntegerRegisterSet(getThreadID());
+    WindbgAARCH64ThreadContext context = new WindbgAARCH64ThreadContext(debugger);
+    for (int i = 0; i < data.length; i++) {
+      context.setRegister(i, data[i]);
+    }
+    return context;
+  }
+
+  public boolean canSetContext() throws DebuggerException {
+    return false;
+  }
+
+  public void setContext(ThreadContext thrCtx)
+    throws IllegalThreadStateException, DebuggerException {
+    throw new DebuggerException("Unimplemented");
+  }
+
+  public boolean equals(Object obj) {
+    if ((obj == null) || !(obj instanceof WindbgAARCH64Thread)) {
+      return false;
+    }
+
+    return (((WindbgAARCH64Thread) obj).getThreadID() == getThreadID());
+  }
+
+  public int hashCode() {
+    return (int) getThreadID();
+  }
+
+  public String toString() {
+    return Long.toString(getThreadID());
+  }
+
+  /** Retrieves the thread ID of this thread by examining the Thread
+      Information Block. */
+  private long getThreadID() {
+    if (!gotID) {
+       id = debugger.getThreadIdFromSysId(sysId);
+    }
+
+    return id;
+  }
+}

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64ThreadContext.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64ThreadContext.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package sun.jvm.hotspot.debugger.windbg.aarch64;
+
+import sun.jvm.hotspot.debugger.*;
+import sun.jvm.hotspot.debugger.aarch64.*;
+import sun.jvm.hotspot.debugger.windbg.*;
+
+class WindbgAARCH64ThreadContext extends AARCH64ThreadContext {
+  private WindbgDebugger debugger;
+
+  public WindbgAARCH64ThreadContext(WindbgDebugger debugger) {
+    super();
+    this.debugger = debugger;
+  }
+
+  public void setRegisterAsAddress(int index, Address value) {
+    setRegister(index, debugger.getAddressValue(value));
+  }
+
+  public Address getRegisterAsAddress(int index) {
+    return debugger.newAddress(getRegister(index));
+  }
+}

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64ThreadFactory.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/windbg/aarch64/WindbgAARCH64ThreadFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package sun.jvm.hotspot.debugger.windbg.aarch64;
+
+import sun.jvm.hotspot.debugger.*;
+import sun.jvm.hotspot.debugger.windbg.*;
+
+public class WindbgAARCH64ThreadFactory implements WindbgThreadFactory {
+  private WindbgDebugger debugger;
+
+  public WindbgAARCH64ThreadFactory(WindbgDebugger debugger) {
+    this.debugger = debugger;
+  }
+
+  public ThreadProxy createThreadWrapper(Address threadIdentifierAddr) {
+    return new WindbgAARCH64Thread(debugger, threadIdentifierAddr);
+  }
+
+  public ThreadProxy createThreadWrapper(long id) {
+    return new WindbgAARCH64Thread(debugger, id);
+  }
+}

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
@@ -28,11 +28,13 @@ import java.util.*;
 
 import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.types.*;
+
 import sun.jvm.hotspot.runtime.solaris_sparc.SolarisSPARCJavaThreadPDAccess;
 import sun.jvm.hotspot.runtime.solaris_x86.SolarisX86JavaThreadPDAccess;
 import sun.jvm.hotspot.runtime.solaris_amd64.SolarisAMD64JavaThreadPDAccess;
-import sun.jvm.hotspot.runtime.win32_amd64.Win32AMD64JavaThreadPDAccess;
 import sun.jvm.hotspot.runtime.win32_x86.Win32X86JavaThreadPDAccess;
+import sun.jvm.hotspot.runtime.win32_amd64.Win32AMD64JavaThreadPDAccess;
+import sun.jvm.hotspot.runtime.win32_aarch64.Win32AARCH64JavaThreadPDAccess;
 import sun.jvm.hotspot.runtime.linux_x86.LinuxX86JavaThreadPDAccess;
 import sun.jvm.hotspot.runtime.linux_amd64.LinuxAMD64JavaThreadPDAccess;
 import sun.jvm.hotspot.runtime.linux_aarch64.LinuxAARCH64JavaThreadPDAccess;
@@ -82,6 +84,8 @@ public class Threads {
                 access =  new Win32X86JavaThreadPDAccess();
             } else if (cpu.equals("amd64")) {
                 access =  new Win32AMD64JavaThreadPDAccess();
+            } else if (cpu.equals("aarch64")) {
+                access =  new Win32AARCH64JavaThreadPDAccess();
             }
         } else if (os.equals("linux")) {
             if (cpu.equals("x86")) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/win32_aarch64/Win32AARCH64JavaThreadPDAccess.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/win32_aarch64/Win32AARCH64JavaThreadPDAccess.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package sun.jvm.hotspot.runtime.win32_aarch64;
+
+import java.io.*;
+import java.util.*;
+import sun.jvm.hotspot.debugger.*;
+import sun.jvm.hotspot.debugger.aarch64.*;
+import sun.jvm.hotspot.runtime.*;
+import sun.jvm.hotspot.runtime.aarch64.*;
+import sun.jvm.hotspot.types.*;
+import sun.jvm.hotspot.utilities.*;
+
+/** This class is only public to allow using the VMObjectFactory to
+    instantiate these.
+*/
+
+public class Win32AARCH64JavaThreadPDAccess implements JavaThreadPDAccess {
+  private static AddressField  lastJavaFPField;
+  private static AddressField  osThreadField;
+
+  // Field from OSThread
+  private static Field         osThreadThreadIDField;
+
+  // This is currently unneeded but is being kept in case we change
+  // the currentFrameGuess algorithm
+  private static final long GUESS_SCAN_RANGE = 128 * 1024;
+
+  static {
+    VM.registerVMInitializedObserver(new Observer() {
+        public void update(Observable o, Object data) {
+          initialize(VM.getVM().getTypeDataBase());
+        }
+      });
+  }
+
+  private static synchronized void initialize(TypeDataBase db) {
+    Type type = db.lookupType("JavaThread");
+    osThreadField = type.getAddressField("_osthread");
+
+    Type anchorType = db.lookupType("JavaFrameAnchor");
+    lastJavaFPField = anchorType.getAddressField("_last_Java_fp");
+
+    Type osThreadType = db.lookupType("OSThread");
+    osThreadThreadIDField = osThreadType.getField("_thread_id");
+  }
+
+  public Address getLastJavaFP(Address addr) {
+    return lastJavaFPField.getValue(addr.addOffsetTo(sun.jvm.hotspot.runtime.JavaThread.getAnchorField().getOffset()));
+  }
+
+  public Address getLastJavaPC(Address addr) {
+    return null;
+  }
+
+  public Address getBaseOfStackPointer(Address addr) {
+    return null;
+  }
+
+  public Frame getLastFramePD(JavaThread thread, Address addr) {
+    Address fp = thread.getLastJavaFP();
+    if (fp == null) {
+      return null; // no information
+    }
+    Address pc =  thread.getLastJavaPC();
+    if ( pc != null ) {
+      return new AARCH64Frame(thread.getLastJavaSP(), fp, pc);
+    } else {
+      return new AARCH64Frame(thread.getLastJavaSP(), fp);
+    }
+  }
+
+  public RegisterMap newRegisterMap(JavaThread thread, boolean updateMap) {
+    return new AARCH64RegisterMap(thread, updateMap);
+  }
+
+  public Frame getCurrentFrameGuess(JavaThread thread, Address addr) {
+    ThreadProxy t = getThreadProxy(addr);
+    AARCH64ThreadContext context = (AARCH64ThreadContext) t.getContext();
+    AARCH64CurrentFrameGuess guesser = new AARCH64CurrentFrameGuess(context, thread);
+    if (!guesser.run(GUESS_SCAN_RANGE)) {
+      return null;
+    }
+    if (guesser.getPC() == null) {
+      return new AARCH64Frame(guesser.getSP(), guesser.getFP());
+    } else {
+      return new AARCH64Frame(guesser.getSP(), guesser.getFP(), guesser.getPC());
+    }
+  }
+
+  public void printThreadIDOn(Address addr, PrintStream tty) {
+    tty.print(getThreadProxy(addr));
+  }
+
+  public void printInfoOn(Address threadAddr, PrintStream tty) {
+  }
+
+  public Address getLastSP(Address addr) {
+    ThreadProxy t = getThreadProxy(addr);
+    AARCH64ThreadContext context = (AARCH64ThreadContext) t.getContext();
+    return context.getRegisterAsAddress(AARCH64ThreadContext.SP);
+  }
+
+  public ThreadProxy getThreadProxy(Address addr) {
+    // Addr is the address of the JavaThread.
+    // Fetch the OSThread (for now and for simplicity, not making a
+    // separate "OSThread" class in this package)
+    Address osThreadAddr = osThreadField.getValue(addr);
+    // Get the address of the thread_id within the OSThread
+    Address threadIdAddr = osThreadAddr.addOffsetTo(osThreadThreadIDField.getOffset());
+
+    JVMDebugger debugger = VM.getVM().getDebugger();
+    return debugger.getThreadForIdentifierAddress(threadIdAddr);
+  }
+}

--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -36,6 +36,9 @@
 #elif _M_AMD64
   #include "sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext.h"
   #define NPRGREG sun_jvm_hotspot_debugger_amd64_AMD64ThreadContext_NPRGREG
+#elif _M_ARM64
+  #include "sun_jvm_hotspot_debugger_aarch64_AARCH64ThreadContext.h"
+  #define NPRGREG sun_jvm_hotspot_debugger_aarch64_AARCH64ThreadContext_NPRGREG
 #else
   #error "SA windbg back-end is not supported for your cpu!"
 #endif

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotJVMCIBackendFactory.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotJVMCIBackendFactory.java
@@ -128,7 +128,11 @@ public class AArch64HotSpotJVMCIBackendFactory implements HotSpotJVMCIBackendFac
     }
 
     protected RegisterConfig createRegisterConfig(AArch64HotSpotVMConfig config, TargetDescription target) {
-        return new AArch64HotSpotRegisterConfig(target, config.useCompressedOops);
+        // ARMv8 defines r18 as being available to the platform ABI. Windows
+        // and Darwin use it for such. Linux doesn't assign it and thus r18 can
+        // be used as an additional register.
+        boolean canUsePlatformRegister = config.linuxOs;
+        return new AArch64HotSpotRegisterConfig(target, config.useCompressedOops, canUsePlatformRegister);
     }
 
     protected HotSpotCodeCacheProvider createCodeCache(HotSpotJVMCIRuntime runtime, TargetDescription target, RegisterConfig regConfig) {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotRegisterConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot.aarch64/src/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotRegisterConfig.java
@@ -34,6 +34,7 @@ import static jdk.vm.ci.aarch64.AArch64.r7;
 import static jdk.vm.ci.aarch64.AArch64.rscratch1;
 import static jdk.vm.ci.aarch64.AArch64.rscratch2;
 import static jdk.vm.ci.aarch64.AArch64.r12;
+import static jdk.vm.ci.aarch64.AArch64.r18;
 import static jdk.vm.ci.aarch64.AArch64.r27;
 import static jdk.vm.ci.aarch64.AArch64.r28;
 import static jdk.vm.ci.aarch64.AArch64.r29;
@@ -122,6 +123,12 @@ public class AArch64HotSpotRegisterConfig implements RegisterConfig {
      */
     public static final Register metaspaceMethodRegister = r12;
 
+    /**
+     * The platform ABI can use r18 to carry inter-procedural state (e.g. thread
+     * context). If not defined as such by the platform ABI, it can be used as
+     * additional temporary register.
+     */
+    public static final Register platformRegister = r18;
     public static final Register heapBaseRegister = r27;
     public static final Register threadRegister = r28;
     public static final Register fp = r29;
@@ -129,15 +136,18 @@ public class AArch64HotSpotRegisterConfig implements RegisterConfig {
     private static final RegisterArray reservedRegisters
         = new RegisterArray(rscratch1, rscratch2, threadRegister, fp, lr, r31, zr, sp);
 
-    private static RegisterArray initAllocatable(Architecture arch, boolean reserveForHeapBase) {
+    private static RegisterArray initAllocatable(Architecture arch, boolean reserveForHeapBase, boolean canUsePlatformRegister) {
         RegisterArray allRegisters = arch.getAvailableValueRegisters();
-        Register[] registers = new Register[allRegisters.size() - reservedRegisters.size() - (reserveForHeapBase ? 1 : 0)];
+        Register[] registers = new Register[allRegisters.size() - reservedRegisters.size() - (reserveForHeapBase ? 1 : 0) - (!canUsePlatformRegister ? 1 : 0)];
         List<Register> reservedRegistersList = reservedRegisters.asList();
 
         int idx = 0;
         for (Register reg : allRegisters) {
             if (reservedRegistersList.contains(reg)) {
                 // skip reserved registers
+                continue;
+            }
+            if (!canUsePlatformRegister && reg.equals(platformRegister)) {
                 continue;
             }
             assert !(reg.equals(threadRegister) || reg.equals(fp) || reg.equals(lr) || reg.equals(r31) || reg.equals(zr) || reg.equals(sp));
@@ -153,8 +163,8 @@ public class AArch64HotSpotRegisterConfig implements RegisterConfig {
         return new RegisterArray(registers);
     }
 
-    public AArch64HotSpotRegisterConfig(TargetDescription target, boolean useCompressedOops) {
-        this(target, initAllocatable(target.arch, useCompressedOops));
+    public AArch64HotSpotRegisterConfig(TargetDescription target, boolean useCompressedOops, boolean canUsePlatformRegister) {
+        this(target, initAllocatable(target.arch, useCompressedOops, canUsePlatformRegister));
         assert callerSaved.size() >= allocatable.size();
     }
 

--- a/test/hotspot/jtreg/runtime/Locals/TestLargeLocalVarsStackRegion.java
+++ b/test/hotspot/jtreg/runtime/Locals/TestLargeLocalVarsStackRegion.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8265756
+ * @library /test/lib /
+ * @compile TestLargeLocalVarsStackRegionHelper.jasm
+ * @run main runtime.Locals.TestLargeLocalVarsStackRegion
+ */
+
+package runtime.Locals;
+
+import jdk.test.lib.Asserts;
+
+public class TestLargeLocalVarsStackRegion {
+
+    // Some platforms (such as windows-aarch64) may have
+    // stack page touch order restrictions.
+    // Test calls method with large local vars stack region
+    // to trigger usage of several stack memory pages and
+    // check the validity of the touch order.
+    //
+    // Helper method is written in jasm as this allows to
+    // specify local vars stack region size directly.
+    public static void main(String args[]) {
+        Asserts.assertEQ(TestLargeLocalVarsStackRegionHelper.tst(), 0);
+    }
+}

--- a/test/hotspot/jtreg/runtime/Locals/TestLargeLocalVarsStackRegionHelper.jasm
+++ b/test/hotspot/jtreg/runtime/Locals/TestLargeLocalVarsStackRegionHelper.jasm
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package runtime/Locals;
+
+public class TestLargeLocalVarsStackRegionHelper
+{
+
+// Method with large locals vars region.
+// Purpose: verify stack pages touch order (see TestLargeLocalVarsStackRegion.java)
+public static Method tst:"()I"
+    stack 3 locals 65535
+{
+                iconst_1;
+                newarray int;
+                dup;
+                astore_w   65500;
+                aload_w  65500;
+                if_acmpne       FAILED;
+
+                iconst_0;
+                ireturn; // passed
+
+        FAILED:
+                iconst_1; // failed
+                ireturn;
+}
+
+public Method <init>:"()V"
+        stack 1 locals 1
+{
+    aload_0;
+    invokespecial   Method java/lang/Object.<init>:"()V";
+    return;
+}
+
+}


### PR DESCRIPTION
This is a more recent version of https://github.com/openjdk/jdk11u/pull/2.

Changes since then:
- [JDK-8254634](https://bugs.openjdk.java.net/browse/JDK-8254634) (backport of [Build failure with VS 2019 (16.5.0) due to C2039 and C2873](https://bugs.openjdk.java.net/browse/JDK-8241087)) was removed, as it had been committed separately.
- [JDK-8269391](https://bugs.openjdk.java.net/browse/JDK-8269391) (backport of [AArch64: initialize memory allocated for locals according to Windows AArch64 stack page growth requirement in template interpreter](https://bugs.openjdk.java.net/browse/JDK-8265756)) was added.
- [JDK-8271095](https://bugs.openjdk.java.net/browse/JDK-8271095) (backport of [C4530 was reported from VS 2019 at access bridge](https://bugs.openjdk.java.net/browse/JDK-8263136)) was added.
- [JDK-8271002](https://bugs.openjdk.java.net/browse/JDK-8271002) (backport of [AArch64: Fix MacroAssembler::get_thread convention](https://bugs.openjdk.java.net/browse/JDK-8261072)) was added.
- [JDK-8272181](https://bugs.openjdk.java.net/browse/JDK-8272181) was added, containing the Windows/AArch64 related part of [JDK-8271571](https://bugs.openjdk.java.net/browse/JDK-8271571) (backport of [AArch64: Backtracing broken on PAC enabled systems](https://bugs.openjdk.java.net/browse/JDK-8266749)), necessary for a correct build.
- Various small merge conflict resolutions.

Similarly to how it was done on tip, we have incorporated parts of [JDK-8253015: Aarch64: Move linux code out from generic CPU feature detection](https://bugs.openjdk.java.net/browse/JDK-8253015) by @AntonKozlov into the [JDK-8253947: Implementation: JEP 388: Windows AArch64 Support](https://bugs.openjdk.java.net/browse/JDK-8253947) commit.

Please let me know how I can make the review process easier / faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Issue of type `Backport` is not allowed for integrations

### Issue
 * [JDK-8253947](https://bugs.openjdk.java.net/browse/JDK-8253947): Implementation: JEP 388: Windows AArch64 Support


### Contributors
 * Monica Beckwith `<mbeckwit@openjdk.org>`
 * Ludovic Henry `<luhenry@openjdk.org>`
 * Bernhard Urban-Forster `<burban@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/222/head:pull/222` \
`$ git checkout pull/222`

Update a local copy of the PR: \
`$ git checkout pull/222` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 222`

View PR using the GUI difftool: \
`$ git pr show -t 222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/222.diff">https://git.openjdk.java.net/jdk11u-dev/pull/222.diff</a>

</details>
