### PR TITLE
8214937: sun/security/tools/jarsigner/warnings/NoTimestampTest.java failed due to unexpected expiration date

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/warnings/NoTimestampTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/warnings/NoTimestampTest.java
@@ -21,8 +21,13 @@
  * questions.
  */
 
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.Locale;
+
 import jdk.testlibrary.OutputAnalyzer;
 import jdk.test.lib.util.JarUtils;
 
@@ -61,15 +66,13 @@ public class NoTimestampTest extends Test {
         Utils.createFiles(FIRST_FILE);
         JarUtils.createJar(UNSIGNED_JARFILE, FIRST_FILE);
 
-        // calculate certificate expiration date
-        Date expirationDate = new Date(System.currentTimeMillis() + VALIDITY
-                * 24 * 60 * 60 * 1000L);
-
         // create key pair
         createAlias(CA_KEY_ALIAS, "-ext", "bc:c");
         createAlias(KEY_ALIAS);
         issueCert(KEY_ALIAS,
                 "-validity", Integer.toString(VALIDITY));
+
+        Date expirationDate = getCertExpirationDate();
 
         // sign jar file
         OutputAnalyzer analyzer = jarsigner(
@@ -114,4 +117,12 @@ public class NoTimestampTest extends Test {
         System.out.println("Test passed");
     }
 
+    private static Date getCertExpirationDate() throws Exception {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        try (InputStream in = new FileInputStream(KEYSTORE)) {
+            ks.load(in, PASSWORD.toCharArray());
+        }
+        X509Certificate cert = (X509Certificate) ks.getCertificate(KEY_ALIAS);
+        return cert.getNotAfter();
+    }
 }


### PR DESCRIPTION
Backporting for `11.0.13-oracle` parity.

Additional testing: 
 - [x] Affected test still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8214937](https://bugs.openjdk.java.net/browse/JDK-8214937): sun/security/tools/jarsigner/warnings/NoTimestampTest.java failed due to unexpected expiration date


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/223/head:pull/223` \
`$ git checkout pull/223`

Update a local copy of the PR: \
`$ git checkout pull/223` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 223`

View PR using the GUI difftool: \
`$ git pr show -t 223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/223.diff">https://git.openjdk.java.net/jdk11u-dev/pull/223.diff</a>

</details>
