### PR TITLE
8242882: opening jar file with large manifest might throw NegativeArraySizeException

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -153,6 +153,8 @@ class JarFile extends ZipFile {
     private static final boolean MULTI_RELEASE_ENABLED;
     private static final boolean MULTI_RELEASE_FORCED;
     private static final ThreadLocal<Boolean> isInitializing = new ThreadLocal<>();
+    // The maximum size of array to allocate. Some VMs reserve some header words in an array.
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
 
     private SoftReference<Manifest> manRef;
     private JarEntry manEntry;
@@ -804,7 +806,11 @@ class JarFile extends ZipFile {
      */
     private byte[] getBytes(ZipEntry ze) throws IOException {
         try (InputStream is = super.getInputStream(ze)) {
-            int len = (int)ze.getSize();
+            long uncompressedSize = ze.getSize();
+            if (uncompressedSize > MAX_ARRAY_SIZE) {
+                throw new OutOfMemoryError("Required array size too large");
+            }
+            int len = (int)uncompressedSize;
             int bytesRead;
             byte[] b;
             // trust specified entry sizes when reasonably small

--- a/test/jdk/java/util/jar/JarFile/LargeManifestOOMTest.java
+++ b/test/jdk/java/util/jar/JarFile/LargeManifestOOMTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.util.JarUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.jar.JarFile;
+
+/**
+ * @test
+ * @bug 8242882
+ * @summary Verify that opening a jar file with a large manifest throws an OutOfMemoryError
+ * and not a NegativeArraySizeException
+ * @library /test/lib
+ * @run testng LargeManifestOOMTest
+ */
+public class LargeManifestOOMTest {
+    // file will be created with size greater than Integer.MAX_VALUE
+    private static final long MANIFEST_FILE_SIZE = Integer.MAX_VALUE + 1024L;
+
+    /**
+     * Creates a jar which has a large manifest file and then uses the {@link JarFile} to
+     * {@link JarFile#getManifest() load the manifest}. The call to the {@link JarFile#getManifest()}
+     * is then expected to throw a {@link OutOfMemoryError}
+     */
+    @Test
+    public void testOutOfMemoryError() throws Exception {
+        final Path jarSourceRoot = Paths.get("jar-source");
+        createLargeManifest(jarSourceRoot.resolve("META-INF"));
+        final Path jarFilePath = Paths.get("oom-test.jar");
+        JarUtils.createJarFile(jarFilePath.toAbsolutePath(), jarSourceRoot, Paths.get("."));
+        final JarFile jar = new JarFile(jarFilePath.toFile());
+        Assert.assertThrows(OutOfMemoryError.class, () -> jar.getManifest());
+    }
+
+    /**
+     * Creates a {@code MANIFEST.MF}, whose content is {@link #MANIFEST_FILE_SIZE} in size,
+     * in the {@code parentDir}
+     *
+     * @param parentDir The directory in which the MANIFEST.MF file will be created
+     */
+    private static void createLargeManifest(final Path parentDir) throws IOException {
+        Files.createDirectories(parentDir.toAbsolutePath());
+        final Path manifestFile = parentDir.resolve("MANIFEST.MF");
+        try (final RandomAccessFile largeManifest = new RandomAccessFile(manifestFile.toFile(), "rw")) {
+            largeManifest.writeUTF("Manifest-Version: 1.0\n");
+            largeManifest.writeUTF("OOM-Test: a\n");
+            largeManifest.setLength(MANIFEST_FILE_SIZE);
+        }
+        System.out.println("Size of file " + manifestFile + " is " + manifestFile.toFile().length());
+    }
+}


### PR DESCRIPTION
Unclean backport to match `11.0.13-oracle`. The uncleanliness is due to ambuity in `JarUtils.createJarFile` that does not have the overload with just `(Path, Path)`, as it was added in later JDKs. I added the `Paths.get(".")` to do the same thing.

```
        JarUtils.createJarFile(jarFilePath.toAbsolutePath(), jarSourceRoot, Paths.get("."));
```

Additional testing:
 - [x] New test fails without the patch
 - [x] New test passes with the patch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242882](https://bugs.openjdk.java.net/browse/JDK-8242882): opening jar file with large manifest might throw NegativeArraySizeException


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/225/head:pull/225` \
`$ git checkout pull/225`

Update a local copy of the PR: \
`$ git checkout pull/225` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 225`

View PR using the GUI difftool: \
`$ git pr show -t 225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/225.diff">https://git.openjdk.java.net/jdk11u-dev/pull/225.diff</a>

</details>
