### PR TITLE
8158066: SourceDebugExtensionTest fails to rename file

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/sde/InstallSDE.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/sde/InstallSDE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,12 +58,18 @@ public class InstallSDE {
     }
 
     public static void install(File inOutClassFile, File attrFile, boolean verbose) throws IOException {
-        File tmpFile = new File(inOutClassFile.getPath() + "tmp");
+        File tmpFile = new File(inOutClassFile.getPath() + "tmp-out");
+        File tmpInOutClassFile = new File(inOutClassFile.getPath() + "tmp-in");
 
-        new InstallSDE(inOutClassFile, attrFile, tmpFile, verbose);
+        // Workaround delayed file deletes on Windows using a tmp file name
+        if (!inOutClassFile.renameTo(tmpInOutClassFile)) {
+            throw new IOException("inOutClassFile.renameTo(tmpInOutClassFile) failed");
+        }
 
-        if (!inOutClassFile.delete()) {
-            throw new IOException("inOutClassFile.delete() failed");
+        new InstallSDE(tmpInOutClassFile, attrFile, tmpFile, verbose);
+
+        if (!tmpInOutClassFile.delete()) {
+            throw new IOException("tmpInOutClassFile.delete() failed");
         }
         if (!tmpFile.renameTo(inOutClassFile)) {
             throw new IOException("tmpFile.renameTo(inOutClassFile) failed");

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -870,8 +870,6 @@ com/sun/jdi/BasicJDWPConnectionTest.java                        8195703 generic-
 
 com/sun/jdi/RepStep.java                                        8043571 generic-all
 
-com/sun/jdi/sde/SourceDebugExtensionTest.java                   8158066 windows-all
-
 com/sun/jdi/NashornPopFrameTest.java                            8187143 generic-all
 
 ############################################################################

--- a/test/jdk/com/sun/jdi/sde/InstallSDE.java
+++ b/test/jdk/com/sun/jdi/sde/InstallSDE.java
@@ -31,10 +31,18 @@ class InstallSDE {
     }
 
     static void install(File inOutClassFile, File attrFile) throws IOException {
-        File tmpFile = new File(inOutClassFile.getPath() + "tmp");
-        new InstallSDE(inOutClassFile, attrFile, tmpFile);
-        if (!inOutClassFile.delete()) {
-            throw new IOException("inOutClassFile.delete() failed");
+        File tmpFile = new File(inOutClassFile.getPath() + "tmp-out");
+        File tmpInOutClassFile = new File(inOutClassFile.getPath() + "tmp-in");
+
+        // Workaround delayed file deletes on Windows using a tmp file name
+        if (!inOutClassFile.renameTo(tmpInOutClassFile)) {
+            throw new IOException("tmp copy of inOutClassFile failed");
+        }
+
+        new InstallSDE(tmpInOutClassFile, attrFile, tmpFile);
+
+        if (!tmpInOutClassFile.delete()) {
+            throw new IOException("tmpInOutClassFile.delete() failed");
         }
         if (!tmpFile.renameTo(inOutClassFile)) {
             throw new IOException("tmpFile.renameTo(inOutClassFile) failed");


### PR DESCRIPTION
Backporting to match `11.0.13-oracle`.

Additional testing: 
 - [x] Linux, test is still passing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8158066](https://bugs.openjdk.java.net/browse/JDK-8158066): SourceDebugExtensionTest fails to rename file


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/227/head:pull/227` \
`$ git checkout pull/227`

Update a local copy of the PR: \
`$ git checkout pull/227` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 227`

View PR using the GUI difftool: \
`$ git pr show -t 227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/227.diff">https://git.openjdk.java.net/jdk11u-dev/pull/227.diff</a>

</details>
