### PR TITLE
8214195: Align stdout messages in test/jdk/java/math/BigInteger/PrimitiveConversionTests.java

### DIFF
--- a/test/jdk/java/math/BigInteger/PrimitiveConversionTests.java
+++ b/test/jdk/java/math/BigInteger/PrimitiveConversionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,7 @@ public class PrimitiveConversionTests {
     }
 
     public static int testDoubleValue() {
+        System.out.println("--- testDoubleValue ---");
         int failures = 0;
         for (BigInteger big : ALL_BIGINTEGER_CANDIDATES) {
             double expected = Double.parseDouble(big.toString());
@@ -71,7 +72,8 @@ public class PrimitiveConversionTests {
             // should be bitwise identical
             if (Double.doubleToRawLongBits(expected) != Double
                     .doubleToRawLongBits(actual)) {
-                System.out.println(big);
+                System.out.format("big: %s, expected: %f, actual: %f%n",
+                    big, expected, actual);
                 failures++;
             }
         }
@@ -79,6 +81,7 @@ public class PrimitiveConversionTests {
     }
 
     public static int testFloatValue() {
+        System.out.println("--- testFloatValue ---");
         int failures = 0;
         for (BigInteger big : ALL_BIGINTEGER_CANDIDATES) {
             float expected = Float.parseFloat(big.toString());
@@ -87,7 +90,8 @@ public class PrimitiveConversionTests {
             // should be bitwise identical
             if (Float.floatToRawIntBits(expected) != Float
                     .floatToRawIntBits(actual)) {
-                System.out.println(big + " " + expected + " " + actual);
+                System.out.format("big: %s, expected: %f, actual: %f%n",
+                    big, expected, actual);
                 failures++;
             }
         }


### PR DESCRIPTION
Clean backport.

Additional testing:
 - [x] Affected test still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8214195](https://bugs.openjdk.java.net/browse/JDK-8214195): Align stdout messages in test/jdk/java/math/BigInteger/PrimitiveConversionTests.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/238/head:pull/238` \
`$ git checkout pull/238`

Update a local copy of the PR: \
`$ git checkout pull/238` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 238`

View PR using the GUI difftool: \
`$ git pr show -t 238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/238.diff">https://git.openjdk.java.net/jdk11u-dev/pull/238.diff</a>

</details>
