### PR TITLE
8254850: Update terminology in java.awt.GridBagLayout source code comments

### DIFF
--- a/src/java.desktop/share/classes/java/awt/GridBagLayout.java
+++ b/src/java.desktop/share/classes/java/awt/GridBagLayout.java
@@ -1122,7 +1122,7 @@ java.io.Serializable {
                 }
 
 
-                /* Cache the current slave's size. */
+                /* Cache the current child's size. */
                 if (sizeflag == PREFERREDSIZE)
                     d = comp.getPreferredSize();
                 else
@@ -1263,7 +1263,7 @@ java.io.Serializable {
                 else if (constraints.gridwidth == 0 && curCol < 0)
                     curRow = curY + curHeight;
 
-                /* Assign the new values to the gridbag slave */
+                /* Assign the new values to the gridbag child */
                 constraints.tempX = curX;
                 constraints.tempY = curY;
                 constraints.tempWidth = curWidth;
@@ -1382,7 +1382,7 @@ java.io.Serializable {
                         px = constraints.tempX + constraints.tempWidth; /* right column */
 
                         /*
-                         * Figure out if we should use this slave\'s weight.  If the weight
+                         * Figure out if we should use this child's weight.  If the weight
                          * is less than the total weight spanned by the width of the cell,
                          * then discard the weight.  Otherwise split the difference
                          * according to the existing weights.
@@ -1408,7 +1408,7 @@ java.io.Serializable {
 
                         /*
                          * Calculate the minWidth array values.
-                         * First, figure out how wide the current slave needs to be.
+                         * First, figure out how wide the current child needs to be.
                          * Then, see if it will fit within the current minWidth values.
                          * If it will not fit, add the difference according to the
                          * weightX array.
@@ -1443,7 +1443,7 @@ java.io.Serializable {
                         py = constraints.tempY + constraints.tempHeight; /* bottom row */
 
                         /*
-                         * Figure out if we should use this slave's weight.  If the weight
+                         * Figure out if we should use this child's weight.  If the weight
                          * is less than the total weight spanned by the height of the cell,
                          * then discard the weight.  Otherwise split it the difference
                          * according to the existing weights.
@@ -1469,7 +1469,7 @@ java.io.Serializable {
 
                         /*
                          * Calculate the minHeight array values.
-                         * First, figure out how tall the current slave needs to be.
+                         * First, figure out how tall the current child needs to be.
                          * Then, see if it will fit within the current minHeight values.
                          * If it will not fit, add the difference according to the
                          * weightY array.
@@ -1993,7 +1993,7 @@ java.io.Serializable {
 
     /**
      * Figures out the minimum size of the
-     * master based on the information from {@code getLayoutInfo}.
+     * parent based on the information from {@code getLayoutInfo}.
      * This method should only be used internally by
      * {@code GridBagLayout}.
      *
@@ -2073,7 +2073,7 @@ java.io.Serializable {
         rightToLeft = !parent.getComponentOrientation().isLeftToRight();
 
         /*
-         * If the parent has no slaves anymore, then don't do anything
+         * If the parent has no children anymore, then don't do anything
          * at all:  just leave the parent's size as-is.
          */
         if (components.length == 0 &&
@@ -2083,7 +2083,7 @@ java.io.Serializable {
         }
 
         /*
-         * Pass #1: scan all the slaves to figure out the total amount
+         * Pass #1: scan all the children to figure out the total amount
          * of space needed.
          */
 
@@ -2173,7 +2173,7 @@ java.io.Serializable {
          */
 
         /*
-         * Now do the actual layout of the slaves using the layout information
+         * Now do the actual layout of the children using the layout information
          * that has been collected.
          */
 


### PR DESCRIPTION
Clean backport to match `11.0.13-oracle`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8254850](https://bugs.openjdk.java.net/browse/JDK-8254850): Update terminology in java.awt.GridBagLayout source code comments


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/240/head:pull/240` \
`$ git checkout pull/240`

Update a local copy of the PR: \
`$ git checkout pull/240` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 240`

View PR using the GUI difftool: \
`$ git pr show -t 240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/240.diff">https://git.openjdk.java.net/jdk11u-dev/pull/240.diff</a>

</details>
