### PR TITLE
8255790: GTKL&F: Java 16 crashes on initialising GTKL&F on Manjaro Linux

### DIFF
--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -535,26 +535,13 @@ endif
 
 ###########################################################################
 
-ifeq ($(USE_EXTERNAL_HARFBUZZ), true)
-  LIBHARFBUZZ_LIBS := $(HARFBUZZ_LIBS)
-else
-  HARFBUZZ_CFLAGS := -DHAVE_OT -DHAVE_FALLBACK -DHAVE_UCDN -DHAVE_ROUND
-  # This is better than adding EXPORT_ALL_SYMBOLS
-  ifneq ($(filter $(TOOLCHAIN_TYPE), gcc clang solstudio), )
-    HARFBUZZ_CFLAGS += -DHB_EXTERN=__attribute__\(\(visibility\(\"default\"\)\)\)
-  else ifeq ($(TOOLCHAIN_TYPE), microsoft)
-    HARFBUZZ_CFLAGS += -DHB_EXTERN=__declspec\(dllexport\)
-  endif
 
-  LIBHARFBUZZ_LDFLAGS := $(LDFLAGS_JDKLIB) \
-                         $(call SET_SHARED_LIBRARY_ORIGIN)
-  ifeq ($(TOOLCHAIN_TYPE), gcc)
-    ifeq ($(CC_VERSION_NUMBER), 4.4.7)
-      LIBHARFBUZZ_LDFLAGS := $(subst -Xlinker -z -Xlinker defs,, \
-        $(subst -Wl$(COMMA)-z$(COMMA)defs,,$(LDFLAGS_JDKLIB))) \
-        $(call SET_SHARED_LIBRARY_ORIGIN)
-    endif
-  endif
+ifeq ($(USE_EXTERNAL_HARFBUZZ), true)
+  LIBFONTMANAGER_EXTRA_SRC =
+  BUILD_LIBFONTMANAGER_FONTLIB += $(HARFBUZZ_LIBS)
+else
+  LIBFONTMANAGER_EXTRA_SRC = libharfbuzz
+  HARFBUZZ_CFLAGS := -DHAVE_OT -DHAVE_FALLBACK -DHAVE_UCDN -DHAVE_ROUND
 
   ifneq ($(OPENJDK_TARGET_OS), windows)
     HARFBUZZ_CFLAGS += -DGETPAGESIZE -DHAVE_MPROTECT -DHAVE_PTHREAD \
@@ -571,73 +558,34 @@ else
     HARFBUZZ_CFLAGS += -DHAVE_CORETEXT
   endif
   ifneq ($(OPENJDK_TARGET_OS), macosx)
-     LIBHARFBUZZ_EXCLUDE_FILES += harfbuzz/hb-coretext.cc
+    LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-coretext.cc
   endif
   # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
-  LIBHARFBUZZ_EXCLUDE_FILES += harfbuzz/hb-ft.cc
+  LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-ft.cc
 
-  LIBHARFBUZZ_CFLAGS += $(HARFBUZZ_CFLAGS)
+  HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing
+  HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
+       maybe-uninitialized class-memaccess
+  HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
+       tautological-constant-out-of-range-compare int-to-pointer-cast \
+       undef missing-field-initializers
+  HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244 4090 4146 4334 4819 4101 4068 4805 4138
+  HARFBUZZ_DISABLED_WARNINGS_C_solstudio := \
+        E_INTEGER_OVERFLOW_DETECTED \
+        E_ARG_INCOMPATIBLE_WITH_ARG_L \
+        E_ENUM_VAL_OVERFLOWS_INT_MAX
+  HARFBUZZ_DISABLED_WARNINGS_CXX_solstudio := \
+        truncwarn wvarhidenmem wvarhidemem wbadlkginit identexpected \
+        hidevf w_novirtualdescr arrowrtn2 unknownpragma
 
-  # For use by libfontmanager:
-  ifeq ($(OPENJDK_TARGET_OS), windows)
-    LIBHARFBUZZ_LIBS := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libharfbuzz/harfbuzz.lib
-  else
-    LIBHARFBUZZ_LIBS := -lharfbuzz
-  endif
-
-  LIBHARFBUZZ_EXTRA_HEADER_DIRS := \
-    libharfbuzz/hb-ucdn \
-    #
-
-  LIBHARFBUZZ_OPTIMIZATION := HIGH
-
-  LIBHARFBUZZ_CFLAGS += $(X_CFLAGS) -DLE_STANDALONE -DHEADLESS
-
-  $(eval $(call SetupJdkLibrary, BUILD_LIBHARFBUZZ, \
-      NAME := harfbuzz, \
-      EXCLUDE_FILES := $(LIBHARFBUZZ_EXCLUDE_FILES), \
-      TOOLCHAIN := TOOLCHAIN_LINK_CXX, \
-      CFLAGS := $(CFLAGS_JDKLIB) $(LIBHARFBUZZ_CFLAGS), \
-      CXXFLAGS := $(CXXFLAGS_JDKLIB) $(LIBHARFBUZZ_CFLAGS), \
-      OPTIMIZATION := $(LIBHARFBUZZ_OPTIMIZATION), \
-      CFLAGS_windows = -DCC_NOEX, \
-      EXTRA_HEADER_DIRS := $(LIBHARFBUZZ_EXTRA_HEADER_DIRS), \
-      WARNINGS_AS_ERRORS_xlc := false, \
-      DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing, \
-      DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
-          maybe-uninitialized class-memaccess, \
-      DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
-          tautological-constant-out-of-range-compare int-to-pointer-cast \
-          undef missing-field-initializers, \
-      DISABLED_WARNINGS_C_solstudio := \
-          E_INTEGER_OVERFLOW_DETECTED \
-          E_ARG_INCOMPATIBLE_WITH_ARG_L \
-          E_ENUM_VAL_OVERFLOWS_INT_MAX, \
-      DISABLED_WARNINGS_CXX_solstudio := \
-          truncwarn wvarhidenmem wvarhidemem wbadlkginit identexpected \
-          hidevf w_novirtualdescr arrowrtn2 unknownpragma, \
-      DISABLED_WARNINGS_microsoft := 4267 4244 4090 4146 4334 4819 4101 4068 4805 4138, \
-      LDFLAGS := $(LIBHARFBUZZ_LDFLAGS), \
-      LDFLAGS_unix := -L$(INSTALL_LIBRARIES_HERE), \
-      LDFLAGS_aix := -Wl$(COMMA)-berok, \
-      LIBS := $(BUILD_LIBHARFBUZZ), \
-      LIBS_unix := $(LIBM) $(LIBCXX), \
-      LIBS_macosx := -framework CoreText -framework CoreFoundation -framework CoreGraphics, \
-      LIBS_windows := user32.lib, \
-  ))
-
-  ifeq ($(FREETYPE_TO_USE), bundled)
-    $(BUILD_LIBHARFBUZZ): $(BUILD_LIBFREETYPE)
-  endif
-
-  TARGETS += $(BUILD_LIBHARFBUZZ)
+  LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
 
 endif
 
-###########################################################################
 
 LIBFONTMANAGER_EXTRA_HEADER_DIRS := \
     libharfbuzz \
+    libharfbuzz/hb-ucdn \
     common/awt \
     common/font \
     libawt/java2d \
@@ -645,10 +593,10 @@ LIBFONTMANAGER_EXTRA_HEADER_DIRS := \
     libawt/java2d/loops \
     #
 
-LIBFONTMANAGER_CFLAGS += $(LIBFREETYPE_CFLAGS) $(HARFBUZZ_FLAGS)
-BUILD_LIBFONTMANAGER_FONTLIB += $(LIBHARFBUZZ_LIBS) $(LIBFREETYPE_LIBS)
+LIBFONTMANAGER_CFLAGS += $(LIBFREETYPE_CFLAGS)
+BUILD_LIBFONTMANAGER_FONTLIB +=  $(LIBFREETYPE_LIBS)
 
-LIBFONTMANAGER_OPTIMIZATION := HIGH
+LIBFONTMANAGER_OPTIMIZATION := HIGHEST
 
 ifeq ($(OPENJDK_TARGET_OS), windows)
   LIBFONTMANAGER_EXCLUDE_FILES += X11FontScaler.c \
@@ -686,17 +634,14 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     OPTIMIZATION := $(LIBFONTMANAGER_OPTIMIZATION), \
     CFLAGS_windows = -DCC_NOEX, \
     EXTRA_HEADER_DIRS := $(LIBFONTMANAGER_EXTRA_HEADER_DIRS), \
+    EXTRA_SRC := $(LIBFONTMANAGER_EXTRA_SRC), \
     WARNINGS_AS_ERRORS_xlc := false, \
-    DISABLED_WARNINGS_gcc := sign-compare unused-function int-to-pointer-cast, \
-    DISABLED_WARNINGS_clang := sign-compare, \
-    DISABLED_WARNINGS_C_solstudio := \
-        E_INTEGER_OVERFLOW_DETECTED \
-        E_ARG_INCOMPATIBLE_WITH_ARG_L \
-        E_ENUM_VAL_OVERFLOWS_INT_MAX, \
-    DISABLED_WARNINGS_CXX_solstudio := \
-        truncwarn wvarhidenmem wvarhidemem wbadlkginit identexpected \
-        hidevf w_novirtualdescr arrowrtn2 unknownpragma, \
-    DISABLED_WARNINGS_microsoft := 4018 4146 4244 4996 4996 4146 4334 4819 4101 4068 4805 4138, \
+    DISABLED_WARNINGS_gcc := sign-compare unused-function int-to-pointer-cast $(HARFBUZZ_DISABLED_WARNINGS_gcc), \
+    DISABLED_WARNINGS_CXX_gcc := $(HARFBUZZ_DISABLED_WARNINGS_CXX_gcc), \
+    DISABLED_WARNINGS_clang := sign-compare $(HARFBUZZ_DISABLED_WARNINGS_clang), \
+    DISABLED_WARNINGS_C_solstudio := $(HARFBUZZ_DISABLED_WARNINGS_C_solstudio), \
+    DISABLED_WARNINGS_CXX_solstudio := $(HARFBUZZ_DISABLED_WARNINGS_CXX_solstudio), \
+    DISABLED_WARNINGS_microsoft := 4018 4996 $(HARFBUZZ_DISABLED_WARNINGS_microsoft), \
     LDFLAGS := $(subst -Xlinker -z -Xlinker defs,, \
         $(subst -Wl$(COMMA)-z$(COMMA)defs,,$(LDFLAGS_JDKLIB))) $(LDFLAGS_CXX_JDK) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
@@ -704,16 +649,12 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     LDFLAGS_aix := -Wl$(COMMA)-berok, \
     LIBS := $(BUILD_LIBFONTMANAGER_FONTLIB), \
     LIBS_unix := -lawt -ljava -ljvm $(LIBM) $(LIBCXX), \
-    LIBS_macosx := -lawt_lwawt, \
+    LIBS_macosx := -lawt_lwawt -framework CoreText -framework CoreFoundation -framework CoreGraphics, \
     LIBS_windows := $(WIN_JAVA_LIB) advapi32.lib user32.lib gdi32.lib \
         $(WIN_AWT_LIB), \
 ))
 
 $(BUILD_LIBFONTMANAGER): $(BUILD_LIBAWT)
-
-ifeq ($(USE_EXTERNAL_HARFBUZZ), false)
-  $(BUILD_LIBFONTMANAGER): $(BUILD_LIBHARFBUZZ)
-endif
 
 ifeq ($(OPENJDK_TARGET_OS), macosx)
   $(BUILD_LIBFONTMANAGER): $(call FindLib, $(MODULE), awt_lwawt)


### PR DESCRIPTION
Please review this backport of JDK-8255790 which fixes a crash of simple FileDialog-using apps on some systems (for example F34 when not using system harfbuzz). See JDK-8272149. In a nutshell, this patch is a not quite complete revert of JDK-8249821. I.e. the OpenJDK 11u version of it. It does not revert the source code re-structuring, though. The JDK 17 patch doesn't apply clean. I've mostly hand-picked changes from the original patch. Note that JDK-8272332 is included in this backport. The differences mostly stem from differences in DISABLED_WARNINGS_ settings when BUILD_FONTMANAGER is being called.

Testing: Build on an affected system with/without --with-harfbuzz=system. Reproducer from JDK-8272149 (crashes before, passes after)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8255790](https://bugs.openjdk.java.net/browse/JDK-8255790): GTKL&F: Java 16 crashes on initialising GTKL&F on Manjaro Linux
 * [JDK-8272332](https://bugs.openjdk.java.net/browse/JDK-8272332): --with-harfbuzz=system doesn't add -lharfbuzz after JDK-8255790


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/241/head:pull/241` \
`$ git checkout pull/241`

Update a local copy of the PR: \
`$ git checkout pull/241` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 241`

View PR using the GUI difftool: \
`$ git pr show -t 241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/241.diff">https://git.openjdk.java.net/jdk11u-dev/pull/241.diff</a>

</details>
