### PR TITLE
8214520: [TEST_BUG] sun/security/mscapi/nonUniqueAliases/NonUniqueAliases.java failed with incorrect jtreg tags order

### DIFF
--- a/test/jdk/sun/security/mscapi/nonUniqueAliases/NonUniqueAliases.java
+++ b/test/jdk/sun/security/mscapi/nonUniqueAliases/NonUniqueAliases.java
@@ -23,11 +23,11 @@
 
 /*
  * @test
- * @ignore Uses certutil.exe that isn't guaranteed to be installed
  * @bug 6483657 8154113
  * @requires os.family == "windows"
  * @library /test/lib
  * @summary Test "keytool -list" displays correctly same named certificates
+ * @ignore Uses certutil.exe that isn't guaranteed to be installed
  */
 
 import jdk.test.lib.process.ProcessTools;


### PR DESCRIPTION
Clean backport to match `11.0.13-oracle`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8214520](https://bugs.openjdk.java.net/browse/JDK-8214520): [TEST_BUG] sun/security/mscapi/nonUniqueAliases/NonUniqueAliases.java failed with incorrect jtreg tags order


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/243/head:pull/243` \
`$ git checkout pull/243`

Update a local copy of the PR: \
`$ git checkout pull/243` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 243`

View PR using the GUI difftool: \
`$ git pr show -t 243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/243.diff">https://git.openjdk.java.net/jdk11u-dev/pull/243.diff</a>

</details>
