### PR TITLE
8248352: [TEST_BUG] Test test/jdk/java/awt/font/TextLayout/ArabicDiacriticTest.java can leave frame open

### DIFF
--- a/test/jdk/java/awt/font/TextLayout/ArabicDiacriticTest.java
+++ b/test/jdk/java/awt/font/TextLayout/ArabicDiacriticTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,8 @@
  */
 
 /* @test
- * @key headful
  * @summary verify Arab Diacritic Positioning
- * @bug 8168759
+ * @bug 8168759 8248352
  */
 
 import java.awt.Font;
@@ -46,19 +45,18 @@ public class ArabicDiacriticTest {
     static final String STR1 = "\u0644\u0639\u064e\u0629";
     static final String STR2 = "\u0644\u0639\u0629";
 
-    static JFrame frame;
     static final String FONT = "DejaVu Sans";
 
-    public static void main(String args[]) throws Exception {
-        showText(); // for a human
+    public static void main(String[] args) throws Exception {
+        if ((args.length > 0) && (args[0].equals("-show"))) {
+            showText(); // for a human
+        }
         measureText(); // for the test harness
-        Thread.sleep(5000);
-        frame.dispose();
     }
 
     static void showText() {
         SwingUtilities.invokeLater(() -> {
-            frame = new JFrame();
+            JFrame frame = new JFrame();
             JLabel label = new JLabel(SAMPLE);
             Font font = new Font(FONT, Font.PLAIN, 36);
             label.setFont(font);


### PR DESCRIPTION
Clean backport to match `11.0.13-oracle`.

Additional testing:
 - [x] Affected test still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8248352](https://bugs.openjdk.java.net/browse/JDK-8248352): [TEST_BUG] Test test/jdk/java/awt/font/TextLayout/ArabicDiacriticTest.java can leave frame open


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/244/head:pull/244` \
`$ git checkout pull/244`

Update a local copy of the PR: \
`$ git checkout pull/244` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 244`

View PR using the GUI difftool: \
`$ git pr show -t 244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/244.diff">https://git.openjdk.java.net/jdk11u-dev/pull/244.diff</a>

</details>
