### PR TITLE
8262862: Harden tests sun/security/x509/URICertStore/ExtensionsWithLDAP.java and krb5/canonicalize/Test.java

### DIFF
--- a/test/jdk/sun/security/krb5/canonicalize/Test.java
+++ b/test/jdk/sun/security/krb5/canonicalize/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,21 +25,16 @@
  * @bug 6682516 8149521
  * @summary SPNEGO_HTTP_AUTH/WWW_KRB and SPNEGO_HTTP_AUTH/WWW_SPNEGO failed on all non-windows platforms
  * @modules java.security.jgss/sun.security.krb5
- * @run main/othervm  -Djava.security.krb5.conf=krb5.conf Test
+ * @run main/othervm -Djdk.net.hosts.file=${test.src}/TestHosts
+ *      -Djava.security.krb5.realm=THIS.REALM
+ *      -Djava.security.krb5.kdc=localhost
+ *      -Djava.security.krb5.conf=krb5.conf Test
  */
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import sun.security.krb5.PrincipalName;
 
 public class Test {
     public static void main(String[] args) throws Exception {
-        // This config file is generated using Kerberos.app on a Mac
-        String hostsFileName = System.getProperty("test.src", ".") + "/TestHosts";
-        System.setProperty("jdk.net.hosts.file", hostsFileName);
-        System.setProperty("java.security.krb5.realm", "THIS.REALM");
-        System.setProperty("java.security.krb5.kdc", "localhost");
-
         // add using canonicalized name
         check("c1", "c1.this.domain");
         check("c1.this", "c1.this.domain");

--- a/test/jdk/sun/security/x509/URICertStore/ExtensionsWithLDAP.java
+++ b/test/jdk/sun/security/x509/URICertStore/ExtensionsWithLDAP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,18 +27,19 @@
  * @test
  * @bug 8134708
  * @summary Check if LDAP resources from CRLDP and AIA extensions can be loaded
- * @run main/othervm ExtensionsWithLDAP CRLDP ldap.host.for.crldp
+ * @run main/othervm -Djdk.net.hosts.file=${test.src}/CRLDP
+ *      -Dcom.sun.security.enableCRLDP=true
+ *      ExtensionsWithLDAP CRLDP ldap.host.for.crldp
  * @modules jdk.security.auth
- * @run main/othervm ExtensionsWithLDAP AIA ldap.host.for.aia
+ * @run main/othervm -Djdk.net.hosts.file=${test.src}/AIA
+ *      -Dcom.sun.security.enableAIAcaIssuers=true
+ *      ExtensionsWithLDAP AIA ldap.host.for.aia
  */
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.cert.CertPath;
 import java.security.cert.CertPathValidator;
 import java.security.cert.CertPathValidatorException;
@@ -131,15 +132,6 @@ public class ExtensionsWithLDAP {
     public static void main(String[] args) throws Exception {
         String extension = args[0];
         String targetHost = args[1];
-
-        // enable CRLDP and AIA extensions
-        System.setProperty("com.sun.security.enableCRLDP", "true");
-        System.setProperty("com.sun.security.enableAIAcaIssuers", "true");
-
-        Path hostsFilePath = Paths.get(System.getProperty("test.src", ".")
-                + File.separator + extension);
-        System.setProperty("jdk.net.hosts.file",
-                hostsFilePath.toFile().getAbsolutePath());
 
         X509Certificate trustedCert = loadCertificate(CA_CERT);
         X509Certificate eeCert = loadCertificate(EE_CERT);


### PR DESCRIPTION
Clean backport to match `11.0.13-oracle`.

Additional testing:
 - [x] Affected tests still pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8262862](https://bugs.openjdk.java.net/browse/JDK-8262862): Harden tests sun/security/x509/URICertStore/ExtensionsWithLDAP.java and krb5/canonicalize/Test.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/245/head:pull/245` \
`$ git checkout pull/245`

Update a local copy of the PR: \
`$ git checkout pull/245` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 245`

View PR using the GUI difftool: \
`$ git pr show -t 245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/245.diff">https://git.openjdk.java.net/jdk11u-dev/pull/245.diff</a>

</details>
