### PR TITLE
8272131: PhaseMacroExpand::generate_slow_arraycopy crash when clone null CallProjections.fallthrough_ioproj

### DIFF
--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -731,7 +731,9 @@ Node* PhaseMacroExpand::generate_arraycopy(ArrayCopyNode *ac, AllocateArrayNode*
   }
 
   _igvn.replace_node(_memproj_fallthrough, out_mem);
-  _igvn.replace_node(_ioproj_fallthrough, *io);
+  if (_ioproj_fallthrough != NULL) {
+    _igvn.replace_node(_ioproj_fallthrough, *io);
+  }
   _igvn.replace_node(_fallthroughcatchproj, *ctrl);
 
 #ifdef ASSERT
@@ -996,8 +998,14 @@ MergeMemNode* PhaseMacroExpand::generate_slow_arraycopy(ArrayCopyNode *ac,
   }
   transform_later(out_mem);
 
-  *io = _ioproj_fallthrough->clone();
-  transform_later(*io);
+  // When src is negative and arraycopy is before an infinite loop, _ioproj_fallthrough
+  // could be NULL. Skip clone and update NULL _ioproj_fallthrough.
+  if (_ioproj_fallthrough != NULL) {
+    *io = _ioproj_fallthrough->clone();
+    transform_later(*io);
+  } else {
+    *io = NULL;
+  }
 
   return out_mem;
 }
@@ -1219,7 +1227,9 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     }
 
     _igvn.replace_node(_memproj_fallthrough, merge_mem);
-    _igvn.replace_node(_ioproj_fallthrough, io);
+    if (_ioproj_fallthrough != NULL) {
+      _igvn.replace_node(_ioproj_fallthrough, io);
+    }
     _igvn.replace_node(_fallthroughcatchproj, ctrl);
     return;
   }

--- a/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestIllegalArrayCopyBeforeInfiniteLoop.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8272131
+ * @requires vm.compiler2.enabled
+ * @summary ArrayCopy with negative index before infinite loop
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,"*TestIllegalArrayCopyBeforeInfiniteLoop::foo"
+ *                   compiler.arraycopy.TestIllegalArrayCopyBeforeInfiniteLoop
+ */
+
+package compiler.arraycopy;
+
+import java.util.Arrays;
+
+public class TestIllegalArrayCopyBeforeInfiniteLoop {
+    private static char src[] = new char[10];
+    private static int count = 0;
+    private static final int iter = 10_000;
+
+    public static void main(String[] args) throws Exception {
+        for (int i = 0; i < iter; ++i) {
+            foo();
+        }
+        if (count != iter) {
+            throw new RuntimeException("test failed");
+        }
+    }
+
+    static void foo() {
+        try {
+            Arrays.copyOfRange(src, -1, 128);
+            do {
+            } while (true);
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            count++;
+        }
+    }
+}


### PR DESCRIPTION
Please help review this backport for 8272131: C2 crash in PhaseMacroExpand::generate_slow_arraycopy because arraycopy node's _ioproj_fallthrough is NULL.

Conflicts when backport
In jdk18:  field name is fallthrough_ioproj , and it is in PhaseMacroExpand's CallProjections class.
In jdk11:  field name is _ioproj_fallthrough, and it is directly in PhaseMacroExpand class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8272131](https://bugs.openjdk.java.net/browse/JDK-8272131): PhaseMacroExpand::generate_slow_arraycopy crash when clone null CallProjections.fallthrough_ioproj ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/247/head:pull/247` \
`$ git checkout pull/247`

Update a local copy of the PR: \
`$ git checkout pull/247` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 247`

View PR using the GUI difftool: \
`$ git pr show -t 247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/247.diff">https://git.openjdk.java.net/jdk11u-dev/pull/247.diff</a>

</details>
