### PR TITLE
8272628: Problemlist gc/stress/gcbasher/TestGCBasherWithCMS.java for x86_32

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -90,6 +90,7 @@ gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/survivorAlignment/TestPromotionFromSurvivorToTenuredAfterMinorGC.java 8177765 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8193639 solaris-all
+gc/stress/gcbasher/TestGCBasherWithCMS.java 8272195 generic-i586
 
 #############################################################################
 


### PR DESCRIPTION
This problem-lists the failing CMS test for x86_32 to get clean GHA runs. 

Additional testing:
 - [x] Linux x86_64 fastdebug, test still runs and passes
 - [x] Linux x86_32 fastdebug, test is now skipped

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272628](https://bugs.openjdk.java.net/browse/JDK-8272628): Problemlist gc/stress/gcbasher/TestGCBasherWithCMS.java for x86_32


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/252/head:pull/252` \
`$ git checkout pull/252`

Update a local copy of the PR: \
`$ git checkout pull/252` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 252`

View PR using the GUI difftool: \
`$ git pr show -t 252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/252.diff">https://git.openjdk.java.net/jdk11u-dev/pull/252.diff</a>

</details>
