### PR TITLE
8213007: Update the link in test/jdk/sun/security/provider/SecureRandom/DrbgCavp.java

### DIFF
--- a/test/jdk/sun/security/provider/SecureRandom/DrbgCavp.java
+++ b/test/jdk/sun/security/provider/SecureRandom/DrbgCavp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,8 +46,9 @@ import java.util.zip.ZipInputStream;
 import static java.security.DrbgParameters.Capability.*;
 
 /**
- * The Known-output DRBG test. The test vector can be obtained from
- * http://csrc.nist.gov/groups/STM/cavp/documents/drbg/drbgtestvectors.zip.
+ * The Known-output DRBG test. The test vector can be downloaded from
+ * https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/drbg/drbgtestvectors.zip.
+ * The test is described on https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Random-Number-Generators.
  *
  * Manually run this test with
  *


### PR DESCRIPTION
Clean backport to match 11.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8213007](https://bugs.openjdk.java.net/browse/JDK-8213007): Update the link in test/jdk/sun/security/provider/SecureRandom/DrbgCavp.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/253/head:pull/253` \
`$ git checkout pull/253`

Update a local copy of the PR: \
`$ git checkout pull/253` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 253`

View PR using the GUI difftool: \
`$ git pr show -t 253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/253.diff">https://git.openjdk.java.net/jdk11u-dev/pull/253.diff</a>

</details>
