### PR TITLE
8219804: java/net/MulticastSocket/Promiscuous.java fails intermittently due to NumberFormatException

### DIFF
--- a/test/jdk/java/net/MulticastSocket/Promiscuous.java
+++ b/test/jdk/java/net/MulticastSocket/Promiscuous.java
@@ -22,7 +22,7 @@
  *
 
 /* @test
- * @bug 8014499
+ * @bug 8014499 8219804
  * @summary Test for interference when two sockets are bound to the same
  *          port but joined to different multicast groups
  * @run main Promiscuous
@@ -42,11 +42,20 @@ public class Promiscuous {
         throws IOException
     {
         byte[] ba = new byte[100];
-        DatagramPacket p = new DatagramPacket(ba, ba.length);
+        DatagramPacket p;
         try {
-            mc.receive(p);
-            int recvId = Integer.parseInt(
-                    new String(p.getData(), 0, p.getLength(), "UTF-8"));
+            String data = null;
+            while (true) {
+                p = new DatagramPacket(ba, ba.length);
+                mc.receive(p);
+                data = new String(p.getData(), 0, p.getLength(), "UTF-8");
+                if (data.length() > UUID.length() && data.startsWith(UUID)) {
+                    data = data.substring(UUID.length());
+                    break;
+                }
+                logUnexpected(p);
+            }
+            int recvId = Integer.parseInt(data);
             if (datagramExpected) {
                 if (recvId != id)
                     throw new RuntimeException("Unexpected id, got " + recvId
@@ -65,19 +74,36 @@ public class Promiscuous {
         }
     }
 
+    static void logUnexpected(DatagramPacket p) {
+        byte[] ba = p.getData();
+        System.out.printf("Unexpected packet: length: %d. First three bytes: %d, %d, %d\n",
+                          p.getLength(), ba[0], ba[1], ba[2]);
+    }
+
+    static final String UUID; // process-id : currentTimeMillis
+
+    static {
+        String s1 = Long.toString(ProcessHandle.current().pid());
+        String s2 = Long.toString(System.currentTimeMillis());
+        UUID = "<" + s1 + s2 + ">";
+    }
+
     static void test(InetAddress group1, InetAddress group2)
         throws IOException
     {
-        try (MulticastSocket mc1 = new MulticastSocket();
-             MulticastSocket mc2 = new MulticastSocket(mc1.getLocalPort());
+        InetSocketAddress ad1 = new InetSocketAddress(group1, 0);
+        try (MulticastSocket mc1 = new MulticastSocket(ad1);
+             MulticastSocket mc2 = new MulticastSocket(
+                 new InetSocketAddress(group2, mc1.getLocalPort()));
              DatagramSocket ds = new DatagramSocket()) {
+
             final int port = mc1.getLocalPort();
             out.printf("Using port: %d\n", port);
 
             mc1.setSoTimeout(TIMEOUT);
             mc2.setSoTimeout(TIMEOUT);
             int nextId = id;
-            byte[] msg = Integer.toString(nextId).getBytes("UTF-8");
+            byte[] msg = (UUID + Integer.toString(nextId)).getBytes("UTF-8");
             DatagramPacket p = new DatagramPacket(msg, msg.length);
             p.setAddress(group1);
             p.setPort(port);
@@ -95,7 +121,7 @@ public class Promiscuous {
             receive(mc2, false, 0);
 
             nextId = ++id;
-            msg = Integer.toString(nextId).getBytes("UTF-8");
+            msg = (UUID + Integer.toString(nextId)).getBytes("UTF-8");
             p = new DatagramPacket(msg, msg.length);
             p.setAddress(group2);
             p.setPort(port);
@@ -129,8 +155,8 @@ public class Promiscuous {
         }
 
         // multicast groups used for the test
-        InetAddress ip4Group1 = InetAddress.getByName("224.7.8.9");
-        InetAddress ip4Group2 = InetAddress.getByName("225.4.5.6");
+        InetAddress ip4Group1 = InetAddress.getByName("224.0.0.120");
+        InetAddress ip4Group2 = InetAddress.getByName("224.0.0.121");
 
         test(ip4Group1, ip4Group2);
     }

--- a/test/jdk/java/net/MulticastSocket/Promiscuous.java
+++ b/test/jdk/java/net/MulticastSocket/Promiscuous.java
@@ -91,12 +91,9 @@ public class Promiscuous {
     static void test(InetAddress group1, InetAddress group2)
         throws IOException
     {
-        InetSocketAddress ad1 = new InetSocketAddress(group1, 0);
-        try (MulticastSocket mc1 = new MulticastSocket(ad1);
-             MulticastSocket mc2 = new MulticastSocket(
-                 new InetSocketAddress(group2, mc1.getLocalPort()));
+        try (MulticastSocket mc1 = new MulticastSocket();
+             MulticastSocket mc2 = new MulticastSocket(mc1.getLocalPort());
              DatagramSocket ds = new DatagramSocket()) {
-
             final int port = mc1.getLocalPort();
             out.printf("Using port: %d\n", port);
 


### PR DESCRIPTION
Backport to stabilize the test and match `11.0.13-oracle`.
It contains two bugfixes that are clean backports on their own.

Additional testing:
 - [x] Affected test still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8219804](https://bugs.openjdk.java.net/browse/JDK-8219804): java/net/MulticastSocket/Promiscuous.java fails intermittently due to NumberFormatException
 * [JDK-8226683](https://bugs.openjdk.java.net/browse/JDK-8226683): Remove review suggestion from fix to 8219804


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/255/head:pull/255` \
`$ git checkout pull/255`

Update a local copy of the PR: \
`$ git checkout pull/255` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 255`

View PR using the GUI difftool: \
`$ git pr show -t 255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/255.diff">https://git.openjdk.java.net/jdk11u-dev/pull/255.diff</a>

</details>
