### PR TITLE
8233790: Forward output from heap dumper to jcmd/jmap

### DIFF
--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -236,19 +236,7 @@ jint dump_heap(AttachOperation* op, outputStream* out) {
     // This helps reduces the amount of unreachable objects in the dump
     // and makes it easier to browse.
     HeapDumper dumper(live_objects_only /* request GC */);
-    int res = dumper.dump(op->arg(0));
-    if (res == 0) {
-      out->print_cr("Heap dump file created");
-    } else {
-      // heap dump failed
-      ResourceMark rm;
-      char* error = dumper.error_as_C_string();
-      if (error == NULL) {
-        out->print_cr("Dump failed - reason unknown");
-      } else {
-        out->print_cr("%s", error);
-      }
-    }
+    dumper.dump(op->arg(0), out);
   }
   return JNI_OK;
 }

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -519,19 +519,7 @@ void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
   // This helps reduces the amount of unreachable objects in the dump
   // and makes it easier to browse.
   HeapDumper dumper(!_all.value() /* request GC if _all is false*/);
-  int res = dumper.dump(_filename.value(), _overwrite.value());
-  if (res == 0) {
-    output()->print_cr("Heap dump file created");
-  } else {
-    // heap dump failed
-    ResourceMark rm;
-    char* error = dumper.error_as_C_string();
-    if (error == NULL) {
-      output()->print_cr("Dump failed - reason unknown");
-    } else {
-      output()->print_cr("%s", error);
-    }
-  }
+  dumper.dump(_filename.value(), output(), _overwrite.value());
 }
 
 int HeapDumpDCmd::num_arguments() {

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1935,12 +1935,12 @@ void VM_HeapDumper::dump_stack_traces() {
 }
 
 // dump the heap to given path.
-int HeapDumper::dump(const char* path, bool overwrite) {
+int HeapDumper::dump(const char* path, outputStream* out, bool overwrite) {
   assert(path != NULL && strlen(path) > 0, "path missing");
 
   // print message in interactive case
-  if (print_to_tty()) {
-    tty->print_cr("Dumping heap to %s ...", path);
+  if (out != NULL) {
+    out->print_cr("Dumping heap to %s ...", path);
     timer()->start();
   }
 
@@ -1948,8 +1948,8 @@ int HeapDumper::dump(const char* path, bool overwrite) {
   DumpWriter writer(path, overwrite);
   if (writer.error() != NULL) {
     set_error(writer.error());
-    if (print_to_tty()) {
-      tty->print_cr("Unable to create %s: %s", path,
+    if (out != NULL) {
+      out->print_cr("Unable to create %s: %s", path,
         (error() != NULL) ? error() : "reason unknown");
     }
     return -1;
@@ -1969,13 +1969,13 @@ int HeapDumper::dump(const char* path, bool overwrite) {
   set_error(writer.error());
 
   // print message in interactive case
-  if (print_to_tty()) {
+  if (out != NULL) {
     timer()->stop();
     if (error() == NULL) {
-      tty->print_cr("Heap dump file created [" JULONG_FORMAT " bytes in %3.3f secs]",
+      out->print_cr("Heap dump file created [" JULONG_FORMAT " bytes in %3.3f secs]",
                     writer.bytes_written(), timer()->seconds());
     } else {
-      tty->print_cr("Dump file is incomplete: %s", writer.error());
+      out->print_cr("Dump file is incomplete: %s", writer.error());
     }
   }
 
@@ -2103,8 +2103,7 @@ void HeapDumper::dump_heap(bool oome) {
   dump_file_seq++;   // increment seq number for next time we dump
 
   HeapDumper dumper(false /* no GC before heap dump */,
-                    true  /* send to tty */,
                     oome  /* pass along out-of-memory-error flag */);
-  dumper.dump(my_path);
+  dumper.dump(my_path, tty);
   os::free(my_path);
 }

--- a/src/hotspot/share/services/heapDumper.hpp
+++ b/src/hotspot/share/services/heapDumper.hpp
@@ -41,23 +41,21 @@
 //  }
 //
 
+class outputStream;
+
 class HeapDumper : public StackObj {
  private:
   char* _error;
-  bool _print_to_tty;
   bool _gc_before_heap_dump;
   bool _oome;
   elapsedTimer _t;
 
-  HeapDumper(bool gc_before_heap_dump, bool print_to_tty, bool oome) :
-    _gc_before_heap_dump(gc_before_heap_dump), _error(NULL), _print_to_tty(print_to_tty), _oome(oome) { }
+  HeapDumper(bool gc_before_heap_dump, bool oome) :
+    _gc_before_heap_dump(gc_before_heap_dump), _error(NULL), _oome(oome) { }
 
   // string representation of error
   char* error() const                   { return _error; }
   void set_error(char* error);
-
-  // indicates if progress messages can be sent to tty
-  bool print_to_tty() const             { return _print_to_tty; }
 
   // internal timer.
   elapsedTimer* timer()                 { return &_t; }
@@ -66,12 +64,13 @@ class HeapDumper : public StackObj {
 
  public:
   HeapDumper(bool gc_before_heap_dump) :
-    _gc_before_heap_dump(gc_before_heap_dump), _error(NULL), _print_to_tty(false), _oome(false) { }
+    _gc_before_heap_dump(gc_before_heap_dump), _error(NULL), _oome(false) { }
 
   ~HeapDumper();
 
   // dumps the heap to the specified file, returns 0 if success.
-  int dump(const char* path, bool overwrite = false);
+  // additional info is written to out if not NULL.
+  int dump(const char* path, outputStream* out = NULL, bool overwrite = false);
 
   // returns error message (resource allocated), or NULL if no error
   char* error_as_C_string() const;


### PR DESCRIPTION
Backport of the heap dump enhancement: Forward output from heap dumper to jcmd/jmap

Patch did not apply cleanly, I had to resolve/modify
src/hotspot/share/services/diagnosticCommand.cpp
src/hotspot/share/services/heapDumper.cpp
src/hotspot/share/services/heapDumper.hpp

since patch 7cbb67a3f8adc83a5b51c092a66480d7b22a6bea is backport before this one, so this patch can't backport cleanly

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8233790](https://bugs.openjdk.java.net/browse/JDK-8233790): Forward output from heap dumper to jcmd/jmap


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/256/head:pull/256` \
`$ git checkout pull/256`

Update a local copy of the PR: \
`$ git checkout pull/256` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 256`

View PR using the GUI difftool: \
`$ git pr show -t 256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/256.diff">https://git.openjdk.java.net/jdk11u-dev/pull/256.diff</a>

</details>
