### PR TITLE
8269478: Shenandoah: gc/shenandoah/mxbeans tests should be more resilient

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestChurnNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestChurnNotifications.java
@@ -25,6 +25,7 @@
  * @test TestChurnNotifications
  * @summary Check that MX notifications are reported for all cycles
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib /
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
@@ -41,6 +42,7 @@
  * @test TestChurnNotifications
  * @summary Check that MX notifications are reported for all cycles
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib /
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
@@ -52,6 +54,7 @@
  * @test TestChurnNotifications
  * @summary Check that MX notifications are reported for all cycles
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib /
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
@@ -63,6 +66,7 @@
  * @test TestChurnNotifications
  * @summary Check that MX notifications are reported for all cycles
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib /
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=static
@@ -74,6 +78,7 @@
  * @test TestChurnNotifications
  * @summary Check that MX notifications are reported for all cycles
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib /
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact
@@ -85,6 +90,7 @@
  * @test TestChurnNotifications
  * @summary Check that MX notifications are reported for all cycles
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib /
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
@@ -103,6 +109,8 @@ import javax.management.*;
 import java.lang.management.*;
 import javax.management.openmbean.*;
 
+import jdk.test.lib.Utils;
+
 import com.sun.management.GarbageCollectionNotificationInfo;
 
 public class TestChurnNotifications {
@@ -120,6 +128,8 @@ public class TestChurnNotifications {
     static volatile Object sink;
 
     public static void main(String[] args) throws Exception {
+        final long startTime = System.currentTimeMillis();
+
         final AtomicLong churnBytes = new AtomicLong();
 
         NotificationListener listener = new NotificationListener() {
@@ -158,17 +168,28 @@ public class TestChurnNotifications {
 
         System.gc();
 
-        // Wait until notifications start arriving, and then wait some more
-        // to catch the ones arriving late.
-        while (churnBytes.get() == 0) {
-            Thread.sleep(1000);
-        }
-        Thread.sleep(5000);
-
-        long actual = churnBytes.get();
-
         long minExpected = PRECISE ? (mem - HEAP_MB * 1024 * 1024) : 1;
         long maxExpected = mem + HEAP_MB * 1024 * 1024;
+        long actual = 0;
+
+        // Look at test timeout to figure out how long we can wait without breaking into timeout.
+        // Default to 1/4 of the remaining time in 1s steps.
+        final long STEP_MS = 1000;
+        long spentTime = System.currentTimeMillis() - startTime;
+        long maxTries = (Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) - spentTime) / STEP_MS / 4;
+
+        // Wait until enough notifications are accrued to match minimum boundary.
+        long tries = 0;
+        while (tries++ < maxTries) {
+            actual = churnBytes.get();
+            if (minExpected <= actual) {
+                // Wait some more to test if we are breaking the maximum boundary.
+                Thread.sleep(5000);
+                actual = churnBytes.get();
+                break;
+            }
+            Thread.sleep(STEP_MS);
+        }
 
         String msg = "Expected = [" + minExpected / M + "; " + maxExpected / M + "] (" + mem / M + "), actual = " + actual / M;
         if (minExpected <= actual && actual <= maxExpected) {

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
@@ -26,6 +26,7 @@
  * @summary Check that MX notifications are reported for all cycles
  * @key gc
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib /
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
@@ -43,6 +44,7 @@
  * @summary Check that MX notifications are reported for all cycles
  * @key gc
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib /
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
@@ -53,6 +55,7 @@
  * @test TestPauseNotifications
  * @summary Check that MX notifications are reported for all cycles
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib /
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
@@ -63,6 +66,7 @@
  * @test TestPauseNotifications
  * @summary Check that MX notifications are reported for all cycles
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib /
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=static
@@ -73,6 +77,7 @@
  * @test TestPauseNotifications
  * @summary Check that MX notifications are reported for all cycles
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib /
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact
@@ -84,6 +89,7 @@
  * @summary Check that MX notifications are reported for all cycles
  * @key gc
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib /
  *
  * @run main/othervm -Xmx128m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
@@ -100,6 +106,8 @@ import javax.management.*;
 import java.lang.management.*;
 import javax.management.openmbean.*;
 
+import jdk.test.lib.Utils;
+
 import com.sun.management.GarbageCollectionNotificationInfo;
 
 public class TestPauseNotifications {
@@ -110,8 +118,12 @@ public class TestPauseNotifications {
     static volatile Object sink;
 
     public static void main(String[] args) throws Exception {
+        final long startTime = System.currentTimeMillis();
+
         final AtomicLong pausesDuration = new AtomicLong();
         final AtomicLong cyclesDuration = new AtomicLong();
+        final AtomicLong pausesCount = new AtomicLong();
+        final AtomicLong cyclesCount = new AtomicLong();
 
         NotificationListener listener = new NotificationListener() {
             @Override
@@ -119,17 +131,17 @@ public class TestPauseNotifications {
                 if (n.getType().equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION)) {
                     GarbageCollectionNotificationInfo info = GarbageCollectionNotificationInfo.from((CompositeData) n.getUserData());
 
-                    System.out.println(info.getGcInfo().toString());
-                    System.out.println(info.getGcName());
-                    System.out.println();
+                    System.out.println("Received: " + info.getGcName());
 
                     long d = info.getGcInfo().getDuration();
 
                     String name = info.getGcName();
                     if (name.contains("Shenandoah")) {
                         if (name.equals("Shenandoah Pauses")) {
+                            pausesCount.incrementAndGet();
                             pausesDuration.addAndGet(d);
                         } else if (name.equals("Shenandoah Cycles")) {
+                            cyclesCount.incrementAndGet();
                             cyclesDuration.addAndGet(d);
                         } else {
                             throw new IllegalStateException("Unknown name: " + name);
@@ -150,22 +162,35 @@ public class TestPauseNotifications {
             sink = new int[size];
         }
 
-        // Wait until notifications start arriving, and then wait some more
-        // to catch the ones arriving late.
-        while (pausesDuration.get() == 0) {
-            Thread.sleep(1000);
+        // Look at test timeout to figure out how long we can wait without breaking into timeout.
+        // Default to 1/4 of the remaining time in 1s steps.
+        final long STEP_MS = 1000;
+        long spentTime = System.currentTimeMillis() - startTime;
+        long maxTries = (Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) - spentTime) / STEP_MS / 4;
+
+        long actualPauses = 0;
+        long actualCycles = 0;
+
+        // Wait until enough notifications are accrued to match minimum boundary.
+        long minExpected = 10;
+
+        long tries = 0;
+        while (tries++ < maxTries) {
+            actualPauses = pausesCount.get();
+            actualCycles = cyclesCount.get();
+            if (minExpected <= actualPauses && minExpected <= actualCycles) {
+                // Wait a little bit to catch the lingering notifications.
+                Thread.sleep(5000);
+                actualPauses = pausesCount.get();
+                actualCycles = cyclesCount.get();
+                break;
+            }
+            Thread.sleep(STEP_MS);
         }
-        Thread.sleep(5000);
-
-        long pausesActual = pausesDuration.get();
-        long cyclesActual = cyclesDuration.get();
-
-        long minExpected = 1;
-        long maxExpected = Long.MAX_VALUE;
 
         {
-            String msg = "Pauses expected = [" + minExpected + "; " + maxExpected + "], actual = " + pausesActual;
-            if (minExpected <= pausesActual && pausesActual <= maxExpected) {
+            String msg = "Pauses expected = [" + minExpected + "; +inf], actual = " + actualPauses;
+            if (minExpected <= actualPauses) {
                 System.out.println(msg);
             } else {
                 throw new IllegalStateException(msg);
@@ -173,8 +198,8 @@ public class TestPauseNotifications {
         }
 
         {
-            String msg = "Cycles expected = [" + minExpected + "; " + maxExpected + "], actual = " + cyclesActual;
-            if (minExpected <= cyclesActual && cyclesActual <= maxExpected) {
+            String msg = "Cycles expected = [" + minExpected + "; +inf], actual = " + actualCycles;
+            if (minExpected <= actualCycles) {
                 System.out.println(msg);
             } else {
                 throw new IllegalStateException(msg);
@@ -182,8 +207,12 @@ public class TestPauseNotifications {
         }
 
         {
-            String msg = "Cycle duration (" + cyclesActual + "), pause duration (" + pausesActual + ")";
-            if (pausesActual <= cyclesActual) {
+            long actualPauseDuration = pausesDuration.get();
+            long actualCycleDuration = cyclesDuration.get();
+
+            String msg = "Pauses duration (" + actualPauseDuration + ") is expected to be not larger than cycles duration (" + actualCycleDuration + ")";
+
+            if (actualPauseDuration <= actualCycleDuration) {
                 System.out.println(msg);
             } else {
                 throw new IllegalStateException(msg);


### PR DESCRIPTION
Clean backport to improve test stability.

Additional testing:
 - [x] Affected tests still pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269478](https://bugs.openjdk.java.net/browse/JDK-8269478): Shenandoah: gc/shenandoah/mxbeans tests should be more resilient


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/258/head:pull/258` \
`$ git checkout pull/258`

Update a local copy of the PR: \
`$ git checkout pull/258` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 258`

View PR using the GUI difftool: \
`$ git pr show -t 258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/258.diff">https://git.openjdk.java.net/jdk11u-dev/pull/258.diff</a>

</details>
