### PR TITLE
8252853: AArch64: gc/shenandoah/TestVerifyJCStress.java fails intermittently with C1

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shenandoah/shenandoahBarrierSetAssembler_aarch64.cpp
@@ -263,16 +263,9 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier_not_null(MacroAssembl
 
 void ShenandoahBarrierSetAssembler::iu_barrier(MacroAssembler* masm, Register dst, Register tmp) {
   if (ShenandoahIUBarrier) {
-    // Save possibly live regs.
-    RegSet live_regs = RegSet::range(r0, r4) - dst;
-    __ push(live_regs, sp);
-    __ strd(v0, __ pre(sp, 2 * -wordSize));
-
+    __ push_call_clobbered_registers();
     satb_write_barrier_pre(masm, noreg, dst, rthread, tmp, true, false);
-
-    // Restore possibly live regs.
-    __ ldrd(v0, __ post(sp, 2 * wordSize));
-    __ pop(live_regs, sp);
+    __ pop_call_clobbered_registers();
   }
 }
 

--- a/test/hotspot/jtreg/gc/shenandoah/TestVerifyJCStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestVerifyJCStress.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2020, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
@@ -70,6 +71,11 @@
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
  *      -XX:+ShenandoahVerify -XX:+IgnoreUnrecognizedVMOptions -XX:+ShenandoahVerifyOptoBarriers
+ *      TestVerifyJCStress
+ *
+ * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
+ *      -XX:+ShenandoahVerify -XX:+IgnoreUnrecognizedVMOptions -XX:TieredStopAtLevel=1
  *      TestVerifyJCStress
  */
 


### PR DESCRIPTION
Unclean backport, because the context is a bit different (StoreVal -> IU renaming already happened). 

Additional testing:
 - [x] Affected test still passes on AArch64, x86_64
 - [x] `hotspot_gc_shenandoah` passes on AArch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252853](https://bugs.openjdk.java.net/browse/JDK-8252853): AArch64: gc/shenandoah/TestVerifyJCStress.java fails intermittently with C1


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/260/head:pull/260` \
`$ git checkout pull/260`

Update a local copy of the PR: \
`$ git checkout pull/260` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 260`

View PR using the GUI difftool: \
`$ git pr show -t 260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/260.diff">https://git.openjdk.java.net/jdk11u-dev/pull/260.diff</a>

</details>
