### PR TITLE
Backport 2f8653fbf0f4ed2ab0e40b2bb541ef2eff913469

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -683,10 +683,10 @@ intptr_t* frame::real_fp() const {
            p[frame::name##_offset], #name);                             \
   }
 
-static __thread unsigned long nextfp;
-static __thread unsigned long nextpc;
-static __thread unsigned long nextsp;
-static __thread RegisterMap *reg_map;
+static THREAD_LOCAL_DECL unsigned long nextfp;
+static THREAD_LOCAL_DECL unsigned long nextpc;
+static THREAD_LOCAL_DECL unsigned long nextsp;
+static THREAD_LOCAL_DECL RegisterMap *reg_map;
 
 static void printbc(Method *m, intptr_t bcx) {
   const char *name;


### PR DESCRIPTION
Not a clean backport. Original patch used a macro called THREAD_LOCAL, this backport uses THREAD_LOCAL_DECL. THREAD_LOCAL_DECL was renamed to THREAD_LOCAL by [JDK-8230877](https://bugs.openjdk.java.net/browse/JDK-8230877) in JDK 14. Testing: tier1.