### PR TITLE
8272602: [macos] not all KEY_PRESSED events sent when control modifier is used

### DIFF
--- a/src/java.desktop/macosx/native/libosxapp/JNIUtilities.m
+++ b/src/java.desktop/macosx/native/libosxapp/JNIUtilities.m
@@ -40,11 +40,18 @@ NSString* JavaStringToNSString(JNIEnv *env, jstring jstr) {
 }
 
 jstring NSStringToJavaString(JNIEnv* env, NSString *str) {
-
     if (str == NULL) {
        return NULL;
     }
-    jstring jStr = (*env)->NewStringUTF(env, [str UTF8String]);
+    jsize len = [str length];
+    unichar *buffer = (unichar*)calloc(len, sizeof(unichar));
+    if (buffer == NULL) {
+       return NULL;
+    }
+    NSRange crange = NSMakeRange(0, len);
+    [str getCharacters:buffer range:crange];
+    jstring jStr = (*env)->NewString(env, buffer, len);
+    free(buffer);
     CHECK_EXCEPTION();
     return jStr;
 }

--- a/test/jdk/java/awt/event/KeyEvent/KeyTyped/CtrlSpace.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyTyped/CtrlSpace.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @key headful
+  @bug 8272602
+  @summary Ctrl+Space should generate a KeyTyped event on macOS
+  @run main CtrlSpace
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.TextField;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+
+public class CtrlSpace extends Frame implements KeyListener {
+
+    static volatile boolean testPassed = false;
+    static volatile Robot robot;
+
+    public static void main(String[] args) throws Exception {
+
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(100);
+
+        Frame frame = createAndShowGUI(robot);
+
+        test(robot);
+        robot.waitForIdle();
+        Thread.sleep(2000);
+        frame.setVisible(false);
+        frame.dispose();
+        if (!testPassed) {
+            throw new RuntimeException("No KeyTyped event");
+        }
+    }
+
+
+   static Frame createAndShowGUI(Robot robot) {
+        CtrlSpace win = new CtrlSpace();
+        win.setSize(300, 300);
+        Panel panel = new Panel(new BorderLayout());
+        TextField textField = new TextField("abcdefghijk");
+        textField.addKeyListener(win);
+        panel.add(textField, BorderLayout.CENTER);
+        win.add(panel);
+        win.setVisible(true);
+        robot.waitForIdle();
+        textField.requestFocusInWindow();
+        robot.waitForIdle();
+        return win;
+    }
+
+    public static void test(Robot robot) {
+        robot.keyPress(KeyEvent.VK_CONTROL);
+        robot.keyPress(KeyEvent.VK_SPACE);
+        robot.keyRelease(KeyEvent.VK_SPACE);
+        robot.keyRelease(KeyEvent.VK_CONTROL);
+        robot.delay(200);
+    }
+
+    public void keyPressed(KeyEvent evt) {
+        System.out.println("Pressed " + evt);
+    }
+
+    public void keyReleased(KeyEvent evt) {
+        System.out.println("Released " + evt);
+    }
+
+    public void keyTyped(KeyEvent evt) {
+        System.out.println("Typed " + evt);
+        testPassed = true;
+    }
+
+}


### PR DESCRIPTION
Clean backport to jdk11u-dev

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272602](https://bugs.openjdk.java.net/browse/JDK-8272602): [macos] not all KEY_PRESSED events sent when control modifier is used


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/264/head:pull/264` \
`$ git checkout pull/264`

Update a local copy of the PR: \
`$ git checkout pull/264` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 264`

View PR using the GUI difftool: \
`$ git pr show -t 264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/264.diff">https://git.openjdk.java.net/jdk11u-dev/pull/264.diff</a>

</details>
