### PR TITLE
8248657: Windows: strengthening in ThreadCritical regarding memory model

### DIFF
--- a/src/hotspot/os/windows/threadCritical_windows.cpp
+++ b/src/hotspot/os/windows/threadCritical_windows.cpp
@@ -35,10 +35,10 @@
 // See threadCritical.hpp for details of this class.
 //
 
-static bool initialized = false;
-static volatile int lock_count = -1;
+static INIT_ONCE initialized = INIT_ONCE_STATIC_INIT;
+static int lock_count = 0;
 static HANDLE lock_event;
-static DWORD lock_owner = -1;
+static DWORD lock_owner = 0;
 
 //
 // Note that Microsoft's critical region code contains a race
@@ -51,48 +51,36 @@ static DWORD lock_owner = -1;
 // and found them ~30 times slower than the critical region code.
 //
 
-ThreadCritical::ThreadCritical() {
-  DWORD current_thread = GetCurrentThreadId();
+static BOOL WINAPI initialize(PINIT_ONCE InitOnce, PVOID Parameter, PVOID *Context) {
+  lock_event = CreateEvent(NULL, false, true, NULL);
+  assert(lock_event != NULL, "unexpected return value from CreateEvent");
+  return true;
+}
 
+ThreadCritical::ThreadCritical() {
+  InitOnceExecuteOnce(&initialized, &initialize, NULL, NULL);
+
+  DWORD current_thread = GetCurrentThreadId();
   if (lock_owner != current_thread) {
     // Grab the lock before doing anything.
-    while (Atomic::cmpxchg(0, &lock_count, -1) != -1) {
-      if (initialized) {
-        DWORD ret = WaitForSingleObject(lock_event,  INFINITE);
-        assert(ret == WAIT_OBJECT_0, "unexpected return value from WaitForSingleObject");
-      }
-    }
-
-    // Make sure the event object is allocated.
-    if (!initialized) {
-      // Locking will not work correctly unless this is autoreset.
-      lock_event = CreateEvent(NULL, false, false, NULL);
-      initialized = true;
-    }
-
-    assert(lock_owner == -1, "Lock acquired illegally.");
+    DWORD ret = WaitForSingleObject(lock_event,  INFINITE);
+    assert(ret == WAIT_OBJECT_0, "unexpected return value from WaitForSingleObject");
     lock_owner = current_thread;
-  } else {
-    // Atomicity isn't required. Bump the recursion count.
-    lock_count++;
   }
-
-  assert(lock_owner == GetCurrentThreadId(), "Lock acquired illegally.");
+  // Atomicity isn't required. Bump the recursion count.
+  lock_count++;
 }
 
 ThreadCritical::~ThreadCritical() {
   assert(lock_owner == GetCurrentThreadId(), "unlock attempt by wrong thread");
   assert(lock_count >= 0, "Attempt to unlock when already unlocked");
 
+  lock_count--;
   if (lock_count == 0) {
     // We're going to unlock
-    lock_owner = -1;
-    lock_count = -1;
+    lock_owner = 0;
     // No lost wakeups, lock_event stays signaled until reset.
     DWORD ret = SetEvent(lock_event);
     assert(ret != 0, "unexpected return value from SetEvent");
-  } else {
-    // Just unwinding a recursive lock;
-    lock_count--;
   }
 }


### PR DESCRIPTION
Removed line [L59](https://github.com/openjdk/jdk11u-dev/pull/265/files#diff-7eb55bd4224b99f2ae0f2df4c3e65e586af8998933eeeba6ea4615ce558a36fbL59) in src/hotspot/os/windows/threadCritical_windows.cpp has changed between 11 and tip ([JDK-8234740](https://bugs.openjdk.java.net/browse/JDK-8234740)), otherwise the backport is clean. Testing: tier1.

This is part of the Windows/AArch64 port.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248657](https://bugs.openjdk.java.net/browse/JDK-8248657): Windows: strengthening in ThreadCritical regarding memory model


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Contributors
 * Bernhard Urban-Forster `<burban@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/265/head:pull/265` \
`$ git checkout pull/265`

Update a local copy of the PR: \
`$ git checkout pull/265` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 265`

View PR using the GUI difftool: \
`$ git pr show -t 265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/265.diff">https://git.openjdk.java.net/jdk11u-dev/pull/265.diff</a>

</details>
