### PR TITLE
8248682: AArch64: Use ATTRIBUTE_ALIGNED helper

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64_log.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64_log.cpp
@@ -65,7 +65,7 @@
 
 // Table with p(r) polynomial coefficients
 // and table representation of logarithm values (hi and low parts)
-__attribute__ ((aligned(64))) juint _L_tbl[] =
+ATTRIBUTE_ALIGNED(64) juint _L_tbl[] =
 {
     // coefficients of p(r) polynomial:
     // _coeff[]

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
@@ -61,7 +61,7 @@ bool StubRoutines::aarch64::_completed = false;
 /**
  *  crc_table[] from jdk/src/share/native/java/util/zip/zlib-1.2.5/crc32.h
  */
-juint StubRoutines::aarch64::_crc_table[] ATTRIBUTE_ALIGNED(4096) =
+ATTRIBUTE_ALIGNED(4096) juint StubRoutines::aarch64::_crc_table[] =
 {
     // Table 0
     0x00000000UL, 0x77073096UL, 0xee0e612cUL, 0x990951baUL, 0x076dc419UL,
@@ -288,11 +288,11 @@ juint StubRoutines::aarch64::_crc_table[] ATTRIBUTE_ALIGNED(4096) =
 };
 
 // Accumulation coefficients for adler32 upper 16 bits
-jubyte StubRoutines::aarch64::_adler_table[] __attribute__ ((aligned(64))) = {
+ATTRIBUTE_ALIGNED(64) jubyte StubRoutines::aarch64::_adler_table[] = {
     16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1
 };
 
-juint StubRoutines::aarch64::_npio2_hw[] __attribute__ ((aligned(64))) = {
+ATTRIBUTE_ALIGNED(64) juint StubRoutines::aarch64::_npio2_hw[] = {
     // first, various coefficient values: 0.5, invpio2, pio2_1, pio2_1t, pio2_2,
     // pio2_2t, pio2_3, pio2_3t
     // This is a small optimization wich keeping double[8] values in int[] table
@@ -324,7 +324,7 @@ juint StubRoutines::aarch64::_npio2_hw[] __attribute__ ((aligned(64))) = {
 
 // Coefficients for sin(x) polynomial approximation: S1..S6.
 // See kernel_sin comments in macroAssembler_aarch64_trig.cpp for details
-jdouble StubRoutines::aarch64::_dsin_coef[] __attribute__ ((aligned(64))) = {
+ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::aarch64::_dsin_coef[] = {
     -1.66666666666666324348e-01, // 0xBFC5555555555549
      8.33333333332248946124e-03, // 0x3F8111111110F8A6
     -1.98412698298579493134e-04, // 0xBF2A01A019C161D5
@@ -335,7 +335,7 @@ jdouble StubRoutines::aarch64::_dsin_coef[] __attribute__ ((aligned(64))) = {
 
 // Coefficients for cos(x) polynomial approximation: C1..C6.
 // See kernel_cos comments in macroAssembler_aarch64_trig.cpp for details
-jdouble StubRoutines::aarch64::_dcos_coef[] __attribute__ ((aligned(64))) = {
+ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::aarch64::_dcos_coef[] = {
      4.16666666666666019037e-02, // c0x3FA555555555554C
     -1.38888888888741095749e-03, // 0xBF56C16C16C15177
      2.48015872894767294178e-05, // 0x3EFA01A019CB1590
@@ -350,7 +350,7 @@ jdouble StubRoutines::aarch64::_dcos_coef[] __attribute__ ((aligned(64))) = {
 // Converted to double to avoid unnecessary conversion in code
 // NOTE: table looks like original int table: {0xA2F983, 0x6E4E44,...} with
 //       only (double) conversion added
-jdouble StubRoutines::aarch64::_two_over_pi[] __attribute__ ((aligned(64))) = {
+ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::aarch64::_two_over_pi[] = {
   (double)0xA2F983, (double)0x6E4E44, (double)0x1529FC, (double)0x2757D1, (double)0xF534DD, (double)0xC0DB62,
   (double)0x95993C, (double)0x439041, (double)0xFE5163, (double)0xABDEBB, (double)0xC561B7, (double)0x246E3A,
   (double)0x424DD2, (double)0xE00649, (double)0x2EEA09, (double)0xD1921C, (double)0xFE1DEB, (double)0x1CB129,
@@ -365,7 +365,7 @@ jdouble StubRoutines::aarch64::_two_over_pi[] __attribute__ ((aligned(64))) = {
 };
 
 // Pi over 2 value
-jdouble StubRoutines::aarch64::_pio2[] __attribute__ ((aligned(64))) = {
+ATTRIBUTE_ALIGNED(64) jdouble StubRoutines::aarch64::_pio2[] = {
   1.57079625129699707031e+00, // 0x3FF921FB40000000
   7.54978941586159635335e-08, // 0x3E74442D00000000
   5.39030252995776476554e-15, // 0x3CF8469880000000


### PR DESCRIPTION
Changes apply cleanly.

This is part of the Windows/AArch64 port.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8248682](https://bugs.openjdk.java.net/browse/JDK-8248682): AArch64: Use ATTRIBUTE_ALIGNED helper


### Contributors
 * Bernhard Urban-Forster `<burban@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/266/head:pull/266` \
`$ git checkout pull/266`

Update a local copy of the PR: \
`$ git checkout pull/266` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 266`

View PR using the GUI difftool: \
`$ git pr show -t 266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/266.diff">https://git.openjdk.java.net/jdk11u-dev/pull/266.diff</a>

</details>
