### PR TITLE
8272772: Shenandoah: compiler/c2/aarch64/TestVolatilesShenandoah.java fails in 11u

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatiles.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatiles.java
@@ -103,7 +103,7 @@ public class TestVolatiles {
             procArgs[argcount - 2] = "-XX:+UseCondCardMark";
             break;
         case "Shenandoah":
-            argcount = 8;
+            argcount = 9;
             procArgs = new String[argcount];
             procArgs[argcount - 2] = "-XX:+UseShenandoahGC";
             break;
@@ -374,9 +374,9 @@ public class TestVolatiles {
                  // Shenandoah generates normal object graphs for
                  // volatile stores
                 matches = new String[] {
-                    "membar_release (elided)",
-                    "stlrw",
-                    "membar_volatile (elided)",
+                    "membar_release \\(elided\\)",
+                    useCompressedOops ? "stlrw?" : "stlr",
+                    "membar_volatile \\(elided\\)",
                     "ret"
                 };
                 break;
@@ -451,7 +451,7 @@ public class TestVolatiles {
                 matches = new String[] {
                     "membar_release",
                     "dmb ish",
-                    "strw",
+                    useCompressedOops ? "strw?" : "str",
                     "membar_volatile",
                     "dmb ish",
                     "ret"
@@ -564,9 +564,9 @@ public class TestVolatiles {
                 // For volatile CAS, Shenanodoah generates normal
                 // graphs with a shenandoah-specific cmpxchg
                 matches = new String[] {
-                    "membar_release (elided)",
-                    "cmpxchgw_acq_shenandoah",
-                    "membar_acquire (elided)",
+                    "membar_release \\(elided\\)",
+                    useCompressedOops ? "cmpxchgw?_acq_shenandoah" : "cmpxchg_acq_shenandoah",
+                    "membar_acquire \\(elided\\)",
                     "ret"
                 };
                 break;
@@ -630,6 +630,17 @@ public class TestVolatiles {
                     "strb",
                     "membar_acquire",
                     "dmb ish",
+                    "ret"
+                };
+                break;
+            case "Shenandoah":
+            case "ShenandoahIU":
+                // For volatile CAS, Shenanodoah generates normal
+                // graphs with a shenandoah-specific cmpxchg
+                matches = new String[] {
+                    "membar_release",
+                    useCompressedOops ? "cmpxchgw?_shenandoah" : "cmpxchg_shenandoah",
+                    "membar_acquire",
                     "ret"
                 };
                 break;
@@ -821,7 +832,7 @@ public class TestVolatiles {
                 matches = new String[] {
                     "membar_release",
                     "dmb ish",
-                    "cmpxchgw_shenandoah",
+                    useCompressedOops ? "cmpxchgw?_shenandoah" : "cmpxchg_shenandoah",
                     "membar_acquire",
                     "dmb ish",
                     "ret"

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatilesShenandoah.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestVolatilesShenandoah.java
@@ -39,34 +39,34 @@
  *        compiler.c2.aarch64.TestUnsafeVolatileStore
  *        compiler.c2.aarch64.TestUnsafeVolatileCAS
  *
- * @run driver compiler.c2.aarch64.TestVolatilesSerial
+ * @run driver compiler.c2.aarch64.TestVolatilesShenandoah
  *      TestVolatileLoad Shenandoah
  *
- * @run driver compiler.c2.aarch64.TestVolatilesSerial
+ * @run driver compiler.c2.aarch64.TestVolatilesShenandoah
  *      TestVolatileStore Shenandoah
  *
- * @run driver compiler.c2.aarch64.TestVolatilesSerial
+ * @run driver compiler.c2.aarch64.TestVolatilesShenandoah
  *      TestUnsafeVolatileLoad Shenandoah
  *
- * @run driver compiler.c2.aarch64.TestVolatilesSerial
+ * @run driver compiler.c2.aarch64.TestVolatilesShenandoah
  *      TestUnsafeVolatileStore Shenandoah
  *
- * @run driver compiler.c2.aarch64.TestVolatilesSerial
+ * @run driver compiler.c2.aarch64.TestVolatilesShenandoah
  *      TestUnsafeVolatileCAS Shenandoah
  *
- * @run driver compiler.c2.aarch64.TestVolatilesSerial
+ * @run driver compiler.c2.aarch64.TestVolatilesShenandoah
  *      TestVolatileLoad ShenandoahIU
  *
- * @run driver compiler.c2.aarch64.TestVolatilesSerial
+ * @run driver compiler.c2.aarch64.TestVolatilesShenandoah
  *      TestVolatileStore ShenandoahIU
  *
- * @run driver compiler.c2.aarch64.TestVolatilesSerial
+ * @run driver compiler.c2.aarch64.TestVolatilesShenandoah
  *      TestUnsafeVolatileLoad ShenandoahIU
  *
- * @run driver compiler.c2.aarch64.TestVolatilesSerial
+ * @run driver compiler.c2.aarch64.TestVolatilesShenandoah
  *      TestUnsafeVolatileStore ShenandoahIU
  *
- * @run driver compiler.c2.aarch64.TestVolatilesSerial
+ * @run driver compiler.c2.aarch64.TestVolatilesShenandoah
  *      TestUnsafeVolatileCAS ShenandoahIU
  */
 


### PR DESCRIPTION
Shenandoah-specific, 11u-specific test bug. See more details in bug report.

Attention @rkennke, @adinn.

Changes:
 - `argcount` is incorrect, should be `9`, matches other configs with single option
 - `\\(elided\\)` should be escaped
 - `useCompressedOops` should be handled
 - 11u version still has `UseBarriersForVolatlie` block, so I had to add it for Shenandoah
 - `TestVolatilesShenandoah.java` should use itself in `@driver` statements

Additional testing:
 - [x] Affected test now passes on AArch64 11u

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272772](https://bugs.openjdk.java.net/browse/JDK-8272772): Shenandoah: compiler/c2/aarch64/TestVolatilesShenandoah.java fails in 11u


### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - Committer)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/267/head:pull/267` \
`$ git checkout pull/267`

Update a local copy of the PR: \
`$ git checkout pull/267` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 267`

View PR using the GUI difftool: \
`$ git pr show -t 267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/267.diff">https://git.openjdk.java.net/jdk11u-dev/pull/267.diff</a>

</details>
