### PR TITLE
8261072: AArch64: Fix MacroAssembler::get_thread convention

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5804,10 +5804,14 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
 // by the call to JavaThread::aarch64_get_thread_helper() or, indeed,
 // the call setup code.
 //
-// aarch64_get_thread_helper() clobbers only r0, r1, and flags.
+// On Linux, aarch64_get_thread_helper() clobbers only r0, r1, and flags.
+// On other systems, the helper is a usual C function.
 //
 void MacroAssembler::get_thread(Register dst) {
-  RegSet saved_regs = RegSet::range(r0, r1) + lr - dst;
+  RegSet saved_regs =
+    LINUX_ONLY(RegSet::range(r0, r1)  + lr - dst)
+    NOT_LINUX (RegSet::range(r0, r17) + lr - dst);
+
   push(saved_regs, sp);
 
   mov(lr, CAST_FROM_FN_PTR(address, JavaThread::aarch64_get_thread_helper));


### PR DESCRIPTION
Clean backport. The non-Linux path will only be exercised once [JEP 388](https://github.com/openjdk/jdk11u-dev/pull/222) is in.

This is part of the Windows/AArch64 port.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8261072](https://bugs.openjdk.java.net/browse/JDK-8261072): AArch64: Fix MacroAssembler::get_thread convention


### Contributors
 * Monica Beckwith `<mbeckwit@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/271/head:pull/271` \
`$ git checkout pull/271`

Update a local copy of the PR: \
`$ git checkout pull/271` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 271`

View PR using the GUI difftool: \
`$ git pr show -t 271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/271.diff">https://git.openjdk.java.net/jdk11u-dev/pull/271.diff</a>

</details>
