### PR TITLE
8265756: AArch64: initialize memory allocated for locals according to Windows AArch64 stack page growth requirement in template interpreter

### DIFF
--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1593,26 +1593,29 @@ address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized) {
   __ add(rlocals, esp, r2, ext::uxtx, 3);
   __ sub(rlocals, rlocals, wordSize);
 
-  // Make room for locals
-  __ sub(rscratch1, esp, r3, ext::uxtx, 3);
-
-  // Padding between locals and fixed part of activation frame to ensure
-  // SP is always 16-byte aligned.
-  __ andr(sp, rscratch1, -16);
+  __ mov(rscratch1, esp);
 
   // r3 - # of additional locals
   // allocate space for locals
   // explicitly initialize locals
+  // Initializing memory allocated for locals in the same direction as
+  // the stack grows to ensure page initialization order according
+  // to windows-aarch64 stack page growth requirement (see
+  // https://docs.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions?view=msvc-160#stack)
   {
     Label exit, loop;
     __ ands(zr, r3, r3);
     __ br(Assembler::LE, exit); // do nothing if r3 <= 0
     __ bind(loop);
-    __ str(zr, Address(__ post(rscratch1, wordSize)));
+    __ str(zr, Address(__ pre(rscratch1, -wordSize)));
     __ sub(r3, r3, 1); // until everything initialized
     __ cbnz(r3, loop);
     __ bind(exit);
   }
+
+  // Padding between locals and fixed part of activation frame to ensure
+  // SP is always 16-byte aligned.
+  __ andr(sp, rscratch1, -16);
 
   // And the base dispatch table
   __ get_dispatch();

--- a/test/hotspot/jtreg/runtime/Locals/TestLargeLocalVarsStackRegion.java
+++ b/test/hotspot/jtreg/runtime/Locals/TestLargeLocalVarsStackRegion.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8265756
+ * @library /test/lib /
+ * @compile TestLargeLocalVarsStackRegionHelper.jasm
+ * @run main runtime.Locals.TestLargeLocalVarsStackRegion
+ */
+
+package runtime.Locals;
+
+import jdk.test.lib.Asserts;
+
+public class TestLargeLocalVarsStackRegion {
+
+    // Some platforms (such as windows-aarch64) may have
+    // stack page touch order restrictions.
+    // Test calls method with large local vars stack region
+    // to trigger usage of several stack memory pages and
+    // check the validity of the touch order.
+    //
+    // Helper method is written in jasm as this allows to
+    // specify local vars stack region size directly.
+    public static void main(String args[]) {
+        Asserts.assertEQ(TestLargeLocalVarsStackRegionHelper.tst(), 0);
+    }
+}

--- a/test/hotspot/jtreg/runtime/Locals/TestLargeLocalVarsStackRegionHelper.jasm
+++ b/test/hotspot/jtreg/runtime/Locals/TestLargeLocalVarsStackRegionHelper.jasm
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package runtime/Locals;
+
+public class TestLargeLocalVarsStackRegionHelper
+{
+
+// Method with large locals vars region.
+// Purpose: verify stack pages touch order (see TestLargeLocalVarsStackRegion.java)
+public static Method tst:"()I"
+    stack 3 locals 65535
+{
+                iconst_1;
+                newarray int;
+                dup;
+                astore_w   65500;
+                aload_w  65500;
+                if_acmpne       FAILED;
+
+                iconst_0;
+                ireturn; // passed
+
+        FAILED:
+                iconst_1; // failed
+                ireturn;
+}
+
+public Method <init>:"()V"
+        stack 1 locals 1
+{
+    aload_0;
+    invokespecial   Method java/lang/Object.<init>:"()V";
+    return;
+}
+
+}


### PR DESCRIPTION
Changes apply cleanly.

This is part of the Windows/AArch64 port.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8265756](https://bugs.openjdk.java.net/browse/JDK-8265756): AArch64: initialize memory allocated for locals according to Windows AArch64 stack page growth requirement in template interpreter


### Contributors
 * Monica Beckwith `<mbeckwit@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/272/head:pull/272` \
`$ git checkout pull/272`

Update a local copy of the PR: \
`$ git checkout pull/272` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 272`

View PR using the GUI difftool: \
`$ git pr show -t 272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/272.diff">https://git.openjdk.java.net/jdk11u-dev/pull/272.diff</a>

</details>
