### PR TITLE
8250810: Push missing parts of JDK-8248817

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2359,7 +2359,8 @@ bool os::win32::get_frame_at_stack_banging_point(JavaThread* thread,
 JNIEXPORT
 LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
   if (InterceptOSException) return EXCEPTION_CONTINUE_SEARCH;
-  DWORD exception_code = exceptionInfo->ExceptionRecord->ExceptionCode;
+  PEXCEPTION_RECORD exception_record = exceptionInfo->ExceptionRecord;
+  DWORD exception_code = exception_record->ExceptionCode;
 #ifdef _M_AMD64
   address pc = (address) exceptionInfo->ContextRecord->Rip;
 #else
@@ -2378,9 +2379,8 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
   // This is safe to do because we have a new/unique ExceptionInformation
   // code for this condition.
   if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
-    PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
-    int exception_subcode = (int) exceptionRecord->ExceptionInformation[0];
-    address addr = (address) exceptionRecord->ExceptionInformation[1];
+    int exception_subcode = (int) exception_record->ExceptionInformation[0];
+    address addr = (address) exception_record->ExceptionInformation[1];
 
     if (exception_subcode == EXCEPTION_INFO_EXEC_VIOLATION) {
       int page_size = os::vm_page_size();
@@ -2444,7 +2444,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 
       // Last unguard failed or not unguarding
       tty->print_raw_cr("Execution protection violation");
-      report_error(t, exception_code, addr, exceptionInfo->ExceptionRecord,
+      report_error(t, exception_code, addr, exception_record,
                    exceptionInfo->ContextRecord);
       return EXCEPTION_CONTINUE_SEARCH;
     }
@@ -2458,33 +2458,30 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
   if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
     if (t != NULL && t->is_Java_thread()) {
       JavaThread* thread = (JavaThread*) t;
-      PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
-      address addr = (address) exceptionRecord->ExceptionInformation[1];
+      address addr = (address) exception_record->ExceptionInformation[1];
       if (os::is_memory_serialize_page(thread, addr)) {
         // Block current thread until the memory serialize page permission restored.
         os::block_on_serialize_page_trap();
         return EXCEPTION_CONTINUE_EXECUTION;
       }
     }
-  }
-
-  if ((exception_code == EXCEPTION_ACCESS_VIOLATION) &&
-      VM_Version::is_cpuinfo_segv_addr(pc)) {
-    // Verify that OS save/restore AVX registers.
-    return Handle_Exception(exceptionInfo, VM_Version::cpuinfo_cont_addr());
+    if (VM_Version::is_cpuinfo_segv_addr(pc)) {
+      // Verify that OS save/restore AVX registers.
+      return Handle_Exception(exceptionInfo, VM_Version::cpuinfo_cont_addr());
+    }
   }
 
   if (t != NULL && t->is_Java_thread()) {
     JavaThread* thread = (JavaThread*) t;
     bool in_java = thread->thread_state() == _thread_in_Java;
+    bool in_native = thread->thread_state() == _thread_in_native;
+    bool in_vm = thread->thread_state() == _thread_in_vm;
 
     // Handle potential stack overflows up front.
     if (exception_code == EXCEPTION_STACK_OVERFLOW) {
       if (thread->stack_guards_enabled()) {
         if (in_java) {
           frame fr;
-          PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
-          address addr = (address) exceptionRecord->ExceptionInformation[1];
           if (os::win32::get_frame_at_stack_banging_point(thread, exceptionInfo, pc, &fr)) {
             assert(fr.is_java_frame(), "Must be a Java frame");
             SharedRuntime::look_for_reserved_stack_annotated_method(thread, fr);
@@ -2493,7 +2490,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
         // Yellow zone violation.  The o/s has unprotected the first yellow
         // zone page for us.  Note:  must call disable_stack_yellow_zone to
         // update the enabled status, even if the zone contains only one page.
-        assert(thread->thread_state() != _thread_in_vm, "Undersized StackShadowPages");
+        assert(!in_vm, "Undersized StackShadowPages");
         thread->disable_stack_yellow_reserved_zone();
         // If not in java code, return and hope for the best.
         return in_java
@@ -2503,15 +2500,14 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
         // Fatal red zone violation.
         thread->disable_stack_red_zone();
         tty->print_raw_cr("An unrecoverable stack overflow has occurred.");
-        report_error(t, exception_code, pc, exceptionInfo->ExceptionRecord,
-                      exceptionInfo->ContextRecord);
+        report_error(t, exception_code, pc, exception_record,
+                     exceptionInfo->ContextRecord);
         return EXCEPTION_CONTINUE_SEARCH;
       }
     } else if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
-      // Either stack overflow or null pointer exception.
       if (in_java) {
-        PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
-        address addr = (address) exceptionRecord->ExceptionInformation[1];
+        // Either stack overflow or null pointer exception.
+        address addr = (address) exception_record->ExceptionInformation[1];
         address stack_end = thread->stack_end();
         if (addr < stack_end && addr >= stack_end - os::vm_page_size()) {
           // Stack overflow.
@@ -2530,47 +2526,38 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
             return Handle_Exception(exceptionInfo, stub);
           }
         }
-        {
 #ifdef _WIN64
-          // If it's a legal stack address map the entire region in
-          //
-          PEXCEPTION_RECORD exceptionRecord = exceptionInfo->ExceptionRecord;
-          address addr = (address) exceptionRecord->ExceptionInformation[1];
-          if (addr > thread->stack_reserved_zone_base() && addr < thread->stack_base()) {
-            addr = (address)((uintptr_t)addr &
-                             (~((uintptr_t)os::vm_page_size() - (uintptr_t)1)));
-            os::commit_memory((char *)addr, thread->stack_base() - addr,
-                              !ExecMem);
-            return EXCEPTION_CONTINUE_EXECUTION;
-          } else
-#endif
-          {
-            // Null pointer exception.
-            if (!MacroAssembler::needs_explicit_null_check((intptr_t)addr)) {
-              address stub = SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime::IMPLICIT_NULL);
-              if (stub != NULL) return Handle_Exception(exceptionInfo, stub);
-            }
-            report_error(t, exception_code, pc, exceptionInfo->ExceptionRecord,
-                         exceptionInfo->ContextRecord);
-            return EXCEPTION_CONTINUE_SEARCH;
-          }
+        // If it's a legal stack address, map the entire region in
+        if (addr > thread->stack_reserved_zone_base() && addr < thread->stack_base()) {
+          addr = (address)((uintptr_t)addr &
+                           (~((uintptr_t)os::vm_page_size() - (uintptr_t)1)));
+          os::commit_memory((char *)addr, thread->stack_base() - addr,
+                            !ExecMem);
+          return EXCEPTION_CONTINUE_EXECUTION;
         }
+#endif
+        // Null pointer exception.
+        if (!MacroAssembler::needs_explicit_null_check((intptr_t)addr)) {
+          address stub = SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime::IMPLICIT_NULL);
+          if (stub != NULL) return Handle_Exception(exceptionInfo, stub);
+        }
+        report_error(t, exception_code, pc, exception_record,
+                     exceptionInfo->ContextRecord);
+        return EXCEPTION_CONTINUE_SEARCH;
       }
 
 #ifdef _WIN64
       // Special care for fast JNI field accessors.
       // jni_fast_Get<Primitive>Field can trap at certain pc's if a GC kicks
       // in and the heap gets shrunk before the field access.
-      if (exception_code == EXCEPTION_ACCESS_VIOLATION) {
-        address addr = JNI_FastGetField::find_slowcase_pc(pc);
-        if (addr != (address)-1) {
-          return Handle_Exception(exceptionInfo, addr);
-        }
+      address slowcase_pc = JNI_FastGetField::find_slowcase_pc(pc);
+      if (slowcase_pc != (address)-1) {
+        return Handle_Exception(exceptionInfo, slowcase_pc);
       }
 #endif
 
       // Stack overflow or null pointer exception in native code.
-      report_error(t, exception_code, pc, exceptionInfo->ExceptionRecord,
+      report_error(t, exception_code, pc, exception_record,
                    exceptionInfo->ContextRecord);
       return EXCEPTION_CONTINUE_SEARCH;
     } // /EXCEPTION_ACCESS_VIOLATION
@@ -2583,8 +2570,7 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
         CodeBlob* cb = CodeCache::find_blob_unsafe(pc);
         nm = (cb != NULL) ? cb->as_compiled_method_or_null() : NULL;
       }
-      if ((thread->thread_state() == _thread_in_vm &&
-          thread->doing_unsafe_access()) ||
+      if ((in_vm && thread->doing_unsafe_access()) ||
           (nm != NULL && nm->has_unsafe_access())) {
         return Handle_Exception(exceptionInfo, SharedRuntime::handle_unsafe_access(thread, (address)Assembler::locate_next_instruction(pc)));
       }
@@ -2600,16 +2586,14 @@ LONG WINAPI topLevelExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
 
       } // switch
     }
-    if (((thread->thread_state() == _thread_in_Java) ||
-         (thread->thread_state() == _thread_in_native)) &&
-         exception_code != EXCEPTION_UNCAUGHT_CXX_EXCEPTION) {
+    if ((in_java || in_native) && exception_code != EXCEPTION_UNCAUGHT_CXX_EXCEPTION) {
       LONG result=Handle_FLT_Exception(exceptionInfo);
       if (result==EXCEPTION_CONTINUE_EXECUTION) return result;
     }
   }
 
   if (exception_code != EXCEPTION_BREAKPOINT) {
-    report_error(t, exception_code, pc, exceptionInfo->ExceptionRecord,
+    report_error(t, exception_code, pc, exception_record,
                  exceptionInfo->ContextRecord);
   }
   return EXCEPTION_CONTINUE_SEARCH;

--- a/src/hotspot/os_cpu/windows_x86/thread_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/thread_windows_x86.cpp
@@ -63,33 +63,22 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava)
   // we try to glean some information out of the CONTEXT
   // if we were running Java code when SIGPROF came in.
   if (isInJava) {
-    CONTEXT* uc = (CONTEXT*)ucontext;
-
-#ifdef AMD64
-    intptr_t* ret_fp = (intptr_t*) uc->Rbp;
-    intptr_t* ret_sp = (intptr_t*) uc->Rsp;
-    ExtendedPC addr = ExtendedPC((address)uc->Rip);
-#else
-    intptr_t* ret_fp = (intptr_t*) uc->Ebp;
-    intptr_t* ret_sp = (intptr_t*) uc->Esp;
-    ExtendedPC addr = ExtendedPC((address)uc->Eip);
-#endif // AMD64
-    if (addr.pc() == NULL || ret_sp == NULL ) {
+    frame ret_frame = os::fetch_frame_from_context(ucontext);
+    if (ret_frame.pc() == NULL || ret_frame.sp() == NULL ) {
       // CONTEXT wasn't useful
       return false;
     }
 
-    if (MetaspaceShared::is_in_trampoline_frame(addr.pc())) {
+    if (MetaspaceShared::is_in_trampoline_frame(ret_frame.pc())) {
       // In the middle of a trampoline call. Bail out for safety.
       // This happens rarely so shouldn't affect profiling.
       return false;
     }
 
-    frame ret_frame(ret_sp, ret_fp, addr.pc());
     if (!ret_frame.safe_for_sender(jt)) {
 #if COMPILER2_OR_JVMCI
       // C2 and JVMCI use ebp as a general register see if NULL fp helps
-      frame ret_frame2(ret_sp, NULL, addr.pc());
+      frame ret_frame2(ret_frame.sp(), NULL, ret_frame.pc());
       if (!ret_frame2.safe_for_sender(jt)) {
         // nothing else to try if the frame isn't good
         return false;


### PR DESCRIPTION
This is a refactoring patch with no functional change. It didn't apply cleanly. Differences to the original commit:

In `thread_windows_x86.cpp`:
- Some removed lines were simpler on tip because of [JDK-8248240](https://github.com/openjdk/jdk/commit/a6e794b3e85d28537bf740d9d7e68339707d38e1#diff-d4111d540c34b1e0f4acac1e92877ce458b29d70126ccb113b439261a503ed95).

In `os_windows.cpp`:
- The block around L2461 is no longer present on tip, that and a bit of the next block can be simplified.
- The conditions on L2539 ([JDK-8234372](https://github.com/openjdk/jdk/commit/4e4d1f2b4dad61b4c4590f1d3a956b9ad86ff74c#diff-84938e7dfe64805a850b8a729495117a972a474622fff12bb97ee45cbc2184f2)) and L2549 ([JDK-8213199](https://github.com/openjdk/jdk/commit/7c3f2b06f13e3d28b74193d8acac4478e8c12bdb#diff-84938e7dfe64805a850b8a729495117a972a474622fff12bb97ee45cbc2184f2)) (original line numbers) are different on tip. We actually didn't touch those, they only show up colored in the diff because of the whitespace changes.
- The surrounding code is different around L2586 because of [JDK-8191278](https://github.com/openjdk/jdk/commit/aedbb7580334cb9131f547845f9b7aa3916ddf4b#diff-84938e7dfe64805a850b8a729495117a972a474622fff12bb97ee45cbc2184f2), but the changes are the same.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250810](https://bugs.openjdk.java.net/browse/JDK-8250810): Push missing parts of JDK-8248817


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to a06cf59aeec047e02492ba76397a9cfbf4dd4677
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Contributors
 * Ludovic Henry `<luhenry@openjdk.org>`
 * Bernhard Urban-Forster `<burban@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/274/head:pull/274` \
`$ git checkout pull/274`

Update a local copy of the PR: \
`$ git checkout pull/274` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 274`

View PR using the GUI difftool: \
`$ git pr show -t 274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/274.diff">https://git.openjdk.java.net/jdk11u-dev/pull/274.diff</a>

</details>
