### PR TITLE
8248899: security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java fails, Certificate has been revoked

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -656,7 +656,6 @@ sun/security/pkcs11/KeyStore/SecretKeysBasic.sh                 8209398 generic-
 security/infra/java/security/cert/CertPathValidator/certification/ActalisCA.java  8224768 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/BuypassCA.java  8243543 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/ComodoCA.java   8263059 generic-all
-security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java 8248899 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/LetsEncryptCA.java 8270280 generic-all
 
 sun/security/smartcardio/TestChannel.java                       8039280 generic-all

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@
 /*
  * Obtain TLS test artifacts for QuoVadis CAs from:
  *
- * https://www.quovadisglobal.com/QVRepository/TestCertificates.aspx
+ * https://www.quovadisglobal.com/download-roots-crl/
  *
  */
 public class QuoVadisCA {
@@ -57,120 +57,127 @@ public class QuoVadisCA {
 
 class RootCA1G3 {
 
-    // Owner: CN=QuoVadis QVRCA1G3 SSL ICA, O=QuoVadis Limited, C=BM
+    // Owner: CN=DigiCert QuoVadis TLS ICA QV Root CA 1 G3, O="DigiCert, Inc", C=US
+    // Issuer: CN=QuoVadis Root CA 1 G3, O=QuoVadis Limited, C=BM
+    // Serial number: 2837d5c3c2b57294becf99afe8bbdcd1bb0b20f1
+    // Valid from: Wed Jan 06 12:50:51 PST 2021 until: Sat Jan 04 12:50:51 PST 2031
     private static final String INT = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIGszCCBJugAwIBAgIUdJ4w/GwP08WekbUIXvYTsQrO+a8wDQYJKoZIhvcNAQEL\n" +
+            "MIIFgDCCA2igAwIBAgIUKDfVw8K1cpS+z5mv6Lvc0bsLIPEwDQYJKoZIhvcNAQEL\n" +
             "BQAwSDELMAkGA1UEBhMCQk0xGTAXBgNVBAoTEFF1b1ZhZGlzIExpbWl0ZWQxHjAc\n" +
-            "BgNVBAMTFVF1b1ZhZGlzIFJvb3QgQ0EgMSBHMzAeFw0xNzA0MTkxNTAzMzZaFw0y\n" +
-            "NzA0MTkxNTAzMzZaMEwxCzAJBgNVBAYTAkJNMRkwFwYDVQQKDBBRdW9WYWRpcyBM\n" +
-            "aW1pdGVkMSIwIAYDVQQDDBlRdW9WYWRpcyBRVlJDQTFHMyBTU0wgSUNBMIICIjAN\n" +
-            "BgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAqVn6XxE+YKKifggi6EPcx7mOOrhA\n" +
-            "HVxHFsFV/OR/dtQlx2oOTAGPpa8o3ZPVubtNH5QiiMBBiPDW1KqBaU+rmgUeGCj0\n" +
-            "hWKbdNGRQ5h3rV+4Vhs45BYxQcUzGTZ+oobao8gNo1LuhPIhOQComGOjZtUP0+qQ\n" +
-            "nXsWJn5004TvCzu7mmt3aTlMeyjSbpoXa3ojwU2BvUzJwcLg0BD49kNXZsM0JLbY\n" +
-            "QgfEfluWFkb5QzjnE45sBni4LJNfSodhNB+mL/VmETO+0m/A1H6in1rG1n4Ao2G6\n" +
-            "KYgtk9rXWfF3g7JqwuZUULfI0467h14oG1PzqVcLgZ1B+wrdyiBJJSpRmhf00xSB\n" +
-            "WM/p93s2xkyQZ2Uh0b0tP90S6spwwpL8PSW3J8x46LaZDEVON/Gm9H891ZgwHLaf\n" +
-            "3idGX93XHFafve8CrJFMhK2AZElwYaz2H6iJuPftyhR3oQIgLst8l+/2LoqDRyaI\n" +
-            "6c+tVnk8LcvUgDEPuA70aNthQQ6PWA7iuI2Oies6GEPm7gKVNxIrg6rp2T9RghLm\n" +
-            "vLnf6Gyn1ONLI7Ib3EyzjE8CJIAtor5KZcs8xm8iPNsDQza+1ugx8D8Zsla64vVw\n" +
-            "w2W2qNH4orutsAQKRImtbDkEnMb3nGDe0ZPohVyw3Fy+b9g6MX7wQzFjIx3UkzZG\n" +
-            "QQqGdIh940Qq3wUCAwEAAaOCAY8wggGLMBIGA1UdEwEB/wQIMAYBAf8CAQAwSQYD\n" +
-            "VR0gBEIwQDA+BgRVHSAAMDYwNAYIKwYBBQUHAgEWKGh0dHA6Ly93d3cucXVvdmFk\n" +
-            "aXNnbG9iYWwuY29tL3JlcG9zaXRvcnkwdAYIKwYBBQUHAQEEaDBmMCoGCCsGAQUF\n" +
-            "BzABhh5odHRwOi8vb2NzcC5xdW92YWRpc2dsb2JhbC5jb20wOAYIKwYBBQUHMAKG\n" +
-            "LGh0dHA6Ly90cnVzdC5xdW92YWRpc2dsb2JhbC5jb20vcXZyY2ExZzMuY3J0MA4G\n" +
-            "A1UdDwEB/wQEAwIBBjAnBgNVHSUEIDAeBggrBgEFBQcDAQYIKwYBBQUHAwIGCCsG\n" +
-            "AQUFBwMJMB8GA1UdIwQYMBaAFKOX1vNeohDhq0WfPBdkPO4BcJzMMDsGA1UdHwQ0\n" +
-            "MDIwMKAuoCyGKmh0dHA6Ly9jcmwucXVvdmFkaXNnbG9iYWwuY29tL3F2cmNhMWcz\n" +
-            "LmNybDAdBgNVHQ4EFgQUIAYNQkuk2dMocCdjvExpRiGBHTwwDQYJKoZIhvcNAQEL\n" +
-            "BQADggIBAEu/Bea66BZPfGNE4Np+PCRrTag/U7EBK/Yhjmf3mHtFMZzZ94QLH1km\n" +
-            "4iJ5dPKTR/+1iYYNHfO7fY2Lj/Tg/E+q2SEfA0n6Y/lYHAlbmnaYGGdtfTOjaQgL\n" +
-            "0Bf0TmLPyc/gf9uKHe230vIaN4QcodBnCmCJOAk/lvIl7b7gRNPN/HuJNQlBohNx\n" +
-            "ih9VAtLXJ6xO6Xfs5o8ZkZkHb2nG/M1yxySEyU3mqQ5PTgy8kg59szWr2ufT8PvL\n" +
-            "JuyGNQmT/PHcLp2zaCC0+5Ra65umjhG8IW2haXu8g8aRAgr9ZRPrcgg2npLBA0Qf\n" +
-            "MTEJPPptGx2GQgE+lMdn5Gff82d3Y35pDmxNTA7hy+4CnWKfmoey7ll8kwGxC+W1\n" +
-            "OUVgzfdXcpsm+HP2z4E/zw6uB0cAFgMJbxgnm6ZW9+R2yEbD6EOpqR8HqCvhVkkv\n" +
-            "CdQBNkk432pKD3+L7o6vkwONFOFWVpbXHIxDf9ys8Jr4B8qYWDUnR6jz/HG9aWPV\n" +
-            "k4vBYYWuahANZCfCKH2B9SqCdK6DjwKihYmallClwsUQnSwW8H7xqmLtAHX0ek7z\n" +
-            "1Ipj/BNS6c52cPxeAoFbUcVt6+M8xURIJ5qrobTYVaJ8AtfW+3Ml2oqT/EiItXOk\n" +
-            "W1319hZuAGD5qaG3dg9aLYUqpD948xJVhYVxwIIwvL4G9ZEVyYmE\n" +
+            "BgNVBAMTFVF1b1ZhZGlzIFJvb3QgQ0EgMSBHMzAeFw0yMTAxMDYyMDUwNTFaFw0z\n" +
+            "MTAxMDQyMDUwNTFaMFkxCzAJBgNVBAYTAlVTMRYwFAYDVQQKDA1EaWdpQ2VydCwg\n" +
+            "SW5jMTIwMAYDVQQDDClEaWdpQ2VydCBRdW9WYWRpcyBUTFMgSUNBIFFWIFJvb3Qg\n" +
+            "Q0EgMSBHMzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALMrbkb9kz/4\n" +
+            "y00r7tfK+uDRomMNd5iCDVMWOvSx1VygKoBn3aavw7gq9Vfb2fIMIWkWG0GMxWbG\n" +
+            "cx3wDHLWemd7yl9MxRUTGXkvH6/dNEavAQhUTL9TSf/N2e8f7q2dRDNYT7lXi/vR\n" +
+            "fTBiYlY7BLNha8C3sPHsKduaJN32cjdjVFH51rFDRdhUXlo2hhOjgB6bqoqs75A3\n" +
+            "Y3w88AdbMkapT63oGsCDO6N/uX2Mo9GSWREvlxHiXSMFf5qFw41vn5QIa5ADL1MP\n" +
+            "CzlLmJSHXE138H1+cG5IutD7tIieKjo/t+66PGMo8xicj3yUd8rHEmBqClG4Ty3d\n" +
+            "fF+bETFjLIUCAwEAAaOCAU8wggFLMBIGA1UdEwEB/wQIMAYBAf8CAQAwHwYDVR0j\n" +
+            "BBgwFoAUo5fW816iEOGrRZ88F2Q87gFwnMwwdAYIKwYBBQUHAQEEaDBmMDgGCCsG\n" +
+            "AQUFBzAChixodHRwOi8vdHJ1c3QucXVvdmFkaXNnbG9iYWwuY29tL3F2cmNhMWcz\n" +
+            "LmNydDAqBggrBgEFBQcwAYYeaHR0cDovL29jc3AucXVvdmFkaXNnbG9iYWwuY29t\n" +
+            "MBMGA1UdIAQMMAowCAYGZ4EMAQICMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEF\n" +
+            "BQcDATA7BgNVHR8ENDAyMDCgLqAshipodHRwOi8vY3JsLnF1b3ZhZGlzZ2xvYmFs\n" +
+            "LmNvbS9xdnJjYTFnMy5jcmwwHQYDVR0OBBYEFJkRfemwrS1iWnDTPI2HIK3a2i5B\n" +
+            "MA4GA1UdDwEB/wQEAwIBhjANBgkqhkiG9w0BAQsFAAOCAgEAb6tTptzzi4ssb+jA\n" +
+            "n2O2vAjAo7ydlfN9v+QH0ZuGHlUc9bm8dpNpBo9yt6fWHIprGLJjVOF7HwVDQcJD\n" +
+            "DhX4638Q7ETDrbTVQ4/edX6Yesq6C1G8Pza1LwStXD/jCQHFvWbPud86V0ikS4rS\n" +
+            "qlmu3fzUrGZ2/Q+n5jrnRqM5IS8TXYcnzLD3azH1+aZjkwQt9HP4IuvAe/Bg9aWE\n" +
+            "XeDmksbg0SqQInrWn+BVYtD+hCZNz8K0GnKKpx3Q9VxzRv+BMbO5e9iqK1Hcj5Wv\n" +
+            "ZXvU45j2r5y9WML4fc8CvphzbF6ezr1e51i+yabNmfld33gRX48V5oNk16wX32ed\n" +
+            "kQ83sKNomQm1dXURWK8aSDcZFAvJQ8vKTLIE9wiQmtjfSGoJzQhKLaN+egrp4L9y\n" +
+            "fjpFIeK4zgAH39P4s4kaPWTdfXe2n6P5o7Xolp4R22SVkI76d8d+5Iv7Rtqd+mqI\n" +
+            "y1hkwyTBbOBLtyF7yMtJQewkkZ0MWxkPvWg193RbYVRx8w1EycnxMgNwy2sJw7MR\n" +
+            "XM6Mihkw910BkvlbsFUXw4uSvRkkRWSBWVrkM5hvZGtbIJkqrdnj55RSk4DLOOT/\n" +
+            "LUyji/KpgD7YCi7emFA4tH6OpkNrjUJ3gdRnD4GwQj/87tYeoQWZ6uCl0MHDUCmw\n" +
+            "73bpxSkjPrYbmKo9mGEAMhW1ZxY=\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=qvsslrca1g3-ssl-v.quovadisglobal.com, O=QuoVadis Limited, L=Hamilton,
-    // ST=Pembroke, C=BM
+    // Owner: CN=quovadis-root-ca-1-g3.chain-demos.digicert.com, O="DigiCert, Inc.", L=Lehi, ST=Utah, C=US
+    // Issuer: CN=DigiCert QuoVadis TLS ICA QV Root CA 1 G3, O="DigiCert, Inc", C=US
+    // Serial number: 2b9bf892d8abbde06c26d764263bfa8
+    // Valid from: Tue Jan 19 16:00:00 PST 2021 until: Sun Feb 20 15:59:59 PST 2022
     private static final String VALID = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIGJzCCBA+gAwIBAgIUGCzNOZhcLiPYbOjRFAp5n04dPNowDQYJKoZIhvcNAQEL\n" +
-            "BQAwTDELMAkGA1UEBhMCQk0xGTAXBgNVBAoMEFF1b1ZhZGlzIExpbWl0ZWQxIjAg\n" +
-            "BgNVBAMMGVF1b1ZhZGlzIFFWUkNBMUczIFNTTCBJQ0EwHhcNMTcwNTAyMTcwMDA4\n" +
-            "WhcNMjAwNTAyMTcxMDAwWjB9MQswCQYDVQQGEwJCTTERMA8GA1UECAwIUGVtYnJv\n" +
-            "a2UxETAPBgNVBAcMCEhhbWlsdG9uMRkwFwYDVQQKDBBRdW9WYWRpcyBMaW1pdGVk\n" +
-            "MS0wKwYDVQQDDCRxdnNzbHJjYTFnMy1zc2wtdi5xdW92YWRpc2dsb2JhbC5jb20w\n" +
-            "ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCLgSX0nduUm87/qmfTdofL\n" +
-            "5P/Xtrly8Z9GaiLPLu1syNqT/Sri4ngYQGXXwF8h6gnHgEb6gDI2p3Q3gb75NthO\n" +
-            "WfWMD6FqafV47pUeNml6JvNbsYAPc8qGxMPtgQ8HhQuU+Trykx3onq/Se5HRYlve\n" +
-            "7MMJixiYQKYwwThHh9G1uGYPMQJT2TQfueIAu0MT6Ljc2YB6noXpzTzU63dvmC1Q\n" +
-            "8TMmFoJYL276lQ3p3vRKEW1nVmjeVoqvK/3Vpg440KbQL5D7Gj/pQPL4d7ljyS/I\n" +
-            "UN3q7QPS7BojsvF90u0YpvYEuBXsxdFnqivj5owSuSENG4nqcZUO8/nY+4b+NbJd\n" +
-            "AgMBAAGjggHOMIIByjB6BggrBgEFBQcBAQRuMGwwPgYIKwYBBQUHMAKGMmh0dHA6\n" +
-            "Ly90cnVzdC5xdW92YWRpc2dsb2JhbC5jb20vcXZyY2ExZzNzc2xpY2EuY3J0MCoG\n" +
-            "CCsGAQUFBzABhh5odHRwOi8vb2NzcC5xdW92YWRpc2dsb2JhbC5jb20wHQYDVR0O\n" +
-            "BBYEFIDk6mMLdh49CFbFiUDnjZhWatYzMB8GA1UdIwQYMBaAFCAGDUJLpNnTKHAn\n" +
-            "Y7xMaUYhgR08MGkGA1UdIARiMGAwRgYMKwYBBAG+WAABZAEBMDYwNAYIKwYBBQUH\n" +
-            "AgEWKGh0dHA6Ly93d3cucXVvdmFkaXNnbG9iYWwuY29tL3JlcG9zaXRvcnkwCAYG\n" +
-            "Z4EMAQICMAwGCisGAQQBvlgBhFgwQQYDVR0fBDowODA2oDSgMoYwaHR0cDovL2Ny\n" +
-            "bC5xdW92YWRpc2dsb2JhbC5jb20vcXZyY2ExZzNzc2xpY2EuY3JsMA4GA1UdDwEB\n" +
-            "/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwLwYDVR0RBCgw\n" +
-            "JoIkcXZzc2xyY2ExZzMtc3NsLXYucXVvdmFkaXNnbG9iYWwuY29tMA0GCSqGSIb3\n" +
-            "DQEBCwUAA4ICAQB2XiV2msE7M8Qp0YIcihD86T8U91PJH7Pb3F/3+8fyX08/oKDo\n" +
-            "s80sE50tiI5lw+tSFQZuvpOFefejEh1uAwu1slZOlvICHOAJNG1EXPa8pEmDU2i5\n" +
-            "nd5r7rM757/+cgsPLvwegVuIL4vIYhnoKzPiXpkl8FkNrhRjqeUIAXf2sLjbbbng\n" +
-            "oYRCypkSovpijPf7Cid19wKh/ipp8DxCNnGMit55mnx7eFNAWpb9cFljd+WaABCA\n" +
-            "IcvcZhZrLKYrbUErdQzzu0sa3IlEC5QBgz+IvT62RHT+vWRiv0LYhkHVLsDQUHpJ\n" +
-            "uTa1xi0qvBVGIP1jxIQv5W3hGPLYt7B/8A8v+xOn4m1VWfGIa4V3RGpbBMw19DH+\n" +
-            "JvLjg8coDWKhqZ150V31Ve8wczSjT+KZHFRWTb4TZt8GSXa56kJV5xadPW8A3EKV\n" +
-            "kulcspO1njb73ImrwTPIOLnDAsMDrAO41FEob87bdZacpg+kHjiAP9BzpgSSX1x5\n" +
-            "b/qy2uRtsf3ZlOb1J6fCqb8lRwSU7uGUStUx4tVMpjR5LQfNVroiDEthN5BE6sye\n" +
-            "zVRq8vyGvG40jSMBZF1KyW4GW6JlgM1THr1egNFhNkHBs7pSTHJp1Ea+QJjB1uVe\n" +
-            "A8kBL0iUlI5PPOqe5KdEXcFy3L+gRh34gyckC4vrLzfNLjKHQvdRHYnQBA==\n" +
+            "MIIGhjCCBW6gAwIBAgIQArm/iS2Ku94Gwm12QmO/qDANBgkqhkiG9w0BAQsFADBZ\n" +
+            "MQswCQYDVQQGEwJVUzEWMBQGA1UECgwNRGlnaUNlcnQsIEluYzEyMDAGA1UEAwwp\n" +
+            "RGlnaUNlcnQgUXVvVmFkaXMgVExTIElDQSBRViBSb290IENBIDEgRzMwHhcNMjEw\n" +
+            "MTIwMDAwMDAwWhcNMjIwMjIwMjM1OTU5WjB9MQswCQYDVQQGEwJVUzENMAsGA1UE\n" +
+            "CBMEVXRhaDENMAsGA1UEBxMETGVoaTEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4x\n" +
+            "NzA1BgNVBAMTLnF1b3ZhZGlzLXJvb3QtY2EtMS1nMy5jaGFpbi1kZW1vcy5kaWdp\n" +
+            "Y2VydC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDUqAk3cOpq\n" +
+            "E+70B1WMI5R3QEqbrF4TE9jpXFIy2HQV60HSyxrsh2xDpU/zD0BF2mwOGZvQKc1F\n" +
+            "JcVpwWXJ4vjS/lqDvZBNlzDejr4sQbzZVGFkqP6wu+KrAa+Eu7Lvayke3vi99Ba3\n" +
+            "MmcauuHQsLwh/A+nLzUZIL56HKREDA6YmvF2Bkz6La+f3y4BhiFcQLWQOSr4LgvD\n" +
+            "7qqdtd550sT4agIh6G1C3CDgUU2OYX8d70YOokO+msZXppD2le5HJDAUwrEKXB/L\n" +
+            "3+jxA2wxgxmGzWigkRFl7UlsuLezUZKIHj8YoQu/0LGLZZUcW0OEHj5sspifmQJ7\n" +
+            "DccQrGWyqU6XAgMBAAGjggMkMIIDIDAfBgNVHSMEGDAWgBSZEX3psK0tYlpw0zyN\n" +
+            "hyCt2touQTAdBgNVHQ4EFgQUDBReNH49ishzOagWgVaxd7nSyrgwOQYDVR0RBDIw\n" +
+            "MIIucXVvdmFkaXMtcm9vdC1jYS0xLWczLmNoYWluLWRlbW9zLmRpZ2ljZXJ0LmNv\n" +
+            "bTAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC\n" +
+            "MIGXBgNVHR8EgY8wgYwwRKBCoECGPmh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9E\n" +
+            "aWdpQ2VydFF1b1ZhZGlzVExTSUNBUVZSb290Q0ExRzMuY3JsMESgQqBAhj5odHRw\n" +
+            "Oi8vY3JsNC5kaWdpY2VydC5jb20vRGlnaUNlcnRRdW9WYWRpc1RMU0lDQVFWUm9v\n" +
+            "dENBMUczLmNybDA+BgNVHSAENzA1MDMGBmeBDAECAjApMCcGCCsGAQUFBwIBFhto\n" +
+            "dHRwOi8vd3d3LmRpZ2ljZXJ0LmNvbS9DUFMwgYMGCCsGAQUFBwEBBHcwdTAkBggr\n" +
+            "BgEFBQcwAYYYaHR0cDovL29jc3AuZGlnaWNlcnQuY29tME0GCCsGAQUFBzAChkFo\n" +
+            "dHRwOi8vY2FjZXJ0cy5kaWdpY2VydC5jb20vRGlnaUNlcnRRdW9WYWRpc1RMU0lD\n" +
+            "QVFWUm9vdENBMUczLmNydDAMBgNVHRMBAf8EAjAAMIIBBAYKKwYBBAHWeQIEAgSB\n" +
+            "9QSB8gDwAHUAKXm+8J45OSHwVnOfY6V35b5XfZxgCvj5TV0mXCVdx4QAAAF3IHgp\n" +
+            "NQAABAMARjBEAiBNOisRzreFHgpQYJmdzN8pKAGcerQHCWfeWeWyDDD8hQIgP2sh\n" +
+            "8KGW4sOt/BqEUNhGdD+ZAbv2+xrT57aSRONrG/UAdwAiRUUHWVUkVpY/oS/x922G\n" +
+            "4CMmY63AS39dxoNcbuIPAgAAAXcgeCmLAAAEAwBIMEYCIQCKVxPY+JbJX4IMcbVc\n" +
+            "HypoqNyozayPjzuHPZXsr5sZfAIhAIdS8wHmUZz6w5Frqa/CTUSugoNgx9H0K9dN\n" +
+            "Cl6gsvdcMA0GCSqGSIb3DQEBCwUAA4IBAQB35ONSVAMAhFpTwQl6HEFEmhh++JaF\n" +
+            "3WLMUODAa79N/GXe0JMvPuTbLsB/H1WXP/27D9ImvWlqLQU3EgqRp0fTdWCnnP4q\n" +
+            "8FKsKslnKPoiqNyTjpKHWk+gugFAyAAUXEFP4QYSMgye7kBNQZoX9MX4LhPBtqTa\n" +
+            "cPXLprb/gZMrNbbf9FdOGQXQgpFoaGnvyGw2oGU1Spb+Tx1QbK8NUWCdc8KNo1WB\n" +
+            "XH37EY8XJJxdjjoocLlFxRBUothYEUk+HdE5MGNqF3egtFKVvDk2OC8redCQ6dDC\n" +
+            "MKkGc7Avhn43gkRpzuush9Ph79aT1lf4Mm4Rs0FSYm8e62bQspH8UTdh\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=qvsslrca1g3-ssl-r.quovadisglobal.com, O=QuoVadis Limited, L=Hamilton,
-    // ST=Pembroke, C=BM
+    // Owner: CN=quovadis-root-ca-1-g3-revoked.chain-demos.digicert.com, O="DigiCert, Inc.", L=Lehi, ST=Utah, C=US
+    // Issuer: CN=DigiCert QuoVadis TLS ICA QV Root CA 1 G3, O="DigiCert, Inc", C=US
+    // Serial number: 8fb833dd0472302df1ddc134d36840d
+    // Valid from: Tue Jan 19 16:00:00 PST 2021 until: Sun Feb 20 15:59:59 PST 2022
     private static final String REVOKED = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIGJzCCBA+gAwIBAgIUGeTgdhQ6UoMWie3kBh4IGxDH4AQwDQYJKoZIhvcNAQEL\n" +
-            "BQAwTDELMAkGA1UEBhMCQk0xGTAXBgNVBAoMEFF1b1ZhZGlzIExpbWl0ZWQxIjAg\n" +
-            "BgNVBAMMGVF1b1ZhZGlzIFFWUkNBMUczIFNTTCBJQ0EwHhcNMTcwNTAyMTY1OTQ4\n" +
-            "WhcNMjAwNTAyMTcwOTAwWjB9MQswCQYDVQQGEwJCTTERMA8GA1UECAwIUGVtYnJv\n" +
-            "a2UxETAPBgNVBAcMCEhhbWlsdG9uMRkwFwYDVQQKDBBRdW9WYWRpcyBMaW1pdGVk\n" +
-            "MS0wKwYDVQQDDCRxdnNzbHJjYTFnMy1zc2wtci5xdW92YWRpc2dsb2JhbC5jb20w\n" +
-            "ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDR/0pcsSc4mmqVkzCO5h1m\n" +
-            "BlZ0uxmakNTNnWqeOXmMgl2KBni6MzIdxBkPmII5TI3nc+DXrWrtBCJKRtww3mbF\n" +
-            "ZoBhrscODv3OjfVqsVfhUPjqLwUEE9X/8IlxFpcsKRH1mC7weLg56kfnHuK2WHPQ\n" +
-            "dbnVgzzjk8mSi8HL3szIiojGC0ZwilrV/LCXBqETC3aMe8PtGnMW96TcvqQEdYFa\n" +
-            "4MEXuYnUwXB0WoKAJkHw/MMc0RytrICtlpaMQ7ZnloW8LvoQ1wIM7nWwCr+dieh6\n" +
-            "lZCWRN/Au+h6qdyDUDUPQFoGpp7AfE2OJmeCY30gp4GdAKtGpTG++gfJrtkc8FnZ\n" +
-            "AgMBAAGjggHOMIIByjB6BggrBgEFBQcBAQRuMGwwPgYIKwYBBQUHMAKGMmh0dHA6\n" +
-            "Ly90cnVzdC5xdW92YWRpc2dsb2JhbC5jb20vcXZyY2ExZzNzc2xpY2EuY3J0MCoG\n" +
-            "CCsGAQUFBzABhh5odHRwOi8vb2NzcC5xdW92YWRpc2dsb2JhbC5jb20wHQYDVR0O\n" +
-            "BBYEFGffDkPGAcip01jKnnvEt1jpKNRnMB8GA1UdIwQYMBaAFCAGDUJLpNnTKHAn\n" +
-            "Y7xMaUYhgR08MGkGA1UdIARiMGAwRgYMKwYBBAG+WAABZAEBMDYwNAYIKwYBBQUH\n" +
-            "AgEWKGh0dHA6Ly93d3cucXVvdmFkaXNnbG9iYWwuY29tL3JlcG9zaXRvcnkwCAYG\n" +
-            "Z4EMAQICMAwGCisGAQQBvlgBhFgwQQYDVR0fBDowODA2oDSgMoYwaHR0cDovL2Ny\n" +
-            "bC5xdW92YWRpc2dsb2JhbC5jb20vcXZyY2ExZzNzc2xpY2EuY3JsMA4GA1UdDwEB\n" +
-            "/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwLwYDVR0RBCgw\n" +
-            "JoIkcXZzc2xyY2ExZzMtc3NsLXIucXVvdmFkaXNnbG9iYWwuY29tMA0GCSqGSIb3\n" +
-            "DQEBCwUAA4ICAQBI/zlzisJLwBNaVZkQDMh1gYY8uRUad6Jn7yBFQbJ796VVlD1A\n" +
-            "yxJD+y9cpwzXvwKau8jIMi96OXo6xtsTDxKY9PzW8DkrlrxqdzLI7s5M30tGu8Sk\n" +
-            "WitIWPC3FU0oZqa9jBPkfujllR5FNuYikMOFIi2+/3haEK/6kviLpe5WyK4yJ3a9\n" +
-            "7dLq0If4vhNbKsuW1ROnq5CpPy+iIuZy3CWtq8WJSHDyZzhzrW48QHmTkoAU5lAb\n" +
-            "3KLMBo/gtUTjABVauADeVZVN6GgLflSIdz1P/aMJQ88q/88w+6KYJlBtg3mWSRHc\n" +
-            "Vh+BkIiKmfTG+N9SJ5jv7VKt8PjcKgqCzOHUslLHgUDFhJ5gdYIixD24ikRHYriH\n" +
-            "UCO3ltEppIUm/xgins75F6V9YBxHA1Ks/S5MfMnI6N+fFurIwIsas5w6gTPNwbBC\n" +
-            "z6G1fu6schk73uvfK4W6PiuMTURsQ1M746K2BlV+FIclTk8jYHe+EyLFgIsgVigo\n" +
-            "JJs0DsIp0RoGvw+bxxyA9CHeFFi+MlAVEj2+qJnwrD3ZqNFFw87/HDIWW+Ue8ERs\n" +
-            "HfPDZvEQZ1BHGzD/H04F0+HwwfItxvgiQVC2L/yjmh7St311OLiK8RM3Ur0X15bZ\n" +
-            "3g4c1gsHx9Gmlk3l8YIOk0yxvLaF03YsNbrfykXHuJM9Phy8Ya3nTpsqtw==\n" +
+            "MIIG1TCCBb2gAwIBAgIQCPuDPdBHIwLfHdwTTTaEDTANBgkqhkiG9w0BAQsFADBZ\n" +
+            "MQswCQYDVQQGEwJVUzEWMBQGA1UECgwNRGlnaUNlcnQsIEluYzEyMDAGA1UEAwwp\n" +
+            "RGlnaUNlcnQgUXVvVmFkaXMgVExTIElDQSBRViBSb290IENBIDEgRzMwHhcNMjEw\n" +
+            "MTIwMDAwMDAwWhcNMjIwMjIwMjM1OTU5WjCBhTELMAkGA1UEBhMCVVMxDTALBgNV\n" +
+            "BAgTBFV0YWgxDTALBgNVBAcTBExlaGkxFzAVBgNVBAoTDkRpZ2lDZXJ0LCBJbmMu\n" +
+            "MT8wPQYDVQQDEzZxdW92YWRpcy1yb290LWNhLTEtZzMtcmV2b2tlZC5jaGFpbi1k\n" +
+            "ZW1vcy5kaWdpY2VydC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB\n" +
+            "AQC/YHOKNPYW2a/aji68VN4EYwz5ANxRuCSHXOe6mg8pYaelrnky3hmNT3Ro86wc\n" +
+            "3UaXE07+fVGjXbbe4eRF5zj1pWsMe81n7NySoLud5C9CU/3okywv6SEPc/RiFKJk\n" +
+            "ic/BpRTE2pMtFfGsqWALjyDhM+W7SvM5eAXqcVVnqHgO5oToe2Cd0IqhgTgOUDdm\n" +
+            "+JuY/kY8gRmFyzfs4Oqe8nkgrdsvsyvRtQt1ldc9XKb+C/gnl8ZMiuLpuKWqezce\n" +
+            "2ED0SW4bVDbaDIhf97CNFeuMHHyZzI7Z0DH29WDcACOVBqVhGJl56T89COM3ISle\n" +
+            "WpYCOUgyzlPVODisfq/1zgepAgMBAAGjggNqMIIDZjAfBgNVHSMEGDAWgBSZEX3p\n" +
+            "sK0tYlpw0zyNhyCt2touQTAdBgNVHQ4EFgQUdZf0H3+QjsIMtfpwZUf3YNaVBQ0w\n" +
+            "fQYDVR0RBHYwdII2cXVvdmFkaXMtcm9vdC1jYS0xLWczLXJldm9rZWQuY2hhaW4t\n" +
+            "ZGVtb3MuZGlnaWNlcnQuY29tgjp3d3cucXVvdmFkaXMtcm9vdC1jYS0xLWczLXJl\n" +
+            "dm9rZWQuY2hhaW4tZGVtb3MuZGlnaWNlcnQuY29tMA4GA1UdDwEB/wQEAwIFoDAd\n" +
+            "BgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwgZcGA1UdHwSBjzCBjDBEoEKg\n" +
+            "QIY+aHR0cDovL2NybDMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0UXVvVmFkaXNUTFNJ\n" +
+            "Q0FRVlJvb3RDQTFHMy5jcmwwRKBCoECGPmh0dHA6Ly9jcmw0LmRpZ2ljZXJ0LmNv\n" +
+            "bS9EaWdpQ2VydFF1b1ZhZGlzVExTSUNBUVZSb290Q0ExRzMuY3JsMD4GA1UdIAQ3\n" +
+            "MDUwMwYGZ4EMAQICMCkwJwYIKwYBBQUHAgEWG2h0dHA6Ly93d3cuZGlnaWNlcnQu\n" +
+            "Y29tL0NQUzCBgwYIKwYBBQUHAQEEdzB1MCQGCCsGAQUFBzABhhhodHRwOi8vb2Nz\n" +
+            "cC5kaWdpY2VydC5jb20wTQYIKwYBBQUHMAKGQWh0dHA6Ly9jYWNlcnRzLmRpZ2lj\n" +
+            "ZXJ0LmNvbS9EaWdpQ2VydFF1b1ZhZGlzVExTSUNBUVZSb290Q0ExRzMuY3J0MAwG\n" +
+            "A1UdEwEB/wQCMAAwggEGBgorBgEEAdZ5AgQCBIH3BIH0APIAdwApeb7wnjk5IfBW\n" +
+            "c59jpXflvld9nGAK+PlNXSZcJV3HhAAAAXcgeVnsAAAEAwBIMEYCIQCBIKm+1buq\n" +
+            "Ws6nDYt1OMGxHa7yaxwQu5yaWCq6wk3kXQIhAL0ImrZZWp0Uq2i3QhDVjAfsP9lF\n" +
+            "LRf2f0qbqJUXzTV7AHcAIkVFB1lVJFaWP6Ev8fdthuAjJmOtwEt/XcaDXG7iDwIA\n" +
+            "AAF3IHlaMwAABAMASDBGAiEAm+RVoIBHAiMN+m/fuo65CLCwTRa/YVrP8wjUT4pM\n" +
+            "5toCIQDhV6pbmxbwGl9rM56ypsKZLJeB4LeCWqJmb7yf61E9WzANBgkqhkiG9w0B\n" +
+            "AQsFAAOCAQEAh82J/F2rBZ6GUFmOdIS8mhzO/ItkpAX+bta5lyPasCgP3JEmHONr\n" +
+            "HBX1UIvKYo7/McgFBt1V90ncQXfuutIyh0hPXSbTqK/b7XCVarh9J0ZXp8gLstQ5\n" +
+            "39DiuiS+qWBSc8C14VIOjeTblTBM6hjvkdnYhTZt2ip3aKYu8sHyC+3DpAYuD2og\n" +
+            "Lzs8Q7wvPwvBE2HMsr6c8dFjC9S8HZvrfJTwuh/7QhafueuwPEfr6a2/TExF/3B1\n" +
+            "QXxgYPg7pQ2gPUqucO47FcEhr5GHzTwNoGAropkFj3g0byEt0i+EwLMjdAlDABzP\n" +
+            "CFww1aRfNklbdRBZ/rr7QzmGtn39JzZKMQ==\n" +
             "-----END CERTIFICATE-----";
 
     public void runTest(ValidatePathWithParams pathValidator)
@@ -182,148 +189,138 @@ class RootCA1G3 {
         // Validate Revoked
         pathValidator.validate(new String[]{REVOKED, INT},
                 ValidatePathWithParams.Status.REVOKED,
-                "Tue May 02 10:15:37 PDT 2017", System.out);
+                "Wed Jan 20 07:46:23 PST 2021", System.out);
     }
 }
 
 class RootCA2G3 {
 
-    // Owner: CN=QuoVadis EV SSL ICA G3, O=QuoVadis Limited, C=BM
+    // Owner: CN=DigiCert QV EV TLS ICA G1, O="DigiCert, Inc.", C=US
+    // Issuer: CN=QuoVadis Root CA 2 G3, O=QuoVadis Limited, C=BM
+    // Serial number: 65e9bcd53e791df22dffeb5ecc2bc7a5588d0883
+    // Valid from: Mon Mar 16 12:39:42 PDT 2020 until: Thu Mar 14 12:39:42 PDT 2030
     private static final String INT = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIGuDCCBKCgAwIBAgIUUk/B8W400XArhKE/sEK7zHw8kDIwDQYJKoZIhvcNAQEL\n" +
+            "MIIFbzCCA1egAwIBAgIUZem81T55HfIt/+tezCvHpViNCIMwDQYJKoZIhvcNAQEL\n" +
             "BQAwSDELMAkGA1UEBhMCQk0xGTAXBgNVBAoTEFF1b1ZhZGlzIExpbWl0ZWQxHjAc\n" +
-            "BgNVBAMTFVF1b1ZhZGlzIFJvb3QgQ0EgMiBHMzAeFw0xNjExMzAxNjIxMDFaFw0y\n" +
-            "NjExMzAxNjIxMDFaMEkxCzAJBgNVBAYTAkJNMRkwFwYDVQQKDBBRdW9WYWRpcyBM\n" +
-            "aW1pdGVkMR8wHQYDVQQDDBZRdW9WYWRpcyBFViBTU0wgSUNBIEczMIICIjANBgkq\n" +
-            "hkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAonyczmwRSnw5BhWIrfcD19EbE7bYu5dF\n" +
-            "tD8o/5NtQCW+XdoLX+X9uNTuvnPw9Hv2RdhYrJgeLgF2wZ52XMGknRdB8tQYrknA\n" +
-            "l/j0N5f8DD82xP2eBkCpIB0UED4zNVwwWcdWvBUgNEdNobz9vQKb7B5LlbXm9kaO\n" +
-            "uxYgcv8WsNMivSP3mkJShEOh4RZ3ZdBM/vtJyuvUyEPjyiSzfN94tZHx/H194S4D\n" +
-            "VAPgE7ny3ISzN+Aa3kjyLebP/sPzI1AY0DWx8Yg4STG1j0PJeuTb6Ago2kmx4Kqn\n" +
-            "4q4kSPL8CgITYHiKaJx6Dt8Q90ieJ7ywG4Mb/YADOIlmoXZ6kXhzGAxyWXFgolLb\n" +
-            "4UToIh6U66v3Iyq+gXyCeMXGT4nUgs3+PduzOei9668jeKQaoU5d7LjJUL+ZH2+Y\n" +
-            "1bPmMAypHFLZryziOzC5kRo4TamgAf3LHHr2C7yIUuo+avlv3cic3NUodcfMi7Ax\n" +
-            "OQFLb32CtDoDeVb5v3x88R0tIEJTizk6M1B/0pGtZiFfXtrNVfHmEYvY2rOLbgWK\n" +
-            "M831ykqZSYHUpiqgnaNJb4Qs8WcxqUw1xki64WwiPclUSn5XgGMIwxSDGjUIJHKR\n" +
-            "rzgQ9lneHOHVb8pXHNFkdBDHTb1KNmDOyLsg3q0LJP6P3nzT/aWDAj3glpJvGQ5d\n" +
-            "kjAbjx+NFk8CAwEAAaOCAZcwggGTMBIGA1UdEwEB/wQIMAYBAf8CAQAwUQYDVR0g\n" +
-            "BEowSDBGBgwrBgEEAb5YAAJkAQIwNjA0BggrBgEFBQcCARYoaHR0cDovL3d3dy5x\n" +
-            "dW92YWRpc2dsb2JhbC5jb20vcmVwb3NpdG9yeTB0BggrBgEFBQcBAQRoMGYwKgYI\n" +
-            "KwYBBQUHMAGGHmh0dHA6Ly9vY3NwLnF1b3ZhZGlzZ2xvYmFsLmNvbTA4BggrBgEF\n" +
-            "BQcwAoYsaHR0cDovL3RydXN0LnF1b3ZhZGlzZ2xvYmFsLmNvbS9xdnJjYTJnMy5j\n" +
-            "cnQwDgYDVR0PAQH/BAQDAgEGMCcGA1UdJQQgMB4GCCsGAQUFBwMBBggrBgEFBQcD\n" +
-            "AgYIKwYBBQUHAwkwHwYDVR0jBBgwFoAU7edvdlq/YOxJW8ald7tyFnGbxD0wOwYD\n" +
-            "VR0fBDQwMjAwoC6gLIYqaHR0cDovL2NybC5xdW92YWRpc2dsb2JhbC5jb20vcXZy\n" +
-            "Y2EyZzMuY3JsMB0GA1UdDgQWBBTlhFTQkEmfOLryyeEqCMVOn6BIPzANBgkqhkiG\n" +
-            "9w0BAQsFAAOCAgEAY/EHWbpNwCgGVQ1B7cIn530n6Rnht8ryN6E4Sis2GG09801s\n" +
-            "eCVMoGUB1uBCWm7uqQqydjTbjLhuub7hTjSJ1J30SOK1CZbk+c1VP9DcjY46hycy\n" +
-            "tUKQ2WbgkaY+l/tZNDKu0djc2hA5apljQCmiIzckbcHr6yRnFK7ZPjSPCAUKm20D\n" +
-            "vORQ7hsIaomsIlqXm5BPssMcxjI48Ezgv/s8ynASI8S5P2vOnBo08sJBM/a0Kbuw\n" +
-            "351SubTzjxG+o1SHe6lAzvIQMuSwxUca8YkiB19w5YZt+Ss2JXNc6F2jZwpr0hto\n" +
-            "IXe+N9/x0CohYRRa+IivRGgdDQc3w2P+pffNQP/qdPuUYyMkYWiuHH/YvwXyuDxv\n" +
-            "yGQfvKmHr1uq/qiqbK1bDSUoEq4Su8yX8YoF9TuxYraIpp9iErO5rarDO6GTNVHh\n" +
-            "1OXAJ/ePhOWzqo3flLTlAdTcs3Mq97kKW8XWCnu/cjJJglf2zVfLAlv95p56B9If\n" +
-            "0pXbN74qDkYEC8TdLOwryhcv8yyimh90/AvW9LpB7swkWnUUYNTep/XMX/RLpHLn\n" +
-            "JOVtnRpn3coVfSR/0rz0XKVXeZGnKztGdIMQhWMTxvZ1UpmRAH2Ab2QnVo1fkPVy\n" +
-            "qNSJces5Y/VKpIvLBk5Jj55fvK8ME/9ASa+LtLrIms8iYHl75cupuYZZlg8=\n" +
+            "BgNVBAMTFVF1b1ZhZGlzIFJvb3QgQ0EgMiBHMzAeFw0yMDAzMTYxOTM5NDJaFw0z\n" +
+            "MDAzMTQxOTM5NDJaMEoxCzAJBgNVBAYTAlVTMRcwFQYDVQQKDA5EaWdpQ2VydCwg\n" +
+            "SW5jLjEiMCAGA1UEAwwZRGlnaUNlcnQgUVYgRVYgVExTIElDQSBHMTCCASIwDQYJ\n" +
+            "KoZIhvcNAQEBBQADggEPADCCAQoCggEBAMhwn6I+pGrJsnisnzP7EU5cFN9UT5XF\n" +
+            "auA13F3jHeUUZmBOcMSOJEhx/e7oeVScTnmKpe7t7uey7lIIC9DWFmP8klbtLBgL\n" +
+            "0jY4MPlCkVyxUIhZ73EHCPqDCX9bo+rMB6C758/tKZOPcoWRixQypPwoC4cXNOOk\n" +
+            "ntqFPRxFSZoBdTDNlAmkAQJCRsXGCEC5pZ0JqzGcAA0/Pw1fB8lSPAti3trubYmd\n" +
+            "aaPFAKzGK7vsexxpuSUKO0opNkFWbLdHZ8jkr86R80oo1vhURJXWNeMS74ws5nbt\n" +
+            "Ll9sJTDW33MQPS0/JO3xYI7bQcW3K1sPSERa4BahqgOJvEXMk1eWRcUCAwEAAaOC\n" +
+            "AU0wggFJMBIGA1UdEwEB/wQIMAYBAf8CAQAwHwYDVR0jBBgwFoAU7edvdlq/YOxJ\n" +
+            "W8ald7tyFnGbxD0wOgYIKwYBBQUHAQEELjAsMCoGCCsGAQUFBzABhh5odHRwOi8v\n" +
+            "b2NzcC5xdW92YWRpc2dsb2JhbC5jb20wSwYDVR0gBEQwQjAHBgVngQwBATA3Bglg\n" +
+            "hkgBhv1sAgEwKjAoBggrBgEFBQcCARYcaHR0cHM6Ly93d3cuZGlnaWNlcnQuY29t\n" +
+            "L0NQUzAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwOwYDVR0fBDQwMjAw\n" +
+            "oC6gLIYqaHR0cDovL2NybC5xdW92YWRpc2dsb2JhbC5jb20vcXZyY2EyZzMuY3Js\n" +
+            "MB0GA1UdDgQWBBQTL6fobnFR9uIMmEeDnn+deHk08zAOBgNVHQ8BAf8EBAMCAYYw\n" +
+            "DQYJKoZIhvcNAQELBQADggIBAEoOxze3kgnR39LX8M63EjiNxx0LThZHROqYqev6\n" +
+            "5ox/c5NNitk8/ODA8osdPpvnUBAlmE0+gqBvnTBRPVrJFd9bOr5BK8z6Os9/U0ed\n" +
+            "c3UINkWLS05B7ChC9s6Zw1Vd/WlW08TQJ80GpvAIbEKcg8EO/DXPniHxC4cMtv1T\n" +
+            "jtNeh98XiVgQXHL1FY+u/l413J8C4utKi4ZOQeCJDqvlSDzRsOi+tHsXrCJxnMWN\n" +
+            "2QBgMGgdPW37zwf0EffoH0Gee3pTgg7I5SzmvBq0t5xRDfv4N0OdM/sN1mc5f3o7\n" +
+            "0YCd9WXhyDCV5W2O8QIbrd42CK5k1rlM6gXwOyDmYY5CVAl1QeXEeRfDk/zNjU/1\n" +
+            "+LnH/Dv88VcZhODYq+VGbyM8bpNr0v95PY3yaH4kzpWGqWAN5i9LosfcaqRPmyL4\n" +
+            "PcKTQwcA9AVTjITExFua/QtGrXLPvMVxR248G9IQpJMxP3JEGkjlKCenmc29r2u1\n" +
+            "KE4TeCs2xxjR1PusTfX91bBW3YAoAPDTRQKZjolegLUY44j3uKSzAdhMEbZQhovH\n" +
+            "Lraqx1WjTayTuq1Vuakcia5shmgFVSNcE+NVgLEIe32oTOm/G6Kd1lcm9C4Ph1Cg\n" +
+            "nfDuqohZrk76kJTk8poAY5aFCQHhVzbpSw3zooMGjjvWnkG+/DC6SZM8rKoOdKiB\n" +
+            "cy+N\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=qvsslrca2g3-ev-v.quovadisglobal.com, O=QuoVadis Limited, L=Hamilton,
-    // ST=Pembroke, C=BM, SERIALNUMBER=28474, OID.2.5.4.15=Private Organization,
-    // OID.1.3.6.1.4.1.311.60.2.1.3=BM
+    // Owner: CN=quovadis-root-ca-2-g3.chain-demos.digicert.com, O="DigiCert, Inc.", L=Lehi, ST=Utah, C=US,
+    // SERIALNUMBER=5299537-0142, OID.1.3.6.1.4.1.311.60.2.1.2=Utah, OID.1.3.6.1.4.1.311.60.2.1.3=US,
+    // OID.2.5.4.15=Private Organization
+    // Issuer: CN=DigiCert QV EV TLS ICA G1, O="DigiCert, Inc.", C=US
+    // Serial number: a54e525a61f2552f65885c6dce9fe21
+    // Valid from: Mon Feb 01 16:00:00 PST 2021 until: Sat Mar 05 15:59:59 PST 2022
     private static final String VALID = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIH4DCCBcigAwIBAgIUUZsNAKy8C5AlCfpCZWUQY2R6VawwDQYJKoZIhvcNAQEL\n" +
-            "BQAwSTELMAkGA1UEBhMCQk0xGTAXBgNVBAoMEFF1b1ZhZGlzIExpbWl0ZWQxHzAd\n" +
-            "BgNVBAMMFlF1b1ZhZGlzIEVWIFNTTCBJQ0EgRzMwHhcNMTcwNDE4MTg1NjEyWhcN\n" +
-            "MTkwNDE4MTkwNjAwWjCBwDETMBEGCysGAQQBgjc8AgEDEwJCTTEdMBsGA1UEDwwU\n" +
-            "UHJpdmF0ZSBPcmdhbml6YXRpb24xDjAMBgNVBAUTBTI4NDc0MQswCQYDVQQGEwJC\n" +
-            "TTERMA8GA1UECAwIUGVtYnJva2UxETAPBgNVBAcMCEhhbWlsdG9uMRkwFwYDVQQK\n" +
-            "DBBRdW9WYWRpcyBMaW1pdGVkMSwwKgYDVQQDDCNxdnNzbHJjYTJnMy1ldi12LnF1\n" +
-            "b3ZhZGlzZ2xvYmFsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\n" +
-            "ALo9QJVNVNVfG//nZiOPX/j2O8GTVlSAfIMliEj78G0xmPZiQD3n/70KcYlsI7No\n" +
-            "ilytC8e/m4Mic9PpYfmhAwiUSmb3ba8qjekUgmBFXuQqj3fH6Na+8f5WC9cYpwlc\n" +
-            "Ew3NuL2WBs86mjM/3GIa61IXrGpRxN6UQJwSxhqlb1QqEGtuwBiy9FJQd0xekCTC\n" +
-            "GBe2zFT1WhyVSMWlxwkcy1p2LeUmlvnV6FHQYcM9te8UPhgY53O6+u0tnnnsED37\n" +
-            "UOU3MLev8T++WL7VPOrjgjXydMC9ndXKRttQFIeJ1r+W7rdMLCWkrTzvJ6GtBZZr\n" +
-            "8jjHNabWPkBslML7oGwvUHMCAwEAAaOCA0YwggNCMHgGCCsGAQUFBwEBBGwwajA5\n" +
-            "BggrBgEFBQcwAoYtaHR0cDovL3RydXN0LnF1b3ZhZGlzZ2xvYmFsLmNvbS9xdmV2\n" +
-            "c3NsZzMuY3J0MC0GCCsGAQUFBzABhiFodHRwOi8vZXYub2NzcC5xdW92YWRpc2ds\n" +
-            "b2JhbC5jb20wHQYDVR0OBBYEFLVK7rSs4x+DZrwYaWl2mjhhAtV/MAwGA1UdEwEB\n" +
-            "/wQCMAAwHwYDVR0jBBgwFoAU5YRU0JBJnzi68snhKgjFTp+gSD8wWgYDVR0gBFMw\n" +
-            "UTBGBgwrBgEEAb5YAAJkAQIwNjA0BggrBgEFBQcCARYoaHR0cDovL3d3dy5xdW92\n" +
-            "YWRpc2dsb2JhbC5jb20vcmVwb3NpdG9yeTAHBgVngQwBATA8BgNVHR8ENTAzMDGg\n" +
-            "L6AthitodHRwOi8vY3JsLnF1b3ZhZGlzZ2xvYmFsLmNvbS9xdmV2c3NsZzMuY3Js\n" +
-            "MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEw\n" +
-            "LgYDVR0RBCcwJYIjcXZzc2xyY2EyZzMtZXYtdi5xdW92YWRpc2dsb2JhbC5jb20w\n" +
-            "ggF9BgorBgEEAdZ5AgQCBIIBbQSCAWkBZwB2ALvZ37wfinG1k5Qjl6qSe0c4V5UK\n" +
-            "q1LoGpCWZDaOHtGFAAABW4J1OtsAAAQDAEcwRQIhANABKS1i5uxEm/HMivDJFyNJ\n" +
-            "gOKRrApqmx3KV0/pWMzqAiAui21HV9lVJ1OT6dEA9mlZAH4NmzklmY9WI978GMYG\n" +
-            "mgB2AFYUBpov18Ls0/XhvUSyPsdGdrm8mRFcwO+UmFXWidDdAAABW4J1Os0AAAQD\n" +
-            "AEcwRQIgTWLHrhex17UyIlr0HC9LXNUv0kyOudo7MpxoWFy1xGICIQCHFSoQGwvv\n" +
-            "zzpQ3JmHSLHy0AQQfWlbV9rFv37F4A7AaAB1AKS5CZC0GFgUh7sTosxncAo8NZgE\n" +
-            "+RvfuON3zQ7IDdwQAAABW4J1OvYAAAQDAEYwRAIgWLm8u/bcMZt5oXAPIqP9/Qqj\n" +
-            "Q61VYX+II6RFK+EJCnwCIBrXxQgngqO7X/aaeWnEjfQeSu7WCK9Md3tcqXsn+gMd\n" +
-            "MA0GCSqGSIb3DQEBCwUAA4ICAQAu0Y29voXdwt/68hwbdj8L50yecl2Z0OkOA31v\n" +
-            "UhAHgRVhQ+WiAgoeGEgjdntQ5pL7Wtr314gHpG6iR849Zr56WOliA6pfBYDk3qkH\n" +
-            "UiRgqQBUEV8oRzgp0E+Ebev+p9leM4RPYmUNsP3K4Z/BY24HNOtNKMC3clqKO35K\n" +
-            "D7B9ObYUb0+IjreKgUyQB7wMgFi7393gXDraVDhDoLrcktAkvkv3Mbt+A3IO5VrO\n" +
-            "4mQwjrLHzj8nFCmsP4RbCIKFO2QZE8sJYwplKUWOk1ngjpOvObPYpMt5M1kiRvau\n" +
-            "agkQ+WvnvuMEgAgafHtI4uu0ZNDW1ib0H+xq5X/x2w1RjEElbXCKMbnf3Pdvh9FG\n" +
-            "mLpkVITXIKzT0Jm+oIs+Vk4ktNEe8hQIzcqimmtlVl2hgMWkmIfRio1+41EY4Din\n" +
-            "QXBVsbRqftamzSpLbW54ryGJB8dSiGe4P53DOcNKiyie7une95ouZY/1DfQIlVG/\n" +
-            "9XexhqdGMKp6qUjgd9hOfHrD+mZHeBdIIONOHOhy6ESIUgpSzaAAM7QXZFqlzLzY\n" +
-            "okRp6cJKDfUmXrk80MopQMhRHJwdxfeZ/A/xAkrWlVPshG+qltSGIZWrNjhQIwk3\n" +
-            "49zFQCuDS+FrkubRueV+MB8Abp+V1nv5PNbhwfPzGSqwn9XX3vUnsp9uLv+3WlrL\n" +
-            "Kl1DeA==\n" +
+            "MIIGuzCCBaOgAwIBAgIQClTlJaYfJVL2WIXG3On+ITANBgkqhkiG9w0BAQsFADBK\n" +
+            "MQswCQYDVQQGEwJVUzEXMBUGA1UECgwORGlnaUNlcnQsIEluYy4xIjAgBgNVBAMM\n" +
+            "GURpZ2lDZXJ0IFFWIEVWIFRMUyBJQ0EgRzEwHhcNMjEwMjAyMDAwMDAwWhcNMjIw\n" +
+            "MzA1MjM1OTU5WjCB3zEdMBsGA1UEDwwUUHJpdmF0ZSBPcmdhbml6YXRpb24xEzAR\n" +
+            "BgsrBgEEAYI3PAIBAxMCVVMxFTATBgsrBgEEAYI3PAIBAhMEVXRhaDEVMBMGA1UE\n" +
+            "BRMMNTI5OTUzNy0wMTQyMQswCQYDVQQGEwJVUzENMAsGA1UECBMEVXRhaDENMAsG\n" +
+            "A1UEBxMETGVoaTEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4xNzA1BgNVBAMTLnF1\n" +
+            "b3ZhZGlzLXJvb3QtY2EtMi1nMy5jaGFpbi1kZW1vcy5kaWdpY2VydC5jb20wggEi\n" +
+            "MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDfknHK7boXh9ysZ0FLDQKEyT2x\n" +
+            "Swtyecb5kkVgJU75XpXccV724mntCu5hpZ7Yt4tOmDZvbpYcqWbhIJgxGFNLyPdB\n" +
+            "Fn8jgZ4N0WoD7u295HI9izEmbM0XrO2rvHUc6ZhFFyx0jhvJPf/k9QbQB4TwKZri\n" +
+            "Iuf1E1Ek70DkTWAg6OrPHMe2ER3aSz2S2rNkMSopURvZuabzPovsGaz+XEZNfE4N\n" +
+            "UfkBLa0DUjFCamOMZKIfkzxpH/NhQcigGnZgxiyUb6KRhu9ydpWeOvOHwPWwR/fV\n" +
+            "7WT+X1DUHojoXeCk2RtIRMihDWPd+lqiUppM8IlEW/gxWbK1wP41qioiK9j5AgMB\n" +
+            "AAGjggMFMIIDATAfBgNVHSMEGDAWgBQTL6fobnFR9uIMmEeDnn+deHk08zAdBgNV\n" +
+            "HQ4EFgQUtAEN4g3bzwES6MoOINihiZQrt+owOQYDVR0RBDIwMIIucXVvdmFkaXMt\n" +
+            "cm9vdC1jYS0yLWczLmNoYWluLWRlbW9zLmRpZ2ljZXJ0LmNvbTAOBgNVHQ8BAf8E\n" +
+            "BAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMHsGA1UdHwR0MHIw\n" +
+            "N6A1oDOGMWh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFFWRVZUTFNJ\n" +
+            "Q0FHMS5jcmwwN6A1oDOGMWh0dHA6Ly9jcmw0LmRpZ2ljZXJ0LmNvbS9EaWdpQ2Vy\n" +
+            "dFFWRVZUTFNJQ0FHMS5jcmwwSgYDVR0gBEMwQTALBglghkgBhv1sAgEwMgYFZ4EM\n" +
+            "AQEwKTAnBggrBgEFBQcCARYbaHR0cDovL3d3dy5kaWdpY2VydC5jb20vQ1BTMHYG\n" +
+            "CCsGAQUFBwEBBGowaDAkBggrBgEFBQcwAYYYaHR0cDovL29jc3AuZGlnaWNlcnQu\n" +
+            "Y29tMEAGCCsGAQUFBzAChjRodHRwOi8vY2FjZXJ0cy5kaWdpY2VydC5jb20vRGln\n" +
+            "aUNlcnRRVkVWVExTSUNBRzEuY3J0MAwGA1UdEwEB/wQCMAAwggEEBgorBgEEAdZ5\n" +
+            "AgQCBIH1BIHyAPAAdgApeb7wnjk5IfBWc59jpXflvld9nGAK+PlNXSZcJV3HhAAA\n" +
+            "AXdkNiYhAAAEAwBHMEUCIQDg62+lrhAGdZcklHTEzYpVIki6v6fYgsbxmkTqV6M2\n" +
+            "BgIgOcYjjM1DGT2FWFK5OO4Qs7T7V28neWwqbMPqLBZgRCoAdgAiRUUHWVUkVpY/\n" +
+            "oS/x922G4CMmY63AS39dxoNcbuIPAgAAAXdkNiaKAAAEAwBHMEUCIQC0ZH0YX6BP\n" +
+            "k4QAm22mVvXXG9EVBWIS5LP49f9VFhb67QIgfYqYV/wJt3czP5rA4NbJXBeFxZXy\n" +
+            "DVnewfs2mz7kNOIwDQYJKoZIhvcNAQELBQADggEBAHIFaq9Edv37sXl07n3H93ym\n" +
+            "AzvQKJGD1khWwHQCGBXVzpUBi2v9Il0oS2pTATGD3ZB81Clryy9X3gHgkJcHFRn0\n" +
+            "cVr88GcyEWrxE8D6sx1X4WhlQknbKXNw8eL97EpZ4zKF1nDaYmf+e/lbmjnZIcdr\n" +
+            "DRcMmWD6LZBWP8MMD+5uJvooO4eBYM/WKVRgg6jAj1HELBHi9E6Xwm5jPx3DKt6W\n" +
+            "voJqcRJg3d4TiV8U/yOs8+514iAw+1YJFtAaxg5/eUQM/22BGXki8QCJ3NaaUGrj\n" +
+            "UNASswMDevD8rVwZ5Bc2iC+c0WVIgHZepyioNC2XSVPovV9pF4Q3ppkSvEGQGSo=\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=qvsslrca2g3-ev-r.quovadisglobal.com, O=QuoVadis Limited, L=Hamilton,
-    // ST=Pembroke, C=BM, SERIALNUMBER=28474, OID.2.5.4.15=Private Organization,
-    // OID.1.3.6.1.4.1.311.60.2.1.3=BM
+    // Owner: CN=quovadis-root-ca-2-g3-revoked.chain-demos.digicert.com, O="DigiCert, Inc.", L=Lehi, ST=Utah, C=US,
+    // SERIALNUMBER=5299537-0142, OID.1.3.6.1.4.1.311.60.2.1.2=Utah, OID.1.3.6.1.4.1.311.60.2.1.3=US,
+    // OID.2.5.4.15=Private Organization
+    // Issuer: CN=DigiCert QV EV TLS ICA G1, O="DigiCert, Inc.", C=US
+    // Serial number: 27c8845dc98ebf433dc5ce8618570d1
+    // Valid from: Mon Feb 01 16:00:00 PST 2021 until: Sat Mar 05 15:59:59 PST 2022
     private static final String REVOKED = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIH4TCCBcmgAwIBAgIUZTuy16qm4LnioIRmiaQZuThb38gwDQYJKoZIhvcNAQEL\n" +
-            "BQAwSTELMAkGA1UEBhMCQk0xGTAXBgNVBAoMEFF1b1ZhZGlzIExpbWl0ZWQxHzAd\n" +
-            "BgNVBAMMFlF1b1ZhZGlzIEVWIFNTTCBJQ0EgRzMwHhcNMTcwNDE4MTg1NjQ0WhcN\n" +
-            "MTkwNDE4MTkwNjAwWjCBwDETMBEGCysGAQQBgjc8AgEDEwJCTTEdMBsGA1UEDwwU\n" +
-            "UHJpdmF0ZSBPcmdhbml6YXRpb24xDjAMBgNVBAUTBTI4NDc0MQswCQYDVQQGEwJC\n" +
-            "TTERMA8GA1UECAwIUGVtYnJva2UxETAPBgNVBAcMCEhhbWlsdG9uMRkwFwYDVQQK\n" +
-            "DBBRdW9WYWRpcyBMaW1pdGVkMSwwKgYDVQQDDCNxdnNzbHJjYTJnMy1ldi1yLnF1\n" +
-            "b3ZhZGlzZ2xvYmFsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\n" +
-            "ALXMNTuogjC2wpziEXbKztdgzBflORLxoAo5Y8HNAZVo8MgJJucshZ5S6cmRjreY\n" +
-            "fOlwo85Vu9s39EMRR+I0AZLbxw2PZxNSHUxTCzWlmJ4yValRPRZjz2LXJ+mjpkc3\n" +
-            "hsVHtCawvPqh2uNwM2qUD6zKfRGdKC27NeICjYe7RtfhLRdrZ8MNtVWMrrFt3Dzd\n" +
-            "SRJXFcLkN4rPzRFCxldU2yH6V4cZwnVz4XxV/nbljVtGyMJWGVzU0Bhy1fedAJ9x\n" +
-            "KGJbM6wackOlpUm0XMQdFxHF2tW4Sus6Mcf+2N8FgXk4PnwXarIc/Sj5Tx+Bvf5y\n" +
-            "TwBOGS02Hzs07ILV3w4dp00CAwEAAaOCA0cwggNDMHgGCCsGAQUFBwEBBGwwajA5\n" +
-            "BggrBgEFBQcwAoYtaHR0cDovL3RydXN0LnF1b3ZhZGlzZ2xvYmFsLmNvbS9xdmV2\n" +
-            "c3NsZzMuY3J0MC0GCCsGAQUFBzABhiFodHRwOi8vZXYub2NzcC5xdW92YWRpc2ds\n" +
-            "b2JhbC5jb20wHQYDVR0OBBYEFALFAuUwkAiTXc+DIW861Mu1o/7RMAwGA1UdEwEB\n" +
-            "/wQCMAAwHwYDVR0jBBgwFoAU5YRU0JBJnzi68snhKgjFTp+gSD8wWgYDVR0gBFMw\n" +
-            "UTBGBgwrBgEEAb5YAAJkAQIwNjA0BggrBgEFBQcCARYoaHR0cDovL3d3dy5xdW92\n" +
-            "YWRpc2dsb2JhbC5jb20vcmVwb3NpdG9yeTAHBgVngQwBATA8BgNVHR8ENTAzMDGg\n" +
-            "L6AthitodHRwOi8vY3JsLnF1b3ZhZGlzZ2xvYmFsLmNvbS9xdmV2c3NsZzMuY3Js\n" +
-            "MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEw\n" +
-            "LgYDVR0RBCcwJYIjcXZzc2xyY2EyZzMtZXYtci5xdW92YWRpc2dsb2JhbC5jb20w\n" +
-            "ggF+BgorBgEEAdZ5AgQCBIIBbgSCAWoBaAB2AFYUBpov18Ls0/XhvUSyPsdGdrm8\n" +
-            "mRFcwO+UmFXWidDdAAABW4J1uUEAAAQDAEcwRQIhAK2LD7cJrN7YYjyBqFDoZva+\n" +
-            "fae1CiuYyxpREVes1c8OAiBLVt/dGKnvwY2CW2TN3/WyRM7al2sLnM+XwNUGZDrJ\n" +
-            "pgB2ALvZ37wfinG1k5Qjl6qSe0c4V5UKq1LoGpCWZDaOHtGFAAABW4J1uVQAAAQD\n" +
-            "AEcwRQIhAIA9IjxIT69JGX+sl1okMiGsXfCOPq5crSX+m04Q7LcgAiBJWUsLDtm9\n" +
-            "5TKsGZvlJRKOn1CcA94sApQ4v+1D+uz+JQB2AKS5CZC0GFgUh7sTosxncAo8NZgE\n" +
-            "+RvfuON3zQ7IDdwQAAABW4J1uWwAAAQDAEcwRQIhAIWbEqGnZSIwrI5eWCIzfMRY\n" +
-            "A+onO3IjQrVAE6ZuGu2bAiAlyoRSfH4s8+lVL225AYD45OkJJfG41T6k+wVLM5Hg\n" +
-            "ezANBgkqhkiG9w0BAQsFAAOCAgEAPwvRI5GmzR72cDoh+7VPj7PihQDG4HBYq5Ta\n" +
-            "bF7NK2v9DoaU99vv01K3WBNIydjQX4j+IK8MoGp9dXV+LDUTsebnsY+nr3O4R0pK\n" +
-            "I2TAazN7zcy3SYc/MtaW7JI+/ckjHaJw+AT+qUz+l20p9shBFlg4QvH2cx2OOCat\n" +
-            "/CRnG2Nqc5nN1xVcS3aVDrGl36XIcjV+ab+3zicm3OhWqn/hlfBBWimuhix68i/L\n" +
-            "k+qUyN6A8Bz7NwsouzG7keS17VZbLFkOuczq9KxJLHtlI1OYFNzrLEx6aXeM5VoH\n" +
-            "mlwETxagSL6fjRvcCaM6As9WVRS08p/RldUrEw+O6r3ob7FaOywwIzSMFV1GbVFG\n" +
-            "eIrSMuSVwbQRa5Duakoe5vz1vOddrZPm3kqpvyT7j51nuedrjc8YgisuyMbxkf5s\n" +
-            "8tesqxdltXjFNwpwveYlgHAi3sZvO2dm6bEZcioxLEWEpwmYXrkBJWLhcILdfY99\n" +
-            "SWFAmwGtmCqh8Sxla77o+gaZkNKf3zBn/34Q91Z96qKgqjXDAGefsZiy4tQeEUJc\n" +
-            "2qIqjb2rWi5Vo7hn2eolNXzp6ZdanicpecpqwpmW9/v6YRxKLGTsdVz82TGWPnpt\n" +
-            "q3rCll0NIAfcjekFmRzmBWF1jOn4fCcF/WOxKW1T4JcMIcNoa5iI9M1WcVKQvJKA\n" +
-            "Zd5LLu4=\n" +
+            "MIIGzDCCBbSgAwIBAgIQAnyIRdyY6/Qz3FzoYYVw0TANBgkqhkiG9w0BAQsFADBK\n" +
+            "MQswCQYDVQQGEwJVUzEXMBUGA1UECgwORGlnaUNlcnQsIEluYy4xIjAgBgNVBAMM\n" +
+            "GURpZ2lDZXJ0IFFWIEVWIFRMUyBJQ0EgRzEwHhcNMjEwMjAyMDAwMDAwWhcNMjIw\n" +
+            "MzA1MjM1OTU5WjCB5zEdMBsGA1UEDwwUUHJpdmF0ZSBPcmdhbml6YXRpb24xEzAR\n" +
+            "BgsrBgEEAYI3PAIBAxMCVVMxFTATBgsrBgEEAYI3PAIBAhMEVXRhaDEVMBMGA1UE\n" +
+            "BRMMNTI5OTUzNy0wMTQyMQswCQYDVQQGEwJVUzENMAsGA1UECBMEVXRhaDENMAsG\n" +
+            "A1UEBxMETGVoaTEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4xPzA9BgNVBAMTNnF1\n" +
+            "b3ZhZGlzLXJvb3QtY2EtMi1nMy1yZXZva2VkLmNoYWluLWRlbW9zLmRpZ2ljZXJ0\n" +
+            "LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL8H5MLxLmlUrb/C\n" +
+            "+GndqTYyAWf7dlxmqK4bRtIQf6YIAum8sZwo7M+av3lNQAqRa9PsV4ms50lUSP6u\n" +
+            "sFPAKINoOIu3ABT3qlSNb7ChxYCaZAiW3D1N4Jc9SU4Pa6tfPM3mSWc2HR7kSqj+\n" +
+            "PtdDHgB8/wjgQwvGRFXTacM/dQVtd8cSLYGMaSgPTKqV87aps7gvd0a9jvJRPmzr\n" +
+            "vJihL8K5MRiKTwXofT2s8/+/XMn0qWzWzBPe/bQuTT3Ot0Ee5u54FVPi0659rDtj\n" +
+            "hDIf1M7GmSA/kuhcxI6vGusPZhrr+BbSbX8bRyXMPyE/V2qN2rGMVqDgo8CYP9oY\n" +
+            "BXBocaECAwEAAaOCAw4wggMKMB8GA1UdIwQYMBaAFBMvp+hucVH24gyYR4Oef514\n" +
+            "eTTzMB0GA1UdDgQWBBSxl5QSK4J6HfhClE1Vq1ElwnnNDzBBBgNVHREEOjA4gjZx\n" +
+            "dW92YWRpcy1yb290LWNhLTItZzMtcmV2b2tlZC5jaGFpbi1kZW1vcy5kaWdpY2Vy\n" +
+            "dC5jb20wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEF\n" +
+            "BQcDAjB7BgNVHR8EdDByMDegNaAzhjFodHRwOi8vY3JsMy5kaWdpY2VydC5jb20v\n" +
+            "RGlnaUNlcnRRVkVWVExTSUNBRzEuY3JsMDegNaAzhjFodHRwOi8vY3JsNC5kaWdp\n" +
+            "Y2VydC5jb20vRGlnaUNlcnRRVkVWVExTSUNBRzEuY3JsMEoGA1UdIARDMEEwCwYJ\n" +
+            "YIZIAYb9bAIBMDIGBWeBDAEBMCkwJwYIKwYBBQUHAgEWG2h0dHA6Ly93d3cuZGln\n" +
+            "aWNlcnQuY29tL0NQUzB2BggrBgEFBQcBAQRqMGgwJAYIKwYBBQUHMAGGGGh0dHA6\n" +
+            "Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBABggrBgEFBQcwAoY0aHR0cDovL2NhY2VydHMu\n" +
+            "ZGlnaWNlcnQuY29tL0RpZ2lDZXJ0UVZFVlRMU0lDQUcxLmNydDAMBgNVHRMBAf8E\n" +
+            "AjAAMIIBBQYKKwYBBAHWeQIEAgSB9gSB8wDxAHcAKXm+8J45OSHwVnOfY6V35b5X\n" +
+            "fZxgCvj5TV0mXCVdx4QAAAF3ZDY16wAABAMASDBGAiEAxiHgWMmElnreF1ItPryX\n" +
+            "1zHYYy8MswsWwPSLCRoNIh8CIQCoMhTfGdeb/YfgU7ADy0zo1ktLjnoWUXy57e2s\n" +
+            "syevwAB2ACJFRQdZVSRWlj+hL/H3bYbgIyZjrcBLf13Gg1xu4g8CAAABd2Q2Nh0A\n" +
+            "AAQDAEcwRQIhAIEUtUcXMIj/5+uNhqtRuzeppiC0dU9pcWuCkOqazlSsAiBeuAjH\n" +
+            "z1EyH5zDDR2dJoVJekXsihpIoXUiClDNBgCNUjANBgkqhkiG9w0BAQsFAAOCAQEA\n" +
+            "s/QeNaPZt8WftrnUqWI+neGyFlh6odWgpKxudOKVdvlGIUZ1bZlNzPcoHvdqgeVy\n" +
+            "Vys3NxfSAX812lYo+IvPM9l3CmuaHkb7l/5O8bwnEPZuLd6EExp8BVYCIwfW+9cm\n" +
+            "uyHXBJUEm1gkF2Utd8EYdf4jEcBCdDIXgNJI+DY05OlHE0E2IseQIHf9kttZzQHH\n" +
+            "QEVtowJsaa2EksksBAmDDHH6ybyee7bZl8W2xkpbzvUvb6SuK+M/XyUjS9SYtun3\n" +
+            "z82BhOhRMbpokpK2Eba6IeC7WoVX2Y8Wsqj198qTVvuyRiw2B3SdZarKV5VTySY3\n" +
+            "aqsEyxenca5EjxU7QZDAHQ==\n" +
             "-----END CERTIFICATE-----";
 
     public void runTest(ValidatePathWithParams pathValidator)
@@ -335,126 +332,132 @@ class RootCA2G3 {
         // Validate Revoked
         pathValidator.validate(new String[]{REVOKED, INT},
                 ValidatePathWithParams.Status.REVOKED,
-                "Tue Apr 18 12:23:14 PDT 2017", System.out);
+                "Tue Feb 02 11:26:52 PST 2021", System.out);
     }
 }
 
 class RootCA3G3 {
 
-    // Owner: CN=QuoVadis QVRCA3G3 SSL ICA, O=QuoVadis Limited, C=BM
+    // Owner: CN=DigiCert QuoVadis TLS ICA QV Root CA 3 G3, O="DigiCert, Inc", C=US
+    // Issuer: CN=QuoVadis Root CA 3 G3, O=QuoVadis Limited, C=BM
+    // Serial number: 427dd33a8ff51d8152e813c7dec93ba76312a7d8
+    // Valid from: Wed Jan 06 12:55:40 PST 2021 until: Sat Jan 04 12:55:40 PST 2031
     private static final String INT = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIGszCCBJugAwIBAgIURUME8OY/YBHyokbgxoTKpPcoiHYwDQYJKoZIhvcNAQEL\n" +
+            "MIIFgDCCA2igAwIBAgIUQn3TOo/1HYFS6BPH3sk7p2MSp9gwDQYJKoZIhvcNAQEL\n" +
             "BQAwSDELMAkGA1UEBhMCQk0xGTAXBgNVBAoTEFF1b1ZhZGlzIExpbWl0ZWQxHjAc\n" +
-            "BgNVBAMTFVF1b1ZhZGlzIFJvb3QgQ0EgMyBHMzAeFw0xNzA0MTkxNDQ4NDBaFw0y\n" +
-            "NzA0MTkxNDQ4NDBaMEwxCzAJBgNVBAYTAkJNMRkwFwYDVQQKDBBRdW9WYWRpcyBM\n" +
-            "aW1pdGVkMSIwIAYDVQQDDBlRdW9WYWRpcyBRVlJDQTNHMyBTU0wgSUNBMIICIjAN\n" +
-            "BgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAt8UIgFvcneWgv29aR2/UV810uW9N\n" +
-            "VpvdEgQDPHao5+i3IwCH1GrV8KeC25vfJAuW2TJ5gHeN5fmWAtWU8NDaNwGxJq/w\n" +
-            "jlOe/UW0KSosuuOBltLY9fl+7lDYqBjEwmCGvZMQOzpsbm8QUYTuZmtw96sT5beZ\n" +
-            "Kwqub/NBDE59IZ+b82obreNFFOgwcHv9E00bfRW7kizNfaC8AiwgV9WfIFgvtb4+\n" +
-            "YflcgGbdWnmNvwL8aZGWpGYjw/H/0kpwfMgrVF3Q7h8Y0yTg/jj8ZdXLdaE/PQzx\n" +
-            "8RUU4xJGxply/RrNUEvm9xeXZG3ssLW56WDEhRLkORX/zF4/mVyO2DpGJs06IUSP\n" +
-            "VWe+JuJGT1UxWqIsDIIHqJNa2BYl6O/XOjE2oGxiCb9w0/kQ8tKWWynFx4XOtrjA\n" +
-            "pGktsjw66tqE08XWOuoKwAXH2Llwz+VGSMzrCDH98VHtAu/XpEjuW3iP+I7EHksm\n" +
-            "W2eLdQdvTJ5DBdLsspIG4HC9Ke+c/gCEJHvOURPXoY7j9JPcQLc+5O7kBqiIjEBU\n" +
-            "NpPX37x7z3msac/IiG/SOYl+kiBESV44QFIOl8sHYmj9HGNlkQz4B/inuGwifIux\n" +
-            "rfdvm6nrpC7jhd/5Ptk4PO1kcAtgwcB99BnRCw47Xl7hrERTpoRISReNG0JMK7Op\n" +
-            "wVFqyi7bV1U/l4MCAwEAAaOCAY8wggGLMBIGA1UdEwEB/wQIMAYBAf8CAQAwSQYD\n" +
-            "VR0gBEIwQDA+BgRVHSAAMDYwNAYIKwYBBQUHAgEWKGh0dHA6Ly93d3cucXVvdmFk\n" +
-            "aXNnbG9iYWwuY29tL3JlcG9zaXRvcnkwdAYIKwYBBQUHAQEEaDBmMCoGCCsGAQUF\n" +
-            "BzABhh5odHRwOi8vb2NzcC5xdW92YWRpc2dsb2JhbC5jb20wOAYIKwYBBQUHMAKG\n" +
-            "LGh0dHA6Ly90cnVzdC5xdW92YWRpc2dsb2JhbC5jb20vcXZyY2EzZzMuY3J0MA4G\n" +
-            "A1UdDwEB/wQEAwIBBjAnBgNVHSUEIDAeBggrBgEFBQcDAQYIKwYBBQUHAwIGCCsG\n" +
-            "AQUFBwMJMB8GA1UdIwQYMBaAFMYX0Lyo6gJD8hsGmV0rkCC515zkMDsGA1UdHwQ0\n" +
-            "MDIwMKAuoCyGKmh0dHA6Ly9jcmwucXVvdmFkaXNnbG9iYWwuY29tL3F2cmNhM2cz\n" +
-            "LmNybDAdBgNVHQ4EFgQUTknx5HQLmDQSOuWxVX3EknK1r6QwDQYJKoZIhvcNAQEL\n" +
-            "BQADggIBAHfmIJkd+URmnVm0X1/43QXu08RTzUr1zjf4ZBVtzUFoEkfZm+zKlhb7\n" +
-            "QeYJ5lprX1tdRfHLI+JC7oyI5+7/0q1j2FN2g0oKYN63dIgtppoCNpBu58f69YxL\n" +
-            "Y3GPSCfgs+ld+HegNSTjQVzelr16aFo9sj1fzUwY4Xj+xEYDjYxFmNGSXY37+DdN\n" +
-            "3WPm1iahBNNCZGfXq5T4qr6+R6RWwxsaBdQfZh3efGB1WG4DVSQBoiCKjS7Eg+Mf\n" +
-            "LT+KEZgawLUVrt/sT5lNfw23XA1gxIOcNRBHjsTWbtTBHJeb8hYvXB38UGK4GfIo\n" +
-            "NxtvRyXgG/U8+OuCQPS2SpJ1VH+yZ4Tn3G4k2+WillxfpqCVgHDVuT8wigw1xUNb\n" +
-            "0Ft9F3OWftWCVILaYEcyuJrnL3jjcZXc/zG01wIGDFvlPshRifVs/69Xq9UQmMfB\n" +
-            "GUh6MteDIsN9NdiArcumSC1dNoA/9eESp1pb186lDx9KxRQ/3NJRDMOIsMYN8Lyu\n" +
-            "cDNzsnymtQyIm3YG7VmZi/6k99n9vT8Ff9PvQ49cdfPl8GIONMdYmhTtLtuC00AU\n" +
-            "550HVLnpFW8d1NX3+XKxQ5FG04nsTxUD2FtT+trEQouktPq9iFqZN+PLPi8UdrBW\n" +
-            "AGUDCnO/TNo7IPW6arQrFpYbRLStiOJw7204Mjuqco/1KcqnEiIC\n" +
+            "BgNVBAMTFVF1b1ZhZGlzIFJvb3QgQ0EgMyBHMzAeFw0yMTAxMDYyMDU1NDBaFw0z\n" +
+            "MTAxMDQyMDU1NDBaMFkxCzAJBgNVBAYTAlVTMRYwFAYDVQQKDA1EaWdpQ2VydCwg\n" +
+            "SW5jMTIwMAYDVQQDDClEaWdpQ2VydCBRdW9WYWRpcyBUTFMgSUNBIFFWIFJvb3Qg\n" +
+            "Q0EgMyBHMzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALxNTdqnFD+A\n" +
+            "MhketYfVfVUWQKPkVEuyYj7Y2uwXBMRP4RStO4CoQih+hX/h94vRlObOIsqcNnyC\n" +
+            "ElwBnLbmusaWYLYnDEWoROL8uN0pkWk0asfhhEsXTkAJ6FLHUD85WBkED4gIVWPi\n" +
+            "Sp4AOwiA+/zpbwgVAgdjJTO3jjMsp4F1lBrdViYSwoPRACH1ZMjJG572oXTpZkQX\n" +
+            "uWmEKLUOnik1i5cbqGLnwXiDvTAhxit7aBlj/C5IDvONWVQL34ZTYppvo8S3Hhy9\n" +
+            "xX0S4HCpTpeBe3mas7VOrjsXNlEoFvejrxcQ+fB/gUf6fLUPxUhcPtm8keBPQuxc\n" +
+            "qP12/+KG0WECAwEAAaOCAU8wggFLMBIGA1UdEwEB/wQIMAYBAf8CAQAwHwYDVR0j\n" +
+            "BBgwFoAUxhfQvKjqAkPyGwaZXSuQILnXnOQwdAYIKwYBBQUHAQEEaDBmMDgGCCsG\n" +
+            "AQUFBzAChixodHRwOi8vdHJ1c3QucXVvdmFkaXNnbG9iYWwuY29tL3F2cmNhM2cz\n" +
+            "LmNydDAqBggrBgEFBQcwAYYeaHR0cDovL29jc3AucXVvdmFkaXNnbG9iYWwuY29t\n" +
+            "MBMGA1UdIAQMMAowCAYGZ4EMAQICMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEF\n" +
+            "BQcDATA7BgNVHR8ENDAyMDCgLqAshipodHRwOi8vY3JsLnF1b3ZhZGlzZ2xvYmFs\n" +
+            "LmNvbS9xdnJjYTNnMy5jcmwwHQYDVR0OBBYEFDNm+y+RBcyzYlLvzTz1fhzOpxeW\n" +
+            "MA4GA1UdDwEB/wQEAwIBhjANBgkqhkiG9w0BAQsFAAOCAgEAY0ZuDgyM4I4MO9ll\n" +
+            "D8qFUPQ8xtcGOuJgSRhDS2onIJ0M8yOGOYJCobIEGIgqyx94kI/n/1Xw+Wvsnhwb\n" +
+            "OYOtVedx6VGDu6IuSKTVgPPhzwKP5ZA7wtmgKR8+W4E3DM1VerA9Po9ycDK9qCdl\n" +
+            "K4tuF37grKEzlQKovG+kn0z+Zi0D/E1kN1Q8YmX35HHRenJWKEnAL9QROh0X9jFi\n" +
+            "SlsHPrxWC3adOdAW+B+kVG0cM2nurd0Ic2YkiLKOOaSd5hbCQY/fCZwohtest+ZU\n" +
+            "Ajyd+FVzSNvEFrwPzZwKfcdemvD4kew8lx5sG6BUL4GkFWnotxSr+F9Huwgj4pC+\n" +
+            "cxE2841a/9r/gliuwDM/8jkt16epFAdw0fXemyM8FdHJDnB++3d8SyjOOQ8j+VHW\n" +
+            "31NWx27sORa5CgRchlldXWDzIIEwbc82a1OAfGUmNAsdEHjMl1HMcZHbjCmdSdsw\n" +
+            "fmyldZrj2YmvOI5ZlE9z4vzi35KyqlxWCtu9O/SJq/rBvYS0TPmm8HbhJQbeMe6p\n" +
+            "vJGrxcb1muSBANn9T9wvukjiNNw32ciSDCjZ0h4N+CGxbzoZtgIAQ29IunYdnJix\n" +
+            "ZiP+ED6xvwgVRBkDSgWD2W/hex/+z4fNmGQJDcri51/tZCqHHv2Y7XReuf4Fk+nP\n" +
+            "l8Sd/Kpqwde/sJkoqwDcBSJygh0=\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=qvsslrca3g3-ssl-v.quovadisglobal.com, O=QuoVadis Limited, L=Hamilton,
-    // ST=Pembroke, C=BM
+    // Owner: CN=quovadis-root-ca-3-g3.chain-demos.digicert.com, O="DigiCert, Inc.", L=Lehi, ST=Utah, C=US
+    // Issuer: CN=DigiCert QuoVadis TLS ICA QV Root CA 3 G3, O="DigiCert, Inc", C=US
+    // Serial number: 19a05758f4ac7061ce9b3badd54d9b3
+    // Valid from: Tue Jan 19 16:00:00 PST 2021 until: Sun Feb 20 15:59:59 PST 2022
     private static final String VALID = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIGJzCCBA+gAwIBAgIUatc95M2rfpt/opXnck37WXW2RpAwDQYJKoZIhvcNAQEL\n" +
-            "BQAwTDELMAkGA1UEBhMCQk0xGTAXBgNVBAoMEFF1b1ZhZGlzIExpbWl0ZWQxIjAg\n" +
-            "BgNVBAMMGVF1b1ZhZGlzIFFWUkNBM0czIFNTTCBJQ0EwHhcNMTcwNTAyMTY1OTAy\n" +
-            "WhcNMjAwNTAyMTcwOTAwWjB9MQswCQYDVQQGEwJCTTERMA8GA1UECAwIUGVtYnJv\n" +
-            "a2UxETAPBgNVBAcMCEhhbWlsdG9uMRkwFwYDVQQKDBBRdW9WYWRpcyBMaW1pdGVk\n" +
-            "MS0wKwYDVQQDDCRxdnNzbHJjYTNnMy1zc2wtdi5xdW92YWRpc2dsb2JhbC5jb20w\n" +
-            "ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC+S725uLLelMIYHWuh6fbT\n" +
-            "lGdi7wf1BlsfQY/ZnLvsFbT1KHodE407RXP0NB6AeEBOlO8xQxaZ5b38aF+HROJw\n" +
-            "TcvUAgQHmNE+ER0JCMi42jSFC2dc93PhdcUEeesxIfu1iIKXxFmlbJtJxG3l27yJ\n" +
-            "L4ufum9iQYeZeoGXAr54x6JMY29kl5t9QM018d9sA9bHY+0iVJevM3xgxVe7xApw\n" +
-            "MSKoZH/OmkX8FaEW9b7TqrWfWcAdD8fkXK8lHCDqmUzSiDGJP16YeQA/4dmFO2vr\n" +
-            "ItXY8rTPjXoaolebHxf5WG5Qosxv0mPyklUb+SVSJagv66zl/H2Uk0bLyFFmuNAd\n" +
-            "AgMBAAGjggHOMIIByjB6BggrBgEFBQcBAQRuMGwwPgYIKwYBBQUHMAKGMmh0dHA6\n" +
-            "Ly90cnVzdC5xdW92YWRpc2dsb2JhbC5jb20vcXZyY2EzZzNzc2xpY2EuY3J0MCoG\n" +
-            "CCsGAQUFBzABhh5odHRwOi8vb2NzcC5xdW92YWRpc2dsb2JhbC5jb20wHQYDVR0O\n" +
-            "BBYEFFhZXE0P1SMuntLc7JYoHTcD8JKfMB8GA1UdIwQYMBaAFE5J8eR0C5g0Ejrl\n" +
-            "sVV9xJJyta+kMGkGA1UdIARiMGAwRgYMKwYBBAG+WAADZAEBMDYwNAYIKwYBBQUH\n" +
-            "AgEWKGh0dHA6Ly93d3cucXVvdmFkaXNnbG9iYWwuY29tL3JlcG9zaXRvcnkwCAYG\n" +
-            "Z4EMAQICMAwGCisGAQQBvlgBhFgwQQYDVR0fBDowODA2oDSgMoYwaHR0cDovL2Ny\n" +
-            "bC5xdW92YWRpc2dsb2JhbC5jb20vcXZyY2EzZzNzc2xpY2EuY3JsMA4GA1UdDwEB\n" +
-            "/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwLwYDVR0RBCgw\n" +
-            "JoIkcXZzc2xyY2EzZzMtc3NsLXYucXVvdmFkaXNnbG9iYWwuY29tMA0GCSqGSIb3\n" +
-            "DQEBCwUAA4ICAQB6QV56jPZzFbFNnKq4xRglTkZSLDMnyrmquWJr4xUWkWIqhQqC\n" +
-            "s+wAchy39Uuu+Nv99N1AxJhorpdbyIOd7B2NAnUXPeOa1Rm34mh2a/df0gTVrrWJ\n" +
-            "YSUd3Tv7tcGrMXa7kNaP0N3lTITC0F0fu0rLyCH5I28t4zkCXadcWTqHUKIDNS1h\n" +
-            "fwx1Y6Dq4fBhKQGpqBq4ThEpBgJdj5aGCNiYfKO/MTDrLxD1BpIjV88O+54cdtYp\n" +
-            "3K+UDN2lP03PNH4Z/0jF4K43DHpwDM0r6qP4yLqFf3K1NlzGkYgNlMrKUPSlu+M8\n" +
-            "F6R45TWkcHndk3SUxbtGsxhiLG4xJKY7Zm/0vSxNqia+UJ5wL5s+IoiXhj22RrPe\n" +
-            "kcx7u3MxB+KWSrtQd8y624J6tqbE7R+aaAX95KTQZoawjypX99P8Kir/NynFHYri\n" +
-            "RAX9qFU8nYQEAe47oxl0bIr7URiQrlz+FJ/bzJZQwROWY723JPXgv7wUMifCYvJz\n" +
-            "4pLkuc4KE+LIEqk5LUuoYGEhKhKVu8YnmDifPPrBBADNvAnnGfDZF9FRvIcD6h8H\n" +
-            "icZBXJHOgu70Rh8Zc77x+v29tKlAJVtswLlV0mVClDUk7U36XL+mAvYntnG9kH5x\n" +
-            "qQ2Fl7AkUewOd4tLeiN4fl+S+ceW9sOZPSWx5aLui9p2mmxuyxhC5egCzg==\n" +
+            "MIIGhjCCBW6gAwIBAgIQAZoFdY9KxwYc6bO63VTZszANBgkqhkiG9w0BAQsFADBZ\n" +
+            "MQswCQYDVQQGEwJVUzEWMBQGA1UECgwNRGlnaUNlcnQsIEluYzEyMDAGA1UEAwwp\n" +
+            "RGlnaUNlcnQgUXVvVmFkaXMgVExTIElDQSBRViBSb290IENBIDMgRzMwHhcNMjEw\n" +
+            "MTIwMDAwMDAwWhcNMjIwMjIwMjM1OTU5WjB9MQswCQYDVQQGEwJVUzENMAsGA1UE\n" +
+            "CBMEVXRhaDENMAsGA1UEBxMETGVoaTEXMBUGA1UEChMORGlnaUNlcnQsIEluYy4x\n" +
+            "NzA1BgNVBAMTLnF1b3ZhZGlzLXJvb3QtY2EtMy1nMy5jaGFpbi1kZW1vcy5kaWdp\n" +
+            "Y2VydC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDCm/KON4FI\n" +
+            "zslgCHcJkdamTiryUif9w+BD1xGb7W7hCo+JuLkMzDSH+gGAdwdjYK1NY5c0gFiw\n" +
+            "Ud3OeHbNe7dZJSXhBP1oF3Xwl0f0DWIfa9nJObzQrN94PnYzDNGuFZut69dqzghO\n" +
+            "1QGG/+dVdITvzqyA/Mqy7TUsZyoaG4OALTdOXAlFmeMf5UP7EDrAEC0dlUoYJnwK\n" +
+            "0BeRNZDPYc/OsHviNa6/PnBli81C1QSrAT93STEAnWsCJrG8KlbSElYz2zwPwBZ7\n" +
+            "ye1m8vH/K7npIIL0d/vSCxLUbC1pstOUahXvZE/Wl1zIV+JyCRmZS7sxTy6s5M4+\n" +
+            "31Va8Y9jdbeBAgMBAAGjggMkMIIDIDAfBgNVHSMEGDAWgBQzZvsvkQXMs2JS7808\n" +
+            "9X4czqcXljAdBgNVHQ4EFgQUsVGPx+H0EHp+wefHsSq0rN9eOzMwOQYDVR0RBDIw\n" +
+            "MIIucXVvdmFkaXMtcm9vdC1jYS0zLWczLmNoYWluLWRlbW9zLmRpZ2ljZXJ0LmNv\n" +
+            "bTAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMC\n" +
+            "MIGXBgNVHR8EgY8wgYwwRKBCoECGPmh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9E\n" +
+            "aWdpQ2VydFF1b1ZhZGlzVExTSUNBUVZSb290Q0EzRzMuY3JsMESgQqBAhj5odHRw\n" +
+            "Oi8vY3JsNC5kaWdpY2VydC5jb20vRGlnaUNlcnRRdW9WYWRpc1RMU0lDQVFWUm9v\n" +
+            "dENBM0czLmNybDA+BgNVHSAENzA1MDMGBmeBDAECAjApMCcGCCsGAQUFBwIBFhto\n" +
+            "dHRwOi8vd3d3LmRpZ2ljZXJ0LmNvbS9DUFMwgYMGCCsGAQUFBwEBBHcwdTAkBggr\n" +
+            "BgEFBQcwAYYYaHR0cDovL29jc3AuZGlnaWNlcnQuY29tME0GCCsGAQUFBzAChkFo\n" +
+            "dHRwOi8vY2FjZXJ0cy5kaWdpY2VydC5jb20vRGlnaUNlcnRRdW9WYWRpc1RMU0lD\n" +
+            "QVFWUm9vdENBM0czLmNydDAMBgNVHRMBAf8EAjAAMIIBBAYKKwYBBAHWeQIEAgSB\n" +
+            "9QSB8gDwAHYAKXm+8J45OSHwVnOfY6V35b5XfZxgCvj5TV0mXCVdx4QAAAF3IHx1\n" +
+            "rwAABAMARzBFAiAHK4QuN606ween6tDb2EiNdYTNGhWayvJemSNKuGIELgIhAKaF\n" +
+            "1/emwlNTMJDlG+kqEhqeO/+XjtfUfhdIeT8dR7dPAHYAIkVFB1lVJFaWP6Ev8fdt\n" +
+            "huAjJmOtwEt/XcaDXG7iDwIAAAF3IHx13QAABAMARzBFAiEA7qBblGimuzeSA3S5\n" +
+            "hkE+fVi0DLn/eElclZRk/RSCcsECIDN91iQV6iQryAeD597RExuxunvz+DXn6iz7\n" +
+            "43/4LdbkMA0GCSqGSIb3DQEBCwUAA4IBAQBZl4PoBJhh6j32nW39aRpOWTEhxZt+\n" +
+            "NItfFhaQSrJWWmWkKyIQ6roKf8mDyf2x6PGiWV1+ZLEJ5iUmuFtcjlvdd6PjP2J9\n" +
+            "qEev/kWfdnBY0Ocvfo6ZYhXy/9lW/1s9RQSNiEXTAi+C3R6iTQ5RYW6w4mStynqH\n" +
+            "dDO763+aE7vxSh6BxvbZugbkDkrHpjrpoWceT0huwbS7y7U0mk94eXXnTzisBHPY\n" +
+            "zbWlJNJVmt2ut9L9TIAZfqTmdWNKVXiVd2tOB2vKwHYzKM55/LqwcX+XfSpT2FQP\n" +
+            "OQ1TllgAl+B+4PexVRfO7MNuZgKwT8LuJp1d6xZNvXiNx6dhNBnaY7eE\n" +
             "-----END CERTIFICATE-----";
 
-    // Owner: CN=qvsslrca3g3-ssl-r.quovadisglobal.com, O=QuoVadis Limited, L=Hamilton,
-    // ST=Pembroke, C=BM
+    // Owner: CN=quovadis-root-ca-3-g3-revoked.chain-demos.digicert.com, O="DigiCert, Inc.", L=Lehi, ST=Utah, C=US
+    // Issuer: CN=DigiCert QuoVadis TLS ICA QV Root CA 3 G3, O="DigiCert, Inc", C=US
+    // Serial number: 804a1f35d45fb0f799c9dd1e54f0a41
+    // Valid from: Tue Jan 19 16:00:00 PST 2021 until: Sun Feb 20 15:59:59 PST 2022
     private static final String REVOKED = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIGJzCCBA+gAwIBAgIUTgJvLquqZ+Padg/W5Y0bTu9jimswDQYJKoZIhvcNAQEL\n" +
-            "BQAwTDELMAkGA1UEBhMCQk0xGTAXBgNVBAoMEFF1b1ZhZGlzIExpbWl0ZWQxIjAg\n" +
-            "BgNVBAMMGVF1b1ZhZGlzIFFWUkNBM0czIFNTTCBJQ0EwHhcNMTcwNTAyMTY1ODQy\n" +
-            "WhcNMjAwNTAyMTcwODAwWjB9MQswCQYDVQQGEwJCTTERMA8GA1UECAwIUGVtYnJv\n" +
-            "a2UxETAPBgNVBAcMCEhhbWlsdG9uMRkwFwYDVQQKDBBRdW9WYWRpcyBMaW1pdGVk\n" +
-            "MS0wKwYDVQQDDCRxdnNzbHJjYTNnMy1zc2wtci5xdW92YWRpc2dsb2JhbC5jb20w\n" +
-            "ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCOdbnnY8GsO002xJ6Snu2W\n" +
-            "snpPmW9ZJ4cEKzdBA4fYKP2V/8ibbOZVH5gI4tSSW+mcMrepS9Jw49sZaKOOGf/7\n" +
-            "YsjFOp4DQ0+w/7FOj4WrKWBhymDGKI8SsDqoCkxjCYkAc7cutm5Ge67Yto2mvkzW\n" +
-            "vThV7o9pJ4z2kMg+Q527908zvP1eqT2g+72X1L3o3RSdGM5V35R+lGiBDum8ojZm\n" +
-            "+QGCGuc6zROgumfYrh11iTNhXJw6KVAS9KJ5GSHzmua/Cu1dwC2SPxp/hRRHlvPp\n" +
-            "07EjY2oGhfe6Hvsu9YuoQCm95H4HPTmTDUCKURRIGcC8jdrjXBowEuH15vUocSIJ\n" +
-            "AgMBAAGjggHOMIIByjB6BggrBgEFBQcBAQRuMGwwPgYIKwYBBQUHMAKGMmh0dHA6\n" +
-            "Ly90cnVzdC5xdW92YWRpc2dsb2JhbC5jb20vcXZyY2EzZzNzc2xpY2EuY3J0MCoG\n" +
-            "CCsGAQUFBzABhh5odHRwOi8vb2NzcC5xdW92YWRpc2dsb2JhbC5jb20wHQYDVR0O\n" +
-            "BBYEFLzYzgqJRXrnLc5OYHF/koTdbIzeMB8GA1UdIwQYMBaAFE5J8eR0C5g0Ejrl\n" +
-            "sVV9xJJyta+kMGkGA1UdIARiMGAwRgYMKwYBBAG+WAADZAEBMDYwNAYIKwYBBQUH\n" +
-            "AgEWKGh0dHA6Ly93d3cucXVvdmFkaXNnbG9iYWwuY29tL3JlcG9zaXRvcnkwCAYG\n" +
-            "Z4EMAQICMAwGCisGAQQBvlgBhFgwQQYDVR0fBDowODA2oDSgMoYwaHR0cDovL2Ny\n" +
-            "bC5xdW92YWRpc2dsb2JhbC5jb20vcXZyY2EzZzNzc2xpY2EuY3JsMA4GA1UdDwEB\n" +
-            "/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwLwYDVR0RBCgw\n" +
-            "JoIkcXZzc2xyY2EzZzMtc3NsLXIucXVvdmFkaXNnbG9iYWwuY29tMA0GCSqGSIb3\n" +
-            "DQEBCwUAA4ICAQAge+6VZgaEFxN38q0MYKs/QbdGowLd5n2CfQfpdOTRnpOtKQw6\n" +
-            "Bc/o1O8O/y0XUl1Be7TCgfXKWgw+rKX+ZrI6wCm7MxYlWXV2guWU/AeEl2uv14s/\n" +
-            "KnKhzZHfb0eQyItfk23flubc7pbh99LaVqozsLCTL78lOB7N7ZQwsNCrEghHWMxl\n" +
-            "w1/IX/h9XOJoBzu4ulebJoQ3hdIYJY7+lkw64uH1FNrCu7P/jjU9ZlPaobZOUy64\n" +
-            "sYIt4GsZbMFaUiamNzBUvULw+ZkZq0hTK0cuyA85MXd+3rm5z2AMemC/29XTUYRU\n" +
-            "L9LkxMF71w8BJzgpVx3s0a6dfi6XtgacP407IhMc3EW1McsSWdT6jL0zidbjXisU\n" +
-            "vfvuzA50b3HwYz8PsRN0Zfi2R1BubaZQ9fQW2fe1EWgq80CqOdO7eNZeaBxbW/qB\n" +
-            "smGA1wiHIVEtyHbwZslcKNy8VPKurfKClwZQxf17/oK6QrhOgxiKJGYBUDTa7Ln7\n" +
-            "Qslp/y3G721NOXzborchs8XB+BYEETtWWkKoWFDiV7vkfyn3x2cYNiv5JCWDszhZ\n" +
-            "RyVrW26YOQ3MqBAiYqgbU2jMdqeRRfMIFqUvvXwoTvYXuN4Yc2ZAOmCBPpUxo66V\n" +
-            "zHDu+QK/2/pI1SMLvU3KG526gUtDd67t8JUHqxyo3NsXUCD8tUYpaJy/vg==\n" +
+            "MIIGlzCCBX+gAwIBAgIQCASh811F+w95nJ3R5U8KQTANBgkqhkiG9w0BAQsFADBZ\n" +
+            "MQswCQYDVQQGEwJVUzEWMBQGA1UECgwNRGlnaUNlcnQsIEluYzEyMDAGA1UEAwwp\n" +
+            "RGlnaUNlcnQgUXVvVmFkaXMgVExTIElDQSBRViBSb290IENBIDMgRzMwHhcNMjEw\n" +
+            "MTIwMDAwMDAwWhcNMjIwMjIwMjM1OTU5WjCBhTELMAkGA1UEBhMCVVMxDTALBgNV\n" +
+            "BAgTBFV0YWgxDTALBgNVBAcTBExlaGkxFzAVBgNVBAoTDkRpZ2lDZXJ0LCBJbmMu\n" +
+            "MT8wPQYDVQQDEzZxdW92YWRpcy1yb290LWNhLTMtZzMtcmV2b2tlZC5jaGFpbi1k\n" +
+            "ZW1vcy5kaWdpY2VydC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB\n" +
+            "AQC1ZjOf9P8AsZUMI2utVu8I9Ap1xOfIrZ0CGh5ZT1O/+PqE27hnqwG7Ed0yuQs7\n" +
+            "OMyo0BP5d8Fg7dbW4LqaA+al3vRH+CQQoeD8zsQd1jWS6ZuitB3CQecZpCaMdzBe\n" +
+            "kQrmj0ofmyEcI5tvQTh4UeGkT66ONB0t4Urol0PCanX8Y3jQVt3FdPDdDTiIHRnl\n" +
+            "maOD1nCkkEEKGbRhxHH/8p8NCQD+i1Rn6KVMjy/hdMVEJCdFDMfKETgfcs2ZgKce\n" +
+            "A8UyPo5pfpvPEptss2Ndj80ou4X0ACV8x0nqWpOojFsml5BYIzRK8s8adAmcUUkG\n" +
+            "uukBGeJTQLd3Ygt6wa2gkeP/AgMBAAGjggMsMIIDKDAfBgNVHSMEGDAWgBQzZvsv\n" +
+            "kQXMs2JS78089X4czqcXljAdBgNVHQ4EFgQUidJlKGbvtsxFbZ+KM2iajjjrEdcw\n" +
+            "QQYDVR0RBDowOII2cXVvdmFkaXMtcm9vdC1jYS0zLWczLXJldm9rZWQuY2hhaW4t\n" +
+            "ZGVtb3MuZGlnaWNlcnQuY29tMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggr\n" +
+            "BgEFBQcDAQYIKwYBBQUHAwIwgZcGA1UdHwSBjzCBjDBEoEKgQIY+aHR0cDovL2Ny\n" +
+            "bDMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0UXVvVmFkaXNUTFNJQ0FRVlJvb3RDQTNH\n" +
+            "My5jcmwwRKBCoECGPmh0dHA6Ly9jcmw0LmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFF1\n" +
+            "b1ZhZGlzVExTSUNBUVZSb290Q0EzRzMuY3JsMD4GA1UdIAQ3MDUwMwYGZ4EMAQIC\n" +
+            "MCkwJwYIKwYBBQUHAgEWG2h0dHA6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzCBgwYI\n" +
+            "KwYBBQUHAQEEdzB1MCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5j\n" +
+            "b20wTQYIKwYBBQUHMAKGQWh0dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdp\n" +
+            "Q2VydFF1b1ZhZGlzVExTSUNBUVZSb290Q0EzRzMuY3J0MAwGA1UdEwEB/wQCMAAw\n" +
+            "ggEEBgorBgEEAdZ5AgQCBIH1BIHyAPAAdQApeb7wnjk5IfBWc59jpXflvld9nGAK\n" +
+            "+PlNXSZcJV3HhAAAAXcgfZ+yAAAEAwBGMEQCIC/jlb+hFwAO0CDUL1hJSIQ9QZOH\n" +
+            "y0fR4gQ3dIXicm26AiAeYJl/ldEn2ojtlL5SYlkpMyf0ry6dNVP0iD8ctUNyngB3\n" +
+            "ACJFRQdZVSRWlj+hL/H3bYbgIyZjrcBLf13Gg1xu4g8CAAABdyB9oAUAAAQDAEgw\n" +
+            "RgIhAMc2AQO/4o79MHwNZAaAFicxyvLCxjKbmR2kPxmL6oSUAiEA1ue6oGS9cIoy\n" +
+            "gTYMxvrLLcETbvapKRFu49dUeger7aUwDQYJKoZIhvcNAQELBQADggEBAG9vJ2sF\n" +
+            "Q/guZdJr8tnMcHNISmZSTCXPvc20kjkVF0M0kW979sskISxEmV9pI49FJqQB1hoz\n" +
+            "4YJhtOKAg5a9PsvOlMaeM/QNtGHdIf+BKJelpH38klHZ51zMPoWJZVDs+FX1s2fZ\n" +
+            "O9kJyU6u22eKhsea2Zt726sIQpL+d4cfBqyXWdUBFp+Kapa/tYhVYW5wo3lxGdf+\n" +
+            "ZgtZMd8tRrYtqD7Zz4fxB9SQj4uqbUydb6n95CR4agO+yNH0mzkD3csoeFfTyKkU\n" +
+            "93P11+3GMBIMY+Tqtm37eDQlZiJZt8zxdjQLO8oM8MgwimKvNeOIdETvZq6dHu8L\n" +
+            "d9QqGEKe5acHUL0=\n" +
             "-----END CERTIFICATE-----";
 
     public void runTest(ValidatePathWithParams pathValidator)
@@ -466,6 +469,6 @@ class RootCA3G3 {
         // Validate Revoked
         pathValidator.validate(new String[]{REVOKED, INT},
                 ValidatePathWithParams.Status.REVOKED,
-                "Tue May 02 10:15:53 PDT 2017", System.out);
+                "Wed Jan 20 07:51:03 PST 2021", System.out);
     }
 }


### PR DESCRIPTION
Unclean backport to match `11.0.14-oracle`. The conflict is in ProblemList, because it is slightly different in 11u, I resolved that conflict by hand.

Additional testing:
 - [x] Affected test passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8248899](https://bugs.openjdk.java.net/browse/JDK-8248899): security/infra/java/security/cert/CertPathValidator/certification/QuoVadisCA.java fails, Certificate has been revoked


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/277/head:pull/277` \
`$ git checkout pull/277`

Update a local copy of the PR: \
`$ git checkout pull/277` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 277`

View PR using the GUI difftool: \
`$ git pr show -t 277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/277.diff">https://git.openjdk.java.net/jdk11u-dev/pull/277.diff</a>

</details>
