### PR TITLE
8263776: [JVMCI] add helper to perform Java upcalls

### DIFF
--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -452,7 +452,7 @@ class ArgumentPusher : public SignatureIterator {
     iterate();
   }
 
-  inline void do_object() {       _jca->push_oop(next_object()); }
+  inline void do_object() { _jca->push_oop(next_object()); }
 
   inline void do_bool()   { if (!is_return_type()) _jca->push_int((jboolean) next_arg(T_BOOLEAN)); }
   inline void do_char()   { if (!is_return_type()) _jca->push_int((jchar) next_arg(T_CHAR)); }
@@ -467,7 +467,7 @@ class ArgumentPusher : public SignatureIterator {
   inline void do_object(int begin, int end) { if (!is_return_type()) do_object(); }
   inline void do_array(int begin, int end)  { if (!is_return_type()) do_object(); }
 
-  inline void do_void()                     { }
+  inline void do_void() { }
 };
 
 

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -409,6 +409,115 @@ JRT_ENTRY(void, JVMCIRuntime::throw_class_cast_exception(JavaThread* thread, con
   SharedRuntime::throw_and_post_jvmti_exception(thread, symbol, message);
 JRT_END
 
+class ArgumentPusher : public SignatureIterator {
+ protected:
+  JavaCallArguments*  _jca;
+  jlong _argument;
+  bool _pushed;
+
+  jlong next_arg(BasicType expectedType) {
+    guarantee(!_pushed, "one argument");
+    _pushed = true;
+    return _argument;
+  }
+
+  float next_float() {
+    guarantee(!_pushed, "one argument");
+    _pushed = true;
+    jvalue v;
+    v.i = (jint) _argument;
+    return v.f;
+  }
+
+  double next_double() {
+    guarantee(!_pushed, "one argument");
+    _pushed = true;
+    jvalue v;
+    v.j = _argument;
+    return v.d;
+  }
+
+  Handle next_object() {
+    guarantee(!_pushed, "one argument");
+    _pushed = true;
+    return Handle(Thread::current(), (oop) (address) _argument);
+  }
+
+ public:
+  ArgumentPusher(Symbol* signature, JavaCallArguments*  jca, jlong argument, bool is_static) : SignatureIterator(signature) {
+    this->_return_type = T_ILLEGAL;
+    _jca = jca;
+    _argument = argument;
+    _pushed = false;
+    iterate();
+  }
+
+  inline void do_object() {       _jca->push_oop(next_object()); }
+
+  inline void do_bool()   { if (!is_return_type()) _jca->push_int((jboolean) next_arg(T_BOOLEAN)); }
+  inline void do_char()   { if (!is_return_type()) _jca->push_int((jchar) next_arg(T_CHAR)); }
+  inline void do_short()  { if (!is_return_type()) _jca->push_int((jint)  next_arg(T_SHORT)); }
+  inline void do_byte()   { if (!is_return_type()) _jca->push_int((jbyte) next_arg(T_BYTE)); }
+  inline void do_int()    { if (!is_return_type()) _jca->push_int((jint)  next_arg(T_INT)); }
+
+  inline void do_long()   { if (!is_return_type()) _jca->push_long((jlong) next_arg(T_LONG)); }
+  inline void do_float()  { if (!is_return_type()) _jca->push_float(next_float()); }
+  inline void do_double() { if (!is_return_type()) _jca->push_double(next_double()); }
+
+  inline void do_object(int begin, int end) { if (!is_return_type()) do_object(); }
+  inline void do_array(int begin, int end)  { if (!is_return_type()) do_object(); }
+
+  inline void do_void()                     { }
+};
+
+
+JRT_ENTRY(jlong, JVMCIRuntime::invoke_static_method_one_arg(JavaThread* thread, Method* method, jlong argument))
+  ResourceMark rm;
+  HandleMark hm;
+
+  methodHandle mh(thread, method);
+  if (mh->size_of_parameters() > 1 && !mh->is_static()) {
+    THROW_MSG_0(vmSymbols::java_lang_IllegalArgumentException(), "Invoked method must be static and take at most one argument");
+  }
+
+  Symbol* signature = mh->signature();
+  JavaCallArguments jca(mh->size_of_parameters());
+  ArgumentPusher jap(signature, &jca, argument, mh->is_static());
+  JavaValue result(jap.get_ret_type());
+  JavaCalls::call(&result, mh, &jca, CHECK_0);
+
+  if (jap.get_ret_type() == T_VOID) {
+    return 0;
+  } else if (jap.get_ret_type() == T_OBJECT || jap.get_ret_type() == T_ARRAY) {
+    thread->set_vm_result((oop) result.get_jobject());
+    return 0;
+  } else {
+    jvalue *value = (jvalue *) result.get_value_addr();
+    // Narrow the value down if required (Important on big endian machines)
+    switch (jap.get_ret_type()) {
+      case T_BOOLEAN:
+        return (jboolean) value->i;
+      case T_BYTE:
+        return (jbyte) value->i;
+      case T_CHAR:
+        return (jchar) value->i;
+      case T_SHORT:
+        return (jshort) value->i;
+      case T_INT:
+        return value->i;
+      case T_LONG:
+        return value->j;
+      case T_FLOAT:
+        return value->f;
+      case T_DOUBLE:
+        return value->d;
+      default:
+        ShouldNotReachHere();
+        return 0;
+    }
+  }
+JRT_END
+
 JRT_LEAF(void, JVMCIRuntime::log_object(JavaThread* thread, oopDesc* obj, bool as_string, bool newline))
   ttyLocker ttyl;
 

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -160,6 +160,11 @@ class JVMCIRuntime: public AllStatic {
   // Forces initialization of the JVMCI runtime.
   static void force_initialization(TRAPS);
 
+  // A helper to allow invocation of an arbitrary Java method.  For simplicity the method is
+  // restricted to a static method that takes at most one argument.  For calling convention
+  // simplicty all types are passed by being converted into a jlong
+  static jlong invoke_static_method_one_arg(JavaThread* thread, Method* method, jlong argument);
+
   // Test only function
   static int test_deoptimize_call_int(JavaThread* thread, int value);
 };

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -632,6 +632,8 @@
   declare_function(JVMCIRuntime::dynamic_new_array) \
   declare_function(JVMCIRuntime::dynamic_new_instance) \
   \
+  declare_function(JVMCIRuntime::invoke_static_method_one_arg) \
+  \
   declare_function(JVMCIRuntime::thread_is_interrupted) \
   declare_function(JVMCIRuntime::vm_message) \
   declare_function(JVMCIRuntime::identity_hash_code) \


### PR DESCRIPTION
Here is a backport for JDK-8263776. The patch doesn't apply cleanly since it uses features only introduced with JDK-8230199 (JDK 15+, not in OpenJDK 11u). This patch is the same labsopenjdk 11 uses. This patch is also needed for using graal js with plain OpenJDK.

Testing: test/hotspot/jtreg/compiler/jvmci and manual upstream Graal unit test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263776](https://bugs.openjdk.java.net/browse/JDK-8263776): [JVMCI] add helper to perform Java upcalls


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Contributors
 * Tom Rodriguez `<never@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/279/head:pull/279` \
`$ git checkout pull/279`

Update a local copy of the PR: \
`$ git checkout pull/279` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 279`

View PR using the GUI difftool: \
`$ git pr show -t 279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/279.diff">https://git.openjdk.java.net/jdk11u-dev/pull/279.diff</a>

</details>
