### PR TITLE
8272700: [macos] Build failure with Xcode 13.0 after JDK-8264848

### DIFF
--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -110,11 +110,11 @@ AC_DEFUN([FLAGS_SETUP_ASFLAGS],
 
     # Fix linker warning.
     # Code taken from make/autoconf/flags-cflags.m4 and adapted.
-    JVM_BASIC_ASFLAGS+="-DMAC_OS_X_VERSION_MIN_REQUIRED=$MACOSX_VERSION_MIN_NODOTS \
+    JVM_BASIC_ASFLAGS+=" -DMAC_OS_X_VERSION_MIN_REQUIRED=$MACOSX_VERSION_MIN_NODOTS \
         -mmacosx-version-min=$MACOSX_VERSION_MIN"
 
     if test -n "$MACOSX_VERSION_MAX"; then
-        JVM_BASIC_ASFLAGS+="$OS_CFLAGS \
+        JVM_BASIC_ASFLAGS+=" $OS_CFLAGS \
             -DMAC_OS_X_VERSION_MAX_ALLOWED=$MACOSX_VERSION_MAX_NODOTS"
     fi
   fi


### PR DESCRIPTION
Backport of 8272700: [macos] Build failure with Xcode 13.0 after JDK-8264848

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272700](https://bugs.openjdk.java.net/browse/JDK-8272700): [macos] Build failure with Xcode 13.0 after JDK-8264848


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/282/head:pull/282` \
`$ git checkout pull/282`

Update a local copy of the PR: \
`$ git checkout pull/282` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 282`

View PR using the GUI difftool: \
`$ git pr show -t 282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/282.diff">https://git.openjdk.java.net/jdk11u-dev/pull/282.diff</a>

</details>
