### PR TITLE
8213718: [TEST] Wrong classname in vmTestbase/nsk/stress/except/except002 and except003

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/except/except002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/except/except002.java
@@ -234,8 +234,8 @@ public class except002 {
 
         // Check ClassNotFoundException (positive):
         try {
-            trash = Class.forName("nsk.stress.except.except002.except002$Abra$Cadabra"); //   correct - should pass
-//          trash = Class.forName("nsk.stress.except.except002.except002.Abra.Cadabra"); // incorrect - should fail
+            trash = Class.forName("nsk.stress.except.except002$Abra$Cadabra"); //   correct - should pass
+//          trash = Class.forName("nsk.stress.except.except002.Abra.Cadabra"); // incorrect - should fail
             if (TRACE_ON)
                 log[messages++] = "Success: ClassNotFoundException (positive)";
         } catch (ClassNotFoundException cnfe) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/except/except003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/except/except003.java
@@ -235,8 +235,8 @@ public class except003 {
 
         // Check ClassNotFoundException (negative):
         try {
-//          trash = Class.forName("nsk.stress.except.except003.except003$Abra$Cadabra"); //   correct - should pass
-            trash = Class.forName("nsk.stress.except.except003.except003.Abra.Cadabra"); // incorrect - should fail
+//          trash = Class.forName("nsk.stress.except.except003$Abra$Cadabra"); //   correct - should pass
+            trash = Class.forName("nsk.stress.except.except003.Abra.Cadabra"); // incorrect - should fail
             log[messages++] = "Failure: ClassNotFoundException (negative)";
             exitCode = 2;
         } catch (ClassNotFoundException cnfe) {


### PR DESCRIPTION
A clean backport for parity with Oracle 11.0.14.

The two affected tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8213718](https://bugs.openjdk.java.net/browse/JDK-8213718): [TEST] Wrong classname in vmTestbase/nsk/stress/except/except002 and except003


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/283/head:pull/283` \
`$ git checkout pull/283`

Update a local copy of the PR: \
`$ git checkout pull/283` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 283`

View PR using the GUI difftool: \
`$ git pr show -t 283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/283.diff">https://git.openjdk.java.net/jdk11u-dev/pull/283.diff</a>

</details>
