### PR TITLE
8261846: [JVMCI] c2v_iterateFrames can get out of sync with the StackFrameStream

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -1040,7 +1040,7 @@ C2V_VMENTRY(jobject, iterateFrames, (JNIEnv*, jobject compilerToVM, jobjectArray
   jobjectArray methods = initial_methods;
 
   int frame_number = 0;
-  vframe* vf = vframe::new_vframe(fst.current(), fst.register_map(), thread);
+  vframe* vf = vframe::new_vframe(fst, thread);
 
   while (true) {
     // look for the given method
@@ -1149,7 +1149,7 @@ C2V_VMENTRY(jobject, iterateFrames, (JNIEnv*, jobject compilerToVM, jobjectArray
           if (fst.current()->sp() != stack_pointer) {
             THROW_MSG_NULL(vmSymbols::java_lang_IllegalStateException(), "stack frame not found after deopt")
           }
-          vf = vframe::new_vframe(fst.current(), fst.register_map(), thread);
+          vf = vframe::new_vframe(fst, thread);
           if (!vf->is_compiled_frame()) {
             THROW_MSG_NULL(vmSymbols::java_lang_IllegalStateException(), "compiled stack frame expected")
           }
@@ -1176,7 +1176,7 @@ C2V_VMENTRY(jobject, iterateFrames, (JNIEnv*, jobject compilerToVM, jobjectArray
       break;
     }
     fst.next();
-    vf = vframe::new_vframe(fst.current(), fst.register_map(), thread);
+    vf = vframe::new_vframe(fst, thread);
     frame_number = 0;
   } // end of frame loop
 

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -59,6 +59,14 @@ vframe::vframe(const frame* fr, JavaThread* thread)
   _fr = *fr;
 }
 
+vframe* vframe::new_vframe(StackFrameStream& fst, JavaThread* thread) {
+  if (fst.current()->is_runtime_frame()) {
+    fst.next();
+  }
+  guarantee(!fst.is_done(), "missing caller");
+  return new_vframe(fst.current(), fst.register_map(), thread);
+}
+
 vframe* vframe::new_vframe(const frame* f, const RegisterMap* reg_map, JavaThread* thread) {
   // Interpreter frame
   if (f->is_interpreted_frame()) {

--- a/src/hotspot/share/runtime/vframe.hpp
+++ b/src/hotspot/share/runtime/vframe.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,8 +60,9 @@ class vframe: public ResourceObj {
   vframe(const frame* fr, const RegisterMap* reg_map, JavaThread* thread);
   vframe(const frame* fr, JavaThread* thread);
  public:
-  // Factory method for creating vframes
+  // Factory methods for creating vframes
   static vframe* new_vframe(const frame* f, const RegisterMap *reg_map, JavaThread* thread);
+  static vframe* new_vframe(StackFrameStream& fst, JavaThread* thread);
 
   // Accessors
   frame              fr()           const { return _fr;       }


### PR DESCRIPTION
This is a JVMCI related backport for OpenJDK 11. It fixes an issue of a fastdebug JVM asserting when running an upstream graal unit test. Applies clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8261846](https://bugs.openjdk.java.net/browse/JDK-8261846): [JVMCI] c2v_iterateFrames can get out of sync with the StackFrameStream


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/288/head:pull/288` \
`$ git checkout pull/288`

Update a local copy of the PR: \
`$ git checkout pull/288` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 288`

View PR using the GUI difftool: \
`$ git pr show -t 288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/288.diff">https://git.openjdk.java.net/jdk11u-dev/pull/288.diff</a>

</details>
