### PR TITLE
Backport 4d6593ce0243457e7431a5990957a8f880e0a3fb

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/Metrics.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/Metrics.java
@@ -116,7 +116,10 @@ public class Metrics implements jdk.internal.platform.Metrics {
         try (Stream<String> lines =
              readFilePrivileged(Paths.get("/proc/self/cgroup"))) {
 
-            lines.map(line -> line.split(":"))
+            // The limit value of 3 is because /proc/self/cgroup contains three
+            // colon-separated tokens per line. The last token, cgroup path, might
+            // contain a ':'.
+            lines.map(line -> line.split(":", 3))
                  .filter(line -> (line.length >= 3))
                  .forEach(line -> setSubSystemPath(metrics, line));
 


### PR DESCRIPTION
Please review this defensive backport of JDK-8272124. OpenJDK 11u is affected too, but it manifests in a different way. Basically Java metrics report wrong results on affected system where the cgroup path contains a colon. The JDK 18 patch doesn't apply cleanly since JDK-8230305 (cgroups v2 support) isn't in 11u. Test support in 11 isn't ass good as well, thus dropped the test changes.

Also, I've kept the token number filter to keep using `>=  3` since that's the more defensive approach. It's not clear if systems with `/proc/self/cgroup` files exist in the wild with less than 3 tokens.

Thoughts?