### PR TITLE
8272966: test/jdk/java/awt/Robot/FlushCurrentEvent.java fails by timeout

### DIFF
--- a/test/jdk/java/awt/Robot/FlushCurrentEvent.java
+++ b/test/jdk/java/awt/Robot/FlushCurrentEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,14 @@ public final class FlushCurrentEvent {
         Robot robot = new Robot();
         AtomicBoolean done = new AtomicBoolean();
         EventQueue.invokeLater(() -> {
-            robot.delay(15000);
+            // Calling the robot.delay() will cause a deadlock because it is a
+            // synchronized method prior to JDK 15 (see JDK-8210231)
+            // robot.delay(15000);
+            try {
+                Thread.sleep(15000);
+            } catch(InterruptedException ite) {
+                throw new RuntimeException(ite);
+            }
             done.set(true);
         });
         robot.waitForIdle();


### PR DESCRIPTION
The test case backported by the [JDK-8267722](https://bugs.openjdk.java.net/browse/JDK-8267722) is too strict for jdk11. It uses the `Robot.delay()` method which is `synchronised` in jdk11 and this caused a deadlock.

Main thread: `synchronized robot.waitForIdle()` - > trying to synchronously execute the code on EDT
EDT: trying to call `synchronized Robot.delay()`

The synchronized keyword was removed by the [JDK-8210231](https://bugs.openjdk.java.net/browse/JDK-8210231) in JDK15 and it cannot be backported due to compatibility reasons.

The solution is to relax this part of the test which does not affect its ability to verify the fix for JDK-8196100

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272966](https://bugs.openjdk.java.net/browse/JDK-8272966): test/jdk/java/awt/Robot/FlushCurrentEvent.java fails by timeout


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/309/head:pull/309` \
`$ git checkout pull/309`

Update a local copy of the PR: \
`$ git checkout pull/309` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 309`

View PR using the GUI difftool: \
`$ git pr show -t 309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/309.diff">https://git.openjdk.java.net/jdk11u-dev/pull/309.diff</a>

</details>
