### PR TITLE
8269984: [macos] JTabbedPane title looks like  disabled

### DIFF
--- a/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
+++ b/src/java.desktop/macosx/classes/apple/laf/JRSUIUtils.java
@@ -36,15 +36,10 @@ public final class JRSUIUtils {
 
     static boolean isLeopard = isMacOSXLeopard();
     static boolean isSnowLeopardOrBelow = isMacOSXSnowLeopardOrBelow();
-    static boolean isCatalinaOrAbove = isMacOSXCatalinaOrAbove();
-    static boolean isBigSurOrAbove = isMacOSXBigSurOrAbove();
 
     public static boolean isMacOSXBigSurOrAbove() {
-        return currentMacOSXVersionMatchesGivenVersionRange(16, true, false, true);
-    }
-
-    static boolean isMacOSXCatalinaOrAbove() {
-        return currentMacOSXVersionMatchesGivenVersionRange(15, true, false, true);
+        return currentMacOSXVersionMatchesGivenVersionRange(10, 16, true,
+                false, true);
     }
 
     static boolean isMacOSXLeopard() {
@@ -52,31 +47,45 @@ public final class JRSUIUtils {
     }
 
     static boolean isMacOSXSnowLeopardOrBelow() {
-        return currentMacOSXVersionMatchesGivenVersionRange(6, true, true, false);
+        return currentMacOSXVersionMatchesGivenVersionRange(10, 6, true,
+                true, false);
     }
 
     static boolean isCurrentMacOSXVersion(final int version) {
-        return currentMacOSXVersionMatchesGivenVersionRange(version, true, false, false);
+        return isCurrentMacOSXVersion(10, version);
+    }
+
+    static boolean isCurrentMacOSXVersion(final int major, final int minor) {
+        return currentMacOSXVersionMatchesGivenVersionRange(major, minor, true, false, false);
     }
 
     static boolean currentMacOSXVersionMatchesGivenVersionRange(
             final int version, final boolean inclusive,
             final boolean matchBelow, final boolean matchAbove) {
-        // split the "10.x.y" version number
+        return currentMacOSXVersionMatchesGivenVersionRange(10, version, inclusive, matchBelow, matchAbove);
+    }
+
+    static boolean currentMacOSXVersionMatchesGivenVersionRange(
+            final int majorVersion, final int minorVersion, final boolean inclusive,
+            final boolean matchBelow, final boolean matchAbove) {
+        // split the "x.y.z" version number
         String osVersion = AccessController.doPrivileged(new GetPropertyAction("os.version"));
         String[] fragments = osVersion.split("\\.");
 
-        // sanity check the "10." part of the version
-        if (!fragments[0].equals("10")) return false;
         if (fragments.length < 2) return false;
 
         // check if os.version matches the given version using the given match method
         try {
+            int majorVers = Integer.parseInt(fragments[0]);
             int minorVers = Integer.parseInt(fragments[1]);
 
-            if (inclusive && minorVers == version) return true;
-            if (matchBelow && minorVers < version) return true;
-            if (matchAbove && minorVers > version) return true;
+            if (inclusive && majorVers == majorVersion && minorVers == minorVersion) return true;
+            if (matchBelow &&
+                    (majorVers < majorVersion ||
+                            (majorVers == majorVersion && minorVers < minorVersion))) return true;
+            if (matchAbove &&
+                    (majorVers > majorVersion ||
+                            (majorVers == majorVersion && minorVers > minorVersion))) return true;
 
         } catch (NumberFormatException e) {
             // was not an integer


### PR DESCRIPTION
Backport of JDK-8269984. Follow-up fix for https://github.com/openjdk/jdk11u-dev/commit/ea1a1d86b92e43bbb4ecadf4ba3bd338b3441ad4. Doesn't apply cleanly, because the workaround (hunk which introduced isCatalinaOrAbove) from the latter is no longer up to date and should get reverted. There are also unrelated context changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269984](https://bugs.openjdk.java.net/browse/JDK-8269984): [macos] JTabbedPane title looks like  disabled


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/310/head:pull/310` \
`$ git checkout pull/310`

Update a local copy of the PR: \
`$ git checkout pull/310` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 310`

View PR using the GUI difftool: \
`$ git pr show -t 310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/310.diff">https://git.openjdk.java.net/jdk11u-dev/pull/310.diff</a>

</details>
