### PR TITLE
JDK-8272316: Wrong Boot JDK help message in 11

### DIFF
--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -90,7 +90,7 @@ apt_help() {
     devkit)
       PKGHANDLER_COMMAND="sudo apt-get install build-essential" ;;
     openjdk)
-      PKGHANDLER_COMMAND="sudo apt-get install openjdk-8-jdk" ;;
+      PKGHANDLER_COMMAND="sudo apt-get install openjdk-11-jdk" ;;
     alsa)
       PKGHANDLER_COMMAND="sudo apt-get install libasound2-dev" ;;
     cups)

--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -117,7 +117,7 @@ yum_help() {
     devkit)
       PKGHANDLER_COMMAND="sudo yum groupinstall \"Development Tools\"" ;;
     openjdk)
-      PKGHANDLER_COMMAND="sudo yum install java-1.8.0-openjdk-devel" ;;
+      PKGHANDLER_COMMAND="sudo yum install java-11-openjdk-devel" ;;
     alsa)
       PKGHANDLER_COMMAND="sudo yum install alsa-lib-devel" ;;
     cups)


### PR DESCRIPTION
Hello please review this small fix. It fixes the configure help output message and mentions openjdk-11-jdk because 8 is not sufficient to build jdk11 as BOOT JDK.

Thanks, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272316](https://bugs.openjdk.java.net/browse/JDK-8272316): Wrong Boot JDK help message in 11


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to 428e328c52faaba4b7149ada63b92d67e1c7b07e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/313/head:pull/313` \
`$ git checkout pull/313`

Update a local copy of the PR: \
`$ git checkout pull/313` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 313`

View PR using the GUI difftool: \
`$ git pr show -t 313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/313.diff">https://git.openjdk.java.net/jdk11u-dev/pull/313.diff</a>

</details>
