### PR TITLE
8195703: BasicJDWPConnectionTest.java: 'App exited unexpectedly with 2'

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -865,8 +865,6 @@ tools/jlink/JLinkReproducibleTest.java                          8258945 generic-
 
 # jdk_jdi
 
-com/sun/jdi/BasicJDWPConnectionTest.java                        8195703 generic-all
-
 com/sun/jdi/RepStep.java                                        8043571 generic-all
 
 com/sun/jdi/NashornPopFrameTest.java                            8187143 generic-all

--- a/test/jdk/com/sun/jdi/BasicJDWPConnectionTest.java
+++ b/test/jdk/com/sun/jdi/BasicJDWPConnectionTest.java
@@ -30,17 +30,15 @@
  */
 
 import java.io.IOException;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 
 import java.net.Socket;
 import java.net.SocketException;
 
 import jdk.test.lib.apps.LingeredApp;
-import jdk.testlibrary.Utils;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 public class BasicJDWPConnectionTest {
@@ -65,25 +63,37 @@ public class BasicJDWPConnectionTest {
         return res;
     }
 
-    public static ArrayList<String> prepareCmd(int port, String allowOpt) {
-         String address = "*:" + String.valueOf(port);
+    public static ArrayList<String> prepareCmd(String allowOpt) {
          ArrayList<String> cmd = new ArrayList<>();
 
          String jdwpArgs = "-agentlib:jdwp=transport=dt_socket,server=y," +
-                           "suspend=n,address=" + address + allowOpt;
+                           "suspend=n,address=*:0" + allowOpt;
          cmd.add(jdwpArgs);
          return cmd;
+    }
+
+    private static Pattern listenRegexp = Pattern.compile("Listening for transport \\b(.+)\\b at address: \\b(\\d+)\\b");
+    private static int detectPort(String s) {
+        Matcher m = listenRegexp.matcher(s);
+        if (!m.find()) {
+            throw new RuntimeException("Could not detect port from '" + s + "'");
+        }
+        // m.group(1) is transport, m.group(2) is port
+        return Integer.parseInt(m.group(2));
     }
 
     public static void positiveTest(String testName, String allowOpt)
         throws InterruptedException, IOException {
         System.err.println("\nStarting " + testName);
-        int port = Utils.getFreePort();
-        ArrayList<String> cmd = prepareCmd(port, allowOpt);
+        ArrayList<String> cmd = prepareCmd(allowOpt);
 
         LingeredApp a = LingeredApp.startApp(cmd);
-        int res = handshake(port);
-        a.stopApp();
+        int res;
+        try {
+            res = handshake(detectPort(a.getProcessStdout()));
+        } finally {
+            a.stopApp();
+        }
         if (res < 0) {
             throw new RuntimeException(testName + " FAILED");
         }
@@ -93,12 +103,15 @@ public class BasicJDWPConnectionTest {
     public static void negativeTest(String testName, String allowOpt)
         throws InterruptedException, IOException {
         System.err.println("\nStarting " + testName);
-        int port = Utils.getFreePort();
-        ArrayList<String> cmd = prepareCmd(port, allowOpt);
+        ArrayList<String> cmd = prepareCmd(allowOpt);
 
         LingeredApp a = LingeredApp.startApp(cmd);
-        int res = handshake(port);
-        a.stopApp();
+        int res;
+        try {
+            res = handshake(detectPort(a.getProcessStdout()));
+        } finally {
+            a.stopApp();
+        }
         if (res > 0) {
             System.err.println(testName + ": res=" + res);
             throw new RuntimeException(testName + " FAILED");
@@ -110,16 +123,18 @@ public class BasicJDWPConnectionTest {
     public static void badAllowOptionTest(String testName, String allowOpt)
         throws InterruptedException, IOException {
         System.err.println("\nStarting " + testName);
-        int port = Utils.getFreePort();
-        ArrayList<String> cmd = prepareCmd(port, allowOpt);
+        ArrayList<String> cmd = prepareCmd(allowOpt);
 
+        LingeredApp a;
         try {
-            LingeredApp a = LingeredApp.startApp(cmd);
+            a = LingeredApp.startApp(cmd);
         } catch (IOException ex) {
             System.err.println(testName + ": caught expected IOException");
             System.err.println(testName + " PASSED");
             return;
         }
+        // LingeredApp.startApp is expected to fail, but if not, terminate the app
+        a.stopApp();
         throw new RuntimeException(testName + " FAILED");
     }
 
@@ -175,26 +190,16 @@ public class BasicJDWPConnectionTest {
         badAllowOptionTest("ExplicitMultiDefault2Test", allowOpt);
     }
 
-    public static void main(String[] args) {
-        try {
-            DefaultTest();
-            ExplicitDefaultTest();
-            AllowTest();
-            MultiAllowTest();
-            DenyTest();
-            MultiDenyTest();
-            EmptyAllowOptionTest();
-            ExplicitMultiDefault1Test();
-            ExplicitMultiDefault2Test();
-            System.err.println("\nTest PASSED");
-        } catch (InterruptedException ex) {
-            System.err.println("\nTest ERROR, getFreePort");
-            ex.printStackTrace();
-            System.exit(3);
-        } catch (IOException ex) {
-            System.err.println("\nTest ERROR");
-            ex.printStackTrace();
-            System.exit(3);
-        }
+    public static void main(String[] args) throws Exception {
+        DefaultTest();
+        ExplicitDefaultTest();
+        AllowTest();
+        MultiAllowTest();
+        DenyTest();
+        MultiDenyTest();
+        EmptyAllowOptionTest();
+        ExplicitMultiDefault1Test();
+        ExplicitMultiDefault2Test();
+        System.err.println("\nTest PASSED");
     }
 }

--- a/test/jdk/com/sun/jdi/DoubleAgentTest.java
+++ b/test/jdk/com/sun/jdi/DoubleAgentTest.java
@@ -42,10 +42,8 @@ public class DoubleAgentTest {
             "test.classes", ".");
 
     public static void main(String[] args) throws Throwable {
-        int port = Utils.getFreePort();
-
         String jdwpOption = "-agentlib:jdwp=transport=dt_socket"
-                         + ",server=y" + ",suspend=n" + ",address=*:" + String.valueOf(port);
+                         + ",server=y" + ",suspend=n" + ",address=*:0";
 
         OutputAnalyzer output = ProcessTools.executeTestJvm("-classpath",
                 TEST_CLASSES,

--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -26,9 +26,6 @@ package jdk.test.lib.apps;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -46,7 +43,6 @@ import java.util.UUID;
 
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputBuffer;
-import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.StreamPumper;
 
 /**
@@ -137,6 +133,14 @@ public class LingeredApp {
      */
     public Process getProcess() {
         return appProcess;
+    }
+
+    /**
+     * @return the LingeredApp's output.
+     * Can be called after the app is run.
+     */
+    public String getProcessStdout() {
+        return stdoutBuffer.toString();
     }
 
     /**


### PR DESCRIPTION
Backport of JDK-8195703. Needed trivial resolve in BasicJDWPConnectionTest.java, diff looks identical though.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8195703](https://bugs.openjdk.java.net/browse/JDK-8195703): BasicJDWPConnectionTest.java: 'App exited unexpectedly with 2'


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)
 * [Alex Menkov](https://openjdk.java.net/census#amenkov) (@alexmenkov - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/316/head:pull/316` \
`$ git checkout pull/316`

Update a local copy of the PR: \
`$ git checkout pull/316` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 316`

View PR using the GUI difftool: \
`$ git pr show -t 316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/316.diff">https://git.openjdk.java.net/jdk11u-dev/pull/316.diff</a>

</details>
