### PR TITLE
8273547: [11u] [JVMCI] Partial module-info.java backport of JDK-8223332

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/module-info.java
+++ b/src/jdk.internal.vm.ci/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,9 @@ module jdk.internal.vm.ci {
     exports jdk.vm.ci.runtime to
         jdk.internal.vm.compiler,
         jdk.internal.vm.compiler.management;
+    exports jdk.vm.ci.meta to jdk.internal.vm.compiler;
+    exports jdk.vm.ci.code to jdk.internal.vm.compiler;
+    exports jdk.vm.ci.hotspot to jdk.internal.vm.compiler;
 
     uses jdk.vm.ci.services.JVMCIServiceLocator;
     uses jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory;


### PR DESCRIPTION
Please review this trivial partial backport of JDK-8223332. The full patch is too large and isn't worth the risk to backport in full. The issue at hand can be resolved by adding only the exports to the `jdk.internal.vm.ci` module. Thoughts?

Testing: jvmci tests, jvmci bootstrap tests, manual testing of the reproducer and tier1 on Linux x86_64