### PR TITLE
8247403: JShell: No custom input (e.g. from GUI) possible with JavaShellToolBuilder

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/LineReaderImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/LineReaderImpl.java
@@ -4157,7 +4157,7 @@ public class LineReaderImpl implements LineReader, Flushable
             } else
                 sb.append(ch);
         }
-        if (padToWidth > cols) {
+        if (padToWidth > cols && padToWidth > 0) {
             int padCharCols = WCWidth.wcwidth(padChar);
             int padCount = (padToWidth - cols) / padCharCols;
             sb = padPartString;

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -100,8 +101,8 @@ class ConsoleIOContext extends IOContext {
 
     String prefix = "";
 
-    ConsoleIOContext(JShellTool repl, InputStream cmdin, PrintStream cmdout) throws Exception {
-        this.allowIncompleteInputs = Boolean.getBoolean("jshell.test.allow.incomplete.inputs");
+    ConsoleIOContext(JShellTool repl, InputStream cmdin, PrintStream cmdout,
+                     boolean interactive) throws Exception {
         this.repl = repl;
         Map<String, Object> variables = new HashMap<>();
         this.input = new StopDetectingInputStream(() -> repl.stop(),
@@ -113,8 +114,20 @@ class ConsoleIOContext extends IOContext {
             }
         };
         Terminal terminal;
-        if (System.getProperty("test.jdk") != null) {
-            terminal = new TestTerminal(nonBlockingInput, cmdout);
+        boolean allowIncompleteInputs = Boolean.getBoolean("jshell.test.allow.incomplete.inputs");
+        Consumer<LineReaderImpl> setupReader = r -> {};
+        if (cmdin != System.in) {
+            if (System.getProperty("test.jdk") != null) {
+                terminal = new TestTerminal(nonBlockingInput, cmdout);
+            } else {
+                Size size = null;
+                terminal = new ProgrammaticInTerminal(nonBlockingInput, cmdout, interactive,
+                                                      size);
+                if (!interactive) {
+                    setupReader = r -> r.unsetOpt(Option.BRACKETED_PASTE);
+                    allowIncompleteInputs = true;
+                }
+            }
             input.setInputStream(cmdin);
         } else {
             terminal = TerminalBuilder.builder().inputStreamWrapper(in -> {
@@ -122,6 +135,7 @@ class ConsoleIOContext extends IOContext {
                 return nonBlockingInput;
             }).build();
         }
+        this.allowIncompleteInputs = allowIncompleteInputs;
         originalAttributes = terminal.getAttributes();
         Attributes noIntr = new Attributes(originalAttributes);
         noIntr.setControlChar(ControlChar.VINTR, 0);
@@ -156,10 +170,11 @@ class ConsoleIOContext extends IOContext {
             }
         };
 
+        setupReader.accept(reader);
         reader.setOpt(Option.DISABLE_EVENT_EXPANSION);
 
         reader.setParser((line, cursor, context) -> {
-            if (!allowIncompleteInputs && !repl.isComplete(line)) {
+            if (!ConsoleIOContext.this.allowIncompleteInputs && !repl.isComplete(line)) {
                 throw new EOFError(cursor, cursor, line);
             }
             return new ArgumentLine(line, cursor);
@@ -206,7 +221,7 @@ class ConsoleIOContext extends IOContext {
         this.prefix = prefix;
         try {
             in.setVariable(LineReader.SECONDARY_PROMPT_PATTERN, continuationPrompt);
-            return in.readLine(firstLinePrompt);
+            return in.readLine(firstLine ? firstLinePrompt : continuationPrompt);
         } catch (UserInterruptException ex) {
             throw (InputInterruptedException) new InputInterruptedException().initCause(ex);
         } catch (EndOfFileException ex) {
@@ -1194,28 +1209,31 @@ class ConsoleIOContext extends IOContext {
         return in.getHistory();
     }
 
-    private static final class TestTerminal extends LineDisciplineTerminal {
+    private static class ProgrammaticInTerminal extends LineDisciplineTerminal {
 
-        private static final int DEFAULT_HEIGHT = 24;
+        protected static final int DEFAULT_HEIGHT = 24;
 
         private final NonBlockingReader inputReader;
+        private final Size bufferSize;
 
-        public TestTerminal(InputStream input, OutputStream output) throws Exception {
-            super("test", "ansi", output, Charset.forName("UTF-8"));
+        public ProgrammaticInTerminal(InputStream input, OutputStream output,
+                                       boolean interactive, Size size) throws Exception {
+            this(input, output, interactive ? "ansi" : "dumb",
+                 size != null ? size : new Size(80, DEFAULT_HEIGHT),
+                 size != null ? size
+                              : interactive ? new Size(80, DEFAULT_HEIGHT)
+                                            : new Size(Integer.MAX_VALUE - 1, DEFAULT_HEIGHT));
+        }
+
+        protected ProgrammaticInTerminal(InputStream input, OutputStream output,
+                                         String terminal, Size size, Size bufferSize) throws Exception {
+            super("non-system-in", terminal, output, Charset.forName("UTF-8"));
             this.inputReader = NonBlocking.nonBlocking(getName(), input, encoding());
             Attributes a = new Attributes(getAttributes());
             a.setLocalFlag(LocalFlag.ECHO, false);
             setAttributes(attributes);
-            int h = DEFAULT_HEIGHT;
-            try {
-                String hp = System.getProperty("test.terminal.height");
-                if (hp != null && !hp.isEmpty()) {
-                    h = Integer.parseInt(hp);
-                }
-            } catch (Throwable ex) {
-                // ignore
-            }
-            setSize(new Size(80, h));
+            setSize(size);
+            this.bufferSize = bufferSize;
         }
 
         @Override
@@ -1230,6 +1248,31 @@ class ConsoleIOContext extends IOContext {
             inputReader.close();
         }
 
+        @Override
+        public Size getBufferSize() {
+            return bufferSize;
+        }
+    }
+
+    private static final class TestTerminal extends ProgrammaticInTerminal {
+        private static Size computeSize() {
+            int h = DEFAULT_HEIGHT;
+            try {
+                String hp = System.getProperty("test.terminal.height");
+                if (hp != null && !hp.isEmpty() && System.getProperty("test.jdk") != null) {
+                    h = Integer.parseInt(hp);
+                }
+            } catch (Throwable ex) {
+                // ignore
+            }
+            return new Size(80, h);
+        }
+        public TestTerminal(InputStream input, OutputStream output) throws Exception {
+            this(input, output, computeSize());
+        }
+        private TestTerminal(InputStream input, OutputStream output, Size size) throws Exception {
+            super(input, output, "ansi", size, size);
+        }
     }
 
     private static final class CompletionState {

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -140,6 +140,8 @@ import static jdk.internal.jshell.tool.ContinuousCompletionProvider.STARTSWITH_M
  */
 public class JShellTool implements MessageHandler {
 
+    private static String PROMPT = "\u0005";
+    private static String CONTINUATION_PROMPT = "\u0006";
     private static final Pattern LINEBREAK = Pattern.compile("\\R");
     private static final Pattern ID = Pattern.compile("[se]?\\d+([-\\s].*)?");
     private static final Pattern RERUN_ID = Pattern.compile("/" + ID.pattern());
@@ -160,6 +162,7 @@ public class JShellTool implements MessageHandler {
     final PersistentStorage prefs;
     final Map<String, String> envvars;
     final Locale locale;
+    final boolean interactiveTerminal;
 
     final Feedback feedback = new Feedback();
 
@@ -179,7 +182,8 @@ public class JShellTool implements MessageHandler {
     JShellTool(InputStream cmdin, PrintStream cmdout, PrintStream cmderr,
             PrintStream console,
             InputStream userin, PrintStream userout, PrintStream usererr,
-            PersistentStorage prefs, Map<String, String> envvars, Locale locale) {
+            PersistentStorage prefs, Map<String, String> envvars, Locale locale,
+            boolean interactiveTerminal) {
         this.cmdin = cmdin;
         this.cmdout = cmdout;
         this.cmderr = cmderr;
@@ -195,6 +199,7 @@ public class JShellTool implements MessageHandler {
         this.prefs = prefs;
         this.envvars = envvars;
         this.locale = locale;
+        this.interactiveTerminal = interactiveTerminal;
     }
 
     private ResourceBundle versionRB = null;
@@ -967,7 +972,7 @@ public class JShellTool implements MessageHandler {
             };
             Runtime.getRuntime().addShutdownHook(shutdownHook);
             // execute from user input
-            try (IOContext in = new ConsoleIOContext(this, cmdin, console)) {
+            try (IOContext in = new ConsoleIOContext(this, cmdin, console, interactiveTerminal)) {
                 while (regenerateOnDeath) {
                     if (!live) {
                         resetState();
@@ -1224,12 +1229,12 @@ public class JShellTool implements MessageHandler {
                 return src;
             }
             String firstLinePrompt = interactive()
-                    ? testPrompt ? " \005"
+                    ? testPrompt ? PROMPT
                                  : feedback.getPrompt(currentNameSpace.tidNext())
                     : "" // Non-interactive -- no prompt
                     ;
             String continuationPrompt = interactive()
-                    ? testPrompt ? " \006"
+                    ? testPrompt ? CONTINUATION_PROMPT
                                  : feedback.getContinuationPrompt(currentNameSpace.tidNext())
                     : "" // Non-interactive -- no prompt
                     ;

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellToolBuilder.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellToolBuilder.java
@@ -51,6 +51,7 @@ public class JShellToolBuilder implements JavaShellToolBuilder {
     private PersistentStorage prefs = null;
     private Map<String, String> vars = null;
     private Locale locale = Locale.getDefault();
+    private boolean interactiveTerminal;
     private boolean capturePrompt = false;
 
     /**
@@ -208,6 +209,12 @@ public class JShellToolBuilder implements JavaShellToolBuilder {
         return this;
     }
 
+    @Override
+    public JavaShellToolBuilder interactiveTerminal(boolean terminal) {
+        this.interactiveTerminal = terminal;
+        return this;
+    }
+
     /**
      * Create a tool instance for testing. Not in JavaShellToolBuilder.
      *
@@ -221,7 +228,7 @@ public class JShellToolBuilder implements JavaShellToolBuilder {
             vars = System.getenv();
         }
         JShellTool sh = new JShellTool(cmdIn, cmdOut, cmdErr, console, userIn,
-                userOut, userErr, prefs, vars, locale);
+                userOut, userErr, prefs, vars, locale, interactiveTerminal);
         sh.testPrompt = capturePrompt;
         return sh;
     }

--- a/src/jdk.jshell/share/classes/jdk/jshell/tool/JavaShellToolBuilder.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/tool/JavaShellToolBuilder.java
@@ -184,6 +184,32 @@ public interface JavaShellToolBuilder {
     JavaShellToolBuilder promptCapture(boolean capture);
 
     /**
+     * Set to true to specify the inputs and outputs are connected to an interactive terminal
+     * that can interpret the ANSI escape codes. The characters sent to the output streams are
+     * assumed to be interpreted by a terminal and shown to the user, and the exact order and nature
+     * of characters sent to the outputs are unspecified.
+     *
+     * Set to false to specify a legacy simpler behavior whose output can be parsed by automatic
+     * tools.
+     *
+     * When the input stream for this Java Shell is {@code System.in}, this value is ignored,
+     * and the behavior is similar to specifying {@code true} in this method, but is more closely
+     * following the specific terminal connected to {@code System.in}.
+     *
+     * @implSpec If this method is not called, the behavior should be
+     * equivalent to calling {@code interactiveTerminal(false)}. The default implementation of
+     * this method returns {@code this}.
+     *
+     * @param terminal if {@code true}, an terminal that can interpret the ANSI escape codes is
+     *                 assumed to interpret the output. If {@code false}, a simpler output is selected.
+     * @return the {@code JavaShellToolBuilder} instance
+     * @since 17
+     */
+    default JavaShellToolBuilder interactiveTerminal(boolean terminal) {
+        return this;
+    }
+
+    /**
      * Run an instance of the Java shell tool as configured by the other methods
      * in this interface.  This call is not destructive, more than one call of
      * this method may be made from a configured builder. The  exit code from

--- a/test/langtools/jdk/jshell/CustomInputToolBuilder.java
+++ b/test/langtools/jdk/jshell/CustomInputToolBuilder.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8247403
+ * @summary Verify JavaShellToolBuilder uses provided inputs
+ * @modules jdk.jshell
+ * @build KullaTesting TestingInputStream
+ * @run testng CustomInputToolBuilder
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
+import jdk.jshell.tool.JavaShellToolBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+@Test
+public class CustomInputToolBuilder extends KullaTesting {
+
+    private static final String TEST_JDK = "test.jdk";
+
+    public void checkCustomInput() throws Exception {
+        String testJdk = System.getProperty(TEST_JDK);
+        try {
+            System.clearProperty(TEST_JDK);
+            doTest("System.out.println(\"read: \" + System.in.read());",
+                   "\u0005System.out.println(\"read: \" + System.in.read());",
+                   "read: 97",
+                   "\u0005/exit");
+            doTest("1 + 1", "\u00051 + 1", "$1 ==> 2", "\u0005/exit");
+            doTest("for (int i = 0; i < 100; i++) {\nSystem.err.println(i);\n}\n",
+                   "\u0005for (int i = 0; i < 100; i++) {",
+                   "\u0006System.err.println(i);", "\u0006}",
+                   "\u0005/exit");
+            StringBuilder longInput = new StringBuilder();
+            String constant = "1_______________1";
+            longInput.append(constant);
+            for (int i = 0; i < 100; i++) {
+                longInput.append(" + ");
+                longInput.append(constant);
+            }
+            doTest(longInput.toString(), "\u0005" + longInput);
+        } finally {
+            System.setProperty(TEST_JDK, testJdk);
+        }
+    }
+
+    private void doTest(String code, String... expectedLines) throws Exception {
+        doTest(false, code, expectedLines);
+    }
+
+    private void doTest(boolean interactiveTerminal, String code, String... expectedLines) throws Exception {
+            byte[] cmdInputData = (code + "\n/exit\n").getBytes();
+            InputStream cmdInput = new ByteArrayInputStream(cmdInputData);
+            InputStream userInput = new ByteArrayInputStream("a\n".getBytes());
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            PrintStream printOut = new PrintStream(out);
+
+            JavaShellToolBuilder.builder()
+                    .in(cmdInput, userInput)
+                    .out(printOut, printOut, printOut)
+                    .interactiveTerminal(interactiveTerminal)
+                    .promptCapture(true)
+                    .start("--no-startup");
+
+            String actual = new String(out.toByteArray());
+            List<String> actualLines = Arrays.asList(actual.split("\\R"));
+
+            for (String expectedLine : expectedLines) {
+                assertTrue(actualLines.contains(expectedLine),
+                            "actual:\n" + actualLines + "\n, expected:\n" + expectedLine);
+            }
+    }
+
+    public void checkInteractiveTerminal() throws Exception {
+        String testJdk = System.getProperty(TEST_JDK);
+        try {
+            System.clearProperty(TEST_JDK);
+
+            //note the exact format of the output is not specified here, and the test mostly validates
+            //the current behavior, and shows the output changes based on the interactiveTerminal setting:
+            doTest(true,
+                   "System.out.println(\"read: \" + System.in.read());",
+                   "\u001b[?2004h\u0005System.out.println(\"read: \" + System.in.read()\u001b[2D\u001b[2C)\u001b[29D\u001b[29C;",
+                   "\u001b[?2004lread: 97",
+                   "\u001b[?2004h\u0005/exit");
+            doTest(true,
+                   "1 + 1",
+                   "\u001b[?2004h\u00051 + 1",
+                   "\u001b[?2004l$1 ==> 2",
+                   "\u001b[?2004h\u0005/exit");
+        } finally {
+            System.setProperty(TEST_JDK, testJdk);
+        }
+    }
+}

--- a/test/langtools/jdk/jshell/HistoryUITest.java
+++ b/test/langtools/jdk/jshell/HistoryUITest.java
@@ -28,6 +28,7 @@
  * @modules
  *     jdk.compiler/com.sun.tools.javac.api
  *     jdk.compiler/com.sun.tools.javac.main
+ *     jdk.jshell/jdk.internal.jshell.tool:open
  *     jdk.jshell/jdk.internal.jshell.tool.resources:open
  *     jdk.jshell/jdk.jshell:open
  * @library /tools/lib

--- a/test/langtools/jdk/jshell/PasteAndMeasurementsUITest.java
+++ b/test/langtools/jdk/jshell/PasteAndMeasurementsUITest.java
@@ -32,6 +32,7 @@
  *     jdk.compiler/com.sun.tools.javac.api
  *     jdk.compiler/com.sun.tools.javac.main
  *     jdk.internal.le/jdk.internal.org.jline.reader.impl
+ *     jdk.jshell/jdk.internal.jshell.tool:open
  *     jdk.jshell/jdk.internal.jshell.tool.resources:open
  *     jdk.jshell/jdk.jshell:open
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask

--- a/test/langtools/jdk/jshell/ToolMultilineSnippetHistoryTest.java
+++ b/test/langtools/jdk/jshell/ToolMultilineSnippetHistoryTest.java
@@ -26,6 +26,7 @@
  * @bug 8182489
  * @summary test history with multiline snippets
  * @modules
+ *     jdk.jshell/jdk.internal.jshell.tool:open
  *     jdk.jshell/jdk.internal.jshell.tool.resources:open
  *     jdk.jshell/jdk.jshell:open
  * @build UITesting

--- a/test/langtools/jdk/jshell/ToolShiftTabTest.java
+++ b/test/langtools/jdk/jshell/ToolShiftTabTest.java
@@ -26,6 +26,7 @@
  * @bug 8166334 8188894
  * @summary test shift-tab shortcuts "fixes"
  * @modules
+ *     jdk.jshell/jdk.internal.jshell.tool:open
  *     jdk.jshell/jdk.internal.jshell.tool.resources:open
  *     jdk.jshell/jdk.jshell:open
  * @build UITesting

--- a/test/langtools/jdk/jshell/ToolTabCommandTest.java
+++ b/test/langtools/jdk/jshell/ToolTabCommandTest.java
@@ -27,6 +27,7 @@
  * @modules
  *     jdk.compiler/com.sun.tools.javac.api
  *     jdk.compiler/com.sun.tools.javac.main
+ *     jdk.jshell/jdk.internal.jshell.tool:open
  *     jdk.jshell/jdk.internal.jshell.tool.resources:open
  *     jdk.jshell/jdk.jshell:open
  * @library /tools/lib

--- a/test/langtools/jdk/jshell/ToolTabSnippetTest.java
+++ b/test/langtools/jdk/jshell/ToolTabSnippetTest.java
@@ -27,7 +27,7 @@
  * @modules
  *     jdk.compiler/com.sun.tools.javac.api
  *     jdk.compiler/com.sun.tools.javac.main
- *     jdk.jshell/jdk.internal.jshell.tool
+ *     jdk.jshell/jdk.internal.jshell.tool:+open
  *     jdk.jshell/jdk.internal.jshell.tool.resources:open
  *     jdk.jshell/jdk.jshell:open
  * @library /tools/lib

--- a/test/langtools/jdk/jshell/UITesting.java
+++ b/test/langtools/jdk/jshell/UITesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.Writer;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.HashMap;
@@ -109,6 +110,13 @@ public class UITesting {
         runner.start();
 
         try {
+            Class<?> jshellToolClass = Class.forName("jdk.internal.jshell.tool.JShellTool");
+            Field promptField = jshellToolClass.getDeclaredField("PROMPT");
+            promptField.setAccessible(true);
+            promptField.set(null, PROMPT);
+            Field continuationPromptField = jshellToolClass.getDeclaredField("CONTINUATION_PROMPT");
+            continuationPromptField.setAccessible(true);
+            continuationPromptField.set(null, CONTINUATION_PROMPT);
             waitOutput(out, PROMPT);
             test.test(inputSink, out);
         } finally {


### PR DESCRIPTION
Almost clean backport of JDK-8247403. Rejected hunks:

- UITesting.java: integrated import change manually due to unrelated context difference
- JShellTool.java: integrated one hunk manually due to unrelated context difference
- ConsoleIOContext.java: integrated Copyright year change and one hunk manually due to unrelated context difference
- IndentUITest.java doesn't exist in 11u. Skipped.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247403](https://bugs.openjdk.java.net/browse/JDK-8247403): JShell: No custom input (e.g. from GUI) possible with JavaShellToolBuilder


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/319/head:pull/319` \
`$ git checkout pull/319`

Update a local copy of the PR: \
`$ git checkout pull/319` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 319`

View PR using the GUI difftool: \
`$ git pr show -t 319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/319.diff">https://git.openjdk.java.net/jdk11u-dev/pull/319.diff</a>

</details>
