### PR TITLE
8210353: Move java/util/Arrays/TimSortStackSize2.java back to tier1

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -35,8 +35,7 @@ tier1_part1 = \
     :jdk_lang
 
 tier1_part2 = \
-    :jdk_util \
-    -java/util/Arrays/TimSortStackSize2.java
+    :jdk_util
 
 tier1_part3 = \
     :jdk_math \
@@ -67,9 +66,7 @@ tier2_part2 = \
     -sun/nio/cs/ISO8859x.java \
     :jdk_other \
     :jdk_text \
-    :jdk_time \
-    java/util/Arrays/TimSortStackSize2.java
-
+    :jdk_time
 
 tier2_part3 = \
     :jdk_net

--- a/test/jdk/java/util/Arrays/TimSortStackSize2.java
+++ b/test/jdk/java/util/Arrays/TimSortStackSize2.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8072909
  * @summary Test TimSort stack size on big arrays
- * @key intermittent
  * @library /lib/testlibrary /test/lib
  * @modules java.management
  *          java.base/jdk.internal


### PR DESCRIPTION
Backport of JDK-8210353. Needed trivial resolve - but bots recognize it as clean. Diff looks same as original.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210353](https://bugs.openjdk.java.net/browse/JDK-8210353): Move java/util/Arrays/TimSortStackSize2.java back to tier1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/321/head:pull/321` \
`$ git checkout pull/321`

Update a local copy of the PR: \
`$ git checkout pull/321` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 321`

View PR using the GUI difftool: \
`$ git pr show -t 321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/321.diff">https://git.openjdk.java.net/jdk11u-dev/pull/321.diff</a>

</details>
