### PR TITLE
8252049: Native memory leak in ciMethodData ctor

### DIFF
--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -37,46 +37,21 @@
 // ------------------------------------------------------------------
 // ciMethodData::ciMethodData
 //
-ciMethodData::ciMethodData(MethodData* md) : ciMetadata(md) {
-  assert(md != NULL, "no null method data");
-  Copy::zero_to_words((HeapWord*) &_orig, sizeof(_orig) / sizeof(HeapWord));
-  _data = NULL;
-  _data_size = 0;
-  _extra_data_size = 0;
-  _current_mileage = 0;
-  _invocation_counter = 0;
-  _backedge_counter = 0;
-  _state = empty_state;
-  _saw_free_extra_data = false;
+ciMethodData::ciMethodData(MethodData* md)
+: ciMetadata(md),
+  _data_size(0), _extra_data_size(0), _data(NULL),
   // Set an initial hint. Don't use set_hint_di() because
   // first_di() may be out of bounds if data_size is 0.
-  _hint_di = first_di();
+  _hint_di(first_di()),
+  _state(empty_state),
+  _saw_free_extra_data(false),
   // Initialize the escape information (to "don't know.");
-  _eflags = _arg_local = _arg_stack = _arg_returned = 0;
-  _parameters = NULL;
-}
-
-// ------------------------------------------------------------------
-// ciMethodData::ciMethodData
-//
-// No MethodData*.
-ciMethodData::ciMethodData() : ciMetadata(NULL) {
-  Copy::zero_to_words((HeapWord*) &_orig, sizeof(_orig) / sizeof(HeapWord));
-  _data = NULL;
-  _data_size = 0;
-  _extra_data_size = 0;
-  _current_mileage = 0;
-  _invocation_counter = 0;
-  _backedge_counter = 0;
-  _state = empty_state;
-  _saw_free_extra_data = false;
-  // Set an initial hint. Don't use set_hint_di() because
-  // first_di() may be out of bounds if data_size is 0.
-  _hint_di = first_di();
-  // Initialize the escape information (to "don't know.");
-  _eflags = _arg_local = _arg_stack = _arg_returned = 0;
-  _parameters = NULL;
-}
+  _eflags(0), _arg_local(0), _arg_stack(0), _arg_returned(0),
+  _current_mileage(0),
+  _invocation_counter(0),
+  _backedge_counter(0),
+  _orig(),
+  _parameters(NULL) {}
 
 void ciMethodData::load_extra_data() {
   MethodData* mdo = get_MethodData();
@@ -141,7 +116,8 @@ bool ciMethodData::load_data() {
   // Snapshot the data -- actually, take an approximate snapshot of
   // the data.  Any concurrently executing threads may be changing the
   // data as we copy it.
-  Copy::disjoint_words_atomic((HeapWord*) mdo,
+  STATIC_ASSERT(sizeof(_orig) % HeapWordSize == 0); // "align"
+  Copy::disjoint_words_atomic((HeapWord*) &mdo->_compiler_counters,
                               (HeapWord*) &_orig,
                               sizeof(_orig) / HeapWordSize);
   Arena* arena = CURRENT_ENV->arena();

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -400,10 +400,10 @@ private:
   u_char _saw_free_extra_data;
 
   // Support for interprocedural escape analysis
-  intx              _eflags;          // flags on escape information
-  intx              _arg_local;       // bit set of non-escaping arguments
-  intx              _arg_stack;       // bit set of stack-allocatable arguments
-  intx              _arg_returned;    // bit set of returned arguments
+  intx _eflags;       // flags on escape information
+  intx _arg_local;    // bit set of non-escaping arguments
+  intx _arg_stack;    // bit set of stack-allocatable arguments
+  intx _arg_returned; // bit set of returned arguments
 
   // Maturity of the oop when the snapshot is taken.
   int _current_mileage;
@@ -415,17 +415,15 @@ private:
   int _backedge_counter;
 
   // Coherent snapshot of original header.
-  MethodData _orig;
+  MethodData::CompilerCounters _orig;
 
-  // Area dedicated to parameters. NULL if no parameter profiling for
-  // this method.
+  // Area dedicated to parameters. NULL if no parameter profiling for this method.
   DataLayout* _parameters;
   int parameters_size() const {
     return _parameters == NULL ? 0 : parameters_type_data()->size_in_bytes();
   }
 
-  ciMethodData(MethodData* md);
-  ciMethodData();
+  ciMethodData(MethodData* md = NULL);
 
   // Accessors
   int data_size() const { return _data_size; }
@@ -554,8 +552,8 @@ public:
   uint trap_count(int reason) const {
     return _orig.trap_count(reason);
   }
-  uint trap_reason_limit() const { return _orig.trap_reason_limit(); }
-  uint trap_count_limit()  const { return _orig.trap_count_limit(); }
+  uint trap_reason_limit() const { return MethodData::trap_reason_limit(); }
+  uint trap_count_limit()  const { return MethodData::trap_count_limit(); }
 
   // Helpful query functions that decode trap_state.
   int has_trap_at(ciProfileData* data, int reason);

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -239,10 +239,10 @@
   nonstatic_field(MethodData,                  _data_size,                                    int)                                   \
   nonstatic_field(MethodData,                  _data[0],                                      intptr_t)                              \
   nonstatic_field(MethodData,                  _parameters_type_data_di,                      int)                                   \
-  nonstatic_field(MethodData,                  _nof_decompiles,                               uint)                                  \
-  nonstatic_field(MethodData,                  _nof_overflow_recompiles,                      uint)                                  \
-  nonstatic_field(MethodData,                  _nof_overflow_traps,                           uint)                                  \
-  nonstatic_field(MethodData,                  _trap_hist._array[0],                          u1)                                    \
+  nonstatic_field(MethodData,                  _compiler_counters._nof_decompiles,            uint)                                  \
+  nonstatic_field(MethodData,                  _compiler_counters._nof_overflow_recompiles,   uint)                                  \
+  nonstatic_field(MethodData,                  _compiler_counters._nof_overflow_traps,        uint)                                  \
+  nonstatic_field(MethodData,                  _compiler_counters._trap_hist._array[0],       u1)                                    \
   nonstatic_field(MethodData,                  _eflags,                                       intx)                                  \
   nonstatic_field(MethodData,                  _arg_local,                                    intx)                                  \
   nonstatic_field(MethodData,                  _arg_stack,                                    intx)                                  \

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "ci/ciMethodData.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "compiler/compilerOracle.hpp"
 #include "interpreter/bytecode.hpp"
@@ -709,7 +710,7 @@ MethodData* MethodData::allocate(ClassLoaderData* loader_data, const methodHandl
   int size = MethodData::compute_allocation_size_in_words(method);
 
   return new (loader_data, size, MetaspaceObj::MethodDataType, THREAD)
-    MethodData(method(), size, THREAD);
+    MethodData(method());
 }
 
 int MethodData::bytecode_cell_count(Bytecodes::Code code) {
@@ -1131,11 +1132,11 @@ void MethodData::post_initialize(BytecodeStream* stream) {
 }
 
 // Initialize the MethodData* corresponding to a given method.
-MethodData::MethodData(const methodHandle& method, int size, TRAPS)
-  : _extra_data_lock(Monitor::leaf, "MDO extra data lock"),
+MethodData::MethodData(const methodHandle& method)
+  : _method(method()),
+    _extra_data_lock(Mutex::leaf, "MDO extra data lock"),
+    _compiler_counters(method()),
     _parameters_type_data_di(parameters_uninitialized) {
-  // Set the method back-pointer.
-  _method = method();
   initialize();
 }
 
@@ -1144,7 +1145,6 @@ void MethodData::initialize() {
   ResourceMark rm;
 
   init();
-  set_creation_mileage(mileage_of(method()));
 
   // Go through the bytecodes and allocate and initialize the
   // corresponding data cells.
@@ -1244,14 +1244,8 @@ void MethodData::init() {
   }
 #endif
 
-  // Initialize flags and trap history.
-  _nof_decompiles = 0;
-  _nof_overflow_recompiles = 0;
-  _nof_overflow_traps = 0;
+  // Initialize escape flags.
   clear_escape_info();
-  assert(sizeof(_trap_hist) % sizeof(HeapWord) == 0, "align");
-  Copy::zero_to_words((HeapWord*) &_trap_hist,
-                      sizeof(_trap_hist) / sizeof(HeapWord));
 }
 
 // Get a measure of how much mileage the method has on it.

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -32,6 +32,7 @@
 #include "oops/oop.hpp"
 #include "runtime/atomic.hpp"
 #include "utilities/align.hpp"
+#include "utilities/copy.hpp"
 #if INCLUDE_JVMCI
 #include "jvmci/jvmci_globals.hpp"
 #endif
@@ -1945,12 +1946,15 @@ public:
 
 class CleanExtraDataClosure;
 
+class ciMethodData;
+
 class MethodData : public Metadata {
   friend class VMStructs;
   friend class JVMCIVMStructs;
 private:
   friend class ProfileData;
   friend class TypeEntriesAtCall;
+  friend class ciMethodData;
 
   // If you add a new field that points to any metaspace object, you
   // must add this field to MethodData::metaspace_pointers_do().
@@ -1966,10 +1970,9 @@ private:
 
   Mutex _extra_data_lock;
 
-  MethodData(const methodHandle& method, int size, TRAPS);
+  MethodData(const methodHandle& method);
 public:
   static MethodData* allocate(ClassLoaderData* loader_data, const methodHandle& method, TRAPS);
-  MethodData() : _extra_data_lock(Monitor::leaf, "MDO extra data lock") {}; // For ciMethodData
 
   bool is_methodData() const volatile { return true; }
   void initialize();
@@ -1980,22 +1983,87 @@ public:
     _trap_hist_mask     = max_jubyte,
     _extra_data_count   = 4     // extra DataLayout headers, for trap history
   }; // Public flag values
+
+  // Compiler-related counters.
+  class CompilerCounters {
+    friend class VMStructs;
+    friend class JVMCIVMStructs;
+
+    int  _creation_mileage;           // method mileage at MDO creation
+    uint _nof_decompiles;             // count of all nmethod removals
+    uint _nof_overflow_recompiles;    // recompile count, excluding recomp. bits
+    uint _nof_overflow_traps;         // trap count, excluding _trap_hist
+    union {
+      intptr_t _align;
+      u1 _array[JVMCI_ONLY(2 *) MethodData::_trap_hist_limit];
+    } _trap_hist;
+
+    void init_trap_hist() {
+      STATIC_ASSERT(sizeof(_trap_hist) % HeapWordSize == 0); // "align"
+      uint size_in_words = sizeof(_trap_hist) / HeapWordSize;
+      Copy::zero_to_words((HeapWord*) &_trap_hist, size_in_words);
+    }
+  public:
+    CompilerCounters(Method* m) : _creation_mileage(MethodData::mileage_of(m)),
+      _nof_decompiles(0), _nof_overflow_recompiles(0), _nof_overflow_traps(0) {
+      init_trap_hist();
+    }
+    CompilerCounters() : _creation_mileage(0), // for ciMethodData
+      _nof_decompiles(0), _nof_overflow_recompiles(0), _nof_overflow_traps(0) {
+      init_trap_hist();
+    }
+
+    int      creation_mileage() const { return _creation_mileage; }
+
+    // Return (uint)-1 for overflow.
+    uint trap_count(int reason) const {
+      assert((uint)reason < JVMCI_ONLY(2*) _trap_hist_limit, "oob");
+      return (int)((_trap_hist._array[reason]+1) & _trap_hist_mask) - 1;
+    }
+
+    uint inc_trap_count(int reason) {
+      // Count another trap, anywhere in this method.
+      assert(reason >= 0, "must be single trap");
+      assert((uint)reason < JVMCI_ONLY(2*) _trap_hist_limit, "oob");
+      uint cnt1 = 1 + _trap_hist._array[reason];
+      if ((cnt1 & _trap_hist_mask) != 0) {  // if no counter overflow...
+        _trap_hist._array[reason] = cnt1;
+        return cnt1;
+      } else {
+        return _trap_hist_mask + (++_nof_overflow_traps);
+      }
+    }
+
+    uint overflow_trap_count() const {
+      return _nof_overflow_traps;
+    }
+    uint overflow_recompile_count() const {
+      return _nof_overflow_recompiles;
+    }
+    uint inc_overflow_recompile_count() {
+      return ++_nof_overflow_recompiles;
+    }
+    uint decompile_count() const {
+      return _nof_decompiles;
+    }
+    uint inc_decompile_count() {
+      return ++_nof_decompiles;
+    }
+
+    // Support for code generation
+    static ByteSize trap_history_offset() {
+      return byte_offset_of(CompilerCounters, _trap_hist._array);
+    }
+  };
+
 private:
-  uint _nof_decompiles;             // count of all nmethod removals
-  uint _nof_overflow_recompiles;    // recompile count, excluding recomp. bits
-  uint _nof_overflow_traps;         // trap count, excluding _trap_hist
-  union {
-    intptr_t _align;
-    u1 _array[JVMCI_ONLY(2 *) _trap_hist_limit];
-  } _trap_hist;
+  CompilerCounters _compiler_counters;
 
   // Support for interprocedural escape analysis, from Thomas Kotzmann.
   intx              _eflags;          // flags on escape information
   intx              _arg_local;       // bit set of non-escaping arguments
   intx              _arg_stack;       // bit set of stack-allocatable arguments
   intx              _arg_returned;    // bit set of returned arguments
-
-  int _creation_mileage;              // method mileage at MDO creation
 
   // How many invocations has this MDO seen?
   // These counters are used to determine the exact age of MDO.
@@ -2145,8 +2213,7 @@ public:
   void collect_statistics(KlassSizeStats *sz) const;
 #endif
 
-  int      creation_mileage() const  { return _creation_mileage; }
-  void set_creation_mileage(int x)   { _creation_mileage = x; }
+  int      creation_mileage() const { return _compiler_counters.creation_mileage(); }
 
   int invocation_count() {
     if (invocation_counter()->carry()) {
@@ -2308,42 +2375,33 @@ public:
 
   // Return (uint)-1 for overflow.
   uint trap_count(int reason) const {
-    assert((uint)reason < JVMCI_ONLY(2*) _trap_hist_limit, "oob");
-    return (int)((_trap_hist._array[reason]+1) & _trap_hist_mask) - 1;
+    return _compiler_counters.trap_count(reason);
   }
   // For loops:
   static uint trap_reason_limit() { return _trap_hist_limit; }
   static uint trap_count_limit()  { return _trap_hist_mask; }
   uint inc_trap_count(int reason) {
-    // Count another trap, anywhere in this method.
-    assert(reason >= 0, "must be single trap");
-    assert((uint)reason < JVMCI_ONLY(2*) _trap_hist_limit, "oob");
-    uint cnt1 = 1 + _trap_hist._array[reason];
-    if ((cnt1 & _trap_hist_mask) != 0) {  // if no counter overflow...
-      _trap_hist._array[reason] = cnt1;
-      return cnt1;
-    } else {
-      return _trap_hist_mask + (++_nof_overflow_traps);
-    }
+    return _compiler_counters.inc_trap_count(reason);
   }
 
   uint overflow_trap_count() const {
-    return _nof_overflow_traps;
+    return _compiler_counters.overflow_trap_count();
   }
   uint overflow_recompile_count() const {
-    return _nof_overflow_recompiles;
+    return _compiler_counters.overflow_recompile_count();
   }
-  void inc_overflow_recompile_count() {
-    _nof_overflow_recompiles += 1;
+  uint inc_overflow_recompile_count() {
+    return _compiler_counters.inc_overflow_recompile_count();
   }
   uint decompile_count() const {
-    return _nof_decompiles;
+    return _compiler_counters.decompile_count();
   }
-  void inc_decompile_count() {
-    _nof_decompiles += 1;
-    if (decompile_count() > (uint)PerMethodRecompilationCutoff) {
+  uint inc_decompile_count() {
+    uint dec_count = _compiler_counters.inc_decompile_count();
+    if (dec_count > (uint)PerMethodRecompilationCutoff) {
       method()->set_not_compilable(CompLevel_full_optimization, true, "decompile_count > PerMethodRecompilationCutoff");
     }
+    return dec_count;
   }
   uint tenure_traps() const {
     return _tenure_traps;
@@ -2369,7 +2427,7 @@ public:
   }
 
   static ByteSize trap_history_offset() {
-    return byte_offset_of(MethodData, _trap_hist._array);
+    return byte_offset_of(MethodData, _compiler_counters) + CompilerCounters::trap_history_offset();
   }
 
   static ByteSize invocation_counter_offset() {

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -277,10 +277,10 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
   nonstatic_field(MethodData,                  _data_size,                                    int)                                   \
   nonstatic_field(MethodData,                  _data[0],                                      intptr_t)                              \
   nonstatic_field(MethodData,                  _parameters_type_data_di,                      int)                                   \
-  nonstatic_field(MethodData,                  _nof_decompiles,                               uint)                                  \
-  nonstatic_field(MethodData,                  _nof_overflow_recompiles,                      uint)                                  \
-  nonstatic_field(MethodData,                  _nof_overflow_traps,                           uint)                                  \
-  nonstatic_field(MethodData,                  _trap_hist._array[0],                          u1)                                    \
+  nonstatic_field(MethodData,                  _compiler_counters._nof_decompiles,            uint)                                  \
+  nonstatic_field(MethodData,                  _compiler_counters._nof_overflow_recompiles,   uint)                                  \
+  nonstatic_field(MethodData,                  _compiler_counters._nof_overflow_traps,        uint)                                  \
+  nonstatic_field(MethodData,                  _compiler_counters._trap_hist._array[0],       u1)                                    \
   nonstatic_field(MethodData,                  _eflags,                                       intx)                                  \
   nonstatic_field(MethodData,                  _arg_local,                                    intx)                                  \
   nonstatic_field(MethodData,                  _arg_stack,                                    intx)                                  \
@@ -901,7 +901,7 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
   nonstatic_field(ciMethodData,                _arg_stack,                                    intx)                                  \
   nonstatic_field(ciMethodData,                _arg_returned,                                 intx)                                  \
   nonstatic_field(ciMethodData,                _current_mileage,                              int)                                   \
-  nonstatic_field(ciMethodData,                _orig,                                         MethodData)                            \
+  nonstatic_field(ciMethodData,                _orig,                                         MethodData::CompilerCounters)          \
                                                                                                                                      \
   nonstatic_field(ciField,                     _holder,                                       ciInstanceKlass*)                      \
   nonstatic_field(ciField,                     _name,                                         ciSymbol*)                             \
@@ -1309,6 +1309,8 @@ typedef PaddedEnd<ObjectMonitor>              PaddedObjectMonitor;
     declare_type(Method, Metadata)                                        \
     declare_type(MethodCounters, MetaspaceObj)                            \
     declare_type(ConstMethod, MetaspaceObj)                               \
+                                                                          \
+  declare_toplevel_type(MethodData::CompilerCounters)                     \
                                                                           \
   declare_toplevel_type(narrowKlass)                                      \
                                                                           \

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
@@ -164,12 +164,12 @@ class HotSpotVMConfig extends HotSpotVMConfigAccess {
     final int methodDataSize = getFieldOffset("MethodData::_size", Integer.class, "int");
     final int methodDataDataSize = getFieldOffset("MethodData::_data_size", Integer.class, "int");
     final int methodDataOopDataOffset = getFieldOffset("MethodData::_data[0]", Integer.class, "intptr_t");
-    final int methodDataOopTrapHistoryOffset = getFieldOffset("MethodData::_trap_hist._array[0]", Integer.class, "u1");
+    final int methodDataOopTrapHistoryOffset = getFieldOffset("MethodData::_compiler_counters._trap_hist._array[0]", Integer.class, "u1");
     final int methodDataIRSizeOffset = getFieldOffset("MethodData::_jvmci_ir_size", Integer.class, "int");
 
-    final int methodDataDecompiles = getFieldOffset("MethodData::_nof_decompiles", Integer.class, "uint");
-    final int methodDataOverflowRecompiles = getFieldOffset("MethodData::_nof_overflow_recompiles", Integer.class, "uint");
-    final int methodDataOverflowTraps = getFieldOffset("MethodData::_nof_overflow_traps", Integer.class, "uint");
+    final int methodDataDecompiles = getFieldOffset("MethodData::_compiler_counters._nof_decompiles", Integer.class, "uint");
+    final int methodDataOverflowRecompiles = getFieldOffset("MethodData::_compiler_counters._nof_overflow_recompiles", Integer.class, "uint");
+    final int methodDataOverflowTraps = getFieldOffset("MethodData::_compiler_counters._nof_overflow_traps", Integer.class, "uint");
 
     final int nmethodCompLevelOffset = getFieldOffset("nmethod::_comp_level", Integer.class, "int");
 


### PR DESCRIPTION
Backport of JDK-8252049. Doesn't apply cleanly and C++11 code needs replacement. Resolution:

- Use `STATIC_ASSERT` instead of `static_assert`.
- Use classical instead of delegating constructor for `CompilerCounters`.
- Integrate hunks manually due to different context: methodData.hpp, methodData.cpp, ciMethodData.cpp
- Skip ciReplay.cpp because JDK-8219642 is not in 11u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252049](https://bugs.openjdk.java.net/browse/JDK-8252049): Native memory leak in ciMethodData ctor


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/327/head:pull/327` \
`$ git checkout pull/327`

Update a local copy of the PR: \
`$ git checkout pull/327` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 327`

View PR using the GUI difftool: \
`$ git pr show -t 327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/327.diff">https://git.openjdk.java.net/jdk11u-dev/pull/327.diff</a>

</details>
