### PR TITLE
8268672: C2: assert(!loop->is_member(u_loop)) failed: can be in outer loop or out of both loops only

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1851,10 +1851,13 @@ static void clone_outer_loop_helper(Node* n, const IdealLoopTree *loop, const Id
     Node* u = n->fast_out(j);
     assert(check_old_new || old_new[u->_idx] == NULL, "shouldn't have been cloned");
     if (!u->is_CFG() && (!check_old_new || old_new[u->_idx] == NULL)) {
-      Node* c = u->in(0) != NULL ? u->in(0) : phase->get_ctrl(u);
+      Node* c = phase->get_ctrl(u);
       IdealLoopTree* u_loop = phase->get_loop(c);
       assert(!loop->is_member(u_loop), "can be in outer loop or out of both loops only");
-      if (outer_loop->is_member(u_loop)) {
+      if (outer_loop->is_member(u_loop) ||
+          // nodes pinned with control in the outer loop but not referenced from the safepoint must be moved out of
+          // the outer loop too
+          (u->in(0) != NULL && outer_loop->is_member(phase->get_loop(u->in(0))))) {
         wq.push(u);
       }
     }

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestPinnedNodeInInnerLoop.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestPinnedNodeInInnerLoop.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8268672
+ * @summary C2: assert(!loop->is_member(u_loop)) failed: can be in outer loop or out of both loops only
+ *
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestPinnedNodeInInnerLoop TestPinnedNodeInInnerLoop
+ *
+ */
+
+public class TestPinnedNodeInInnerLoop {
+    boolean b;
+    double d;
+    int iArr[];
+
+    public static void main(String[] args) {
+        TestPinnedNodeInInnerLoop t = new TestPinnedNodeInInnerLoop();
+        for (int i = 0; i < 10; i++) {
+            t.test();
+        }
+    }
+
+    void test() {
+        int e = 4, f = -51874, g = 7, h = 0;
+
+        for (; f < 3; ++f) {
+        }
+        while (++g < 2) {
+            if (b) {
+                d = h;
+            } else {
+                iArr[g] = e;
+            }
+        }
+        System.out.println(g);
+    }
+}


### PR DESCRIPTION
Dependent PR for JDK-8268672 on top of JDK-8263303.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268672](https://bugs.openjdk.java.net/browse/JDK-8268672): C2: assert(!loop->is_member(u_loop)) failed: can be in outer loop or out of both loops only


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/341/head:pull/341` \
`$ git checkout pull/341`

Update a local copy of the PR: \
`$ git checkout pull/341` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 341`

View PR using the GUI difftool: \
`$ git pr show -t 341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/341.diff">https://git.openjdk.java.net/jdk11u-dev/pull/341.diff</a>

</details>
