### PR TITLE
8268019: C2: assert(no_dead_loop) failed: dead loop detected

### DIFF
--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -115,10 +115,11 @@ static Node* split_if(IfNode *iff, PhaseIterGVN *igvn) {
   if( !t->singleton() ) return NULL;
 
   // No intervening control, like a simple Call
-  Node *r = iff->in(0);
-  if( !r->is_Region() ) return NULL;
-  if (r->is_Loop()) return NULL;
-  if( phi->region() != r ) return NULL;
+  Node* r = iff->in(0);
+  if (!r->is_Region() || r->is_Loop() || phi->region() != r || r->as_Region()->is_copy()) {
+    return NULL;
+  }
+
   // No other users of the cmp/bool
   if (b->outcnt() != 1 || cmp->outcnt() != 1) {
     //tty->print_cr("many users of cmp/bool");
@@ -244,13 +245,23 @@ static Node* split_if(IfNode *iff, PhaseIterGVN *igvn) {
     }
     Node* proj = PhaseIdealLoop::find_predicate(r->in(ii));
     if (proj != NULL) {
+      // Bail out if splitting through a region with a predicate input (could
+      // also be a loop header before loop opts creates a LoopNode for it).
       return NULL;
     }
   }
 
   // If all the defs of the phi are the same constant, we already have the desired end state.
   // Skip the split that would create empty phi and region nodes.
-  if((r->req() - req_c) == 1) {
+  if ((r->req() - req_c) == 1) {
+    return NULL;
+  }
+
+  // At this point we know that we can apply the split if optimization. If the region is still on the worklist,
+  // we should wait until it is processed. The region might be removed which makes this optimization redundant.
+  // This also avoids the creation of dead data loops when rewiring data nodes below when a region is dying.
+  if (igvn->_worklist.member(r)) {
+    igvn->_worklist.push(iff); // retry split if later again
     return NULL;
   }
 

--- a/test/hotspot/jtreg/compiler/c2/TestDeadLoopSplitIfLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDeadLoopSplitIfLoop.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key stress
+ * @requires vm.compiler2.enabled
+ * @bug 8268019
+ * @summary Splitting an If through a dying loop header region that is not a LoopNode, yet, results in a dead data loop.
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileCommand=compileonly,compiler.c2.TestDeadLoopSplitIfLoop::test -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:CompileCommand=dontinline,compiler.c2.TestDeadLoopSplitIfLoop::test
+ *                   compiler.c2.TestDeadLoopSplitIfLoop
+ */
+package compiler.c2;
+
+public class TestDeadLoopSplitIfLoop {
+    int a;
+    int b;
+    boolean c;
+
+    public static void main(String[] g) {
+        TestDeadLoopSplitIfLoop h = new TestDeadLoopSplitIfLoop();
+        h.test();
+    }
+
+    void test() {
+        int e = 4;
+        long f[] = new long[a];
+        if (c) {
+        } else if (c) {
+            // Dead path is removed after parsing which results in a dead data loop for certain node orderings in IGVN.
+            switch (126) {
+                case 126:
+                    do {
+                        f[e] = b;
+                        switch (6) {
+                            case 7:
+                                f = f;
+                        }
+                    } while (e++ < 93);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backport of JDK-8268019. Applies cleanly, but test needs modification. Some VM options from the original test are not available in 11u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268019](https://bugs.openjdk.java.net/browse/JDK-8268019): C2: assert(no_dead_loop) failed: dead loop detected


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/342/head:pull/342` \
`$ git checkout pull/342`

Update a local copy of the PR: \
`$ git checkout pull/342` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 342`

View PR using the GUI difftool: \
`$ git pr show -t 342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/342.diff">https://git.openjdk.java.net/jdk11u-dev/pull/342.diff</a>

</details>
