### PR TITLE
8269951: [macos] Focus not painted in JButton when  setBorderPainted(false) is invoked

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -324,6 +324,35 @@ public class AquaButtonUI extends BasicButtonUI implements Sizeable {
                 paintText(g, b, textRect, text);
             }
         }
+    }
+
+    protected void paintFocus(Graphics g, AbstractButton b,
+                              Rectangle viewRect, Rectangle textRect, Rectangle iconRect) {
+        Graphics2D g2d = null;
+        Stroke oldStroke = null;
+        Object oldAntialiasingHint = null;
+        Color oldColor = g.getColor();
+        if (g instanceof Graphics2D) {
+            g2d = (Graphics2D)g;
+            oldStroke = g2d.getStroke();
+            oldAntialiasingHint = g2d.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
+            g2d.setStroke(new BasicStroke(3));
+            g2d.setRenderingHint(
+                    RenderingHints.KEY_ANTIALIASING,
+                    RenderingHints.VALUE_ANTIALIAS_ON);
+
+        }
+        Color ringColor = UIManager.getColor("Focus.color");
+        g.setColor(ringColor);
+        g.drawRoundRect(5, 3, b.getWidth() - 10, b.getHeight() - 7, 15, 15);
+        if (g2d != null) {
+            // Restore old state of Java2D renderer
+            g2d.setStroke(oldStroke);
+            g2d.setRenderingHint(
+                    RenderingHints.KEY_ANTIALIASING,
+                    oldAntialiasingHint);
+        }
+        g.setColor(oldColor);
     }
 
     protected String layoutAndGetText(final Graphics g, final AbstractButton b, final AquaButtonBorder aquaBorder, final Insets i, Rectangle viewRect, Rectangle iconRect, Rectangle textRect) {

--- a/test/jdk/javax/swing/plaf/aqua/AquaButtonFocusTest.java
+++ b/test/jdk/javax/swing/plaf/aqua/AquaButtonFocusTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires (os.family == "mac")
+ * @bug 8269951
+ * @summary Test checks that focus is painted on JButton even
+ *          when borders turned off
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main AquaButtonFocusTest
+ */
+
+
+import javax.swing.JButton;
+import javax.swing.UIManager;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+
+public class AquaButtonFocusTest {
+    public static void main(String[] args) {
+        new AquaButtonFocusTest().performTest();
+    }
+
+    public void performTest() {
+        try {
+            UIManager.setLookAndFeel("com.apple.laf.AquaLookAndFeel");
+        } catch (Exception e) {
+            throw new RuntimeException("Can not initialize Aqua L&F");
+        }
+
+        FocusableButton one = new FocusableButton("One");
+        one.setSize(100, 100);
+        one.setBorderPainted(false);
+        BufferedImage noFocus = new BufferedImage(200, 100, BufferedImage.TYPE_INT_ARGB);
+        Graphics g = noFocus.createGraphics();
+        one.paint(g);
+        g.dispose();
+        BufferedImage focus = new BufferedImage(200, 100, BufferedImage.TYPE_INT_ARGB);
+        one.setFocusOwner(true);
+        g = focus.createGraphics();
+        one.paint(g);
+        g.dispose();
+        if (Util.compareBufferedImages(noFocus, focus)) {
+            throw new RuntimeException("Focus is not painted on JButton");
+        }
+    }
+
+    class FocusableButton extends JButton {
+        private boolean focusOwner = false;
+
+        public FocusableButton(String label) {
+            super(label);
+        }
+
+        public void setFocusOwner(boolean focused) {
+            this.focusOwner = focused;
+        }
+
+        @Override
+        public boolean isFocusOwner() {
+            return focusOwner;
+        }
+
+        @Override
+        public boolean hasFocus() {
+            return this.focusOwner;
+        }
+    }
+}


### PR DESCRIPTION
Backport of JDK-8269951. Applies cleanly except Copyright year update.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269951](https://bugs.openjdk.java.net/browse/JDK-8269951): [macos] Focus not painted in JButton when  setBorderPainted(false) is invoked


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/344/head:pull/344` \
`$ git checkout pull/344`

Update a local copy of the PR: \
`$ git checkout pull/344` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 344`

View PR using the GUI difftool: \
`$ git pr show -t 344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/344.diff">https://git.openjdk.java.net/jdk11u-dev/pull/344.diff</a>

</details>
