### PR TITLE
8272806: [macOS] "Apple AWT Internal Exception" when input method is changed

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CInputMethod.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CInputMethod.m
@@ -115,9 +115,7 @@ static void initializeInputMethodController() {
     AWT_ASSERT_APPKIT_THREAD;
 
     if (!view) return;
-    if (!inputMethod) return;
-
-    [view setInputMethod:inputMethod]; // inputMethod is a GlobalRef
+    [view setInputMethod:inputMethod]; // inputMethod is a GlobalRef or null to disable.
 }
 
 + (void) _nativeEndComposition:(AWTView *)view {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
@@ -259,6 +259,7 @@ BOOL isSWTInWebStart(JNIEnv* env) {
 
 static void AWT_NSUncaughtExceptionHandler(NSException *exception) {
     NSLog(@"Apple AWT Internal Exception: %@", [exception description]);
+    NSLog(@"trace: %@", [exception callStackSymbols]);
 }
 
 @interface AWTStarter : NSObject


### PR DESCRIPTION
Clean backport of JDK-8272806.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272806](https://bugs.openjdk.java.net/browse/JDK-8272806): [macOS] "Apple AWT Internal Exception" when input method is changed


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/345/head:pull/345` \
`$ git checkout pull/345`

Update a local copy of the PR: \
`$ git checkout pull/345` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 345`

View PR using the GUI difftool: \
`$ git pr show -t 345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/345.diff">https://git.openjdk.java.net/jdk11u-dev/pull/345.diff</a>

</details>
