### PR TITLE
8210182: Remove macros for C compilation from vmTestBase but non jvmti

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn004/libforceEarlyReturn004a.c
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn004/libforceEarlyReturn004a.c
@@ -23,25 +23,8 @@
 
 #include "jni.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_PTR
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG_2(x, y) y
-#define JNI_ENV_ARG_3(x, y, z) y, z
-#define JNI_ENV_ARG_4(x, y, z, a) y, z, a
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG_2(x,y) x, y
-#define JNI_ENV_ARG_3(x, y, z) x, y, z
-#define JNI_ENV_ARG_4(x, y, z, a) x, y, z, a
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 int always_true = 1;
 
@@ -50,9 +33,9 @@ Java_nsk_jdi_ThreadReference_forceEarlyReturn_forceEarlyReturn004_forceEarlyRetu
 {
     int dummy_counter = 0;
     // notify another thread that thread in native method
-    jclass klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, object));
-    jfieldID field = JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG_4(env, klass, "threadInNative", "Z"));
-    JNI_ENV_PTR(env)->SetBooleanField(JNI_ENV_ARG_4(env, object, field, 1));
+    jclass klass = env->GetObjectClass(object);
+    jfieldID field = env->GetFieldID(klass, "threadInNative", "Z");
+    env->SetBooleanField(object, field, 1);
 
     // execute infinite loop to be sure that thread in native method
     while(always_true)
@@ -66,6 +49,4 @@ Java_nsk_jdi_ThreadReference_forceEarlyReturn_forceEarlyReturn004_forceEarlyRetu
     return dummy_counter >= 0 ? 0 : 1;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/libforceEarlyReturn002a.c
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/libforceEarlyReturn002a.c
@@ -23,25 +23,8 @@
 
 #include "jni.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_PTR
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG_2(x, y) y
-#define JNI_ENV_ARG_3(x, y, z) y, z
-#define JNI_ENV_ARG_4(x, y, z, a) y, z, a
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG_2(x,y) x, y
-#define JNI_ENV_ARG_3(x, y, z) x, y, z
-#define JNI_ENV_ARG_4(x, y, z, a) x, y, z, a
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 int always_true = 1;
 
@@ -50,9 +33,9 @@ Java_nsk_jdwp_ThreadReference_ForceEarlyReturn_forceEarlyReturn002_forceEarlyRet
 {
     int dummy_counter = 0;
     // notify another thread that thread in native method
-    jclass klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, object));
-    jfieldID field = JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG_4(env, klass, "threadInNative", "Z"));
-    JNI_ENV_PTR(env)->SetBooleanField(JNI_ENV_ARG_4(env, object, field, 1));
+    jclass klass = env->GetObjectClass(object);
+    jfieldID field = env->GetFieldID(klass, "threadInNative", "Z");
+    env->SetBooleanField(object, field, 1);
 
     // execute infinite loop to be sure that thread in native method
     while(always_true)
@@ -66,6 +49,4 @@ Java_nsk_jdwp_ThreadReference_ForceEarlyReturn_forceEarlyReturn002_forceEarlyRet
     return dummy_counter >= 0 ? 0 : 1;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/MonitorEnterExecutor.c
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/MonitorEnterExecutor.c
@@ -23,45 +23,34 @@
 #include "jni.h"
 #include "nsk_tools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_PTR
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG_2(x, y) y
-#define JNI_ENV_ARG_3(x,y, z) y, z
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG_2(x,y) x, y
-#define JNI_ENV_ARG_3(x,y, z) x, y, z
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 JNIEXPORT void JNICALL
 Java_nsk_share_jdi_MonitorEnterExecutor_nativeJNIMonitorEnter(JNIEnv *env, jobject thisObject)
 {
         jint success;
 
-        success  = JNI_ENV_PTR(env)->MonitorEnter(JNI_ENV_ARG_2(env, thisObject));
+        success  = env->MonitorEnter(thisObject);
 
         if(success != 0)
         {
                 NSK_COMPLAIN1("MonitorEnter return non-zero: %d\n", success);
 
-                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestJNIError")), "MonitorEnter return non-zero"));
+                env->ThrowNew(
+                    env->FindClass("nsk/share/TestJNIError"),
+                    "MonitorEnter return non-zero");
         }
 
-        success  = JNI_ENV_PTR(env)->MonitorExit(JNI_ENV_ARG_2(env, thisObject));
+        success  = env->MonitorExit(thisObject);
 
         if(success != 0)
         {
                 NSK_COMPLAIN1("MonitorExit return non-zero: %d\n", success);
 
-                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestJNIError")), "MonitorExit return non-zero"));
+                env->ThrowNew(
+                    env->FindClass("nsk/share/TestJNIError"),
+                    "MonitorExit return non-zero");
         }
 }
 
@@ -70,22 +59,26 @@ Java_nsk_share_jdi_MonitorEnterExecutor_11Subclass_nativeJNIMonitorEnter(JNIEnv 
 {
         jint success;
 
-        success  = JNI_ENV_PTR(env)->MonitorEnter(JNI_ENV_ARG_2(env, thisObject));
+        success  = env->MonitorEnter(thisObject);
 
         if(success != 0)
         {
                 NSK_COMPLAIN1("MonitorEnter return non-zero: %d\n", success);
 
-                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestJNIError")), "MonitorEnter return non-zero"));
+                env->ThrowNew(
+                    env->FindClass("nsk/share/TestJNIError"),
+                    "MonitorEnter return non-zero");
         }
 
-        success  = JNI_ENV_PTR(env)->MonitorExit(JNI_ENV_ARG_2(env, thisObject));
+        success  = env->MonitorExit(thisObject);
 
         if(success != 0)
         {
                 NSK_COMPLAIN1("MonitorExit return non-zero: %d\n", success);
 
-                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestJNIError")), "MonitorExit return non-zero"));
+                env->ThrowNew(
+                    env->FindClass("nsk/share/TestJNIError"),
+                    "MonitorExit return non-zero");
         }
 }
 
@@ -94,25 +87,27 @@ Java_nsk_share_jdi_MonitorEnterExecutor_12Subclass_nativeJNIMonitorEnter(JNIEnv 
 {
         jint success;
 
-        success  = JNI_ENV_PTR(env)->MonitorEnter(JNI_ENV_ARG_2(env, thisObject));
+        success  = env->MonitorEnter(thisObject);
 
         if(success != 0)
         {
                 NSK_COMPLAIN1("MonitorEnter return non-zero: %d\n", success);
 
-                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestJNIError")), "MonitorEnter return non-zero"));
+                env->ThrowNew(
+                    env->FindClass("nsk/share/TestJNIError"),
+                    "MonitorEnter return non-zero");
         }
 
-        success  = JNI_ENV_PTR(env)->MonitorExit(JNI_ENV_ARG_2(env, thisObject));
+        success  = env->MonitorExit(thisObject);
 
         if(success != 0)
         {
                 NSK_COMPLAIN1("MonitorExit return non-zero: %d\n", success);
 
-                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestJNIError")), "MonitorExit return non-zero"));
+                env->ThrowNew(
+                    env->FindClass("nsk/share/TestJNIError"),
+                    "MonitorExit return non-zero");
         }
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jni/JNIreferences.c
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jni/JNIreferences.c
@@ -24,25 +24,8 @@
 #include <stdlib.h>
 #include "nsk_tools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_PTR
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG_2(x, y) y
-#define JNI_ENV_ARG_3(x, y, z) y, z
-#define JNI_ENV_ARG_4(x, y, z, a) y, z, a
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG_2(x,y) x, y
-#define JNI_ENV_ARG_3(x, y, z) x, y, z
-#define JNI_ENV_ARG_4(x, y, z, a) x, y, z, a
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 static jobject* globalReferences = NULL;
 static jweak* weakReferences = NULL;
@@ -76,13 +59,15 @@ Java_nsk_share_ReferringObject_createJNIGlobalReferenceNative(JNIEnv *env,
 
                 if(reference == NULL)
                 {
-                        reference = JNI_ENV_PTR(env)->NewGlobalRef(JNI_ENV_ARG_2(env, object));
+                        reference = env->NewGlobalRef(object);
 
                         if(reference == NULL)
                         {
                                 NSK_COMPLAIN0("NewGlobalRef return NULL\n");
 
-                                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestJNIError")), "NewGlobalRef return NULL"));
+                                env->ThrowNew(
+                                    env->FindClass("nsk/share/TestJNIError"),
+                                    "NewGlobalRef return NULL");
                         }
 
                         globalReferences[i] = reference;
@@ -106,10 +91,12 @@ Java_nsk_share_ReferringObject_deleteJNIGlobalReferenceNative(JNIEnv *env,
         {
                 NSK_COMPLAIN1("globalReferences[%d] = NULL, possible wrong index is passed\n", index);
 
-                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestBug")), "Requested globalReferences[] element is NULL, possible wrong index is passed"));
+                env->ThrowNew(
+                    env->FindClass("nsk/share/TestBug"),
+                    "Requested globalReferences[] element is NULL, possible wrong index is passed");
         }
 
-        JNI_ENV_PTR(env)->DeleteGlobalRef(JNI_ENV_ARG_2(env, reference));
+        env->DeleteGlobalRef(reference);
 
         globalReferences[index] = NULL;
 }
@@ -119,23 +106,27 @@ JNIEXPORT void JNICALL
 Java_nsk_share_ReferringObject_createJNILocalReferenceNative(JNIEnv *env,
         jobject thisObject, jobject object, jobject createWicket, jobject deleteWicket)
 {
-        jobject reference = JNI_ENV_PTR(env)->NewLocalRef(JNI_ENV_ARG_2(env, object));
+        jobject reference = env->NewLocalRef(object);
         jclass klass;
 
         if(reference == NULL)
         {
                 NSK_COMPLAIN0("NewLocalRef return NULL\n");
 
-                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestJNIError")), "NewLocalRef return NULL"));
+                env->ThrowNew(
+                    env->FindClass("nsk/share/TestJNIError"),
+                    "NewLocalRef return NULL");
         }
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, createWicket));
+        klass = env->GetObjectClass(createWicket);
 
         // notify another thread that JNI local reference has been created
-        JNI_ENV_PTR(env)->CallVoidMethod(JNI_ENV_ARG_3(env, createWicket, JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG_4(env, klass, "unlock", "()V"))));
+        env->CallVoidMethod(createWicket,
+                            env->GetMethodID(klass, "unlock", "()V"));
 
         // wait till JNI local reference can be released (it will heppen then we will leave the method)
-        JNI_ENV_PTR(env)->CallVoidMethod(JNI_ENV_ARG_3(env, deleteWicket, JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG_4(env, klass, "waitFor", "()V"))));
+        env->CallVoidMethod(deleteWicket,
+                            env->GetMethodID(klass, "waitFor", "()V"));
 }
 
 JNIEXPORT jint JNICALL
@@ -168,13 +159,15 @@ Java_nsk_share_ReferringObject_createJNIWeakReferenceNative(JNIEnv *env,
 
                 if(reference == NULL)
                 {
-                        reference = JNI_ENV_PTR(env)->NewWeakGlobalRef(JNI_ENV_ARG_2(env, object));
+                        reference = env->NewWeakGlobalRef(object);
 
                         if(reference == NULL)
                         {
                                 NSK_COMPLAIN0("NewWeakGlobalRef return NULL\n");
 
-                                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestJNIError")), "NewWeakGlobalRef return NULL"));
+                                env->ThrowNew(
+                                    env->FindClass("nsk/share/TestJNIError"),
+                                    "NewWeakGlobalRef return NULL");
                         }
 
                         weakReferences[i] = reference;
@@ -198,21 +191,23 @@ Java_nsk_share_ReferringObject_deleteJNIWeakReferenceNative(JNIEnv *env,
         {
                 NSK_COMPLAIN1("weakReferences[%d] = NULL, possible wrong index is passed\n", index);
 
-                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestBug")), "Requested weakReferences[] element is NULL, possible wrong index is passed"));
+                env->ThrowNew(
+                    env->FindClass("nsk/share/TestBug"),
+                    "Requested weakReferences[] element is NULL, possible wrong index is passed");
         }
 
-        if(JNI_ENV_PTR(env)->IsSameObject(JNI_ENV_ARG_3(env, reference, NULL)) == JNI_TRUE)
+        if(env->IsSameObject(reference, NULL) == JNI_TRUE)
         {
                 NSK_COMPLAIN0("TEST BUG: Weak reference was collected\n");
 
-                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestBug")), "TEST BUG: Weak reference was collected"));
+                env->ThrowNew(
+                    env->FindClass("nsk/share/TestBug"),
+                    "TEST BUG: Weak reference was collected");
         }
 
-        JNI_ENV_PTR(env)->DeleteWeakGlobalRef(JNI_ENV_ARG_2(env, reference));
+        env->DeleteWeakGlobalRef(reference);
 
         weakReferences[index] = NULL;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/libNativeMethodsTestThread.c
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/libNativeMethodsTestThread.c
@@ -23,36 +23,16 @@
 #include "jni.h"
 #include <stdlib.h>
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_PTR
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG_2(x, y) y
-#define JNI_ENV_ARG_3(x, y, z) y, z
-#define JNI_ENV_ARG_4(x, y, z, a) y, z, a
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG_2(x,y) x, y
-#define JNI_ENV_ARG_3(x, y, z) x, y, z
-#define JNI_ENV_ARG_4(x, y, z, a) x, y, z, a
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 static void logMessage(JNIEnv *env, jobject thisObject, jstring message)
 {
         jclass klass;
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
-        JNI_ENV_PTR(env)->CallVoidMethod(
-        JNI_ENV_ARG_4(
-                env,
-                thisObject,
-                JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG_4(env, klass, "log", "(Ljava/lang/String;)V")),
-                message));
+        klass = env->GetObjectClass(thisObject);
+        env->CallVoidMethod(thisObject,
+                            env->GetMethodID(klass, "log", "(Ljava/lang/String;)V"),
+                            message);
 }
 
 JNIEXPORT void JNICALL
@@ -71,15 +51,11 @@ Java_nsk_share_jpda_NativeMethodsTestThread_BooleanMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedBooleanValue",
-                "Z"));
+        valueField = env->GetStaticFieldID(klass, "expectedBooleanValue", "Z");
 
-        return JNI_ENV_PTR(env)->GetStaticBooleanField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticBooleanField(klass, valueField);
 }
 
 JNIEXPORT jbyte JNICALL
@@ -91,15 +67,11 @@ Java_nsk_share_jpda_NativeMethodsTestThread_ByteMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedByteValue",
-                "B"));
+        valueField = env->GetStaticFieldID(klass, "expectedByteValue", "B");
 
-        return JNI_ENV_PTR(env)->GetStaticByteField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticByteField(klass, valueField);
 }
 
 JNIEXPORT jshort JNICALL
@@ -111,15 +83,11 @@ Java_nsk_share_jpda_NativeMethodsTestThread_ShortMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedShortValue",
-                "S"));
+        valueField = env->GetStaticFieldID(klass, "expectedShortValue", "S");
 
-        return JNI_ENV_PTR(env)->GetStaticShortField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticShortField(klass, valueField);
 }
 
 JNIEXPORT jchar JNICALL
@@ -131,15 +99,11 @@ Java_nsk_share_jpda_NativeMethodsTestThread_CharMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedCharValue",
-                "C"));
+        valueField = env->GetStaticFieldID(klass, "expectedCharValue", "C");
 
-        return JNI_ENV_PTR(env)->GetStaticCharField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticCharField(klass, valueField);
 }
 
 JNIEXPORT jint JNICALL
@@ -151,15 +115,11 @@ Java_nsk_share_jpda_NativeMethodsTestThread_IntMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedIntValue",
-                "I"));
+        valueField = env->GetStaticFieldID(klass, "expectedIntValue", "I");
 
-        return JNI_ENV_PTR(env)->GetStaticIntField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticIntField(klass, valueField);
 }
 
 JNIEXPORT jlong JNICALL
@@ -171,15 +131,11 @@ Java_nsk_share_jpda_NativeMethodsTestThread_LongMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedLongValue",
-                "J"));
+        valueField = env->GetStaticFieldID(klass, "expectedLongValue", "J");
 
-        return JNI_ENV_PTR(env)->GetStaticLongField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticLongField(klass, valueField);
 }
 
 JNIEXPORT jfloat JNICALL
@@ -191,15 +147,11 @@ Java_nsk_share_jpda_NativeMethodsTestThread_FloatMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedFloatValue",
-                "F"));
+        valueField = env->GetStaticFieldID(klass, "expectedFloatValue", "F");
 
-        return JNI_ENV_PTR(env)->GetStaticFloatField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticFloatField(klass, valueField);
 }
 
 JNIEXPORT jdouble JNICALL
@@ -211,15 +163,11 @@ Java_nsk_share_jpda_NativeMethodsTestThread_DoubleMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedDoubleValue",
-                "D"));
+        valueField = env->GetStaticFieldID(klass, "expectedDoubleValue", "D");
 
-        return JNI_ENV_PTR(env)->GetStaticDoubleField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticDoubleField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -231,15 +179,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_ObjectArrayMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedObjectArrayValue",
-                "[Ljava/lang/Object;"));
+        valueField = env->GetStaticFieldID(klass, "expectedObjectArrayValue",
+                                           "[Ljava/lang/Object;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -251,15 +196,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_StringMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedStringValue",
-                "Ljava/lang/String;"));
+        valueField = env->GetStaticFieldID(klass, "expectedStringValue",
+                                           "Ljava/lang/String;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -271,15 +213,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_ThreadMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedThreadValue",
-                "Ljava/lang/Thread;"));
+        valueField = env->GetStaticFieldID(klass, "expectedThreadValue",
+                                           "Ljava/lang/Thread;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -291,15 +230,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_ThreadGroupMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedThreadGroupValue",
-                "Ljava/lang/ThreadGroup;"));
+        valueField = env->GetStaticFieldID(klass, "expectedThreadGroupValue",
+                                           "Ljava/lang/ThreadGroup;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -311,15 +247,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_ClassObjectMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedClassObjectValue",
-                "Ljava/lang/Class;"));
+        valueField = env->GetStaticFieldID(klass, "expectedClassObjectValue",
+                                           "Ljava/lang/Class;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -331,15 +264,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_ClassLoaderMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedClassLoaderValue",
-                "Ljava/lang/ClassLoader;"));
+        valueField = env->GetStaticFieldID(klass, "expectedClassLoaderValue",
+                                           "Ljava/lang/ClassLoader;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -351,15 +281,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_ObjectMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedObjectValue",
-                "Ljava/lang/Object;"));
+        valueField = env->GetStaticFieldID(klass, "expectedObjectValue",
+                                           "Ljava/lang/Object;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -371,15 +298,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_BooleanWrapperMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedBooleanWrapperValue",
-                "Ljava/lang/Boolean;"));
+        valueField = env->GetStaticFieldID(klass, "expectedBooleanWrapperValue",
+                                           "Ljava/lang/Boolean;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -391,15 +315,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_ByteWrapperMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedByteWrapperValue",
-                "Ljava/lang/Byte;"));
+        valueField = env->GetStaticFieldID(klass, "expectedByteWrapperValue",
+                                           "Ljava/lang/Byte;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -411,15 +332,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_ShortWrapperMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedShortWrapperValue",
-                "Ljava/lang/Short;"));
+        valueField = env->GetStaticFieldID(klass, "expectedShortWrapperValue",
+                                           "Ljava/lang/Short;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -431,15 +349,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_CharWrapperMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedCharWrapperValue",
-                "Ljava/lang/Character;"));
+        valueField = env->GetStaticFieldID(klass, "expectedCharWrapperValue",
+                                           "Ljava/lang/Character;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -451,15 +366,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_IntWrapperMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedIntWrapperValue",
-                "Ljava/lang/Integer;"));
+        valueField = env->GetStaticFieldID(klass, "expectedIntWrapperValue",
+                                           "Ljava/lang/Integer;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -471,15 +383,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_LongWrapperMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedLongWrapperValue",
-                "Ljava/lang/Long;"));
+        valueField = env->GetStaticFieldID(klass, "expectedLongWrapperValue",
+                                           "Ljava/lang/Long;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -491,15 +400,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_FloatWrapperMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedFloatWrapperValue",
-                "Ljava/lang/Float;"));
+        valueField = env->GetStaticFieldID(klass, "expectedFloatWrapperValue",
+                                           "Ljava/lang/Float;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
 JNIEXPORT jobject JNICALL
@@ -511,17 +417,12 @@ Java_nsk_share_jpda_NativeMethodsTestThread_DoubleWrapperMethod(JNIEnv *env,
 
         logMessage(env, thisObject, message);
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        valueField = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG_4(
-                env,
-                klass,
-                "expectedDoubleWrapperValue",
-                "Ljava/lang/Double;"));
+        valueField = env->GetStaticFieldID(klass, "expectedDoubleWrapperValue",
+                                           "Ljava/lang/Double;");
 
-        return JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG_3(env, klass, valueField));
+        return env->GetStaticObjectField(klass, valueField);
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/locks/LockingThread.c
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/locks/LockingThread.c
@@ -23,25 +23,8 @@
 #include "jni.h"
 #include "nsk_tools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_PTR
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG_2(x, y) y
-#define JNI_ENV_ARG_3(x, y, z) y, z
-#define JNI_ENV_ARG_4(x, y, z, a) y, z, a
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG_2(x,y) x, y
-#define JNI_ENV_ARG_3(x, y, z) x, y, z
-#define JNI_ENV_ARG_4(x, y, z, a) x, y, z, a
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 JNIEXPORT void JNICALL
 Java_nsk_share_locks_LockingThread_nativeJNIMonitorEnter(JNIEnv *env, jobject thisObject, jobject object)
@@ -49,29 +32,32 @@ Java_nsk_share_locks_LockingThread_nativeJNIMonitorEnter(JNIEnv *env, jobject th
         jint success;
         jclass klass;
 
-        success  = JNI_ENV_PTR(env)->MonitorEnter(JNI_ENV_ARG_2(env, object));
+        success  = env->MonitorEnter(object);
 
         if(success != 0)
         {
                 NSK_COMPLAIN1("MonitorEnter return non-zero: %d\n", success);
 
-                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestJNIError")), "MonitorEnter return non-zero"));
+                env->ThrowNew(
+                    env->FindClass("nsk/share/TestJNIError"),
+                    "MonitorEnter return non-zero");
         }
 
-        klass = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG_2(env, thisObject));
+        klass = env->GetObjectClass(thisObject);
 
-        JNI_ENV_PTR(env)->CallVoidMethod(JNI_ENV_ARG_3(env, thisObject, JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG_4(env, klass, "createStackFrame", "()V"))));
+        env->CallVoidMethod(thisObject,
+                            env->GetMethodID(klass, "createStackFrame", "()V"));
 
-        success  = JNI_ENV_PTR(env)->MonitorExit(JNI_ENV_ARG_2(env, object));
+        success  = env->MonitorExit(object);
 
         if(success != 0)
         {
                 NSK_COMPLAIN1("MonitorExit return non-zero: %d\n", success);
 
-                JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG_3(env, JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG_2(env, "nsk/share/TestJNIError")), "MonitorExit return non-zero"));
+                env->ThrowNew(
+                    env->FindClass("nsk/share/TestJNIError"),
+                    "MonitorExit return non-zero");
         }
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/vm/runtime/defmeth/shared/redefineClasses.c
+++ b/test/hotspot/jtreg/vmTestbase/vm/runtime/defmeth/shared/redefineClasses.c
@@ -30,21 +30,8 @@
 #include "JVMTITools.h"
 #include "jvmti_tools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 static jvmtiEnv *test_jvmti = NULL;
 static jvmtiCapabilities caps;
@@ -126,6 +113,4 @@ JNIEXPORT jint JNICALL Agent_OnAttach(JavaVM *jvm, char *options, void *reserved
     return Agent_Initialize(jvm, options, reserved);
 }
 
-#ifdef __cplusplus
 }
-#endif


### PR DESCRIPTION
Backport of JDK-8210182: Remove macros for C compilation from vmTestBase but non jvmti. Changes apply clean, except for 3 files which don't exist in 11u:
	test/hotspot/jtreg/vmTestbase/gc/g1/unloading/libdefine.cpp
	test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/forceEarlyReturn/forceEarlyReturn005/libforceEarlyReturn005a.cpp
	test/hotspot/jtreg/vmTestbase/nsk/share/locks/JNIMonitorLocker.cpp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8210182](https://bugs.openjdk.java.net/browse/JDK-8210182): Remove macros for C compilation from vmTestBase but non jvmti


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/346/head:pull/346` \
`$ git checkout pull/346`

Update a local copy of the PR: \
`$ git checkout pull/346` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 346`

View PR using the GUI difftool: \
`$ git pr show -t 346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/346.diff">https://git.openjdk.java.net/jdk11u-dev/pull/346.diff</a>

</details>
