### PR TITLE
8273795: Zero SPARC64 debug builds fail due to missing interpreter fields

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/bytecodeInterpreter.cpp
@@ -3487,12 +3487,6 @@ BytecodeInterpreter::print() {
   tty->print_cr("stack_base: " INTPTR_FORMAT, (uintptr_t) this->_stack_base);
   tty->print_cr("stack_limit: " INTPTR_FORMAT, (uintptr_t) this->_stack_limit);
   tty->print_cr("monitor_base: " INTPTR_FORMAT, (uintptr_t) this->_monitor_base);
-#ifdef SPARC
-  tty->print_cr("last_Java_pc: " INTPTR_FORMAT, (uintptr_t) this->_last_Java_pc);
-  tty->print_cr("frame_bottom: " INTPTR_FORMAT, (uintptr_t) this->_frame_bottom);
-  tty->print_cr("&native_fresult: " INTPTR_FORMAT, (uintptr_t) &this->_native_fresult);
-  tty->print_cr("native_lresult: " INTPTR_FORMAT, (uintptr_t) this->_native_lresult);
-#endif
 #if !defined(ZERO) && defined(PPC)
   tty->print_cr("last_Java_fp: " INTPTR_FORMAT, (uintptr_t) this->_last_Java_fp);
 #endif // !ZERO


### PR DESCRIPTION
This is a SPARC-specific, Zero-specific, 11u-specific problem. See the bug trail investigation in the bug. @glaubitz, I don't suppose Debian builds OpenJDK 11u Zero SPARC64 fastdebug builds, so must have never faced this issue?

Additional testing:
 - [x] Linux SPARC64 Zero cross-compilation completes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273795](https://bugs.openjdk.java.net/browse/JDK-8273795): Zero SPARC64 debug builds fail due to missing interpreter fields


### Reviewers
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/349/head:pull/349` \
`$ git checkout pull/349`

Update a local copy of the PR: \
`$ git checkout pull/349` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 349`

View PR using the GUI difftool: \
`$ git pr show -t 349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/349.diff">https://git.openjdk.java.net/jdk11u-dev/pull/349.diff</a>

</details>
