### PR TITLE
8269574: C2: Avoid redundant uncommon traps in GraphKit::builtin_throw() for JVMTI exception events

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -525,13 +525,6 @@ void GraphKit::uncommon_trap_if_should_post_on_exceptions(Deoptimization::DeoptR
 void GraphKit::builtin_throw(Deoptimization::DeoptReason reason, Node* arg) {
   bool must_throw = true;
 
-  if (env()->jvmti_can_post_on_exceptions()) {
-    // check if we must post exception events, take uncommon trap if so
-    uncommon_trap_if_should_post_on_exceptions(reason, must_throw);
-    // here if should_post_on_exceptions is false
-    // continue on with the normal codegen
-  }
-
   // If this particular condition has not yet happened at this
   // bytecode, then use the uncommon trap mechanism, and allow for
   // a future recompilation if several traps occur here.
@@ -594,6 +587,13 @@ void GraphKit::builtin_throw(Deoptimization::DeoptReason reason, Node* arg) {
     }
     if (failing()) { stop(); return; }  // exception allocation might fail
     if (ex_obj != NULL) {
+      if (env()->jvmti_can_post_on_exceptions()) {
+        // check if we must post exception events, take uncommon trap if so
+        uncommon_trap_if_should_post_on_exceptions(reason, must_throw);
+        // here if should_post_on_exceptions is false
+        // continue on with the normal codegen
+      }
+
       // Cheat with a preallocated exception object.
       if (C->log() != NULL)
         C->log()->elem("hot_throw preallocated='1' reason='%s'",


### PR DESCRIPTION
Hi all,

this pull request contains a backport of commit 72530ef6 from the openjdk/jdk repository. The fix is small and applies cleanly.

I would like to backport this to jdk11u as a fix for the describe performance issue.

The commit being backported was authored by Richard Reingruber on 7 Jul 2021 and was reviewed by Vladimir Kozlov, Roland Westrelin and Nils Eliasson.

Thanks!
Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269574](https://bugs.openjdk.java.net/browse/JDK-8269574): C2: Avoid redundant uncommon traps in GraphKit::builtin_throw() for JVMTI exception events


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/350/head:pull/350` \
`$ git checkout pull/350`

Update a local copy of the PR: \
`$ git checkout pull/350` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 350`

View PR using the GUI difftool: \
`$ git pr show -t 350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/350.diff">https://git.openjdk.java.net/jdk11u-dev/pull/350.diff</a>

</details>
