### PR TITLE
8261036: Reduce classes loaded by CleanerFactory initialization

### DIFF
--- a/src/java.base/share/classes/jdk/internal/ref/CleanerFactory.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,6 @@ package jdk.internal.ref;
 import jdk.internal.misc.InnocuousThread;
 
 import java.lang.ref.Cleaner;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.concurrent.ThreadFactory;
 
 /**
@@ -42,14 +40,8 @@ public final class CleanerFactory {
     private final static Cleaner commonCleaner = Cleaner.create(new ThreadFactory() {
         @Override
         public Thread newThread(Runnable r) {
-            return AccessController.doPrivileged(new PrivilegedAction<>() {
-                @Override
-                public Thread run() {
-                    Thread t = InnocuousThread.newSystemThread("Common-Cleaner", r);
-                    t.setPriority(Thread.MAX_PRIORITY - 2);
-                    return t;
-                }
-            });
+            return InnocuousThread.newSystemThread("Common-Cleaner",
+                    r, Thread.MAX_PRIORITY - 2);
         }
     });
 

--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -324,15 +324,8 @@ public final class CleanerImpl implements Runnable {
         final AtomicInteger cleanerThreadNumber = new AtomicInteger();
 
         public Thread newThread(Runnable r) {
-            return AccessController.doPrivileged(new PrivilegedAction<>() {
-                @Override
-                public Thread run() {
-                    Thread t = InnocuousThread.newThread(r);
-                    t.setPriority(Thread.MAX_PRIORITY - 2);
-                    t.setName("Cleaner-" + cleanerThreadNumber.getAndIncrement());
-                    return t;
-                }
-            });
+            return InnocuousThread.newThread("Cleaner-" + cleanerThreadNumber.getAndIncrement(),
+                r, Thread.MIN_PRIORITY - 2);
         }
     }
 


### PR DESCRIPTION
Clean backport of JDK-8261036.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8261036](https://bugs.openjdk.java.net/browse/JDK-8261036): Reduce classes loaded by CleanerFactory initialization


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/353/head:pull/353` \
`$ git checkout pull/353`

Update a local copy of the PR: \
`$ git checkout pull/353` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 353`

View PR using the GUI difftool: \
`$ git pr show -t 353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/353.diff">https://git.openjdk.java.net/jdk11u-dev/pull/353.diff</a>

</details>
