### PR TITLE
8273541: Cleaner Thread creates with normal priority instead of MAX_PRIORITY - 2

### DIFF
--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -325,7 +325,7 @@ public final class CleanerImpl implements Runnable {
 
         public Thread newThread(Runnable r) {
             return InnocuousThread.newThread("Cleaner-" + cleanerThreadNumber.getAndIncrement(),
-                r, Thread.MIN_PRIORITY - 2);
+                r, Thread.MAX_PRIORITY - 2);
         }
     }
 


### PR DESCRIPTION
Clean backport of JDK-8273541.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273541](https://bugs.openjdk.java.net/browse/JDK-8273541): Cleaner Thread creates with normal priority instead of MAX_PRIORITY - 2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/354/head:pull/354` \
`$ git checkout pull/354`

Update a local copy of the PR: \
`$ git checkout pull/354` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 354`

View PR using the GUI difftool: \
`$ git pr show -t 354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/354.diff">https://git.openjdk.java.net/jdk11u-dev/pull/354.diff</a>

</details>
