### PR TITLE
8213189: Make restricted headers in HTTP Client configurable and remove Date by default

### DIFF
--- a/src/java.base/share/conf/net.properties
+++ b/src/java.base/share/conf/net.properties
@@ -100,6 +100,24 @@ ftp.nonProxyHosts=localhost|127.*|[::1]
 jdk.http.auth.tunneling.disabledSchemes=Basic
 
 #
+# Allow restricted HTTP request headers
+#
+# By default, the following request headers are not allowed to be set by user code
+# in HttpRequests: "connection", "content-length", "expect", "host" and "upgrade".
+# The 'jdk.httpclient.allowRestrictedHeaders' property allows one or more of these
+# headers to be specified as a comma separated list to override the default restriction.
+# The names are case-insensitive and white-space is ignored (removed before processing
+# the list). Note, this capability is mostly intended for testing and isn't expected
+# to be used in real deployments. Protocol errors or other undefined behavior is likely
+# to occur when using them. The property is not set by default.
+# Note also, that there may be other headers that are restricted from being set
+# depending on the context. This includes the "Authorization" header when the
+# relevant HttpClient has an authenticator set. These restrictions cannot be
+# overridden by this property.
+#
+# jdk.httpclient.allowRestrictedHeaders=host
+#
+#
 # Transparent NTLM HTTP authentication mode on Windows. Transparent authentication
 # can be used for the NTLM scheme, where the security credentials based on the
 # currently logged in user's name and password can be obtained directly from the

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Exchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Exchange.java
@@ -598,6 +598,19 @@ final class Exchange<T> {
         } catch (SecurityException e) {
             return e;
         }
+        String hostHeader = userHeaders.firstValue("Host").orElse(null);
+        if (hostHeader != null && !hostHeader.equalsIgnoreCase(u.getHost())) {
+            // user has set a Host header different to request URI
+            // must check that for URLPermission also
+            URI u1 = replaceHostInURI(u, hostHeader);
+            URLPermission p1 = permissionForServer(u1, method, userHeaders.map());
+            try {
+                assert acc != null;
+                sm.checkPermission(p1, acc);
+            } catch (SecurityException e) {
+                return e;
+            }
+        }
         ProxySelector ps = client.proxySelector();
         if (ps != null) {
             if (!method.equals("CONNECT")) {
@@ -613,6 +626,15 @@ final class Exchange<T> {
             }
         }
         return null;
+    }
+
+    private static URI replaceHostInURI(URI u, String hostPort) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(u.getScheme())
+                .append("://")
+                .append(hostPort)
+                .append(u.getRawPath());
+        return URI.create(sb.toString());
     }
 
     HttpClient.Version version() {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ExchangeImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ExchangeImpl.java
@@ -26,6 +26,7 @@
 package jdk.internal.net.http;
 
 import java.io.IOException;
+import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -65,6 +66,9 @@ abstract class ExchangeImpl<T> {
         return exchange;
     }
 
+    HttpClient client() {
+        return exchange.client();
+    }
 
     /**
      * Returns the {@link HttpConnection} instance to which this exchange is

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Exchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Exchange.java
@@ -27,6 +27,7 @@ package jdk.internal.net.http;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodySubscriber;
@@ -712,6 +713,10 @@ class Http1Exchange<T> extends ExchangeImpl<T> {
                 writeScheduler.runOrSchedule(client.theExecutor());
             }
         }
+    }
+
+    HttpClient client() {
+        return client;
     }
 
     String dbgString() {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -617,8 +617,20 @@ class Stream<T> extends ExchangeImpl<T> {
         if (contentLength > 0) {
             h.setHeader("content-length", Long.toString(contentLength));
         }
+        URI uri = request.uri();
+        if (uri != null) {
+            h.setHeader("host", Utils.hostString(request));
+        }
         HttpHeaders sysh = filterHeaders(h.build());
         HttpHeaders userh = filterHeaders(request.getUserHeaders());
+        // Filter context restricted from userHeaders
+        userh = HttpHeaders.of(userh.map(), Utils.CONTEXT_RESTRICTED(client()));
+
+        final HttpHeaders uh = userh;
+
+        // Filter any headers from systemHeaders that are set in userHeaders
+        sysh = HttpHeaders.of(sysh.map(), (k,v) -> uh.firstValue(k).isEmpty());
+
         OutgoingHeaders<Stream<T>> f = new OutgoingHeaders<>(sysh, userh, this);
         if (contentLength == 0) {
             f.setFlag(HeadersFrame.END_STREAM);

--- a/test/jdk/java/net/httpclient/RequestBuilderTest.java
+++ b/test/jdk/java/net/httpclient/RequestBuilderTest.java
@@ -339,7 +339,7 @@ public class RequestBuilderTest {
 
     // headers that are allowed now, but weren't before
     private static final Set<String> FORMERLY_RESTRICTED = Set.of("referer", "origin",
-            "OriGin", "Referer");
+            "OriGin", "Referer", "Date", "via", "WarnIng");
 
     @Test
     public void testFormerlyRestricted()  throws URISyntaxException {
@@ -354,14 +354,9 @@ public class RequestBuilderTest {
     }
 
     private static final Set<String> RESTRICTED = Set.of("connection", "content-length",
-            "date", "expect", "from", "host",
-            "upgrade", "via", "warning",
-            "Connection", "Content-Length",
-            "DATE", "eXpect", "frOm", "hosT",
-            "upgradE", "vIa", "Warning",
-            "CONNection", "CONTENT-LENGTH",
-            "Date", "EXPECT", "From", "Host",
-            "Upgrade", "Via", "WARNING");
+            "expect", "host", "upgrade", "Connection", "Content-Length",
+            "eXpect", "hosT", "upgradE", "CONNection", "CONTENT-LENGTH",
+            "EXPECT", "Host", "Upgrade");
 
     interface WithHeader {
         HttpRequest.Builder withHeader(HttpRequest.Builder builder, String name, String value);

--- a/test/jdk/java/net/httpclient/RestrictedHeadersTest.java
+++ b/test/jdk/java/net/httpclient/RestrictedHeadersTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8178699
+ * @modules java.net.http
+ * @run main/othervm RestrictedHeadersTest
+ * @run main/othervm -Djdk.httpclient.allowRestrictedHeaders=content-length,connection RestrictedHeadersTest content-length connection
+ * @run main/othervm -Djdk.httpclient.allowRestrictedHeaders=host,upgrade RestrictedHeadersTest host upgrade
+ * @run main/othervm -Djdk.httpclient.allowRestrictedHeaders=via RestrictedHeadersTest via
+ */
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.util.Set;
+
+public class RestrictedHeadersTest {
+    public static void main(String[] args) {
+        if (args.length == 0) {
+            runDefaultTest();
+        } else {
+            runTest(Set.of(args));
+        }
+    }
+
+    // This list must be same as impl
+
+    static Set<String> defaultRestrictedHeaders =
+            Set.of("connection", "content-length", "expect", "host", "upgrade");
+
+    private static void runDefaultTest() {
+        System.out.println("DEFAULT TEST: no property set");
+        for (String header : defaultRestrictedHeaders) {
+            checkHeader(header, "foo", false);
+        }
+        // miscellaneous others that should succeed
+        checkHeader("foobar", "barfoo", true);
+        checkHeader("date", "today", true);
+    }
+
+    private static void checkHeader(String name, String value, boolean succeed) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder(URI.create("https://foo.com/"))
+                    .header(name, value)
+                    .GET()
+                    .build();
+            if (!succeed) {
+                String s = name+"/"+value+" should have failed";
+                throw new RuntimeException(s);
+            }
+            System.out.printf("%s = %s succeeded as expected\n", name, value);
+        } catch (IllegalArgumentException iae) {
+            if (succeed) {
+                String s = name+"/"+value+" should have succeeded";
+                throw new RuntimeException(s);
+            }
+            System.out.printf("%s = %s failed as expected\n", name, value);
+        }
+    }
+
+    // args is the Set of allowed restricted headers
+    private static void runTest(Set<String> args) {
+        System.out.print("RUNTEST: allowed headers set in property: ");
+        for (String arg : args) System.out.printf("%s ", arg);
+        System.out.println("");
+
+        for (String header : args) {
+            checkHeader(header, "val", true);
+        }
+        for (String header : defaultRestrictedHeaders) {
+            if (!args.contains(header)) {
+                checkHeader(header, "foo", false);
+            }
+        }
+    }
+}

--- a/test/jdk/java/net/httpclient/security/16.policy
+++ b/test/jdk/java/net/httpclient/security/16.policy
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 2 only, as
+// published by the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// version 2 for more details (a copy is included in the LICENSE file that
+// accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version
+// 2 along with this work; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+// or visit www.oracle.com if you need additional information or have any
+// questions.
+//
+
+// Policy 16: Test tries to set Host header to localhost:123 but there is no permission
+
+grant {
+    // permissions common to all tests
+    permission java.util.PropertyPermission "*", "read";
+    permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
+    permission java.lang.RuntimePermission "modifyThread";
+    permission java.util.logging.LoggingPermission "control", "";
+    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
+    permission java.lang.RuntimePermission "createClassLoader";
+
+
+    // permissions specific to this test
+    permission java.net.URLPermission "http://localhost:${port.number}/files/foo.txt", "GET:Host";
+};
+
+// For proxy only. Not being tested
+grant codebase "file:${test.classes}/proxydir/-" {
+    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
+    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+};

--- a/test/jdk/java/net/httpclient/security/17.policy
+++ b/test/jdk/java/net/httpclient/security/17.policy
@@ -1,0 +1,45 @@
+//
+// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 2 only, as
+// published by the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+// version 2 for more details (a copy is included in the LICENSE file that
+// accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version
+// 2 along with this work; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+// or visit www.oracle.com if you need additional information or have any
+// questions.
+//
+
+// Policy 17. Grant permission to port 123 (no connect attempt is actually made)
+grant {
+    // permissions common to all tests
+    permission java.util.PropertyPermission "*", "read";
+    permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
+    permission java.lang.RuntimePermission "modifyThread";
+    permission java.util.logging.LoggingPermission "control", "";
+    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
+    permission java.lang.RuntimePermission "createClassLoader";
+
+
+    // permissions specific to this test
+    permission java.net.URLPermission "http://localhost:${port.number}/files/foo.txt", "GET:Host";
+    permission java.net.URLPermission "http://foohost:123/files/foo.txt", "GET:Host";
+};
+
+// For proxy only. Not being tested
+grant codebase "file:${test.classes}/proxydir/-" {
+    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
+    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+};

--- a/test/jdk/java/net/httpclient/security/Driver.java
+++ b/test/jdk/java/net/httpclient/security/Driver.java
@@ -70,6 +70,8 @@ public class Driver {
         runtest("10.policy", "10");
         runtest("11.policy", "11");
         runtest("12.policy", "12");
+        runtest("16.policy", "16", "-Djdk.httpclient.allowRestrictedHeaders=Host");
+        runtest("17.policy", "17", "-Djdk.httpclient.allowRestrictedHeaders=Host");
         System.out.println("DONE");
     }
 
@@ -114,7 +116,11 @@ public class Driver {
     }
 
     public static void runtest(String policy, String testnum) throws Throwable {
+        runtest(policy, testnum, null);
+    }
 
+
+    public static void runtest(String policy, String testnum, String addProp) throws Throwable {
         String testJdk = System.getProperty("test.jdk", "?");
         String testSrc = System.getProperty("test.src", "?");
         String testClassPath = System.getProperty("test.class.path", "?");
@@ -136,6 +142,9 @@ public class Driver {
             cmd.add("-Dport.number=" + Integer.toString(Utils.getFreePort()));
             cmd.add("-Dport.number1=" + Integer.toString(Utils.getFreePort()));
             cmd.add("-Djdk.httpclient.HttpClient.log=all,frames:all");
+            if (addProp != null) {
+                cmd.add(addProp);
+            }
             cmd.add("-cp");
             cmd.add(testClassPath);
             cmd.add("Security");

--- a/test/jdk/java/net/httpclient/security/Security.java
+++ b/test/jdk/java/net/httpclient/security/Security.java
@@ -377,6 +377,24 @@ public class Security {
                     else
                         throw new RuntimeException(t);
                 }
+            }),
+            // (16) allowed to set Host header but does not have permission
+            TestAndResult.of(true, () -> { //Policy 16
+                URI u = URI.create("http://localhost:" + port + "/files/foo.txt");
+                HttpRequest request = HttpRequest.newBuilder(u)
+                        .header("Host", "foohost:123")
+                        .GET().build();
+                HttpResponse<?> response = client.send(request, ofString());
+                System.out.println("Received response:" + response);
+            }),
+            // (17) allowed to set Host header and does have permission
+            TestAndResult.of(false, () -> { //Policy 17
+                URI u = URI.create("http://localhost:" + port + "/files/foo.txt");
+                HttpRequest request = HttpRequest.newBuilder(u)
+                        .header("Host", "foohost:123")
+                        .GET().build();
+                HttpResponse<?> response = client.send(request, ofString());
+                System.out.println("Received response:" + response);
             })
         };
     }


### PR DESCRIPTION
Backport of JDK-8213189: Make restricted headers in HTTP Client configurable and remove Date by default.

I had to fit the patch a bit into the context of 11u, but no modifications necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8213189](https://bugs.openjdk.java.net/browse/JDK-8213189): Make restricted headers in HTTP Client configurable and remove Date by default


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/355/head:pull/355` \
`$ git checkout pull/355`

Update a local copy of the PR: \
`$ git checkout pull/355` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 355`

View PR using the GUI difftool: \
`$ git pr show -t 355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/355.diff">https://git.openjdk.java.net/jdk11u-dev/pull/355.diff</a>

</details>
