### PR TITLE
8246114: java/net/MulticastSocket/Promiscuous.java fails after 8241072 (multi-homed systems)

### DIFF
--- a/test/jdk/java/net/MulticastSocket/Promiscuous.java
+++ b/test/jdk/java/net/MulticastSocket/Promiscuous.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,7 +117,7 @@ public class Promiscuous {
 
             // join groups on all network interfaces
             NetworkConfiguration.probe()
-                    .multicastInterfaces(false)
+                    .ip4MulticastInterfaces(false)
                     .forEach((nic) -> {
                 try {
                     mc1.joinGroup(toSocketAddress(group1), nic);
@@ -153,7 +153,7 @@ public class Promiscuous {
 
             // leave groups on all network interfaces
             NetworkConfiguration.probe()
-                    .multicastInterfaces(false)
+                    .ip4MulticastInterfaces(false)
                     .forEach((nic) -> {
                 try {
                     mc1.leaveGroup(toSocketAddress(group1), nic);


### PR DESCRIPTION
This is a test-only backport. This test fix was merged in 11.0.13-oracle.

The test started to fail in JDK mainline after JDK-8241072, but that change is not in-scope for jdk11u. The test in jdk11u right now passes (for me) before and after applying. The test fix seems reasonable to me despite the failure not triggering in 11u (yet?)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8246114](https://bugs.openjdk.java.net/browse/JDK-8246114): java/net/MulticastSocket/Promiscuous.java fails after 8241072 (multi-homed systems)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/356/head:pull/356` \
`$ git checkout pull/356`

Update a local copy of the PR: \
`$ git checkout pull/356` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 356`

View PR using the GUI difftool: \
`$ git pr show -t 356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/356.diff">https://git.openjdk.java.net/jdk11u-dev/pull/356.diff</a>

</details>
