### PR TITLE
8269034: AccessControlException for SunPKCS11 daemon threads

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -186,6 +186,7 @@ module java.base {
         jdk.attach,
         jdk.charsets,
         jdk.compiler,
+        jdk.crypto.cryptoki,
         java.net.http,
         jdk.jfr,
         jdk.jlink,

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -124,6 +124,7 @@ grant codeBase "jrt:/jdk.crypto.ec" {
 grant codeBase "jrt:/jdk.crypto.cryptoki" {
     permission java.lang.RuntimePermission
                    "accessClassInPackage.com.sun.crypto.provider";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.misc";
     permission java.lang.RuntimePermission
                    "accessClassInPackage.sun.security.*";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.ch";

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -40,6 +40,7 @@ import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.PasswordCallback;
 
+import jdk.internal.misc.InnocuousThread;
 import sun.security.util.Debug;
 import sun.security.util.ResourcesMgr;
 import static sun.security.util.SecurityConstants.PROVIDER_VER;
@@ -830,15 +831,11 @@ public final class SunPKCS11 extends AuthProvider {
     // background thread that periodically checks for token insertion
     // if no token is present. We need to do that in a separate thread because
     // the insertion check may block for quite a long time on some tokens.
-    private static class TokenPoller extends Thread {
+    private static class TokenPoller implements Runnable {
         private final SunPKCS11 provider;
         private volatile boolean enabled;
 
         private TokenPoller(SunPKCS11 provider) {
-            super((ThreadGroup)null, "Poller-" + provider.getName());
-            setContextClassLoader(null);
-            setDaemon(true);
-            setPriority(Thread.MIN_PRIORITY);
             this.provider = provider;
             enabled = true;
         }
@@ -867,12 +864,20 @@ public final class SunPKCS11 extends AuthProvider {
     }
 
     // create the poller thread, if not already active
+    @SuppressWarnings("removal")
     private void createPoller() {
         if (poller != null) {
             return;
         }
         poller = new TokenPoller(this);
-        poller.start();
+        Thread t = InnocuousThread.newSystemThread(
+                "Poller-" + getName(),
+                poller,
+                Thread.MIN_PRIORITY);
+        assert t.getContextClassLoader() == null;
+        t.setDaemon(true);
+        t.start();
+
     }
 
     // destroy the poller thread, if active
@@ -895,17 +900,10 @@ public final class SunPKCS11 extends AuthProvider {
         return (token != null) && token.isValid();
     }
 
-    private class NativeResourceCleaner extends Thread {
+    private class NativeResourceCleaner implements Runnable {
         private long sleepMillis = config.getResourceCleanerShortInterval();
         private int count = 0;
         boolean keyRefFound, sessRefFound;
-
-        private NativeResourceCleaner() {
-            super((ThreadGroup)null, "Cleanup-SunPKCS11");
-            setContextClassLoader(null);
-            setDaemon(true);
-            setPriority(Thread.MIN_PRIORITY);
-        }
 
         /*
          * The cleaner.shortInterval and cleaner.longInterval properties
@@ -924,7 +922,7 @@ public final class SunPKCS11 extends AuthProvider {
         public void run() {
             while (true) {
                 try {
-                    sleep(sleepMillis);
+                    Thread.sleep(sleepMillis);
                 } catch (InterruptedException ie) {
                     break;
                 }
@@ -943,6 +941,19 @@ public final class SunPKCS11 extends AuthProvider {
                 }
             }
         }
+    }
+
+    // create the cleaner thread, if not already active
+    @SuppressWarnings("removal")
+    private void createCleaner() {
+        cleaner = new NativeResourceCleaner();
+        Thread t = InnocuousThread.newSystemThread(
+                "Cleanup-SunPKCS11",
+                cleaner,
+                Thread.MIN_PRIORITY);
+        assert t.getContextClassLoader() == null;
+        t.setDaemon(true);
+        t.start();
     }
 
     // destroy the token. Called if we detect that it has been removed
@@ -1111,8 +1122,7 @@ public final class SunPKCS11 extends AuthProvider {
 
         this.token = token;
         if (cleaner == null) {
-            cleaner = new NativeResourceCleaner();
-            cleaner.start();
+            createCleaner();
         }
     }
 

--- a/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.java
+++ b/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,9 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.security.KeyStore;
-import java.security.Provider;
-import java.security.Security;
+import java.security.*;
 import java.util.Iterator;
+import java.util.PropertyPermission;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
@@ -45,16 +44,28 @@ public class MultipleLogins {
     private static final int NUM_PROVIDERS = 20;
     private static final SunPKCS11[] providers = new SunPKCS11[NUM_PROVIDERS];
 
+    static final Policy DEFAULT_POLICY = Policy.getPolicy();
 
     public static void main(String[] args) throws Exception {
+        String nssConfig = PKCS11Test.getNssConfig();
+        if (nssConfig == null) {
+            // No test framework support yet. Ignore
+            System.out.println("No NSS config found. Skipping.");
+            return;
+        }
+
         for (int i =0; i < NUM_PROVIDERS; i++) {
-            String nssConfig = PKCS11Test.getNssConfig();
-            if (nssConfig == null) {
-                throw new RuntimeException("issue setting up config");
-            }
-            providers[i] =
-                    (SunPKCS11)PKCS11Test.newPKCS11Provider()
-                    .configure(nssConfig);
+            // loop to set up test without security manger
+            providers[i] = (SunPKCS11)PKCS11Test.newPKCS11Provider();
+        }
+
+        if (args.length > 0) {
+            Policy.setPolicy(new SimplePolicy());
+            System.setSecurityManager(new SecurityManager());
+        }
+
+        for (int i =0; i < NUM_PROVIDERS; i++) {
+            providers[i] = (SunPKCS11)providers[i].configure(nssConfig);
             Security.addProvider(providers[i]);
             test(providers[i]);
         }
@@ -90,7 +101,6 @@ public class MultipleLogins {
 
     private static void test(SunPKCS11 p) throws Exception {
         KeyStore ks = KeyStore.getInstance(KS_TYPE, p);
-
         p.setCallbackHandler(new PasswordCallbackHandler());
         try {
             ks.load(null, (char[]) null);
@@ -112,6 +122,23 @@ public class MultipleLogins {
             } else {
                 throw new RuntimeException("Token was present", e);
             }
+        }
+    }
+
+    static final class SimplePolicy extends Policy {
+
+        final Permissions perms = new Permissions();
+        SimplePolicy() {
+            perms.add(new PropertyPermission("*", "read, write"));
+            perms.add(new SecurityPermission("authProvider.*"));
+            perms.add(new SecurityPermission("insertProvider.*"));
+            perms.add(new SecurityPermission("removeProvider.*"));
+        }
+
+        @Override
+        public boolean implies(ProtectionDomain domain, Permission permission) {
+            return perms.implies(permission) ||
+                    DEFAULT_POLICY.implies(domain, permission);
         }
     }
 

--- a/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.sh
+++ b/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.sh
@@ -22,7 +22,7 @@
 #
 
 # @test
-# @bug 7777777
+# @bug 8240256 8269034
 # @summary
 # @library /test/lib/
 # @build jdk.test.lib.util.ForceGC
@@ -114,9 +114,7 @@ ${COMPILEJAVA}${FS}bin${FS}javac ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} \
         ${TESTSRC}${FS}MultipleLogins.java \
         ${TESTSRC}${FS}..${FS}PKCS11Test.java
 
-# run test
-${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} \
-        -classpath ${TESTCLASSPATH} \
+TEST_ARGS="${TESTVMOPTS} -classpath ${TESTCLASSPATH} \
         --add-modules jdk.crypto.cryptoki \
         --add-exports jdk.crypto.cryptoki/sun.security.pkcs11=ALL-UNNAMED \
         -DCUSTOM_DB_DIR=${TESTCLASSES} \
@@ -125,11 +123,13 @@ ${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} \
         -DNO_DEIMOS=true \
         -Dtest.src=${TESTSRC} \
         -Dtest.classes=${TESTCLASSES} \
-        -Djava.security.debug=${DEBUG} \
-        MultipleLogins
+        -Djava.security.debug=${DEBUG}"
 
-# save error status
-status=$?
+# run test without security manager
+${TESTJAVA}${FS}bin${FS}java ${TEST_ARGS} MultipleLogins || exit 10
 
-# return
-exit $status
+# run test with security manager
+${TESTJAVA}${FS}bin${FS}java ${TEST_ARGS} MultipleLogins useSimplePolicy || exit 11
+
+echo Done
+exit 0


### PR DESCRIPTION
Backport of JDK-8269034. Manual integration was needed for 'module-info.java' and 'MultipleLogins.java'.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269034](https://bugs.openjdk.java.net/browse/JDK-8269034): AccessControlException for SunPKCS11 daemon threads


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to 89962bf5ed087dbe2461cd6354d1089b8781ceb0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/358/head:pull/358` \
`$ git checkout pull/358`

Update a local copy of the PR: \
`$ git checkout pull/358` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 358`

View PR using the GUI difftool: \
`$ git pr show -t 358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/358.diff">https://git.openjdk.java.net/jdk11u-dev/pull/358.diff</a>

</details>
