### PR TITLE
8213707: [TEST] vmTestbase/nsk/stress/except/except011.java failed due to wrong class name

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/except/except011.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/except/except011.java
@@ -123,7 +123,7 @@ public class except011 {
      */
     private static int messages = 0;
 
-    private static final String className = "nsk.stress.except.except011.except011oops";
+    private static final String className = "nsk.stress.except.except011oops";
 
     /**
      * Re-call to the method <code>run(out)</code> (ignore <code>args[]</code>),


### PR DESCRIPTION
A clean backport for parity with Oracle 11.0.14.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8213707](https://bugs.openjdk.java.net/browse/JDK-8213707): [TEST] vmTestbase/nsk/stress/except/except011.java failed due to wrong class name


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/360/head:pull/360` \
`$ git checkout pull/360`

Update a local copy of the PR: \
`$ git checkout pull/360` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 360`

View PR using the GUI difftool: \
`$ git pr show -t 360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/360.diff">https://git.openjdk.java.net/jdk11u-dev/pull/360.diff</a>

</details>
