### PR TITLE
8129310: java/net/Socket/asyncClose/AsyncClose.java fails intermittently

### DIFF
--- a/test/jdk/java/net/Socket/asyncClose/AsyncCloseTest.java
+++ b/test/jdk/java/net/Socket/asyncClose/AsyncCloseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,19 +36,20 @@ public abstract class AsyncCloseTest {
     }
 
     protected synchronized AsyncCloseTest passed() {
-        if (reason == null)
+        if (failureReason() == null) {
             passed = true;
+        }
         return this;
     }
 
     protected synchronized AsyncCloseTest failed(String r) {
         passed = false;
-        reason = r;
+        reason.append(String.format("%n - %s", r));
         return this;
     }
 
     public synchronized String failureReason() {
-        return reason;
+        return reason.length() > 0 ? reason.toString() : null;
     }
 
     protected synchronized void closed() {
@@ -60,6 +61,6 @@ public abstract class AsyncCloseTest {
     }
 
     private boolean passed;
-    private String reason;
+    private final StringBuilder reason = new StringBuilder();
     private boolean closed;
 }

--- a/test/jdk/java/net/Socket/asyncClose/DatagramSocket_receive.java
+++ b/test/jdk/java/net/Socket/asyncClose/DatagramSocket_receive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public class DatagramSocket_receive extends AsyncCloseTest implements Runnable {
     public DatagramSocket_receive(int timeout) throws SocketException {
         this.timeout = timeout;
         latch = new CountDownLatch(1);
-        s = new DatagramSocket();
+        s = new DatagramSocket(0, InetAddress.getLoopbackAddress());
     }
 
     public String description() {
@@ -60,7 +60,7 @@ public class DatagramSocket_receive extends AsyncCloseTest implements Runnable {
             }
             latch.countDown();
             s.receive(p);
-            failed("DatagramSocket.receive(DatagramPacket) returned unexpectly!!");
+            failed("DatagramSocket.receive(DatagramPacket) returned unexpectly!!" + " - " + p.getAddress());
         } catch (SocketException se) {
             if (latch.getCount() != 1) {
                 closed();

--- a/test/jdk/java/net/Socket/asyncClose/ServerSocket_accept.java
+++ b/test/jdk/java/net/Socket/asyncClose/ServerSocket_accept.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class ServerSocket_accept extends AsyncCloseTest implements Runnable {
     public ServerSocket_accept(int timeout) throws IOException {
         this.timeout = timeout;
         latch = new CountDownLatch(1);
-        ss = new ServerSocket(0);
+        ss = new ServerSocket(0, 0, InetAddress.getLoopbackAddress());
     }
 
     public String description() {
@@ -56,7 +56,7 @@ public class ServerSocket_accept extends AsyncCloseTest implements Runnable {
         try {
             latch.countDown();
             Socket s = ss.accept();
-            failed("ServerSocket.accept() returned unexpectly!!");
+            failed("ServerSocket.accept() returned unexpectly!!" + " - " + s);
         } catch (SocketException se) {
             closed();
         } catch (Exception e) {


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8129310 from the openjdk/jdk repository.

The commit being backported was authored by Chris Yin on 20 Nov 2018 and was reviewed by Daniel Fuchs.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8129310](https://bugs.openjdk.java.net/browse/JDK-8129310): java/net/Socket/asyncClose/AsyncClose.java fails intermittently


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/363/head:pull/363` \
`$ git checkout pull/363`

Update a local copy of the PR: \
`$ git checkout pull/363` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 363`

View PR using the GUI difftool: \
`$ git pr show -t 363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/363.diff">https://git.openjdk.java.net/jdk11u-dev/pull/363.diff</a>

</details>
