### PR TITLE
8259237: Demo selection changes with left/right arrow key. No need to press space for selection.

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicButtonUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicButtonUI.java
@@ -757,8 +757,11 @@ public class BasicButtonUI extends ButtonUI{
         }
 
         /**
-         * Find the new toggle button that focus needs to be
+         * Find the new toggle/radio button that focus needs to be
          * moved to in the group, select the button
+         * In case of radio button, setPressed and setArmed is called
+         * on the button model, so that Action set on button is performed
+         * on selecting the button
          *
          * @param next, indicate if it's arrow up/left or down/right
          */
@@ -780,12 +783,16 @@ public class BasicButtonUI extends ButtonUI{
                 if (newSelectedBtn != null &&
                         (newSelectedBtn != activeBtn)) {
                     ButtonModel btnModel = newSelectedBtn.getModel();
-                    btnModel.setPressed(true);
-                    btnModel.setArmed(true);
+                    if (newSelectedBtn instanceof JRadioButton) {
+                        btnModel.setPressed(true);
+                        btnModel.setArmed(true);
+                    }
                     newSelectedBtn.requestFocusInWindow();
                     newSelectedBtn.setSelected(true);
-                    btnModel.setPressed(false);
-                    btnModel.setArmed(false);
+                    if (newSelectedBtn instanceof JRadioButton) {
+                        btnModel.setPressed(false);
+                        btnModel.setArmed(false);
+                    }
                 }
             }
         }

--- a/test/jdk/javax/swing/ButtonGroup/TestButtonGroupFocusTraversal.java
+++ b/test/jdk/javax/swing/ButtonGroup/TestButtonGroupFocusTraversal.java
@@ -24,13 +24,15 @@
 /*
  * @test
  * @key headful
- * @bug 8249548
+ * @bug 8249548 8259237
  * @summary Test focus traversal in button group containing JToggleButton
  * and JRadioButton
  * @run main TestButtonGroupFocusTraversal
  */
 
+import javax.swing.AbstractAction;
 import javax.swing.ButtonGroup;
+import javax.swing.JCheckBox;
 import javax.swing.JFrame;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
@@ -43,12 +45,16 @@ import java.awt.FlowLayout;
 import java.awt.KeyboardFocusManager;
 import java.awt.Point;
 import java.awt.Robot;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 
 public class TestButtonGroupFocusTraversal {
     private static JFrame frame;
     private static JTextField textFieldFirst, textFieldLast;
     private static JToggleButton toggleButton1, toggleButton2;
+    private static JCheckBox checkBox1, checkBox2;
+    private static boolean toggleButtonActionPerformed;
+    private static boolean checkboxActionPerformed;
     private static JRadioButton radioButton1, radioButton2;
     private static Robot robot;
 
@@ -75,6 +81,36 @@ public class TestButtonGroupFocusTraversal {
                 toggleButton2 = new JToggleButton("2");
                 radioButton1 = new JRadioButton("1");
                 radioButton2 = new JRadioButton("2");
+                checkBox1 = new JCheckBox("1");
+                checkBox2 = new JCheckBox("2");
+
+                toggleButton1.setAction(new AbstractAction() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        toggleButtonActionPerformed = true;
+                    }
+                });
+
+                toggleButton2.setAction(new AbstractAction() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        toggleButtonActionPerformed = true;
+                    }
+                });
+
+                checkBox1.setAction(new AbstractAction() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        checkboxActionPerformed = true;
+                    }
+                });
+
+                checkBox2.setAction(new AbstractAction() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        checkboxActionPerformed = true;
+                    }
+                });
 
                 ButtonGroup toggleGroup = new ButtonGroup();
                 toggleGroup.add(toggleButton1);
@@ -84,8 +120,13 @@ public class TestButtonGroupFocusTraversal {
                 radioGroup.add(radioButton1);
                 radioGroup.add(radioButton2);
 
+                ButtonGroup checkboxButtonGroup = new ButtonGroup();
+                checkboxButtonGroup.add(checkBox1);
+                checkboxButtonGroup.add(checkBox2);
+
                 toggleButton2.setSelected(true);
                 radioButton2.setSelected(true);
+                checkBox2.setSelected(true);
 
                 frame = new JFrame("Test");
                 frame.setLayout(new FlowLayout());
@@ -96,6 +137,8 @@ public class TestButtonGroupFocusTraversal {
                 pane.add(toggleButton2);
                 pane.add(radioButton1);
                 pane.add(radioButton2);
+                pane.add(checkBox1);
+                pane.add(checkBox2);
                 pane.add(textFieldLast);
 
                 frame.pack();
@@ -124,6 +167,20 @@ public class TestButtonGroupFocusTraversal {
             System.out.println(component);
             System.out.println(focusedComponent);
             throw new RuntimeException("Wrong Component Selected");
+        }
+    }
+
+    private static void checkToggleButtonActionPerformed() {
+        if (toggleButtonActionPerformed) {
+            throw new RuntimeException("Toggle Button Action should not be" +
+                    "performed");
+        }
+    }
+
+    private static void checkCheckboxActionPerformed() {
+        if (toggleButtonActionPerformed) {
+            throw new RuntimeException("Checkbox Action should not be" +
+                    "performed");
         }
     }
 
@@ -165,7 +222,13 @@ public class TestButtonGroupFocusTraversal {
                 checkFocusedComponent(radioButton2);
 
                 pressKey(KeyEvent.VK_TAB);
+                checkFocusedComponent(checkBox2);
+
+                pressKey(KeyEvent.VK_TAB);
                 checkFocusedComponent(textFieldLast);
+
+                pressKey(KeyEvent.VK_SHIFT, KeyEvent.VK_TAB);
+                checkFocusedComponent(checkBox2);
 
                 pressKey(KeyEvent.VK_SHIFT, KeyEvent.VK_TAB);
                 checkFocusedComponent(radioButton2);
@@ -181,15 +244,19 @@ public class TestButtonGroupFocusTraversal {
 
                 pressKey(KeyEvent.VK_LEFT);
                 checkFocusedComponent(toggleButton1);
+                checkToggleButtonActionPerformed();
 
                 pressKey(KeyEvent.VK_RIGHT);
                 checkFocusedComponent(toggleButton2);
+                checkToggleButtonActionPerformed();
 
                 pressKey(KeyEvent.VK_UP);
                 checkFocusedComponent(toggleButton1);
+                checkToggleButtonActionPerformed();
 
                 pressKey(KeyEvent.VK_DOWN);
                 checkFocusedComponent(toggleButton2);
+                checkToggleButtonActionPerformed();
 
                 pressKey(KeyEvent.VK_TAB);
                 checkFocusedComponent(radioButton2);
@@ -206,6 +273,24 @@ public class TestButtonGroupFocusTraversal {
                 pressKey(KeyEvent.VK_DOWN);
                 checkFocusedComponent(radioButton2);
 
+                pressKey(KeyEvent.VK_TAB);
+                checkFocusedComponent(checkBox2);
+
+                pressKey(KeyEvent.VK_LEFT);
+                checkCheckboxActionPerformed();
+                checkFocusedComponent(checkBox1);
+
+                pressKey(KeyEvent.VK_RIGHT);
+                checkCheckboxActionPerformed();
+                checkFocusedComponent(checkBox2);
+
+                pressKey(KeyEvent.VK_UP);
+                checkCheckboxActionPerformed();
+                checkFocusedComponent(checkBox1);
+
+                pressKey(KeyEvent.VK_DOWN);
+                checkCheckboxActionPerformed();
+                checkFocusedComponent(checkBox2);
             } finally {
                 if (frame != null) {
                     SwingUtilities.invokeAndWait(frame::dispose);
@@ -214,4 +299,3 @@ public class TestButtonGroupFocusTraversal {
         }
     }
 }
-


### PR DESCRIPTION
Clean backport of JDK-8259237.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8259237](https://bugs.openjdk.java.net/browse/JDK-8259237): Demo selection changes with left/right arrow key. No need to press space for selection.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/366/head:pull/366` \
`$ git checkout pull/366`

Update a local copy of the PR: \
`$ git checkout pull/366` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 366`

View PR using the GUI difftool: \
`$ git pr show -t 366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/366.diff">https://git.openjdk.java.net/jdk11u-dev/pull/366.diff</a>

</details>
