### PR TITLE
8256066: Tests use deprecated TestNG API that is no longer available in new versions

### DIFF
--- a/test/jdk/java/lang/invoke/ConstantIdentityMHTest.java
+++ b/test/jdk/java/lang/invoke/ConstantIdentityMHTest.java
@@ -61,8 +61,7 @@ public class ConstantIdentityMHTest {
         assertEquals(MethodHandles.zero(expectedtype).type().toString(), expected);
     }
 
-    @Test
-    @ExpectedExceptions(NullPointerException.class)
+    @Test(expectedExceptions={ NullPointerException.class })
     public void testZeroNPE() {
         MethodHandle mh = MethodHandles.zero(null);
     }
@@ -75,8 +74,7 @@ public class ConstantIdentityMHTest {
         assertEquals(null, (String)mhEmpty.invoke("x","y"));
     }
 
-    @Test
-    @ExpectedExceptions(NullPointerException.class)
+    @Test(expectedExceptions = { NullPointerException.class })
     void testEmptyNPE() {
         MethodHandle lenEmptyMH = MethodHandles.empty(null);
     }

--- a/test/jdk/java/lang/invoke/DropArgumentsTest.java
+++ b/test/jdk/java/lang/invoke/DropArgumentsTest.java
@@ -65,8 +65,7 @@ public class DropArgumentsTest {
         };
     }
 
-    @Test(dataProvider = "dropArgumentsToMatchNPEData")
-    @ExpectedExceptions(NullPointerException.class)
+    @Test(dataProvider = "dropArgumentsToMatchNPEData", expectedExceptions = { NullPointerException.class })
     public void dropArgumentsToMatchNPE(MethodHandle target, int pos, List<Class<?>> valueType, int skip) {
         MethodHandles.dropArgumentsToMatch(target, pos, valueType , skip);
     }
@@ -85,14 +84,12 @@ public class DropArgumentsTest {
         };
     }
 
-    @Test(dataProvider = "dropArgumentsToMatchIAEData")
-    @ExpectedExceptions(IllegalArgumentException.class)
+    @Test(dataProvider = "dropArgumentsToMatchIAEData", expectedExceptions = { IllegalArgumentException.class })
     public void dropArgumentsToMatchIAE(MethodHandle target, int pos, List<Class<?>> valueType, int skip) {
         MethodHandles.dropArgumentsToMatch(target, pos, valueType , skip);
     }
 
-    @Test
-    @ExpectedExceptions(IllegalArgumentException.class)
+    @Test(expectedExceptions = { IllegalArgumentException.class })
     public void dropArgumentsToMatchTestWithVoid() throws Throwable {
         MethodHandle cat = lookup().findVirtual(String.class, "concat",
                                    MethodType.methodType(String.class, String.class));

--- a/test/jdk/java/lang/invoke/VarArgsTest.java
+++ b/test/jdk/java/lang/invoke/VarArgsTest.java
@@ -69,8 +69,7 @@ public class VarArgsTest {
         assertEquals("[two, too]", asListWithVarargs.invoke("two", "too").toString());
     }
 
-    @Test
-    @ExpectedExceptions(IllegalArgumentException.class)
+    @Test(expectedExceptions = { IllegalArgumentException.class })
     public void testWithVarargsIAE() throws Throwable {
         MethodHandle lenMH = publicLookup()
             .findVirtual(String.class, "length", methodType(int.class));


### PR DESCRIPTION
Clean backport of JDK-8256066.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8256066](https://bugs.openjdk.java.net/browse/JDK-8256066): Tests use deprecated TestNG API that is no longer available in new versions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/367/head:pull/367` \
`$ git checkout pull/367`

Update a local copy of the PR: \
`$ git checkout pull/367` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 367`

View PR using the GUI difftool: \
`$ git pr show -t 367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/367.diff">https://git.openjdk.java.net/jdk11u-dev/pull/367.diff</a>

</details>
