### PR TITLE
8197560: test javax/swing/JTree/8003400/Test8003400.java fails

### DIFF
--- a/test/jdk/javax/swing/JTree/8003400/Test8003400.java
+++ b/test/jdk/javax/swing/JTree/8003400/Test8003400.java
@@ -27,14 +27,13 @@
  * @bug 8003400
  * @summary Tests that JTree shows the last row
  * @author Sergey Malenkov
- * @library ../../../../lib/testlibrary
- * @build ExtendedRobot
  * @run main/othervm Test8003400
  * @run main/othervm Test8003400 reverse
- * @run main/othervm Test8003400 system
- * @run main/othervm Test8003400 system reverse
  */
 
+import java.awt.Component;
+import java.awt.event.InputEvent;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.event.KeyEvent;
@@ -53,59 +52,100 @@ public class Test8003400 {
     private static final String TITLE = "Test JTree with a large model";
     private static List<String> OBJECTS = Arrays.asList(TITLE, "x", "y", "z");
     private static JScrollPane pane;
+    private static JFrame frame;
+    private static JTree tree;
+    private static Point point;
+    private static Rectangle rect;
+
+    public static void blockTillDisplayed(Component comp) {
+        Point p = null;
+        while (p == null) {
+            try {
+                p = comp.getLocationOnScreen();
+            } catch (IllegalStateException e) {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException ie) {
+                }
+            }
+        }
+    }
 
     public static void main(String[] args) throws Exception {
         for (String arg : args) {
             if (arg.equals("reverse")) {
                 Collections.reverse(OBJECTS);
             }
-            if (arg.equals("system")) {
-                UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        }
+        UIManager.LookAndFeelInfo infos[] = UIManager.getInstalledLookAndFeels();
+        for (UIManager.LookAndFeelInfo info : infos) {
+            UIManager.setLookAndFeel(info.getClassName());
+            System.out.println(info.getClassName());
+            try {
+                SwingUtilities.invokeAndWait(new Runnable() {
+                    public void run() {
+                        DefaultMutableTreeNode root = new DefaultMutableTreeNode();
+
+                        tree = new JTree(root);
+                        tree.setLargeModel(true);
+                        tree.setRowHeight(16);
+
+                        frame = new JFrame(TITLE);
+                        frame.add(pane = new JScrollPane(tree));
+                        frame.setSize(200, 100);
+                        frame.setAlwaysOnTop(true);
+                        frame.setLocationRelativeTo(null);
+                        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+                        frame.setVisible(true);
+
+                        for (String object : OBJECTS) {
+                            root.add(new DefaultMutableTreeNode(object));
+                        }
+                        tree.expandRow(0);
+                    }
+                });
+
+                blockTillDisplayed(frame);
+
+                Robot robot = new Robot();
+                robot.setAutoDelay(100);
+                SwingUtilities.invokeAndWait(() -> {
+                    point = tree.getLocationOnScreen();
+                    rect = tree.getBounds();
+                });
+                robot.waitForIdle();
+                robot.delay(500);
+                robot.mouseMove(point.x + rect.width / 2, point.y + rect.height / 3);
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+                robot.waitForIdle();
+                robot.delay(1000);
+                robot.keyPress(KeyEvent.VK_END);
+                robot.keyRelease(KeyEvent.VK_END);
+                robot.waitForIdle();
+                robot.delay(1000);
+
+                SwingUtilities.invokeAndWait(new Runnable() {
+                    public void run() {
+                        JTree tree = (JTree) pane.getViewport().getView();
+                        Rectangle inner = tree.getRowBounds(tree.getRowCount() - 1);
+                        Rectangle outer = SwingUtilities.convertRectangle(tree, inner, pane);
+                        int heightDifference = outer.y + tree.getRowHeight() - pane.getVerticalScrollBar().getHeight();
+                        // error reporting only for automatic testing
+                        if (null != System.getProperty("test.src", null)) {
+                            frame.dispose();
+                            if (heightDifference > 3) {
+                                throw new Error("TEST FAILED: " + heightDifference);
+                            }
+                        }
+                    }
+                });
+            } finally {
+                if (frame != null) {
+                    SwingUtilities.invokeAndWait(frame::dispose);
+                }
             }
         }
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                DefaultMutableTreeNode root = new DefaultMutableTreeNode();
-
-                JTree tree = new JTree(root);
-                tree.setLargeModel(true);
-                tree.setRowHeight(16);
-
-                JFrame frame = new JFrame(TITLE);
-                frame.add(pane = new JScrollPane(tree));
-                frame.setSize(200, 100);
-                frame.setLocationRelativeTo(null);
-                frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-                frame.setVisible(true);
-
-                for (String object : OBJECTS) {
-                    root.add(new DefaultMutableTreeNode(object));
-                }
-                tree.expandRow(0);
-            }
-        });
-
-        ExtendedRobot robot = new ExtendedRobot();
-        robot.waitForIdle(500);
-        robot.keyPress(KeyEvent.VK_END);
-        robot.waitForIdle(500);
-        robot.keyRelease(KeyEvent.VK_END);
-        robot.waitForIdle();
-
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                JTree tree = (JTree) pane.getViewport().getView();
-                Rectangle inner = tree.getRowBounds(tree.getRowCount() - 1);
-                Rectangle outer = SwingUtilities.convertRectangle(tree, inner, pane);
-                outer.y += tree.getRowHeight() - 1 - pane.getVerticalScrollBar().getHeight();
-                // error reporting only for automatic testing
-                if (null != System.getProperty("test.src", null)) {
-                    SwingUtilities.getWindowAncestor(pane).dispose();
-                    if (outer.y != 0) {
-                        throw new Error("TEST FAILED: " + outer.y);
-                    }
-                }
-            }
-        });
     }
 }


### PR DESCRIPTION
Hi

I want to downport this for parity with 11.0.13-oracle.
Only a test fix, no risk.

I had to resolve the @test description. 
The change to ProblemList is not needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8197560](https://bugs.openjdk.java.net/browse/JDK-8197560): test javax/swing/JTree/8003400/Test8003400.java fails


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/374/head:pull/374` \
`$ git checkout pull/374`

Update a local copy of the PR: \
`$ git checkout pull/374` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 374`

View PR using the GUI difftool: \
`$ git pr show -t 374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/374.diff">https://git.openjdk.java.net/jdk11u-dev/pull/374.diff</a>

</details>
