### PR TITLE
8217377: javax/swing/JPopupMenu/6583251/bug6583251.java failed with UnsupportedOperation exception

### DIFF
--- a/test/jdk/javax/swing/JPopupMenu/6583251/bug6583251.java
+++ b/test/jdk/javax/swing/JPopupMenu/6583251/bug6583251.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 /*
  * @test
  * @key headful
- * @bug 6583251
+ * @bug 6583251 8217377
  * @summary One more ClassCastException in Swing with TrayIcon
  * @author Alexander Potochkin
  * @run main bug6583251
@@ -57,22 +57,32 @@ public class bug6583251 {
     }
 
     public static void main(String[] args) throws Exception {
+        if (SystemTray.isSupported()) {
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    createGui();
+                }
+            });
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                createGui();
-            }
-        });
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            menu.show(frame, 0, 0);
+            robot.waitForIdle();
 
-        Robot robot = new Robot();
-        robot.waitForIdle();
-        menu.show(frame, 0, 0);
-        robot.waitForIdle();
+            TrayIcon trayIcon = new TrayIcon(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB));
+            MouseEvent ev = new MouseEvent(
+                    new JButton(), MouseEvent.MOUSE_PRESSED, System.currentTimeMillis(), 0, 0, 0, 1, false);
+            ev.setSource(trayIcon);
+            Toolkit.getDefaultToolkit().getSystemEventQueue().postEvent(ev);
 
-        TrayIcon trayIcon = new TrayIcon(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB));
-        MouseEvent ev = new MouseEvent(
-                new JButton(), MouseEvent.MOUSE_PRESSED, System.currentTimeMillis(), 0, 0, 0, 1, false);
-        ev.setSource(trayIcon);
-        Toolkit.getDefaultToolkit().getSystemEventQueue().postEvent(ev);
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    frame.dispose();
+                }
+            });
+
+        } else {
+            System.out.println("SystemTray not supported. " + "Skipping the test.");
+        }
     }
 }


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.
Test change applies clean.
ProblemList change is pointless, test not problem listed in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8217377](https://bugs.openjdk.java.net/browse/JDK-8217377): javax/swing/JPopupMenu/6583251/bug6583251.java failed with UnsupportedOperation exception


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/378/head:pull/378` \
`$ git checkout pull/378`

Update a local copy of the PR: \
`$ git checkout pull/378` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 378`

View PR using the GUI difftool: \
`$ git pr show -t 378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/378.diff">https://git.openjdk.java.net/jdk11u-dev/pull/378.diff</a>

</details>
