### PR TITLE
8217903: java/net/httpclient/Response204.java fails with 404

### DIFF
--- a/test/jdk/java/net/httpclient/Response204.java
+++ b/test/jdk/java/net/httpclient/Response204.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public class Response204 {
         logger.addHandler (c);
         logger.setLevel (Level.WARNING);
         Handler handler = new Handler();
-        InetSocketAddress addr = new InetSocketAddress (0);
+        InetSocketAddress addr = new InetSocketAddress (InetAddress.getLoopbackAddress(), 0);
         HttpServer server = HttpServer.create (addr, 0);
         HttpContext ctx = server.createContext ("/test", handler);
         server.createContext ("/zero", new ZeroContentLengthHandler());
@@ -65,7 +65,10 @@ public class Response204 {
         server.setExecutor (executor);
         server.start ();
 
-        URI uri = new URI("http://localhost:"+server.getAddress().getPort()+"/test/foo.html");
+        URI uri = new URI("http", null,
+                server.getAddress().getHostString(),
+                server.getAddress().getPort(),
+                "/test/foo.html", null, null);
 
         try {
             HttpClient client = HttpClient.newHttpClient();


### PR DESCRIPTION
I am downporting this for parity with 11.0.13-oracle.
I had to do trivial resolves due to conflicts. Test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8217903](https://bugs.openjdk.java.net/browse/JDK-8217903): java/net/httpclient/Response204.java fails with 404


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/379/head:pull/379` \
`$ git checkout pull/379`

Update a local copy of the PR: \
`$ git checkout pull/379` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 379`

View PR using the GUI difftool: \
`$ git pr show -t 379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/379.diff">https://git.openjdk.java.net/jdk11u-dev/pull/379.diff</a>

</details>
