### PR TITLE
8217438: Adapt tools//launcher/Test7029048.java for AIX

### DIFF
--- a/test/jdk/tools/launcher/Test7029048.java
+++ b/test/jdk/tools/launcher/Test7029048.java
@@ -154,12 +154,22 @@ public class Test7029048 extends TestHelper {
                     }
 
                     desc = "LD_LIBRARY_PATH should not be set (no libjvm.so)";
+                    if (TestHelper.isAIX) {
+                        System.out.println("Skipping test case \"" + desc +
+                                           "\" because the Aix launcher adds the paths in any case.");
+                        continue;
+                    }
                     break;
                 case NO_DIR:
                     if (dstLibDir.exists()) {
                         recursiveDelete(dstLibDir);
                     }
                     desc = "LD_LIBRARY_PATH should not be set (no directory)";
+                    if (TestHelper.isAIX) {
+                        System.out.println("Skipping test case \"" + desc +
+                                           "\" because the Aix launcher adds the paths in any case.");
+                        continue;
+                    }
                     break;
                 default:
                     throw new RuntimeException("unknown case");


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8217438 from the openjdk/jdk repository.
The commit being backported was authored by Goetz Lindenmaier on 21 Jan 2019 and was reviewed by Christoph Langer and Arno Zeller.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8217438](https://bugs.openjdk.java.net/browse/JDK-8217438): Adapt tools//launcher/Test7029048.java for AIX


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/383/head:pull/383` \
`$ git checkout pull/383`

Update a local copy of the PR: \
`$ git checkout pull/383` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 383`

View PR using the GUI difftool: \
`$ git pr show -t 383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/383.diff">https://git.openjdk.java.net/jdk11u-dev/pull/383.diff</a>

</details>
