### PR TITLE
8221259: New tests for java.net.Socket to exercise long standing behavior

### DIFF
--- a/test/jdk/java/net/Socket/AsyncShutdown.java
+++ b/test/jdk/java/net/Socket/AsyncShutdown.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires (os.family == "linux" | os.family == "mac")
+ * @run testng AsyncShutdown
+ * @summary Test shutdownInput/shutdownOutput with threads blocked in read/write
+ */
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+@Test
+public class AsyncShutdown {
+
+    public void testShutdownInput1() throws IOException {
+        withConnection((s1, s2) -> {
+            scheduleShutdownInput(s1, 2000);
+            int n = s1.getInputStream().read();
+            assertTrue(n == -1);
+        });
+    }
+
+    public void testShutdownInput2() throws IOException {
+        withConnection((s1, s2) -> {
+            scheduleShutdownInput(s1, 2000);
+            s1.setSoTimeout(30*1000);
+            int n = s1.getInputStream().read();
+            assertTrue(n == -1);
+        });
+    }
+
+    public void testShutdownOutput1() throws IOException {
+        withConnection((s1, s2) -> {
+            scheduleShutdownOutput(s1, 2000);
+            byte[] data = new byte[128*1024];
+            try {
+                while (true) {
+                    s1.getOutputStream().write(data);
+                }
+            } catch (IOException expected) { }
+        });
+    }
+
+    public void testShutdownOutput2() throws IOException {
+        withConnection((s1, s2) -> {
+            s1.setSoTimeout(100);
+            try {
+                s1.getInputStream().read();
+                assertTrue(false);
+            } catch (SocketTimeoutException e) { }
+
+            scheduleShutdownOutput(s1, 2000);
+            byte[] data = new byte[128*1024];
+            try {
+                while (true) {
+                    s1.getOutputStream().write(data);
+                }
+            } catch (IOException expected) { }
+        });
+    }
+
+    static void scheduleShutdownInput(Socket s, long delay) {
+        schedule(() -> {
+            try {
+                s.shutdownInput();
+            } catch (IOException ioe) { }
+        }, delay);
+    }
+
+    static void scheduleShutdownOutput(Socket s, long delay) {
+        schedule(() -> {
+            try {
+                s.shutdownOutput();
+            } catch (IOException ioe) { }
+        }, delay);
+    }
+
+    static void schedule(Runnable task, long delay) {
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        try {
+            executor.schedule(task, delay, TimeUnit.MILLISECONDS);
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    interface ThrowingBiConsumer<T, U> {
+        void accept(T t, U u) throws IOException;
+    }
+
+    static void withConnection(ThrowingBiConsumer<Socket, Socket> consumer)
+        throws IOException
+    {
+        Socket s1 = null;
+        Socket s2 = null;
+        try (ServerSocket ss = new ServerSocket(0)) {
+            s1 = new Socket();
+            s1.connect(ss.getLocalSocketAddress());
+            s2 = ss.accept();
+            consumer.accept(s1, s2);
+        } finally {
+            if (s1 != null) s1.close();
+            if (s2 != null) s2.close();
+        }
+    }
+
+}

--- a/test/jdk/java/net/Socket/ConnectionReset.java
+++ b/test/jdk/java/net/Socket/ConnectionReset.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @requires os.family != "solaris"
+ * @run testng ConnectionReset
+ * @summary Test behavior of read and available when a connection is reset
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+@Test
+public class ConnectionReset {
+
+    static final int REPEAT_COUNT = 5;
+
+    /**
+     * Tests available before read when there are no bytes to read
+     */
+    public void testAvailableBeforeRead1() throws IOException {
+        System.out.println("testAvailableBeforeRead1");
+        withResetConnection(null, s -> {
+            InputStream in = s.getInputStream();
+            for (int i=0; i<REPEAT_COUNT; i++) {
+                int bytesAvailable = in.available();
+                System.out.format("available => %d%n", bytesAvailable);
+                assertTrue(bytesAvailable == 0);
+                try {
+                    int bytesRead = in.read();
+                    if (bytesRead == -1) {
+                        System.out.println("read => EOF");
+                    } else {
+                        System.out.println("read => 1 byte");
+                    }
+                    assertTrue(false);
+                } catch (IOException ioe) {
+                    System.out.format("read => %s (expected)%n", ioe);
+                }
+            }
+        });
+    }
+
+    /**
+     * Tests available before read when there are bytes to read
+     */
+    public void testAvailableBeforeRead2() throws IOException {
+        System.out.println("testAvailableBeforeRead2");
+        byte[] data = { 1, 2, 3 };
+        withResetConnection(data, s -> {
+            InputStream in = s.getInputStream();
+            int remaining = data.length;
+            for (int i=0; i<REPEAT_COUNT; i++) {
+                int bytesAvailable = in.available();
+                System.out.format("available => %d%n", bytesAvailable);
+                assertTrue(bytesAvailable <= remaining);
+                try {
+                    int bytesRead = in.read();
+                    if (bytesRead == -1) {
+                        System.out.println("read => EOF");
+                        assertTrue(false);
+                    } else {
+                        System.out.println("read => 1 byte");
+                        assertTrue(remaining > 0);
+                        remaining--;
+                    }
+                } catch (IOException ioe) {
+                    System.out.format("read => %s%n", ioe);
+                    remaining = 0;
+                }
+            }
+        });
+    }
+
+    /**
+     * Tests read before available when there are no bytes to read
+     */
+    public void testReadBeforeAvailable1() throws IOException {
+        System.out.println("testReadBeforeAvailable1");
+        withResetConnection(null, s -> {
+            InputStream in = s.getInputStream();
+            for (int i=0; i<REPEAT_COUNT; i++) {
+                try {
+                    int bytesRead = in.read();
+                    if (bytesRead == -1) {
+                        System.out.println("read => EOF");
+                    } else {
+                        System.out.println("read => 1 byte");
+                    }
+                    assertTrue(false);
+                } catch (IOException ioe) {
+                    System.out.format("read => %s (expected)%n", ioe);
+                }
+                int bytesAvailable = in.available();
+                System.out.format("available => %d%n", bytesAvailable);
+                assertTrue(bytesAvailable == 0);
+            }
+        });
+    }
+
+    /**
+     * Tests read before available when there are bytes to read
+     */
+    public void testReadBeforeAvailable2() throws IOException {
+        System.out.println("testReadBeforeAvailable2");
+        byte[] data = { 1, 2, 3 };
+        withResetConnection(data, s -> {
+            InputStream in = s.getInputStream();
+            int remaining = data.length;
+            for (int i=0; i<REPEAT_COUNT; i++) {
+                try {
+                    int bytesRead = in.read();
+                    if (bytesRead == -1) {
+                        System.out.println("read => EOF");
+                        assertTrue(false);
+                    } else {
+                        System.out.println("read => 1 byte");
+                        assertTrue(remaining > 0);
+                        remaining--;
+                    }
+                } catch (IOException ioe) {
+                    System.out.format("read => %s%n", ioe);
+                    remaining = 0;
+                }
+                int bytesAvailable = in.available();
+                System.out.format("available => %d%n", bytesAvailable);
+                assertTrue(bytesAvailable <= remaining);
+            }
+        });
+    }
+
+    /**
+     * Tests available and read on a socket closed after connection reset
+     */
+    public void testAfterClose() throws IOException {
+        System.out.println("testAfterClose");
+        withResetConnection(null, s -> {
+            InputStream in = s.getInputStream();
+            try {
+                in.read();
+                assertTrue(false);
+            } catch (IOException ioe) {
+                // expected
+            }
+            s.close();
+            try {
+                int bytesAvailable = in.available();
+                System.out.format("available => %d%n", bytesAvailable);
+                assertTrue(false);
+            } catch (IOException ioe) {
+                System.out.format("available => %s (expected)%n", ioe);
+            }
+            try {
+                int n = in.read();
+                System.out.format("read => %d%n", n);
+                assertTrue(false);
+            } catch (IOException ioe) {
+                System.out.format("read => %s (expected)%n", ioe);
+            }
+        });
+    }
+
+    interface ThrowingConsumer<T> {
+        void accept(T t) throws IOException;
+    }
+
+    /**
+     * Invokes a consumer with a Socket connected to a peer that has closed the
+     * connection with a "connection reset". The peer sends the given data bytes
+     * before closing (when data is not null).
+     */
+    static void withResetConnection(byte[] data, ThrowingConsumer<Socket> consumer)
+        throws IOException
+    {
+        var loopback = InetAddress.getLoopbackAddress();
+        try (var listener = new ServerSocket()) {
+            listener.bind(new InetSocketAddress(loopback, 0));
+            try (var socket = new Socket()) {
+                socket.connect(listener.getLocalSocketAddress());
+                try (Socket peer = listener.accept()) {
+                    if (data != null) {
+                        peer.getOutputStream().write(data);
+                    }
+                    peer.setSoLinger(true, 0);
+                }
+                consumer.accept(socket);
+            }
+        }
+    }
+}

--- a/test/jdk/java/net/Socket/Timeouts.java
+++ b/test/jdk/java/net/Socket/Timeouts.java
@@ -1,0 +1,497 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library /test/lib
+ * @build jdk.test.lib.Utils
+ * @run testng Timeouts
+ * @summary Test Socket timeouts
+ */
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ConnectException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+import jdk.test.lib.Utils;
+
+@Test
+public class Timeouts {
+
+    /**
+     * Test timed connect where connection is established
+     */
+    public void testTimedConnect1() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            try (Socket s = new Socket()) {
+                s.connect(ss.getLocalSocketAddress(), 2000);
+            }
+        }
+    }
+
+    /**
+     * Test timed connect where connection is refused
+     */
+    public void testTimedConnect2() throws IOException {
+        try (Socket s = new Socket()) {
+            SocketAddress remote = Utils.refusingEndpoint();
+            try {
+                s.connect(remote, 2000);
+            } catch (ConnectException expected) { }
+        }
+    }
+
+    /**
+     * Test connect with a timeout of Integer.MAX_VALUE
+     */
+    public void testTimedConnect3() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            try (Socket s = new Socket()) {
+                s.connect(ss.getLocalSocketAddress(), Integer.MAX_VALUE);
+            }
+        }
+    }
+
+    /**
+     * Test connect with a negative timeout. This case is not currently specified
+     * but the long standing behavior is to throw IllegalArgumentException.
+     */
+    public void testTimedConnect4() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            try (Socket s = new Socket()) {
+                try {
+                    s.connect(ss.getLocalSocketAddress(), -1);
+                    assertTrue(false);
+                } catch (IllegalArgumentException expected) { }
+            }
+        }
+    }
+
+    /**
+     * Test timed read where the read succeeds immediately
+     */
+    public void testTimedRead1() throws IOException {
+        withConnection((s1, s2) -> {
+            s1.getOutputStream().write(99);
+            s2.setSoTimeout(30*1000);
+            int b = s2.getInputStream().read();
+            assertTrue(b == 99);
+        });
+    }
+
+    /**
+     * Test timed read where the read succeeds after a delay
+     */
+    public void testTimedRead2() throws IOException {
+        withConnection((s1, s2) -> {
+            scheduleWrite(s1.getOutputStream(), 99, 2000);
+            s2.setSoTimeout(30*1000);
+            int b = s2.getInputStream().read();
+            assertTrue(b == 99);
+        });
+    }
+
+    /**
+     * Test timed read where the read times out
+     */
+    public void testTimedRead3() throws IOException {
+        withConnection((s1, s2) -> {
+            s2.setSoTimeout(2000);
+            try {
+                s2.getInputStream().read();
+                assertTrue(false);
+            } catch (SocketTimeoutException expected) { }
+        });
+    }
+
+    /**
+     * Test timed read that succeeds after a previous read has timed out
+     */
+    public void testTimedRead4() throws IOException {
+        withConnection((s1, s2) -> {
+            s2.setSoTimeout(2000);
+            try {
+                s2.getInputStream().read();
+                assertTrue(false);
+            } catch (SocketTimeoutException e) { }
+            s1.getOutputStream().write(99);
+            int b = s2.getInputStream().read();
+            assertTrue(b == 99);
+        });
+    }
+
+    /**
+     * Test timed read that succeeds after a previous read has timed out and
+     * after a short delay
+     */
+    public void testTimedRead5() throws IOException {
+        withConnection((s1, s2) -> {
+            s2.setSoTimeout(2000);
+            try {
+                s2.getInputStream().read();
+                assertTrue(false);
+            } catch (SocketTimeoutException e) { }
+            s2.setSoTimeout(30*3000);
+            scheduleWrite(s1.getOutputStream(), 99, 2000);
+            int b = s2.getInputStream().read();
+            assertTrue(b == 99);
+        });
+    }
+
+    /**
+     * Test untimed read that succeeds after a previous read has timed out
+     */
+    public void testTimedRead6() throws IOException {
+        withConnection((s1, s2) -> {
+            s2.setSoTimeout(2000);
+            try {
+                s2.getInputStream().read();
+                assertTrue(false);
+            } catch (SocketTimeoutException e) { }
+            s1.getOutputStream().write(99);
+            s2.setSoTimeout(0);
+            int b = s2.getInputStream().read();
+            assertTrue(b == 99);
+        });
+    }
+
+    /**
+     * Test untimed read that succeeds after a previous read has timed out and
+     * after a short delay
+     */
+    public void testTimedRead7() throws IOException {
+        withConnection((s1, s2) -> {
+            s2.setSoTimeout(2000);
+            try {
+                s2.getInputStream().read();
+                assertTrue(false);
+            } catch (SocketTimeoutException e) { }
+            scheduleWrite(s1.getOutputStream(), 99, 2000);
+            s2.setSoTimeout(0);
+            int b = s2.getInputStream().read();
+            assertTrue(b == 99);
+        });
+    }
+
+    /**
+     * Test async close of timed read
+     */
+    public void testTimedRead8() throws IOException {
+        withConnection((s1, s2) -> {
+            s2.setSoTimeout(30*1000);
+            scheduleClose(s2, 2000);
+            try {
+                s2.getInputStream().read();
+                assertTrue(false);
+            } catch (SocketException expected) { }
+        });
+    }
+
+    /**
+     * Test read with a timeout of Integer.MAX_VALUE
+     */
+    public void testTimedRead9() throws IOException {
+        withConnection((s1, s2) -> {
+            scheduleWrite(s1.getOutputStream(), 99, 2000);
+            s2.setSoTimeout(Integer.MAX_VALUE);
+            int b = s2.getInputStream().read();
+            assertTrue(b == 99);
+        });
+    }
+
+    /**
+     * Test writing after a timed read.
+     */
+    public void testTimedWrite1() throws IOException {
+        withConnection((s1, s2) -> {
+            s1.getOutputStream().write(99);
+            s2.setSoTimeout(3000);
+            int b = s2.getInputStream().read();
+            assertTrue(b == 99);
+
+            // schedule thread to read s1 to EOF
+            scheduleReadToEOF(s1.getInputStream(), 3000);
+
+            // write a lot so that write blocks
+            byte[] data = new byte[128*1024];
+            for (int i = 0; i < 100; i++) {
+                s2.getOutputStream().write(data);
+            }
+        });
+    }
+
+    /**
+     * Test async close of writer (after a timed read).
+     */
+    public void testTimedWrite2() throws IOException {
+        withConnection((s1, s2) -> {
+            s1.getOutputStream().write(99);
+            s2.setSoTimeout(3000);
+            int b = s2.getInputStream().read();
+            assertTrue(b == 99);
+
+            // schedule s2 to be be closed
+            scheduleClose(s2, 3000);
+
+            // write a lot so that write blocks
+            byte[] data = new byte[128*1024];
+            try {
+                while (true) {
+                    s2.getOutputStream().write(data);
+                }
+            } catch (SocketException expected) { }
+        });
+    }
+
+    /**
+     * Test timed accept where a connection is established immediately
+     */
+    public void testTimedAccept1() throws IOException {
+        Socket s1 = null;
+        Socket s2 = null;
+        try (ServerSocket ss = new ServerSocket(0)) {
+            s1 = new Socket();
+            s1.connect(ss.getLocalSocketAddress());
+            ss.setSoTimeout(30*1000);
+            s2 = ss.accept();
+        } finally {
+            if (s1 != null) s1.close();
+            if (s2 != null) s2.close();
+        }
+    }
+
+    /**
+     * Test timed accept where a connection is established after a short delay
+     */
+    public void testTimedAccept2() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            ss.setSoTimeout(30*1000);
+            scheduleConnect(ss.getLocalSocketAddress(), 2000);
+            Socket s = ss.accept();
+            s.close();
+        }
+    }
+
+    /**
+     * Test timed accept where the accept times out
+     */
+    public void testTimedAccept3() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            ss.setSoTimeout(2000);
+            try {
+                Socket s = ss.accept();
+                s.close();
+                assertTrue(false);
+            } catch (SocketTimeoutException expected) { }
+        }
+    }
+
+    /**
+     * Test timed accept where a connection is established immediately after a
+     * previous accept timed out.
+     */
+    public void testTimedAccept4() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            ss.setSoTimeout(2000);
+            try {
+                Socket s = ss.accept();
+                s.close();
+                assertTrue(false);
+            } catch (SocketTimeoutException expected) { }
+            try (Socket s1 = new Socket()) {
+                s1.connect(ss.getLocalSocketAddress());
+                Socket s2 = ss.accept();
+                s2.close();
+            }
+        }
+    }
+
+    /**
+     * Test untimed accept where a connection is established after a previous
+     * accept timed out
+     */
+    public void testTimedAccept5() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            ss.setSoTimeout(2000);
+            try {
+                Socket s = ss.accept();
+                s.close();
+                assertTrue(false);
+            } catch (SocketTimeoutException expected) { }
+            ss.setSoTimeout(0);
+            try (Socket s1 = new Socket()) {
+                s1.connect(ss.getLocalSocketAddress());
+                Socket s2 = ss.accept();
+                s2.close();
+            }
+        }
+    }
+
+    /**
+     * Test untimed accept where a connection is established after a previous
+     * accept timed out and after a short delay
+     */
+    public void testTimedAccept6() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            ss.setSoTimeout(2000);
+            try {
+                Socket s = ss.accept();
+                s.close();
+                assertTrue(false);
+            } catch (SocketTimeoutException expected) { }
+            ss.setSoTimeout(0);
+            scheduleConnect(ss.getLocalSocketAddress(), 2000);
+            Socket s = ss.accept();
+            s.close();
+        }
+    }
+
+    /**
+     * Test async close of a timed accept
+     */
+    public void testTimedAccept7() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            ss.setSoTimeout(30*1000);
+            scheduleClose(ss, 2000);
+            try {
+                ss.accept().close();
+                assertTrue(false);
+            } catch (SocketException expected) { }
+        }
+    }
+
+    /**
+     * Test Socket setSoTimeout with a negative timeout. This case is not currently
+     * specified but the long standing behavior is to throw IllegalArgumentException.
+     */
+    @Test(expectedExceptions = { IllegalArgumentException.class })
+    public void testBadTimeout1() throws IOException {
+        try (Socket s = new Socket()) {
+            s.setSoTimeout(-1);
+        }
+    }
+
+    /**
+     * Test ServerSocket setSoTimeout with a negative timeout. This case is not
+     * currently specified but the long standing behavior is to throw
+     * IllegalArgumentException.
+     */
+    @Test(expectedExceptions = { IllegalArgumentException.class })
+    public void testBadTimeout2() throws IOException {
+        try (ServerSocket ss = new ServerSocket()) {
+            ss.setSoTimeout(-1);
+        }
+    }
+
+    interface ThrowingBiConsumer<T, U> {
+        void accept(T t, U u) throws IOException;
+    }
+
+    /**
+     * Invokes the consumer with a connected pair of sockets
+     */
+    static void withConnection(ThrowingBiConsumer<Socket, Socket> consumer)
+        throws IOException
+    {
+        Socket s1 = null;
+        Socket s2 = null;
+        try (ServerSocket ss = new ServerSocket(0)) {
+            s1 = new Socket();
+            s1.connect(ss.getLocalSocketAddress());
+            s2 = ss.accept();
+            consumer.accept(s1, s2);
+        } finally {
+            if (s1 != null) s1.close();
+            if (s2 != null) s2.close();
+        }
+    }
+
+    /**
+     * Schedule c to be closed after a delay
+     */
+    static void scheduleClose(Closeable c, long delay) {
+        schedule(() -> {
+            try {
+                c.close();
+            } catch (IOException ioe) { }
+        }, delay);
+    }
+
+    /**
+     * Schedule a thread to connect to the given end point after a delay
+     */
+    static void scheduleConnect(SocketAddress remote, long delay) {
+        schedule(() -> {
+            try (Socket s = new Socket()) {
+                s.connect(remote);
+            } catch (IOException ioe) { }
+        }, delay);
+    }
+
+    /**
+     * Schedule a thread to read to EOF after a delay
+     */
+    static void scheduleReadToEOF(InputStream in, long delay) {
+        schedule(() -> {
+            byte[] bytes = new byte[8192];
+            try {
+                while (in.read(bytes) != -1) { }
+            } catch (IOException ioe) { }
+        }, delay);
+    }
+
+    /**
+     * Schedule a thread to write after a delay
+     */
+    static void scheduleWrite(OutputStream out, byte[] data, long delay) {
+        schedule(() -> {
+            try {
+                out.write(data);
+            } catch (IOException ioe) { }
+        }, delay);
+    }
+    static void scheduleWrite(OutputStream out, int b, long delay) {
+        scheduleWrite(out, new byte[] { (byte)b }, delay);
+    }
+
+    static void schedule(Runnable task, long delay) {
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        try {
+            executor.schedule(task, delay, TimeUnit.MILLISECONDS);
+        } finally {
+            executor.shutdown();
+        }
+    }
+}

--- a/test/jdk/java/net/Socket/UdpSocket.java
+++ b/test/jdk/java/net/Socket/UdpSocket.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @run main UdpSocket
+ * @summary Basic test for a Socket to a UDP socket
+ */
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.util.Arrays;
+
+public class UdpSocket {
+
+    static final String MESSAGE = "hello";
+
+    public static void main(String[] args) throws IOException {
+        try (DatagramChannel dc = DatagramChannel.open()) {
+            var loopback = InetAddress.getLoopbackAddress();
+            dc.bind(new InetSocketAddress(loopback, 0));
+
+            int port = ((InetSocketAddress) dc.getLocalAddress()).getPort();
+            try (Socket s = new Socket(loopback, port, false)) {
+
+                // send datagram with socket output stream
+                byte[] array1 = MESSAGE.getBytes("UTF-8");
+                s.getOutputStream().write(array1);
+
+                // receive the datagram
+                var buf = ByteBuffer.allocate(100);
+                SocketAddress remote = dc.receive(buf);
+                buf.flip();
+                if (buf.remaining() != MESSAGE.length())
+                    throw new RuntimeException("Unexpected size");
+
+                // echo the datagram
+                dc.send(buf, remote);
+
+                // receive datagram with the socket input stream
+                byte[] array2 = new byte[100];
+                int n = s.getInputStream().read(array2);
+                if (n != MESSAGE.length())
+                    throw new RuntimeException("Unexpected size");
+                if (!Arrays.equals(array1, 0, n, array2, 0, n))
+                    throw new RuntimeException("Unexpected contents");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8221259 from the openjdk/jdk repository.
The commit being backported was authored by Alan Bateman on 21 Mar 2019 and was reviewed by Chris Hegarty.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8221259](https://bugs.openjdk.java.net/browse/JDK-8221259): New tests for java.net.Socket to exercise long standing behavior


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/384/head:pull/384` \
`$ git checkout pull/384`

Update a local copy of the PR: \
`$ git checkout pull/384` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 384`

View PR using the GUI difftool: \
`$ git pr show -t 384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/384.diff">https://git.openjdk.java.net/jdk11u-dev/pull/384.diff</a>

</details>
