### PR TITLE
8214469: [macos] PIT: java/awt/Choice/ChoiceKeyEventReaction/ChoiceKeyEventReaction.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -511,7 +511,6 @@ java/awt/event/MouseEvent/ClickDuringKeypress/ClickDuringKeypress.java 8233568 m
 java/awt/event/KeyEvent/DeadKey/DeadKeyMacOSXInputText.java 8233568 macosx-all
 java/awt/event/KeyEvent/DeadKey/deadKeyMacOSX.java 8233568 macosx-all
 com/apple/eawt/DefaultMenuBar/DefaultMenuBarTest.java 8233648 macosx-all
-java/awt/Choice/ChoiceKeyEventReaction/ChoiceKeyEventReaction.java 7185258 macosx-all
 java/awt/TrayIcon/RightClickWhenBalloonDisplayed/RightClickWhenBalloonDisplayed.java 8238720 windows-all
 java/awt/PopupMenu/PopupMenuLocation.java 8238720 windows-all
 java/awt/GridLayout/ComponentPreferredSize/ComponentPreferredSize.java 8238720 windows-all

--- a/test/jdk/java/awt/Choice/ChoiceKeyEventReaction/ChoiceKeyEventReaction.java
+++ b/test/jdk/java/awt/Choice/ChoiceKeyEventReaction/ChoiceKeyEventReaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,18 +30,18 @@
  * @run main ChoiceKeyEventReaction
  */
 
-import java.awt.Robot;
 import java.awt.Choice;
-import java.awt.Point;
-import java.awt.Toolkit;
-import java.awt.TextField;
 import java.awt.FlowLayout;
-import java.awt.event.InputEvent;
-import java.awt.event.KeyEvent;
-import java.awt.event.ItemEvent;
-import java.awt.event.KeyAdapter;
-import java.awt.event.ItemListener;
 import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextField;
+import java.awt.Toolkit;
+import java.awt.event.InputEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 
 public class ChoiceKeyEventReaction
 {
@@ -60,6 +60,7 @@ public class ChoiceKeyEventReaction
         try {
             robot = new Robot();
             robot.setAutoDelay(100);
+            robot.waitForIdle();
 
             moveFocusToTextField();
             testKeyOnChoice(InputEvent.BUTTON1_MASK, KeyEvent.VK_UP);
@@ -99,6 +100,7 @@ public class ChoiceKeyEventReaction
         frame.add(choice1);
         frame.setLayout (new FlowLayout());
         frame.setSize (200,200);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 
@@ -108,33 +110,31 @@ public class ChoiceKeyEventReaction
 
         robot.mousePress(button);
         robot.mouseRelease(button);
+        robot.waitForIdle();
 
         robot.keyPress(key);
         robot.keyRelease(key);
+        robot.waitForIdle();
 
         System.out.println("keyTypedOnTextField = "+keyTypedOnTextField +": itemChanged = " + itemChanged);
         if (itemChanged) {
             throw new RuntimeException("Test failed. ItemChanged event occur on Choice.");
         }
 
-       // We may just write
-       // if (toolkit.equals("sun.awt.windows.WToolkit") == keyTypedOnTextField) {fail;}
-       // but  must report differently in these cases so put two separate if statements for simplicity.
-       if (toolkit.equals("sun.awt.windows.WToolkit") &&
-           !keyTypedOnTextField) {
-           throw new RuntimeException("Test failed. (Win32) KeyEvent wasn't addressed to TextField. ");
-       }
+        // We may just write
+        // if (toolkit.equals("sun.awt.windows.WToolkit") == keyTypedOnTextField) {fail;}
+        // but  must report differently in these cases so put two separate if statements for simplicity.
+        if (!toolkit.equals("sun.awt.X11.XToolkit") &&
+               !keyTypedOnTextField) {
+           throw new RuntimeException("Test failed. (Win32/MacOS) KeyEvent wasn't addressed to TextField. ");
+        }
 
-       if (!toolkit.equals("sun.awt.windows.WToolkit") &&
-          keyTypedOnTextField) {
-           throw new RuntimeException("Test failed. (XToolkit/MToolkit). KeyEvent was addressed to TextField.");
+        if (toolkit.equals("sun.awt.X11.XToolkit") &&
+                keyTypedOnTextField) {
+            throw new RuntimeException("Test failed. (XToolkit/MToolkit). KeyEvent was addressed to TextField.");
         }
 
         System.out.println("Test passed. Unfocusable Choice doesn't react on keys.");
-
-        //close opened choice
-        robot.keyPress(KeyEvent.VK_ESCAPE);
-        robot.keyRelease(KeyEvent.VK_ESCAPE);
     }
 
     public static void moveFocusToTextField() {


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

I had to resolve the ProblemList. 
The entry removed for this test mentions a different bugID in 11u, but that one has been downported, too:
https://bugs.openjdk.java.net/browse/JDK-7185258
I enabled the test again on mac.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8214469](https://bugs.openjdk.java.net/browse/JDK-8214469): [macos] PIT: java/awt/Choice/ChoiceKeyEventReaction/ChoiceKeyEventReaction.java fails


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/387/head:pull/387` \
`$ git checkout pull/387`

Update a local copy of the PR: \
`$ git checkout pull/387` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 387`

View PR using the GUI difftool: \
`$ git pr show -t 387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/387.diff">https://git.openjdk.java.net/jdk11u-dev/pull/387.diff</a>

</details>
