### PR TITLE
8165828: [TEST_BUG] The reg case:javax/swing/plaf/metal/MetalIcons/MetalHiDPIIconsTest.java failed as No Metal Look and Feel

### DIFF
--- a/test/jdk/javax/swing/plaf/metal/MetalIcons/MetalHiDPIIconsTest.java
+++ b/test/jdk/javax/swing/plaf/metal/MetalIcons/MetalHiDPIIconsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8160986 8174845 8176883
+ * @bug 8160986 8174845 8176883 8165828
  * @summary Bad rendering of Swing UI controls with Metal L&F on HiDPI display
  * @run main/manual MetalHiDPIIconsTest
  */
@@ -50,7 +50,7 @@ public class MetalHiDPIIconsTest {
             + "Verify that icons are painted smoothly for standard Swing UI controls.\n\n"
             + "If the display does not support HiDPI mode press PASS.\n\n"
             + "1. Run the SwingSet2 demo on HiDPI Display.\n"
-            + "2. Select Metal Look and Feel\n"
+            + "2. Select Java Look and Feel. It is equivalent to Metal Look And Feel\n"
             + "3. Check that the icons are painted smoothly on Swing UI controls like:\n"
             + "  - JRadioButton\n"
             + "  - JCheckBox\n"


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.
Applies clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8165828](https://bugs.openjdk.java.net/browse/JDK-8165828): [TEST_BUG] The reg case:javax/swing/plaf/metal/MetalIcons/MetalHiDPIIconsTest.java failed as No Metal Look and Feel


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/389/head:pull/389` \
`$ git checkout pull/389`

Update a local copy of the PR: \
`$ git checkout pull/389` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 389`

View PR using the GUI difftool: \
`$ git pr show -t 389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/389.diff">https://git.openjdk.java.net/jdk11u-dev/pull/389.diff</a>

</details>
