### PR TITLE
8233634: [TESTBUG] Swing text test bug4278839.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -788,7 +788,6 @@ javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233561 macosx-all
 javax/swing/text/JTextComponent/6361367/bug6361367.java 8233569 macosx-all
 javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java 233570 macosx-all
 javax/swing/text/GlyphPainter2/6427244/bug6427244.java 8208566 macosx-all
-javax/swing/text/DefaultEditorKit/4278839/bug4278839.java 8233634 macosx-all
 javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java 8233635 macosx-all
 javax/swing/plaf/nimbus/TestNimbusOverride.java 8233559 macosx-all
 javax/swing/JTree/4927934/bug4927934.java 8233550 macosx-all

--- a/test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java
+++ b/test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @key headful
- * @bug 4278839
+ * @bug 4278839 8233634
  * @summary Incorrect cursor movement between words at the end of line
  * @author Anton Nashatyrev
  * @library ../../../regtesthelpers
@@ -41,12 +41,13 @@ public class bug4278839 extends JFrame {
     private static boolean passed = true;
     private static JTextArea area;
     private static Robot robo;
+    private static JFrame frame;
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         try {
 
             robo = new Robot();
-            robo.setAutoDelay(100);
+            robo.setAutoDelay(200);
 
             SwingUtilities.invokeAndWait(new Runnable() {
                 @Override
@@ -60,6 +61,7 @@ public class bug4278839 extends JFrame {
             clickMouse();
             robo.waitForIdle();
 
+            area.setCaretPosition(0);
 
             if ("Aqua".equals(UIManager.getLookAndFeel().getID())) {
                 Util.hitKeys(robo, KeyEvent.VK_HOME);
@@ -86,6 +88,10 @@ public class bug4278839 extends JFrame {
         } catch (Exception e) {
             throw new RuntimeException("Test failed because of an exception:",
                     e);
+        } finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(() -> frame.dispose());
+            }
         }
 
         if (!passed) {
@@ -143,7 +149,7 @@ public class bug4278839 extends JFrame {
     }
 
     private static void createAndShowGUI() {
-        JFrame frame = new JFrame();
+        frame = new JFrame();
         frame.setTitle("Bug# 4278839");
         frame.setSize(200, 200);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233634](https://bugs.openjdk.java.net/browse/JDK-8233634): [TESTBUG] Swing text test bug4278839.java fails on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/391/head:pull/391` \
`$ git checkout pull/391`

Update a local copy of the PR: \
`$ git checkout pull/391` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 391`

View PR using the GUI difftool: \
`$ git pr show -t 391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/391.diff">https://git.openjdk.java.net/jdk11u-dev/pull/391.diff</a>

</details>
