### PR TITLE
8221903: PIT: javax/swing/RepaintManager/IconifyTest/IconifyTest.java fails on ubuntu18.04

### DIFF
--- a/test/jdk/javax/swing/RepaintManager/IconifyTest/IconifyTest.java
+++ b/test/jdk/javax/swing/RepaintManager/IconifyTest/IconifyTest.java
@@ -62,6 +62,7 @@ public class IconifyTest {
             }
         });
         robot.waitForIdle();
+        robot.delay(1000);
 
         SwingUtilities.invokeAndWait(new Runnable() {
             public void run() {
@@ -69,6 +70,7 @@ public class IconifyTest {
             }
         });
         robot.waitForIdle();
+        robot.delay(1000);
 
         if (!windowIconifiedIsCalled) {
             throw new Exception("Test failed: window was not iconified.");


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

The original change removes the fixed test from the ProblemList. In 11u, the test is not problem listed, so the change is not necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8221903](https://bugs.openjdk.java.net/browse/JDK-8221903): PIT: javax/swing/RepaintManager/IconifyTest/IconifyTest.java fails on ubuntu18.04


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/392/head:pull/392` \
`$ git checkout pull/392`

Update a local copy of the PR: \
`$ git checkout pull/392` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 392`

View PR using the GUI difftool: \
`$ git pr show -t 392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/392.diff">https://git.openjdk.java.net/jdk11u-dev/pull/392.diff</a>

</details>
