### PR TITLE
8242526: PIT: javax/swing/JInternalFrame/8020708/bug8020708.java fails in mach5 ubuntu system

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -810,7 +810,6 @@ javax/swing/JMenuItem/4171437/bug4171437.java 8233641 macosx-all
 javax/swing/JMenuBar/4750590/bug4750590.java 8233642 macosx-all
 javax/swing/JMenu/4692443/bug4692443.java 8171998 macosx-all
 javax/swing/JMenu/4515762/bug4515762.java 8233643 macosx-all
-javax/swing/JInternalFrame/8020708/bug8020708.java 8233644 macosx-all
 javax/swing/JColorChooser/Test8051548.java 8233647 macosx-all
 javax/swing/plaf/synth/7158712/bug7158712.java 8238720 windows-all
 javax/swing/plaf/basic/BasicComboPopup/JComboBoxPopupLocation/JComboBoxPopupLocation.java 8238720 windows-all

--- a/test/jdk/javax/swing/JInternalFrame/8020708/bug8020708.java
+++ b/test/jdk/javax/swing/JInternalFrame/8020708/bug8020708.java
@@ -73,14 +73,15 @@ public class bug8020708 {
                 if (!installLookAndFeel(laf)) {
                     continue;
                 }
-                testInternalFrameMnemonic();
+                testInternalFrameMnemonic(locale);
             }
         }
     }
 
-    static void testInternalFrameMnemonic() throws Exception {
+    static void testInternalFrameMnemonic(Locale locale) throws Exception {
         Robot robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(250);
+        robot.setAutoWaitForIdle(true);
 
         SwingUtilities.invokeAndWait(new Runnable() {
             @Override
@@ -108,10 +109,11 @@ public class bug8020708 {
         robot.mouseMove(clickPoint.x, clickPoint.y);
         robot.mousePress(InputEvent.BUTTON1_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_MASK);
-        robot.waitForIdle();
+        robot.delay(500);
 
         Util.hitKeys(robot, KeyEvent.VK_SHIFT, KeyEvent.VK_ESCAPE);
-        robot.waitForIdle();
+        robot.delay(500);
+
         int keyCode = KeyEvent.VK_C;
         String mnemonic = UIManager
                 .getString("InternalFrameTitlePane.closeButton.mnemonic");
@@ -119,15 +121,14 @@ public class bug8020708 {
             keyCode = Integer.parseInt(mnemonic);
         } catch (NumberFormatException e) {
         }
+        System.out.println("keyCode " + keyCode);
         Util.hitKeys(robot, keyCode);
-        robot.waitForIdle();
-        robot.delay(500);
 
         SwingUtilities.invokeAndWait(new Runnable() {
             @Override
             public void run() {
                 if (internalFrame.isVisible()) {
-                    throw new RuntimeException("Close mnemonic does not work in "+UIManager.getLookAndFeel());
+                    throw new RuntimeException("Close mnemonic does not work in "+UIManager.getLookAndFeel() + " for locale " + locale);
                 }
                 frame.dispose();
             }


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

Test passes. Even the ProblemList patch applied clean!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8242526](https://bugs.openjdk.java.net/browse/JDK-8242526): PIT: javax/swing/JInternalFrame/8020708/bug8020708.java fails in mach5 ubuntu system
 * [JDK-8233644](https://bugs.openjdk.java.net/browse/JDK-8233644): [TESTBUG] JInternalFrame test bug8020708.java is failing on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/398/head:pull/398` \
`$ git checkout pull/398`

Update a local copy of the PR: \
`$ git checkout pull/398` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 398`

View PR using the GUI difftool: \
`$ git pr show -t 398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/398.diff">https://git.openjdk.java.net/jdk11u-dev/pull/398.diff</a>

</details>
