### PR TITLE
8221902: PIT: javax/swing/JRadioButton/FocusTraversal/FocusTraversal.java fails on ubuntu

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -781,7 +781,6 @@ javax/swing/JComboBox/7031551/bug7031551.java 8199056 generic-all
 javax/swing/JScrollBar/6924059/bug6924059.java 8199078 generic-all
 javax/swing/JTabbedPane/TabProb.java 8236635 linux-all
 javax/swing/JTree/8003830/bug8003830.java 8199057 generic-all
-javax/swing/JRadioButton/FocusTraversal/FocusTraversal.java 8221902 linux-all,macosx-all
 javax/swing/ToolTipManager/Test6256140.java 8233560 macosx-all
 javax/swing/text/View/8014863/bug8014863.java 8233561 macosx-all
 javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233561 macosx-all

--- a/test/jdk/javax/swing/JRadioButton/FocusTraversal/FocusTraversal.java
+++ b/test/jdk/javax/swing/JRadioButton/FocusTraversal/FocusTraversal.java
@@ -134,6 +134,8 @@ public class FocusTraversal {
     private static void runTestCase() throws Exception {
         focusOn(a);
 
+        robot.waitForIdle();
+        robot.delay(500);
         robot.keyPress(KeyEvent.VK_ENTER);
         robot.keyRelease(KeyEvent.VK_ENTER);
         robot.waitForIdle();
@@ -189,6 +191,7 @@ public class FocusTraversal {
                 | IllegalAccessException e) {
             return false;
         }
+        System.out.println("Testing lookAndFeel " + lookAndFeelString);
         return true;
     }
 


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

Applied clean except for context in ProblemList.txt.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8221902](https://bugs.openjdk.java.net/browse/JDK-8221902): PIT: javax/swing/JRadioButton/FocusTraversal/FocusTraversal.java fails on ubuntu


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/399/head:pull/399` \
`$ git checkout pull/399`

Update a local copy of the PR: \
`$ git checkout pull/399` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 399`

View PR using the GUI difftool: \
`$ git pr show -t 399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/399.diff">https://git.openjdk.java.net/jdk11u-dev/pull/399.diff</a>

</details>
