### PR TITLE
8263773: Reenable German localization for builds at Oracle

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -242,7 +242,7 @@ var getJibProfilesCommon = function (input, data) {
         dependencies: ["boot_jdk", "gnumake", "jtreg", "jib", "autoconf"],
         default_make_targets: ["product-bundles", "test-bundles", "static-libs-bundles"],
         configure_args: concat(["--enable-jtreg-failure-handler"],
-            "--with-exclude-translations=de,es,fr,it,ko,pt_BR,sv,ca,tr,cs,sk,ja_JP_A,ja_JP_HA,ja_JP_HI,ja_JP_I,zh_TW,zh_HK",
+            "--with-exclude-translations=es,fr,it,ko,pt_BR,sv,ca,tr,cs,sk,ja_JP_A,ja_JP_HA,ja_JP_HI,ja_JP_I,zh_TW,zh_HK",
             "--disable-manpages",
             versionArgs(input, common))
     };

--- a/test/jdk/build/translations/VerifyTranslations.java
+++ b/test/jdk/build/translations/VerifyTranslations.java
@@ -45,7 +45,7 @@ public class VerifyTranslations {
      * The set of translations we want to see in an Oracle built image
      */
     private static final Set<String> VALID_TRANSLATION_SUFFIXES = Set.of(
-            "_en", "_en_US", "_en_US_POSIX", "_ja", "_zh_CN"
+            "_en", "_en_US", "_en_US_POSIX", "_ja", "_zh_CN", "_de"
     );
 
     /**


### PR DESCRIPTION
Trivial backport of JDK-8263773.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8263773](https://bugs.openjdk.java.net/browse/JDK-8263773): Reenable German localization for builds at Oracle


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/401/head:pull/401` \
`$ git checkout pull/401`

Update a local copy of the PR: \
`$ git checkout pull/401` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 401`

View PR using the GUI difftool: \
`$ git pr show -t 401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/401.diff">https://git.openjdk.java.net/jdk11u-dev/pull/401.diff</a>

</details>
