### PR TITLE
8230019: [REDO] compiler/types/correctness/* tests fail with "assert(recv == __null || recv->is_klass()) failed: wrong type"

### DIFF
--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -174,6 +174,8 @@ void ciReceiverTypeData::translate_receiver_data_from(const ProfileData* data) {
     if (k != NULL) {
       ciKlass* klass = CURRENT_ENV->get_klass(k);
       set_receiver(row, klass);
+    } else {
+      set_receiver(row, NULL);
     }
   }
 }

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -48,8 +48,8 @@ compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
 compiler/jvmci/compilerToVM/GetResolvedJavaTypeTest.java 8158860 generic-all
 compiler/jvmci/compilerToVM/InvalidateInstalledCodeTest.java 8163894 generic-all
 compiler/tiered/LevelTransitionTest.java 8067651 generic-all
-compiler/types/correctness/CorrectnessTest.java 8066173 generic-all
-compiler/types/correctness/OffTest.java 8066173 generic-all
+compiler/types/correctness/CorrectnessTest.java 8225620 solaris-sparcv9
+compiler/types/correctness/OffTest.java 8225620 solaris-sparcv9
 
 compiler/c2/Test6852078.java 8194310 generic-all
 


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

I had to resolve the ProblemList. 
I took the version of the new patch.
The old bug mentioned, JDK-8066173,  was closed with a patch just modifying the ProblemList -- which is strange.
The new bug, JDK-8225620, was closed, too.  But it was not resolved, it was only closed because the solaris port was removed. 
So I think mentioning the new bug is the right thing here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8230019](https://bugs.openjdk.java.net/browse/JDK-8230019): [REDO] compiler/types/correctness/* tests fail with "assert(recv == __null || recv->is_klass()) failed: wrong type"


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/402/head:pull/402` \
`$ git checkout pull/402`

Update a local copy of the PR: \
`$ git checkout pull/402` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 402`

View PR using the GUI difftool: \
`$ git pr show -t 402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/402.diff">https://git.openjdk.java.net/jdk11u-dev/pull/402.diff</a>

</details>
