### PR TITLE
8244292: Headful clients failing with --illegal-access=deny

### DIFF
--- a/test/jdk/com/sun/java/swing/plaf/windows/RevalidateOnPropertyChange.java
+++ b/test/jdk/com/sun/java/swing/plaf/windows/RevalidateOnPropertyChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import javax.swing.plaf.FontUIResource;
  * @summary tests if the desktop property changes this will force the UIs to
  *          update all known Frames
  * @requires (os.family == "windows")
- * @modules java.desktop/sun.awt
+ * @modules java.desktop/java.awt:open java.desktop/sun.awt
  */
 public final class RevalidateOnPropertyChange {
 

--- a/test/jdk/java/awt/Toolkit/DisplayChangesException/DisplayChangesException.java
+++ b/test/jdk/java/awt/Toolkit/DisplayChangesException/DisplayChangesException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import sun.awt.SunToolkit;
  * @bug 8207070
  * @modules java.desktop/sun.java2d
  *          java.desktop/sun.awt
+ *          java.desktop/sun.awt.windows:open
  */
 public final class DisplayChangesException {
 

--- a/test/jdk/java/awt/event/SequencedEvent/MultipleContextsUnitTest.java
+++ b/test/jdk/java/awt/event/SequencedEvent/MultipleContextsUnitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import sun.awt.SunToolkit;
  * @bug 8204142
  * @author Sergey Bylokhov
  * @key headful
- * @modules java.desktop/sun.awt
+ * @modules java.desktop/java.awt:open java.desktop/sun.awt
  * @run main/othervm/timeout=30 MultipleContextsUnitTest
  */
 public final class MultipleContextsUnitTest {


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

The patch to TabbedPaneMemLeak.java is not needed because the test is not in 11.  JDK-6714324 is missing in 11u which brings the new test.  I commented in the bug to include this fix in case it is downported.
The rest applied clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244292](https://bugs.openjdk.java.net/browse/JDK-8244292): Headful clients failing with --illegal-access=deny


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/403/head:pull/403` \
`$ git checkout pull/403`

Update a local copy of the PR: \
`$ git checkout pull/403` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 403`

View PR using the GUI difftool: \
`$ git pr show -t 403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/403.diff">https://git.openjdk.java.net/jdk11u-dev/pull/403.diff</a>

</details>
