### PR TITLE
8223658: Performance regression of XML.validation in 13-b19

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DeferredDocumentImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DeferredDocumentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -42,7 +42,7 @@ import org.w3c.dom.Node;
  * @xerces.internal
  *
  * @since  PR-DOM-Level-1-19980818.
- * @LastModified: Oct 2017
+ * @LastModified: May 2019
  */
 public class DeferredDocumentImpl
     extends DocumentImpl
@@ -69,7 +69,7 @@ public class DeferredDocumentImpl
     // protected
 
     /** Chunk shift. */
-    protected static final int CHUNK_SHIFT = 11;           // 2^11 = 2k
+    protected static final int CHUNK_SHIFT = 8;           // 2^8 = 256
 
     /** Chunk size. */
     protected static final int CHUNK_SIZE = (1 << CHUNK_SHIFT);
@@ -78,7 +78,7 @@ public class DeferredDocumentImpl
     protected static final int CHUNK_MASK = CHUNK_SIZE - 1;
 
     /** Initial chunk size. */
-    protected static final int INITIAL_CHUNK_COUNT = (1 << (16 - CHUNK_SHIFT));   // 2^16 = 64k
+    protected static final int INITIAL_CHUNK_COUNT = (1 << (13 - CHUNK_SHIFT));   // 32
 
     //
     // Data


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8223658 from the openjdk/jdk repository.

The commit being backported was authored by Joe Wang on 24 May 2019 and was reviewed by Lance Andersen.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8223658](https://bugs.openjdk.java.net/browse/JDK-8223658): Performance regression of XML.validation in 13-b19


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/405/head:pull/405` \
`$ git checkout pull/405`

Update a local copy of the PR: \
`$ git checkout pull/405` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 405`

View PR using the GUI difftool: \
`$ git pr show -t 405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/405.diff">https://git.openjdk.java.net/jdk11u-dev/pull/405.diff</a>

</details>
