### PR TITLE
8245165: Update bug id for javax/swing/text/StyledEditorKit/4506788/bug4506788.java in ProblemList

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -782,7 +782,7 @@ javax/swing/JTabbedPane/TabProb.java 8236635 linux-all
 javax/swing/JTree/8003830/bug8003830.java 8199057 generic-all
 javax/swing/ToolTipManager/Test6256140.java 8233560 macosx-all
 javax/swing/text/View/8014863/bug8014863.java 8233561 macosx-all
-javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233561 macosx-all
+javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233562 macosx-all
 javax/swing/text/JTextComponent/6361367/bug6361367.java 8233569 macosx-all
 javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java 233570 macosx-all
 javax/swing/text/GlyphPainter2/6427244/bug6427244.java 8208566 macosx-all


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

Most trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8245165](https://bugs.openjdk.java.net/browse/JDK-8245165): Update bug id for javax/swing/text/StyledEditorKit/4506788/bug4506788.java in ProblemList


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/408/head:pull/408` \
`$ git checkout pull/408`

Update a local copy of the PR: \
`$ git checkout pull/408` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 408`

View PR using the GUI difftool: \
`$ git pr show -t 408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/408.diff">https://git.openjdk.java.net/jdk11u-dev/pull/408.diff</a>

</details>
