### PR TITLE
8245665: Test WeakAlg.java should only make sure no warning for weak signature algorithms by keytool on root CA

### DIFF
--- a/test/jdk/sun/security/tools/keytool/WeakAlg.java
+++ b/test/jdk/sun/security/tools/keytool/WeakAlg.java
@@ -433,9 +433,9 @@ public class WeakAlg {
             // The following 2 commands still have a warning on why not using
             // the -cacerts option directly.
             kt("-list -keystore " + KeyStoreUtil.getCacerts())
-                    .shouldNotContain("risk");
+                    .shouldNotMatch("signature algorithm.*risk");
             kt("-list -v -keystore " + KeyStoreUtil.getCacerts())
-                    .shouldNotContain("risk");
+                    .shouldNotMatch("signature algorithm.*risk");
 
             // -printcert will always show warnings
             kt("-printcert -file ca.cert")
@@ -451,10 +451,10 @@ public class WeakAlg {
             kt("-delete -alias d");
             kt("-importcert -alias d -trustcacerts -file ca.cert", "no")
                     .shouldContain("Certificate already exists in system-wide CA")
-                    .shouldNotContain("risk")
+                    .shouldNotMatch("signature algorithm.*risk")
                     .shouldContain("Do you still want to add it to your own keystore?");
             kt("-importcert -alias d -trustcacerts -file ca.cert -noprompt")
-                    .shouldNotContain("risk")
+                    .shouldNotMatch("signature algorithm.*risk")
                     .shouldNotContain("[no]");
 
             // but not without -trustcacerts


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8245665](https://bugs.openjdk.java.net/browse/JDK-8245665): Test WeakAlg.java should only make sure no warning for weak signature algorithms by keytool on root CA


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/409/head:pull/409` \
`$ git checkout pull/409`

Update a local copy of the PR: \
`$ git checkout pull/409` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 409`

View PR using the GUI difftool: \
`$ git pr show -t 409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/409.diff">https://git.openjdk.java.net/jdk11u-dev/pull/409.diff</a>

</details>
