### PR TITLE
Backport 5805cbeaaf72657bbd758766d47261dd5c74e70b

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -546,7 +546,6 @@ java/lang/instrument/BootClassPath/BootClassPathTest.sh         8072130 macosx-a
 java/lang/management/MemoryMXBean/Pending.java                  8158837 generic-all
 java/lang/management/MemoryMXBean/PendingAllGC.sh               8158837 generic-all
 
-java/lang/management/ThreadMXBean/ThreadMXBeanStateTest.java    8081652 generic-all
 java/lang/management/ThreadMXBean/AllThreadIds.java             8131745 generic-all
 
 ############################################################################

--- a/test/jdk/java/lang/Thread/ThreadStateController.java
+++ b/test/jdk/java/lang/Thread/ThreadStateController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -359,7 +359,16 @@ public class ThreadStateController extends Thread {
      * @throws InterruptedException
      */
     public String getLog() throws InterruptedException {
-        this.join();
+        return getLog(0);
+    }
+
+    /**
+     * Waits at most {@code millis} milliseconds for the controller
+     * to complete the test run and returns the generated log.
+     * A timeout of {@code 0} means to wait forever.
+     */
+    public String getLog(long millis) throws InterruptedException {
+        this.join(millis);
 
         return logger.toString();
     }

--- a/test/jdk/java/lang/management/ThreadMXBean/ThreadMXBeanStateTest.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/ThreadMXBeanStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@
  * @build ThreadMXBeanStateTest ThreadStateController
  * @run main ThreadMXBeanStateTest
  */
+
+import jdk.test.lib.Utils;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
@@ -114,7 +116,7 @@ public class ThreadMXBeanStateTest {
             thread.checkThreadState(TERMINATED);
         } finally {
             try {
-                System.out.println(thread.getLog());
+                System.out.println(thread.getLog(Utils.adjustTimeout(60_000)));
             } catch (InterruptedException e) {
                 e.printStackTrace();
                 System.out.println("TEST FAILED: Unexpected exception.");


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

ProblemList: Context differs.
ThreadStateController.java: Copyright