### PR TITLE
8169954: JFileChooser/8021253: java.lang.RuntimeException: Default button is not pressed

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -750,7 +750,6 @@ javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
 javax/swing/plaf/basic/BasicGraphicsUtils/8132119/bug8132119.java 8196434 linux-all,solaris-all
 javax/swing/JComboBox/8182031/ComboPopupTest.java 8196465 linux-all,macosx-all
 javax/swing/JFileChooser/6738668/bug6738668.java 8194946 generic-all
-javax/swing/JFileChooser/8021253/bug8021253.java 8169954 windows-all,linux-all,macosx-all
 javax/swing/JFileChooser/8062561/bug8062561.java 8196466 linux-all,macosx-all
 javax/swing/JInternalFrame/Test6325652.java 8196467 macosx-all
 javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java 8225045 linux-all

--- a/test/jdk/javax/swing/JFileChooser/8021253/bug8021253.java
+++ b/test/jdk/javax/swing/JFileChooser/8021253/bug8021253.java
@@ -47,34 +47,41 @@ public class bug8021253 {
     private static volatile boolean defaultKeyPressed;
     private static JFileChooser fileChooser;
     private static File file;
+    private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
 
-        Robot robot = new Robot();
-        robot.setAutoDelay(50);
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    createAndShowGUI();
+                }
+            });
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                createAndShowGUI();
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    fileChooser.setSelectedFile(file);
+                }
+            });
+
+            robot.waitForIdle();
+
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+            robot.waitForIdle();
+
+            if (!defaultKeyPressed) {
+                throw new RuntimeException("Default button is not pressed");
             }
-        });
-
-        robot.waitForIdle();
-
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                fileChooser.setSelectedFile(file);
+        } finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
             }
-        });
-
-        robot.waitForIdle();
-
-        robot.keyPress(KeyEvent.VK_ENTER);
-        robot.keyRelease(KeyEvent.VK_ENTER);
-        robot.waitForIdle();
-
-        if (!defaultKeyPressed) {
-            throw new RuntimeException("Default button is not pressed");
         }
     }
 
@@ -82,7 +89,7 @@ public class bug8021253 {
 
         file = getTempFile();
 
-        final JFrame frame = new JFrame("Test");
+        frame = new JFrame("Test");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setSize(200, 300);
 
@@ -97,6 +104,7 @@ public class bug8021253 {
 
         frame.getContentPane().add(BorderLayout.CENTER, fileChooser);
         frame.setSize(fileChooser.getPreferredSize());
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8169954](https://bugs.openjdk.java.net/browse/JDK-8169954): JFileChooser/8021253: java.lang.RuntimeException: Default button is not pressed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/416/head:pull/416` \
`$ git checkout pull/416`

Update a local copy of the PR: \
`$ git checkout pull/416` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 416`

View PR using the GUI difftool: \
`$ git pr show -t 416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/416.diff">https://git.openjdk.java.net/jdk11u-dev/pull/416.diff</a>

</details>
