### PR TITLE
8253866: Security Libs Terminology Refresh

### DIFF
--- a/make/ToolsJdk.gmk
+++ b/make/ToolsJdk.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -73,9 +73,9 @@ TOOL_HASHER = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
 TOOL_TZDB = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
     build.tools.tzdb.TzdbZoneRulesCompiler
 
-TOOL_BLACKLISTED_CERTS = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
+TOOL_BLOCKED_CERTS = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
     --add-exports java.base/sun.security.util=ALL-UNNAMED \
-    build.tools.blacklistedcertsconverter.BlacklistedCertsConverter
+    build.tools.blockedcertsconverter.BlockedCertsConverter
 
 TOOL_MAKEJAVASECURITY = $(JAVA_SMALL) -cp $(BUILDTOOLS_OUTPUTDIR)/jdk_tools_classes \
     build.tools.makejavasecurity.MakeJavaSecurity

--- a/make/data/blockedcertsconverter/blocked.certs.pem
+++ b/make/data/blockedcertsconverter/blocked.certs.pem
@@ -1,4 +1,4 @@
-#! java BlacklistedCertsConverter SHA-256
+#! java BlockedCertsConverter SHA-256
 
 # The line above must be the first line of this file. Do not
 # remove it.

--- a/make/gendata/Gendata-java.base.gmk
+++ b/make/gendata/Gendata-java.base.gmk
@@ -32,7 +32,7 @@ include GendataBreakIterator.gmk
 
 include GendataTZDB.gmk
 
-include GendataBlacklistedCerts.gmk
+include GendataBlockedCerts.gmk
 
 include GendataCryptoPolicy.gmk
 

--- a/make/gendata/GendataBlockedCerts.gmk
+++ b/make/gendata/GendataBlockedCerts.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -23,14 +23,14 @@
 # questions.
 #
 
-$(eval $(call IncludeCustomExtension, gendata/GendataBlacklistedCerts.gmk))
+$(eval $(call IncludeCustomExtension, gendata/GendataBlockedCerts.gmk))
 
-GENDATA_BLACKLISTED_CERTS_SRC += $(TOPDIR)/make/data/blacklistedcertsconverter/blacklisted.certs.pem
-GENDATA_BLACKLISTED_CERTS := $(SUPPORT_OUTPUTDIR)/modules_libs/$(MODULE)/security/blacklisted.certs
+GENDATA_BLOCKED_CERTS_SRC += $(TOPDIR)/make/data/blockedcertsconverter/blocked.certs.pem
+GENDATA_BLOCKED_CERTS := $(SUPPORT_OUTPUTDIR)/modules_libs/$(MODULE)/security/blocked.certs
 
-$(GENDATA_BLACKLISTED_CERTS): $(BUILD_TOOLS_JDK) $(GENDATA_BLACKLISTED_CERTS_SRC)
-	$(call LogInfo, Generating blacklisted certs)
+$(GENDATA_BLOCKED_CERTS): $(BUILD_TOOLS_JDK) $(GENDATA_BLOCKED_CERTS_SRC)
+	$(call LogInfo, Generating blocked certs)
 	$(call MakeDir, $(@D))
-	($(CAT) $(GENDATA_BLACKLISTED_CERTS_SRC) | $(TOOL_BLACKLISTED_CERTS) > $@) || exit 1
+	($(CAT) $(GENDATA_BLOCKED_CERTS_SRC) | $(TOOL_BLOCKED_CERTS) > $@) || exit 1
 
-TARGETS += $(GENDATA_BLACKLISTED_CERTS)
+TARGETS += $(GENDATA_BLOCKED_CERTS)

--- a/make/jdk/src/classes/build/tools/blockedcertsconverter/BlockedCertsConverter.java
+++ b/make/jdk/src/classes/build/tools/blockedcertsconverter/BlockedCertsConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
  * questions.
  */
 
-package build.tools.blacklistedcertsconverter;
+package build.tools.blockedcertsconverter;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -45,15 +45,15 @@ import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 
 /**
- * Converts blacklisted.certs.pem from System.in to blacklisted.certs in
+ * Converts blocked.certs.pem from System.in to blocked.certs in
  * System.out. The input must start with a #! line including the fingerprint
  * algorithm. The output is sorted and unique.
  */
-public class BlacklistedCertsConverter {
+public class BlockedCertsConverter {
 
     public static void main(String[] args) throws Exception {
 
-        byte[] pattern = "#! java BlacklistedCertsConverter ".getBytes();
+        byte[] pattern = "#! java BlockedCertsConverter ".getBytes();
         String mdAlg = "";
 
         for (int i=0; ; i++) {

--- a/make/scripts/compare.sh
+++ b/make/scripts/compare.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -1044,7 +1044,7 @@ compare_all_execs() {
             -o -name '*.zip' -o -name '*.jimage' -o -name '*.java' -o -name '*.mf' \
             -o -name '*.jpg' -o -name '*.wsdl' -o -name '*.js' -o -name '*.sh' \
             -o -name '*.bat' -o -name '*LICENSE' -o -name '*.d' -o -name '*store' \
-            -o -name 'blacklist' -o -name '*certs' -o -name '*.ttf' \
+            -o -name 'blocked' -o -name '*certs' -o -name '*.ttf' \
             -o -name '*.jfc' -o -name '*.dat'  -o -name 'release' -o -name '*.dir'\
             -o -name '*.sym' -o -name '*.idl' -o -name '*.h' -o -name '*.access' \
             -o -name '*.template' -o -name '*.policy' -o -name '*.security' \

--- a/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -549,7 +549,7 @@ public final class JceKeyStore extends KeyStoreSpi {
              *     }
              *
              * ended by a keyed SHA1 hash (bytes only) of
-             *     { password + whitener + preceding body }
+             *     { password + extra data + preceding body }
              */
 
             // password is mandatory when storing
@@ -895,7 +895,7 @@ public final class JceKeyStore extends KeyStoreSpi {
 
     /**
      * To guard against tampering with the keystore, we append a keyed
-     * hash with a bit of whitener.
+     * hash with a bit of extra data.
      */
     private MessageDigest getPreKeyedHash(char[] password)
     throws NoSuchAlgorithmException, UnsupportedEncodingException {

--- a/src/java.base/share/classes/java/util/jar/JarVerifier.java
+++ b/src/java.base/share/classes/java/util/jar/JarVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,7 @@ class JarVerifier {
     /** makes code source singleton instances unique to us */
     private Object csdomain = new Object();
 
-    /** collect -DIGEST-MANIFEST values for blacklist */
+    /** collect -DIGEST-MANIFEST values for deny list */
     private List<Object> manifestDigests;
 
     public JarVerifier(String name, byte rawBytes[]) {

--- a/src/java.base/share/classes/sun/security/provider/JavaKeyStore.java
+++ b/src/java.base/share/classes/sun/security/provider/JavaKeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -536,7 +536,7 @@ public abstract class JavaKeyStore extends KeyStoreSpi {
              *     }
              *
              * ended by a keyed SHA1 hash (bytes only) of
-             *     { password + whitener + preceding body }
+             *     { password + extra data + preceding body }
              */
 
             // password is mandatory when storing
@@ -802,7 +802,7 @@ public abstract class JavaKeyStore extends KeyStoreSpi {
 
     /**
      * To guard against tampering with the keystore, we append a keyed
-     * hash with a bit of whitener.
+     * hash with a bit of extra data.
      */
     private MessageDigest getPreKeyedHash(char[] password)
         throws NoSuchAlgorithmException, UnsupportedEncodingException

--- a/src/java.base/share/classes/sun/security/util/UntrustedCertificates.java
+++ b/src/java.base/share/classes/sun/security/util/UntrustedCertificates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,12 +55,12 @@ public final class UntrustedCertificates {
             @Override
             public Void run() {
                 File f = new File(StaticProperty.javaHome(),
-                        "lib/security/blacklisted.certs");
+                        "lib/security/blocked.certs");
                 try (FileInputStream fin = new FileInputStream(f)) {
                     props.load(fin);
                 } catch (IOException fnfe) {
                     if (debug != null) {
-                        debug.println("Error parsing blacklisted.certs");
+                        debug.println("Error parsing blocked.certs");
                     }
                 }
                 return null;

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -450,21 +450,22 @@ networkaddress.cache.negative.ttl=10
 # Policy for failed Kerberos KDC lookups:
 #
 # When a KDC is unavailable (network error, service failure, etc), it is
-# put inside a blacklist and accessed less often for future requests. The
+# put inside a secondary list and accessed less often for future requests. The
 # value (case-insensitive) for this policy can be:
 #
 # tryLast
-#    KDCs in the blacklist are always tried after those not on the list.
+#    KDCs in the secondary list are always tried after those not on the list.
 #
 # tryLess[:max_retries,timeout]
-#    KDCs in the blacklist are still tried by their order in the configuration,
-#    but with smaller max_retries and timeout values. max_retries and timeout
-#    are optional numerical parameters (default 1 and 5000, which means once
-#    and 5 seconds). Please notes that if any of the values defined here is
-#    more than what is defined in krb5.conf, it will be ignored.
+#    KDCs in the secondary list are still tried by their order in the
+#    configuration, but with smaller max_retries and timeout values.
+#    max_retries and timeout are optional numerical parameters (default 1 and
+#    5000, which means once and 5 seconds). Please note that if any of the
+#    values defined here are more than what is defined in krb5.conf, it will be
+#    ignored.
 #
-# Whenever a KDC is detected as available, it is removed from the blacklist.
-# The blacklist is reset when krb5.conf is reloaded. You can add
+# Whenever a KDC is detected as available, it is removed from the secondary
+# list. The secondary list is reset when krb5.conf is reloaded. You can add
 # refreshKrb5Config=true to a JAAS configuration file so that krb5.conf is
 # reloaded whenever a JAAS authentication is attempted.
 #

--- a/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1332,7 +1332,7 @@ public class Config {
     /**
      * Locate KDC using DNS
      *
-     * @param realm the realm for which the master KDC is desired
+     * @param realm the realm for which the primary KDC is desired
      * @return the KDC
      */
     private String getKDCFromDNS(String realm) throws KrbException {

--- a/src/java.security.jgss/share/classes/sun/security/krb5/KdcComm.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/KdcComm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -492,12 +492,12 @@ public final class KdcComm {
 
     /**
      * Maintains a KDC accessible list. Unavailable KDCs are put into a
-     * blacklist, when a KDC in the blacklist is available, it's removed
-     * from there. No insertion order in the blacklist.
+     * secondary KDC list. When a KDC in the secondary list is available,
+     * it is removed from there. No insertion order in the secondary KDC list.
      *
-     * There are two methods to deal with KDCs in the blacklist. 1. Only try
-     * them when there's no KDC not on the blacklist. 2. Still try them, but
-     * with lesser number of retries and smaller timeout value.
+     * There are two methods to deal with KDCs in the secondary KDC list.
+     * 1. Only try them when they are the only known KDCs.
+     * 2. Still try them, but with fewer retries and a smaller timeout value.
      */
     static class KdcAccessibility {
         // Known bad KDCs

--- a/test/jdk/sun/security/krb5/auto/BogusKDC.java
+++ b/test/jdk/sun/security/krb5/auto/BogusKDC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,8 @@ import javax.security.auth.login.LoginException;
 /*
  * @test
  * @bug 4515853 8075297 8194486
- * @summary Checks that Kerberos client tries slave KDC
- *          if master KDC is not responding
+ * @summary Checks that Kerberos client tries replica KDC
+ *          if primary KDC is not responding
  * @library /test/lib
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
  * @run main/othervm -Djdk.net.hosts.file=TestHosts BogusKDC
@@ -80,8 +80,8 @@ public class BogusKDC {
         CallbackHandler handler = new Helper.UserPasswordHandler(
                 USER, USER_PASSWORD);
 
-        // create a krb5 config with non-existing host for master KDC,
-        // and wrong port for slave KDC
+        // create a krb5 config with non-existing host for primary KDC,
+        // and wrong port for replica KDC
         try (PrintWriter w = new PrintWriter(new FileWriter(KRB5_CONF))) {
             w.write(String.format(KRB5_CONF_TEMPLATE,
                     KDC.NOT_EXISTING_HOST, WRONG_KDC_PORT));
@@ -96,8 +96,8 @@ public class BogusKDC {
             System.out.println("Expected login failure: " + le);
         }
 
-        // create a krb5 config with non-existing host for master KDC,
-        // but correct port for slave KDC
+        // create a krb5 config with non-existing host for primary KDC,
+        // but correct port for replica KDC
         try (PrintWriter w = new PrintWriter(new FileWriter(KRB5_CONF))) {
             w.write(String.format(KRB5_CONF_TEMPLATE,
                     KDC.NOT_EXISTING_HOST, kdc.getPort()));

--- a/test/jdk/sun/security/lib/CheckBlockedCerts.java
+++ b/test/jdk/sun/security/lib/CheckBlockedCerts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import java.security.KeyStore;
 import java.security.cert.*;
 import java.util.*;
 
-public class CheckBlacklistedCerts {
+public class CheckBlockedCerts {
     public static void main(String[] args) throws Exception {
 
         String home = System.getProperty("java.home");
@@ -57,29 +57,30 @@ public class CheckBlacklistedCerts {
         }
 
         // All certs in the pem files
-        Set<Certificate> blacklisted = new HashSet<>();
+        Set<Certificate> blocked = new HashSet<>();
 
         // Assumes the full src is available
-        File blacklist = new File(System.getProperty("test.src"),
-                "../../../../../make/data/blacklistedcertsconverter/blacklisted.certs.pem");
+        File blockedCertsFile = new File(System.getProperty("test.src"),
+                "../../../../../make/data/blockedcertsconverter/blocked.certs.pem");
 
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        try (FileInputStream fis = new FileInputStream(blacklist)) {
+        try (FileInputStream fis = new FileInputStream(blockedCertsFile)) {
             Collection<? extends Certificate> certs
                     = cf.generateCertificates(fis);
             System.out.println(certs.size());
             for (Certificate c: certs) {
-                blacklisted.add(c);
+                blocked.add(c);
                 X509Certificate cert = ((X509Certificate)c);
                 if (!UntrustedCertificates.isUntrusted(cert)) {
-                    System.out.println(cert.getSubjectDN() + " is trusted");
+                    System.out.println(cert.getSubjectX500Principal() +
+                            " is trusted");
                     failed = true;
                 }
             }
         }
 
-        // Check the blacklisted.certs file itself
-        file = new File(home, "lib/security/blacklisted.certs");
+        // Check the blocked.certs file itself
+        file = new File(home, "lib/security/blocked.certs");
         System.out.print("Check for " + file + ": ");
         try (BufferedReader reader = new BufferedReader(
                 new InputStreamReader(new FileInputStream(file)))) {
@@ -100,11 +101,11 @@ public class CheckBlacklistedCerts {
                 failed = true;
             }
             // There are two unique fingerprints for each RSA certificate
-            if (ccount != blacklisted.size() * 2
-                    && !blacklisted.isEmpty()) {
-                System.out.println("Wrong blacklisted.certs size: "
+            if (ccount != blocked.size() * 2
+                    && !blocked.isEmpty()) {
+                System.out.println("Wrong blocked.certs size: "
                         + ccount + " fingerprints, "
-                        + blacklisted.size() + " certs");
+                        + blocked.size() + " certs");
                 failed = true;
             }
         }


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

make/modules/java.base/gendata/GendataBlacklistedCerts.gmk does not exist.
Instead, renamed make/gendata/GendataBlacklistedCerts.gmk and adapted content.

make/modules/java.base/Gendata.gmk does not exist: Applied change to make/gendata/Gendata-java.base.gmk instead

Copyright: JarVerifier.java, JavaKeyStore.java, KdcComm.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253866](https://bugs.openjdk.java.net/browse/JDK-8253866): Security Libs Terminology Refresh


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/419/head:pull/419` \
`$ git checkout pull/419`

Update a local copy of the PR: \
`$ git checkout pull/419` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 419`

View PR using the GUI difftool: \
`$ git pr show -t 419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/419.diff">https://git.openjdk.java.net/jdk11u-dev/pull/419.diff</a>

</details>
