### PR TITLE
8258855: Two tests sun/security/krb5/auto/ReplayCacheTestProc.java and ReplayCacheTestProcWithMD5.java failed on OL8.3

### DIFF
--- a/test/jdk/sun/security/krb5/auto/ReplayCacheTestProc.java
+++ b/test/jdk/sun/security/krb5/auto/ReplayCacheTestProc.java
@@ -29,7 +29,9 @@
  * @build jdk.test.lib.Platform
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
  * @run main/othervm/timeout=300 -Djdk.net.hosts.file=TestHosts
- *      ReplayCacheTestProc
+ *      -Dtest.libs=J ReplayCacheTestProc
+ * @run main/othervm/timeout=300 -Djdk.net.hosts.file=TestHosts
+ *      -Dtest.libs=N ReplayCacheTestProc
  */
 
 import java.io.*;
@@ -45,6 +47,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jdk.test.lib.Asserts;
 import jdk.test.lib.Platform;
 import sun.security.jgss.GSSUtil;
 import sun.security.krb5.internal.rcache.AuthTime;
@@ -53,9 +56,8 @@ import sun.security.krb5.internal.rcache.AuthTime;
  * This test runs multiple acceptor Procs to mimic AP-REQ replays.
  * These system properties are supported:
  *
- * - test.libs on what types of acceptors to use
+ * - test.libs on what types of acceptors to use. Cannot be null.
  *   Format: CSV of (J|N|N<suffix>=<libname>|J<suffix>=<launcher>)
- *   Default: J,N on Solaris and Linux where N is available, or J
  *   Example: J,N,N14=/krb5-1.14/lib/libgssapi_krb5.so,J8=/java8/bin/java
  *
  * - test.runs on manual runs. If empty, a iterate through all pattern
@@ -125,6 +127,16 @@ public class ReplayCacheTestProc {
             Ex[] result;
             int numPerType = 2; // number of acceptors per type
 
+            // User-provided libs
+            String userLibs = System.getProperty("test.libs");
+            Asserts.assertNotNull(userLibs, "test.libs property must be provided");
+            libs = userLibs.split(",");
+            if (Arrays.asList(libs).contains("N") && !isNativeLibAvailable()) {
+                // Skip test when native GSS libs are not available in running platform
+                System.out.println("Native mode not available - skipped");
+                return;
+            }
+
             KDC kdc = KDC.create(OneKDC.REALM, HOST, 0, true);
             for (int i=0; i<nc; i++) {
                 kdc.addPrincipal(client(i), OneKDC.PASS);
@@ -141,25 +153,6 @@ public class ReplayCacheTestProc {
 
             // Write KTAB after krb5.conf so it contains no aes-sha2 keys
             kdc.writeKtab(OneKDC.KTAB);
-
-            // User-provided libs
-            String userLibs = System.getProperty("test.libs");
-
-            if (userLibs != null) {
-                libs = userLibs.split(",");
-            } else {
-                if (Platform.isOSX() || Platform.isWindows()) {
-                    // macOS uses Heimdal and Windows has no native lib
-                    libs = new String[]{"J"};
-                } else {
-                    if (acceptor("N", "sanity").waitFor() != 0) {
-                        Proc.d("Native mode sanity check failed, only java");
-                        libs = new String[]{"J"};
-                    } else {
-                        libs = new String[]{"J", "N"};
-                    }
-                }
-            }
 
             pi = Proc.create("ReplayCacheTestProc").debug("C")
                     .inheritProp("jdk.net.hosts.file")
@@ -335,6 +328,13 @@ public class ReplayCacheTestProc {
             Proc.d(e);
             throw e;
         }
+    }
+
+    // returns true if native lib is available in running platform
+    // macOS uses Heimdal and Windows has no native lib
+    private static boolean isNativeLibAvailable() throws Exception {
+        return !Platform.isOSX() && !Platform.isWindows()
+                && acceptor("N", "sanity").waitFor() == 0;
     }
 
     // returns the client name

--- a/test/jdk/sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java
+++ b/test/jdk/sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java
@@ -32,5 +32,6 @@
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
  * @run main/othervm/timeout=300 -Djdk.krb5.rcache.useMD5=true
  *           -Djdk.net.hosts.file=TestHosts
- *           -Dtest.service=host ReplayCacheTestProc
+ *           -Dtest.service=host
+ *           -Dtest.libs=J ReplayCacheTestProc
  */


### PR DESCRIPTION
The changes to the tests applied clean.
The change to the ProblemList is pointless. The methods are not in the list in 11u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258855](https://bugs.openjdk.java.net/browse/JDK-8258855): Two tests sun/security/krb5/auto/ReplayCacheTestProc.java and ReplayCacheTestProcWithMD5.java failed on OL8.3


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/420/head:pull/420` \
`$ git checkout pull/420`

Update a local copy of the PR: \
`$ git checkout pull/420` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 420`

View PR using the GUI difftool: \
`$ git pr show -t 420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/420.diff">https://git.openjdk.java.net/jdk11u-dev/pull/420.diff</a>

</details>
