### PR TITLE
8163086: java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -887,7 +887,6 @@ java/awt/Modal/PrintDialogsTest/PrintDialogsTest.java 8068378 generic-all
 java/awt/dnd/DnDFileGroupDescriptor/DnDFileGroupDescriptor.html 8080185 macosx-all,linux-all
 javax/swing/JTabbedPane/4666224/bug4666224.html 8144124  macosx-all
 java/awt/event/MouseEvent/AltGraphModifierTest/AltGraphModifierTest.java 8162380 generic-all
-java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java 8163086 macosx-all
 java/awt/image/multiresolution/MultiResolutionIcon/IconTest.java 8250804 macosx-all,linux-all
 java/awt/image/VolatileImage/VolatileImageConfigurationTest.java 8171069 macosx-all,linux-all
 java/awt/Modal/InvisibleParentTest/InvisibleParentTest.java 8172245 linux-all

--- a/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
+++ b/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,12 @@
  */
 
 /*
- * @test %I% %E%
+ * @test
+ * @key headful
  * @bug 6683728
  * @summary Tests that a JApplet in a translucent JFrame works properly
- * @author Kenneth.Russell@sun.com: area=Graphics
  * @compile -XDignore.symbol.file=true TranslucentJAppletTest.java
- * @run main/manual/othervm TranslucentJAppletTest
+ * @run main TranslucentJAppletTest
  */
 
 import java.awt.*;


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

Clean except for context in ProblemList.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8163086](https://bugs.openjdk.java.net/browse/JDK-8163086): java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/423/head:pull/423` \
`$ git checkout pull/423`

Update a local copy of the PR: \
`$ git checkout pull/423` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 423`

View PR using the GUI difftool: \
`$ git pr show -t 423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/423.diff">https://git.openjdk.java.net/jdk11u-dev/pull/423.diff</a>

</details>
