### PR TITLE
8264824: java/net/Inet6Address/B6206527.java doesn't close ServerSocket properly

### DIFF
--- a/test/jdk/java/net/Inet6Address/B6206527.java
+++ b/test/jdk/java/net/Inet6Address/B6206527.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,22 +40,24 @@ public class B6206527 {
     public static void main (String[] args) throws Exception {
         Inet6Address addr = getLocalAddr();
         if (addr == null) {
-            System.out.println ("Could not find a link-local address");
+            System.out.println("Could not find a link-local address");
             return;
         }
 
-        ServerSocket ss = new ServerSocket();
-        System.out.println ("trying LL addr: " + addr);
-        ss.bind(new InetSocketAddress(addr, 0));
+        try (ServerSocket ss = new ServerSocket()) {
+            System.out.println("trying LL addr: " + addr);
+            ss.bind(new InetSocketAddress(addr, 0));
+        }
 
         // need to remove the %scope suffix
-        addr = (Inet6Address)InetAddress.getByAddress (
+        addr = (Inet6Address) InetAddress.getByAddress (
             addr.getAddress()
         );
 
-        System.out.println ("trying LL addr: " + addr);
-        ss = new ServerSocket();
-        ss.bind(new InetSocketAddress(addr, 0));
+        try (ServerSocket ss = new ServerSocket()) {
+            System.out.println("trying LL addr: " + addr);
+            ss.bind(new InetSocketAddress(addr, 0));
+        }
     }
 
     public static Inet6Address getLocalAddr() throws Exception {


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8264824](https://bugs.openjdk.java.net/browse/JDK-8264824): java/net/Inet6Address/B6206527.java doesn't close ServerSocket properly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/424/head:pull/424` \
`$ git checkout pull/424`

Update a local copy of the PR: \
`$ git checkout pull/424` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 424`

View PR using the GUI difftool: \
`$ git pr show -t 424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/424.diff">https://git.openjdk.java.net/jdk11u-dev/pull/424.diff</a>

</details>
