### PR TITLE
8233569: [TESTBUG] JTextComponent test bug6361367.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -783,7 +783,6 @@ javax/swing/JTree/8003830/bug8003830.java 8199057 generic-all
 javax/swing/ToolTipManager/Test6256140.java 8233560 macosx-all
 javax/swing/text/View/8014863/bug8014863.java 8233561 macosx-all
 javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233562 macosx-all
-javax/swing/text/JTextComponent/6361367/bug6361367.java 8233569 macosx-all
 javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java 233570 macosx-all
 javax/swing/text/GlyphPainter2/6427244/bug6427244.java 8208566 macosx-all
 javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java 8233635 macosx-all

--- a/test/jdk/javax/swing/text/JTextComponent/6361367/bug6361367.java
+++ b/test/jdk/javax/swing/text/JTextComponent/6361367/bug6361367.java
@@ -79,7 +79,7 @@ public class bug6361367 {
         waitForFocus(textComponent);
         Robot robot = new Robot();
         robot.setAutoWaitForIdle(true);
-        robot.setAutoDelay(250);
+        robot.setAutoDelay(100);
         robot.keyPress(KeyEvent.VK_END);
         robot.keyRelease(KeyEvent.VK_END);
         robot.keyPress(KeyEvent.VK_SHIFT);


### PR DESCRIPTION
This is a nearly-trivial backport of a test-only bug fix for 11u. Oracle backported this in 11.0.13-oracle . It applies clean except for ProblemList.txt.

Prior to backport, the test in 11u passes for me on macos anyway. Reading a comment by Philip Race [1], the underlying bug was believed to have been fixed by 225144 which is already backported. However they continued to see some test failures after 225144, which were presumably eventually addressed by this patch which followed it.

Please consider either for 11u or I request the bug be labelled jdk11u-na.

Thanks!

[1] https://bugs.openjdk.java.net/browse/JDK-8233569?focusedCommentId=14339145

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233569](https://bugs.openjdk.java.net/browse/JDK-8233569): [TESTBUG] JTextComponent test bug6361367.java fails on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/426/head:pull/426` \
`$ git checkout pull/426`

Update a local copy of the PR: \
`$ git checkout pull/426` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 426`

View PR using the GUI difftool: \
`$ git pr show -t 426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/426.diff">https://git.openjdk.java.net/jdk11u-dev/pull/426.diff</a>

</details>
