### PR TITLE
8196096: javax/swing/JPopupMenu/6580930/bug6580930.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -736,7 +736,7 @@ javax/swing/JFileChooser/8002077/bug8002077.java 8196094 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8058231 generic-all
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8193942 generic-all
 javax/swing/JList/6462008/bug6462008.java 7156347 generic-all
-javax/swing/JPopupMenu/6580930/bug6580930.java 8196096 windows-all,macosx-all
+javax/swing/JPopupMenu/6580930/bug6580930.java 7124313 macosx-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JPopupMenu/6675802/bug6675802.java 8196097 windows-all
 javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all

--- a/test/jdk/javax/swing/JPopupMenu/6580930/bug6580930.java
+++ b/test/jdk/javax/swing/JPopupMenu/6580930/bug6580930.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ public class bug6580930 {
     private static JPopupMenu popup;
     private static Toolkit toolkit;
     private static volatile boolean skipTest = false;
+    private static Point loc;
+    private static int y;
 
     private static void createGui() {
         frame = new JFrame();
@@ -94,12 +96,15 @@ public class bug6580930 {
             if (skipTest) {
                 return;
             }
-            Point loc = frame.getLocationOnScreen();
+
+            SwingUtilities.invokeAndWait(() -> loc = frame.getLocationOnScreen());
+            robot.waitForIdle();
 
             robot.mouseMove(loc.x, loc.y);
             showPopup();
             robot.waitForIdle();
-            if (isHeavyWeightMenuVisible()) {
+            if (!System.getProperty("os.name").startsWith("Mac")
+                && isHeavyWeightMenuVisible()) {
                 throw new RuntimeException("HeavyWeightPopup is unexpectedly visible");
             }
 
@@ -107,12 +112,16 @@ public class bug6580930 {
             robot.keyRelease(KeyEvent.VK_ESCAPE);
 
             int x = loc.x;
-            int y = loc.y + (frame.getHeight() - popup.getPreferredSize().height) + 1;
+            SwingUtilities.invokeAndWait( () -> y = loc.y + (frame.getHeight() -
+                    popup.getPreferredSize().height) + 1);
+            robot.waitForIdle();
             robot.mouseMove(x, y);
 
             showPopup();
+            SwingUtilities.invokeAndWait(() -> loc = popup.getLocationOnScreen());
+            robot.waitForIdle();
 
-            if (!popup.getLocationOnScreen().equals(new Point(x, y))) {
+            if (!loc.equals(new Point(x, y))) {
                 throw new RuntimeException("Popup is unexpectedly shifted");
             }
 


### PR DESCRIPTION
Backport of JDK-8196096: javax/swing/JPopupMenu/6580930/bug6580930.java fails

Needed some manual resolving in the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8196096](https://bugs.openjdk.java.net/browse/JDK-8196096): javax/swing/JPopupMenu/6580930/bug6580930.java fails


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/431/head:pull/431` \
`$ git checkout pull/431`

Update a local copy of the PR: \
`$ git checkout pull/431` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 431`

View PR using the GUI difftool: \
`$ git pr show -t 431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/431.diff">https://git.openjdk.java.net/jdk11u-dev/pull/431.diff</a>

</details>
