### PR TITLE
8269426: Rename test/jdk/java/lang/invoke/t8150782 to accessClassAndFindClass

### DIFF
--- a/test/jdk/java/lang/invoke/accessClassAndFindClass/TestAccessClass.java
+++ b/test/jdk/java/lang/invoke/accessClassAndFindClass/TestAccessClass.java
@@ -26,9 +26,9 @@
 /* @test
  * @bug 8150782 8207027
  * @compile TestAccessClass.java TestCls.java
- * @run testng/othervm -ea -esa test.java.lang.invoke.t8150782.TestAccessClass
+ * @run testng/othervm -ea -esa test.java.lang.invoke.TestAccessClass
  */
-package test.java.lang.invoke.t8150782;
+package test.java.lang.invoke;
 
 import java.lang.invoke.*;
 

--- a/test/jdk/java/lang/invoke/accessClassAndFindClass/TestCls.java
+++ b/test/jdk/java/lang/invoke/accessClassAndFindClass/TestCls.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package test.java.lang.invoke.t8150782;
+package test.java.lang.invoke;
 
 import static java.lang.invoke.MethodHandles.*;
 

--- a/test/jdk/java/lang/invoke/accessClassAndFindClass/TestFindClass.java
+++ b/test/jdk/java/lang/invoke/accessClassAndFindClass/TestFindClass.java
@@ -26,9 +26,9 @@
 /* @test
  * @bug 8150782 8207027
  * @compile TestFindClass.java TestCls.java
- * @run testng/othervm -ea -esa test.java.lang.invoke.t8150782.TestFindClass
+ * @run testng/othervm -ea -esa test.java.lang.invoke.TestFindClass
  */
-package test.java.lang.invoke.t8150782;
+package test.java.lang.invoke;
 
 import java.lang.invoke.*;
 
@@ -40,7 +40,7 @@ import org.testng.annotations.*;
 
 public class TestFindClass {
 
-    private static final String PACKAGE_PREFIX = "test.java.lang.invoke.t8150782.";
+    private static final String PACKAGE_PREFIX = "test.java.lang.invoke.";
 
     private static boolean initializedClass1;
 

--- a/test/jdk/java/lang/invoke/accessClassAndFindClass/TestLookup.java
+++ b/test/jdk/java/lang/invoke/accessClassAndFindClass/TestLookup.java
@@ -25,9 +25,9 @@
 
 /* @test
  * @compile TestLookup.java TestCls.java
- * @run testng/othervm -ea -esa test.java.lang.invoke.t8150782.TestLookup
+ * @run testng/othervm -ea -esa test.java.lang.invoke.TestLookup
  */
-package test.java.lang.invoke.t8150782;
+package test.java.lang.invoke;
 
 import org.testng.annotations.Test;
 
@@ -48,7 +48,7 @@ public class TestLookup {
     @Test(expectedExceptions = {ClassNotFoundException.class})
     public void testPublicCannotLoadUserClass() throws IllegalAccessException, ClassNotFoundException {
         Lookup lookup = publicLookup();
-        lookup.findClass("test.java.lang.invoke.t8150782.TestCls");
+        lookup.findClass("test.java.lang.invoke.TestCls");
     }
 
     @Test


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

Files p/Foo.java and q/Bar.java are not in 11.  They were added by 
8266269: Lookup::accessClass fails with IAE when accessing an arrayCl...
This is not in 11, and was not downported by Oracle. It has a CSR and changes
exceptions, so probably Oracle had a good reason not to bring it to 11.
Because 8266269 is missing though, I had to adapt the change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269426](https://bugs.openjdk.java.net/browse/JDK-8269426): Rename test/jdk/java/lang/invoke/t8150782 to accessClassAndFindClass


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/436/head:pull/436` \
`$ git checkout pull/436`

Update a local copy of the PR: \
`$ git checkout pull/436` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 436`

View PR using the GUI difftool: \
`$ git pr show -t 436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/436.diff">https://git.openjdk.java.net/jdk11u-dev/pull/436.diff</a>

</details>
