### PR TITLE
8269768: JFR Terminology Refresh

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/AnnotationElement.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/AnnotationElement.java
@@ -391,7 +391,7 @@ public final class AnnotationElement {
         throw new IllegalArgumentException("Only primitives types or java.lang.String are allowed");
     }
 
-    // Whitelist of annotation classes that are allowed, even though
+    // List of annotation classes that are allowed, even though
     // they don't have @MetadataDefinition.
     private static boolean isKnownJFRAnnotation(Class<? extends Annotation> annotationType) {
         if (annotationType == Registered.class) {


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269768](https://bugs.openjdk.java.net/browse/JDK-8269768): JFR Terminology Refresh


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/438/head:pull/438` \
`$ git checkout pull/438`

Update a local copy of the PR: \
`$ git checkout pull/438` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 438`

View PR using the GUI difftool: \
`$ git pr show -t 438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/438.diff">https://git.openjdk.java.net/jdk11u-dev/pull/438.diff</a>

</details>
