### PR TITLE
8229935: [TEST_BUG]: bug8132119.java inconsistently positions text

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -761,7 +761,6 @@ javax/swing/MultiUIDefaults/Test6860438.java 8198391 generic-all
 javax/swing/MultiUIDefaults/4300666/bug4300666.java 7105119 macosx-all
 javax/swing/UITest/UITest.java 8198392 generic-all
 javax/swing/plaf/basic/BasicComboBoxEditor/Test8015336.java 8198394 generic-all
-javax/swing/plaf/basic/BasicGraphicsUtils/8132119/bug8132119.java linux-all
 javax/swing/plaf/metal/MetalLookAndFeel/Test8039750.java 8198395 generic-all
 javax/swing/text/DevanagariEditor.java 8198397 generic-all
 javax/swing/SpringLayout/4726194/bug4726194.java 8198399 generic-all

--- a/test/jdk/javax/swing/plaf/basic/BasicGraphicsUtils/8132119/bug8132119.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicGraphicsUtils/8132119/bug8132119.java
@@ -26,6 +26,7 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.GraphicsEnvironment;
+import java.awt.RenderingHints;
 import java.awt.font.FontRenderContext;
 import java.awt.font.NumericShaper;
 import java.awt.font.TextAttribute;
@@ -145,6 +146,8 @@ public class bug8132119 {
 
         g2.setColor(DRAW_COLOR);
         g2.setFont(comp.getFont());
+        g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                            RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
 
         FontMetrics fontMetrices = comp.getFontMetrics(comp.getFont());
         float width = BasicGraphicsUtils.getStringWidth(comp, fontMetrices, str);
@@ -159,7 +162,7 @@ public class bug8132119 {
         g2.dispose();
 
         float xx = BasicGraphicsUtils.getStringWidth(comp, fontMetrices, "A") +
-                BasicGraphicsUtils.getStringWidth(comp, fontMetrices, "O")/2;
+                BasicGraphicsUtils.getStringWidth(comp, fontMetrices, "O")/2 -  10;
 
         checkImageContainsSymbol(buffImage, (int) xx, underlined ? 3 : 2);
     }


### PR DESCRIPTION
I downport this for parity with 11.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8229935](https://bugs.openjdk.java.net/browse/JDK-8229935): [TEST_BUG]: bug8132119.java inconsistently positions text


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/444/head:pull/444` \
`$ git checkout pull/444`

Update a local copy of the PR: \
`$ git checkout pull/444` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 444`

View PR using the GUI difftool: \
`$ git pr show -t 444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/444.diff">https://git.openjdk.java.net/jdk11u-dev/pull/444.diff</a>

</details>
