### PR TITLE
8234823: java/net/Socket/Timeouts.java testcase testTimedConnect2() fails on Windows 10

### DIFF
--- a/test/jdk/java/net/Socket/Timeouts.java
+++ b/test/jdk/java/net/Socket/Timeouts.java
@@ -68,7 +68,7 @@ public class Timeouts {
         try (Socket s = new Socket()) {
             SocketAddress remote = Utils.refusingEndpoint();
             try {
-                s.connect(remote, 2000);
+                s.connect(remote, 10000);
             } catch (ConnectException expected) { }
         }
     }


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8234823 from the openjdk/jdk repository.

The commit being backported was authored by Michael McMahon on 3 Dec 2019 and was reviewed by Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8234823](https://bugs.openjdk.java.net/browse/JDK-8234823): java/net/Socket/Timeouts.java testcase testTimedConnect2() fails on Windows 10


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/447/head:pull/447` \
`$ git checkout pull/447`

Update a local copy of the PR: \
`$ git checkout pull/447` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 447`

View PR using the GUI difftool: \
`$ git pr show -t 447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/447.diff">https://git.openjdk.java.net/jdk11u-dev/pull/447.diff</a>

</details>
