### PR TITLE
8248187: [TESTBUG] javax/swing/plaf/basic/BasicGraphicsUtils/8132119/bug8132119.java fails with String is not properly drawn

### DIFF
--- a/test/jdk/javax/swing/plaf/basic/BasicGraphicsUtils/8132119/bug8132119.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicGraphicsUtils/8132119/bug8132119.java
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+import java.io.File;
+import javax.imageio.ImageIO;
 
 import java.awt.Color;
 import java.awt.Font;
@@ -151,18 +153,23 @@ public class bug8132119 {
 
         FontMetrics fontMetrices = comp.getFontMetrics(comp.getFont());
         float width = BasicGraphicsUtils.getStringWidth(comp, fontMetrices, str);
-        float x = (WIDTH - width) / 2;
         int y = 3 * HEIGHT / 4;
 
         if (underlined) {
-            BasicGraphicsUtils.drawStringUnderlineCharAt(comp, g2, str, 1, x, y);
+            BasicGraphicsUtils.drawStringUnderlineCharAt(comp, g2, str, 1, 0, y);
         } else {
-            BasicGraphicsUtils.drawString(comp, g2, str, x, y);
+            BasicGraphicsUtils.drawString(comp, g2, str, 0, y);
         }
         g2.dispose();
 
-        float xx = BasicGraphicsUtils.getStringWidth(comp, fontMetrices, "A") +
-                BasicGraphicsUtils.getStringWidth(comp, fontMetrices, "O")/2 -  10;
+        float xx = 0;
+        if (underlined) {
+            xx = BasicGraphicsUtils.getStringWidth(comp, fontMetrices, "A") +
+                BasicGraphicsUtils.getStringWidth(comp, fontMetrices, "O")/2  - 5;
+        } else {
+            xx = BasicGraphicsUtils.getStringWidth(comp, fontMetrices, "A") +
+                BasicGraphicsUtils.getStringWidth(comp, fontMetrices, "O")/2;
+        }
 
         checkImageContainsSymbol(buffImage, (int) xx, underlined ? 3 : 2);
     }
@@ -347,7 +354,11 @@ public class bug8132119 {
             }
         }
 
+
         if (backgroundChangesCount != intersections * 2) {
+            try {
+                ImageIO.write(buffImage, "png", new File("image.png"));
+            } catch (Exception e) {}
             throw new RuntimeException("String is not properly drawn!");
         }
     }


### PR DESCRIPTION
I downport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8248187](https://bugs.openjdk.java.net/browse/JDK-8248187): [TESTBUG] javax/swing/plaf/basic/BasicGraphicsUtils/8132119/bug8132119.java fails with String is not properly drawn


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/450/head:pull/450` \
`$ git checkout pull/450`

Update a local copy of the PR: \
`$ git checkout pull/450` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 450`

View PR using the GUI difftool: \
`$ git pr show -t 450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/450.diff">https://git.openjdk.java.net/jdk11u-dev/pull/450.diff</a>

</details>
