### PR TITLE
8143021: [TEST_BUG] Test javax/swing/JColorChooser/Test6541987.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -715,7 +715,6 @@ javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 802462
 # The next test below is an intermittent failure
 javax/swing/JComboBox/8033069/bug8033069ScrollBar.java 8163367 generic-all
 javax/swing/JColorChooser/Test6827032.java 8197825 windows-all
-javax/swing/JColorChooser/Test6541987.java 8143021 windows-all,linux-all,macosx-all
 javax/swing/JColorChooser/Test7194184.java 8194126 linux-all,macosx-all
 javax/swing/JTable/7124218/SelectEditTableCell.java 8148958 linux-all,macosx-all
 javax/swing/JTable/4235420/bug4235420.java     8079127 generic-all

--- a/test/jdk/javax/swing/JColorChooser/Test6541987.java
+++ b/test/jdk/javax/swing/JColorChooser/Test6541987.java
@@ -42,24 +42,33 @@ import javax.swing.SwingUtilities;
 
 public class Test6541987 implements Runnable {
     private static Robot robot;
+    private static JFrame frame;
 
-    public static void main(String[] args) throws AWTException {
-        robot = new Robot();
-        // test escape after selection
-        start();
-        click(KeyEvent.VK_ESCAPE);
-        robot.waitForIdle();
-        // test double escape after editing
-        start();
-        click(KeyEvent.VK_1);
-        click(KeyEvent.VK_0);
-        click(KeyEvent.VK_ESCAPE);
-        click(KeyEvent.VK_ESCAPE);
-        robot.waitForIdle();
-        // all windows should be closed
-        for (Window window : Window.getWindows()) {
-            if (window.isVisible()) {
-                throw new Error("found visible window: " + window.getName());
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(100);
+            // test escape after selection
+            start();
+            click(KeyEvent.VK_ESCAPE);
+            robot.waitForIdle();
+            // test double escape after editing
+            start();
+            click(KeyEvent.VK_1);
+            click(KeyEvent.VK_0);
+            click(KeyEvent.VK_ESCAPE);
+            click(KeyEvent.VK_ESCAPE);
+            robot.waitForIdle();
+            robot.delay(500);
+            // all windows should be closed
+            for (Window window : Window.getWindows()) {
+                if (window.isVisible()) {
+                    throw new Error("found visible window: " + window.getName());
+                }
+            }
+        } finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
             }
         }
     }
@@ -85,7 +94,8 @@ public class Test6541987 implements Runnable {
 
     public void run() {
         String title = getClass().getName();
-        JFrame frame = new JFrame(title);
+        frame = new JFrame(title);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
 
         Color color = JColorChooser.showDialog(frame, title, Color.BLACK);


### PR DESCRIPTION
I downport this for parity with 11.0.14-oracle.

Only context resolve in ProblemList. Clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8143021](https://bugs.openjdk.java.net/browse/JDK-8143021): [TEST_BUG] Test javax/swing/JColorChooser/Test6541987.java fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/451/head:pull/451` \
`$ git checkout pull/451`

Update a local copy of the PR: \
`$ git checkout pull/451` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 451`

View PR using the GUI difftool: \
`$ git pr show -t 451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/451.diff">https://git.openjdk.java.net/jdk11u-dev/pull/451.diff</a>

</details>
