### PR TITLE
8272783: Epsilon: Refactor tests to improve performance

### DIFF
--- a/test/hotspot/jtreg/gc/epsilon/TestAlignment.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestAlignment.java
@@ -27,10 +27,24 @@
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Check Epsilon runs fine with (un)usual alignments
  * @bug 8212005
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:+UseTLAB TestAlignment
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:-UseTLAB TestAlignment
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:+UseTLAB -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16 TestAlignment
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:-UseTLAB -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16 TestAlignment
+ *
+ * @run main/othervm -Xmx64m -XX:+UseTLAB
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestAlignment
+ *
+ * @run main/othervm -Xmx64m -XX:-UseTLAB
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestAlignment
+ *
+ * @run main/othervm -Xmx64m -XX:+UseTLAB
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ *                   TestAlignment
+ *
+ * @run main/othervm -Xmx64m -XX:-UseTLAB
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ *                   TestAlignment
  */
 
 public class TestAlignment {

--- a/test/hotspot/jtreg/gc/epsilon/TestAlwaysPretouch.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestAlwaysPretouch.java
@@ -25,13 +25,31 @@
  * @test TestAlwaysPretouch
  * @key gc
  * @requires vm.gc.Epsilon & !vm.graal.enabled
- * @summary Basic sanity test for Epsilon
- * @run main/othervm -Xms128m -Xmx1g                     -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestAlwaysPretouch
- * @run main/othervm -Xms128m -Xmx1g -XX:-AlwaysPreTouch -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestAlwaysPretouch
- * @run main/othervm -Xms128m -Xmx1g -XX:+AlwaysPreTouch -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestAlwaysPretouch
- * @run main/othervm          -Xmx1g                     -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestAlwaysPretouch
- * @run main/othervm          -Xmx1g -XX:-AlwaysPreTouch -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestAlwaysPretouch
- * @run main/othervm          -Xmx1g -XX:+AlwaysPreTouch -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestAlwaysPretouch
+ * @summary Test that pre-touch works
+ *
+ * @run main/othervm -Xms64m -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestAlwaysPretouch
+ *
+ * @run main/othervm -Xms64m -Xmx256m -XX:-AlwaysPreTouch
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestAlwaysPretouch
+ *
+ * @run main/othervm -Xms64m -Xmx256m -XX:+AlwaysPreTouch
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestAlwaysPretouch
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestAlwaysPretouch
+ *
+ * @run main/othervm -Xmx256m -XX:-AlwaysPreTouch
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestAlwaysPretouch
+ *
+ * @run main/othervm -Xmx256m -XX:+AlwaysPreTouch
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestAlwaysPretouch
  */
 
 public class TestAlwaysPretouch {

--- a/test/hotspot/jtreg/gc/epsilon/TestArraycopyCheckcast.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestArraycopyCheckcast.java
@@ -29,11 +29,24 @@
  * @library /test/lib
  * @bug 8215724
  *
- * @run main/othervm -Xmx1g                                        -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestArraycopyCheckcast
- * @run main/othervm -Xmx1g -Xint                                  -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestArraycopyCheckcast
- * @run main/othervm -Xmx1g -Xbatch -Xcomp                         -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestArraycopyCheckcast
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestArraycopyCheckcast
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:-TieredCompilation  -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestArraycopyCheckcast
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestArraycopyCheckcast
+ *
+ * @run main/othervm -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestArraycopyCheckcast
+ *
+ * @run main/othervm -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestArraycopyCheckcast
+ *
+ * @run main/othervm -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestArraycopyCheckcast
  */
 
 import java.util.Random;

--- a/test/hotspot/jtreg/gc/epsilon/TestByteArrays.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestByteArrays.java
@@ -24,20 +24,46 @@
 /**
  * @test TestByteArrays
  * @key gc
- * @requires vm.gc.Epsilon & !vm.graal.enabled & os.maxMemory > 1G
+ * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Epsilon is able to allocate arrays, and does not corrupt their state
  *
- * @run main/othervm -Xmx1g                                        -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestByteArrays
- * @run main/othervm -Xmx1g -Xint                                  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestByteArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp                         -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestByteArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestByteArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:-TieredCompilation  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestByteArrays
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestByteArrays
  *
- * @run main/othervm -Xmx1g                                        -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestByteArrays
- * @run main/othervm -Xmx1g -Xint                                  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestByteArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp                         -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestByteArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestByteArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:-TieredCompilation  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestByteArrays
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestByteArrays
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestByteArrays
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestByteArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestByteArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestByteArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestByteArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestByteArrays
  */
 
 import java.util.Random;
@@ -45,7 +71,7 @@ import java.util.Random;
 public class TestByteArrays {
 
   static long SEED = Long.getLong("seed", System.nanoTime());
-  static int COUNT = Integer.getInteger("count", 3000); // ~500 MB allocation
+  static int COUNT = Integer.getInteger("count", 500); // ~100 MB allocation
 
   static byte[][] arr;
 

--- a/test/hotspot/jtreg/gc/epsilon/TestClasses.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestClasses.java
@@ -30,7 +30,10 @@
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.misc
  *
- * @run main/othervm -Xmx1g -XX:MetaspaceSize=1m -XX:MaxMetaspaceSize=64m -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -Xlog:gc+metaspace TestClasses
+ * @run main/othervm -Xmx256m
+ *                   -XX:MetaspaceSize=1m -XX:MaxMetaspaceSize=64m -Xlog:gc -Xlog:gc+metaspace
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestClasses
  */
 
 import jdk.internal.org.objectweb.asm.ClassWriter;

--- a/test/hotspot/jtreg/gc/epsilon/TestDieDefault.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieDefault.java
@@ -52,31 +52,24 @@ public class TestDieDefault {
   }
 
   public static void main(String[] args) throws Exception {
-    passWith("-Xmx128m",
+    passWith("-Xmx64m",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-Dcount=1",
              TestDieDefault.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              TestDieDefault.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xint",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              TestDieDefault.Workload.class.getName());
 
-    failWith("-Xmx128m",
-             "-Xbatch",
-             "-Xcomp",
-             "-XX:+UnlockExperimentalVMOptions",
-             "-XX:+UseEpsilonGC",
-             TestDieDefault.Workload.class.getName());
-
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xbatch",
              "-Xcomp",
              "-XX:TieredStopAtLevel=1",
@@ -84,7 +77,7 @@ public class TestDieDefault {
              "-XX:+UseEpsilonGC",
              TestDieDefault.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xbatch",
              "-Xcomp",
              "-XX:-TieredCompilation",

--- a/test/hotspot/jtreg/gc/epsilon/TestDieWithHeapDump.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieWithHeapDump.java
@@ -58,35 +58,27 @@ public class TestDieWithHeapDump {
   }
 
   public static void main(String[] args) throws Exception {
-    passWith("-Xmx128m",
+    passWith("-Xmx64m",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-Dcount=1",
              "-XX:+HeapDumpOnOutOfMemoryError",
              TestDieWithHeapDump.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-XX:+HeapDumpOnOutOfMemoryError",
              TestDieWithHeapDump.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xint",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-XX:+HeapDumpOnOutOfMemoryError",
              TestDieWithHeapDump.Workload.class.getName());
 
-    failWith("-Xmx128m",
-             "-Xbatch",
-             "-Xcomp",
-             "-XX:+UnlockExperimentalVMOptions",
-             "-XX:+UseEpsilonGC",
-             "-XX:+HeapDumpOnOutOfMemoryError",
-             TestDieWithHeapDump.Workload.class.getName());
-
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xbatch",
              "-Xcomp",
              "-XX:TieredStopAtLevel=1",
@@ -95,7 +87,7 @@ public class TestDieWithHeapDump {
              "-XX:+HeapDumpOnOutOfMemoryError",
              TestDieWithHeapDump.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xbatch",
              "-Xcomp",
              "-XX:-TieredCompilation",

--- a/test/hotspot/jtreg/gc/epsilon/TestDieWithOnError.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieWithOnError.java
@@ -56,35 +56,27 @@ public class TestDieWithOnError {
   }
 
   public static void main(String[] args) throws Exception {
-    passWith("-Xmx128m",
+    passWith("-Xmx64m",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-Dcount=1",
              "-XX:OnOutOfMemoryError=echo " + ON_ERR_MSG,
              TestDieWithOnError.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-XX:OnOutOfMemoryError=echo " + ON_ERR_MSG,
              TestDieWithOnError.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xint",
              "-XX:+UnlockExperimentalVMOptions",
              "-XX:+UseEpsilonGC",
              "-XX:OnOutOfMemoryError=echo " + ON_ERR_MSG,
              TestDieWithOnError.Workload.class.getName());
 
-    failWith("-Xmx128m",
-             "-Xbatch",
-             "-Xcomp",
-             "-XX:+UnlockExperimentalVMOptions",
-             "-XX:+UseEpsilonGC",
-             "-XX:OnOutOfMemoryError=echo " + ON_ERR_MSG,
-             TestDieWithOnError.Workload.class.getName());
-
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xbatch",
              "-Xcomp",
              "-XX:TieredStopAtLevel=1",
@@ -93,7 +85,7 @@ public class TestDieWithOnError {
              "-XX:OnOutOfMemoryError=echo " + ON_ERR_MSG,
              TestDieWithOnError.Workload.class.getName());
 
-    failWith("-Xmx128m",
+    failWith("-Xmx64m",
              "-Xbatch",
              "-Xcomp",
              "-XX:-TieredCompilation",

--- a/test/hotspot/jtreg/gc/epsilon/TestElasticTLAB.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestElasticTLAB.java
@@ -24,15 +24,33 @@
 /**
  * @test TestElasticTLAB
  * @key gc
- * @requires vm.gc.Epsilon & !vm.graal.enabled & os.maxMemory > 1G
+ * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Epsilon is able to work with/without elastic TLABs
  *
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:-EpsilonElasticTLAB                               TestElasticTLAB
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=1   TestElasticTLAB
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=1.1 TestElasticTLAB
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=2.0 TestElasticTLAB
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=42  TestElasticTLAB
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=100 TestElasticTLAB
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:-EpsilonElasticTLAB
+ *                   TestElasticTLAB
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=1
+ *                   TestElasticTLAB
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=1.1
+ *                   TestElasticTLAB
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=2.0
+ *                   TestElasticTLAB
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=100
+ *                   TestElasticTLAB
  */
 
 import java.util.Random;
@@ -40,7 +58,7 @@ import java.util.Random;
 public class TestElasticTLAB {
 
   static long SEED = Long.getLong("seed", System.nanoTime());
-  static int COUNT = Integer.getInteger("count", 3000); // ~500 MB allocation
+  static int COUNT = Integer.getInteger("count", 500); // ~100 MB allocation
 
   static byte[][] arr;
 

--- a/test/hotspot/jtreg/gc/epsilon/TestElasticTLABDecay.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestElasticTLABDecay.java
@@ -24,12 +24,23 @@
 /**
  * @test TestElasticTLABDecay
  * @key gc
- * @requires vm.gc.Epsilon & !vm.graal.enabled & os.maxMemory > 1G
+ * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Epsilon is able to work with/without elastic TLABs
  *
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:-EpsilonElasticTLABDecay                               TestElasticTLABDecay
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:+EpsilonElasticTLABDecay -XX:EpsilonTLABDecayTime=1    TestElasticTLABDecay
- * @run main/othervm -Xmx1g -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+EpsilonElasticTLAB -XX:+EpsilonElasticTLABDecay -XX:EpsilonTLABDecayTime=100  TestElasticTLABDecay
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:-EpsilonElasticTLABDecay
+ *                   TestElasticTLABDecay
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:+EpsilonElasticTLABDecay -XX:EpsilonTLABDecayTime=1
+ *                   TestElasticTLABDecay
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:+EpsilonElasticTLAB -XX:+EpsilonElasticTLABDecay -XX:EpsilonTLABDecayTime=100
+ *                   TestElasticTLABDecay
  */
 
 import java.util.Random;
@@ -37,7 +48,7 @@ import java.util.Random;
 public class TestElasticTLABDecay {
 
   static long SEED = Long.getLong("seed", System.nanoTime());
-  static int COUNT = Integer.getInteger("count", 3000); // ~500 MB allocation
+  static int COUNT = Integer.getInteger("count", 500); // ~100 MB allocation
 
   static byte[][] arr;
 

--- a/test/hotspot/jtreg/gc/epsilon/TestEpsilonEnabled.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestEpsilonEnabled.java
@@ -27,7 +27,10 @@
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Basic sanity test for Epsilon
  * @library /test/lib
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestEpsilonEnabled
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestEpsilonEnabled
  */
 
 import jdk.test.lib.Platform;

--- a/test/hotspot/jtreg/gc/epsilon/TestHelloWorld.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestHelloWorld.java
@@ -26,7 +26,8 @@
  * @key gc
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Basic sanity test for Epsilon
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestHelloWorld
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestHelloWorld
  */
 
 public class TestHelloWorld {

--- a/test/hotspot/jtreg/gc/epsilon/TestLogTrace.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestLogTrace.java
@@ -26,7 +26,9 @@
  * @key gc
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Test that tracing does not crash Epsilon
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc*=trace TestLogTrace
+ * @run main/othervm -Xmx256m -Xlog:gc*=trace
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestLogTrace
  */
 
 public class TestLogTrace {

--- a/test/hotspot/jtreg/gc/epsilon/TestManyThreads.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestManyThreads.java
@@ -27,17 +27,43 @@
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Test allocations from many threads
  *
- * @run main/othervm -Xmx128m -Xss512k                                        -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xint                                  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xbatch -Xcomp                         -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xbatch -Xcomp -XX:-TieredCompilation  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestManyThreads
+ * @run main/othervm -XX:-UseTLAB -Xmx256m -Xss512k
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestManyThreads
  *
- * @run main/othervm -Xmx128m -Xss512k                                        -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xint                                  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xbatch -Xcomp                         -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestManyThreads
- * @run main/othervm -Xmx128m -Xss512k -Xbatch -Xcomp -XX:-TieredCompilation  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestManyThreads
+ * @run main/othervm -XX:-UseTLAB -Xmx256m -Xss512k
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestManyThreads
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m -Xss512k
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestManyThreads
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m -Xss512k
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestManyThreads
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m -Xss512k
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestManyThreads
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m -Xss512k
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestManyThreads
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m -Xss512k
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestManyThreads
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m -Xss512k
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestManyThreads
  */
 
 import java.util.concurrent.atomic.*;

--- a/test/hotspot/jtreg/gc/epsilon/TestMaxTLAB.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestMaxTLAB.java
@@ -28,15 +28,49 @@
  * @summary Check EpsilonMaxTLAB options
  * @bug 8212177
  *
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=1     TestMaxTLAB
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=1K    TestMaxTLAB
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=1M    TestMaxTLAB
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=12345 TestMaxTLAB
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=1
+ *                   TestMaxTLAB
  *
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=1     -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16 TestMaxTLAB
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=1K    -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16 TestMaxTLAB
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=1M    -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16 TestMaxTLAB
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -Xmx128m -XX:+UseEpsilonGC -XX:EpsilonMaxTLABSize=12345 -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16 TestMaxTLAB
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=1K
+ *                   TestMaxTLAB
+ *
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=1M
+ *                   TestMaxTLAB
+ *
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=12345
+ *                   TestMaxTLAB
+ *
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=1
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ *                   TestMaxTLAB
+ *
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=1K
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ *                   TestMaxTLAB
+ *
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=1M
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ *                   TestMaxTLAB
+ *
+ * @run main/othervm -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonMaxTLABSize=12345
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ *                   TestMaxTLAB
  */
 
 public class TestMaxTLAB {

--- a/test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java
@@ -29,9 +29,21 @@
  * @summary Test JMX memory beans
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC          -Xmx1g TestMemoryMXBeans   -1 1024
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xms1g   -Xmx1g TestMemoryMXBeans 1024 1024
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xms128m -Xmx1g TestMemoryMXBeans  128 1024
+ *
+ * @run main/othervm -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestMemoryMXBeans
+ *                   -1 256
+ *
+ * @run main/othervm -Xmx256m -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestMemoryMXBeans
+ *                   256 256
+ *
+ * @run main/othervm -Xms64m -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestMemoryMXBeans
+ *                   64 256
  */
 
 import java.lang.management.*;

--- a/test/hotspot/jtreg/gc/epsilon/TestMemoryPools.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestMemoryPools.java
@@ -25,11 +25,14 @@
 /**
  * @test TestMemoryPools
  * @key gc
- * @requires vm.gc.Epsilon & !vm.graal.enabled & os.maxMemory >= 2G
+ * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Test JMX memory pools
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xmx1g -Xms1g TestMemoryPools
+ *
+ * @run main/othervm -Xms64m -Xmx64m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestMemoryPools
  */
 
 import java.lang.management.*;

--- a/test/hotspot/jtreg/gc/epsilon/TestObjects.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestObjects.java
@@ -27,17 +27,43 @@
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Epsilon is able to allocate objects, and does not corrupt their state
  *
- * @run main/othervm -Xmx128m                                        -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestObjects
- * @run main/othervm -Xmx128m -Xint                                  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestObjects
- * @run main/othervm -Xmx128m -Xbatch -Xcomp                         -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestObjects
- * @run main/othervm -Xmx128m -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestObjects
- * @run main/othervm -Xmx128m -Xbatch -Xcomp -XX:-TieredCompilation  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestObjects
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestObjects
  *
- * @run main/othervm -Xmx128m                                        -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestObjects
- * @run main/othervm -Xmx128m -Xint                                  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestObjects
- * @run main/othervm -Xmx128m -Xbatch -Xcomp                         -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestObjects
- * @run main/othervm -Xmx128m -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestObjects
- * @run main/othervm -Xmx128m -Xbatch -Xcomp -XX:-TieredCompilation  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestObjects
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestObjects
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestObjects
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestObjects
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestObjects
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestObjects
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestObjects
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestObjects
  */
 
 import java.util.Random;

--- a/test/hotspot/jtreg/gc/epsilon/TestPrintHeapSteps.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestPrintHeapSteps.java
@@ -26,9 +26,21 @@
  * @key gc
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Tests -XX:EpsilonPrintHeapSteps works
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonPrintHeapSteps=0    TestPrintHeapSteps
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonPrintHeapSteps=1    TestPrintHeapSteps
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonPrintHeapSteps=1000 TestPrintHeapSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonPrintHeapSteps=0
+ *                   TestPrintHeapSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonPrintHeapSteps=1
+ *                   TestPrintHeapSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonPrintHeapSteps=1000
+ *                   TestPrintHeapSteps
  */
 
 public class TestPrintHeapSteps {

--- a/test/hotspot/jtreg/gc/epsilon/TestRefArrays.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestRefArrays.java
@@ -28,17 +28,43 @@
  * @summary Epsilon is able to allocate arrays, and does not corrupt their state
  * @library /test/lib
  *
- * @run main/othervm -Xmx1g                                        -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestRefArrays
- * @run main/othervm -Xmx1g -Xint                                  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestRefArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp                         -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestRefArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestRefArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:-TieredCompilation  -XX:+UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestRefArrays
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestRefArrays
  *
- * @run main/othervm -Xmx1g                                        -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestRefArrays
- * @run main/othervm -Xmx1g -Xint                                  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestRefArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp                         -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestRefArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:TieredStopAtLevel=1 -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestRefArrays
- * @run main/othervm -Xmx1g -Xbatch -Xcomp -XX:-TieredCompilation  -XX:-UseTLAB -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC TestRefArrays
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestRefArrays
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestRefArrays
+ *
+ * @run main/othervm -XX:+UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestRefArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestRefArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xint
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestRefArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestRefArrays
+ *
+ * @run main/othervm -XX:-UseTLAB -Xmx256m
+ *                   -Xbatch -Xcomp -XX:-TieredCompilation
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   TestRefArrays
  */
 
 import java.util.Random;
@@ -46,7 +72,7 @@ import java.util.Random;
 public class TestRefArrays {
 
   static long SEED = Long.getLong("seed", System.nanoTime());
-  static int COUNT = Integer.getInteger("count", 1000); // ~500 MB allocation
+  static int COUNT = Integer.getInteger("count", 200); // ~100 MB allocation
 
   static MyObject[][] arr;
 

--- a/test/hotspot/jtreg/gc/epsilon/TestUpdateCountersSteps.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestUpdateCountersSteps.java
@@ -26,10 +26,26 @@
  * @key gc
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Test EpsilonUpdateCountersStep works
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonUpdateCountersStep=1    TestUpdateCountersSteps
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonUpdateCountersStep=10   TestUpdateCountersSteps
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonUpdateCountersStep=100  TestUpdateCountersSteps
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -XX:EpsilonUpdateCountersStep=1000 TestUpdateCountersSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonUpdateCountersStep=1
+ *                   TestUpdateCountersSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonUpdateCountersStep=10
+ *                   TestUpdateCountersSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonUpdateCountersStep=100
+ *                   TestUpdateCountersSteps
+ *
+ * @run main/othervm -Xmx64m -Xlog:gc
+ *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
+ *                   -XX:EpsilonUpdateCountersStep=1000
+ *                   TestUpdateCountersSteps
  */
 
 public class TestUpdateCountersSteps {


### PR DESCRIPTION
Unclean backport to improve Epsilon testing. The original patch does not apply cleanly because the tests were moved to `gc.epsilon` package as part of bulk test move.

Additional testing: 
 - [x] Linux x86_64 fastdebug, `gc/epsilon`
 - [x] Linux x86_64 release, `gc/epsilon`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272783](https://bugs.openjdk.java.net/browse/JDK-8272783): Epsilon: Refactor tests to improve performance


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/453/head:pull/453` \
`$ git checkout pull/453`

Update a local copy of the PR: \
`$ git checkout pull/453` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 453`

View PR using the GUI difftool: \
`$ git pr show -t 453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/453.diff">https://git.openjdk.java.net/jdk11u-dev/pull/453.diff</a>

</details>
