### PR TITLE
8273894: ConcurrentModificationException raised every time ReferralsCache drops referral

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ReferralsCache.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ReferralsCache.java
@@ -28,6 +28,7 @@ package sun.security.krb5.internal;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -174,10 +175,11 @@ final class ReferralsCache {
         Date now = new Date();
         Map<String, ReferralCacheEntry> entries = referralsMap.get(k);
         if (entries != null) {
-            for (Entry<String, ReferralCacheEntry> mapEntry :
-                    entries.entrySet()) {
+            Iterator<Entry<String, ReferralCacheEntry>> it = entries.entrySet().iterator();
+            while (it.hasNext()) {
+                Entry<String, ReferralCacheEntry> mapEntry = it.next();
                 if (mapEntry.getValue().getCreds().getEndTime().before(now)) {
-                    entries.remove(mapEntry.getKey());
+                    it.remove();
                 }
             }
         }


### PR DESCRIPTION
Clean backport to fix the ReferralsCache bug.

Additional testing:
 - [x] Linux x86_64 fastdebug `jdk_security`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273894](https://bugs.openjdk.java.net/browse/JDK-8273894): ConcurrentModificationException raised every time ReferralsCache drops referral


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/455/head:pull/455` \
`$ git checkout pull/455`

Update a local copy of the PR: \
`$ git checkout pull/455` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 455`

View PR using the GUI difftool: \
`$ git pr show -t 455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/455.diff">https://git.openjdk.java.net/jdk11u-dev/pull/455.diff</a>

</details>
