### PR TITLE
8272914: Create hotspot:tier2 and hotspot:tier3 test groups

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -344,8 +344,6 @@ tier1 = \
 tier2 = \
   :hotspot_tier2_runtime \
   :hotspot_tier2_runtime_platform_agnostic \
-  :hotspot_tier2_serviceability \
-  :tier2_gc_epsilon \
   :tier2_gc_shenandoah
 
 tier3 = \

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -341,6 +341,17 @@ tier1 = \
   :tier1_runtime \
   :tier1_serviceability
 
+tier2 = \
+  :hotspot_tier2_runtime \
+  :hotspot_tier2_runtime_platform_agnostic \
+  :hotspot_tier2_serviceability \
+  :tier2_gc_epsilon \
+  :tier2_gc_shenandoah
+
+tier3 = \
+  :hotspot_tier3_runtime \
+  :tier3_gc_shenandoah
+
 hotspot_tier2_runtime = \
   runtime/ \
   serviceability/ \


### PR DESCRIPTION
Unclean backport to introduce `hotspot:tier2` and `hotspot:tier3` groups. It is unclean because there is no `hotspot_tier2_serviceability` (added by test reshufflings in JDK-8231981) and no `tier2_gc_epsilon` test groups (added by reshuffling for Critical JNI tests, which do not exist in 11u). 

This is a stepping stone towards introducing `tier4` test group that catches everything else.

Additional testing:
 - [x] Linux x86_64 `hotspot:tier2` passes
 - [x] Linux x86_64 `hotspot:tier3` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272914](https://bugs.openjdk.java.net/browse/JDK-8272914): Create hotspot:tier2 and hotspot:tier3 test groups


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/456/head:pull/456` \
`$ git checkout pull/456`

Update a local copy of the PR: \
`$ git checkout pull/456` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 456`

View PR using the GUI difftool: \
`$ git pr show -t 456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/456.diff">https://git.openjdk.java.net/jdk11u-dev/pull/456.diff</a>

</details>
