### PR TITLE
8273373: Zero: Cannot invoke JVM in primordial threads on Zero

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3522,6 +3522,9 @@ bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
 
     if (mincore((address)stack_extent, os::vm_page_size(), vec) == -1) {
       // Fallback to slow path on all errors, including EAGAIN
+      assert((uintptr_t)addr >= stack_extent,
+             "Sanity: addr should be larger than extent, " PTR_FORMAT " >= " PTR_FORMAT,
+             p2i(addr), stack_extent);
       stack_extent = (uintptr_t) get_stack_commited_bottom(
                                                            os::Linux::initial_thread_stack_bottom(),
                                                            (size_t)addr - stack_extent);

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -317,6 +317,20 @@ size_t os::Posix::default_stack_size(os::ThreadType thr_type) {
 }
 
 static void current_stack_region(address *bottom, size_t *size) {
+  if (os::is_primordial_thread()) {
+    // primordial thread needs special handling because pthread_getattr_np()
+    // may return bogus value.
+    address stack_bottom = os::Linux::initial_thread_stack_bottom();
+    size_t stack_bytes  = os::Linux::initial_thread_stack_size();
+
+    assert(os::current_stack_pointer() >= stack_bottom, "should do");
+    assert(os::current_stack_pointer() < stack_bottom + stack_bytes, "should do");
+
+    *bottom = stack_bottom;
+    *size = stack_bytes;
+    return;
+  }
+
   pthread_attr_t attr;
   int res = pthread_getattr_np(pthread_self(), &attr);
   if (res != 0) {
@@ -364,18 +378,6 @@ static void current_stack_region(address *bottom, size_t *size) {
   stack_bottom += guard_bytes;
 
   pthread_attr_destroy(&attr);
-
-  // The initial thread has a growable stack, and the size reported
-  // by pthread_attr_getstack is the maximum size it could possibly
-  // be given what currently mapped.  This can be huge, so we cap it.
-  if (os::is_primordial_thread()) {
-    stack_bytes = stack_top - stack_bottom;
-
-    if (stack_bytes > JavaThread::stack_size_at_create())
-      stack_bytes = JavaThread::stack_size_at_create();
-
-    stack_bottom = stack_top - stack_bytes;
-  }
 
   assert(os::current_stack_pointer() >= stack_bottom, "should do");
   assert(os::current_stack_pointer() < stack_top, "should do");


### PR DESCRIPTION
This fixes gtests with Zero.

Additional testing:
 - [x] gtests now run mostly fine with Linux x86_64 Zero, with unrelated failures fixed by subsequent backports

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273373](https://bugs.openjdk.java.net/browse/JDK-8273373): Zero: Cannot invoke JVM in primordial threads on Zero


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/458/head:pull/458` \
`$ git checkout pull/458`

Update a local copy of the PR: \
`$ git checkout pull/458` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 458`

View PR using the GUI difftool: \
`$ git pr show -t 458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/458.diff">https://git.openjdk.java.net/jdk11u-dev/pull/458.diff</a>

</details>
