### PR TITLE
8187649: ArrayIndexOutOfBoundsException in java.util.JapaneseImperialCalendar

### DIFF
--- a/src/java.base/share/classes/java/util/JapaneseImperialCalendar.java
+++ b/src/java.base/share/classes/java/util/JapaneseImperialCalendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -885,7 +885,7 @@ class JapaneseImperialCalendar extends Calendar {
                 } else if (nfd >= (month1 + monthLength)) {
                     nfd = month1 + monthLength - 1;
                 }
-                set(DAY_OF_MONTH, (int)(nfd - month1) + 1);
+                set(DAY_OF_MONTH, getCalendarDate(nfd).getDayOfMonth());
                 return;
             }
 
@@ -1457,7 +1457,7 @@ class JapaneseImperialCalendar extends Calendar {
                     CalendarDate d = gcal.newCalendarDate(TimeZone.NO_TIMEZONE);
                     d.setDate(date.getNormalizedYear(), date.getMonth(), 1);
                     int dayOfWeek = gcal.getDayOfWeek(d);
-                    int monthLength = gcal.getMonthLength(d);
+                    int monthLength = actualMonthLength();
                     dayOfWeek -= getFirstDayOfWeek();
                     if (dayOfWeek < 0) {
                         dayOfWeek += 7;
@@ -2238,7 +2238,7 @@ class JapaneseImperialCalendar extends Calendar {
     private int actualMonthLength() {
         int length = jcal.getMonthLength(jdate);
         int eraIndex = getTransitionEraIndex(jdate);
-        if (eraIndex == -1) {
+        if (eraIndex != -1) {
             long transitionFixedDate = sinceFixedDates[eraIndex];
             CalendarDate d = eras[eraIndex].getSinceDate();
             if (transitionFixedDate <= cachedFixedDate) {

--- a/test/jdk/java/util/Calendar/CalendarTestScripts/JapaneseTests.java
+++ b/test/jdk/java/util/Calendar/CalendarTestScripts/JapaneseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary tests Japanese Calendar.
- * @bug 4609228
+ * @bug 4609228 8187649
  * @modules java.base/sun.util
  *          java.base/sun.util.calendar
  * @compile

--- a/test/jdk/java/util/Calendar/CalendarTestScripts/japanese/japanese_roll.cts
+++ b/test/jdk/java/util/Calendar/CalendarTestScripts/japanese/japanese_roll.cts
@@ -435,12 +435,48 @@ test roll WEEK_OF_YEAR
 	check date BeforeMeiji $minyear Dec 25
 
 test WEEK_OF_MONTH
-	# Needs to wait for 6191841 fix. (WEEK_OF_MONTH needs to change
-	# ERA and YEAR in a transition month.)
+	use jcal
+	clear all
+
+	# Make sure this test does not throw AIOOBE
+	set date Heisei 1 Aug 1
+	roll week_of_month 1
+	check date Heisei 1 Aug 8
+
+	# Check transition dates
+	set date Showa 64 Jan 7
+	roll week_of_month 1
+	check date Showa 64 Jan 7
+	roll week_of_month -1
+	check date Showa 64 Jan 7
+
+	set date Heisei 1 Jan 31
+	roll week_of_month 1
+	check date Heisei 1 Jan 10
+	roll week_of_month -1
+	check date Heisei 1 Jan 31
 
 test DAY_OF_MONTH
-	# Needs to wait for 6191841 fix. (DAY_OF_MONTH needs to change
-	# ERA and YEAR in a transition month.)
+	use jcal
+	clear all
+
+	# Make sure this test does not throw AIOOBE
+	Set date Heisei 1 Aug 1
+	roll day_of_month 1
+	check date Heisei 1 Aug 2
+
+	# Check transition dates
+	set date Showa 64 Jan 7
+	roll day_of_month 1
+	check date Showa 64 Jan 1
+	roll day_of_month -1
+	check date Showa 64 Jan 7
+
+	set date Heisei 1 Jan 31
+	roll day_of_month 1
+	check date Heisei 1 Jan 8
+	roll day_of_month -1
+	check date Heisei 1 Jan 31
 
 test DAY_OF_YEAR
     use jcal


### PR DESCRIPTION
A clean backport for parity with Oracle 11.0.14.

Test:

- [x] jdk/java/util/Calendar/CalendarTestScripts/JapaneseTests.java  test passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8187649](https://bugs.openjdk.java.net/browse/JDK-8187649): ArrayIndexOutOfBoundsException in java.util.JapaneseImperialCalendar


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/460/head:pull/460` \
`$ git checkout pull/460`

Update a local copy of the PR: \
`$ git checkout pull/460` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 460`

View PR using the GUI difftool: \
`$ git pr show -t 460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/460.diff">https://git.openjdk.java.net/jdk11u-dev/pull/460.diff</a>

</details>
