### PR TITLE
8075909: [TEST_BUG] The regression-swing case failed as it does not have the 'Open' button when select 'subdir' folder with NimbusLAF

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/6698013/bug6698013.java
+++ b/test/jdk/javax/swing/JFileChooser/6698013/bug6698013.java
@@ -21,16 +21,18 @@
  * questions.
  */
 
-/* @test %W% %E%
+/* @test
    @bug 6698013
    @summary JFileChooser can no longer navigate non-local file systems.
-   @author Pavel Porvatov
    @run applet/manual=done bug6698013.html
 */
 
-import javax.swing.*;
-import javax.swing.filechooser.FileSystemView;
 import java.io.File;
+
+import javax.swing.JApplet;
+import javax.swing.JFileChooser;
+import javax.swing.SwingUtilities;
+import javax.swing.filechooser.FileSystemView;
 
 public class bug6698013 extends JApplet {
 
@@ -42,16 +44,14 @@ public class bug6698013 extends JApplet {
 
     final static VirtualFile subdirFile = new VirtualFile("testdir/subdir/subtest.txt", false);
 
-    public static void main(String[] args) {
-        JFileChooser chooser = new JFileChooser(new VirtualFileSystemView());
-        chooser.setCurrentDirectory(root);
-        chooser.showSaveDialog(null);
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> new bug6698013().init());
     }
 
     public void init() {
         JFileChooser chooser = new JFileChooser(new VirtualFileSystemView());
         chooser.setCurrentDirectory(root);
-        chooser.showSaveDialog(null);
+        chooser.showOpenDialog(null);
     }
 }
 


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8075909](https://bugs.openjdk.java.net/browse/JDK-8075909): [TEST_BUG] The regression-swing case failed as it does not have the 'Open' button when select 'subdir' folder with NimbusLAF


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/466/head:pull/466` \
`$ git checkout pull/466`

Update a local copy of the PR: \
`$ git checkout pull/466` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 466`

View PR using the GUI difftool: \
`$ git pr show -t 466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/466.diff">https://git.openjdk.java.net/jdk11u-dev/pull/466.diff</a>

</details>
