### PR TITLE
8252051: Make mlvmJvmtiUtils strncpy uses GCC 10.x friendly

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/mlvmJvmtiUtils.c
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/mlvmJvmtiUtils.c
@@ -45,11 +45,6 @@ void copyFromJString(JNIEnv * pEnv, jstring src, char ** dst) {
     NSK_CPP_STUB3(ReleaseStringUTFChars, pEnv, src, pStr);
 }
 
-#if !defined(__clang_major__) && defined(__GNUC__) && (__GNUC__ >= 8)
-_Pragma("GCC diagnostic push")
-_Pragma("GCC diagnostic ignored \"-Wstringop-truncation\"")
-#endif
-
 struct MethodName * getMethodName(jvmtiEnv * pJvmtiEnv, jmethodID method) {
     char * szName;
     char * szSignature;
@@ -71,17 +66,15 @@ struct MethodName * getMethodName(jvmtiEnv * pJvmtiEnv, jmethodID method) {
     }
 
     mn = malloc(sizeof(MethodNameStruct));
-    strncpy(mn->methodName, szName, sizeof(mn->methodName));
-    strncpy(mn->classSig, szSignature, sizeof(mn->classSig));
+    strncpy(mn->methodName, szName, sizeof(mn->methodName) - 1);
+    mn->methodName[sizeof(mn->methodName) - 1] = '\0';
+    strncpy(mn->classSig, szSignature, sizeof(mn->classSig) - 1);
+    mn->classSig[sizeof(mn->classSig) - 1] = '\0';
 
     NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, pJvmtiEnv, (void *) szName));
     NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, pJvmtiEnv, (void *) szSignature));
     return mn;
 }
-
-#if !defined(__clang_major__) && defined(__GNUC__) && (__GNUC__ >= 8)
-_Pragma("GCC diagnostic pop")
-#endif
 
 char * locationToString(jvmtiEnv * pJvmtiEnv, jmethodID method, jlocation location) {
     struct MethodName * pMN;


### PR DESCRIPTION
Backport of 51a3b25d71e0. Removing Pragma's that ignore the stringop-truncation warning, which does not exist in tip. This backport eliminates the need for the warnings. The change is in test code so no danger of regressions in hotspot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252051](https://bugs.openjdk.java.net/browse/JDK-8252051): Make mlvmJvmtiUtils strncpy uses GCC 10.x friendly ⚠️ Issue is not open.


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/475/head:pull/475` \
`$ git checkout pull/475`

Update a local copy of the PR: \
`$ git checkout pull/475` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 475`

View PR using the GUI difftool: \
`$ git pr show -t 475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/475.diff">https://git.openjdk.java.net/jdk11u-dev/pull/475.diff</a>

</details>
