### PR TITLE
Backport 1f8af524ffe2d2d1469d8f07887b1f61c6e4d7b8

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -350,6 +350,13 @@ tier3 = \
   :hotspot_tier3_runtime \
   :tier3_gc_shenandoah
 
+# Everything that is not in other tiers, but not apps
+tier4 = \
+  :hotspot_all_no_apps \
+ -:tier1 \
+ -:tier2 \
+ -:tier3
+
 hotspot_tier2_runtime = \
   runtime/ \
   serviceability/ \

--- a/test/jaxp/TEST.groups
+++ b/test/jaxp/TEST.groups
@@ -32,5 +32,8 @@ tier2 = \
 # No tier 3 tests.
 tier3 = 
 
+# No tier 4 tests.
+tier4 =
+
 jaxp_all = \
     javax/xml/jaxp

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -79,6 +79,13 @@ tier3 = \
     :jdk_sound \
     :jdk_client_sanity
 
+# Everything not in other tiers
+tier4 = \
+    / \
+   -:tier1 \
+   -:tier2 \
+   -:tier3
+
 ###############################################################################
 #
 # Other test definitions; generally smaller granularity than tiers

--- a/test/langtools/TEST.groups
+++ b/test/langtools/TEST.groups
@@ -58,4 +58,7 @@ tier2 = \
     jdk/jshell/UserJdiUserRemoteTest.java
 
 # No langtools tests are tier 3 either.
-tier3 = 
+tier3 =
+
+# No langtools tests are tier 4 either.
+tier4 =


### PR DESCRIPTION
Semi-clean backport to improve testing in 11u. There seemed to a little trailing whitespace in langtools TEST.groups, which broke the cleanliness. I resolved that by hand.

Additional testing:
 - [x] Linux x86_64 fastdebug `jdk:tier4` passes with a few known testbugs