### PR TITLE
8272856: DoubleFlagWithIntegerValue uses G1GC-only flag

### DIFF
--- a/test/hotspot/jtreg/runtime/CommandLine/DoubleFlagWithIntegerValue.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/DoubleFlagWithIntegerValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class DoubleFlagWithIntegerValue {
   public static void testDoubleFlagWithValue(String value) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:G1ConcMarkStepDurationMillis=" + value, "-version");
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:SweeperThreshold=" + value, "-version");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldNotContain("Improperly specified VM option");
     output.shouldHaveExitValue(0);


### PR DESCRIPTION
Semi-clean backport to fix another Zero test failure. There is a minor conflict in the copyright line, I accepted the newer version from the patch.

Additional testing:
 - [ ] Linux x86_64 Zero now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8272856](https://bugs.openjdk.java.net/browse/JDK-8272856): DoubleFlagWithIntegerValue uses G1GC-only flag


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/479/head:pull/479` \
`$ git checkout pull/479`

Update a local copy of the PR: \
`$ git checkout pull/479` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 479`

View PR using the GUI difftool: \
`$ git pr show -t 479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/479.diff">https://git.openjdk.java.net/jdk11u-dev/pull/479.diff</a>

</details>
