### PR TITLE
8274860: gcc 10.2.1 produces an uninitialized warning in sharedRuntimeTrig.cpp

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntimeTrig.cpp
+++ b/src/hotspot/share/runtime/sharedRuntimeTrig.cpp
@@ -297,7 +297,12 @@ recompute:
     fw = 0.0;
     for (i=jz;i>=0;i--) fw += fq[i];
     y[0] = (ih==0)? fw: -fw;
+
+PRAGMA_DIAG_PUSH
+PRAGMA_MAYBE_UNINITIALIZED_IGNORED
     fw = fq[0]-fw;
+PRAGMA_DIAG_POP
+
     for (i=1;i<=jz;i++) fw += fq[i];
     y[1] = (ih==0)? fw: -fw;
     break;

--- a/src/hotspot/share/utilities/compilerWarnings.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings.hpp
@@ -57,6 +57,7 @@
 // https://gcc.gnu.org/gcc-8/changes.html
 #if !defined(__clang_major__) && (__GNUC__ >= 8)
 #define PRAGMA_STRINGOP_TRUNCATION_IGNORED PRAGMA_DISABLE_GCC_WARNING("-Wstringop-truncation")
+#define PRAGMA_MAYBE_UNINITIALIZED_IGNORED PRAGMA_DISABLE_GCC_WARNING("-Wmaybe-uninitialized")
 #endif
 
 #if defined(__clang_major__) && \
@@ -82,6 +83,10 @@
 
 #ifndef PRAGMA_STRINGOP_TRUNCATION_IGNORED
 #define PRAGMA_STRINGOP_TRUNCATION_IGNORED
+#endif
+
+#ifndef PRAGMA_MAYBE_UNINITIALIZED_IGNORED
+#define PRAGMA_MAYBE_UNINITIALIZED_IGNORED
 #endif
 
 #ifndef PRAGMA_FORMAT_NONLITERAL_IGNORED


### PR DESCRIPTION
Fix the warning by initializing `fq` to an array of zeroes.

Warning suppressed in tip https://github.com/openjdk/jdk/blob/master/make/hotspot/lib/CompileJvm.gmk#L83, but not suppressed in JDK11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274860](https://bugs.openjdk.java.net/browse/JDK-8274860): gcc 10.2.1 produces an uninitialized warning in sharedRuntimeTrig.cpp


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/489/head:pull/489` \
`$ git checkout pull/489`

Update a local copy of the PR: \
`$ git checkout pull/489` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 489`

View PR using the GUI difftool: \
`$ git pr show -t 489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/489.diff">https://git.openjdk.java.net/jdk11u-dev/pull/489.diff</a>

</details>
