### PR TITLE
8273498: compiler/c2/Test7179138_1.java timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/Test7179138_1.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7179138_1.java
@@ -29,7 +29,7 @@
  * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation
  *      compiler.c2.Test7179138_1
  * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:-TieredCompilation
- *      -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:RepeatCompilation=100 compiler.c2.Test7179138_1
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN compiler.c2.Test7179138_1
  *
  * @author Skip Balk
  */


### PR DESCRIPTION
Clean backport of JDK-8273498 (taken from 17u).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273498](https://bugs.openjdk.java.net/browse/JDK-8273498): compiler/c2/Test7179138_1.java timed out


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/493/head:pull/493` \
`$ git checkout pull/493`

Update a local copy of the PR: \
`$ git checkout pull/493` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 493`

View PR using the GUI difftool: \
`$ git pr show -t 493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/493.diff">https://git.openjdk.java.net/jdk11u-dev/pull/493.diff</a>

</details>
