### PR TITLE
7105119: [TEST_BUG] [macosx] In test UIDefaults.toString() must be called with the invokeLater()

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -757,7 +757,6 @@ javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all
 javax/swing/JPopupMenu/4966112/bug4966112.java 8064915 macosx-all
 javax/swing/JSpinner/8223788/JSpinnerButtonFocusTest.java 8238085 macosx-all
 javax/swing/MultiUIDefaults/Test6860438.java 8198391 generic-all
-javax/swing/MultiUIDefaults/4300666/bug4300666.java 7105119 macosx-all
 javax/swing/UITest/UITest.java 8198392 generic-all
 javax/swing/plaf/basic/BasicComboBoxEditor/Test8015336.java 8198394 generic-all
 javax/swing/plaf/metal/MetalLookAndFeel/Test8039750.java 8198395 generic-all

--- a/test/jdk/javax/swing/MultiUIDefaults/4300666/bug4300666.java
+++ b/test/jdk/javax/swing/MultiUIDefaults/4300666/bug4300666.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,34 @@
  * @summary Printing UIDefaults throws NoSuchElementExcept
  */
 
-import javax.swing.*;
+import java.awt.EventQueue;
 
-public class bug4300666 {
+import javax.swing.UIDefaults;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 
-    public static void main(final String[] args) {
-        UIDefaults d = UIManager.getDefaults();
-        d.toString();
+import static javax.swing.UIManager.getInstalledLookAndFeels;
+
+public final class bug4300666 {
+
+    public static void main(final String[] args) throws Exception {
+        for (UIManager.LookAndFeelInfo laf : getInstalledLookAndFeels()) {
+            EventQueue.invokeAndWait(() -> setLookAndFeel(laf));
+            EventQueue.invokeAndWait(() -> {
+                UIDefaults d = UIManager.getDefaults();
+                d.toString();
+            });
+        }
+    }
+
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported L&F: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException
+                | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
Backport of JDK-7105119. Applied clean but problemlist needed some resolving.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7105119](https://bugs.openjdk.java.net/browse/JDK-7105119): [TEST_BUG] [macosx] In test UIDefaults.toString() must be called with the invokeLater()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/496/head:pull/496` \
`$ git checkout pull/496`

Update a local copy of the PR: \
`$ git checkout pull/496` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 496`

View PR using the GUI difftool: \
`$ git pr show -t 496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/496.diff">https://git.openjdk.java.net/jdk11u-dev/pull/496.diff</a>

</details>
