### PR TITLE
Backport a5108a605e6a1e427d90dbeeb8630a3d01d6b405

### DIFF
--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -82,8 +82,8 @@ public class OpensslArtifactFetcher {
     }
 
     private static String getDefaultSystemOpensslPath(String version) {
-        if (verifyOpensslVersion("/usr/bin/openssl", version)) {
-            return "/usr/bin/openssl";
+        if (verifyOpensslVersion("openssl", version)) {
+            return "openssl";
         } else if (verifyOpensslVersion("/usr/local/bin/openssl", version)) {
             return "/usr/local/bin/openssl";
         }


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.