### PR TITLE
8273826: Correct Manifest file name and NPE checks

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -758,7 +758,7 @@ class JarFile extends ZipFile {
                         }
                         if (mev == null) {
                             mev = new ManifestEntryVerifier
-                                (getManifestFromReference());
+                                (getManifestFromReference(), jv.manifestName);
                         }
                         byte[] b = getBytes(e);
                         if (b != null && b.length > 0) {

--- a/src/java.base/share/classes/java/util/jar/JarInputStream.java
+++ b/src/java.base/share/classes/java/util/jar/JarInputStream.java
@@ -96,7 +96,7 @@ class JarInputStream extends ZipInputStream {
             closeEntry();
             if (doVerify) {
                 jv = new JarVerifier(e.getName(), bytes);
-                mev = new ManifestEntryVerifier(man);
+                mev = new ManifestEntryVerifier(man, jv.manifestName);
             }
             return (JarEntry)super.getNextEntry();
         }

--- a/src/java.base/share/classes/java/util/jar/JarVerifier.java
+++ b/src/java.base/share/classes/java/util/jar/JarVerifier.java
@@ -444,7 +444,7 @@ class JarVerifier {
         {
             this.is = is;
             this.jv = jv;
-            this.mev = new ManifestEntryVerifier(man);
+            this.mev = new ManifestEntryVerifier(man, jv.manifestName);
             this.jv.beginEntry(je, mev);
             this.numLeft = je.getSize();
             if (this.numLeft == 0)

--- a/test/jdk/sun/security/tools/jarsigner/warnings/LowerCaseManifest.java
+++ b/test/jdk/sun/security/tools/jarsigner/warnings/LowerCaseManifest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.testlibrary.OutputAnalyzer;
+import jdk.test.lib.util.JarUtils;
+
+import java.nio.file.*;
+import java.security.Security;
+import java.util.Collections;
+
+
+/**
+ * @test
+ * @bug 8273826
+ * @summary Test for signed jar file with lowercase META-INF files
+ * @library /lib/testlibrary /test/lib ../
+ * @build jdk.test.lib.util.JarUtils
+ * @run main LowerCaseManifest
+ */
+public class LowerCaseManifest extends Test {
+
+    public static void main(String[] args) throws Throwable {
+        new LowerCaseManifest().start();
+    }
+
+    private void start() throws Throwable {
+        // create a jar file that contains one class file
+        Utils.createFiles(FIRST_FILE);
+        JarUtils.createJar(UNSIGNED_JARFILE, FIRST_FILE);
+
+        // create key pair for jar signing
+        createAlias(CA_KEY_ALIAS, "-ext", "bc:c");
+        createAlias(KEY_ALIAS);
+
+        issueCert(KEY_ALIAS);
+
+        // sign jar
+        OutputAnalyzer analyzer = jarsigner(
+                "-keystore", KEYSTORE,
+                "-verbose",
+                "-storepass", PASSWORD,
+                "-keypass", PASSWORD,
+                "-signedjar", SIGNED_JARFILE,
+                UNSIGNED_JARFILE,
+                KEY_ALIAS);
+
+        checkSigning(analyzer);
+
+        // verify signed jar
+        analyzer = jarsigner(
+                "-verify",
+                "-verbose",
+                "-keystore", KEYSTORE,
+                "-storepass", PASSWORD,
+                "-keypass", PASSWORD,
+                SIGNED_JARFILE,
+                KEY_ALIAS);
+
+        checkVerifying(analyzer, 0, JAR_VERIFIED);
+
+        // verify signed jar in strict mode
+        analyzer = jarsigner(
+                "-verify",
+                "-verbose",
+                "-strict",
+                "-keystore", KEYSTORE,
+                "-storepass", PASSWORD,
+                "-keypass", PASSWORD,
+                SIGNED_JARFILE,
+                KEY_ALIAS);
+
+        checkVerifying(analyzer, 0, JAR_VERIFIED);
+
+        // convert the META-INF/ files to lower case
+        FileSystem fs = FileSystems.newFileSystem(Path.of(SIGNED_JARFILE), null);
+        for (String s : new String[]{"ALIAS.SF",  "ALIAS.RSA", "MANIFEST.MF"}) {
+            Path origPath = fs.getPath("META-INF/" + s);
+            Path lowerCase = fs.getPath("META-INF/" + s.toLowerCase());
+            Files.write(lowerCase, Files.readAllBytes(origPath));
+            Files.delete(origPath);
+        }
+        fs.close();
+
+        // verify signed jar in strict mode (with lower case META-INF names in place)
+        analyzer = jarsigner(
+                "-verify",
+                "-verbose",
+                "-strict",
+                "-J-Djava.security.debug=jar",
+                "-keystore", KEYSTORE,
+                "-storepass", PASSWORD,
+                "-keypass", PASSWORD,
+                SIGNED_JARFILE,
+                KEY_ALIAS);
+
+        checkVerifying(analyzer, 0,
+                JAR_VERIFIED, "!not present in verifiedSigners");
+        System.out.println("Test passed");
+    }
+
+}


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

I had to do a few minor adaptions:

Resolve JarFile.java due to context.

Fix the test to run in the jdk11u environment.
Also, I changed an argument to newFileSystem() form 
Collections.emptyMap() to null. This factory method
internally uses emptyMap(), so the result is the same.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273826](https://bugs.openjdk.java.net/browse/JDK-8273826): Correct Manifest file name and NPE checks


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/503/head:pull/503` \
`$ git checkout pull/503`

Update a local copy of the PR: \
`$ git checkout pull/503` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 503`

View PR using the GUI difftool: \
`$ git pr show -t 503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/503.diff">https://git.openjdk.java.net/jdk11u-dev/pull/503.diff</a>

</details>
