### PR TITLE
8169953: JComboBox/8057893: ComboBoxEdited event is not fired! on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -726,7 +726,6 @@ javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-al
 javax/swing/Action/8133039/bug8133039.java 8196089 windows-all,macosx-all
 javax/swing/JComboBox/6559152/bug6559152.java 8196090 windows-all,macosx-all
 javax/swing/JComboBox/6607130/bug6607130.java 8196091 windows-all
-javax/swing/JComboBox/8057893/bug8057893.java 8169953 windows-all,macosx-all
 javax/swing/JComboBox/8072767/bug8072767.java 8196093 windows-all,macosx-all
 javax/swing/JComponent/4337267/bug4337267.java 8146451 windows-all
 javax/swing/JFileChooser/4524490/bug4524490.java 8042380 generic-all


### PR DESCRIPTION
This backport just removes a problem list entry, had to be resolved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8169953](https://bugs.openjdk.java.net/browse/JDK-8169953): JComboBox/8057893: ComboBoxEdited event is not fired! on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/505/head:pull/505` \
`$ git checkout pull/505`

Update a local copy of the PR: \
`$ git checkout pull/505` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 505`

View PR using the GUI difftool: \
`$ git pr show -t 505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/505.diff">https://git.openjdk.java.net/jdk11u-dev/pull/505.diff</a>

</details>
