### PR TITLE
8233638: [TESTBUG] Swing test ScreenMenuBarInputTwice.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -797,7 +797,6 @@ javax/swing/JPopupMenu/6544309/bug6544309.java 8233556 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8233556 macosx-all
 javax/swing/JPopupMenu/4458079/bug4458079.java 8233556 macosx-all
 javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8233637 macosx-all
-javax/swing/JMenuItem/8139169/ScreenMenuBarInputTwice.java 8233638 macosx-all
 javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
 javax/swing/JMenuItem/4171437/bug4171437.java 8233641 macosx-all
 javax/swing/JMenuBar/4750590/bug4750590.java 8233642 macosx-all

--- a/test/jdk/javax/swing/JMenuItem/8139169/ScreenMenuBarInputTwice.java
+++ b/test/jdk/javax/swing/JMenuItem/8139169/ScreenMenuBarInputTwice.java
@@ -71,10 +71,20 @@ public class ScreenMenuBarInputTwice {
         robot.setAutoDelay(200);
         robot.setAutoWaitForIdle(true);
         createUIWithSeperateMenuBar();
+        robot.waitForIdle();
+        robot.delay(500);
         shortcutTestCase();
+        robot.waitForIdle();
+        robot.delay(250);
         cleanUp();
+        robot.waitForIdle();
+        robot.delay(250);
         createUIWithIntegratedMenuBar();
+        robot.waitForIdle();
+        robot.delay(500);
         menuTestCase();
+        robot.waitForIdle();
+        robot.delay(250);
         cleanUp();
     }
 


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8233638 from the openjdk/jdk repository.

The commit being backported was authored by Prasanta Sadhukhan on 4 May 2020 and was reviewed by Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233638](https://bugs.openjdk.java.net/browse/JDK-8233638): [TESTBUG] Swing test ScreenMenuBarInputTwice.java fails on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/506/head:pull/506` \
`$ git checkout pull/506`

Update a local copy of the PR: \
`$ git checkout pull/506` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 506`

View PR using the GUI difftool: \
`$ git pr show -t 506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/506.diff">https://git.openjdk.java.net/jdk11u-dev/pull/506.diff</a>

</details>
