### PR TITLE
8261071: AArch64: Refactor interpreter native wrappers

### DIFF
--- a/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
@@ -44,215 +44,103 @@ Register InterpreterRuntime::SignatureHandlerGenerator::from() { return rlocals;
 Register InterpreterRuntime::SignatureHandlerGenerator::to()   { return sp; }
 Register InterpreterRuntime::SignatureHandlerGenerator::temp() { return rscratch1; }
 
+Register InterpreterRuntime::SignatureHandlerGenerator::next_gpr() {
+  if (_num_reg_int_args < Argument::n_int_register_parameters_c-1) {
+    return as_Register(_num_reg_int_args++ + c_rarg1->encoding());
+  }
+  return noreg;
+}
+
+FloatRegister InterpreterRuntime::SignatureHandlerGenerator::next_fpr() {
+  if (_num_reg_fp_args < Argument::n_float_register_parameters_c) {
+    return as_FloatRegister(_num_reg_fp_args++);
+  }
+  return fnoreg;
+}
+
+int InterpreterRuntime::SignatureHandlerGenerator::next_stack_offset() {
+  int ret = _stack_offset;
+  _stack_offset += wordSize;
+  return ret;
+}
+
 InterpreterRuntime::SignatureHandlerGenerator::SignatureHandlerGenerator(
       const methodHandle& method, CodeBuffer* buffer) : NativeSignatureIterator(method) {
   _masm = new MacroAssembler(buffer);
-  _num_int_args = (method->is_static() ? 1 : 0);
-  _num_fp_args = 0;
+  _num_reg_int_args = (method->is_static() ? 1 : 0);
+  _num_reg_fp_args = 0;
   _stack_offset = 0;
 }
 
 void InterpreterRuntime::SignatureHandlerGenerator::pass_int() {
   const Address src(from(), Interpreter::local_offset_in_bytes(offset()));
 
-  switch (_num_int_args) {
-  case 0:
-    __ ldr(c_rarg1, src);
-    _num_int_args++;
-    break;
-  case 1:
-    __ ldr(c_rarg2, src);
-    _num_int_args++;
-    break;
-  case 2:
-    __ ldr(c_rarg3, src);
-    _num_int_args++;
-    break;
-  case 3:
-    __ ldr(c_rarg4, src);
-    _num_int_args++;
-    break;
-  case 4:
-    __ ldr(c_rarg5, src);
-    _num_int_args++;
-    break;
-  case 5:
-    __ ldr(c_rarg6, src);
-    _num_int_args++;
-    break;
-  case 6:
-    __ ldr(c_rarg7, src);
-    _num_int_args++;
-    break;
-  default:
-    __ ldr(r0, src);
-    __ str(r0, Address(to(), _stack_offset));
-    _stack_offset += wordSize;
-    _num_int_args++;
-    break;
+  Register reg = next_gpr();
+  if (reg != noreg) {
+    __ ldr(reg, src);
+  } else {
+    __ ldrw(r0, src);
+    __ strw(r0, Address(to(), next_stack_offset()));
   }
 }
 
 void InterpreterRuntime::SignatureHandlerGenerator::pass_long() {
   const Address src(from(), Interpreter::local_offset_in_bytes(offset() + 1));
 
-  switch (_num_int_args) {
-  case 0:
-    __ ldr(c_rarg1, src);
-    _num_int_args++;
-    break;
-  case 1:
-    __ ldr(c_rarg2, src);
-    _num_int_args++;
-    break;
-  case 2:
-    __ ldr(c_rarg3, src);
-    _num_int_args++;
-    break;
-  case 3:
-    __ ldr(c_rarg4, src);
-    _num_int_args++;
-    break;
-  case 4:
-    __ ldr(c_rarg5, src);
-    _num_int_args++;
-    break;
-  case 5:
-    __ ldr(c_rarg6, src);
-    _num_int_args++;
-    break;
-  case 6:
-    __ ldr(c_rarg7, src);
-    _num_int_args++;
-    break;
-  default:
+  Register reg = next_gpr();
+  if (reg != noreg) {
+    __ ldr(reg, src);
+  } else {
     __ ldr(r0, src);
-    __ str(r0, Address(to(), _stack_offset));
-    _stack_offset += wordSize;
-    _num_int_args++;
-    break;
+    __ str(r0, Address(to(), next_stack_offset()));
   }
 }
 
 void InterpreterRuntime::SignatureHandlerGenerator::pass_float() {
   const Address src(from(), Interpreter::local_offset_in_bytes(offset()));
 
-  if (_num_fp_args < Argument::n_float_register_parameters_c) {
-    __ ldrs(as_FloatRegister(_num_fp_args++), src);
+  FloatRegister reg = next_fpr();
+  if (reg != fnoreg) {
+    __ ldrs(reg, src);
   } else {
     __ ldrw(r0, src);
-    __ strw(r0, Address(to(), _stack_offset));
-    _stack_offset += wordSize;
-    _num_fp_args++;
+    __ strw(r0, Address(to(), next_stack_offset()));
   }
 }
 
 void InterpreterRuntime::SignatureHandlerGenerator::pass_double() {
   const Address src(from(), Interpreter::local_offset_in_bytes(offset() + 1));
 
-  if (_num_fp_args < Argument::n_float_register_parameters_c) {
-    __ ldrd(as_FloatRegister(_num_fp_args++), src);
+  FloatRegister reg = next_fpr();
+  if (reg != fnoreg) {
+    __ ldrd(reg, src);
   } else {
     __ ldr(r0, src);
-    __ str(r0, Address(to(), _stack_offset));
-    _stack_offset += wordSize;
-    _num_fp_args++;
+    __ str(r0, Address(to(), next_stack_offset()));
   }
 }
 
 void InterpreterRuntime::SignatureHandlerGenerator::pass_object() {
-
-  switch (_num_int_args) {
-  case 0:
+  Register reg = next_gpr();
+  if (reg == c_rarg1) {
     assert(offset() == 0, "argument register 1 can only be (non-null) receiver");
     __ add(c_rarg1, from(), Interpreter::local_offset_in_bytes(offset()));
-    _num_int_args++;
-    break;
-  case 1:
-    {
-      __ add(r0, from(), Interpreter::local_offset_in_bytes(offset()));
-      __ mov(c_rarg2, 0);
-      __ ldr(temp(), r0);
-      Label L;
-      __ cbz(temp(), L);
-      __ mov(c_rarg2, r0);
-      __ bind(L);
-      _num_int_args++;
-      break;
-    }
-  case 2:
-    {
-      __ add(r0, from(), Interpreter::local_offset_in_bytes(offset()));
-      __ mov(c_rarg3, 0);
-      __ ldr(temp(), r0);
-      Label L;
-      __ cbz(temp(), L);
-      __ mov(c_rarg3, r0);
-      __ bind(L);
-      _num_int_args++;
-      break;
-    }
-  case 3:
-    {
-      __ add(r0, from(), Interpreter::local_offset_in_bytes(offset()));
-      __ mov(c_rarg4, 0);
-      __ ldr(temp(), r0);
-      Label L;
-      __ cbz(temp(), L);
-      __ mov(c_rarg4, r0);
-      __ bind(L);
-      _num_int_args++;
-      break;
-    }
-  case 4:
-    {
-      __ add(r0, from(), Interpreter::local_offset_in_bytes(offset()));
-      __ mov(c_rarg5, 0);
-      __ ldr(temp(), r0);
-      Label L;
-      __ cbz(temp(), L);
-      __ mov(c_rarg5, r0);
-      __ bind(L);
-      _num_int_args++;
-      break;
-    }
-  case 5:
-    {
-      __ add(r0, from(), Interpreter::local_offset_in_bytes(offset()));
-      __ mov(c_rarg6, 0);
-      __ ldr(temp(), r0);
-      Label L;
-      __ cbz(temp(), L);
-      __ mov(c_rarg6, r0);
-      __ bind(L);
-      _num_int_args++;
-      break;
-    }
-  case 6:
-    {
-      __ add(r0, from(), Interpreter::local_offset_in_bytes(offset()));
-      __ mov(c_rarg7, 0);
-      __ ldr(temp(), r0);
-      Label L;
-      __ cbz(temp(), L);
-      __ mov(c_rarg7, r0);
-      __ bind(L);
-      _num_int_args++;
-      break;
-    }
- default:
-   {
-      __ add(r0, from(), Interpreter::local_offset_in_bytes(offset()));
-      __ ldr(temp(), r0);
-      Label L;
-      __ cbnz(temp(), L);
-      __ mov(r0, zr);
-      __ bind(L);
-      __ str(r0, Address(to(), _stack_offset));
-      _stack_offset += wordSize;
-      _num_int_args++;
-      break;
-   }
+  } else if (reg != noreg) {
+    __ add(r0, from(), Interpreter::local_offset_in_bytes(offset()));
+    __ mov(reg, 0);
+    __ ldr(temp(), r0);
+    Label L;
+    __ cbz(temp(), L);
+    __ mov(reg, r0);
+    __ bind(L);
+  } else {
+    __ add(r0, from(), Interpreter::local_offset_in_bytes(offset()));
+    __ ldr(temp(), r0);
+    Label L;
+    __ cbnz(temp(), L);
+    __ mov(r0, zr);
+    __ bind(L);
+    __ str(r0, Address(to(), next_stack_offset()));
   }
 }
 
@@ -281,77 +169,77 @@ class SlowSignatureHandler
   intptr_t* _int_args;
   intptr_t* _fp_args;
   intptr_t* _fp_identifiers;
-  unsigned int _num_int_args;
-  unsigned int _num_fp_args;
+  unsigned int _num_reg_int_args;
+  unsigned int _num_reg_fp_args;
 
-  virtual void pass_int()
-  {
-    jint from_obj = *(jint *)(_from+Interpreter::local_offset_in_bytes(0));
+  intptr_t* single_slot_addr() {
+    intptr_t* from_addr = (intptr_t*)(_from+Interpreter::local_offset_in_bytes(0));
     _from -= Interpreter::stackElementSize;
-
-    if (_num_int_args < Argument::n_int_register_parameters_c-1) {
-      *_int_args++ = from_obj;
-      _num_int_args++;
-    } else {
-      *_to++ = from_obj;
-      _num_int_args++;
-    }
+    return from_addr;
   }
 
-  virtual void pass_long()
-  {
-    intptr_t from_obj = *(intptr_t*)(_from+Interpreter::local_offset_in_bytes(1));
+  intptr_t* double_slot_addr() {
+    intptr_t* from_addr = (intptr_t*)(_from+Interpreter::local_offset_in_bytes(1));
     _from -= 2*Interpreter::stackElementSize;
+    return from_addr;
+  }
 
-    if (_num_int_args < Argument::n_int_register_parameters_c-1) {
-      *_int_args++ = from_obj;
-      _num_int_args++;
-    } else {
-      *_to++ = from_obj;
-      _num_int_args++;
+  int pass_gpr(intptr_t value) {
+    if (_num_reg_int_args < Argument::n_int_register_parameters_c-1) {
+      *_int_args++ = value;
+      return _num_reg_int_args++;
+    }
+    return -1;
+  }
+
+  int pass_fpr(intptr_t value) {
+    if (_num_reg_fp_args < Argument::n_float_register_parameters_c) {
+      *_fp_args++ = value;
+      return _num_reg_fp_args++;
+    }
+    return -1;
+  }
+
+  void pass_stack(intptr_t value) {
+    *_to++ = value;
+  }
+
+  virtual void pass_int() {
+    jint value = *(jint*)single_slot_addr();
+    if (pass_gpr(value) < 0) {
+      pass_stack(value);
     }
   }
 
-  virtual void pass_object()
-  {
-    intptr_t *from_addr = (intptr_t*)(_from + Interpreter::local_offset_in_bytes(0));
-    _from -= Interpreter::stackElementSize;
-
-    if (_num_int_args < Argument::n_int_register_parameters_c-1) {
-      *_int_args++ = (*from_addr == 0) ? NULL : (intptr_t)from_addr;
-      _num_int_args++;
-    } else {
-      *_to++ = (*from_addr == 0) ? NULL : (intptr_t) from_addr;
-      _num_int_args++;
+  virtual void pass_long() {
+    intptr_t value = *double_slot_addr();
+    if (pass_gpr(value) < 0) {
+      pass_stack(value);
     }
   }
 
-  virtual void pass_float()
-  {
-    jint from_obj = *(jint*)(_from+Interpreter::local_offset_in_bytes(0));
-    _from -= Interpreter::stackElementSize;
-
-    if (_num_fp_args < Argument::n_float_register_parameters_c) {
-      *_fp_args++ = from_obj;
-      _num_fp_args++;
-    } else {
-      *_to++ = from_obj;
-      _num_fp_args++;
+  virtual void pass_object() {
+    intptr_t* addr = single_slot_addr();
+    intptr_t value = *addr == 0 ? NULL : (intptr_t)addr;
+    if (pass_gpr(value) < 0) {
+      pass_stack(value);
     }
   }
 
-  virtual void pass_double()
-  {
-    intptr_t from_obj = *(intptr_t*)(_from+Interpreter::local_offset_in_bytes(1));
-    _from -= 2*Interpreter::stackElementSize;
+  virtual void pass_float() {
+    jint value = *(jint*)single_slot_addr();
+    if (pass_fpr(value) < 0) {
+      pass_stack(value);
+    }
+  }
 
-    if (_num_fp_args < Argument::n_float_register_parameters_c) {
-      *_fp_args++ = from_obj;
-      *_fp_identifiers |= (1ull << _num_fp_args); // mark as double
-      _num_fp_args++;
+  virtual void pass_double() {
+    intptr_t value = *double_slot_addr();
+    int arg = pass_fpr(value);
+    if (0 <= arg) {
+      *_fp_identifiers |= (1ull << arg); // mark as double
     } else {
-      *_to++ = from_obj;
-      _num_fp_args++;
+      pass_stack(value);
     }
   }
 
@@ -366,8 +254,8 @@ class SlowSignatureHandler
     _fp_args =  to - 8;
     _fp_identifiers = to - 9;
     *(int*) _fp_identifiers = 0;
-    _num_int_args = (method->is_static() ? 1 : 0);
-    _num_fp_args = 0;
+    _num_reg_int_args = (method->is_static() ? 1 : 0);
+    _num_reg_fp_args = 0;
   }
 
 };

--- a/src/hotspot/cpu/aarch64/interpreterRT_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/interpreterRT_aarch64.hpp
@@ -34,8 +34,8 @@
 class SignatureHandlerGenerator: public NativeSignatureIterator {
  private:
   MacroAssembler* _masm;
-  unsigned int _num_fp_args;
-  unsigned int _num_int_args;
+  unsigned int _num_reg_fp_args;
+  unsigned int _num_reg_int_args;
   int _stack_offset;
 
   void pass_int();
@@ -43,6 +43,10 @@ class SignatureHandlerGenerator: public NativeSignatureIterator {
   void pass_float();
   void pass_double();
   void pass_object();
+
+  Register next_gpr();
+  FloatRegister next_fpr();
+  int next_stack_offset();
 
  public:
   // Creation


### PR DESCRIPTION
Clean backport from upstream. Macos-aarch64 prerequest.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8261071](https://bugs.openjdk.java.net/browse/JDK-8261071): AArch64: Refactor interpreter native wrappers


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/507/head:pull/507` \
`$ git checkout pull/507`

Update a local copy of the PR: \
`$ git checkout pull/507` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 507`

View PR using the GUI difftool: \
`$ git pr show -t 507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/507.diff">https://git.openjdk.java.net/jdk11u-dev/pull/507.diff</a>

</details>
