### PR TITLE
Backport c833b4d130fabfa6a6f3a38313f76eb7e392c6a5

### DIFF
--- a/src/hotspot/share/compiler/methodMatcher.cpp
+++ b/src/hotspot/share/compiler/methodMatcher.cpp
@@ -41,22 +41,28 @@
 // 0x28 '(' and 0x29 ')' are used for the signature
 // 0x2e '.' is always replaced before the matching
 // 0x2f '/' is only used in the class name as package separator
+//
+// It seems hard to get Non-ASCII characters to work in all circumstances due
+// to limitations in Windows. So only ASCII characters are supported on Windows.
 
-#define RANGEBASE "\x1\x2\x3\x4\x5\x6\x7\x8\xa\xb\xc\xd\xe\xf" \
+#define RANGEBASE_ASCII "\x1\x2\x3\x4\x5\x6\x7\x8\xa\xb\xc\xd\xe\xf" \
     "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f" \
     "\x21\x22\x23\x24\x25\x26\x27\x2a\x2b\x2c\x2d" \
     "\x30\x31\x32\x33\x34\x35\x36\x37\x38\x39\x3a\x3b\x3c\x3d\x3e\x3f" \
     "\x40\x41\x42\x43\x44\x45\x46\x47\x48\x49\x4a\x4b\x4c\x4d\x4e\x4f" \
     "\x50\x51\x52\x53\x54\x55\x56\x57\x58\x59\x5a\x5c\x5e\x5f" \
     "\x60\x61\x62\x63\x64\x65\x66\x67\x68\x69\x6a\x6b\x6c\x6d\x6e\x6f" \
-    "\x70\x71\x72\x73\x74\x75\x76\x77\x78\x79\x7a\x7b\x7c\x7d\x7e\x7f" \
-    "\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f" \
+    "\x70\x71\x72\x73\x74\x75\x76\x77\x78\x79\x7a\x7b\x7c\x7d\x7e\x7f"
+
+#define RANGEBASE_NON_ASCII "\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f" \
     "\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f" \
     "\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf" \
     "\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf" \
     "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf" \
     "\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf" \
     "\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef"
+
+#define RANGEBASE RANGEBASE_ASCII NOT_WINDOWS(RANGEBASE_NON_ASCII)
 
 #define RANGE0 "[*" RANGEBASE "]"
 #define RANGESLASH "[*" RANGEBASE "/]"
@@ -164,6 +170,15 @@ bool MethodMatcher::canonicalize(char * line, const char *& error_msg) {
       if (*lp == ':')  *lp = ' ';
     }
     if (*lp == ',' || *lp == '.')  *lp = ' ';
+
+#ifdef _WINDOWS
+    // It seems hard to get Non-ASCII characters to work in all circumstances due
+    // to limitations in Windows. So only ASCII characters are supported on Windows.
+    if (!isascii(*lp)) {
+      error_msg = "Non-ASCII characters are not supported on Windows.";
+      return false;
+    }
+#endif
   }
   return true;
 }
@@ -237,12 +252,6 @@ void skip_leading_spaces(char*& line, int* total_bytes_read ) {
   }
 }
 
-#ifdef _MSC_VER
-#pragma warning(push)
-// warning C4189: The file contains a character that cannot be represented
-//                in the current code page
-#pragma warning(disable : 4819)
-#endif
 void MethodMatcher::parse_method_pattern(char*& line, const char*& error_msg, MethodMatcher* matcher) {
   MethodMatcher::Mode c_match;
   MethodMatcher::Mode m_match;
@@ -312,9 +321,6 @@ void MethodMatcher::parse_method_pattern(char*& line, const char*& error_msg, Me
     error_msg = "Could not parse method pattern";
   }
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 bool MethodMatcher::matches(const methodHandle& method) const {
   Symbol* class_name  = method->method_holder()->name();


### PR DESCRIPTION
Hi all,

This is the backport of c833b4d130fabfa6a6f3a38313f76eb7e392c6a5.
I'd like to backport it to fix the build failure on Windows for non-English speaking countries.

Patch doesn't apply cleanly (only the removal of `pragma warning` should be manually adjusted).

Thanks.
Best regards,
Jie