### PR TITLE
8271459: C2: Missing NegativeArraySizeException when creating StringBuilder with negative capacity

### DIFF
--- a/src/hotspot/share/opto/stringopts.cpp
+++ b/src/hotspot/share/opto/stringopts.cpp
@@ -62,7 +62,8 @@ class StringConcat : public ResourceObj {
     StringMode,
     IntMode,
     CharMode,
-    StringNullCheckMode
+    StringNullCheckMode,
+    NegativeIntCheckMode
   };
 
   StringConcat(PhaseStringOpts* stringopts, CallStaticJavaNode* end):
@@ -119,12 +120,19 @@ class StringConcat : public ResourceObj {
   void push_string(Node* value) {
     push(value, StringMode);
   }
+
   void push_string_null_check(Node* value) {
     push(value, StringNullCheckMode);
   }
+
+  void push_negative_int_check(Node* value) {
+    push(value, NegativeIntCheckMode);
+  }
+
   void push_int(Node* value) {
     push(value, IntMode);
   }
+
   void push_char(Node* value) {
     push(value, CharMode);
   }
@@ -499,13 +507,35 @@ StringConcat* PhaseStringOpts::build_candidate(CallStaticJavaNode* call) {
 #ifndef PRODUCT
                 if (PrintOptimizeStringConcat) {
                   tty->print("giving up because StringBuilder(null) throws exception");
-                  alloc->jvms()->dump_spec(tty); tty->cr();
+                  alloc->jvms()->dump_spec(tty);
+                  tty->cr();
                 }
 #endif
                 return NULL;
               }
               // StringBuilder(str) argument needs null check.
               sc->push_string_null_check(use->in(TypeFunc::Parms + 1));
+            } else if (sig == ciSymbol::int_void_signature()) {
+              // StringBuilder(int) case.
+              Node* parm = use->in(TypeFunc::Parms + 1);
+              assert(parm != NULL, "must exist");
+              const TypeInt* type = _gvn->type(parm)->is_int();
+              if (type->_hi < 0) {
+                // Initial capacity argument is always negative in which case StringBuilder(int) throws
+                // a NegativeArraySizeException. Bail out from string opts.
+#ifndef PRODUCT
+                if (PrintOptimizeStringConcat) {
+                  tty->print("giving up because a negative argument is passed to StringBuilder(int) which "
+                             "throws a NegativeArraySizeException");
+                  alloc->jvms()->dump_spec(tty);
+                  tty->cr();
+                }
+#endif
+                return NULL;
+              } else if (type->_lo < 0) {
+                // Argument could be negative: We need a runtime check to throw NegativeArraySizeException in that case.
+                sc->push_negative_int_check(parm);
+              }
             }
             // The int variant takes an initial size for the backing
             // array so just treat it like the void version.
@@ -1792,6 +1822,23 @@ void PhaseStringOpts::replace_string_concat(StringConcat* sc) {
   for (int argi = 0; argi < sc->num_arguments(); argi++) {
     Node* arg = sc->argument(argi);
     switch (sc->mode(argi)) {
+      case StringConcat::NegativeIntCheckMode: {
+        // Initial capacity argument might be negative in which case StringBuilder(int) throws
+        // a NegativeArraySizeException. Insert a runtime check with an uncommon trap.
+        const TypeInt* type = kit.gvn().type(arg)->is_int();
+        assert(type->_hi >= 0 && type->_lo < 0, "no runtime int check needed");
+        Node* p = __ Bool(__ CmpI(arg, kit.intcon(0)), BoolTest::ge);
+        IfNode* iff = kit.create_and_map_if(kit.control(), p, PROB_MIN, COUNT_UNKNOWN);
+        {
+          // Negative int -> uncommon trap.
+          PreserveJVMState pjvms(&kit);
+          kit.set_control(__ IfFalse(iff));
+          kit.uncommon_trap(Deoptimization::Reason_intrinsic,
+                            Deoptimization::Action_maybe_recompile);
+        }
+        kit.set_control(__ IfTrue(iff));
+        break;
+      }
       case StringConcat::IntMode: {
         Node* string_size = int_stringSize(kit, arg);
 
@@ -1961,6 +2008,8 @@ void PhaseStringOpts::replace_string_concat(StringConcat* sc) {
       for (int argi = 0; argi < sc->num_arguments(); argi++) {
         Node* arg = sc->argument(argi);
         switch (sc->mode(argi)) {
+          case StringConcat::NegativeIntCheckMode:
+            break; // Nothing to do, was only needed to add a runtime check earlier.
           case StringConcat::IntMode: {
             start = int_getChars(kit, arg, dst_array, coder, start, string_sizes->in(argi));
             break;


### PR DESCRIPTION
Backport of JDK-8271459. Fix applies almost cleanly (ciSymbol was renamed to ciSymbols). Skipped tests because IR test framework is not in 11u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271459](https://bugs.openjdk.java.net/browse/JDK-8271459): C2: Missing NegativeArraySizeException when creating StringBuilder with negative capacity


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/510/head:pull/510` \
`$ git checkout pull/510`

Update a local copy of the PR: \
`$ git checkout pull/510` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 510`

View PR using the GUI difftool: \
`$ git pr show -t 510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/510.diff">https://git.openjdk.java.net/jdk11u-dev/pull/510.diff</a>

</details>
