### PR TITLE
8233642: [TESTBUG] JMenuBar test bug 4750590.java  fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -798,7 +798,6 @@ javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.ja
 javax/swing/JMenuItem/8139169/ScreenMenuBarInputTwice.java 8233638 macosx-all
 javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
 javax/swing/JMenuItem/4171437/bug4171437.java 8233641 macosx-all
-javax/swing/JMenuBar/4750590/bug4750590.java 8233642 macosx-all
 javax/swing/JMenu/4692443/bug4692443.java 8171998 macosx-all
 javax/swing/JMenu/4515762/bug4515762.java 8233643 macosx-all
 javax/swing/JColorChooser/Test8051548.java 8233647 macosx-all


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8233642 from the openjdk/jdk repository.

The commit being backported was authored by Prasanta Sadhukhan on 8 May 2020 and was reviewed by Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233642](https://bugs.openjdk.java.net/browse/JDK-8233642): [TESTBUG] JMenuBar test bug 4750590.java  fails on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/511/head:pull/511` \
`$ git checkout pull/511`

Update a local copy of the PR: \
`$ git checkout pull/511` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 511`

View PR using the GUI difftool: \
`$ git pr show -t 511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/511.diff">https://git.openjdk.java.net/jdk11u-dev/pull/511.diff</a>

</details>
