### PR TITLE
8233643: [TESTBUG] JMenu test bug4515762.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -800,7 +800,6 @@ javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
 javax/swing/JMenuItem/4171437/bug4171437.java 8233641 macosx-all
 javax/swing/JMenuBar/4750590/bug4750590.java 8233642 macosx-all
 javax/swing/JMenu/4692443/bug4692443.java 8171998 macosx-all
-javax/swing/JMenu/4515762/bug4515762.java 8233643 macosx-all
 javax/swing/JColorChooser/Test8051548.java 8233647 macosx-all
 javax/swing/plaf/synth/7158712/bug7158712.java 8238720 windows-all
 javax/swing/plaf/basic/BasicComboPopup/JComboBoxPopupLocation/JComboBoxPopupLocation.java 8238720 windows-all

--- a/test/jdk/javax/swing/JMenu/4515762/bug4515762.java
+++ b/test/jdk/javax/swing/JMenu/4515762/bug4515762.java
@@ -121,6 +121,7 @@ public class bug4515762 {
                     frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
                     frame.pack();
                     frame.setVisible(true);
+                    frame.toFront();
                 }
             });
 
@@ -140,6 +141,7 @@ public class bug4515762 {
             actionExpected = true;
             Util.hitMnemonics(robot, KeyEvent.VK_U);
 
+            robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_S);
             robot.keyRelease(KeyEvent.VK_S);
             robot.waitForIdle();
@@ -147,6 +149,8 @@ public class bug4515762 {
             checkAction();
 
             Util.hitMnemonics(robot, KeyEvent.VK_U);
+            robot.waitForIdle();
+
             robot.keyPress(KeyEvent.VK_M);
             robot.keyRelease(KeyEvent.VK_M);
             robot.waitForIdle();
@@ -154,17 +158,21 @@ public class bug4515762 {
             checkAction();
 
             Util.hitMnemonics(robot, KeyEvent.VK_U);
+            robot.waitForIdle();
             Util.hitKeys(robot, KeyEvent.VK_T);
             robot.waitForIdle();
 
             checkAction();
+
             Util.hitMnemonics(robot, KeyEvent.VK_U);
+            robot.waitForIdle();
             Util.hitKeys(robot, KeyEvent.VK_W);
             robot.waitForIdle();
 
             checkAction();
 
             Util.hitMnemonics(robot, KeyEvent.VK_U);
+            robot.waitForIdle();
             Util.hitKeys(robot, KeyEvent.VK_U);
             robot.waitForIdle();
 


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8233643 from the openjdk/jdk repository.

The commit being backported was authored by Prasanta Sadhukhan on 8 May 2020 and was reviewed by Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233643](https://bugs.openjdk.java.net/browse/JDK-8233643): [TESTBUG] JMenu test bug4515762.java fails on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/512/head:pull/512` \
`$ git checkout pull/512`

Update a local copy of the PR: \
`$ git checkout pull/512` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 512`

View PR using the GUI difftool: \
`$ git pr show -t 512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/512.diff">https://git.openjdk.java.net/jdk11u-dev/pull/512.diff</a>

</details>
