### PR TITLE
8269656: The test test/langtools/tools/javac/versions/Versions.java has duplicate test cycles

### DIFF
--- a/test/langtools/tools/javac/versions/Versions.java
+++ b/test/langtools/tools/javac/versions/Versions.java
@@ -131,7 +131,7 @@ public class Versions {
             String target = st.target();
             boolean dotOne = st.dotOne();
             check_source_target(dotOne, List.of(classFileVer, target, target));
-            for (int j = i; j > 0; j--) {
+            for (int j = i - 1; j >= 0; j--) {
                 String source = sourceTargets[j].target();
                 check_source_target(dotOne, List.of(classFileVer, source, target));
             }
@@ -150,7 +150,7 @@ public class Versions {
                 st.checksrc(this, List.of("-source 1." + st.target(), "-target 1." + st.target()));
             }
 
-            if (i == sourceTargets.length) {
+            if (i == sourceTargets.length - 1) {
                 // Can use -target without -source setting only for
                 // most recent target since the most recent source is
                 // the default.


### PR DESCRIPTION
Fix request [11u]

I backport this for parity with 11.0.14-oracle.
No risk, only a test change.
Clean backport.
Test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269656](https://bugs.openjdk.java.net/browse/JDK-8269656): The test test/langtools/tools/javac/versions/Versions.java has duplicate test cycles


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/513/head:pull/513` \
`$ git checkout pull/513`

Update a local copy of the PR: \
`$ git checkout pull/513` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 513`

View PR using the GUI difftool: \
`$ git pr show -t 513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/513.diff">https://git.openjdk.java.net/jdk11u-dev/pull/513.diff</a>

</details>
