### PR TITLE
8251155: HostIdentifier fails to canonicalize hostnames starting with digits

### DIFF
--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/HostIdentifier.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/HostIdentifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,6 +109,11 @@ public class HostIdentifier {
         if ((uriString == null) || (uriString.compareTo("localhost") == 0)) {
             uriString = "//localhost";
             return new URI(uriString);
+        }
+
+        if (Character.isDigit(uriString.charAt(0))) {
+            // may be hostname or hostname:port since it starts with digits
+            uriString = "//" + uriString;
         }
 
         URI u = new URI(uriString);

--- a/test/jdk/sun/tools/jps/TestJpsHostName.java
+++ b/test/jdk/sun/tools/jps/TestJpsHostName.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.testlibrary.OutputAnalyzer;
+
+/*
+ * @test
+ * @bug 8251155
+ * @summary Test host names starting with digits
+ * @library /lib/testlibrary /test/lib
+ * @build jdk.testlibrary.* JpsHelper
+ * @run driver TestJpsHostName
+ */
+public class TestJpsHostName {
+
+    public static void main(String[] args) throws Throwable {
+        testJpsHostName("12345");
+        testJpsHostName("12345:37266");
+    }
+
+    private static void testJpsHostName(String hostname) throws Exception {
+        OutputAnalyzer output = JpsHelper.jps(hostname);
+        output.shouldNotContain("Malformed Host Identifier: " + hostname);
+    }
+
+}


### PR DESCRIPTION
Hi all,

I'd like to backport JDK-8251155 to jdk11u.

Tools like jps in jdk11u still fail on machines when the hostnames starting with digits.
And this bug can be reproduced by jtreg tests:
```
sun/tools/jstatd/TestJstatdExternalRegistry.java
sun/tools/jstatd/TestJstatdPort.java
sun/tools/jstatd/TestJstatdPortAndServer.java
```

It's worth doing this since quite a lot of cloud hosts are named with digits only.
Although patch can be applied cleanly, the backported test has been adjusted (see the following diff) to make it successfully compiled with the jdk11 test framework.
```
diff --git a/test/jdk/sun/tools/jps/TestJpsHostName.java b/test/jdk/sun/tools/jps/TestJpsHostName.java
index 4ef9d91ac3..9d15399a86 100644
--- a/test/jdk/sun/tools/jps/TestJpsHostName.java
+++ b/test/jdk/sun/tools/jps/TestJpsHostName.java
@@ -21,14 +21,14 @@
  * questions.
  */
 
-import jdk.test.lib.process.OutputAnalyzer;
+import jdk.testlibrary.OutputAnalyzer;
 
 /*
  * @test
  * @bug 8251155
  * @summary Test host names starting with digits
- * @library /test/lib
- * @build JpsHelper
+ * @library /lib/testlibrary /test/lib
+ * @build jdk.testlibrary.* JpsHelper
  * @run driver TestJpsHostName
  */
 public class TestJpsHostName {
```

Testing:
 - Affected tests passed after this patch
 - tier1~3 on Linux/x64, no regression

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251155](https://bugs.openjdk.java.net/browse/JDK-8251155): HostIdentifier fails to canonicalize hostnames starting with digits


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/516/head:pull/516` \
`$ git checkout pull/516`

Update a local copy of the PR: \
`$ git checkout pull/516` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 516`

View PR using the GUI difftool: \
`$ git pr show -t 516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/516.diff">https://git.openjdk.java.net/jdk11u-dev/pull/516.diff</a>

</details>
