### PR TITLE
8250888: nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java fails

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java
@@ -64,16 +64,18 @@
  */
 
 import sun.hotspot.code.Compiler;
+import sun.hotspot.WhiteBox;
+import sun.hotspot.gc.GC;
 
 public class TestDriver {
     public static void main(String[] args) throws Exception {
-        sun.hotspot.WhiteBox wb = sun.hotspot.WhiteBox.getWhiteBox();
+        WhiteBox wb = WhiteBox.getWhiteBox();
         Boolean isExplicitGCInvokesConcurrentOn = wb.getBooleanVMFlag("ExplicitGCInvokesConcurrent");
-        Boolean isUseG1GCon = wb.getBooleanVMFlag("UseG1GC");
         Boolean isUseConcMarkSweepGCon = wb.getBooleanVMFlag("UseConcMarkSweepGC");
-        Boolean isUseZGCon = wb.getBooleanVMFlag("UseZGC");
-        Boolean isShenandoahGCon = wb.getBooleanVMFlag("UseShenandoahGC");
-        Boolean isUseEpsilonGCon = wb.getBooleanVMFlag("UseEpsilonGC");
+        boolean isUseG1GCon = GC.G1.isSelected();
+        boolean isUseZGCon = GC.Z.isSelected();
+        boolean isShenandoahGCon = GC.Shenandoah.isSelected();
+        boolean isUseEpsilonGCon = GC.Epsilon.isSelected();
 
         if (Compiler.isGraalEnabled() &&
             (isUseConcMarkSweepGCon || isUseZGCon || isUseEpsilonGCon || isShenandoahGCon)) {


### PR DESCRIPTION
The test also fails in jdk11u. The patch does not apply cleanly due to context difference, but it is easy to resolve manually. Low risk, only a test change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250888](https://bugs.openjdk.java.net/browse/JDK-8250888): nsk/jvmti/scenarios/general_functions/GF08/gf08t001/TestDriver.java fails


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/517/head:pull/517` \
`$ git checkout pull/517`

Update a local copy of the PR: \
`$ git checkout pull/517` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 517`

View PR using the GUI difftool: \
`$ git pr show -t 517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/517.diff">https://git.openjdk.java.net/jdk11u-dev/pull/517.diff</a>

</details>
