### PR TITLE
8233550: [TESTBUG] JTree tests fail regularly on MacOS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -779,9 +779,6 @@ javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java 233570 macosx-all
 javax/swing/text/GlyphPainter2/6427244/bug6427244.java 8208566 macosx-all
 javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java 8233635 macosx-all
 javax/swing/plaf/nimbus/TestNimbusOverride.java 8233559 macosx-all
-javax/swing/JTree/4927934/bug4927934.java 8233550 macosx-all
-javax/swing/JTree/4908142/bug4908142.java 8233550 macosx-all
-javax/swing/JTree/4330357/bug4330357.java 8233550 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java 8233555 macosx-all
 javax/swing/JRadioButton/8075609/bug8075609.java 8233555 macosx-all

--- a/test/jdk/javax/swing/JTree/4330357/bug4330357.java
+++ b/test/jdk/javax/swing/JTree/4330357/bug4330357.java
@@ -31,13 +31,34 @@
  * @author Peter Zhelezniakov
  * @run main bug4330357
  */
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
-import javax.swing.tree.*;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+import javax.swing.AbstractCellEditor;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextField;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.tree.DefaultTreeCellEditor;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import javax.swing.tree.TreeCellEditor;
 
 public class bug4330357 {
 
+    private static JFrame frame;
     private static JTree tree;
     private static JButton button;
     private static Robot robot;
@@ -48,38 +69,44 @@ public class bug4330357 {
 
         UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
 
-        javax.swing.SwingUtilities.invokeAndWait(new Runnable() {
+        try {
+            javax.swing.SwingUtilities.invokeAndWait(new Runnable() {
 
-            public void run() {
-                createAndShowGUI();
+                public void run() {
+                    createAndShowGUI();
+                }
+            });
+
+            robot.waitForIdle();
+
+            clickMouse(getTreeRowClickPoint(1));
+            Util.hitKeys(robot, KeyEvent.VK_F2);
+            Util.hitKeys(robot, KeyEvent.VK_A, KeyEvent.VK_B, KeyEvent.VK_C);
+            robot.waitForIdle();
+
+            if (!hasComponent(JTextField.class)) {
+                throw new RuntimeException("Cell editor is missed for path: color");
             }
-        });
-
-        robot.waitForIdle();
-
-        clickMouse(getTreeRowClickPoint(1));
-        Util.hitKeys(robot, KeyEvent.VK_F2);
-        Util.hitKeys(robot, KeyEvent.VK_A, KeyEvent.VK_B, KeyEvent.VK_C);
-        robot.waitForIdle();
-
-        if (!hasComponent(JTextField.class)) {
-            throw new RuntimeException("Cell editor is missed for path: color");
-        }
 
 
-        clickMouse(getButtonClickPoint());
-        robot.waitForIdle();
+            clickMouse(getButtonClickPoint());
+            robot.waitForIdle();
 
-        clickMouse(getTreeRowClickPoint(2));
-        Util.hitKeys(robot, KeyEvent.VK_F2);
-        robot.waitForIdle();
+            clickMouse(getTreeRowClickPoint(2));
+            Util.hitKeys(robot, KeyEvent.VK_F2);
+            robot.waitForIdle();
 
-        if (!hasComponent(JComboBox.class)) {
-            throw new RuntimeException("Cell editor is missed for path: sports");
-        }
+            if (!hasComponent(JComboBox.class)) {
+                throw new RuntimeException("Cell editor is missed for path: sports");
+            }
 
-        if (hasComponent(JTextField.class)) {
-            throw new RuntimeException("Cell editor is wrongly shown for path: color");
+            if (hasComponent(JTextField.class)) {
+                throw new RuntimeException("Cell editor is wrongly shown for path: color");
+            }
+        } finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
+            }
         }
     }
 
@@ -137,7 +164,7 @@ public class bug4330357 {
     }
 
     private static void createAndShowGUI() {
-        JFrame frame = new JFrame("Test");
+        frame = new JFrame("Test");
         frame.setSize(200, 200);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 

--- a/test/jdk/javax/swing/JTree/4908142/bug4908142.java
+++ b/test/jdk/javax/swing/JTree/4908142/bug4908142.java
@@ -32,65 +32,75 @@
  * @build Util
  * @run main bug4908142
  */
-import javax.swing.*;
-import javax.swing.tree.*;
-import java.awt.*;
-import java.awt.event.*;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.tree.DefaultMutableTreeNode;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
 import java.util.concurrent.Callable;
 
 public class bug4908142 {
 
-    private static JTree tree;
+    private static JFrame fr = null;
+    private static JTree tree = null;
 
     public static void main(String[] args) throws Exception {
 
         Robot robot = new Robot();
         robot.setAutoDelay(50);
 
-        SwingUtilities.invokeAndWait(new Runnable() {
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
 
-            public void run() {
-                createAndShowGUI();
+                public void run() {
+                    createAndShowGUI();
+                }
+            });
+
+            robot.waitForIdle();
+
+            SwingUtilities.invokeAndWait(new Runnable() {
+
+                public void run() {
+                    tree.requestFocus();
+                    tree.setSelectionRow(0);
+                }
+            });
+
+            robot.waitForIdle();
+
+
+            robot.keyPress(KeyEvent.VK_A);
+            robot.keyRelease(KeyEvent.VK_A);
+            robot.keyPress(KeyEvent.VK_A);
+            robot.keyRelease(KeyEvent.VK_A);
+            robot.keyPress(KeyEvent.VK_D);
+            robot.keyRelease(KeyEvent.VK_D);
+            robot.waitForIdle();
+
+
+            String sel = Util.invokeOnEDT(new Callable<String>() {
+
+                @Override
+                public String call() throws Exception {
+                    return tree.getLastSelectedPathComponent().toString();
+                }
+            });
+
+            if (!"aad".equals(sel)) {
+                throw new Error("The selected index should be \"aad\", but not " + sel);
             }
-        });
-
-        robot.waitForIdle();
-
-        SwingUtilities.invokeAndWait(new Runnable() {
-
-            public void run() {
-                tree.requestFocus();
-                tree.setSelectionRow(0);
+        } finally {
+            if (fr != null) {
+                SwingUtilities.invokeAndWait(fr::dispose);
             }
-        });
-
-        robot.waitForIdle();
-
-
-        robot.keyPress(KeyEvent.VK_A);
-        robot.keyRelease(KeyEvent.VK_A);
-        robot.keyPress(KeyEvent.VK_A);
-        robot.keyRelease(KeyEvent.VK_A);
-        robot.keyPress(KeyEvent.VK_D);
-        robot.keyRelease(KeyEvent.VK_D);
-        robot.waitForIdle();
-
-
-        String sel = Util.invokeOnEDT(new Callable<String>() {
-
-            @Override
-            public String call() throws Exception {
-                return tree.getLastSelectedPathComponent().toString();
-            }
-        });
-
-        if (!"aad".equals(sel)) {
-            throw new Error("The selected index should be \"aad\", but not " + sel);
         }
     }
 
     private static void createAndShowGUI() {
-        JFrame fr = new JFrame("Test");
+        fr = new JFrame("Test");
         fr.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
         String[] data = {"aaa", "aab", "aac", "aad", "ade", "bba"};

--- a/test/jdk/javax/swing/JTree/4927934/bug4927934.java
+++ b/test/jdk/javax/swing/JTree/4927934/bug4927934.java
@@ -22,19 +22,28 @@
  */
 /*
    @test
-  @key headful
+   @key headful
    @bug 4927934
    @summary JTree traversal is unlike Native windows tree traversal
    @author Andrey Pikalev
    @run main bug4927934
 */
 
-import javax.swing.*;
-import javax.swing.event.*;
-import javax.swing.tree.*;
-import java.awt.*;
-import java.awt.event.*;
-import java.lang.reflect.InvocationTargetException;
+import java.awt.Robot;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyEvent;
+
+import javax.swing.JFrame;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.JScrollPane;
+import javax.swing.event.TreeSelectionListener;
+import javax.swing.event.TreeExpansionListener;
+import javax.swing.event.TreeSelectionEvent;
+import javax.swing.event.TreeExpansionEvent;
+import javax.swing.tree.DefaultMutableTreeNode;
 
 public class bug4927934 implements TreeSelectionListener, TreeExpansionListener, FocusListener {
 
@@ -55,107 +64,113 @@ public class bug4927934 implements TreeSelectionListener, TreeExpansionListener,
         robot = new Robot();
         robot.setAutoDelay(50);
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                frame = new JFrame();
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    frame = new JFrame();
 
-                DefaultMutableTreeNode root = new DefaultMutableTreeNode("root");
-                createNodes(root);
-                tree = new JTree(root);
-                JScrollPane scrollPane = new JScrollPane(tree);
-                frame.getContentPane().add(scrollPane);
+                    DefaultMutableTreeNode root = new DefaultMutableTreeNode("root");
+                    createNodes(root);
+                    tree = new JTree(root);
+                    JScrollPane scrollPane = new JScrollPane(tree);
+                    frame.getContentPane().add(scrollPane);
 
-                tree.addFocusListener((FocusListener)listener);
-                tree.addTreeSelectionListener((TreeSelectionListener)listener);
-                tree.addTreeExpansionListener((TreeExpansionListener)listener);
+                    tree.addFocusListener((FocusListener) listener);
+                    tree.addTreeSelectionListener((TreeSelectionListener) listener);
+                    tree.addTreeExpansionListener((TreeExpansionListener) listener);
 
-                frame.setSize(300, 300);
-                frame.setVisible(true);
-            }
-        });
+                    frame.setSize(300, 300);
+                    frame.setVisible(true);
+                }
+            });
 
-        robot.waitForIdle();
-        Thread.sleep(1000);
+            robot.waitForIdle();
+            Thread.sleep(1000);
 
-        SwingUtilities.invokeLater(new Runnable() {
-            public void run() {
-                tree.requestFocus();
-            }
-        });
+            SwingUtilities.invokeLater(new Runnable() {
+                public void run() {
+                    tree.requestFocus();
+                }
+            });
 
-        synchronized(listener) {
-            if (!focusGained) {
-                System.out.println("waiting focusGained...");
-                try {
-                    listener.wait(10000);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
+            synchronized (listener) {
+                if (!focusGained) {
+                    System.out.println("waiting focusGained...");
+                    try {
+                        listener.wait(10000);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
                 }
             }
-        }
 
-        // GO TO RIGHT
-        selectionChanged = false;
-        hitKey(KeyEvent.VK_RIGHT);
-        robot.waitForIdle();
-        if (!checkSelectionChanged(tree, 0)) {
-            throw new RuntimeException("Root should be selected");
-        }
+            // GO TO RIGHT
+            selectionChanged = false;
+            hitKey(KeyEvent.VK_RIGHT);
+            robot.waitForIdle();
+            if (!checkSelectionChanged(tree, 0)) {
+                throw new RuntimeException("Root should be selected");
+            }
 
-        selectionChanged = false;
-        hitKey(KeyEvent.VK_RIGHT);
-        robot.waitForIdle();
-        if (!checkSelectionChanged(tree, 1)) {
-            throw new RuntimeException("Node should be selected");
-        }
+            selectionChanged = false;
+            hitKey(KeyEvent.VK_RIGHT);
+            robot.waitForIdle();
+            if (!checkSelectionChanged(tree, 1)) {
+                throw new RuntimeException("Node should be selected");
+            }
 
-        treeExpanded = false;
-        hitKey(KeyEvent.VK_RIGHT);
-        robot.waitForIdle();
-        if (!isTreeExpanded()) {
-            throw new RuntimeException("Node should be expanded");
-        }
+            treeExpanded = false;
+            hitKey(KeyEvent.VK_RIGHT);
+            robot.waitForIdle();
+            if (!isTreeExpanded()) {
+                throw new RuntimeException("Node should be expanded");
+            }
 
-        selectionChanged = false;
-        hitKey(KeyEvent.VK_RIGHT);
-        robot.waitForIdle();
-        if (!checkSelectionChanged(tree, 2)) {
-            throw new RuntimeException("Leaf1 should be selected");
-        }
+            selectionChanged = false;
+            hitKey(KeyEvent.VK_RIGHT);
+            robot.waitForIdle();
+            if (!checkSelectionChanged(tree, 2)) {
+                throw new RuntimeException("Leaf1 should be selected");
+            }
 
-        selectionChanged = false;
-        hitKey(KeyEvent.VK_RIGHT);
-        robot.waitForIdle();
-        if (!checkSelectionChanged(tree, 2)) {
-            throw new RuntimeException("Leaf1 should be selected");
-        }
+            selectionChanged = false;
+            hitKey(KeyEvent.VK_RIGHT);
+            robot.waitForIdle();
+            if (!checkSelectionChanged(tree, 2)) {
+                throw new RuntimeException("Leaf1 should be selected");
+            }
 
-        // GO TO LEFT
-        selectionChanged = false;
-        hitKey(KeyEvent.VK_LEFT);
-        robot.waitForIdle();
-        if (!checkSelectionChanged(tree, 1)) {
-            throw new RuntimeException("Node should be selected");
-        }
+            // GO TO LEFT
+            selectionChanged = false;
+            hitKey(KeyEvent.VK_LEFT);
+            robot.waitForIdle();
+            if (!checkSelectionChanged(tree, 1)) {
+                throw new RuntimeException("Node should be selected");
+            }
 
-        treeCollapsed = false;
-        hitKey(KeyEvent.VK_LEFT);
-        if (!isTreeCollapsed()) {
-            throw new RuntimeException("Node should be collapsed");
-        }
+            treeCollapsed = false;
+            hitKey(KeyEvent.VK_LEFT);
+            if (!isTreeCollapsed()) {
+                throw new RuntimeException("Node should be collapsed");
+            }
 
-        selectionChanged = false;
-        hitKey(KeyEvent.VK_LEFT);
-        robot.waitForIdle();
-        if (!checkSelectionChanged(tree, 0)) {
-            throw new RuntimeException("Root should be selected");
-        }
+            selectionChanged = false;
+            hitKey(KeyEvent.VK_LEFT);
+            robot.waitForIdle();
+            if (!checkSelectionChanged(tree, 0)) {
+                throw new RuntimeException("Root should be selected");
+            }
 
-        treeCollapsed = false;
-        hitKey(KeyEvent.VK_LEFT);
-        robot.waitForIdle();
-        if (!isTreeCollapsed()) {
-            throw new RuntimeException("Root should be collapsed");
+            treeCollapsed = false;
+            hitKey(KeyEvent.VK_LEFT);
+            robot.waitForIdle();
+            if (!isTreeCollapsed()) {
+                throw new RuntimeException("Root should be collapsed");
+            }
+        } finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
+            }
         }
     }
 


### PR DESCRIPTION
Backport of 8233550: [TESTBUG] JTree tests fail regularly on MacOS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233550](https://bugs.openjdk.java.net/browse/JDK-8233550): [TESTBUG] JTree tests fail regularly on MacOS


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/523/head:pull/523` \
`$ git checkout pull/523`

Update a local copy of the PR: \
`$ git checkout pull/523` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 523`

View PR using the GUI difftool: \
`$ git pr show -t 523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/523.diff">https://git.openjdk.java.net/jdk11u-dev/pull/523.diff</a>

</details>
