### PR TITLE
8274293: Build failure on macOS with Xcode 13.0 as vfork is deprecated

### DIFF
--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -347,8 +347,8 @@ static int copystrings(char *buf, int offset, const char * const *arg) {
 __attribute_noinline__
 #endif
 
-/* vfork(2) is deprecated on Solaris */
-#ifndef __solaris__
+/* vfork(2) is deprecated on Solaris and Darwin */
+#if !defined(__APPLE__) && !defined(__solaris__)
 static pid_t
 vforkChild(ChildStuff *c) {
     volatile pid_t resultPid;
@@ -478,8 +478,8 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
 static pid_t
 startChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) {
     switch (c->mode) {
-/* vfork(2) is deprecated on Solaris */
-#ifndef __solaris__
+/* vfork(2) is deprecated on Solaris and Darwin */
+#if !defined(__APPLE__) && !defined(__solaris__)
       case MODE_VFORK:
         return vforkChild(c);
 #endif


### PR DESCRIPTION
Backport 252aaa9249d8979366b37d59487b5b039d923e35

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274293](https://bugs.openjdk.java.net/browse/JDK-8274293): Build failure on macOS with Xcode 13.0 as vfork is deprecated


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/529/head:pull/529` \
`$ git checkout pull/529`

Update a local copy of the PR: \
`$ git checkout pull/529` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 529`

View PR using the GUI difftool: \
`$ git pr show -t 529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/529.diff">https://git.openjdk.java.net/jdk11u-dev/pull/529.diff</a>

</details>
