### PR TITLE
8263364: sun/net/www/http/KeepAliveStream/KeepAliveStreamCloseWithWrongContentLength.java wedged in getInputStream

### DIFF
--- a/test/jdk/sun/net/www/http/KeepAliveStream/KeepAliveStreamCloseWithWrongContentLength.java
+++ b/test/jdk/sun/net/www/http/KeepAliveStream/KeepAliveStreamCloseWithWrongContentLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,82 +23,161 @@
 
 /*
  * @test
- * @bug 4533243
- * @summary Closing a keep alive stream gives NullPointerException
+ * @bug 4533243 8263364
+ * @summary Closing a keep alive stream should not give NullPointerException and should accept a connection from  a
+ *          client only from this test
+ * @library /test/lib
  * @run main/othervm/timeout=30 KeepAliveStreamCloseWithWrongContentLength
  */
 
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.URIBuilder;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
 
 public class KeepAliveStreamCloseWithWrongContentLength {
 
-    static class XServer extends Thread {
-        ServerSocket srv;
-        Socket s;
-        InputStream is;
-        OutputStream os;
+    private final static String path = "/KeepAliveStreamCloseWithWrongContentLength";
+    private final static String getRequest1stLine = "GET /KeepAliveStreamCloseWithWrongContentLength";
 
-        XServer (ServerSocket s) {
-            srv = s;
+    static class XServer extends Thread implements AutoCloseable {
+
+        final ServerSocket serverSocket;
+        volatile Socket clientSocket;
+
+        XServer (InetAddress address) throws IOException {
+            ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+            ServerSocket serversocket = serverSocketChannel.socket();
+            serversocket.bind(new InetSocketAddress(address, 0));
+            this.serverSocket = serversocket;
+        }
+
+        public int getLocalPort() {
+            return serverSocket.getLocalPort();
         }
 
         public void run() {
+
             try {
-                s = srv.accept ();
-                // read HTTP request from client
-                InputStream is = s.getInputStream();
-                // read the first ten bytes
-                for (int i=0; i<10; i++) {
-                    is.read();
+                ByteArrayOutputStream clientBytes;
+                clientSocket = null;
+
+                // in a concurrent test environment it can happen that other rouge clients connect to this server
+                // so we need to identify and connect only to the client from this test
+                // if the rouge client sends as least bytes as there is in getRequest1stLine it will be discarded and
+                // the test should proceed otherwise it should timeout on readNBytes below
+                do {
+                    if (clientSocket != null) {
+                        final String client =
+                            clientSocket.getInetAddress().getHostAddress() + ":" +
+                            clientSocket.getPort();
+                        try {
+                            clientSocket.close();
+                        }
+                        catch (IOException ioe) {
+                            ioe.printStackTrace();
+                        }
+                        finally {
+                            System.err.println("rogue client (" + client + ") connection attempt, ignoring");
+                        }
+                    }
+                    clientSocket = serverSocket.accept();
+                    // read HTTP request from client
+                    clientBytes = new ByteArrayOutputStream();
+                    clientBytes.write(clientSocket.getInputStream().readNBytes(getRequest1stLine.getBytes().length));
                 }
-                OutputStreamWriter ow =
-                    new OutputStreamWriter((os = s.getOutputStream()));
-                ow.write("HTTP/1.0 200 OK\n");
+                while(!getRequest1stLine.equals(clientBytes.toString()));
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+            }
+            try  {
+                OutputStreamWriter outputStreamWriter = new OutputStreamWriter(clientSocket.getOutputStream());
+                outputStreamWriter.write("HTTP/1.0 200 OK\n");
 
                 // Note: The client expects 10 bytes.
-                ow.write("Content-Length: 10\n");
-                ow.write("Content-Type: text/html\n");
+                outputStreamWriter.write("Content-Length: 10\n");
+                outputStreamWriter.write("Content-Type: text/html\n");
 
                 // Note: If this line is missing, everything works fine.
-                ow.write("Connection: Keep-Alive\n");
-                ow.write("\n");
+                outputStreamWriter.write("Connection: Keep-Alive\n");
+                outputStreamWriter.write("\n");
 
                 // Note: The (buggy) server only sends 9 bytes.
-                ow.write("123456789");
-                ow.flush();
-            } catch (Exception e) {
-            } finally {
-                try {if (os != null) { os.close(); }} catch (IOException e) {}
+                outputStreamWriter.write("123456789");
+                outputStreamWriter.flush();
+                clientSocket.getChannel().shutdownOutput();
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            final var clientSocket = this.clientSocket;
+            try {
+                long drained = drain(clientSocket.getChannel());
+                System.err.printf("Server drained %d bytes from the channel%n", drained);
+            } catch (Exception x) {
+                System.err.println("Server failed to drain client socket: " + x);
+                x.printStackTrace();
+            }
+            serverSocket.close();
+        }
+
+    }
+
+    static long drain(SocketChannel channel) throws IOException {
+        if (!channel.isOpen()) return 0;
+        System.err.println("Not reading server: draining socket");
+        var blocking = channel.isBlocking();
+        if (blocking) channel.configureBlocking(false);
+        long count = 0;
+        try {
+            ByteBuffer buffer = ByteBuffer.allocateDirect(8 * 1024);
+            int read;
+            while ((read = channel.read(buffer)) > 0) {
+                count += read;
+                buffer.clear();
+            }
+            return count;
+        } finally {
+            if (blocking != channel.isBlocking()) {
+                channel.configureBlocking(blocking);
             }
         }
     }
 
+
     public static void main (String[] args) throws Exception {
-        ServerSocket serversocket = new ServerSocket (0);
-        try {
-            int port = serversocket.getLocalPort ();
-            XServer server = new XServer (serversocket);
-            server.start ();
-            URL url = new URL ("http://localhost:"+port);
-            HttpURLConnection urlc = (HttpURLConnection)url.openConnection ();
-            InputStream is = urlc.getInputStream ();
+
+        final InetAddress loopback = InetAddress.getLoopbackAddress();
+
+        try (XServer server = new XServer(loopback)) {
+            server.start();
+            URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .path(path)
+                .port(server.getLocalPort())
+                .toURL();
+            HttpURLConnection urlc = (HttpURLConnection)url.openConnection(Proxy.NO_PROXY);
+            InputStream is = urlc.getInputStream();
             int c = 0;
             while (c != -1) {
                 try {
                     c=is.read();
+                    System.out.println("client reads: "+c);
                 } catch (IOException ioe) {
                     is.read ();
                     break;
                 }
             }
             is.close();
-        } catch (IOException e) {
-            return;
-        } catch (NullPointerException e) {
-            throw new RuntimeException (e);
-        } finally {
-            if (serversocket != null) serversocket.close();
         }
+
     }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

I did the following changes to the patch:
 * I also include the changes from "8222938 Replace wildcard address with loopback or local host in tests - part 21".
    As this is a cleanup it is pointless to undo all the changes in the patch.
 * I removed "...".formatted() calls.  That is not supported in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263364](https://bugs.openjdk.java.net/browse/JDK-8263364): sun/net/www/http/KeepAliveStream/KeepAliveStreamCloseWithWrongContentLength.java wedged in getInputStream


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/530/head:pull/530` \
`$ git checkout pull/530`

Update a local copy of the PR: \
`$ git checkout pull/530` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 530`

View PR using the GUI difftool: \
`$ git pr show -t 530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/530.diff">https://git.openjdk.java.net/jdk11u-dev/pull/530.diff</a>

</details>
