### PR TITLE
8275131: Exceptions after a touchpad gesture on macOS

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -128,7 +128,7 @@ AWT_NS_WINDOW_IMPLEMENTATION
 
             // send up to the GestureHandler to recursively dispatch on the AWT event thread
             DECLARE_CLASS(jc_GestureHandler, "com/apple/eawt/event/GestureHandler");
-            DECLARE_METHOD(sjm_handleGestureFromNative, jc_GestureHandler,
+            DECLARE_STATIC_METHOD(sjm_handleGestureFromNative, jc_GestureHandler,
                             "handleGestureFromNative", "(Ljava/awt/Window;IDDDD)V");
             (*env)->CallStaticVoidMethod(env, jc_GestureHandler, sjm_handleGestureFromNative,
                                awtWindow, type, (jdouble)loc.x, (jdouble)loc.y, (jdouble)a, (jdouble)b);


### PR DESCRIPTION
Good morning,

This pull request contains a backport of commit 89999f70 from the openjdk/jdk repository.

The commit being backported was authored by Dmitry Batrak on 12 Oct 2021 and was reviewed by Dmitry Markov and Phil Race.

It applies clean to jdk11u-dev. The test program in the JBS report exhibits the unwanted behaviour before the patch and does not afterwards. The patch was backported to 11.0.14-oracle. (and 17u)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275131](https://bugs.openjdk.java.net/browse/JDK-8275131): Exceptions after a touchpad gesture on macOS


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/531/head:pull/531` \
`$ git checkout pull/531`

Update a local copy of the PR: \
`$ git checkout pull/531` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 531`

View PR using the GUI difftool: \
`$ git pr show -t 531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/531.diff">https://git.openjdk.java.net/jdk11u-dev/pull/531.diff</a>

</details>
