### PR TITLE
8275051: Shenandoah: Correct ordering of requested gc cause and gc request flag

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
@@ -89,8 +90,10 @@ void ShenandoahControlThread::run_service() {
   while (!in_graceful_shutdown() && !should_terminate()) {
     // Figure out if we have pending requests.
     bool alloc_failure_pending = _alloc_failure_gc.is_set();
-    bool explicit_gc_requested = _gc_requested.is_set() &&  is_explicit_gc(_requested_gc_cause);
-    bool implicit_gc_requested = _gc_requested.is_set() && !is_explicit_gc(_requested_gc_cause);
+    bool is_gc_requested = _gc_requested.is_set();
+    GCCause::Cause requested_gc_cause = _requested_gc_cause;
+    bool explicit_gc_requested = is_gc_requested && is_explicit_gc(requested_gc_cause);
+    bool implicit_gc_requested = is_gc_requested && !is_explicit_gc(requested_gc_cause);
 
     // This control loop iteration have seen this much allocations.
     size_t allocs_seen = Atomic::xchg<size_t>(0, &_allocs_seen, memory_order_relaxed);
@@ -124,7 +127,7 @@ void ShenandoahControlThread::run_service() {
       }
 
     } else if (explicit_gc_requested) {
-      cause = _requested_gc_cause;
+      cause = requested_gc_cause;
       log_info(gc)("Trigger: Explicit GC request (%s)", GCCause::to_string(cause));
 
       heuristics->record_requested_gc();
@@ -140,7 +143,7 @@ void ShenandoahControlThread::run_service() {
         mode = stw_full;
       }
     } else if (implicit_gc_requested) {
-      cause = _requested_gc_cause;
+      cause = requested_gc_cause;
       log_info(gc)("Trigger: Implicit GC request (%s)", GCCause::to_string(cause));
 
       heuristics->record_requested_gc();
@@ -536,8 +539,11 @@ void ShenandoahControlThread::handle_requested_gc(GCCause::Cause cause) {
   size_t current_gc_id = get_gc_id();
   size_t required_gc_id = current_gc_id + 1;
   while (current_gc_id < required_gc_id) {
-    _gc_requested.set();
+    // Although setting gc request is under _gc_waiters_lock, but read side (run_service())
+    // does not take the lock. We need to enforce following order, so that read side sees
+    // latest requested gc cause when the flag is set.
     _requested_gc_cause = cause;
+    _gc_requested.set();
     ml.wait();
     current_gc_id = get_gc_id();
   }


### PR DESCRIPTION
I would like to backport this Shenandoah specific patch to 11u.

The patch corrects the order of a couple of GC flags, ensure GC sees latest GC cause when a GC is requested.

The original patch does not apply cleanly, due to context differences, especially, the grand refactoring in 17. The conflicts are resolved manually.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275051](https://bugs.openjdk.java.net/browse/JDK-8275051): Shenandoah: Correct ordering of requested gc cause and gc request flag


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/533/head:pull/533` \
`$ git checkout pull/533`

Update a local copy of the PR: \
`$ git checkout pull/533` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 533`

View PR using the GUI difftool: \
`$ git pr show -t 533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/533.diff">https://git.openjdk.java.net/jdk11u-dev/pull/533.diff</a>

</details>
