### PR TITLE
8256201: java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java failed

### DIFF
--- a/test/jdk/java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java
+++ b/test/jdk/java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java
@@ -55,6 +55,7 @@ public final class FullscreenWindowProps {
             }
         };
         try {
+            frame.setUndecorated(true); // workaround JDK-8256257
             frame.setBackground(Color.MAGENTA);
             frame.setVisible(true);
             gd.setFullScreenWindow(frame);


### PR DESCRIPTION
Clean backport of JDK-8256201.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8256201](https://bugs.openjdk.java.net/browse/JDK-8256201): java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java failed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/538/head:pull/538` \
`$ git checkout pull/538`

Update a local copy of the PR: \
`$ git checkout pull/538` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 538`

View PR using the GUI difftool: \
`$ git pr show -t 538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/538.diff">https://git.openjdk.java.net/jdk11u-dev/pull/538.diff</a>

</details>
