### PR TITLE
8198619: java/awt/Focus/FocusTraversalPolicy/ButtonGroupLayoutTraversal/ButtonGroupLayoutTraversalTest.java fails on mac

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -133,7 +133,6 @@ javax/swing/dnd/7171812/bug7171812.java 8041447 macosx-all
 java/awt/Focus/ChoiceFocus/ChoiceFocus.java 8169103 windows-all,macosx-all
 java/awt/Focus/ClearLwQueueBreakTest/ClearLwQueueBreakTest.java 8198618 macosx-all
 java/awt/Focus/ConsumeNextKeyTypedOnModalShowTest/ConsumeNextKeyTypedOnModalShowTest.java 6986252 macosx-all
-java/awt/Focus/FocusTraversalPolicy/ButtonGroupLayoutTraversal/ButtonGroupLayoutTraversalTest.java 8198619 macosx-all
 java/awt/Focus/KeyEventForBadFocusOwnerTest/KeyEventForBadFocusOwnerTest.java 8198621 macosx-all
 java/awt/Focus/MouseClickRequestFocusRaceTest/MouseClickRequestFocusRaceTest.java 8194753 linux-all,macosx-all
 java/awt/Focus/NoAutotransferToDisabledCompTest/NoAutotransferToDisabledCompTest.java 7152980 macosx-all

--- a/test/jdk/java/awt/Focus/FocusTraversalPolicy/ButtonGroupLayoutTraversal/ButtonGroupLayoutTraversalTest.java
+++ b/test/jdk/java/awt/Focus/FocusTraversalPolicy/ButtonGroupLayoutTraversal/ButtonGroupLayoutTraversalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,71 +58,76 @@ public class ButtonGroupLayoutTraversalTest {
 
     public static void main(String[] args) throws Exception {
 
-        SwingUtilities.invokeAndWait(() -> changeLAF());
-        SwingUtilities.invokeAndWait(() -> initLayout(nx, ny));
-        Robot robot = new Robot();
-        robot.setAutoDelay(100);
-        robot.waitForIdle();
-        robot.delay(200);
+        try {
+            SwingUtilities.invokeAndWait(() -> changeLAF());
+            SwingUtilities.invokeAndWait(() -> initLayout(nx, ny));
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.waitForIdle();
+            robot.delay(1000);
 
-        for (int i = 0; i < nx * ny - nx * ny / 2 - 1; i++) {
-            robot.keyPress(KeyEvent.VK_RIGHT);
-            robot.keyRelease(KeyEvent.VK_RIGHT);
-        }
-
-        for (int i = 0; i < nx * ny / 2; i++) {
-            robot.keyPress(KeyEvent.VK_TAB);
-            robot.keyRelease(KeyEvent.VK_TAB);
-        }
-
-        robot.waitForIdle();
-        robot.delay(200);
-
-        for (int i = 0; i < nx * ny; i++) {
-            if (focusCnt[i] < 1) {
-                SwingUtilities.invokeLater(window::dispose);
-                throw new RuntimeException("Component " + i
-                        + " is not reachable in the forward focus cycle");
-            } else if (focusCnt[i] > 1) {
-                SwingUtilities.invokeLater(window::dispose);
-                throw new RuntimeException("Component " + i
-                        + " got focus more than once in the forward focus cycle");
+            for (int i = 0; i < nx * ny - nx * ny / 2 - 1; i++) {
+                robot.keyPress(KeyEvent.VK_RIGHT);
+                robot.keyRelease(KeyEvent.VK_RIGHT);
+                robot.waitForIdle();
             }
-        }
 
-        for (int i = 0; i < nx * ny / 2; i++) {
+            for (int i = 0; i < nx * ny / 2; i++) {
+                robot.keyPress(KeyEvent.VK_TAB);
+                robot.keyRelease(KeyEvent.VK_TAB);
+                robot.waitForIdle();
+            }
+
+            robot.delay(200);
+
+            for (int i = 0; i < nx * ny; i++) {
+                if (focusCnt[i] < 1) {
+                    throw new RuntimeException("Component " + i
+                        + " is not reachable in the forward focus cycle");
+                } else if (focusCnt[i] > 1) {
+                    throw new RuntimeException("Component " + i
+                        + " got focus more than once in the forward focus cycle");
+                }
+            }
+
+            for (int i = 0; i < nx * ny / 2; i++) {
+                robot.keyPress(KeyEvent.VK_SHIFT);
+                robot.keyPress(KeyEvent.VK_TAB);
+                robot.keyRelease(KeyEvent.VK_TAB);
+                robot.keyRelease(KeyEvent.VK_SHIFT);
+                robot.waitForIdle();
+            }
+
+            for (int i = 0; i < nx * ny - nx * ny / 2 - 1; i++) {
+                robot.keyPress(KeyEvent.VK_LEFT);
+                robot.keyRelease(KeyEvent.VK_LEFT);
+                robot.waitForIdle();
+            }
+
             robot.keyPress(KeyEvent.VK_SHIFT);
             robot.keyPress(KeyEvent.VK_TAB);
             robot.keyRelease(KeyEvent.VK_TAB);
             robot.keyRelease(KeyEvent.VK_SHIFT);
-        }
+            robot.waitForIdle();
 
-        for (int i = 0; i < nx * ny - nx * ny / 2 - 1; i++) {
-            robot.keyPress(KeyEvent.VK_LEFT);
-            robot.keyRelease(KeyEvent.VK_LEFT);
-        }
+            robot.delay(200);
 
-        robot.keyPress(KeyEvent.VK_SHIFT);
-        robot.keyPress(KeyEvent.VK_TAB);
-        robot.keyRelease(KeyEvent.VK_TAB);
-        robot.keyRelease(KeyEvent.VK_SHIFT);
-
-        robot.waitForIdle();
-        robot.delay(200);
-
-        for (int i = 0; i < nx * ny; i++) {
-            if (focusCnt[i] < 2) {
-                SwingUtilities.invokeLater(window::dispose);
-                throw new RuntimeException("Component " + i
+            for (int i = 0; i < nx * ny; i++) {
+                if (focusCnt[i] < 2) {
+                    throw new RuntimeException("Component " + i
                         + " is not reachable in the backward focus cycle");
-            } else if (focusCnt[i] > 2) {
-                SwingUtilities.invokeLater(window::dispose);
-                throw new RuntimeException("Component " + i
+                } else if (focusCnt[i] > 2) {
+                    throw new RuntimeException("Component " + i
                         + " got focus more than once in the backward focus cycle");
+                }
             }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (window != null) {
+                    window.dispose();
+                }
+            });
         }
-
-        SwingUtilities.invokeLater(window::dispose);
     }
 
     private static void changeLAF() {
@@ -179,6 +184,7 @@ public class ButtonGroupLayoutTraversalTest {
         }
         rootPanel.add(formPanel, BorderLayout.CENTER);
         window.add(rootPanel);
+        window.setLocationRelativeTo(null);
         window.pack();
         window.setVisible(true);
     }


### PR DESCRIPTION
Backport of JDK-8198619. Fix applies cleanly, but removal from ProblemList had to be done manually. Headful test has passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8198619](https://bugs.openjdk.java.net/browse/JDK-8198619): java/awt/Focus/FocusTraversalPolicy/ButtonGroupLayoutTraversal/ButtonGroupLayoutTraversalTest.java fails on mac


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/539/head:pull/539` \
`$ git checkout pull/539`

Update a local copy of the PR: \
`$ git checkout pull/539` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 539`

View PR using the GUI difftool: \
`$ git pr show -t 539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/539.diff">https://git.openjdk.java.net/jdk11u-dev/pull/539.diff</a>

</details>
