### PR TITLE
8197800: Test java/awt/Focus/NonFocusableWindowTest/NoEventsTest.java fails on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -254,7 +254,6 @@ java/awt/Component/GetScreenLocTest/GetScreenLocTest.java 4753654 generic-all
 java/awt/Component/SetEnabledPerformance/SetEnabledPerformance.java 8165863 macosx-all
 java/awt/Choice/SelectCurrentItemTest/SelectCurrentItemTest.html 8192929 windows-all,linux-all
 java/awt/Clipboard/HTMLTransferTest/HTMLTransferTest.java 8017454 macosx-all
-java/awt/Focus/NonFocusableWindowTest/NoEventsTest.java 8000171 windows-all
 java/awt/Frame/MiscUndecorated/RepaintTest.java 8079267 windows-all,linux-all
 java/awt/Robot/ModifierRobotKey/ModifierRobotKeyTest.java 8157173 generic-all
 java/awt/Modal/FileDialog/FileDialogAppModal1Test.java 8198664 macosx-all


### PR DESCRIPTION
Clean backport of JDK-8197800. This only removes the test from the ProblemList. Fix JDK-8196100 is already backported to 11.0.12.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8197800](https://bugs.openjdk.java.net/browse/JDK-8197800): Test java/awt/Focus/NonFocusableWindowTest/NoEventsTest.java fails on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/540/head:pull/540` \
`$ git checkout pull/540`

Update a local copy of the PR: \
`$ git checkout pull/540` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 540`

View PR using the GUI difftool: \
`$ git pr show -t 540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/540.diff">https://git.openjdk.java.net/jdk11u-dev/pull/540.diff</a>

</details>
