### PR TITLE
8239422: [TESTBUG] compiler/c1/TestPrintIRDuringConstruction.java failed when C1 is disabled

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/TestPrintIRDuringConstruction.java
+++ b/test/hotspot/jtreg/compiler/c1/TestPrintIRDuringConstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @summary load/store elimination will print out instructions without bcis.
  * @bug 8235383
- * @requires vm.debug == true
+ * @requires vm.debug == true & vm.compiler1.enabled
  * @run main/othervm -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -Xcomp -XX:+PrintIRDuringConstruction -XX:+Verbose compiler.c1.TestPrintIRDuringConstruction
  */
 


### PR DESCRIPTION
The patch applies clean. Low risk, only test changes. The modified test passed on linux-x64 with and without compiler1 (without c1: no tests selected).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8239422](https://bugs.openjdk.java.net/browse/JDK-8239422): [TESTBUG] compiler/c1/TestPrintIRDuringConstruction.java failed when C1 is disabled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/544/head:pull/544` \
`$ git checkout pull/544`

Update a local copy of the PR: \
`$ git checkout pull/544` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 544`

View PR using the GUI difftool: \
`$ git pr show -t 544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/544.diff">https://git.openjdk.java.net/jdk11u-dev/pull/544.diff</a>

</details>
