### PR TITLE
8246807: Incorrect copyright header in TimeZoneDatePermissionCheck.sh

### DIFF
--- a/test/jdk/java/util/TimeZone/TimeZoneDatePermissionCheck.sh
+++ b/test/jdk/java/util/TimeZone/TimeZoneDatePermissionCheck.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, Red Hat Inc.
+# Copyright (c) 2009, Red Hat, Inc. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Update of the incorrect license header.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246807](https://bugs.openjdk.java.net/browse/JDK-8246807): Incorrect copyright header in TimeZoneDatePermissionCheck.sh ⚠️ Issue is not open.


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to 88c7c265571e3d869fae2b6d4355260a80bef2e0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/546/head:pull/546` \
`$ git checkout pull/546`

Update a local copy of the PR: \
`$ git checkout pull/546` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 546`

View PR using the GUI difftool: \
`$ git pr show -t 546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/546.diff">https://git.openjdk.java.net/jdk11u-dev/pull/546.diff</a>

</details>
