### PR TITLE
8220575: Correctly format test URI's that contain a retrieved IPv6 address

### DIFF
--- a/test/jdk/com/sun/net/httpserver/TestLogging.java
+++ b/test/jdk/com/sun/net/httpserver/TestLogging.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 6422914
+ * @library /test/lib
  * @summary change httpserver exception printouts
  */
 
@@ -37,6 +38,7 @@ import java.net.*;
 import java.security.*;
 import java.security.cert.*;
 import javax.net.ssl.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class TestLogging extends Test {
 
@@ -63,13 +65,25 @@ public class TestLogging extends Test {
 
             int p1 = s1.getAddress().getPort();
 
-            URL url = new URL ("http://127.0.0.1:"+p1+"/test1/smallfile.txt");
+            URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(p1)
+                .path("/test1/smallfile.txt")
+                .toURLUnchecked();
+            System.out.println("URL: " + url);
             HttpURLConnection urlc = (HttpURLConnection)url.openConnection();
             InputStream is = urlc.getInputStream();
             while (is.read() != -1) ;
             is.close();
 
-            url = new URL ("http://127.0.0.1:"+p1+"/test1/doesntexist.txt");
+            url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(p1)
+                .path("/test1/doesntexist.txt")
+                .toURLUnchecked();
+            System.out.println("URL: " + url);
             urlc = (HttpURLConnection)url.openConnection();
             try {
                 is = urlc.getInputStream();

--- a/test/jdk/com/sun/net/httpserver/bugs/6725892/Test.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/6725892/Test.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 6725892
+ * @library /test/lib
  * @run main/othervm -Dsun.net.httpserver.maxReqTime=2 Test
  * @summary
  */
@@ -35,6 +36,8 @@ import java.util.logging.*;
 import java.io.*;
 import java.net.*;
 import javax.net.ssl.*;
+
+import jdk.test.lib.net.URIBuilder;
 
 public class Test {
 
@@ -76,7 +79,13 @@ public class Test {
 
             port = s1.getAddress().getPort();
             System.out.println ("Server on port " + port);
-            url = new URL ("http://127.0.0.1:"+port+"/foo");
+            url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(port)
+                .path("/foo")
+                .toURLUnchecked();
+            System.out.println("URL: " + url);
             test1();
             test2();
             test3();

--- a/test/jdk/com/sun/net/httpserver/bugs/B6373555.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6373555.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 6373555
+ * @library /test/lib
  * @summary HTTP Server failing to answer client requests
  */
 
@@ -32,6 +33,7 @@ import java.io.*;
 import java.util.*;
 import com.sun.net.httpserver.*;
 import java.util.concurrent.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class B6373555 {
 
@@ -96,7 +98,13 @@ public class B6373555 {
             try {
                 Thread.sleep(10);
                 byte[] buf = getBuf();
-                URL url = new URL("http://127.0.0.1:"+port+"/test");
+                URL url = URIBuilder.newBuilder()
+                    .scheme("http")
+                    .loopback()
+                    .port(port)
+                    .path("/test")
+                    .toURLUnchecked();
+                System.out.println("URL: " + url);
                 HttpURLConnection con = (HttpURLConnection)url.openConnection();
                 con.setDoOutput(true);
                 con.setDoInput(true);

--- a/test/jdk/com/sun/net/httpserver/bugs/B6401598.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6401598.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @library /test/lib
  * @bug 6401598
  * @summary  new HttpServer cannot serve binary stream data
  */
@@ -31,8 +32,11 @@ import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.*;
+
+import jdk.test.lib.net.URIBuilder;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -90,7 +94,14 @@ public class B6401598 {
                         short counter;
 
                         for (counter = 0; counter < 1000; counter++) {
-                                HttpURLConnection connection = getHttpURLConnection(new URL("http://127.0.0.1:"+port+"/server/"), 10000);
+                                URL url = URIBuilder.newBuilder()
+                                    .scheme("http")
+                                    .loopback()
+                                    .port(port)
+                                    .path("/server/")
+                                    .toURLUnchecked();
+                                System.out.println("URL: " + url);
+                                HttpURLConnection connection = getHttpURLConnection(url, 10000);
 
                                 OutputStream os = connection.getOutputStream();
 

--- a/test/jdk/java/net/HttpCookie/ExpiredCookieTest.java
+++ b/test/jdk/java/net/HttpCookie/ExpiredCookieTest.java
@@ -24,12 +24,14 @@
 /*
  * @test
  * @bug 8000525
+ * @library /test/lib
  */
 
 import java.net.*;
 import java.util.*;
 import java.io.*;
 import java.text.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class ExpiredCookieTest {
     // lifted from HttpCookie.java
@@ -81,7 +83,13 @@ public class ExpiredCookieTest {
                 "TEST4=TEST4; Path=/; Expires=" + datestring.toString());
 
             header.put("Set-Cookie", values);
-            cm.put(new URI("http://127.0.0.1/"), header);
+            URI uri = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .path("/")
+                .buildUnchecked();
+            System.out.println("URI: " + uri);
+            cm.put(uri, header);
 
             CookieStore cookieJar =  cm.getCookieStore();
             List <HttpCookie> cookies = cookieJar.getCookies();

--- a/test/jdk/java/net/HttpURLConnection/NoProxyTest.java
+++ b/test/jdk/java/net/HttpURLConnection/NoProxyTest.java
@@ -24,11 +24,13 @@
  /*
  * @test
  * @bug 8144008
+ * @library /test/lib
  * @summary Setting NO_PROXY on HTTP URL connections does not stop proxying
  * @run main/othervm NoProxyTest
  */
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.ProxySelector;
@@ -37,6 +39,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.List;
+import jdk.test.lib.net.URIBuilder;
 
 public class NoProxyTest {
 
@@ -52,7 +55,12 @@ public class NoProxyTest {
     public static void main(String args[]) throws MalformedURLException {
         ProxySelector.setDefault(new NoProxyTestSelector());
 
-        URL url = URI.create("http://127.0.0.1/").toURL();
+        URL url = URIBuilder.newBuilder()
+            .scheme("http")
+            .loopback()
+            .path("/")
+            .toURLUnchecked();
+        System.out.println("URL: " + url);
         URLConnection connection;
         try {
             connection = url.openConnection(Proxy.NO_PROXY);

--- a/test/jdk/java/net/ProxySelector/NullSelector.java
+++ b/test/jdk/java/net/ProxySelector/NullSelector.java
@@ -23,15 +23,22 @@
 
 /* @test
  * @bug 6215885
+ * @library /test/lib
  * @summary URLConnection.openConnection NPE if ProxySelector.setDefault is set to null
  */
 
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class NullSelector {
     public static void main(String[] args) throws Exception {
-        URL url = new URL("http://127.0.0.1/");
+        URL url = URIBuilder.newBuilder()
+            .scheme("http")
+            .loopback()
+            .path("/")
+            .toURLUnchecked();
+        System.out.println("URL: " + url);
         ProxySelector.setDefault(null);
         URLConnection con = url.openConnection();
         con.setConnectTimeout(500);

--- a/test/jdk/java/net/URLClassLoader/closetest/CloseTest.java
+++ b/test/jdk/java/net/URLClassLoader/closetest/CloseTest.java
@@ -50,6 +50,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import jdk.test.lib.compiler.CompilerUtils;
+import jdk.test.lib.net.URIBuilder;
 import jdk.test.lib.util.JarUtils;
 
 import com.sun.net.httpserver.HttpContext;
@@ -158,8 +159,12 @@ public class CloseTest extends Common {
 
     static URL getServerURL() throws Exception {
         int port = httpServer.getAddress().getPort();
-        String s = "http://127.0.0.1:" + port + "/";
-        return new URL(s);
+        return URIBuilder.newBuilder()
+            .scheme("http")
+            .loopback()
+            .port(port)
+            .path("/")
+            .toURL();
     }
 
     static void startHttpServer(String docroot) throws Exception {

--- a/test/jdk/java/net/URLConnection/TimeoutTest.java
+++ b/test/jdk/java/net/URLConnection/TimeoutTest.java
@@ -24,12 +24,14 @@
 /*
  * @test
  * @bug 4389976
+ * @library /test/lib
  * @summary    can't unblock read() of InputStream from URL connection
  * @run main/timeout=40/othervm -Dsun.net.client.defaultReadTimeout=2000 TimeoutTest
  */
 
 import java.io.*;
 import java.net.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class TimeoutTest {
 
@@ -68,7 +70,12 @@ public class TimeoutTest {
         ServerSocket ss = new ServerSocket(0);
         Server s = new Server (ss);
         try{
-            URL url = new URL ("http://127.0.0.1:"+ss.getLocalPort());
+            URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(ss.getLocalPort())
+                .toURL();
+            System.out.println("URL: " + url);
             URLConnection urlc = url.openConnection ();
             InputStream is = urlc.getInputStream ();
             throw new RuntimeException("Should have received timeout");

--- a/test/jdk/java/net/URLPermission/OpenURL.java
+++ b/test/jdk/java/net/URLPermission/OpenURL.java
@@ -24,11 +24,13 @@
 /*
  * @test
  * @bug 8029354
+ * @library /test/lib
  * @run main/othervm OpenURL
  */
 
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class OpenURL {
 
@@ -37,7 +39,13 @@ public class OpenURL {
         System.setSecurityManager(new SecurityManager());
 
         try {
-            URL url = new URL ("http://joe@127.0.0.1/a/b");
+            URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .userInfo("joe")
+                .loopback()
+                .path("/a/b")
+                .toURL();
+            System.out.println("URL: " + url);
             HttpURLConnection urlc = (HttpURLConnection)url.openConnection();
             InputStream is = urlc.getInputStream();
             // error will throw exception other than SecurityException

--- a/test/jdk/java/net/httpclient/LargeResponseContent.java
+++ b/test/jdk/java/net/httpclient/LargeResponseContent.java
@@ -39,10 +39,12 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Flow;
+import jdk.test.lib.net.URIBuilder;
 
 /**
  * @test
  * @bug 8212926
+ * @library /test/lib
  * @summary Basic tests for response timeouts
  * @run main/othervm LargeResponseContent
  */
@@ -60,7 +62,13 @@ public class LargeResponseContent {
     }
 
     void runClient() throws IOException, InterruptedException {
-        URI uri = URI.create("http://127.0.0.1:" + Integer.toString(port) + "/foo");
+        URI uri = URIBuilder.newBuilder()
+            .scheme("http")
+            .loopback()
+            .port(port)
+            .path("/foo")
+            .buildUnchecked();
+        System.out.println("URI: " + uri);
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder(uri)
                 .GET()

--- a/test/jdk/sun/net/www/http/KeepAliveCache/KeepAliveTimerThread.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/KeepAliveTimerThread.java
@@ -23,24 +23,26 @@
 
 /*
  * @test
+ * @library /test/lib
  * @bug 4701299
  * @summary Keep-Alive-Timer thread management in KeepAliveCache causes memory leak
  */
+
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class KeepAliveTimerThread {
     static class Fetcher implements Runnable {
-        String url;
+        URL url;
 
-        Fetcher(String url) {
+        Fetcher(URL url) {
             this.url = url;
         }
 
         public void run() {
             try {
-                InputStream in =
-                    (new URL(url)).openConnection().getInputStream();
+                InputStream in = url.openConnection().getInputStream();
                 byte b[] = new byte[128];
                 int n;
                 do {
@@ -105,7 +107,12 @@ public class KeepAliveTimerThread {
         Server s = new Server (ss);
         s.start();
 
-        String url = "http://127.0.0.1:"+ss.getLocalPort();
+        URL url = URIBuilder.newBuilder()
+            .scheme("http")
+            .loopback()
+            .port(ss.getLocalPort())
+            .toURL();
+        System.out.println("URL: " + url);
 
         // start fetch in its own thread group
         ThreadGroup grp = new ThreadGroup("MyGroup");

--- a/test/jdk/sun/net/www/protocol/http/6550798/test.java
+++ b/test/jdk/sun/net/www/protocol/http/6550798/test.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 6550798
+ * @library /test/lib
  * @summary Using InputStream.skip with ResponseCache will cause partial data to be cached
  * @modules jdk.httpserver
  * @run main/othervm test
@@ -32,6 +33,8 @@
 import java.net.*;
 import com.sun.net.httpserver.*;
 import java.io.*;
+
+import jdk.test.lib.net.URIBuilder;
 
 public class test {
 
@@ -58,7 +61,13 @@ public class test {
         s.start();
 
         System.out.println("http request with cache hander");
-        URL u = new URL("http://127.0.0.1:"+s.getAddress().getPort()+"/f");
+        URL u = URIBuilder.newBuilder()
+            .scheme("http")
+            .loopback()
+            .port(s.getAddress().getPort())
+            .path("/f")
+            .toURL();
+        System.out.println("URL: " + u);
         URLConnection conn = u.openConnection();
 
         InputStream is = null;

--- a/test/jdk/sun/net/www/protocol/http/B6890349.java
+++ b/test/jdk/sun/net/www/protocol/http/B6890349.java
@@ -39,7 +39,11 @@ public class B6890349 extends Thread {
             System.out.println ("listening on "  + port);
             B6890349 t = new B6890349 (server);
             t.start();
-            URL u = new URL ("http://127.0.0.1:"+port+"/foo\nbar");
+            URL u = new URL("http",
+                InetAddress.getLoopbackAddress().getHostAddress(),
+                port,
+                "/foo\nbar");
+            System.out.println("URL: " + u);
             HttpURLConnection urlc = (HttpURLConnection)u.openConnection ();
             InputStream is = urlc.getInputStream();
             throw new RuntimeException ("Test failed");

--- a/test/jdk/sun/net/www/protocol/http/B8012625.java
+++ b/test/jdk/sun/net/www/protocol/http/B8012625.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8012625
+ * @library /test/lib
  * @modules jdk.httpserver
  * @run main B8012625
  */
@@ -34,6 +35,9 @@ import java.io.*;
 import java.net.*;
 import java.io.*;
 import java.util.concurrent.*;
+
+import jdk.test.lib.net.URIBuilder;
+
 import com.sun.net.httpserver.*;
 
 public class B8012625 implements HttpHandler {
@@ -44,8 +48,13 @@ public class B8012625 implements HttpHandler {
     }
 
     public void run() throws Exception {
-        String u = "http://127.0.0.1:" + port + "/foo";
-        URL url = new URL(u);
+        URL url = URIBuilder.newBuilder()
+            .scheme("http")
+            .loopback()
+            .port(port)
+            .path("/foo")
+            .toURL();
+        System.out.println("URL: " + url);
         HttpURLConnection uc = (HttpURLConnection)url.openConnection();
         uc.setDoOutput(true);
         uc.setRequestMethod("POST");

--- a/test/jdk/sun/net/www/protocol/http/NoNTLM.java
+++ b/test/jdk/sun/net/www/protocol/http/NoNTLM.java
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 8004502
+ * @library /test/lib
  * @summary Sanity check that NTLM will not be selected by the http protocol
  *    handler when running on a profile that does not support NTLM
  * @modules java.base/sun.net.www
@@ -34,11 +35,13 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.Authenticator;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URL;
+import jdk.test.lib.net.URIBuilder;
 import sun.net.www.MessageHeader;
 
 public class NoNTLM {
@@ -57,7 +60,13 @@ public class NoNTLM {
         private volatile int respCode;
 
         Client(int port) throws IOException {
-            this.url = new URL("http://127.0.0.1:" + port + "/foo.html");
+            this.url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(port)
+                .path("/foo.html")
+                .toURLUnchecked();
+            System.out.println("Client URL: " + this.url);
         }
 
         public void run() {

--- a/test/jdk/sun/net/www/protocol/http/RedirectOnPost.java
+++ b/test/jdk/sun/net/www/protocol/http/RedirectOnPost.java
@@ -39,6 +39,7 @@ import com.sun.net.httpserver.*;
 import java.util.concurrent.*;
 import javax.net.ssl.*;
 import jdk.testlibrary.SimpleSSLContext;
+import jdk.test.lib.net.URIBuilder;
 
 public class RedirectOnPost {
 
@@ -55,8 +56,8 @@ public class RedirectOnPost {
             int sslPort = httpsServer.getAddress().getPort();
             httpServer.start();
             httpsServer.start();
-            runTest("http://127.0.0.1:"+port+"/test/", null);
-            runTest("https://127.0.0.1:"+sslPort+"/test/", ctx);
+            runTest("http", port, null);
+            runTest("https", sslPort, ctx);
             System.out.println("Main thread waiting");
         } finally {
             httpServer.stop(0);
@@ -65,10 +66,17 @@ public class RedirectOnPost {
         }
     }
 
-    public static void runTest(String baseURL, SSLContext ctx) throws Exception
+    public static void runTest(String scheme, int port, SSLContext ctx) throws Exception
     {
         byte[] buf = "Hello world".getBytes();
-        URL url = new URL(baseURL + "a");
+
+        URL url = URIBuilder.newBuilder()
+            .scheme(scheme)
+            .loopback()
+            .port(port)
+            .path("/test/a")
+            .toURL();
+        System.out.println("URL: " + url);
         HttpURLConnection con = (HttpURLConnection)url.openConnection();
         if (con instanceof HttpsURLConnection) {
             HttpsURLConnection ssl = (HttpsURLConnection)con;
@@ -107,10 +115,12 @@ public class RedirectOnPost {
 
     static class Handler implements HttpHandler {
 
-        String baseURL;
+        String scheme;
+        int port;
 
-        Handler(String baseURL) {
-            this.baseURL = baseURL;
+        Handler(String scheme, int port) {
+          this.scheme = scheme;
+          this.port = port;
         }
 
         int calls = 0;
@@ -118,6 +128,12 @@ public class RedirectOnPost {
         public void handle(HttpExchange msg) {
             try {
                 String method = msg.getRequestMethod();
+                URL baseURL = URIBuilder.newBuilder()
+                    .scheme(scheme)
+                    .loopback()
+                    .path("/test/b")
+                    .port(port)
+                    .toURLUnchecked();
                 System.out.println ("Server: " + baseURL);
                 if (calls++ == 0) {
                     System.out.println ("Server: redirecting");
@@ -125,7 +141,7 @@ public class RedirectOnPost {
                     byte[] buf = readFully(is);
                     is.close();
                     Headers h = msg.getResponseHeaders();
-                    h.add("Location", baseURL + "b");
+                    h.add("Location", baseURL.toString());
                     msg.sendResponseHeaders(302, -1);
                     msg.close();
                 } else {
@@ -153,9 +169,9 @@ public class RedirectOnPost {
         HttpServer testServer = HttpServer.create(inetAddress, 15);
         int port = testServer.getAddress().getPort();
         testServer.setExecutor(execs);
-        String base = "http://127.0.0.1:"+port+"/test";
+
         HttpContext context = testServer.createContext("/test");
-        context.setHandler(new Handler(base));
+        context.setHandler(new Handler("http", port));
         return testServer;
     }
 
@@ -169,9 +185,9 @@ public class RedirectOnPost {
         int port = testServer.getAddress().getPort();
         testServer.setExecutor(execs);
         testServer.setHttpsConfigurator(new HttpsConfigurator (ctx));
-        String base = "https://127.0.0.1:"+port+"/test";
+
         HttpContext context = testServer.createContext("/test");
-        context.setHandler(new Handler(base));
+        context.setHandler(new Handler("https", port));
         return testServer;
     }
 }

--- a/test/jdk/sun/net/www/protocol/http/ResponseCacheStream.java
+++ b/test/jdk/sun/net/www/protocol/http/ResponseCacheStream.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 6262486
+ * @library /test/lib
  * @modules java.base/sun.net.www
  * @library ../../httptest/
  * @build HttpCallback TestHttpServer ClosedChannelList HttpTransaction
@@ -34,6 +35,7 @@
 import java.net.*;
 import java.io.*;
 import java.util.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class ResponseCacheStream implements HttpCallback {
 
@@ -100,7 +102,12 @@ public class ResponseCacheStream implements HttpCallback {
             ResponseCache.setDefault(cache);
             server = new TestHttpServer (new ResponseCacheStream());
             System.out.println ("Server: listening on port: " + server.getLocalPort());
-            URL url = new URL ("http://127.0.0.1:"+server.getLocalPort()+"/");
+            URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(server.getLocalPort())
+                .path("/")
+                .toURL();
             System.out.println ("Client: connecting to " + url);
             HttpURLConnection urlc = (HttpURLConnection)url.openConnection();
             InputStream is = urlc.getInputStream();

--- a/test/jdk/sun/net/www/protocol/http/RetryUponTimeout.java
+++ b/test/jdk/sun/net/www/protocol/http/RetryUponTimeout.java
@@ -24,12 +24,14 @@
 /**
  * @test
  * @bug 4772077
+ * @library /test/lib
  * @summary  using defaultReadTimeout appear to retry request upon timeout
  * @modules java.base/sun.net.www
  */
 
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.URIBuilder;
 import sun.net.www.*;
 
 public class RetryUponTimeout implements Runnable {
@@ -63,7 +65,12 @@ public class RetryUponTimeout implements Runnable {
             int port = server.getLocalPort ();
             new Thread(new RetryUponTimeout()).start ();
 
-            URL url = new URL("http://127.0.0.1:"+port);
+            URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(port)
+                .toURL();
+            System.out.println("URL: " + url);
             java.net.URLConnection uc = url.openConnection();
             uc.setReadTimeout(1000);
             uc.getInputStream();

--- a/test/jdk/sun/net/www/protocol/http/SetChunkedStreamingMode.java
+++ b/test/jdk/sun/net/www/protocol/http/SetChunkedStreamingMode.java
@@ -26,6 +26,7 @@
  * @bug 5049976
  * @modules java.base/sun.net.www
  * @library ../../httptest/
+ * @library /test/lib
  * @build HttpCallback TestHttpServer ClosedChannelList HttpTransaction
  * @run main SetChunkedStreamingMode
  * @summary Unspecified NPE is thrown when streaming output mode is enabled
@@ -33,6 +34,7 @@
 
 import java.io.*;
 import java.net.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class SetChunkedStreamingMode implements HttpCallback {
 
@@ -67,7 +69,12 @@ public class SetChunkedStreamingMode implements HttpCallback {
         try {
             server = new TestHttpServer (new SetChunkedStreamingMode(), 1, 10, 0);
             System.out.println ("Server: listening on port: " + server.getLocalPort());
-            URL url = new URL ("http://127.0.0.1:"+server.getLocalPort()+"/");
+            URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(server.getLocalPort())
+                .path("/")
+                .toURL();
             System.out.println ("Client: connecting to " + url);
             HttpURLConnection urlc = (HttpURLConnection)url.openConnection();
             urlc.setChunkedStreamingMode (0);

--- a/test/jdk/sun/net/www/protocol/http/UserAgent.java
+++ b/test/jdk/sun/net/www/protocol/http/UserAgent.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 4512200
+ * @library /test/lib
  * @modules java.base/sun.net.www
  * @run main/othervm -Dhttp.agent=foo UserAgent
  * @summary  HTTP header "User-Agent" format incorrect
@@ -32,6 +33,7 @@
 import java.io.*;
 import java.util.*;
 import java.net.*;
+import jdk.test.lib.net.URIBuilder;
 import sun.net.www.MessageHeader;
 
 class Server extends Thread {
@@ -89,7 +91,12 @@ public class UserAgent {
         Server s = new Server (server);
         s.start ();
         int port = server.getLocalPort ();
-        URL url = new URL ("http://127.0.0.1:"+port);
+        URL url = URIBuilder.newBuilder()
+            .scheme("http")
+            .loopback()
+            .port(port)
+            .toURL();
+        System.out.println("URL: " + url);
         URLConnection urlc = url.openConnection ();
         urlc.getInputStream ();
         s.join ();

--- a/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/IPAddressDNSIdentities.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/IPAddressDNSIdentities.java
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 6766775
+ * @library /test/lib
  * @summary X509 certificate hostname checking is broken in JDK1.6.0_10
  * @run main/othervm IPAddressDNSIdentities
  *
@@ -42,6 +43,7 @@ import java.security.cert.CertificateFactory;
 import java.security.spec.*;
 import java.security.interfaces.*;
 import java.math.BigInteger;
+import jdk.test.lib.net.URIBuilder;
 
 /*
  * Certificates and key used in the test.
@@ -710,7 +712,12 @@ public class IPAddressDNSIdentities {
             HttpsURLConnection http = null;
 
             /* establish http connection to server */
-            URL url = new URL("https://127.0.0.1:" + serverPort+"/");
+            URL url = URIBuilder.newBuilder()
+                .scheme("https")
+                .loopback()
+                .port(serverPort)
+                .path("/")
+                .toURL();
             System.out.println("url is "+url.toString());
 
             try {

--- a/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/IPAddressIPIdentities.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/IPAddressIPIdentities.java
@@ -28,6 +28,7 @@
 
 /* @test
  * @summary X509 certificate hostname checking is broken in JDK1.6.0_10
+ * @library /test/lib
  * @bug 6766775
  * @run main/othervm IPAddressIPIdentities
  * @author Xuelei Fan
@@ -45,6 +46,7 @@ import java.security.cert.CertificateFactory;
 import java.security.spec.*;
 import java.security.interfaces.*;
 import java.math.BigInteger;
+import jdk.test.lib.net.URIBuilder;
 
 /*
  * Certificates and key used in the test.
@@ -714,7 +716,12 @@ public class IPAddressIPIdentities {
             HttpsURLConnection http = null;
 
             /* establish http connection to server */
-            URL url = new URL("https://127.0.0.1:" + serverPort+"/");
+            URL url = URIBuilder.newBuilder()
+                .scheme("https")
+                .loopback()
+                .port(serverPort)
+                .path("/")
+                .toURL();
             System.out.println("url is "+url.toString());
 
             try {


### PR DESCRIPTION
Backport of JDK-8220575.
/net/httpclient/AuthSchemesTest.java does not exist in 11u
test/jdk/sun/net/www/protocol/http/RedirectOnPost.java needed trivial resolving.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8220575](https://bugs.openjdk.java.net/browse/JDK-8220575): Correctly format test URI's that contain a retrieved IPv6 address


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/547/head:pull/547` \
`$ git checkout pull/547`

Update a local copy of the PR: \
`$ git checkout pull/547` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 547`

View PR using the GUI difftool: \
`$ git pr show -t 547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/547.diff">https://git.openjdk.java.net/jdk11u-dev/pull/547.diff</a>

</details>
