### PR TITLE
8233555: [TESTBUG] JRadioButton tests failing on MacoS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -772,9 +772,6 @@ javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java 233570 macosx-all
 javax/swing/text/GlyphPainter2/6427244/bug6427244.java 8208566 macosx-all
 javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java 8233635 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
-javax/swing/JRadioButton/ButtonGroupFocus/ButtonGroupFocusTest.java 8233555 macosx-all
-javax/swing/JRadioButton/8075609/bug8075609.java 8233555 macosx-all
-javax/swing/JRadioButton/8033699/bug8033699.java 8233555 macosx-all
 javax/swing/JPopupMenu/6827786/bug6827786.java 8233556 macosx-all
 javax/swing/JPopupMenu/6544309/bug6544309.java 8233556 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8233556 macosx-all


### PR DESCRIPTION
Backport of JDK-8233555. Enables 3 tests by removing them from ProblemList.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233555](https://bugs.openjdk.java.net/browse/JDK-8233555): [TESTBUG] JRadioButton tests failing on MacoS


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/549/head:pull/549` \
`$ git checkout pull/549`

Update a local copy of the PR: \
`$ git checkout pull/549` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 549`

View PR using the GUI difftool: \
`$ git pr show -t 549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/549.diff">https://git.openjdk.java.net/jdk11u-dev/pull/549.diff</a>

</details>
