### PR TITLE
8233567: [TESTBUG] FocusSubRequestTest.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -495,7 +495,6 @@ java/awt/Window/WindowOwnedByEmbeddedFrameTest/WindowOwnedByEmbeddedFrameTest.ja
 java/awt/Modal/NullModalityDialogTest/NullModalityDialogTest.java 8233565 macosx-all
 java/awt/keyboard/AllKeyCode/AllKeyCode.java 8242930 macosx-all
 java/awt/FullScreen/8013581/bug8013581.java 8169471 macosx-all
-java/awt/Focus/FocusSubRequestTest/FocusSubRequestTest.java 8233567 macosx-all
 java/awt/event/MouseEvent/RobotLWTest/RobotLWTest.java 8233568 macosx-all
 java/awt/event/MouseEvent/MultipleMouseButtonsTest/MultipleMouseButtonsTest.java 8233568 macosx-all
 java/awt/event/MouseEvent/ClickDuringKeypress/ClickDuringKeypress.java 8233568 macosx-all

--- a/test/jdk/java/awt/Focus/FocusSubRequestTest/FocusSubRequestTest.java
+++ b/test/jdk/java/awt/Focus/FocusSubRequestTest/FocusSubRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,7 @@ public class FocusSubRequestTest {
 
         try {
             robot = new Robot();
+            robot.setAutoDelay(100);
         } catch(Exception e) {
             throw new RuntimeException("Error: unable to create robot", e);
         }
@@ -77,7 +78,6 @@ public class FocusSubRequestTest {
 
         robot.delay(100);
         robot.keyPress(KeyEvent.VK_K);
-        robot.delay(100);
         robot.keyRelease(KeyEvent.VK_K);
 
         robot.waitForIdle();
@@ -90,14 +90,16 @@ public class FocusSubRequestTest {
     }
 
     private void waitTillShown(Component component) {
-        while (true) {
+        Point p = null;
+        while (p == null) {
             try {
-                Thread.sleep(100);
-                component.getLocationOnScreen();
-                break;
-            } catch(InterruptedException ie) {
-                throw new RuntimeException(ie);
-            } catch(IllegalComponentStateException icse) {}
+                p = component.getLocationOnScreen();
+            } catch (IllegalStateException e) {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException ie) {
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Clean backport of JDK-8233567.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233567](https://bugs.openjdk.java.net/browse/JDK-8233567): [TESTBUG] FocusSubRequestTest.java fails on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/551/head:pull/551` \
`$ git checkout pull/551`

Update a local copy of the PR: \
`$ git checkout pull/551` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 551`

View PR using the GUI difftool: \
`$ git pr show -t 551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/551.diff">https://git.openjdk.java.net/jdk11u-dev/pull/551.diff</a>

</details>
