### PR TITLE
8275713: TestDockerMemoryMetrics test fails on recent runc

### DIFF
--- a/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
+++ b/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
@@ -25,6 +25,9 @@ import java.util.Arrays;
 import jdk.internal.platform.Metrics;
 
 public class MetricsMemoryTester {
+
+    private static final long UNLIMITED = -1;
+
     public static void main(String[] args) {
         System.out.println(Arrays.toString(args));
         switch (args[0]) {
@@ -109,7 +112,10 @@ public class MetricsMemoryTester {
     private static void testKernelMemoryLimit(String value) {
         long limit = getMemoryValue(value);
         long kmemlimit = Metrics.systemMetrics().getKernelMemoryLimit();
-        if (kmemlimit != 0 && limit != kmemlimit) {
+        // Note that the kernel memory limit might get ignored by OCI runtimes
+        // This feature is deprecated. Only perform the check if we get an actual
+        // limit back.
+        if (kmemlimit != UNLIMITED && limit != kmemlimit) {
             throw new RuntimeException("Kernel Memory limit not equal, expected : ["
                     + limit + "]" + ", got : ["
                     + kmemlimit + "]");


### PR DESCRIPTION
Please review this test bug which only affects JDK less than 15. Kernel memory tracking is deprecated. In head I'll follow up with a bug that'll remove that code entirely as it's pretty useless at this point.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275713](https://bugs.openjdk.java.net/browse/JDK-8275713): TestDockerMemoryMetrics test fails on recent runc


### Reviewers
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/552/head:pull/552` \
`$ git checkout pull/552`

Update a local copy of the PR: \
`$ git checkout pull/552` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 552`

View PR using the GUI difftool: \
`$ git pr show -t 552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/552.diff">https://git.openjdk.java.net/jdk11u-dev/pull/552.diff</a>

</details>
