### PR TITLE
8198623: java/awt/KeyboardFocusmanager/TypeAhead/EnqueueWithDialogButtonTest/EnqueueWithDialogButtonTest.java fails on mac

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -147,8 +147,6 @@ java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java 8144030 macosx-all
 java/awt/Frame/UnfocusableMaximizedFrameResizablity/UnfocusableMaximizedFrameResizablity.java 8208290 macosx-all
 java/awt/grab/EmbeddedFrameTest1/EmbeddedFrameTest1.java 7080150 macosx-all
 java/awt/event/InputEvent/EventWhenTest/EventWhenTest.java 8168646 generic-all
-java/awt/KeyboardFocusmanager/TypeAhead/EnqueueWithDialogButtonTest/EnqueueWithDialogButtonTest.java 8198623 macosx-all
-java/awt/KeyboardFocusmanager/TypeAhead/FreezeTest/FreezeTest.java 8198623 macosx-all
 java/awt/KeyboardFocusmanager/TypeAhead/TestDialogTypeAhead.java 8198626 macosx-all
 java/awt/Mixing/AWT_Mixing/HierarchyBoundsListenerMixingTest.java 8049405 macosx-all
 java/awt/Mixing/AWT_Mixing/OpaqueOverlappingChoice.java 8048171 generic-all

--- a/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/EnqueueWithDialogButtonTest/EnqueueWithDialogButtonTest.java
+++ b/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/EnqueueWithDialogButtonTest/EnqueueWithDialogButtonTest.java
@@ -30,12 +30,6 @@
  * @run main EnqueueWithDialogButtonTest
  */
 
-import java.awt.*;
-import java.lang.reflect.InvocationTargetException;
-import java.awt.event.*;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 /*
  * Tests that type-ahead works correctly. That means
  * that the key events are not delivered until a focus
@@ -44,6 +38,29 @@ import java.util.concurrent.TimeUnit;
  * written in time before 6347235 resolution. We'll keep it
  * to track quite unrelated suspicious waitForIdle behavior.
  */
+
+import java.awt.AWTEvent;
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.AWTEventListener;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class EnqueueWithDialogButtonTest
 {
@@ -55,11 +72,22 @@ public class EnqueueWithDialogButtonTest
     static CountDownLatch robotLatch = new CountDownLatch(1);
     static volatile boolean gotFocus = false;
     static Robot robot;
+
     public static void main(String args[]) throws Exception {
         EnqueueWithDialogButtonTest test = new EnqueueWithDialogButtonTest();
-        test.init();
-        test.start();
+        try {
+            test.init();
+            test.start();
+        } finally {
+            if (d != null) {
+                d.dispose();
+            }
+            if (f != null) {
+                f.dispose();
+            }
+        }
     }
+
     public void init()
     {
         Toolkit.getDefaultToolkit().addAWTEventListener(new AWTEventListener() {

--- a/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/FreezeTest/FreezeTest.java
+++ b/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/FreezeTest/FreezeTest.java
@@ -29,15 +29,32 @@
  * @run main FreezeTest
  */
 
-import java.awt.*;
-import java.lang.reflect.InvocationTargetException;
-import java.awt.event.*;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 /*
  * Tests that type-ahead doesn't block program.
  */
+
+import java.awt.AWTEvent;
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextField;
+import java.awt.Toolkit;
+import java.awt.event.AWTEventListener;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class FreezeTest
 {
@@ -52,9 +69,19 @@ public class FreezeTest
 
     public static void main(String args[]) throws Exception {
         FreezeTest test = new FreezeTest();
-        test.init();
-        test.start();
+        try {
+            test.init();
+            test.start();
+        } finally {
+            if (d != null) {
+                d.dispose();
+            }
+            if (f != null) {
+                f.dispose();
+            }
+        }
     }
+
     public void init()
     {
         Toolkit.getDefaultToolkit().addAWTEventListener(new AWTEventListener() {


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8198623 from the openjdk/jdk repository.

The commit being backported was authored by Pankaj Bansal on 22 Jun 2020 and was reviewed by Jayathirth D V.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8198623](https://bugs.openjdk.java.net/browse/JDK-8198623): java/awt/KeyboardFocusmanager/TypeAhead/EnqueueWithDialogButtonTest/EnqueueWithDialogButtonTest.java fails on mac


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/554/head:pull/554` \
`$ git checkout pull/554`

Update a local copy of the PR: \
`$ git checkout pull/554` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 554`

View PR using the GUI difftool: \
`$ git pr show -t 554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/554.diff">https://git.openjdk.java.net/jdk11u-dev/pull/554.diff</a>

</details>
