### PR TITLE
8131745: java/lang/management/ThreadMXBean/AllThreadIds.java still fails intermittently

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -536,8 +536,6 @@ java/lang/instrument/BootClassPath/BootClassPathTest.sh         8072130 macosx-a
 java/lang/management/MemoryMXBean/Pending.java                  8158837 generic-all
 java/lang/management/MemoryMXBean/PendingAllGC.sh               8158837 generic-all
 
-java/lang/management/ThreadMXBean/AllThreadIds.java             8131745 generic-all
-
 ############################################################################
 
 # jdk_io


### PR DESCRIPTION
Backport of JDK-8131745: java/lang/management/ThreadMXBean/AllThreadIds.java still fails intermittently

Merely clean, I only had to resolve ProblemList.txt.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8131745](https://bugs.openjdk.java.net/browse/JDK-8131745): java/lang/management/ThreadMXBean/AllThreadIds.java still fails intermittently


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/556/head:pull/556` \
`$ git checkout pull/556`

Update a local copy of the PR: \
`$ git checkout pull/556` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 556`

View PR using the GUI difftool: \
`$ git pr show -t 556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/556.diff">https://git.openjdk.java.net/jdk11u-dev/pull/556.diff</a>

</details>
