### PR TITLE
8249195: Change to Xcode 11.3.1 for building on Macos at Oracle

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -854,7 +854,7 @@ var getJibProfilesDependencies = function (input, common) {
 
     var devkit_platform_revisions = {
         linux_x64: "gcc7.3.0-OEL6.4+1.1",
-        macosx_x64: "Xcode10.1-MacOSX10.14+1.0",
+        macosx_x64: "Xcode11.3.1-MacOSX10.15+1.0",
         solaris_x64: "SS12u4-Solaris11u1+1.0",
         solaris_sparcv9: "SS12u4-Solaris11u1+1.1",
         windows_x64: "VS2017-15.9.16+1.0",

--- a/make/devkit/createMacosxDevkit.sh
+++ b/make/devkit/createMacosxDevkit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -63,45 +63,42 @@ mkdir -p $DEVKIT_ROOT
 ################################################################################
 # Copy the relevant parts of Xcode.app, removing things that are both big and
 # unecessary for our purposes, without building an impossibly long exclude list.
-#
-# Not including WatchSimulator.platform makes ibtool crashes in some situations.
-# It doesn't seem to matter which extra platform is included, but that is the
-# smallest one.
-
 EXCLUDE_DIRS=" \
     Contents/_CodeSignature \
-    $XCODE_APP_DIR_NAME/Contents/Applications \
-    $XCODE_APP_DIR_NAME/Contents/Resources \
-    $XCODE_APP_DIR_NAME/Contents/Library \
-    $XCODE_APP_DIR_NAME/Contents/XPCServices \
-    $XCODE_APP_DIR_NAME/Contents/OtherFrameworks \
-    $XCODE_APP_DIR_NAME/Contents/Developer/Documentation \
-    $XCODE_APP_DIR_NAME/Contents/Developer/usr/share \
-    $XCODE_APP_DIR_NAME/Contents/Developer/usr/libexec/git-core \
-    $XCODE_APP_DIR_NAME/Contents/Developer/usr/bin/git* \
-    $XCODE_APP_DIR_NAME/Contents/Developer/usr/bin/svn* \
-    $XCODE_APP_DIR_NAME/Contents/Developer/usr/lib/libgit* \
-    $XCODE_APP_DIR_NAME/Contents/Developer/usr/lib/libsvn* \
-    $XCODE_APP_DIR_NAME/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/share/man \
-    $XCODE_APP_DIR_NAME/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/${SDK_VERSION}.sdk/usr/share/man \
-    $XCODE_APP_DIR_NAME/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/share/man \
-    $XCODE_APP_DIR_NAME/Contents/Developer/Platforms/MacOSX.platform/usr \
-    $XCODE_APP_DIR_NAME/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man \
-    $XCODE_APP_DIR_NAME/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift* \
-    $XCODE_APP_DIR_NAME/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift* \
-    $XCODE_APP_DIR_NAME/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/sourcekitd.framework \
-    $XCODE_APP_DIR_NAME/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/libexec/swift* \
-    $XCODE_APP_DIR_NAME/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/swift* \
-    $XCODE_APP_DIR_NAME/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/arc \
+    Contents/Applications \
+    Contents/Resources \
+    Contents/Library \
+    Contents/XPCServices \
+    Contents/OtherFrameworks \
+    Contents/Developer/Documentation \
+    Contents/Developer/usr/share \
+    Contents/Developer/usr/libexec/git-core \
+    Contents/Developer/usr/bin/git* \
+    Contents/Developer/usr/bin/svn* \
+    Contents/Developer/usr/lib/libgit* \
+    Contents/Developer/usr/lib/libsvn* \
+    Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/share/man \
+    Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/${SDK_VERSION}.sdk/usr/share/man \
+    Contents/Developer/Platforms/MacOSX.platform/Developer/usr/share/man \
+    Contents/Developer/Platforms/MacOSX.platform/usr \
+    Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man \
+    Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift* \
+    Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift* \
+    Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/sourcekitd.framework \
+    Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/libexec/swift* \
+    Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/swift* \
+    Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/arc \
     Platforms/AppleTVSimulator.platform \
     Platforms/iPhoneSimulator.platform \
-    $XCODE_APP_DIR_NAME/Contents/SharedFrameworks/LLDB.framework \
-    $XCODE_APP_DIR_NAME/Contents/SharedFrameworks/ModelIO.framework \
-    $XCODE_APP_DIR_NAME/Contents/SharedFrameworks/XCSUI.framework \
-    $XCODE_APP_DIR_NAME/Contents/SharedFrameworks/SceneKit.framework \
-    $XCODE_APP_DIR_NAME/Contents/SharedFrameworks/XCBuild.framework \
-    $XCODE_APP_DIR_NAME/Contents/SharedFrameworks/GPUTools.framework \
-    $(cd $XCODE_APP/.. && ls -d $XCODE_APP_DIR_NAME/Contents/Developer/Platforms/* \
+    Platforms/WatchSimulator.platform \
+    Contents/SharedFrameworks/LLDB.framework \
+    Contents/SharedFrameworks/ModelIO.framework \
+    Contents/SharedFrameworks/XCSUI.framework \
+    Contents/SharedFrameworks/SceneKit.framework \
+    Contents/SharedFrameworks/XCBuild.framework \
+    Contents/SharedFrameworks/GPUTools*.framework \
+    Contents/SharedFrameworks/DNTDocumentationSupport.framework/Versions/A/Resources/external \
+    $(cd $XCODE_APP && ls -d Contents/Developer/Platforms/* \
         | grep -v MacOSX.platform | grep -v WatchSimulator.platform) \
 "
 
@@ -110,8 +107,8 @@ for ex in $EXCLUDE_DIRS; do
 done
 
 echo "Copying Xcode.app..."
-echo rsync -rlH $INCLUDE_ARGS $EXCLUDE_ARGS "$XCODE_APP" $DEVKIT_ROOT/
-rsync -rlH $INCLUDE_ARGS $EXCLUDE_ARGS "$XCODE_APP" $DEVKIT_ROOT/
+echo rsync -rlH $INCLUDE_ARGS $EXCLUDE_ARGS "$XCODE_APP/." $DEVKIT_ROOT/Xcode.app/
+rsync -rlH $INCLUDE_ARGS $EXCLUDE_ARGS "$XCODE_APP/." $DEVKIT_ROOT/Xcode.app/
 
 ################################################################################
 


### PR DESCRIPTION
Backport of JDK-8249195

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8249195](https://bugs.openjdk.java.net/browse/JDK-8249195): Change to Xcode 11.3.1 for building on Macos at Oracle


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to d1ac1b8378f63246b85f1aa3fdb48a1dc716cdd0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/558/head:pull/558` \
`$ git checkout pull/558`

Update a local copy of the PR: \
`$ git checkout pull/558` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 558`

View PR using the GUI difftool: \
`$ git pr show -t 558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/558.diff">https://git.openjdk.java.net/jdk11u-dev/pull/558.diff</a>

</details>
