### PR TITLE
8199529: javax/swing/text/Utilities/8142966/SwingFontMetricsTest.java fails on windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -800,7 +800,6 @@ javax/swing/text/html/parser/Parser/8078268/bug8078268.java 8199092 generic-all
 javax/swing/PopupFactory/8048506/bug8048506.java 8202660 windows-all
 javax/swing/JTextArea/TextViewOOM/TextViewOOM.java 8167355 generic-all
 javax/swing/JEditorPane/8195095/ImageViewTest.java 8202656 windows-all
-javax/swing/text/Utilities/8142966/SwingFontMetricsTest.java 8199529 windows-all
 javax/swing/JPopupMenu/8075063/ContextMenuScrollTest.java 202880 linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all
 javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all

--- a/test/jdk/javax/swing/text/Utilities/8142966/SwingFontMetricsTest.java
+++ b/test/jdk/javax/swing/text/Utilities/8142966/SwingFontMetricsTest.java
@@ -22,6 +22,11 @@
  */
 import java.awt.Font;
 import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import static java.awt.RenderingHints.*;
+import java.awt.Toolkit;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.swing.JFrame;
@@ -31,7 +36,7 @@ import javax.swing.SwingUtilities;
 /**
  * @test
  * @key headful
- * @bug 8142966
+ * @bug 8142966 8199529
  * @summary Wrong cursor position in text components on HiDPI display
  * @run main/othervm -Dsun.java2d.uiScale=2 SwingFontMetricsTest
  */
@@ -42,8 +47,15 @@ public class SwingFontMetricsTest {
     private static final String TEXT = LOWER_CASE_TEXT + UPPER_CASE_TEXT;
     private static boolean passed = false;
     private static CountDownLatch latch = new CountDownLatch(1);
+    private static Object aaHint = null;
 
     public static void main(String[] args) throws Exception {
+        Map map = (Map)Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
+        aaHint = map.get(RenderingHints.KEY_TEXT_ANTIALIASING);
+        if (aaHint == null) {
+            aaHint = VALUE_TEXT_ANTIALIAS_DEFAULT;
+        }
+
         SwingUtilities.invokeAndWait(SwingFontMetricsTest::createAndShowGUI);
         latch.await(5, TimeUnit.SECONDS);
 
@@ -61,7 +73,10 @@ public class SwingFontMetricsTest {
             public void paint(Graphics g) {
                 super.paint(g);
                 Font font = getFont();
+                Graphics2D g2d = (Graphics2D)g;
                 int width1 = getFontMetrics(font).stringWidth(TEXT);
+                // Set the same AA hint that the built-in Swing L&Fs set.
+                g2d.setRenderingHint(KEY_TEXT_ANTIALIASING, aaHint);
                 int width2 = g.getFontMetrics(font).stringWidth(TEXT);
                 passed = (width1 == width2);
                 latch.countDown();


### PR DESCRIPTION
Backport of JDK-8199529. Applies clean, only problem list needed resolving.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8199529](https://bugs.openjdk.java.net/browse/JDK-8199529): javax/swing/text/Utilities/8142966/SwingFontMetricsTest.java fails on windows


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/559/head:pull/559` \
`$ git checkout pull/559`

Update a local copy of the PR: \
`$ git checkout pull/559` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 559`

View PR using the GUI difftool: \
`$ git pr show -t 559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/559.diff">https://git.openjdk.java.net/jdk11u-dev/pull/559.diff</a>

</details>
