### PR TITLE
8233635: [TESTBUG] ProgressMonitorEscapeKeyPress.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -769,7 +769,6 @@ javax/swing/text/View/8014863/bug8014863.java 8233561 macosx-all
 javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233562 macosx-all
 javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java 233570 macosx-all
 javax/swing/text/GlyphPainter2/6427244/bug6427244.java 8208566 macosx-all
-javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java 8233635 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JPopupMenu/6827786/bug6827786.java 8233556 macosx-all
 javax/swing/JPopupMenu/6544309/bug6544309.java 8233556 macosx-all


### PR DESCRIPTION
Backport of JDK-8233635.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233635](https://bugs.openjdk.java.net/browse/JDK-8233635): [TESTBUG] ProgressMonitorEscapeKeyPress.java fails on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/560/head:pull/560` \
`$ git checkout pull/560`

Update a local copy of the PR: \
`$ git checkout pull/560` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 560`

View PR using the GUI difftool: \
`$ git pr show -t 560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/560.diff">https://git.openjdk.java.net/jdk11u-dev/pull/560.diff</a>

</details>
