### PR TITLE
8197811: Test java/awt/Choice/PopupPosTest/PopupPosTest.java fails on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -247,7 +247,6 @@ java/awt/print/PrinterJob/PSQuestionMark.java 7003378 generic-all
 java/awt/print/PrinterJob/GlyphPositions.java 7003378 generic-all
 java/awt/print/PrinterJob/Margins.java 8196301 windows-all,macosx-all
 java/awt/PrintJob/PrinterException.java 8196301 windows-all,macosx-all
-java/awt/Choice/PopupPosTest/PopupPosTest.java 8192930 windows-all
 java/awt/Choice/ChoiceMouseWheelTest/ChoiceMouseWheelTest.java 7100044 macosx-all
 java/awt/Component/GetScreenLocTest/GetScreenLocTest.java 4753654 generic-all
 java/awt/Component/SetEnabledPerformance/SetEnabledPerformance.java 8165863 macosx-all

--- a/test/jdk/java/awt/Choice/PopupPosTest/PopupPosTest.java
+++ b/test/jdk/java/awt/Choice/PopupPosTest/PopupPosTest.java
@@ -27,8 +27,7 @@
   @bug 5044150
   @summary Tests that pupup doesn't popdown if no space to display under
   @author andrei.dmitriev area=awt.choice
-  @library ../../../../lib/testlibrary
-  @build jdk.testlibrary.OSInfo
+  @requires (os.family == "linux")
   @run main PopupPosTest
 */
 
@@ -36,15 +35,9 @@ import java.applet.Applet;
 import java.awt.*;
 import java.awt.event.*;
 
-import jdk.testlibrary.OSInfo;
-
 public class PopupPosTest
 {
     public static void main(final String[] args) {
-        if(OSInfo.getOSType().equals(OSInfo.OSType.MACOSX)) {
-            // On OS X, popup isn't under the mouse
-            return;
-        }
         Frame frame = new TestFrame();
     }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

In 11, the test is problem listed with bug 8192930, but that is a duplicate
of 8197811, so clearing the ProblemList is fine.

The patch for the test had to be adapted because 
in head it uses Platform.java instead of OSInfo.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8197811](https://bugs.openjdk.java.net/browse/JDK-8197811): Test java/awt/Choice/PopupPosTest/PopupPosTest.java fails on Windows


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/561/head:pull/561` \
`$ git checkout pull/561`

Update a local copy of the PR: \
`$ git checkout pull/561` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 561`

View PR using the GUI difftool: \
`$ git pr show -t 561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/561.diff">https://git.openjdk.java.net/jdk11u-dev/pull/561.diff</a>

</details>
