### PR TITLE
8262844: (fs) FileStore.supportsFileAttributeView might return false negative in case of ext3

### DIFF
--- a/src/java.base/linux/classes/sun/nio/fs/LinuxFileStore.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxFileStore.java
@@ -162,12 +162,6 @@ class LinuxFileStore
                 return false;
             }
 
-            // user_{no}xattr options not present but we special-case ext3 as
-            // we know that extended attributes are not enabled by default.
-            if (entry().fstype().equals("ext3")) {
-                return false;
-            }
-
             // user_xattr option not present but we special-case ext4 as we
             // know that extended attributes are enabled by default for
             // kernel version >= 2.6.39
@@ -184,7 +178,7 @@ class LinuxFileStore
                 return xattrEnabled;
             }
 
-            // not ext3/4 so probe mount point
+            // not ext4 so probe mount point
             if (!xattrChecked) {
                 UnixPath dir = new UnixPath(file().getFileSystem(), entry().dir());
                 xattrEnabled = isExtendedAttributesEnabled(dir);


### PR DESCRIPTION
I think we should have this fix in 11, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8262844](https://bugs.openjdk.java.net/browse/JDK-8262844): (fs) FileStore.supportsFileAttributeView might return false negative in case of ext3


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/563/head:pull/563` \
`$ git checkout pull/563`

Update a local copy of the PR: \
`$ git checkout pull/563` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 563`

View PR using the GUI difftool: \
`$ git pr show -t 563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/563.diff">https://git.openjdk.java.net/jdk11u-dev/pull/563.diff</a>

</details>
