### PR TITLE
8256202: Some tweaks for jarsigner tests PosixPermissionsTest and SymLinkTest

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/PosixPermissionsTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/PosixPermissionsTest.java
@@ -32,9 +32,16 @@
  */
 
 import java.net.URI;
-import java.nio.file.*;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.util.*;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 import jdk.test.lib.SecurityTools;
 
@@ -59,6 +66,7 @@ public class PosixPermissionsTest {
 
         createFiles();
 
+        // generate key for signing
         SecurityTools.keytool(
                 "-genkey",
                 "-keyalg", "RSA",
@@ -70,6 +78,7 @@ public class PosixPermissionsTest {
                 "-validity", "365")
                 .shouldHaveExitValue(0);
 
+        // sign zip file - expect warning
         SecurityTools.jarsigner(
                 "-keystore", "examplekeystore",
                 "-verbose", ZIPFILENAME,
@@ -79,8 +88,9 @@ public class PosixPermissionsTest {
                 .shouldHaveExitValue(0)
                 .shouldContain(WARNING_MSG);
 
-        // sign jar file - no posix warning message expected
-        SecurityTools.jarsigner("-keystore", "examplekeystore",
+        // sign jar file - expect no warning
+        SecurityTools.jarsigner(
+                "-keystore", "examplekeystore",
                 "-verbose", JARFILENAME,
                 "-storepass", "password",
                 "-keypass", "password",
@@ -88,7 +98,9 @@ public class PosixPermissionsTest {
                 .shouldHaveExitValue(0)
                 .shouldNotContain(WARNING_MSG);
 
-        SecurityTools.jarsigner("-keystore", "examplekeystore",
+        // verify zip file - expect warning
+        SecurityTools.jarsigner(
+                "-keystore", "examplekeystore",
                 "-storepass", "password",
                 "-keypass", "password",
                 "-verbose",
@@ -96,8 +108,9 @@ public class PosixPermissionsTest {
                 .shouldHaveExitValue(0)
                 .shouldContain(WARNING_MSG);
 
-        // no warning expected for regular jar file
-        SecurityTools.jarsigner("-keystore", "examplekeystore",
+        // verify jar file - expect no warning
+        SecurityTools.jarsigner(
+                "-keystore", "examplekeystore",
                 "-storepass", "password",
                 "-keypass", "password",
                 "-verbose",

--- a/test/jdk/sun/security/tools/jarsigner/SymLinkTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/SymLinkTest.java
@@ -31,28 +31,35 @@
  * @run main/othervm SymLinkTest
  */
 
-import java.io.*;
-import java.net.URI;
-import java.nio.file.*;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Formatter;
 
 import jdk.test.lib.SecurityTools;
 
 public class SymLinkTest {
+    private final static int BYTES_PER_ROW = 8;
     private final static String ZIPFILENAME = "8250968-test.zip";
     private static final String WARNING_MSG = "POSIX file permission and/or symlink " +
             "attributes detected. These attributes are ignored when signing and are not " +
             "protected by the signature.";
 
     public static void main(String[] args) throws Exception {
-        Files.deleteIfExists(Paths.get(ZIPFILENAME));
-        try (FileOutputStream fos = new FileOutputStream(ZIPFILENAME)) {
-            fos.write(ZIPBYTES);
+        // call main with an argument to print the prepared zipfile as byte array declaration
+        if (args.length > 0) {
+            System.out.println("Bytes of " + ZIPFILENAME + ":");
+            System.out.println(createByteArray(Files.readAllBytes(Path.of(ZIPFILENAME)), "ZIPBYTES"));
+            System.exit(0);
         }
 
-        // check permissions before signing
+        Files.write(Path.of(ZIPFILENAME), ZIPBYTES);
+
+        // check attributes before signing
         verifyExtraAttrs(ZIPFILENAME);
 
+        // generate key for signing
         SecurityTools.keytool(
                 "-genkey",
                 "-keyalg", "RSA",
@@ -64,6 +71,7 @@ public class SymLinkTest {
                 "-validity", "365")
                 .shouldHaveExitValue(0);
 
+        // sign zip file - expect warning
         SecurityTools.jarsigner(
                 "-keystore", "examplekeystore",
                 "-verbose", ZIPFILENAME,
@@ -73,10 +81,12 @@ public class SymLinkTest {
                 .shouldHaveExitValue(0)
                 .shouldContain(WARNING_MSG);
 
-        // zip file now signed. Recheck attributes
+        // recheck attributes after signing
         verifyExtraAttrs(ZIPFILENAME);
 
-        SecurityTools.jarsigner("-keystore", "examplekeystore",
+        // verify zip file - expect warning
+        SecurityTools.jarsigner(
+                "-keystore", "examplekeystore",
                 "-storepass", "password",
                 "-keypass", "password",
                 "-verbose",
@@ -114,48 +124,57 @@ public class SymLinkTest {
      * @param name Name to be used in the byte array declaration
      * @return The formatted byte array declaration
      */
-    public static String createByteArray(byte[] bytes, String name) {
-        StringBuilder sb = new StringBuilder(bytes.length * 5);
-        Formatter fmt = new Formatter(sb);
-        fmt.format("    public static byte[] %s = {", name);
-        final int linelen = 8;
-        for (int i = 0; i < bytes.length; i++) {
-            if (i % linelen == 0) {
-                fmt.format("%n        ");
+    private static String createByteArray(byte[] bytes, String name) {
+        StringBuilder sb = new StringBuilder();
+        try (Formatter fmt = new Formatter(sb)) {
+            fmt.format("    public final static byte[] %s = {", name);
+            for (int i = 0; i < bytes.length; i++) {
+                int mod = i % BYTES_PER_ROW;
+                if (mod == 0) {
+                    fmt.format("%n        ");
+                } else {
+                    fmt.format(" ");
+                }
+                fmt.format("(byte)0x%02x", bytes[i]);
+                if (i != bytes.length - 1) {
+                    fmt.format(",");
+                }
             }
-            fmt.format(" (byte) 0x%x,", bytes[i] & 0xff);
+            fmt.format("%n    };%n");
         }
-        fmt.format("%n    };%n");
         return sb.toString();
     }
 
     /*
-     * Created using the createByteArray utility method.
-     * The zipfile itself was created via this example:
+     * The zipfile itself was created like this:
+     * $ ln -s ../z z
      * $ ls -l z
      * lrwxrwxrwx 1 test test 4 Aug 27 18:33 z -> ../z
-     * $ zip -ry test.zip z
+     * $ zip -ry 8250968-test.zip z
+     *
+     * The byte array representation was generated using the createByteArray utility method:
+     * $ java SymLinkTest generate
      */
     public final static byte[] ZIPBYTES = {
-            (byte) 0x50, (byte) 0x4b, (byte) 0x3, (byte) 0x4, (byte) 0xa, (byte) 0x0, (byte) 0x0, (byte) 0x0,
-            (byte) 0x0, (byte) 0x0, (byte) 0x2e, (byte) 0x94, (byte) 0x1b, (byte) 0x51, (byte) 0xb4, (byte) 0xcc,
-            (byte) 0xb6, (byte) 0xf1, (byte) 0x4, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x4, (byte) 0x0,
-            (byte) 0x0, (byte) 0x0, (byte) 0x1, (byte) 0x0, (byte) 0x1c, (byte) 0x0, (byte) 0x7a, (byte) 0x55,
-            (byte) 0x54, (byte) 0x9, (byte) 0x0, (byte) 0x3, (byte) 0x77, (byte) 0xfc, (byte) 0x47, (byte) 0x5f,
-            (byte) 0x78, (byte) 0xfc, (byte) 0x47, (byte) 0x5f, (byte) 0x75, (byte) 0x78, (byte) 0xb, (byte) 0x0,
-            (byte) 0x1, (byte) 0x4, (byte) 0xec, (byte) 0x3, (byte) 0x0, (byte) 0x0, (byte) 0x4, (byte) 0xec,
-            (byte) 0x3, (byte) 0x0, (byte) 0x0, (byte) 0x2e, (byte) 0x2e, (byte) 0x2f, (byte) 0x7a, (byte) 0x50,
-            (byte) 0x4b, (byte) 0x1, (byte) 0x2, (byte) 0x1e, (byte) 0x3, (byte) 0xa, (byte) 0x0, (byte) 0x0,
-            (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x2e, (byte) 0x94, (byte) 0x1b, (byte) 0x51, (byte) 0xb4,
-            (byte) 0xcc, (byte) 0xb6, (byte) 0xf1, (byte) 0x4, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x4,
-            (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x1, (byte) 0x0, (byte) 0x18, (byte) 0x0, (byte) 0x0,
-            (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0xff,
-            (byte) 0xa1, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x7a, (byte) 0x55, (byte) 0x54,
-            (byte) 0x5, (byte) 0x0, (byte) 0x3, (byte) 0x77, (byte) 0xfc, (byte) 0x47, (byte) 0x5f, (byte) 0x75,
-            (byte) 0x78, (byte) 0xb, (byte) 0x0, (byte) 0x1, (byte) 0x4, (byte) 0xec, (byte) 0x3, (byte) 0x0,
-            (byte) 0x0, (byte) 0x4, (byte) 0xec, (byte) 0x3, (byte) 0x0, (byte) 0x0, (byte) 0x50, (byte) 0x4b,
-            (byte) 0x5, (byte) 0x6, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x1, (byte) 0x0,
-            (byte) 0x1, (byte) 0x0, (byte) 0x47, (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x3f, (byte) 0x0,
-            (byte) 0x0, (byte) 0x0, (byte) 0x0, (byte) 0x0,
+        (byte)0x50, (byte)0x4b, (byte)0x03, (byte)0x04, (byte)0x0a, (byte)0x00, (byte)0x00, (byte)0x00,
+        (byte)0x00, (byte)0x00, (byte)0x2e, (byte)0x94, (byte)0x1b, (byte)0x51, (byte)0xb4, (byte)0xcc,
+        (byte)0xb6, (byte)0xf1, (byte)0x04, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x04, (byte)0x00,
+        (byte)0x00, (byte)0x00, (byte)0x01, (byte)0x00, (byte)0x1c, (byte)0x00, (byte)0x7a, (byte)0x55,
+        (byte)0x54, (byte)0x09, (byte)0x00, (byte)0x03, (byte)0x77, (byte)0xfc, (byte)0x47, (byte)0x5f,
+        (byte)0x78, (byte)0xfc, (byte)0x47, (byte)0x5f, (byte)0x75, (byte)0x78, (byte)0x0b, (byte)0x00,
+        (byte)0x01, (byte)0x04, (byte)0xec, (byte)0x03, (byte)0x00, (byte)0x00, (byte)0x04, (byte)0xec,
+        (byte)0x03, (byte)0x00, (byte)0x00, (byte)0x2e, (byte)0x2e, (byte)0x2f, (byte)0x7a, (byte)0x50,
+        (byte)0x4b, (byte)0x01, (byte)0x02, (byte)0x1e, (byte)0x03, (byte)0x0a, (byte)0x00, (byte)0x00,
+        (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x2e, (byte)0x94, (byte)0x1b, (byte)0x51, (byte)0xb4,
+        (byte)0xcc, (byte)0xb6, (byte)0xf1, (byte)0x04, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x04,
+        (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x01, (byte)0x00, (byte)0x18, (byte)0x00, (byte)0x00,
+        (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0xff,
+        (byte)0xa1, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x7a, (byte)0x55, (byte)0x54,
+        (byte)0x05, (byte)0x00, (byte)0x03, (byte)0x77, (byte)0xfc, (byte)0x47, (byte)0x5f, (byte)0x75,
+        (byte)0x78, (byte)0x0b, (byte)0x00, (byte)0x01, (byte)0x04, (byte)0xec, (byte)0x03, (byte)0x00,
+        (byte)0x00, (byte)0x04, (byte)0xec, (byte)0x03, (byte)0x00, (byte)0x00, (byte)0x50, (byte)0x4b,
+        (byte)0x05, (byte)0x06, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x01, (byte)0x00,
+        (byte)0x01, (byte)0x00, (byte)0x47, (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x3f, (byte)0x00,
+        (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x00
     };
 }


### PR DESCRIPTION
Backport of JDK-8256202. Changes in SymLinkTest.java apply cleanly.
Hunks in PosixPermissionsTest.java had to be integrated manually because the test is different in 11u (see backport of the related issues JDK-8218021 and JDK-8250968). This backport only contains cleanup in this file. Other hunks are not applicable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256202](https://bugs.openjdk.java.net/browse/JDK-8256202): Some tweaks for jarsigner tests PosixPermissionsTest and SymLinkTest


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/564/head:pull/564` \
`$ git checkout pull/564`

Update a local copy of the PR: \
`$ git checkout pull/564` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 564`

View PR using the GUI difftool: \
`$ git pr show -t 564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/564.diff">https://git.openjdk.java.net/jdk11u-dev/pull/564.diff</a>

</details>
