### PR TITLE
7151826: [TEST_BUG] [macosx] The test javax/swing/JPopupMenu/4966112/bug4966112.java not for mac

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -737,7 +737,6 @@ javax/swing/JInternalFrame/Test6325652.java 8196467 macosx-all
 javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java 8225045 linux-all
 javax/swing/JLabel/6596966/bug6596966.java 8040914 macosx-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all
-javax/swing/JPopupMenu/4966112/bug4966112.java 8064915 macosx-all
 javax/swing/JSpinner/8223788/JSpinnerButtonFocusTest.java 8238085 macosx-all
 javax/swing/MultiUIDefaults/Test6860438.java 8198391 generic-all
 javax/swing/UITest/UITest.java 8198392 generic-all

--- a/test/jdk/javax/swing/JPopupMenu/4966112/bug4966112.java
+++ b/test/jdk/javax/swing/JPopupMenu/4966112/bug4966112.java
@@ -31,11 +31,27 @@
  * @author Alexander Zuev
  * @run main bug4966112
  */
-import javax.swing.*;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JSpinner;
+import javax.swing.JSplitPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.event.PopupMenuListener;
 import javax.swing.event.PopupMenuEvent;
-import java.awt.*;
-import java.awt.event.*;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Robot;
+import java.awt.Point;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 
 public class bug4966112 {
 
@@ -48,6 +64,7 @@ public class bug4966112 {
     private static volatile JFileChooser filec;
     private static int buttonMask;
     private static Robot robot;
+    private static boolean isAquaFileChooser;
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
@@ -99,6 +116,11 @@ public class bug4966112 {
         createAndShowFileChooser();
         robot.waitForIdle();
 
+        if ((UIManager.getLookAndFeel().getID()).equals("Aqua")) {
+            isAquaFileChooser = true;
+        } else {
+            isAquaFileChooser = false;
+        }
         clickMouse(filec);
         robot.waitForIdle();
 
@@ -146,7 +168,11 @@ public class bug4966112 {
             public void run() {
                 Point p = c.getLocationOnScreen();
                 Dimension size = c.getSize();
-                result[0] = new Point(p.x + size.width / 2, p.y + size.height / 2);
+                if (isAquaFileChooser) {
+                    result[0] = new Point(p.x + size.width / 2, p.y + 5);
+                } else {
+                    result[0] = new Point(p.x + size.width / 2, p.y + size.height / 2);
+                }
             }
         });
 


### PR DESCRIPTION
Backport of JDK-7151826

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7151826](https://bugs.openjdk.java.net/browse/JDK-7151826): [TEST_BUG] [macosx] The test javax/swing/JPopupMenu/4966112/bug4966112.java not for mac


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/565/head:pull/565` \
`$ git checkout pull/565`

Update a local copy of the PR: \
`$ git checkout pull/565` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 565`

View PR using the GUI difftool: \
`$ git pr show -t 565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/565.diff">https://git.openjdk.java.net/jdk11u-dev/pull/565.diff</a>

</details>
