### PR TITLE
8015602: [macosx] Test javax/swing/SpringLayout/4726194/bug4726194.java fails on MacOSX

### DIFF
--- a/test/jdk/javax/swing/SpringLayout/4726194/bug4726194.java
+++ b/test/jdk/javax/swing/SpringLayout/4726194/bug4726194.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,22 @@
  * @test
  * @bug 4726194 7124209
  * @summary Tests for 4726194
- * @author Phil Milne
  */
-import java.awt.*;
-import java.lang.reflect.InvocationTargetException;
-import java.util.*;
+
+import java.awt.Font;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import javax.swing.*;
+
+import javax.swing.BorderFactory;
+import javax.swing.JTextField;
+import javax.swing.Spring;
+import javax.swing.SpringLayout;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+import static javax.swing.UIManager.getInstalledLookAndFeels;
 
 public class bug4726194 {
 
@@ -40,22 +49,29 @@ public class bug4726194 {
     private static int[] FAIL = new int[3];
     private static boolean TEST_DUPLICATES = false;
 
-    public static void main(String[] args) {
-        try {
-            SwingUtilities.invokeAndWait(new Runnable() {
-                @Override
-                public void run() {
-                    int minLevel = 2;
-                    int maxLevel = 2;
-                    for (int i = minLevel; i <= maxLevel; i++) {
-                        test(i, true);
-                        test(i, false);
-                    }
+    public static void main(String[] args) throws Exception {
+        for (final UIManager.LookAndFeelInfo laf : getInstalledLookAndFeels()) {
+            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+            SwingUtilities.invokeAndWait(() -> {
+                int minLevel = 2;
+                int maxLevel = 2;
+                for (int i = minLevel; i <= maxLevel; i++) {
+                    test(i, true);
+                    test(i, false);
                 }
             });
-        } catch (InterruptedException | InvocationTargetException ex) {
-            ex.printStackTrace();
-            throw new RuntimeException("FAILED: SwingUtilities.invokeAndWait method failed!");
+        }
+    }
+
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            System.out.println("LookAndFeel: " + laf.getClassName());
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored){
+            System.out.println("Unsupported LookAndFeel: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException |
+                IllegalAccessException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -64,6 +80,7 @@ public class bug4726194 {
         String[] constraints = horizontal ? hConstraints : vConstraints;
         test(level, constraints, result, Arrays.asList(new Object[level]));
         JTextField tf = new JTextField("");
+        tf.setBorder(BorderFactory.createEmptyBorder());
         tf.setFont(new Font("Dialog", Font.PLAIN, 6));
         System.out.print("\t\t");
         for (int j = 0; j < constraints.length; j++) {


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8015602 from the openjdk/jdk repository.

The commit being backported was authored by Sergey Bylokhov on 27 Oct 2020 and was reviewed by Prasanta Sadhukhan and Pankaj Bansal.

I ran javax/swing/SpringLayout/4726194/bug4726194.java on my MacOS and it passes. It is, however, still excluded. One would have to backport JDK-8254976 to enable it.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8015602](https://bugs.openjdk.java.net/browse/JDK-8015602): [macosx] Test javax/swing/SpringLayout/4726194/bug4726194.java fails on MacOSX


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/569/head:pull/569` \
`$ git checkout pull/569`

Update a local copy of the PR: \
`$ git checkout pull/569` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 569`

View PR using the GUI difftool: \
`$ git pr show -t 569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/569.diff">https://git.openjdk.java.net/jdk11u-dev/pull/569.diff</a>

</details>
