### PR TITLE
8233570: [TESTBUG] HTMLEditorKit test bug5043626.java is failing on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -761,7 +761,6 @@ javax/swing/JTree/8003830/bug8003830.java 8199057 generic-all
 javax/swing/ToolTipManager/Test6256140.java 8233560 macosx-all
 javax/swing/text/View/8014863/bug8014863.java 8233561 macosx-all
 javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233562 macosx-all
-javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java 233570 macosx-all
 javax/swing/text/GlyphPainter2/6427244/bug6427244.java 8208566 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all

--- a/test/jdk/javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java
+++ b/test/jdk/javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java
@@ -26,9 +26,6 @@
  * @key headful
  * @bug 5043626
  * @summary  Tests pressing Home or Ctrl+Home set cursor to invisible element <head>
- * @author Alexander Potochkin
- * @library ../../../../regtesthelpers
- * @build Util
  * @run main bug5043626
  */
 
@@ -43,38 +40,51 @@ public class bug5043626 {
 
     private static Document doc;
     private static Robot robot;
+    private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
-        robot = new Robot();
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(100);
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                createAndShowGUI();
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    createAndShowGUI();
+                }
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            robot.keyPress(KeyEvent.VK_HOME);
+            robot.keyRelease(KeyEvent.VK_HOME);
+            robot.keyPress(KeyEvent.VK_1);
+            robot.keyRelease(KeyEvent.VK_1);
+
+            robot.waitForIdle();
+
+            String test = getText();
+
+            if (!"1test".equals(test)) {
+                throw new RuntimeException("Begin line action set cursor inside <head> tag");
             }
-        });
 
-        robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_HOME);
+            robot.keyRelease(KeyEvent.VK_HOME);
+            robot.keyPress(KeyEvent.VK_2);
+            robot.keyRelease(KeyEvent.VK_2);
 
-        Util.hitKeys(robot, KeyEvent.VK_HOME);
-        Util.hitKeys(robot, KeyEvent.VK_1);
+            robot.waitForIdle();
 
-        robot.waitForIdle();
+            test = getText();
 
-        String test = getText();
-
-        if (!"1test".equals(test)) {
-            throw new RuntimeException("Begin line action set cursor inside <head> tag");
-        }
-
-        Util.hitKeys(robot, KeyEvent.VK_HOME);
-        Util.hitKeys(robot, KeyEvent.VK_2);
-
-        robot.waitForIdle();
-
-        test = getText();
-
-        if (!"21test".equals(test)) {
-            throw new RuntimeException("Begin action set cursor inside <head> tag");
+            if (!"21test".equals(test)) {
+                throw new RuntimeException("Begin action set cursor inside <head> tag");
+            }
+        } finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
+            }
         }
     }
 
@@ -95,7 +105,7 @@ public class bug5043626 {
     }
 
     private static void createAndShowGUI() {
-        JFrame frame = new JFrame();
+        frame = new JFrame();
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
         JEditorPane editorPane = new JEditorPane();
@@ -104,6 +114,7 @@ public class bug5043626 {
         editorPane.setEditable(true);
         frame.add(editorPane);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
         doc = editorPane.getDocument();
         editorPane.setCaretPosition(doc.getLength());


### PR DESCRIPTION
Backport of JDK-8233570.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233570](https://bugs.openjdk.java.net/browse/JDK-8233570): [TESTBUG] HTMLEditorKit test bug5043626.java is failing on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/571/head:pull/571` \
`$ git checkout pull/571`

Update a local copy of the PR: \
`$ git checkout pull/571` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 571`

View PR using the GUI difftool: \
`$ git pr show -t 571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/571.diff">https://git.openjdk.java.net/jdk11u-dev/pull/571.diff</a>

</details>
