### PR TITLE
8270533: AArch64: size_fits_all_mem_uses should return false if its output is a CAS

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2297,6 +2297,13 @@ const RegMask Matcher::method_handle_invoke_SP_save_mask() {
 bool size_fits_all_mem_uses(AddPNode* addp, int shift) {
   for (DUIterator_Fast imax, i = addp->fast_outs(imax); i < imax; i++) {
     Node* u = addp->fast_out(i);
+    if (u->is_LoadStore()) {
+      // On AArch64, LoadStoreNodes (i.e. compare and swap
+      // instructions) only take register indirect as an operand, so
+      // any attempt to use an AddPNode as an input to a LoadStoreNode
+      // must fail.
+      return false;
+    }
     if (u->is_Mem()) {
       int opsize = u->as_Mem()->memory_size();
       assert(opsize > 0, "unexpected memory operand size");


### PR DESCRIPTION
I'd like to backport JDK-8190753 to jdk11u

The fix prevents using a result of Add-n-Shift operation as an input for CAS operation that takes only register operands for Aarch64

The original patch applied cleanly

Testing: original patch does not have verification tests. Regression: hotspot_all (arm64/20.04 LTS)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270533](https://bugs.openjdk.java.net/browse/JDK-8270533): AArch64: size_fits_all_mem_uses should return false if its output is a CAS


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/573/head:pull/573` \
`$ git checkout pull/573`

Update a local copy of the PR: \
`$ git checkout pull/573` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 573`

View PR using the GUI difftool: \
`$ git pr show -t 573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/573.diff">https://git.openjdk.java.net/jdk11u-dev/pull/573.diff</a>

</details>
