### PR TITLE
8267304: Bump global JTReg memory limit to 768m

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -312,8 +312,6 @@ langtools_JTREG_PROBLEM_LIST += $(TOPDIR)/test/langtools/ProblemList.txt
 nashorn_JTREG_PROBLEM_LIST += $(TOPDIR)/test/nashorn/ProblemList.txt
 hotspot_JTREG_PROBLEM_LIST += $(TOPDIR)/test/hotspot/jtreg/ProblemList.txt
 
-langtools_JTREG_MAX_MEM := 768m
-
 ################################################################################
 # Parse test selection
 #
@@ -627,7 +625,7 @@ define SetupRunJtregTestBody
   # Convert JTREG_foo into $1_JTREG_foo with a suitable value.
   $$(eval $$(call SetJtregValue,$1,JTREG_TEST_MODE,agentvm))
   $$(eval $$(call SetJtregValue,$1,JTREG_ASSERT,true))
-  $$(eval $$(call SetJtregValue,$1,JTREG_MAX_MEM,512m))
+  $$(eval $$(call SetJtregValue,$1,JTREG_MAX_MEM,768m))
   $$(eval $$(call SetJtregValue,$1,JTREG_NATIVEPATH))
   $$(eval $$(call SetJtregValue,$1,JTREG_BASIC_OPTIONS))
   $$(eval $$(call SetJtregValue,$1,JTREG_PROBLEM_LIST))


### PR DESCRIPTION
Clean backport to improve testing speed.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8267304](https://bugs.openjdk.java.net/browse/JDK-8267304): Bump global JTReg memory limit to 768m


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/575/head:pull/575` \
`$ git checkout pull/575`

Update a local copy of the PR: \
`$ git checkout pull/575` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 575`

View PR using the GUI difftool: \
`$ git pr show -t 575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/575.diff">https://git.openjdk.java.net/jdk11u-dev/pull/575.diff</a>

</details>
