### PR TITLE
8255254: Split os::reserve_memory and os::map_memory_to_file interfaces

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1757,7 +1757,7 @@ static void local_sem_init() {
   } else {
     // Memory semaphores must live in shared mem.
     guarantee0(p_sig_msem == NULL);
-    p_sig_msem = (msemaphore*)os::reserve_memory(sizeof(msemaphore), NULL);
+    p_sig_msem = (msemaphore*)os::reserve_memory(sizeof(msemaphore));
     guarantee(p_sig_msem, "Cannot allocate memory for memory semaphore");
     guarantee(::msem_init(p_sig_msem, 0) == p_sig_msem, "msem_init failed");
   }
@@ -2373,19 +2373,7 @@ char *os::scan_pages(char *start, char* end, page_info* page_expected, page_info
 }
 
 // Reserves and attaches a shared memory segment.
-// Will assert if a wish address is given and could not be obtained.
-char* os::pd_reserve_memory(size_t bytes, char* requested_addr, size_t alignment_hint) {
-
-  // All other Unices do a mmap(MAP_FIXED) if the addr is given,
-  // thereby clobbering old mappings at that place. That is probably
-  // not intended, never used and almost certainly an error were it
-  // ever be used this way (to try attaching at a specified address
-  // without clobbering old mappings an alternate API exists,
-  // os::attempt_reserve_memory_at()).
-  // Instead of mimicking the dangerous coding of the other platforms, here I
-  // just ignore the request address (release) or assert(debug).
-  assert0(requested_addr == NULL);
-
+char* os::pd_reserve_memory(size_t bytes, size_t alignment_hint) {
   // Always round to os::vm_page_size(), which may be larger than 4K.
   bytes = align_up(bytes, os::vm_page_size());
   const size_t alignment_hint0 =
@@ -2394,12 +2382,12 @@ char* os::pd_reserve_memory(size_t bytes, char* requested_addr, size_t alignment
   // In 4K mode always use mmap.
   // In 64K mode allocate small sizes with mmap, large ones with 64K shmatted.
   if (os::vm_page_size() == 4*K) {
-    return reserve_mmaped_memory(bytes, requested_addr, alignment_hint);
+    return reserve_mmaped_memory(bytes, NULL /* requested_addr */, alignment_hint);
   } else {
     if (bytes >= Use64KPagesThreshold) {
-      return reserve_shmated_memory(bytes, requested_addr, alignment_hint);
+      return reserve_shmated_memory(bytes, NULL /* requested_addr */, alignment_hint);
     } else {
-      return reserve_mmaped_memory(bytes, requested_addr, alignment_hint);
+      return reserve_mmaped_memory(bytes, NULL /* requested_addr */, alignment_hint);
     }
   }
 }

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -2562,7 +2562,7 @@ bool os::can_execute_large_page_memory() {
   return false;
 }
 
-char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr, int file_desc) {
+char* os::pd_attempt_map_memory_to_file_at(size_t bytes, char* requested_addr, int file_desc) {
   assert(file_desc >= 0, "file_desc is not valid");
   char* result = NULL;
 

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2111,27 +2111,17 @@ bool os::remove_stack_guard_pages(char* addr, size_t size) {
   return os::uncommit_memory(addr, size);
 }
 
-// If 'fixed' is true, anon_mmap() will attempt to reserve anonymous memory
-// at 'requested_addr'. If there are existing memory mappings at the same
-// location, however, they will be overwritten. If 'fixed' is false,
 // 'requested_addr' is only treated as a hint, the return value may or
 // may not start from the requested address. Unlike Bsd mmap(), this
 // function returns NULL to indicate failure.
-static char* anon_mmap(char* requested_addr, size_t bytes, bool fixed) {
-  char * addr;
-  int flags;
-
-  flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS;
-  if (fixed) {
-    assert((uintptr_t)requested_addr % os::Bsd::page_size() == 0, "unaligned address");
-    flags |= MAP_FIXED;
-  }
+static char* anon_mmap(char* requested_addr, size_t bytes) {
+  // MAP_FIXED is intentionally left out, to leave existing mappings intact.
+  const int flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS;
 
   // Map reserved/uncommitted pages PROT_NONE so we fail early if we
   // touch an uncommitted page. Otherwise, the read/write might
   // succeed if we have enough swap space to back the physical page.
-  addr = (char*)::mmap(requested_addr, bytes, PROT_NONE,
-                       flags, -1, 0);
+  char* addr = (char*)::mmap(requested_addr, bytes, PROT_NONE, flags, -1, 0);
 
   return addr == MAP_FAILED ? NULL : addr;
 }
@@ -2140,9 +2130,9 @@ static int anon_munmap(char * addr, size_t size) {
   return ::munmap(addr, size) == 0;
 }
 
-char* os::pd_reserve_memory(size_t bytes, char* requested_addr,
-                            size_t alignment_hint) {
-  return anon_mmap(requested_addr, bytes, (requested_addr != NULL));
+char* os::pd_reserve_memory(size_t bytes, size_t alignment_hint) {
+  // Ignores alignment hint
+  return anon_mmap(NULL /* addr */, bytes);
 }
 
 bool os::pd_release_memory(char* addr, size_t size) {
@@ -2325,7 +2315,7 @@ char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr) {
 
   // Bsd mmap allows caller to pass an address as hint; give it a try first,
   // if kernel honors the hint then we can return immediately.
-  char * addr = anon_mmap(requested_addr, bytes, false);
+  char * addr = anon_mmap(requested_addr, bytes);
   if (addr == requested_addr) {
     return requested_addr;
   }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2283,7 +2283,7 @@ bool os::can_execute_large_page_memory() {
   return UseHugeTLBFS;
 }
 
-char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr, int file_desc) {
+char* os::pd_attempt_map_memory_to_file_at(size_t bytes, char* requested_addr, int file_desc) {
   assert(file_desc >= 0, "file_desc is not valid");
   char* result = pd_attempt_reserve_memory_at(bytes, requested_addr);
   if (result != NULL) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4267,7 +4267,7 @@ bool os::can_execute_large_page_memory() {
   return UseTransparentHugePages || UseHugeTLBFS;
 }
 
-char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr, int file_desc) {
+char* os::pd_attempt_map_memory_to_file_at(size_t bytes, char* requested_addr, int file_desc) {
   assert(file_desc >= 0, "file_desc is not valid");
   char* result = pd_attempt_reserve_memory_at(bytes, requested_addr);
   if (result != NULL) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3566,27 +3566,17 @@ bool os::remove_stack_guard_pages(char* addr, size_t size) {
   return os::uncommit_memory(addr, size);
 }
 
-// If 'fixed' is true, anon_mmap() will attempt to reserve anonymous memory
-// at 'requested_addr'. If there are existing memory mappings at the same
-// location, however, they will be overwritten. If 'fixed' is false,
 // 'requested_addr' is only treated as a hint, the return value may or
 // may not start from the requested address. Unlike Linux mmap(), this
 // function returns NULL to indicate failure.
-static char* anon_mmap(char* requested_addr, size_t bytes, bool fixed) {
-  char * addr;
-  int flags;
-
-  flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS;
-  if (fixed) {
-    assert((uintptr_t)requested_addr % os::Linux::page_size() == 0, "unaligned address");
-    flags |= MAP_FIXED;
-  }
+static char* anon_mmap(char* requested_addr, size_t bytes) {
+  // MAP_FIXED is intentionally left out, to leave existing mappings intact.
+  const int flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS;
 
   // Map reserved/uncommitted pages PROT_NONE so we fail early if we
   // touch an uncommitted page. Otherwise, the read/write might
   // succeed if we have enough swap space to back the physical page.
-  addr = (char*)::mmap(requested_addr, bytes, PROT_NONE,
-                       flags, -1, 0);
+  char* addr = (char*)::mmap(requested_addr, bytes, PROT_NONE, flags, -1, 0);
 
   return addr == MAP_FAILED ? NULL : addr;
 }
@@ -3599,19 +3589,14 @@ static char* anon_mmap(char* requested_addr, size_t bytes, bool fixed) {
 //     It must be a multiple of allocation granularity.
 // Returns address of memory or NULL. If req_addr was not NULL, will only return
 //  req_addr or NULL.
-static char* anon_mmap_aligned(size_t bytes, size_t alignment, char* req_addr) {
-
+static char* anon_mmap_aligned(char* req_addr, size_t bytes, size_t alignment) {
   size_t extra_size = bytes;
   if (req_addr == NULL && alignment > 0) {
     extra_size += alignment;
   }
 
-  char* start = (char*) ::mmap(req_addr, extra_size, PROT_NONE,
-    MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE,
-    -1, 0);
-  if (start == MAP_FAILED) {
-    start = NULL;
-  } else {
+  char* start = anon_mmap(req_addr, bytes);
+  if (start != NULL) {
     if (req_addr != NULL) {
       if (start != req_addr) {
         ::munmap(start, extra_size);
@@ -3637,9 +3622,9 @@ static int anon_munmap(char * addr, size_t size) {
   return ::munmap(addr, size) == 0;
 }
 
-char* os::pd_reserve_memory(size_t bytes, char* requested_addr,
-                            size_t alignment_hint) {
-  return anon_mmap(requested_addr, bytes, (requested_addr != NULL));
+char* os::pd_reserve_memory(size_t bytes, size_t alignment_hint) {
+  // Ignores alignment hint
+  return anon_mmap(NULL, bytes);
 }
 
 bool os::pd_release_memory(char* addr, size_t size) {
@@ -3947,7 +3932,7 @@ static char* shmat_with_alignment(int shmid, size_t bytes, size_t alignment) {
   // To ensure that we get 'alignment' aligned memory from shmat,
   // we pre-reserve aligned virtual memory and then attach to that.
 
-  char* pre_reserved_addr = anon_mmap_aligned(bytes, alignment, NULL);
+  char* pre_reserved_addr = anon_mmap_aligned(NULL /* req_addr */, bytes, alignment);
   if (pre_reserved_addr == NULL) {
     // Couldn't pre-reserve aligned memory.
     shm_warning("Failed to pre-reserve aligned memory for shmat.");
@@ -4113,7 +4098,7 @@ char* os::Linux::reserve_memory_special_huge_tlbfs_mixed(size_t bytes,
   assert(is_aligned(bytes, alignment), "Must be");
 
   // First reserve - but not commit - the address range in small pages.
-  char* const start = anon_mmap_aligned(bytes, alignment, req_addr);
+  char* const start = anon_mmap_aligned(req_addr, bytes, alignment);
 
   if (start == NULL) {
     return NULL;
@@ -4314,7 +4299,7 @@ char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr) {
 
   // Linux mmap allows caller to pass an address as hint; give it a try first,
   // if kernel honors the hint then we can return immediately.
-  char * addr = anon_mmap(requested_addr, bytes, false);
+  char * addr = anon_mmap(requested_addr, bytes);
   if (addr == requested_addr) {
     return requested_addr;
   }

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -304,7 +304,7 @@ char* os::reserve_memory_aligned(size_t size, size_t alignment, int file_desc) {
       MemTracker::record_virtual_memory_reserve((address)extra_base, extra_size, CALLER_PC);
     }
   } else {
-    extra_base = os::reserve_memory(extra_size, NULL, alignment);
+    extra_base = os::reserve_memory(extra_size, alignment);
   }
 
   if (extra_base == NULL) {

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -281,36 +281,18 @@ char* os::replace_existing_mapping_with_file_mapping(char* base, size_t size, in
   return map_memory_to_file(base, size, fd);
 }
 
-// Multiple threads can race in this code, and can remap over each other with MAP_FIXED,
-// so on posix, unmap the section at the start and at the end of the chunk that we mapped
-// rather than unmapping and remapping the whole chunk to get requested alignment.
-char* os::reserve_memory_aligned(size_t size, size_t alignment, int file_desc) {
+static size_t calculate_aligned_extra_size(size_t size, size_t alignment) {
   assert((alignment & (os::vm_allocation_granularity() - 1)) == 0,
       "Alignment must be a multiple of allocation granularity (page size)");
   assert((size & (alignment -1)) == 0, "size must be 'alignment' aligned");
 
   size_t extra_size = size + alignment;
   assert(extra_size >= size, "overflow, size is too large to allow alignment");
+  return extra_size;
+}
 
-  char* extra_base;
-  if (file_desc != -1) {
-    // For file mapping, we do not call os:reserve_memory(extra_size, NULL, alignment, file_desc) because
-    // we need to deal with shrinking of the file space later when we release extra memory after alignment.
-    // We also cannot called os:reserve_memory() with file_desc set to -1 because on aix we might get SHM memory.
-    // So here to call a helper function while reserve memory for us. After we have a aligned base,
-    // we will replace anonymous mapping with file mapping.
-    extra_base = reserve_mmapped_memory(extra_size, NULL);
-    if (extra_base != NULL) {
-      MemTracker::record_virtual_memory_reserve((address)extra_base, extra_size, CALLER_PC);
-    }
-  } else {
-    extra_base = os::reserve_memory(extra_size, alignment);
-  }
-
-  if (extra_base == NULL) {
-    return NULL;
-  }
-
+// After a bigger chunk was mapped, unmaps start and end parts to get the requested alignment.
+static char* chop_extra_memory(size_t size, size_t alignment, char* extra_base, size_t extra_size) {
   // Do manual alignment
   char* aligned_base = align_up(extra_base, alignment);
 
@@ -332,13 +314,39 @@ char* os::reserve_memory_aligned(size_t size, size_t alignment, int file_desc) {
       os::release_memory(extra_base + begin_offset + size, end_offset);
   }
 
-  if (file_desc != -1) {
-    // After we have an aligned address, we can replace anonymous mapping with file mapping
-    if (replace_existing_mapping_with_file_mapping(aligned_base, size, file_desc) == NULL) {
-      vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
-    }
-    MemTracker::record_virtual_memory_commit((address)aligned_base, size, CALLER_PC);
+  return aligned_base;
+}
+
+// Multiple threads can race in this code, and can remap over each other with MAP_FIXED,
+// so on posix, unmap the section at the start and at the end of the chunk that we mapped
+// rather than unmapping and remapping the whole chunk to get requested alignment.
+char* os::reserve_memory_aligned(size_t size, size_t alignment) {
+  size_t extra_size = calculate_aligned_extra_size(size, alignment);
+  char* extra_base = os::reserve_memory(extra_size, alignment);
+  if (extra_base == NULL) {
+    return NULL;
   }
+  return chop_extra_memory(size, alignment, extra_base, extra_size);
+}
+
+char* os::map_memory_to_file_aligned(size_t size, size_t alignment, int file_desc) {
+  size_t extra_size = calculate_aligned_extra_size(size, alignment);
+  // For file mapping, we do not call os:map_memory_to_file(size,fd) since:
+  // - we later chop away parts of the mapping using os::release_memory and that could fail if the
+  //   original mmap call had been tied to an fd.
+  // - The memory API os::reserve_memory uses is an implementation detail. It may (and usually is)
+  //   mmap but it also may System V shared memory which cannot be uncommitted as a whole, so
+  //   chopping off and unmapping excess bits back and front (see below) would not work.
+  char* extra_base = reserve_mmapped_memory(extra_size, NULL);
+  if (extra_base == NULL) {
+    return NULL;
+  }
+  char* aligned_base = chop_extra_memory(size, alignment, extra_base, extra_size);
+  // After we have an aligned address, we can replace anonymous mapping with file mapping
+  if (replace_existing_mapping_with_file_mapping(aligned_base, size, file_desc) == NULL) {
+    vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
+  }
+  MemTracker::record_virtual_memory_commit((address)aligned_base, size, CALLER_PC);
   return aligned_base;
 }
 

--- a/src/hotspot/os/solaris/os_solaris.cpp
+++ b/src/hotspot/os/solaris/os_solaris.cpp
@@ -2573,7 +2573,7 @@ char* os::pd_reserve_memory(size_t bytes, size_t alignment_hint) {
   return addr;
 }
 
-char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr, int file_desc) {
+char* os::pd_attempt_map_memory_to_file_at(size_t bytes, char* requested_addr, int file_desc) {
   assert(file_desc >= 0, "file_desc is not valid");
   char* result = pd_attempt_reserve_memory_at(bytes, requested_addr);
   if (result != NULL) {

--- a/src/hotspot/os/solaris/os_solaris.hpp
+++ b/src/hotspot/os/solaris/os_solaris.hpp
@@ -162,7 +162,7 @@ class Solaris {
   static int commit_memory_impl(char* addr, size_t bytes,
                                 size_t alignment_hint, bool exec);
   static char* mmap_chunk(char *addr, size_t size, int flags, int prot);
-  static char* anon_mmap(char* requested_addr, size_t bytes, size_t alignment_hint, bool fixed);
+  static char* anon_mmap(char* requested_addr, size_t bytes, size_t alignment_hint);
   static bool mpss_sanity_check(bool warn, size_t * page_size);
 
   // Workaround for 4352906. thr_stksegment sometimes returns

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3055,7 +3055,7 @@ void os::pd_split_reserved_memory(char *base, size_t size, size_t split,
   if (size > 0) {
     release_memory(base, size);
     if (realloc) {
-      reserve_memory(split, base);
+      attempt_reserve_memory_at(split, base);
     }
     if (size != split) {
       attempt_reserve_memory_at(size - split, base + split);

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -822,7 +822,7 @@ bool os::is_allocatable(size_t bytes) {
     return true;
   }
 
-  char* addr = reserve_memory(bytes, NULL);
+  char* addr = reserve_memory(bytes);
 
   if (addr != NULL) {
     release_memory(addr, bytes);

--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
@@ -264,7 +264,7 @@ bool os::is_allocatable(size_t bytes) {
     return true;
   }
 
-  char* addr = reserve_memory(bytes, NULL);
+  char* addr = reserve_memory(bytes);
 
   if (addr != NULL) {
     release_memory(addr, bytes);

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -696,7 +696,7 @@ bool os::is_allocatable(size_t bytes) {
     return true;
   }
 
-  char* addr = reserve_memory(bytes, NULL);
+  char* addr = reserve_memory(bytes);
 
   if (addr != NULL) {
     release_memory(addr, bytes);

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -290,7 +290,7 @@ bool os::is_allocatable(size_t bytes) {
     return true;
   }
 
-  char* addr = reserve_memory(bytes, NULL);
+  char* addr = reserve_memory(bytes);
 
   if (addr != NULL) {
     release_memory(addr, bytes);

--- a/src/hotspot/share/memory/allocation.inline.hpp
+++ b/src/hotspot/share/memory/allocation.inline.hpp
@@ -60,7 +60,7 @@ E* MmapArrayAllocator<E>::allocate_or_null(size_t length, MEMFLAGS flags) {
   size_t size = size_for(length);
   int alignment = os::vm_allocation_granularity();
 
-  char* addr = os::reserve_memory(size, NULL, alignment, flags);
+  char* addr = os::reserve_memory(size, alignment, flags);
   if (addr == NULL) {
     return NULL;
   }
@@ -78,7 +78,7 @@ E* MmapArrayAllocator<E>::allocate(size_t length, MEMFLAGS flags) {
   size_t size = size_for(length);
   int alignment = os::vm_allocation_granularity();
 
-  char* addr = os::reserve_memory(size, NULL, alignment, flags);
+  char* addr = os::reserve_memory(size, alignment, flags);
   if (addr == NULL) {
     vm_exit_out_of_memory(size, OOM_MMAP_ERROR, "Allocator (reserve)");
   }

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -196,7 +196,7 @@ void ReservedSpace::initialize(size_t size, size_t alignment, bool large,
         base = NULL;
       }
     } else {
-      base = os::reserve_memory(size, NULL, alignment, _fd_for_heap);
+      base = os::reserve_memory_with_fd(size, alignment, _fd_for_heap);
     }
 
     if (base == NULL) return;
@@ -390,7 +390,7 @@ void ReservedHeapSpace::try_reserve_heap(size_t size,
     if (requested_address != 0) {
       base = os::attempt_reserve_memory_at(size, requested_address, _fd_for_heap);
     } else {
-      base = os::reserve_memory(size, NULL, alignment, _fd_for_heap);
+      base = os::reserve_memory_with_fd(size, alignment, _fd_for_heap);
     }
   }
   if (base == NULL) { return; }

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -83,6 +83,30 @@ ReservedSpace::ReservedSpace(char* base, size_t size, size_t alignment,
 }
 
 // Helper method
+static char* attempt_map_or_reserve_memory_at(size_t size, char* base, int fd) {
+  if (fd != -1) {
+    return os::attempt_map_memory_to_file_at(size, base, fd);
+  }
+  return os::attempt_reserve_memory_at(size, base);
+}
+
+// Helper method
+static char* map_or_reserve_memory(size_t size, int fd) {
+  if (fd != -1) {
+    return os::map_memory_to_file(size, fd);
+  }
+  return os::reserve_memory(size);
+}
+
+// Helper method
+static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fd) {
+  if (fd != -1) {
+    return os::map_memory_to_file_aligned(size, alignment, fd);
+  }
+  return os::reserve_memory_aligned(size, alignment);
+}
+
+// Helper method
 static void unmap_or_release_memory(char* base, size_t size, bool is_file_mapped) {
   if (is_file_mapped) {
     if (!os::unmap_memory(base, size)) {
@@ -190,13 +214,13 @@ void ReservedSpace::initialize(size_t size, size_t alignment, bool large,
     // important.  If available space is not detected, return NULL.
 
     if (requested_address != 0) {
-      base = os::attempt_reserve_memory_at(size, requested_address, _fd_for_heap);
+      base = attempt_map_or_reserve_memory_at(size, requested_address, _fd_for_heap);
       if (failed_to_reserve_as_requested(base, requested_address, size, false, _fd_for_heap != -1)) {
         // OS ignored requested address. Try different address.
         base = NULL;
       }
     } else {
-      base = os::reserve_memory_with_fd(size, alignment, _fd_for_heap);
+      base = map_or_reserve_memory(size, _fd_for_heap);
     }
 
     if (base == NULL) return;
@@ -208,7 +232,7 @@ void ReservedSpace::initialize(size_t size, size_t alignment, bool large,
 
       // Make sure that size is aligned
       size = align_up(size, alignment);
-      base = os::reserve_memory_aligned(size, alignment, _fd_for_heap);
+      base = map_or_reserve_memory_aligned(size, alignment, _fd_for_heap);
 
       if (requested_address != 0 &&
           failed_to_reserve_as_requested(base, requested_address, size, false, _fd_for_heap != -1)) {
@@ -388,9 +412,9 @@ void ReservedHeapSpace::try_reserve_heap(size_t size,
     // important.  If available space is not detected, return NULL.
 
     if (requested_address != 0) {
-      base = os::attempt_reserve_memory_at(size, requested_address, _fd_for_heap);
+      base = attempt_map_or_reserve_memory_at(size, requested_address, _fd_for_heap);
     } else {
-      base = os::reserve_memory_with_fd(size, alignment, _fd_for_heap);
+      base = map_or_reserve_memory(size, _fd_for_heap);
     }
   }
   if (base == NULL) { return; }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1321,7 +1321,7 @@ WB_ENTRY(void, WB_ReadReservedMemory(JNIEnv* env, jobject o))
   static char c;
   static volatile char* p;
 
-  p = os::reserve_memory(os::vm_allocation_granularity(), NULL, 0);
+  p = os::reserve_memory(os::vm_allocation_granularity());
   if (p == NULL) {
     THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(), "Failed to reserve memory");
   }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1737,32 +1737,33 @@ bool os::create_stack_guard_pages(char* addr, size_t bytes) {
   return os::pd_create_stack_guard_pages(addr, bytes);
 }
 
-char* os::reserve_memory(size_t bytes, char* addr, size_t alignment_hint, int file_desc) {
-  char* result = NULL;
-
-  if (file_desc != -1) {
-    // Could have called pd_reserve_memory() followed by replace_existing_mapping_with_file_mapping(),
-    // but AIX may use SHM in which case its more trouble to detach the segment and remap memory to the file.
-    result = os::map_memory_to_file(addr, bytes, file_desc);
-    if (result != NULL) {
-      MemTracker::record_virtual_memory_reserve_and_commit((address)result, bytes, CALLER_PC);
-    }
-  } else {
-    result = pd_reserve_memory(bytes, addr, alignment_hint);
-    if (result != NULL) {
-      MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
+char* os::reserve_memory(size_t bytes, size_t alignment_hint, MEMFLAGS flags) {
+  char* result = pd_reserve_memory(bytes, alignment_hint);
+  if (result != NULL) {
+    MemTracker::record_virtual_memory_reserve(result, bytes, CALLER_PC);
+    if (flags != mtOther) {
+      MemTracker::record_virtual_memory_type(result, flags);
     }
   }
 
   return result;
 }
 
-char* os::reserve_memory(size_t bytes, char* addr, size_t alignment_hint,
-   MEMFLAGS flags) {
-  char* result = pd_reserve_memory(bytes, addr, alignment_hint);
-  if (result != NULL) {
-    MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
-    MemTracker::record_virtual_memory_type((address)result, flags);
+char* os::reserve_memory_with_fd(size_t bytes, size_t alignment_hint, int file_desc) {
+  char* result;
+
+  if (file_desc != -1) {
+    // Could have called pd_reserve_memory() followed by replace_existing_mapping_with_file_mapping(),
+    // but AIX may use SHM in which case its more trouble to detach the segment and remap memory to the file.
+    result = os::map_memory_to_file(NULL /* addr */, bytes, file_desc);
+    if (result != NULL) {
+      MemTracker::record_virtual_memory_reserve_and_commit(result, bytes, CALLER_PC);
+    }
+  } else {
+    result = pd_reserve_memory(bytes, alignment_hint);
+    if (result != NULL) {
+      MemTracker::record_virtual_memory_reserve(result, bytes, CALLER_PC);
+    }
   }
 
   return result;

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1749,38 +1749,11 @@ char* os::reserve_memory(size_t bytes, size_t alignment_hint, MEMFLAGS flags) {
   return result;
 }
 
-char* os::reserve_memory_with_fd(size_t bytes, size_t alignment_hint, int file_desc) {
-  char* result;
 
-  if (file_desc != -1) {
-    // Could have called pd_reserve_memory() followed by replace_existing_mapping_with_file_mapping(),
-    // but AIX may use SHM in which case its more trouble to detach the segment and remap memory to the file.
-    result = os::map_memory_to_file(NULL /* addr */, bytes, file_desc);
-    if (result != NULL) {
-      MemTracker::record_virtual_memory_reserve_and_commit(result, bytes, CALLER_PC);
-    }
-  } else {
-    result = pd_reserve_memory(bytes, alignment_hint);
-    if (result != NULL) {
-      MemTracker::record_virtual_memory_reserve(result, bytes, CALLER_PC);
-    }
-  }
-
-  return result;
-}
-
-char* os::attempt_reserve_memory_at(size_t bytes, char* addr, int file_desc) {
-  char* result = NULL;
-  if (file_desc != -1) {
-    result = pd_attempt_reserve_memory_at(bytes, addr, file_desc);
-    if (result != NULL) {
-      MemTracker::record_virtual_memory_reserve_and_commit((address)result, bytes, CALLER_PC);
-    }
-  } else {
-    result = pd_attempt_reserve_memory_at(bytes, addr);
-    if (result != NULL) {
-      MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
-    }
+char* os::attempt_reserve_memory_at(size_t bytes, char* addr) {
+  char* result = pd_attempt_reserve_memory_at(bytes, addr);
+  if (result != NULL) {
+    MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
   }
   return result;
 }
@@ -1851,6 +1824,25 @@ void os::pretouch_memory(void* start, void* end, size_t page_size) {
   for (volatile char *p = (char*)start; p < (char*)end; p += page_size) {
     *p = 0;
   }
+}
+
+char* os::map_memory_to_file(size_t bytes, int file_desc) {
+  // Could have called pd_reserve_memory() followed by replace_existing_mapping_with_file_mapping(),
+  // but AIX may use SHM in which case its more trouble to detach the segment and remap memory to the file.
+  // On all current implementations NULL is interpreted as any available address.
+  char* result = os::map_memory_to_file(NULL /* addr */, bytes, file_desc);
+  if (result != NULL) {
+    MemTracker::record_virtual_memory_reserve_and_commit(result, bytes, CALLER_PC);
+  }
+  return result;
+}
+
+char* os::attempt_map_memory_to_file_at(size_t bytes, char* addr, int file_desc) {
+  char* result = pd_attempt_map_memory_to_file_at(bytes, addr, file_desc);
+  if (result != NULL) {
+    MemTracker::record_virtual_memory_reserve_and_commit((address)result, bytes, CALLER_PC);
+  }
+  return result;
 }
 
 char* os::map_memory(int fd, const char* file_name, size_t file_offset,

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -114,7 +114,6 @@ class os: AllStatic {
   static char*  pd_reserve_memory(size_t bytes, size_t alignment_hint);
 
   static char*  pd_attempt_reserve_memory_at(size_t bytes, char* addr);
-  static char*  pd_attempt_reserve_memory_at(size_t bytes, char* addr, int file_desc);
 
   static void   pd_split_reserved_memory(char *base, size_t size,
                                       size_t split, bool realloc);
@@ -130,6 +129,8 @@ class os: AllStatic {
                                          bool executable, const char* mesg);
   static bool   pd_uncommit_memory(char* addr, size_t bytes);
   static bool   pd_release_memory(char* addr, size_t bytes);
+
+  static char*  pd_attempt_map_memory_to_file_at(size_t bytes, char* addr, int file_desc);
 
   static char*  pd_map_memory(int fd, const char* file_name, size_t file_offset,
                            char *addr, size_t bytes, bool read_only = false,
@@ -331,16 +332,12 @@ class os: AllStatic {
   // alignment_hint - currently only used by AIX
   static char*  reserve_memory(size_t bytes, size_t alignment_hint = 0, MEMFLAGS flags = mtOther);
 
-  // Reserves virtual memory.
-  // if file_desc != -1, also attaches the memory to the file.
-  static char*  reserve_memory_with_fd(size_t bytes, size_t alignment_hint, int file_desc);
-
   // Reserves virtual memory that starts at an address that is aligned to 'alignment'.
-  static char*  reserve_memory_aligned(size_t size, size_t alignment, int file_desc = -1);
+  static char*  reserve_memory_aligned(size_t size, size_t alignment);
 
   // Attempts to reserve the virtual memory at [addr, addr + bytes).
   // Does not overwrite existing mappings.
-  static char*  attempt_reserve_memory_at(size_t bytes, char* addr, int file_desc = -1);
+  static char*  attempt_reserve_memory_at(size_t bytes, char* addr);
 
   static void   split_reserved_memory(char *base, size_t size,
                                       size_t split, bool realloc);
@@ -377,7 +374,10 @@ class os: AllStatic {
   static int create_file_for_heap(const char* dir);
   // Map memory to the file referred by fd. This function is slightly different from map_memory()
   // and is added to be used for implementation of -XX:AllocateHeapAt
+  static char* map_memory_to_file(size_t size, int fd);
+  static char* map_memory_to_file_aligned(size_t size, size_t alignment, int fd);
   static char* map_memory_to_file(char* base, size_t size, int fd);
+  static char* attempt_map_memory_to_file_at(size_t size, char* base, int fd);
   // Replace existing reserved memory with file mapping
   static char* replace_existing_mapping_with_file_mapping(char* base, size_t size, int fd);
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -111,10 +111,11 @@ class os: AllStatic {
     _page_sizes[1] = 0; // sentinel
   }
 
-  static char*  pd_reserve_memory(size_t bytes, char* addr = 0,
-                                  size_t alignment_hint = 0);
+  static char*  pd_reserve_memory(size_t bytes, size_t alignment_hint);
+
   static char*  pd_attempt_reserve_memory_at(size_t bytes, char* addr);
   static char*  pd_attempt_reserve_memory_at(size_t bytes, char* addr, int file_desc);
+
   static void   pd_split_reserved_memory(char *base, size_t size,
                                       size_t split, bool realloc);
   static bool   pd_commit_memory(char* addr, size_t bytes, bool executable);
@@ -325,12 +326,22 @@ class os: AllStatic {
                                                   const size_t size);
 
   static int    vm_allocation_granularity();
-  static char*  reserve_memory(size_t bytes, char* addr = 0,
-                               size_t alignment_hint = 0, int file_desc = -1);
-  static char*  reserve_memory(size_t bytes, char* addr,
-                               size_t alignment_hint, MEMFLAGS flags);
+
+  // Reserves virtual memory.
+  // alignment_hint - currently only used by AIX
+  static char*  reserve_memory(size_t bytes, size_t alignment_hint = 0, MEMFLAGS flags = mtOther);
+
+  // Reserves virtual memory.
+  // if file_desc != -1, also attaches the memory to the file.
+  static char*  reserve_memory_with_fd(size_t bytes, size_t alignment_hint, int file_desc);
+
+  // Reserves virtual memory that starts at an address that is aligned to 'alignment'.
   static char*  reserve_memory_aligned(size_t size, size_t alignment, int file_desc = -1);
+
+  // Attempts to reserve the virtual memory at [addr, addr + bytes).
+  // Does not overwrite existing mappings.
   static char*  attempt_reserve_memory_at(size_t bytes, char* addr, int file_desc = -1);
+
   static void   split_reserved_memory(char *base, size_t size,
                                       size_t split, bool realloc);
   static bool   commit_memory(char* addr, size_t bytes, bool executable);

--- a/src/hotspot/share/runtime/safepointMechanism.cpp
+++ b/src/hotspot/share/runtime/safepointMechanism.cpp
@@ -49,7 +49,7 @@ void SafepointMechanism::default_initialize() {
       // Polling page
       const size_t page_size = os::vm_page_size();
       const size_t allocation_size = 2 * page_size;
-      char* polling_page = os::reserve_memory(allocation_size, NULL, page_size);
+      char* polling_page = os::reserve_memory(allocation_size, page_size);
       os::commit_memory_or_exit(polling_page, allocation_size, false, "Unable to commit Safepoint polling page");
       MemTracker::record_virtual_memory_type((address)polling_page, mtSafepoint);
 
@@ -73,7 +73,7 @@ void SafepointMechanism::default_initialize() {
     _poll_disarmed_value = reinterpret_cast<void*>(poll_disarmed_value);
   } else {
     const size_t page_size = os::vm_page_size();
-    char* polling_page = os::reserve_memory(page_size, NULL, page_size);
+    char* polling_page = os::reserve_memory(page_size, page_size);
     os::commit_memory_or_exit(polling_page, page_size, false, "Unable to commit Safepoint polling page");
     os::protect_memory(polling_page, page_size, os::MEM_PROT_READ);
     MemTracker::record_virtual_memory_type((address)polling_page, mtSafepoint);
@@ -100,7 +100,7 @@ void SafepointMechanism::initialize_header(JavaThread* thread) {
 void SafepointMechanism::initialize_serialize_page() {
   if (!UseMembar) {
     const size_t page_size = os::vm_page_size();
-    char* serialize_page = os::reserve_memory(page_size, NULL, page_size);
+    char* serialize_page = os::reserve_memory(page_size, page_size);
     os::commit_memory_or_exit(serialize_page, page_size, false, "Unable to commit memory serialization page");
     log_info(os)("Memory Serialize Page address: " INTPTR_FORMAT, p2i(serialize_page));
     os::set_memory_serialize_page((address)(serialize_page));

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -101,7 +101,7 @@ public:
   static void test_committed_region_impl(size_t num_pages, size_t touch_pages, int* page_num) {
     const size_t page_sz = os::vm_page_size();
     const size_t size = num_pages * page_sz;
-    char* base = os::reserve_memory(size, NULL, page_sz, mtThreadStack);
+    char* base = os::reserve_memory(size, page_sz, mtThreadStack);
     bool result = os::commit_memory(base, size, false);
     size_t index;
     ASSERT_NE(base, (char*)NULL);
@@ -169,7 +169,7 @@ public:
     const size_t page_sz = os::vm_page_size();
     const size_t num_pages = 4;
     const size_t size = num_pages * page_sz;
-    char* base = os::reserve_memory(size, NULL, page_sz, mtTest);
+    char* base = os::reserve_memory(size, page_sz, mtTest);
     ASSERT_NE(base, (char*)NULL);
     result = os::commit_memory(base, size, false);
 


### PR DESCRIPTION
Please review this backport of JDK-8255254 to jdk11u-dev.
This is a prerequest for mac-aarch64 and MAP_JIT support.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8255254](https://bugs.openjdk.java.net/browse/JDK-8255254): Split os::reserve_memory and os::map_memory_to_file interfaces


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/577/head:pull/577` \
`$ git checkout pull/577`

Update a local copy of the PR: \
`$ git checkout pull/577` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 577`

View PR using the GUI difftool: \
`$ git pr show -t 577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/577.diff">https://git.openjdk.java.net/jdk11u-dev/pull/577.diff</a>

</details>
