### PR TITLE
8276066: Reset LoopPercentProfileLimit for x86 due to suboptimal performance

### DIFF
--- a/src/hotspot/cpu/x86/c2_globals_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_globals_x86.hpp
@@ -46,7 +46,7 @@ define_pd_global(intx, OnStackReplacePercentage,     140);
 define_pd_global(intx, ConditionalMoveLimit,         3);
 define_pd_global(intx, FreqInlineSize,               325);
 define_pd_global(intx, MinJumpTableSize,             10);
-define_pd_global(intx, LoopPercentProfileLimit,      30);
+define_pd_global(intx, LoopPercentProfileLimit,      10);
 #ifdef AMD64
 define_pd_global(intx,  INTPRESSURE,                 13);
 define_pd_global(intx,  FLOATPRESSURE,               14);

--- a/test/micro/org/openjdk/bench/vm/compiler/LoopUnroll.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/LoopUnroll.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.*;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Fork(value=1)
+public class LoopUnroll {
+    @Param({"16", "32", "64", "128", "256", "512", "1024"})
+    private int VECLEN;
+
+    private byte[][] a;
+    private byte[][] b;
+    private byte[][] c;
+
+    @Setup
+    public void init() {
+        a = new byte[VECLEN][VECLEN];
+        b = new byte[VECLEN][VECLEN];
+        c = new byte[VECLEN][VECLEN];
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private int run_workload1(int count, byte[][] a , byte[][] b, byte[][] c) {
+        for(int i = 0; i < a.length; i++) {
+            for (int j = 0; j < a[0].length; j++) {
+                a[i][j] = (byte)(b[i][j] + c[i][j]);
+            }
+        }
+        return a[count][count];
+    }
+
+    @Benchmark
+    public void workload1_caller(Blackhole bh) {
+        int r = 0;
+        for(int i = 0 ; i < 100; i++) {
+            r += run_workload1(i % a.length, a, b, c);
+        }
+        bh.consume(r);
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    private int run_workload2(int count, byte[][] a , byte[][] b) {
+        for(int i = 0; i < b.length; i++) {
+            for (int j = 0; j < b[0].length; j++) {
+                a[i][j] = b[i][j];
+            }
+        }
+        return a[count][count];
+    }
+
+    @Benchmark
+    public void workload2_caller(Blackhole bh) {
+        int r = 0;
+        for(int i = 0 ; i < 100; i++) {
+            r += run_workload2(i % a.length, a, b);
+        }
+        bh.consume(r);
+    }
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276066](https://bugs.openjdk.java.net/browse/JDK-8276066): Reset LoopPercentProfileLimit for x86 due to suboptimal performance


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/582/head:pull/582` \
`$ git checkout pull/582`

Update a local copy of the PR: \
`$ git checkout pull/582` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 582`

View PR using the GUI difftool: \
`$ git pr show -t 582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/582.diff">https://git.openjdk.java.net/jdk11u-dev/pull/582.diff</a>

</details>
