### PR TITLE
8274338: com/sun/jdi/RedefineCrossEvent.java failed "assert(m != __null) failed: NULL mirror"

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -342,6 +342,9 @@ void ClassLoaderData::methods_do(void f(Method*)) {
 }
 
 void ClassLoaderData::loaded_classes_do(KlassClosure* klass_closure) {
+  // To call this, one must have the MultiArray_lock held, but the _klasses list still has lock free reads.
+  assert_locked_or_safepoint(MultiArray_lock);
+
   // Lock-free access requires load_acquire
   for (Klass* k = OrderAccess::load_acquire(&_klasses); k != NULL; k = k->next_link()) {
     // Do not filter ArrayKlass oops here...

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -1627,6 +1627,7 @@ void MetaspaceShared::link_and_cleanup_shared_classes(TRAPS) {
   // We need to iterate because verification may cause additional classes
   // to be loaded.
   LinkSharedClassesClosure link_closure(THREAD);
+  MutexLocker locker(MultiArray_lock);
   do {
     link_closure.reset();
     ClassLoaderDataGraph::loaded_classes_do(&link_closure);

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -1627,6 +1627,8 @@ void MetaspaceShared::link_and_cleanup_shared_classes(TRAPS) {
   // We need to iterate because verification may cause additional classes
   // to be loaded.
   LinkSharedClassesClosure link_closure(THREAD);
+  // To get a consistent list of classes we need MultiArray_lock to ensure
+  // array classes aren't created.
   MutexLocker locker(MultiArray_lock);
   do {
     link_closure.reset();

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2378,6 +2378,9 @@ void InstanceKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handl
   constants()->restore_unshareable_info(CHECK);
 
   if (array_klasses() != NULL) {
+    // To get a consistent list of classes we need MultiArray_lock to ensure
+    // array classes aren't observed while they are being restored.
+     MutexLocker ml(MultiArray_lock);
     // Array classes have null protection domain.
     // --> see ArrayKlass::complete_create_array_klass()
     array_klasses()->restore_unshareable_info(ClassLoaderData::the_null_class_loader_data(), Handle(), CHECK);


### PR DESCRIPTION
Backport for parity with Oracle 11.0.15.

The original patch applies cleanly, but some of CDS tests fail due to following new assertion in `ClassLoaderData::loaded_classes_do()`

`  // To call this, one must have the MultiArray_lock held, but the _klasses list still has lock free reads.
  assert_locked_or_safepoint(MultiArray_lock);
`
The solution is to take `MultiArray_lock` in `MetaspaceShared::link_and_cleanup_shared_classes()` method

Test:
- [x]  tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274338](https://bugs.openjdk.java.net/browse/JDK-8274338): com/sun/jdi/RedefineCrossEvent.java failed "assert(m != __null) failed: NULL mirror"


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/584/head:pull/584` \
`$ git checkout pull/584`

Update a local copy of the PR: \
`$ git checkout pull/584` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 584`

View PR using the GUI difftool: \
`$ git pr show -t 584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/584.diff">https://git.openjdk.java.net/jdk11u-dev/pull/584.diff</a>

</details>
