### PR TITLE
8233560: [TESTBUG] ToolTipManager/Test6256140.java  is failing on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -758,7 +758,6 @@ javax/swing/JComboBox/7031551/bug7031551.java 8199056 generic-all
 javax/swing/JScrollBar/6924059/bug6924059.java 8199078 generic-all
 javax/swing/JTabbedPane/TabProb.java 8236635 linux-all
 javax/swing/JTree/8003830/bug8003830.java 8199057 generic-all
-javax/swing/ToolTipManager/Test6256140.java 8233560 macosx-all
 javax/swing/text/View/8014863/bug8014863.java 8233561 macosx-all
 javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233562 macosx-all
 javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java 233570 macosx-all

--- a/test/jdk/javax/swing/ToolTipManager/Test6256140.java
+++ b/test/jdk/javax/swing/ToolTipManager/Test6256140.java
@@ -40,49 +40,58 @@ public class Test6256140 {
 
     private final static String initialText = "value";
     private final static JLabel toolTipLabel = new JLabel("tip");
+    private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
 
-        Robot robot = new Robot();
-        robot.setAutoDelay(10);
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    createAndShowGUI();
+                }
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                createAndShowGUI();
+            Point point = ft.getLocationOnScreen();
+            robot.mouseMove(point.x, point.y);
+            robot.waitForIdle();
+            robot.mouseMove(point.x + 3, point.y + 3);
+            robot.waitForIdle();
+
+            robot.keyPress(KeyEvent.VK_A);
+            robot.keyRelease(KeyEvent.VK_A);
+            robot.waitForIdle();
+
+            if (!isTooltipShowning()) {
+                throw new RuntimeException("Tooltip is not shown");
             }
-        });
-        robot.waitForIdle();
 
-        Point point = ft.getLocationOnScreen();
-        robot.mouseMove(point.x, point.y);
-        robot.mouseMove(point.x + 3, point.y + 3);
+            robot.keyPress(KeyEvent.VK_ESCAPE);
+            robot.keyRelease(KeyEvent.VK_ESCAPE);
+            robot.waitForIdle();
 
-        robot.keyPress(KeyEvent.VK_A);
-        robot.keyRelease(KeyEvent.VK_A);
-        robot.waitForIdle();
+            if (isTooltipShowning()) {
+                throw new RuntimeException("Tooltip must be hidden now");
+            }
 
-        if (!isTooltipShowning()) {
-            throw new RuntimeException("Tooltip is not shown");
-        }
+            if (isTextEqual()) {
+                throw new RuntimeException("FormattedTextField must *not* cancel the updated value this time");
+            }
 
-        robot.keyPress(KeyEvent.VK_ESCAPE);
-        robot.keyRelease(KeyEvent.VK_ESCAPE);
-        robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_ESCAPE);
+            robot.keyRelease(KeyEvent.VK_ESCAPE);
+            robot.waitForIdle();
 
-        if (isTooltipShowning()) {
-            throw new RuntimeException("Tooltip must be hidden now");
-        }
-
-        if (isTextEqual()) {
-            throw new RuntimeException("FormattedTextField must *not* cancel the updated value this time");
-        }
-
-        robot.keyPress(KeyEvent.VK_ESCAPE);
-        robot.keyRelease(KeyEvent.VK_ESCAPE);
-        robot.waitForIdle();
-
-        if (!isTextEqual()) {
-            throw new RuntimeException("FormattedTextField must cancel the updated value");
+            if (!isTextEqual()) {
+                throw new RuntimeException("FormattedTextField must cancel the updated value");
+            }
+        } finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
+            }
         }
     }
 
@@ -116,7 +125,7 @@ public class Test6256140 {
         ToolTipManager.sharedInstance().setDismissDelay(Integer.MAX_VALUE);
         ToolTipManager.sharedInstance().setInitialDelay(0);
 
-        final JFrame frame = new JFrame();
+        frame = new JFrame();
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setLayout(new FlowLayout());
 


### PR DESCRIPTION
Backport of JDK-8233560.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233560](https://bugs.openjdk.java.net/browse/JDK-8233560): [TESTBUG] ToolTipManager/Test6256140.java  is failing on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/585/head:pull/585` \
`$ git checkout pull/585`

Update a local copy of the PR: \
`$ git checkout pull/585` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 585`

View PR using the GUI difftool: \
`$ git pr show -t 585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/585.diff">https://git.openjdk.java.net/jdk11u-dev/pull/585.diff</a>

</details>
