### PR TITLE
8233641: [TESTBUG] JMenuItem test bug4171437.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -766,7 +766,6 @@ javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
 javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8233637 macosx-all
 javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
-javax/swing/JMenuItem/4171437/bug4171437.java 8233641 macosx-all
 javax/swing/plaf/synth/7158712/bug7158712.java 8238720 windows-all
 javax/swing/plaf/basic/BasicComboPopup/JComboBoxPopupLocation/JComboBoxPopupLocation.java 8238720 windows-all
 javax/swing/plaf/basic/BasicComboPopup/7072653/bug7072653.java 8238720 windows-all

--- a/test/jdk/javax/swing/JMenuItem/4171437/bug4171437.java
+++ b/test/jdk/javax/swing/JMenuItem/4171437/bug4171437.java
@@ -44,21 +44,21 @@ public class bug4171437 {
 
     public static void main(String[] args) throws Exception {
         try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
             SwingUtilities.invokeAndWait(new Runnable() {
                 public void run() {
                     createAndShowGUI();
                 }
             });
 
-            Robot robot = new Robot();
-            robot.setAutoDelay(50);
             robot.waitForIdle();
+            robot.delay(1000);
 
             Util.hitMnemonics(robot, KeyEvent.VK_F);
             Util.hitKeys(robot, KeyEvent.VK_C);
 
             robot.waitForIdle();
-            Thread.sleep(1000);
 
             if (!closeActivated || customActivated) {
                 throw new RuntimeException("Didn't pass the muster");
@@ -109,6 +109,7 @@ public class bug4171437 {
         frame.setSize(300, 300);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 }


### PR DESCRIPTION
Backport of JDK-8233641.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233641](https://bugs.openjdk.java.net/browse/JDK-8233641): [TESTBUG] JMenuItem test bug4171437.java fails on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/586/head:pull/586` \
`$ git checkout pull/586`

Update a local copy of the PR: \
`$ git checkout pull/586` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 586`

View PR using the GUI difftool: \
`$ git pr show -t 586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/586.diff">https://git.openjdk.java.net/jdk11u-dev/pull/586.diff</a>

</details>
