### PR TITLE
8233637: [TESTBUG] Swing ActionListenerCalledTwiceTest.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -765,7 +765,6 @@ javax/swing/text/html/HTMLEditorKit/5043626/bug5043626.java 233570 macosx-all
 javax/swing/text/GlyphPainter2/6427244/bug6427244.java 8208566 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
-javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8233637 macosx-all
 javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
 javax/swing/JMenuItem/4171437/bug4171437.java 8233641 macosx-all
 javax/swing/plaf/synth/7158712/bug7158712.java 8238720 windows-all

--- a/test/jdk/javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java
+++ b/test/jdk/javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java
@@ -63,13 +63,15 @@ public class ActionListenerCalledTwiceTest {
         }
 
         try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
 
             System.setProperty("apple.laf.useScreenMenuBar", "true");
             SwingUtilities.invokeAndWait(
                     ActionListenerCalledTwiceTest::createAndShowGUI);
 
-            Robot robot = new Robot();
-            robot.setAutoDelay(100);
+            robot.waitForIdle();
+            robot.delay(1000);
 
             testForTwice(robot, "");
 
@@ -99,6 +101,7 @@ public class ActionListenerCalledTwiceTest {
         frame.setJMenuBar(bar);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 


### PR DESCRIPTION
Backport of JDK-8233637.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233637](https://bugs.openjdk.java.net/browse/JDK-8233637): [TESTBUG] Swing ActionListenerCalledTwiceTest.java fails on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/587/head:pull/587` \
`$ git checkout pull/587`

Update a local copy of the PR: \
`$ git checkout pull/587` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 587`

View PR using the GUI difftool: \
`$ git pr show -t 587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/587.diff">https://git.openjdk.java.net/jdk11u-dev/pull/587.diff</a>

</details>
