### PR TITLE
8256182: Update qemu-debootstrap cross-compilation recipe

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -686,11 +686,24 @@ cp: cannot stat `arm-linux-gnueabihf/libXt.so&#39;: No such file or directory</c
 <li><p>Install cross-compiler on the <em>build</em> system:</p>
 <pre><code>apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu</code></pre></li>
 <li><p>Create chroot on the <em>build</em> system, configuring it for <em>target</em> system:</p>
-<pre><code>sudo qemu-debootstrap --arch=arm64 --verbose \
-   --include=fakeroot,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng12-dev \
-   --resolve-deps jessie /chroots/arm64 http://httpredir.debian.org/debian/</code></pre></li>
+<pre><code>sudo qemu-debootstrap \
+  --arch=arm64 \
+  --verbose \
+  --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev \
+  --resolve-deps \
+  buster \
+  ~/sysroot-arm64 \
+  http://httpredir.debian.org/debian/</code></pre></li>
+<li><p>Make sure the symlinks inside the newly created chroot point to proper locations:</p>
+<pre><code>sudo chroot ~/sysroot-arm64 symlinks -cr .</code></pre></li>
 <li><p>Configure and build with newly created chroot as sysroot/toolchain-path:</p>
-<pre><code>CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ sh ./configure --openjdk-target=aarch64-linux-gnu --with-sysroot=/chroots/arm64/ --with-toolchain-path=/chroots/arm64/
+<pre><code>CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ sh ./configure \
+ --openjdk-target=aarch64-linux-gnu \
+ --with-sysroot=~/sysroot-arm64 \
+ --with-toolchain-path=~/sysroot-arm64 \
+ --with-freetype-lib=~/sysroot-arm64/usr/lib/aarch64-linux-gnu/ \
+ --with-freetype-include=~/sysroot-arm64/usr/include/freetype2/ \
+ --x-libraries=~/sysroot-arm64/usr/lib/aarch64-linux-gnu/
 make images
 ls build/linux-aarch64-normal-server-release/</code></pre></li>
 </ul>

--- a/doc/building.md
+++ b/doc/building.md
@@ -1100,23 +1100,39 @@ for foreign architectures with native compilation speed.
 For example, cross-compiling to AArch64 from x86_64 could be done like this:
 
   * Install cross-compiler on the *build* system:
-```
-apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
-```
+    ```
+    apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+    ```
 
   * Create chroot on the *build* system, configuring it for *target* system:
-```
-sudo qemu-debootstrap --arch=arm64 --verbose \
-       --include=fakeroot,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng12-dev \
-       --resolve-deps jessie /chroots/arm64 http://httpredir.debian.org/debian/
-```
+    ```
+    sudo qemu-debootstrap \
+      --arch=arm64 \
+      --verbose \
+      --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev \
+      --resolve-deps \
+      buster \
+      ~/sysroot-arm64 \
+      http://httpredir.debian.org/debian/
+    ```
+
+  * Make sure the symlinks inside the newly created chroot point to proper locations:
+    ```
+    sudo chroot ~/sysroot-arm64 symlinks -cr .
+    ```
 
   * Configure and build with newly created chroot as sysroot/toolchain-path:
-```
-CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ sh ./configure --openjdk-target=aarch64-linux-gnu --with-sysroot=/chroots/arm64/ --with-toolchain-path=/chroots/arm64/
-make images
-ls build/linux-aarch64-normal-server-release/
-```
+    ```
+    CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ sh ./configure \
+     --openjdk-target=aarch64-linux-gnu \
+     --with-sysroot=~/sysroot-arm64 \
+     --with-toolchain-path=~/sysroot-arm64 \
+     --with-freetype-lib=~/sysroot-arm64/usr/lib/aarch64-linux-gnu/ \
+     --with-freetype-include=~/sysroot-arm64/usr/include/freetype2/ \
+     --x-libraries=~/sysroot-arm64/usr/lib/aarch64-linux-gnu/
+    make images
+    ls build/linux-aarch64-normal-server-release/
+    ```
 
 The build does not create new files in that chroot, so it can be reused for multiple builds
 without additional cleanup.


### PR DESCRIPTION
Unclean backport to improve cross-build implementation. The uncleanliness comes from the fact that 11u builds are in `linux-aarch64-*normal*-server-release`, so the hunks do not apply cleanly. I just accepted the hunks from the mainline patch and added "normal" manually.

Original change was to match the docs with what we run in GHA. The same motivation holds for 11u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256182](https://bugs.openjdk.java.net/browse/JDK-8256182): Update qemu-debootstrap cross-compilation recipe


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/589/head:pull/589` \
`$ git checkout pull/589`

Update a local copy of the PR: \
`$ git checkout pull/589` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 589`

View PR using the GUI difftool: \
`$ git pr show -t 589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/589.diff">https://git.openjdk.java.net/jdk11u-dev/pull/589.diff</a>

</details>
