### PR TITLE
8261916: gtest/GTestWrapper.java vmErrorTest.unimplemented1_vm_assert failed

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1188,7 +1188,7 @@ void os::abort(bool dump_core, void* siginfo, const void* context) {
     ::abort(); // dump core
   }
 
-  ::exit(1);
+  ::_exit(1);
 }
 
 // Die immediately, no exit hook, no abort hook, no cleanup.

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1092,7 +1092,7 @@ void os::abort(bool dump_core, void* siginfo, const void* context) {
     ::abort(); // dump core
   }
 
-  ::exit(1);
+  ::_exit(1);
 }
 
 // Die immediately, no exit hook, no abort hook, no cleanup.

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1512,7 +1512,7 @@ void os::abort(bool dump_core, void* siginfo, const void* context) {
     ::abort(); // dump core
   }
 
-  ::exit(1);
+  ::_exit(1);
 }
 
 // Die immediately, no exit hook, no abort hook, no cleanup.

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -2265,4 +2265,5 @@ void Parker::unpark() {
   }
 }
 
+
 #endif // !SOLARIS

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -2265,5 +2265,4 @@ void Parker::unpark() {
   }
 }
 
-
 #endif // !SOLARIS

--- a/src/hotspot/os/solaris/os_solaris.cpp
+++ b/src/hotspot/os/solaris/os_solaris.cpp
@@ -1343,7 +1343,7 @@ void os::abort(bool dump_core, void* siginfo, const void* context) {
     ::abort(); // dump core (for debugging)
   }
 
-  ::exit(1);
+  ::_exit(1);
 }
 
 // Die immediately, no exit hook, no abort hook, no cleanup.

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1341,12 +1341,13 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
   static bool log_done = false;         // done saving error log
   static bool transmit_report_done = false; // done error reporting
 
-  if (SuppressFatalErrorMessage) {
-      os::abort(CreateCoredumpOnCrash);
-  }
   intptr_t mytid = os::current_thread_id();
   if (first_error_tid == -1 &&
       Atomic::cmpxchg(mytid, &first_error_tid, (intptr_t)-1) == -1) {
+
+    if (SuppressFatalErrorMessage) {
+      os::abort(CreateCoredumpOnCrash);
+    }
 
     // Initialize time stamps to use the same base.
     out.time_stamp().update_to(1);
@@ -1400,19 +1401,31 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
     // This is not the first error, see if it happened in a different thread
     // or in the same thread during error reporting.
     if (first_error_tid != mytid) {
-      char msgbuf[64];
-      jio_snprintf(msgbuf, sizeof(msgbuf),
-                   "[thread " INTX_FORMAT " also had an error]",
-                   mytid);
-      out.print_raw_cr(msgbuf);
+      if (!SuppressFatalErrorMessage) {
+        char msgbuf[64];
+        jio_snprintf(msgbuf, sizeof(msgbuf),
+                     "[thread " INTX_FORMAT " also had an error]",
+                     mytid);
+        out.print_raw_cr(msgbuf);
+      }
 
-      // error reporting is not MT-safe, block current thread
+      // Error reporting is not MT-safe, nor can we let the current thread
+      // proceed, so we block it.
       os::infinite_sleep();
 
     } else {
       if (recursive_error_count++ > 30) {
-        out.print_raw_cr("[Too many errors, abort]");
+        if (!SuppressFatalErrorMessage) {
+          out.print_raw_cr("[Too many errors, abort]");
+        }
         os::die();
+      }
+
+      if (SuppressFatalErrorMessage) {
+        // If we already hit a secondary error during abort, then calling
+        // it again is likely to hit another one. But eventually, if we
+        // don't deadlock somewhere, we will call os::die() above.
+        os::abort(CreateCoredumpOnCrash);
       }
 
       outputStream* const st = log.is_open() ? &log : &out;


### PR DESCRIPTION
Hi,

I'd like to backport "JDK-8263728: gtest/GTestWrapper.java vmErrorTest.unimplemented1_vm_assert failed", since it prevents sporadic gtest errors.

Original commit: https://github.com/openjdk/jdk/commit/8c1112a6

This one is not a clean backport:
- `vmError.cpp` changed slightly, since https://bugs.openjdk.java.net/browse/JDK-8258479 did some code cleanups for JDK17
- more importantly, this patch touches `os::abort()`. That function had been unified into `os_posix.cpp` for all posix platforms with https://bugs.openjdk.java.net/browse/JDK-8263564 for JDK 17. I briefly considered backporting JDK-8263564, but decided against it since it is too invasive and unnecessary. Instead, I changed the various os::abort() implementations for all individual OSes, including Solaris.

Tests: Nightlies at SAP, GHAs.

Thanks, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261916](https://bugs.openjdk.java.net/browse/JDK-8261916): gtest/GTestWrapper.java vmErrorTest.unimplemented1_vm_assert failed


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/590/head:pull/590` \
`$ git checkout pull/590`

Update a local copy of the PR: \
`$ git checkout pull/590` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 590`

View PR using the GUI difftool: \
`$ git pr show -t 590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/590.diff">https://git.openjdk.java.net/jdk11u-dev/pull/590.diff</a>

</details>
