### PR TITLE
8233561: [TESTBUG] Swing text test bug8014863.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -758,7 +758,6 @@ javax/swing/JComboBox/7031551/bug7031551.java 8199056 generic-all
 javax/swing/JScrollBar/6924059/bug6924059.java 8199078 generic-all
 javax/swing/JTabbedPane/TabProb.java 8236635 linux-all
 javax/swing/JTree/8003830/bug8003830.java 8199057 generic-all
-javax/swing/text/View/8014863/bug8014863.java 8233561 macosx-all
 javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233562 macosx-all
 javax/swing/text/GlyphPainter2/6427244/bug6427244.java 8208566 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all

--- a/test/jdk/javax/swing/text/View/8014863/bug8014863.java
+++ b/test/jdk/javax/swing/text/View/8014863/bug8014863.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ public class bug8014863 {
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
         glyphViews = new ArrayList<GlyphView>();
 
         createAndShowGUI(text1);
@@ -152,6 +152,7 @@ public class bug8014863 {
 
                 frame.add(editorPane);
                 frame.setSize(200, 200);
+                frame.setLocationRelativeTo(null);
                 frame.setVisible(true);
             }
         });


### PR DESCRIPTION
Backport of JDK-8233561

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233561](https://bugs.openjdk.java.net/browse/JDK-8233561): [TESTBUG] Swing text test bug8014863.java fails on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/591/head:pull/591` \
`$ git checkout pull/591`

Update a local copy of the PR: \
`$ git checkout pull/591` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 591`

View PR using the GUI difftool: \
`$ git pr show -t 591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/591.diff">https://git.openjdk.java.net/jdk11u-dev/pull/591.diff</a>

</details>
