### PR TITLE
8233562: [TESTBUG] Swing StyledEditorKit test bug4506788.java fails on MacOS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -758,7 +758,6 @@ javax/swing/JComboBox/7031551/bug7031551.java 8199056 generic-all
 javax/swing/JScrollBar/6924059/bug6924059.java 8199078 generic-all
 javax/swing/JTabbedPane/TabProb.java 8236635 linux-all
 javax/swing/JTree/8003830/bug8003830.java 8199057 generic-all
-javax/swing/text/StyledEditorKit/4506788/bug4506788.java 8233562 macosx-all
 javax/swing/text/GlyphPainter2/6427244/bug6427244.java 8208566 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all

--- a/test/jdk/javax/swing/text/StyledEditorKit/4506788/bug4506788.java
+++ b/test/jdk/javax/swing/text/StyledEditorKit/4506788/bug4506788.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,6 +65,7 @@ public class bug4506788 {
         Robot robot;
         try {
             robot = new Robot();
+            robot.setAutoDelay(100);
         } catch (AWTException e) {
             throw new RuntimeException("Robot could not be created");
         }
@@ -78,7 +79,6 @@ public class bug4506788 {
             throw new RuntimeException("Could not get JEditorPane location on screen");
         }
 
-        robot.setAutoDelay(50);
         robot.mouseMove(p.x, p.y);
         robot.mousePress(InputEvent.BUTTON1_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_MASK);


### PR DESCRIPTION
Backport of JDK-8233562.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233562](https://bugs.openjdk.java.net/browse/JDK-8233562): [TESTBUG] Swing StyledEditorKit test bug4506788.java fails on MacOS


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/592/head:pull/592` \
`$ git checkout pull/592`

Update a local copy of the PR: \
`$ git checkout pull/592` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 592`

View PR using the GUI difftool: \
`$ git pr show -t 592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/592.diff">https://git.openjdk.java.net/jdk11u-dev/pull/592.diff</a>

</details>
