### PR TITLE
8171381: [TEST_BUG] [macos] javax/swing/JPopupMenu/7156657/bug7156657.java fails on OS X

### DIFF
--- a/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
+++ b/test/jdk/javax/swing/JPopupMenu/7156657/bug7156657.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.Robot;
-import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.image.BufferedImage;
 import java.util.concurrent.Callable;
@@ -38,8 +37,6 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
 
-import sun.awt.SunToolkit;
-
 /*
    @test
    @key headful
@@ -47,7 +44,6 @@ import sun.awt.SunToolkit;
    @summary Version 7 doesn't support translucent popup menus against a
             translucent window
    @library ../../regtesthelpers
-   @modules java.desktop/sun.awt
 */
 public class bug7156657 {
     private static JFrame lowerFrame;
@@ -58,7 +54,6 @@ public class bug7156657 {
 
     public static void main(String[] args) throws Exception {
         final Robot robot = new Robot();
-        final SunToolkit toolkit = ((SunToolkit) Toolkit.getDefaultToolkit());
 
         Boolean skipTest = Util.invokeOnEDT(new Callable<Boolean>() {
             @Override
@@ -94,7 +89,7 @@ public class bug7156657 {
             return;
         }
 
-        toolkit.realSync();
+        robot.waitForIdle();
 
         SwingUtilities.invokeAndWait(new Runnable() {
             @Override
@@ -103,7 +98,7 @@ public class bug7156657 {
             }
         });
 
-        toolkit.realSync();
+        robot.waitForIdle();
 
         Rectangle popupRectangle = Util.invokeOnEDT(new Callable<Rectangle>() {
             @Override
@@ -121,7 +116,7 @@ public class bug7156657 {
             }
         });
 
-        toolkit.realSync();
+        robot.waitForIdle();
 
         BufferedImage greenBackgroundCapture = robot.createScreenCapture(popupRectangle);
 


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8171381 from the openjdk/jdk repository.

The commit being backported was authored by Alexander Zuev on 21 Apr 2021 and was reviewed by Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8171381](https://bugs.openjdk.java.net/browse/JDK-8171381): [TEST_BUG] [macos] javax/swing/JPopupMenu/7156657/bug7156657.java fails on OS X


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/593/head:pull/593` \
`$ git checkout pull/593`

Update a local copy of the PR: \
`$ git checkout pull/593` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 593`

View PR using the GUI difftool: \
`$ git pr show -t 593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/593.diff">https://git.openjdk.java.net/jdk11u-dev/pull/593.diff</a>

</details>
