### PR TITLE
8136517: [macosx]Test  java/awt/Focus/8073453/AWTFocusTransitionTest.java fails on MacOSX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -170,8 +170,6 @@ java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java 7019055 windows-all,l
 java/awt/Focus/8013611/JDK8013611.java 8175366 windows-all,macosx-all
 java/awt/Focus/6382144/EndlessLoopTest.java 8198617 macosx-all
 java/awt/Focus/6981400/Test1.java 8029675 windows-all,macosx-all
-java/awt/Focus/8073453/AWTFocusTransitionTest.java 8136517 macosx-all
-java/awt/Focus/8073453/SwingFocusTransitionTest.java 8136517 macosx-all
 java/awt/Focus/6981400/Test3.java 8173264 generic-all
 java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java 8169476 windows-all,macosx-all
 java/awt/event/KeyEvent/KeyChar/KeyCharTest.java 8169474,8224055 macosx-all,windows-all

--- a/test/jdk/java/awt/Focus/8073453/AWTFocusTransitionTest.java
+++ b/test/jdk/java/awt/Focus/8073453/AWTFocusTransitionTest.java
@@ -26,12 +26,18 @@
  * @key headful
  * @bug 8073453
  * @summary Focus doesn't move when pressing Shift + Tab keys
- * @author Dmitry Markov
  * @compile AWTFocusTransitionTest.java
  * @run main/othervm AWTFocusTransitionTest
  */
 
-import java.awt.*;
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.DefaultFocusTraversalPolicy;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Robot;
+import java.awt.TextField;
 import java.awt.event.KeyEvent;
 
 public class AWTFocusTransitionTest {
@@ -43,7 +49,7 @@ public class AWTFocusTransitionTest {
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
 
         try {
             createAndShowGUI();
@@ -101,14 +107,15 @@ public class AWTFocusTransitionTest {
         p.add(panel);
 
         frame.add(p);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 
     private static void checkFocusOwner(Component component) {
         if (component != frame.getFocusOwner()) {
-            throw new RuntimeException("Test Failed! Incorrect focus owner: " + frame.getFocusOwner() +
+            throw new RuntimeException("Test Failed! Incorrect focus " +
+                    "owner: " + frame.getFocusOwner() +
                     ", but expected: " + component);
         }
     }
 }
-

--- a/test/jdk/java/awt/Focus/8073453/SwingFocusTransitionTest.java
+++ b/test/jdk/java/awt/Focus/8073453/SwingFocusTransitionTest.java
@@ -26,13 +26,20 @@
  * @key headful
  * @bug 8073453
  * @summary Focus doesn't move when pressing Shift + Tab keys
- * @author Dmitry Markov
  * @compile SwingFocusTransitionTest.java
  * @run main/othervm SwingFocusTransitionTest
  */
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.LayoutFocusTraversalPolicy;
+import javax.swing.SwingUtilities;
+import java.awt.Component;
+import java.awt.DefaultFocusTraversalPolicy;
+import java.awt.GridLayout;
+import java.awt.Robot;
 import java.awt.event.KeyEvent;
 
 public class SwingFocusTransitionTest {
@@ -44,7 +51,7 @@ public class SwingFocusTransitionTest {
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
 
         try {
             SwingUtilities.invokeAndWait(new Runnable() {
@@ -112,19 +119,21 @@ public class SwingFocusTransitionTest {
         p.add(panel);
 
         frame.add(p);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 
-    private static void checkFocusOwner(final Component component) throws Exception {
+    private static void checkFocusOwner(final Component component)
+            throws Exception {
         SwingUtilities.invokeAndWait(new Runnable() {
             @Override
             public void run() {
                 if (component != frame.getFocusOwner()) {
-                    throw new RuntimeException("Test Failed! Incorrect focus owner: " + frame.getFocusOwner() +
+                    throw new RuntimeException("Test Failed! Incorrect focus" +
+                            " owner: " + frame.getFocusOwner() +
                             ", but expected: " + component);
                 }
             }
         });
     }
 }
-


### PR DESCRIPTION
Hi all,

this pull request contains a backport of JDK-8136517 from the openjdk/jdk repository.

The commit being backported was authored by Pankaj Bansal on 28 Apr 2021 and was reviewed by Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8136517](https://bugs.openjdk.java.net/browse/JDK-8136517): [macosx]Test  java/awt/Focus/8073453/AWTFocusTransitionTest.java fails on MacOSX


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/594/head:pull/594` \
`$ git checkout pull/594`

Update a local copy of the PR: \
`$ git checkout pull/594` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 594`

View PR using the GUI difftool: \
`$ git pr show -t 594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/594.diff">https://git.openjdk.java.net/jdk11u-dev/pull/594.diff</a>

</details>
