### PR TITLE
8256956: RegisterImpl::max_slots_per_register is incorrect on AMD64

### DIFF
--- a/src/hotspot/cpu/x86/register_x86.hpp
+++ b/src/hotspot/cpu/x86/register_x86.hpp
@@ -50,7 +50,7 @@ class RegisterImpl: public AbstractRegisterImpl {
 #else
     number_of_registers      = 16,
     number_of_byte_registers = 16,
-    max_slots_per_register   = 1
+    max_slots_per_register   = 2
 #endif // AMD64
   };
 
@@ -274,10 +274,7 @@ class ConcreteRegisterImpl : public AbstractRegisterImpl {
   // There is no requirement that any ordering here matches any ordering c2 gives
   // it's optoregs.
 
-    number_of_registers = RegisterImpl::number_of_registers +
-#ifdef AMD64
-      RegisterImpl::number_of_registers +  // "H" half of a 64bit register
-#endif // AMD64
+    number_of_registers = RegisterImpl::number_of_registers * RegisterImpl::max_slots_per_register +
       2 * FloatRegisterImpl::number_of_registers +
       XMMRegisterImpl::max_slots_per_register * XMMRegisterImpl::number_of_registers +
       KRegisterImpl::number_of_registers + // mask registers


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8256956](https://bugs.openjdk.java.net/browse/JDK-8256956): RegisterImpl::max_slots_per_register is incorrect on AMD64


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/597/head:pull/597` \
`$ git checkout pull/597`

Update a local copy of the PR: \
`$ git checkout pull/597` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 597`

View PR using the GUI difftool: \
`$ git pr show -t 597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/597.diff">https://git.openjdk.java.net/jdk11u-dev/pull/597.diff</a>

</details>
