### PR TITLE
8267246: -XX:MaxRAMPercentage=0 is unreasonable for jtreg tests on many-core machines

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -641,7 +641,7 @@ define SetupRunJtregTestBody
 
   # Make sure MaxRAMPercentage is high enough to not cause OOM or swapping since
   # we may end up with a lot of JVM's
-  $1_JTREG_MAX_RAM_PERCENTAGE := $$(shell $$(EXPR) 25 / $$($1_JTREG_JOBS))
+  $1_JTREG_MAX_RAM_PERCENTAGE := $$(shell $(AWK) 'BEGIN { print 25 / $$($1_JTREG_JOBS); }')
 
   # SPARC is in general slower per core so need to scale up timeouts a bit.
   ifeq ($(OPENJDK_TARGET_CPU_ARCH), sparc)


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8267246](https://bugs.openjdk.java.net/browse/JDK-8267246): -XX:MaxRAMPercentage=0 is unreasonable for jtreg tests on many-core machines


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/600/head:pull/600` \
`$ git checkout pull/600`

Update a local copy of the PR: \
`$ git checkout pull/600` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 600`

View PR using the GUI difftool: \
`$ git pr show -t 600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/600.diff">https://git.openjdk.java.net/jdk11u-dev/pull/600.diff</a>

</details>
