### PR TITLE
8274523: java/lang/management/MemoryMXBean/MemoryTest.java test should handle Shenandoah

### DIFF
--- a/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/MemoryTest.java
@@ -26,11 +26,23 @@
  * @bug     4530538
  * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
  *          MemoryMXBean.getMemoryManager().
- * @requires vm.gc != "Z"
+ * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @author  Mandy Chung
  *
  * @modules jdk.management
  * @run main MemoryTest 2 3
+ */
+
+/*
+ * @test
+ * @bug     4530538
+ * @summary Basic unit test of MemoryMXBean.getMemoryPools() and
+ *          MemoryMXBean.getMemoryManager().
+ * @requires vm.gc == "Shenandoah"
+ * @author  Mandy Chung
+ *
+ * @modules jdk.management
+ * @run main MemoryTest 2 1
  */
 
 /*


### PR DESCRIPTION
Unclean backport to improve Shenandoah test. The uncleanliness is due to test block missing for Z (added later by JDK-8240679). I just dropped the `@requires vm.gc != Z` clause from one of the blocks.

Additional testing:
 - [x] Linux x86_64 fastdebug test now passes with Shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274523](https://bugs.openjdk.java.net/browse/JDK-8274523): java/lang/management/MemoryMXBean/MemoryTest.java test should handle Shenandoah


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/603/head:pull/603` \
`$ git checkout pull/603`

Update a local copy of the PR: \
`$ git checkout pull/603` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 603`

View PR using the GUI difftool: \
`$ git pr show -t 603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/603.diff">https://git.openjdk.java.net/jdk11u-dev/pull/603.diff</a>

</details>
