### PR TITLE
8208242: Add @requires to vmTestbase/gc/g1 tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_inMemoryCompilation_keep_class/TestDescription.java
@@ -39,6 +39,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_inMemoryCompilation_keep_obj/TestDescription.java
@@ -39,6 +39,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_keep_class/TestDescription.java
@@ -39,6 +39,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_keep_obj/TestDescription.java
@@ -39,6 +39,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_cl/TestDescription.java
@@ -42,6 +42,9 @@
  * @comment build classPool.jar
  * @run driver gc.g1.unloading.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_class/TestDescription.java
@@ -42,6 +42,9 @@
  * @comment build classPool.jar
  * @run driver gc.g1.unloading.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_obj/TestDescription.java
@@ -42,6 +42,9 @@
  * @comment build classPool.jar
  * @run driver gc.g1.unloading.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_keep_cl/TestDescription.java
@@ -42,6 +42,9 @@
  * @comment build classPool.jar
  * @run driver gc.g1.unloading.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_keep_class/TestDescription.java
@@ -42,6 +42,9 @@
  * @comment build classPool.jar
  * @run driver gc.g1.unloading.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_keep_obj/TestDescription.java
@@ -42,6 +42,9 @@
  * @comment build classPool.jar
  * @run driver gc.g1.unloading.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_inMemoryCompilation_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_inMemoryCompilation_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_inMemoryCompilation_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_keep_cl/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_keep_class/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_keep_obj/TestDescription.java
@@ -38,6 +38,9 @@
  * @comment generate HumongousTemplateClass and compile it to test.classes
  * @run driver gc.g1.unloading.bytecode.GenClassesBuilder
  *
+ * @requires vm.gc.G1
+ * @requires vm.opt.ClassUnloading != false
+ * @requires vm.opt.ClassUnloadingWithConcurrentMark != false
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission


### PR DESCRIPTION
Backport of JDK-8208242

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8208242](https://bugs.openjdk.java.net/browse/JDK-8208242): Add @requires to vmTestbase/gc/g1 tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/604/head:pull/604` \
`$ git checkout pull/604`

Update a local copy of the PR: \
`$ git checkout pull/604` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 604`

View PR using the GUI difftool: \
`$ git pr show -t 604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/604.diff">https://git.openjdk.java.net/jdk11u-dev/pull/604.diff</a>

</details>
