### PR TITLE
8276943: Backout JDK-8274338 11u backport

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -342,9 +342,6 @@ void ClassLoaderData::methods_do(void f(Method*)) {
 }
 
 void ClassLoaderData::loaded_classes_do(KlassClosure* klass_closure) {
-  // To call this, one must have the MultiArray_lock held, but the _klasses list still has lock free reads.
-  assert_locked_or_safepoint(MultiArray_lock);
-
   // Lock-free access requires load_acquire
   for (Klass* k = OrderAccess::load_acquire(&_klasses); k != NULL; k = k->next_link()) {
     // Do not filter ArrayKlass oops here...

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -1627,9 +1627,6 @@ void MetaspaceShared::link_and_cleanup_shared_classes(TRAPS) {
   // We need to iterate because verification may cause additional classes
   // to be loaded.
   LinkSharedClassesClosure link_closure(THREAD);
-  // To get a consistent list of classes we need MultiArray_lock to ensure
-  // array classes aren't created.
-  MutexLocker locker(MultiArray_lock);
   do {
     link_closure.reset();
     ClassLoaderDataGraph::loaded_classes_do(&link_closure);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2378,9 +2378,6 @@ void InstanceKlass::restore_unshareable_info(ClassLoaderData* loader_data, Handl
   constants()->restore_unshareable_info(CHECK);
 
   if (array_klasses() != NULL) {
-    // To get a consistent list of classes we need MultiArray_lock to ensure
-    // array classes aren't observed while they are being restored.
-     MutexLocker ml(MultiArray_lock);
     // Array classes have null protection domain.
     // --> see ArrayKlass::complete_create_array_klass()
     array_klasses()->restore_unshareable_info(ClassLoaderData::the_null_class_loader_data(), Handle(), CHECK);


### PR DESCRIPTION
JDK-8274338 11u backport caused [SAP nightly test to fail on some of cds tests](http://mail.openjdk.java.net/pipermail/jdk-updates-dev/2021-November/009840.html). Let's back it out.

Test:

- [x] hotspot_runtime
- [x] hotspot_cds
  
