### PR TITLE
8276550: Use SHA256 hash in build.tools.depend.Depend

### DIFF
--- a/make/jdk/src/classes/build/tools/depend/Depend.java
+++ b/make/jdk/src/classes/build/tools/depend/Depend.java
@@ -101,7 +101,7 @@ public class Depend implements Plugin {
             private final MessageDigest apiHash;
             {
                 try {
-                    apiHash = MessageDigest.getInstance("MD5");
+                    apiHash = MessageDigest.getInstance("SHA-256");
                 } catch (NoSuchAlgorithmException ex) {
                     throw new IllegalStateException(ex);
                 }


### PR DESCRIPTION
Clean backport for consistency with other releases. I don't think you can bootstrap 11u with non-MD5-carrying JDK just yet, because MD5 is still a requirement for `MessageDigest`. But, that might change in future, as FIPS compliance requires dropping weaker and weaker hashing schemes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276550](https://bugs.openjdk.java.net/browse/JDK-8276550): Use SHA256 hash in build.tools.depend.Depend


### Reviewers
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/611/head:pull/611` \
`$ git checkout pull/611`

Update a local copy of the PR: \
`$ git checkout pull/611` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 611`

View PR using the GUI difftool: \
`$ git pr show -t 611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/611.diff">https://git.openjdk.java.net/jdk11u-dev/pull/611.diff</a>

</details>
