### PR TITLE
8276201: Shenandoah: Race results degenerated GC to enter wrong entry point

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1735,7 +1735,9 @@ void ShenandoahHeap::op_degenerated(ShenandoahDegenPoint point) {
       }
 
     case _degenerated_mark:
-      op_final_mark();
+      if (is_concurrent_mark_in_progress()) {
+        op_final_mark();
+      }
       if (cancelled_gc()) {
         op_degenerated_fail();
         return;


### PR DESCRIPTION
This is a Shenandoah specific backport. It fixes a race that results degenerated GC to enter wrong degen entry point.

The original patch does not apply cleanly due to code divergence, especially the grand refactoring that is not in jdk11u. However, the backport is simple and straight forward.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276201](https://bugs.openjdk.java.net/browse/JDK-8276201): Shenandoah: Race results degenerated GC to enter wrong entry point


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/612/head:pull/612` \
`$ git checkout pull/612`

Update a local copy of the PR: \
`$ git checkout pull/612` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 612`

View PR using the GUI difftool: \
`$ git pr show -t 612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/612.diff">https://git.openjdk.java.net/jdk11u-dev/pull/612.diff</a>

</details>
