### PR TITLE
8034084: nsk.nsk/jvmti/ThreadStart/threadstart003  Wrong number of thread end events

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -198,7 +198,6 @@ vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java 7013
 vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java 6606767 generic-all
 vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004/TestDescription.java 7013634,6606767 generic-all
 vmTestbase/nsk/jvmti/ThreadStart/threadstart001/TestDescription.java 8016181 generic-all
-vmTestbase/nsk/jvmti/ThreadStart/threadstart003/TestDescription.java 8034084 generic-all
 vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t002/TestDescription.java 8204506,8203350 generic-all
 vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t001/hs204t001.java 6813266 generic-all
 vmTestbase/nsk/jvmti/AttachOnDemand/attach034/TestDescription.java 8042145 generic-all

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadStart/threadstart003/threadstart003.c
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadStart/threadstart003/threadstart003.c
@@ -216,7 +216,7 @@ Java_nsk_jvmti_ThreadStart_threadstart003_check(JNIEnv *env,
                TranslateError(err), err);
         result = STATUS_FAILED;
     }
-    err = (*jvmti)->RawMonitorWait(jvmti, wait_lock, (jlong)WAIT_TIME);
+    err = (*jvmti)->RawMonitorWait(jvmti, wait_lock, 0);
     if (err != JVMTI_ERROR_NONE) {
         printf("(RawMonitorWait) unexpected error: %s (%d)\n",
                TranslateError(err), err);
@@ -235,7 +235,16 @@ Java_nsk_jvmti_ThreadStart_threadstart003_check(JNIEnv *env,
                TranslateError(err), err);
         result = STATUS_FAILED;
     }
-    err = (*jvmti)->RawMonitorWait(jvmti, wait_lock, (jlong)WAIT_TIME);
+    // Wait for up to 3 seconds for the thread end event
+    {
+        int i;
+        for (i = 0; i < 3 ; i++) {
+            err = (*jvmti)->RawMonitorWait(jvmti, wait_lock, (jlong)WAIT_TIME);
+            if (endsCount == endsExpected || err != JVMTI_ERROR_NONE) {
+                break;
+            }
+        }
+    }
     if (err != JVMTI_ERROR_NONE) {
         printf("(RawMonitorWait) unexpected error: %s (%d)\n",
                TranslateError(err), err);


### PR DESCRIPTION
I backport this test only fix as preparation for 8209611.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8034084](https://bugs.openjdk.java.net/browse/JDK-8034084): nsk.nsk/jvmti/ThreadStart/threadstart003  Wrong number of thread end events


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/617/head:pull/617` \
`$ git checkout pull/617`

Update a local copy of the PR: \
`$ git checkout pull/617` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 617`

View PR using the GUI difftool: \
`$ git pr show -t 617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/617.diff">https://git.openjdk.java.net/jdk11u-dev/pull/617.diff</a>

</details>
