### PR TITLE
8201224: Make string buffer size dynamic in mlvmJvmtiUtils.c

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/func/jvmti/share/IndyRedefineClass.c
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/func/jvmti/share/IndyRedefineClass.c
@@ -165,8 +165,14 @@ SingleStep(jvmtiEnv *jvmti_env,
         char * locStr;
     gIsSingleStepWorking = JNI_TRUE;
     locStr = locationToString(jvmti_env, method, location);
-    NSK_DISPLAY1("Single step event: %s\n", locStr);
-    free(locStr);
+
+    if (locStr == NULL) {
+        NSK_DISPLAY0("Error in Single step event: locationToString failed\n");
+        gIsErrorOccured = JNI_TRUE;
+    } else {
+        NSK_DISPLAY1("Single step event: %s\n", locStr);
+        free(locStr);
+    }
 
     popFrameLogic(jvmti_env, thread);
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/mlvmJvmtiUtils.c
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/mlvmJvmtiUtils.c
@@ -78,18 +78,31 @@ struct MethodName * getMethodName(jvmtiEnv * pJvmtiEnv, jmethodID method) {
 
 char * locationToString(jvmtiEnv * pJvmtiEnv, jmethodID method, jlocation location) {
     struct MethodName * pMN;
-    // gcc 7.3 claims that snprintf below can output between 6 and 531 bytes. Setting buffer size to 600.
-    char r[600];
+    int len;
+    char * result;
+    const char * const format = "%s .%s :" JLONG_FORMAT;
 
     pMN = getMethodName(pJvmtiEnv, method);
     if ( ! pMN )
         return strdup("NONE");
 
-    snprintf(r, sizeof(r), "%s .%s :%lx", pMN->classSig, pMN->methodName, (long) location);
+    len = snprintf(NULL, 0, format, pMN->classSig, pMN->methodName, location) + 1;
+
+    if (len <= 0) {
+        free(pMN);
+        return NULL;
+    }
+
+    result = malloc(len);
+    if (result == NULL) {
+        free(pMN);
+        return NULL;
+    }
+
+    snprintf(result, len, format, pMN->classSig, pMN->methodName, location);
 
     free(pMN);
-
-    return strdup(r);
+    return result;
 }
 
 void * getTLS(jvmtiEnv * pJvmtiEnv, jthread thread, jsize sizeToAllocate) {


### PR DESCRIPTION
I want to backport this to prepare for 8209611.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8201224](https://bugs.openjdk.java.net/browse/JDK-8201224): Make string buffer size dynamic in mlvmJvmtiUtils.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/618/head:pull/618` \
`$ git checkout pull/618`

Update a local copy of the PR: \
`$ git checkout pull/618` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 618`

View PR using the GUI difftool: \
`$ git pr show -t 618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/618.diff">https://git.openjdk.java.net/jdk11u-dev/pull/618.diff</a>

</details>
