### PR TITLE
8202342: [Graal] fromTonga/nsk/jvmti/unit/FollowReferences/followref003/TestDescription.java fails with "Location mismatch" errors

### DIFF
--- a/test/hotspot/jtreg/ProblemList-graal.txt
+++ b/test/hotspot/jtreg/ProblemList-graal.txt
@@ -147,8 +147,6 @@ vmTestbase/nsk/jvmti/PopFrame/popframe009/TestDescription.java                  
 vmTestbase/nsk/jvmti/ForceEarlyReturn/ForceEarlyReturn001/TestDescription.java     8195674   generic-all
 vmTestbase/nsk/jvmti/ForceEarlyReturn/ForceEarlyReturn002/TestDescription.java     8195674   generic-all
 
-vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/TestDescription.java       8202342   generic-all
-
 vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t002/TestDescription.java        8204506   macosx-all
 
 compiler/stable/TestStableBoolean.java                           8204347   generic-all

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/followref003.c
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/followref003.c
@@ -770,10 +770,13 @@ jint JNICALL heapReferenceCallback(
             break;
 
         case JVMTI_HEAP_REFERENCE_STACK_LOCAL:
-            thr_idx  = registerThread(thr_id, thr_tag);
-            meth_idx = registerFrame(thr_id, depth, method, ref_kind);
-            if (meth_idx > 0) {
-                jint loc_idx  = registerLocal(meth_idx, location, slot, tag);
+            // Skip local references from non-main (e.g. compiler) threads.
+            if (thr_tag == TARG_THREAD_TAG) {
+                thr_idx  = registerThread(thr_id, thr_tag);
+                meth_idx = registerFrame(thr_id, depth, method, ref_kind);
+                if (meth_idx > 0) {
+                    jint loc_idx  = registerLocal(meth_idx, location, slot, tag);
+                }
             }
             /* This part is kind of hack. It has some expectations about stack layout */
             if (thr_tag == TARG_THREAD_TAG &&
@@ -811,10 +814,13 @@ jint JNICALL heapReferenceCallback(
                    nsk_jvmti_setFailStatus();
                }
             }
-            /* Fall through */
+            break;
         case JVMTI_HEAP_REFERENCE_JNI_LOCAL:
-            thr_idx  = registerThread(thr_id, thr_tag);
-            meth_idx = registerFrame(thr_id, depth, method, ref_kind);
+            // Skip JNI local references from non-main (e.g. compiler) threads.
+            if (thr_tag == TARG_THREAD_TAG) {
+                thr_idx  = registerThread(thr_id, thr_tag);
+                meth_idx = registerFrame(thr_id, depth, method, ref_kind);
+            }
             break;
 
         case JVMTI_REFERENCE_ARRAY_ELEMENT:


### PR DESCRIPTION
I backport this test only fix to simplify addressing 8209611. 
I only resolved the graal ProblemList.
Original JBS issue is not visible.
Backport issue: https://bugs.openjdk.java.net/browse/JDK-8277034

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8202342](https://bugs.openjdk.java.net/browse/JDK-8202342): [Graal] fromTonga/nsk/jvmti/unit/FollowReferences/followref003/TestDescription.java fails with "Location mismatch" errors


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/620/head:pull/620` \
`$ git checkout pull/620`

Update a local copy of the PR: \
`$ git checkout pull/620` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 620`

View PR using the GUI difftool: \
`$ git pr show -t 620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/620.diff">https://git.openjdk.java.net/jdk11u-dev/pull/620.diff</a>

</details>
