### PR TITLE
8276157: C2: Compiler stack overflow during escape analysis on Linux x86_32

### DIFF
--- a/src/hotspot/os_cpu/linux_x86/globals_linux_x86.hpp
+++ b/src/hotspot/os_cpu/linux_x86/globals_linux_x86.hpp
@@ -34,7 +34,13 @@ define_pd_global(intx, CompilerThreadStackSize,  1024);
 define_pd_global(intx, ThreadStackSize,          1024); // 0 => use system default
 define_pd_global(intx, VMThreadStackSize,        1024);
 #else
-define_pd_global(intx, CompilerThreadStackSize,  512);
+// Some tests in debug VM mode run out of compile thread stack.
+// Observed on some x86_32 VarHandles tests during escape analysis.
+#ifdef ASSERT
+define_pd_global(intx, CompilerThreadStackSize,   768);
+#else
+define_pd_global(intx, CompilerThreadStackSize,   512);
+#endif
 // ThreadStackSize 320 allows a couple of test cases to run while
 // keeping the number of threads that can be created high.  System
 // default ThreadStackSize appears to be 512 which is too big.


### PR DESCRIPTION
Clean backport to workaround x86_32 C2 compilation troubles.

Additional testing:
 - [x] Linux x86_32 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276157](https://bugs.openjdk.java.net/browse/JDK-8276157): C2: Compiler stack overflow during escape analysis on Linux x86_32


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/622/head:pull/622` \
`$ git checkout pull/622`

Update a local copy of the PR: \
`$ git checkout pull/622` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 622`

View PR using the GUI difftool: \
`$ git pr show -t 622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/622.diff">https://git.openjdk.java.net/jdk11u-dev/pull/622.diff</a>

</details>
