### PR TITLE
8258457: testlibrary_tests/ctw/JarDirTest.java fails with InvalidPathException on windows

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/ctw/CtwTest.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ctw/CtwTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,9 +95,11 @@ public abstract class CtwTest {
         String[] cmd = Arrays.copyOf(CTW_COMMAND, CTW_COMMAND.length + args.length - 1);
         System.arraycopy(args, 1, cmd, CTW_COMMAND.length, args.length - 1);
         if (Platform.isWindows()) {
-            // '*' has to be escaped on windows
+            // arguments with '*' has to be quoted on windows
             for (int i = 0; i < cmd.length; ++i) {
-                cmd[i] = cmd[i].replace("*", "\"*\"");
+                if (cmd[i].charAt(0) != '"' && cmd[i].indexOf('*') >= 0) {
+                    cmd[i] = '"' + cmd[i] + '"';
+                }
             }
         }
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, cmd);


### PR DESCRIPTION
Backport of JDK-8258457

Mostly clean. Change to problemlist is not relevant for 11u. I also had to resolve copyright header update.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258457](https://bugs.openjdk.java.net/browse/JDK-8258457): testlibrary_tests/ctw/JarDirTest.java fails with InvalidPathException on windows


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/623/head:pull/623` \
`$ git checkout pull/623`

Update a local copy of the PR: \
`$ git checkout pull/623` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 623`

View PR using the GUI difftool: \
`$ git pr show -t 623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/623.diff">https://git.openjdk.java.net/jdk11u-dev/pull/623.diff</a>

</details>
