### PR TITLE
8268882: C2: assert(n->outcnt() != 0 || C->top() == n || n->is_Proj()) failed: No dead instructions after post-alloc

### DIFF
--- a/src/hotspot/share/opto/postaloc.cpp
+++ b/src/hotspot/share/opto/postaloc.cpp
@@ -600,7 +600,7 @@ void PhaseChaitin::post_allocate_copy_removal() {
         if( phi != x && u != x ) // Found a different input
           u = u ? NodeSentinel : x; // Capture unique input, or NodeSentinel for 2nd input
       }
-      if (u != NodeSentinel) {    // Junk Phi.  Remove
+      if (u != NodeSentinel || phi->outcnt() == 0) {    // Junk Phi.  Remove
         phi->replace_by(u);
         j -= yank_if_dead(phi, block, &value, &regnd);
         phi_dex--;


### PR DESCRIPTION
Clean backport of JDK-8268882.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268882](https://bugs.openjdk.java.net/browse/JDK-8268882): C2: assert(n->outcnt() != 0 || C->top() == n || n->is_Proj()) failed: No dead instructions after post-alloc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/624/head:pull/624` \
`$ git checkout pull/624`

Update a local copy of the PR: \
`$ git checkout pull/624` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 624`

View PR using the GUI difftool: \
`$ git pr show -t 624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/624.diff">https://git.openjdk.java.net/jdk11u-dev/pull/624.diff</a>

</details>
