### PR TITLE
8253147: The javax/swing/JPopupMenu/7154841/bug7154841.java fail on big screens

### DIFF
--- a/test/jdk/java/awt/ColorClass/AlphaColorTest.java
+++ b/test/jdk/java/awt/ColorClass/AlphaColorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,8 +84,8 @@ public class AlphaColorTest extends Component {
         Color color = new Color(255, 255, 255, 127);
         frame.add("Center", new AlphaColorTest(color));
         frame.setUndecorated(true);
-        frame.setLocationRelativeTo(null);
         frame.pack();
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 }

--- a/test/jdk/javax/swing/JPopupMenu/7154841/bug7154841.java
+++ b/test/jdk/javax/swing/JPopupMenu/7154841/bug7154841.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class bug7154841 {
 
     private static void initAndShowUI() {
         popupMenu = new JPopupMenu();
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 400; i++) {
             JRadioButtonMenuItem item = new JRadioButtonMenuItem(" Test " + i);
             item.addMouseMotionListener(new MouseMotionAdapter() {
                 @Override


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.
Testchange only, Copyright resolved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253147](https://bugs.openjdk.java.net/browse/JDK-8253147): The javax/swing/JPopupMenu/7154841/bug7154841.java fail on big screens


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/625/head:pull/625` \
`$ git checkout pull/625`

Update a local copy of the PR: \
`$ git checkout pull/625` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 625`

View PR using the GUI difftool: \
`$ git pr show -t 625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/625.diff">https://git.openjdk.java.net/jdk11u-dev/pull/625.diff</a>

</details>
