### PR TITLE
8250521: Configure initial RTO to use minimal retry for loopback connections on Windows

### DIFF
--- a/src/java.base/windows/native/libnet/net_util_md.c
+++ b/src/java.base/windows/native/libnet/net_util_md.c
@@ -754,6 +754,57 @@ NET_EnableFastTcpLoopback(int fd) {
     return result == SOCKET_ERROR ? WSAGetLastError() : 0;
 }
 
+int
+IsWindows10RS3OrGreater() {
+    OSVERSIONINFOEXW osvi = { sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0 };
+    DWORDLONG const cond_mask = VerSetConditionMask(
+        VerSetConditionMask(
+          VerSetConditionMask(
+            0, VER_MAJORVERSION, VER_GREATER_EQUAL),
+               VER_MINORVERSION, VER_GREATER_EQUAL),
+               VER_BUILDNUMBER,  VER_GREATER_EQUAL);
+
+    osvi.dwMajorVersion = HIBYTE(_WIN32_WINNT_WIN10);
+    osvi.dwMinorVersion = LOBYTE(_WIN32_WINNT_WIN10);
+    osvi.dwBuildNumber  = 16299; // RS3 (Redstone 3)
+
+    return VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_BUILDNUMBER, cond_mask) != 0;
+}
+
+/**
+ * Shortens the default Windows socket
+ * connect timeout. Recommended for usage
+ * on the loopback adapter only.
+ */
+JNIEXPORT jint JNICALL
+NET_EnableFastTcpLoopbackConnect(int fd) {
+    TCP_INITIAL_RTO_PARAMETERS rto = {
+        TCP_INITIAL_RTO_UNSPECIFIED_RTT,    // Use the default or overriden by the Administrator
+        1                                   // Minimum possible value before Windows 10 RS3
+    };
+
+    /**
+     * In Windows 10 RS3+ we can use the no retransmissions flag to
+     * completely remove the timeout delay, which is fixed to 500ms
+     * if Windows receives RST when the destination port is not open.
+     */
+    if (IsWindows10RS3OrGreater()) {
+        rto.MaxSynRetransmissions = TCP_INITIAL_RTO_NO_SYN_RETRANSMISSIONS;
+    }
+
+    DWORD result_byte_count = -1;
+    int result = WSAIoctl(fd,                       // descriptor identifying a socket
+                          SIO_TCP_INITIAL_RTO,      // dwIoControlCode
+                          &rto,                     // pointer to TCP_INITIAL_RTO_PARAMETERS structure
+                          sizeof(rto),              // size, in bytes, of the input buffer
+                          NULL,                     // pointer to output buffer
+                          0,                        // size of output buffer
+                          &result_byte_count,       // number of bytes returned
+                          NULL,                     // OVERLAPPED structure
+                          NULL);                    // completion routine
+    return (result == SOCKET_ERROR) ? WSAGetLastError() : 0;
+}
+
 /**
  * See net_util.h for documentation
  */

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -194,11 +194,23 @@ Java_sun_nio_ch_Net_connect0(JNIEnv *env, jclass clazz, jboolean preferIPv6, job
 {
     SOCKETADDRESS sa;
     int rv;
+    int so_rv;
     int sa_len = 0;
     SOCKET s = (SOCKET)fdval(env, fdo);
+    int type = 0, optlen = sizeof(type);
 
     if (NET_InetAddressToSockaddr(env, iao, port, &sa, &sa_len, preferIPv6) != 0) {
         return IOS_THROWN;
+    }
+
+    so_rv = getsockopt(s, SOL_SOCKET, SO_TYPE, (char*)&type, &optlen);
+
+    /**
+     * Windows has a very long socket connect timeout of 2 seconds.
+     * If it's the loopback adapter we can shorten the wait interval.
+     */
+    if (so_rv == 0 && type == SOCK_STREAM && IS_LOOPBACK_ADDRESS(&sa)) {
+        NET_EnableFastTcpLoopbackConnect((jint)s);
     }
 
     rv = connect(s, &sa.sa, sa_len);
@@ -211,9 +223,7 @@ Java_sun_nio_ch_Net_connect0(JNIEnv *env, jclass clazz, jboolean preferIPv6, job
         return IOS_THROWN;
     } else {
         /* Enable WSAECONNRESET errors when a UDP socket is connected */
-        int type = 0, optlen = sizeof(type);
-        rv = getsockopt(s, SOL_SOCKET, SO_TYPE, (char*)&type, &optlen);
-        if (rv == 0 && type == SOCK_DGRAM) {
+        if (so_rv == 0 && type == SOCK_DGRAM) {
             setConnectionReset(s, TRUE);
         }
     }


### PR DESCRIPTION
Backport of JDK-8250521

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8250521](https://bugs.openjdk.java.net/browse/JDK-8250521): Configure initial RTO to use minimal retry for loopback connections on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/626/head:pull/626` \
`$ git checkout pull/626`

Update a local copy of the PR: \
`$ git checkout pull/626` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 626`

View PR using the GUI difftool: \
`$ git pr show -t 626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/626.diff">https://git.openjdk.java.net/jdk11u-dev/pull/626.diff</a>

</details>
