### PR TITLE
8273235: tools/launcher/HelpFlagsTest.java Fails on Windows 32bit

### DIFF
--- a/test/jdk/tools/launcher/HelpFlagsTest.java
+++ b/test/jdk/tools/launcher/HelpFlagsTest.java
@@ -47,7 +47,9 @@ public class HelpFlagsTest extends TestHelper {
     static final String[] TOOLS_NOT_TO_TEST = {
         "appletviewer",     // deprecated, don't test
         "jaccessinspector", // gui, don't test, win only
+        "jaccessinspector-32", // gui, don't test, win-32 only
         "jaccesswalker",    // gui, don't test, win only
+        "jaccesswalker-32", // gui, don't test, win-32 only
         "jconsole",         // gui, don't test
         "servertool",       // none. Shell, don't test.
         "javaw",            // don't test, win only


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273235](https://bugs.openjdk.java.net/browse/JDK-8273235): tools/launcher/HelpFlagsTest.java Fails on Windows 32bit


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/633/head:pull/633` \
`$ git checkout pull/633`

Update a local copy of the PR: \
`$ git checkout pull/633` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 633`

View PR using the GUI difftool: \
`$ git pr show -t 633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/633.diff">https://git.openjdk.java.net/jdk11u-dev/pull/633.diff</a>

</details>
