### PR TITLE
8260282: Add option to compress heap dumps created by -XX:+HeapDumpOnOutOfMemoryError

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -668,6 +668,12 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
   develop(bool, UseFakeTimers, false,                                       \
           "Tell whether the VM should use system time or a fake timer")     \
                                                                             \
+  product(intx, HeapDumpGzipLevel, 0,                                       \
+          "When HeapDumpOnOutOfMemoryError is on, the gzip compression "    \
+          "level of the dump file. 0 (the default) disables gzip "          \
+          "compression. Otherwise the level must be between 1 and 9.")      \
+          range(0, 9)                                                       \
+                                                                            \
   product(ccstr, NativeMemoryTracking, "off",                               \
           "Native memory tracking options")                                 \
                                                                             \

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2040,7 +2040,7 @@ void HeapDumper::dump_heap(bool oome) {
   const int max_digit_chars = 20;
 
   const char* dump_file_name = "java_pid";
-  const char* dump_file_ext  = ".hprof";
+  const char* dump_file_ext  = HeapDumpGzipLevel > 0 ? ".hprof.gz" : ".hprof";
 
   // The dump file defaults to java_pid<pid>.hprof in the current working
   // directory. HeapDumpPath=<file> can be used to specify an alternative
@@ -2107,6 +2107,6 @@ void HeapDumper::dump_heap(bool oome) {
 
   HeapDumper dumper(false /* no GC before heap dump */,
                     oome  /* pass along out-of-memory-error flag */);
-  dumper.dump(my_path, tty);
+  dumper.dump(my_path, tty, HeapDumpGzipLevel);
   os::free(my_path);
 }

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestGZippedHeapDumpOnOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestGZippedHeapDumpOnOutOfMemoryError.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test verifies that -XX:HeapDumpGzipLevel=0 works
+ * @library /test/lib
+ * @run driver/timeout=240 TestGZippedHeapDumpOnOutOfMemoryError run 0
+ */
+
+/*
+ * @test
+ * @summary Test verifies that -XX:HeapDumpGzipLevel=1 works
+ * @library /test/lib
+ * @run driver/timeout=240 TestGZippedHeapDumpOnOutOfMemoryError run 1
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.hprof.HprofParser;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.io.File;
+
+public class TestGZippedHeapDumpOnOutOfMemoryError {
+
+    static volatile Object[] oa;
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 2) {
+            test(Integer.parseInt(args[1]));
+            return;
+        }
+
+        try {
+            oa = new Object[Integer.MAX_VALUE];
+            throw new Error("OOME not triggered");
+        } catch (OutOfMemoryError err) {
+            // Ignore
+        }
+    }
+
+    static void test(int level) throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-XX:+HeapDumpOnOutOfMemoryError",
+            "-XX:HeapDumpGzipLevel=" + level,
+            "-Xmx128M",
+            TestGZippedHeapDumpOnOutOfMemoryError.class.getName());
+
+        Process proc = pb.start();
+        String heapdumpFilename = "java_pid" + proc.pid() + ".hprof" + (level > 0 ? ".gz" : "");
+        OutputAnalyzer output = new OutputAnalyzer(proc);
+        output.stdoutShouldNotBeEmpty();
+        output.shouldContain("Dumping heap to " + heapdumpFilename);
+        File dump = new File(heapdumpFilename);
+        Asserts.assertTrue(dump.exists() && dump.isFile(),
+                "Could not find dump file " + dump.getAbsolutePath());
+
+        HprofParser.parse(new File(heapdumpFilename));
+        System.out.println("PASSED");
+    }
+
+}


### PR DESCRIPTION
Add option to compress heap dumps created by -XX:+HeapDumpOnOutOfMemoryError

The change itself had to be slightly modified, since VM arguments are declared slightly different in JDK11 (the MANAGABLE flag is not supported). Otherwise no adjustments were needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260282](https://bugs.openjdk.java.net/browse/JDK-8260282): Add option to compress heap dumps created by -XX:+HeapDumpOnOutOfMemoryError


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/640/head:pull/640` \
`$ git checkout pull/640`

Update a local copy of the PR: \
`$ git checkout pull/640` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 640`

View PR using the GUI difftool: \
`$ git pr show -t 640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/640.diff">https://git.openjdk.java.net/jdk11u-dev/pull/640.diff</a>

</details>
