### PR TITLE
8236042: [TESTBUG] serviceability/sa/ClhsdbCDSCore.java fails with -Xcomp -XX:TieredStopAtLevel=1

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
@@ -54,6 +54,7 @@ import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import jdk.internal.misc.Unsafe;
 import java.util.Scanner;
+import jdk.test.lib.Utils;
 import jtreg.SkippedException;
 
 class CrashApp {
@@ -164,7 +165,16 @@ public class ClhsdbCDSCore {
                 throw new SkippedException("The CDS archive is not mapped");
             }
 
-            cmds = List.of("printmdo -a", "printall", "jstack -v");
+            List testJavaOpts = Arrays.asList(Utils.getTestJavaOpts());
+
+            if (testJavaOpts.contains("-Xcomp") && testJavaOpts.contains("-XX:TieredStopAtLevel=1")) {
+                // No MDOs are allocated in -XX:TieredStopAtLevel=1 + -Xcomp mode
+                // The reason is methods being compiled aren't hot enough
+                // Let's not call printmdo in such scenario
+                cmds = List.of("printall", "jstack -v");
+            } else {
+                cmds = List.of("printmdo -a", "printall", "jstack -v");
+            }
 
             Map<String, List<String>> expStrMap = new HashMap<>();
             Map<String, List<String>> unExpStrMap = new HashMap<>();


### PR DESCRIPTION
Backport for parity with Oracle 11.0.15.

The original patch does not apply cleanly due to context difference. However, that patch is small, can be applied manually.

Test:

- [x]  Without patch, serviceability/sa/ClhsdbCDSCore.java test failed with -Xcomp -XX:TieredStopAtLevel=1, passed with patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8236042](https://bugs.openjdk.java.net/browse/JDK-8236042): [TESTBUG] serviceability/sa/ClhsdbCDSCore.java fails with -Xcomp -XX:TieredStopAtLevel=1


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/642/head:pull/642` \
`$ git checkout pull/642`

Update a local copy of the PR: \
`$ git checkout pull/642` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 642`

View PR using the GUI difftool: \
`$ git pr show -t 642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/642.diff">https://git.openjdk.java.net/jdk11u-dev/pull/642.diff</a>

</details>
