### PR TITLE
8210593: Clean up JNI_ENV_ARG and factorize the macros for vmTestbase/jvmti[N-R] tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe001/popframe001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe001/popframe001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -195,8 +182,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -257,6 +243,4 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     return JNI_OK;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe002/popframe002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe002/popframe002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -211,8 +198,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -268,6 +254,4 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     return JNI_OK;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe003/popframe003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe003/popframe003.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -196,8 +183,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -258,6 +244,4 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     return JNI_OK;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe004/popframe004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe004/popframe004.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -220,8 +207,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -289,12 +275,10 @@ Java_nsk_jvmti_PopFrame_popframe004_getResult(JNIEnv *env, jclass cls) {
 
 void nativeMeth2(JNIEnv *env, jobject obj, jint vrb,
         jobject frameThr) {
-    jclass cls =
-        JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG(env, frameThr));
+    jclass cls = env->GetObjectClass(frameThr);
     jmethodID mid = NULL;
 
-    if ((mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-        "activeMethod", "()V")) == NULL) {
+    if ((mid = env->GetMethodID(cls, "activeMethod", "()V")) == NULL) {
         printf("TEST FAILURE: nativeMeth2(): Unable to get method ID\n");
         tot_result = STATUS_FAILED;
         return;
@@ -303,7 +287,7 @@ void nativeMeth2(JNIEnv *env, jobject obj, jint vrb,
         printf("nativeMeth2(): calling the Java activeMethod()\n");
         fflush(stdout);
     }
-    JNI_ENV_PTR(env)->CallVoidMethod(JNI_ENV_ARG(env, frameThr), mid);
+    env->CallVoidMethod(frameThr, mid);
 }
 
 JNIEXPORT void JNICALL
@@ -316,6 +300,4 @@ Java_nsk_jvmti_PopFrame_popframe004_nativeMeth(JNIEnv *env, jobject obj, jint vr
     nativeMeth2(env, obj, vrb, frameThr);
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe006/popframe006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe006/popframe006.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -364,8 +351,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -435,39 +421,35 @@ Java_nsk_jvmti_PopFrame_popframe006_getReady(JNIEnv *env,
         return;
     }
 
-    clazz = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG(env, thr));
+    clazz = env->GetObjectClass(thr);
     if (clazz == NULL) {
         printf("Cannot get the class of thread object\n");
         result = STATUS_FAILED;
         return;
     }
 
-    mid_run = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, clazz),
-        "run", "()V");
+    mid_run = env->GetMethodID(clazz, "run", "()V");
     if (mid_run == NULL) {
         printf("Cannot find Method ID for method \"run\"\n");
         result = STATUS_FAILED;
         return;
     }
 
-    mid_A = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, clazz),
-        "A", "()V");
+    mid_A = env->GetStaticMethodID(clazz, "A", "()V");
     if (mid_A == NULL) {
         printf("Cannot find Method ID for method \"A\"\n");
         result = STATUS_FAILED;
         return;
     }
 
-    mid_B = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, clazz),
-        "B", "()V");
+    mid_B = env->GetStaticMethodID(clazz, "B", "()V");
     if (mid_B == NULL) {
         printf("Cannot find Method ID for method \"B\"\n");
         result = STATUS_FAILED;
         return;
     }
 
-    mid_C = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, clazz),
-        "C", "()V");
+    mid_C = env->GetStaticMethodID(clazz, "C", "()V");
     if (mid_C == NULL) {
         printf("Cannot find Method ID for method \"C\"\n");
         result = STATUS_FAILED;
@@ -529,6 +511,4 @@ Java_nsk_jvmti_PopFrame_popframe006_getRes(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe007/popframe007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe007/popframe007.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -103,8 +90,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -166,15 +152,14 @@ Java_nsk_jvmti_PopFrame_popframe007_getReady(JNIEnv *env,
         return;
     }
 
-    clazz = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG(env, thr));
+    clazz = env->GetObjectClass(thr);
     if (clazz == NULL) {
         printf("Cannot get class of the thread object\n");
         result = STATUS_FAILED;
         return;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, clazz),
-        "C", "()V");
+    mid = env->GetStaticMethodID(clazz, "C", "()V");
     if (mid == NULL) {
         printf("Cannot find Method ID for method \"C\"\n");
         result = STATUS_FAILED;
@@ -206,10 +191,8 @@ Java_nsk_jvmti_PopFrame_popframe007_getRes(JNIEnv *env, jclass cls) {
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_PopFrame_popframe007_B(JNIEnv *env, jclass cls) {
     if (mid != NULL) {
-        JNI_ENV_PTR(env)->CallStaticVoidMethod(JNI_ENV_ARG(env, cls), mid);
+        env->CallStaticVoidMethod(cls, mid);
     }
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe008/popframe008.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe008/popframe008.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -212,8 +199,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -279,22 +265,21 @@ Java_nsk_jvmti_PopFrame_popframe008_getReady(JNIEnv *env,
         return;
     }
 
-    clazz = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG(env, thr));
+    clazz = env->GetObjectClass(thr);
     if (clazz == NULL) {
         printf("Cannot get class of the thread object\n");
         result = STATUS_FAILED;
         return;
     }
 
-    midD = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, clazz), "D", "()V");
+    midD = env->GetMethodID(clazz, "D", "()V");
     if (midD == NULL) {
         printf("Cannot get Method ID for method \"D\"\n");
         result = STATUS_FAILED;
         return;
     }
 
-    midRun = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, clazz),
-        "run", "()V");
+    midRun = env->GetMethodID(clazz, "run", "()V");
     if (midRun == NULL) {
         printf("Cannot get Method ID for method \"run\"\n");
         result = STATUS_FAILED;
@@ -328,6 +313,4 @@ Java_nsk_jvmti_PopFrame_popframe008_getRes(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe009/popframe009.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe009/popframe009.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -182,8 +169,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -251,8 +237,7 @@ Java_nsk_jvmti_PopFrame_popframe009_getReady(JNIEnv *env, jclass cls) {
         return;
     }
 
-    midCheckPoint = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
+    midCheckPoint = env->GetStaticMethodID(cls, "checkPoint", "()V");
     if (midCheckPoint == NULL) {
         printf("Cannot find Method ID for method checkPoint\n");
         result = STATUS_FAILED;
@@ -426,21 +411,19 @@ Java_nsk_jvmti_PopFrame_popframe009_check(JNIEnv *env, jclass cls, jthread thr) 
         result = STATUS_FAILED;
     }
 
-    midFibonacci = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-        "fibonacci", "(I)I");
+    midFibonacci = env->GetStaticMethodID(cls, "fibonacci", "(I)I");
     if (midFibonacci == NULL) {
         printf("Cannot get method ID for method \"fibonacci\"\n");
         result = STATUS_FAILED;
     }
 
-    clazz = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG(env, thr));
+    clazz = env->GetObjectClass(thr);
     if (clazz == NULL) {
         printf("Cannot get class of thread object\n");
         return STATUS_FAILED;
     }
 
-    midRun = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, clazz),
-        "run", "()V");
+    midRun = env->GetMethodID(clazz, "run", "()V");
     if (midRun == NULL) {
         printf("Cannot get method ID for \"run\"\n");
         return STATUS_FAILED;
@@ -608,6 +591,4 @@ Java_nsk_jvmti_PopFrame_popframe009_check(JNIEnv *env, jclass cls, jthread thr) 
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe010/popframe010.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe010/popframe010.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -249,8 +236,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -314,16 +300,14 @@ Java_nsk_jvmti_PopFrame_popframe010_getReady(JNIEnv *env, jclass c, jclass cls, 
         return;
     }
 
-    midRun = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "run", "()V");
+    midRun = env->GetMethodID(cls, "run", "()V");
     if (midRun == NULL) {
         printf("Cannot find Method ID for method run\n");
         result = STATUS_FAILED;
         return;
     }
 
-    midCheckPoint = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
+    midCheckPoint = env->GetMethodID(cls, "checkPoint", "()V");
     if (midCheckPoint == NULL) {
         printf("Cannot find Method ID for method checkPoint\n");
         result = STATUS_FAILED;
@@ -359,6 +343,4 @@ Java_nsk_jvmti_PopFrame_popframe010_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe011/popframe011.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe011/popframe011.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -257,8 +244,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -314,6 +300,4 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     return JNI_OK;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter001/rawmonenter001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter001/rawmonenter001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -119,8 +106,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -194,6 +180,4 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_RawMonitorEnter_rawmonenter001_check(JNIEn
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter002/rawmonenter002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter002/rawmonenter002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -105,6 +91,4 @@ Java_nsk_jvmti_RawMonitorEnter_rawmonenter002_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter003/rawmonenter003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter003/rawmonenter003.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -107,6 +93,4 @@ Java_nsk_jvmti_RawMonitorEnter_rawmonenter003_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter004/rawmonenter004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorEnter/rawmonenter004/rawmonenter004.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -74,8 +61,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -137,15 +123,14 @@ Java_nsk_jvmti_RawMonitorEnter_rawmonenter004_check(JNIEnv *env, jclass cls, job
         return STATUS_FAILED;
     }
 
-    threads_limit = JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, threads));
+    threads_limit = env->GetArrayLength(threads);
 
     if (printdump == JNI_TRUE) {
         printf(">>> starting %d threads ...\n", threads_limit);
     }
 
     for (i = 0; i < threads_limit; i++) {
-        thr = JNI_ENV_PTR(env)->GetObjectArrayElement(JNI_ENV_ARG(env,
-            threads), i);
+        thr = env->GetObjectArrayElement(threads, i);
         err = jvmti->RunAgentThread(thr, increment_thread, NULL,
                                     JVMTI_THREAD_NORM_PRIORITY);
         if (err != JVMTI_ERROR_NONE) {
@@ -192,6 +177,4 @@ Java_nsk_jvmti_RawMonitorEnter_rawmonenter004_check(JNIEnv *env, jclass cls, job
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit001/rawmonexit001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit001/rawmonexit001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -132,8 +119,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -220,6 +206,4 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_RawMonitorExit_rawmonexit001_check(JNIEnv 
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit002/rawmonexit002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit002/rawmonexit002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -105,6 +91,4 @@ Java_nsk_jvmti_RawMonitorExit_rawmonexit002_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit003/rawmonexit003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit003/rawmonexit003.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -107,6 +93,4 @@ Java_nsk_jvmti_RawMonitorExit_rawmonexit003_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit005/rawmonexit005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorExit/rawmonexit005/rawmonexit005.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -114,6 +100,4 @@ Java_nsk_jvmti_RawMonitorExit_rawmonexit005_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy001/rawmnntfy001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy001/rawmnntfy001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -145,8 +132,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -246,6 +232,4 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_RawMonitorNotify_rawmnntfy001_check(JNIEnv
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy002/rawmnntfy002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy002/rawmnntfy002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -105,6 +91,4 @@ Java_nsk_jvmti_RawMonitorNotify_rawmnntfy002_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy003/rawmnntfy003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy003/rawmnntfy003.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -107,6 +93,4 @@ Java_nsk_jvmti_RawMonitorNotify_rawmnntfy003_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy004/rawmnntfy004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotify/rawmnntfy004/rawmnntfy004.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -113,6 +99,4 @@ Java_nsk_jvmti_RawMonitorNotify_rawmnntfy004_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall001/rawmnntfyall001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall001/rawmnntfyall001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -145,8 +132,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -246,6 +232,4 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_RawMonitorNotifyAll_rawmnntfyall001_check(
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall002/rawmnntfyall002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall002/rawmnntfyall002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -105,6 +91,4 @@ Java_nsk_jvmti_RawMonitorNotifyAll_rawmnntfyall002_check(JNIEnv *env, jclass cls
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall003/rawmnntfyall003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall003/rawmnntfyall003.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -107,6 +93,4 @@ Java_nsk_jvmti_RawMonitorNotifyAll_rawmnntfyall003_check(JNIEnv *env, jclass cls
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall004/rawmnntfyall004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorNotifyAll/rawmnntfyall004/rawmnntfyall004.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -113,6 +99,4 @@ Java_nsk_jvmti_RawMonitorNotifyAll_rawmnntfyall004_check(JNIEnv *env, jclass cls
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait001/rawmnwait001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait001/rawmnwait001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -146,8 +133,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -247,6 +233,4 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_RawMonitorWait_rawmnwait001_check(JNIEnv *
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait002/rawmnwait002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait002/rawmnwait002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -69,8 +56,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -106,6 +92,4 @@ Java_nsk_jvmti_RawMonitorWait_rawmnwait002_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait003/rawmnwait003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait003/rawmnwait003.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -71,8 +58,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -108,6 +94,4 @@ Java_nsk_jvmti_RawMonitorWait_rawmnwait003_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait004/rawmnwait004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait004/rawmnwait004.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -69,8 +56,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -114,6 +100,4 @@ Java_nsk_jvmti_RawMonitorWait_rawmnwait004_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait005/rawmnwait005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RawMonitorWait/rawmnwait005/rawmnwait005.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -74,8 +61,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -300,6 +286,4 @@ Java_nsk_jvmti_RawMonitorWait_rawmnwait005_check(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/StressRedefine/stressRedefine.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/StressRedefine/stressRedefine.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -53,8 +40,7 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    if ((res = JNI_ENV_PTR(vm)->GetEnv(JNI_ENV_ARG(vm, (void **) &jvmti),
-            JVMTI_VERSION_1_1)) != JNI_OK) {
+    if ((res = vm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1)) != JNI_OK) {
         printf("%s: Failed to call GetEnv: error=%d\n", __FILE__, res);
         return JNI_ERR;
     }
@@ -104,11 +90,8 @@ Java_nsk_jvmti_RedefineClasses_StressRedefine_makeRedefinition(JNIEnv *env,
 
 /* filling the structure jvmtiClassDefinition */
     classDef.klass = redefCls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, classBytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, classBytes),
-            NULL);
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(classBytes, NULL);
 
     if (fl == 2) {
         printf(">>>>>>>> Invoke RedefineClasses():\n");
@@ -128,6 +111,4 @@ Java_nsk_jvmti_RedefineClasses_StressRedefine_makeRedefinition(JNIEnv *env,
     return PASSED;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass001/redefclass001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass001/redefclass001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -64,8 +51,7 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    if ((res = JNI_ENV_PTR(vm)->GetEnv(JNI_ENV_ARG(vm, (void **) &jvmti),
-            JVMTI_VERSION_1_1)) != JNI_OK) {
+    if ((res = vm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1)) != JNI_OK) {
         printf("%s: Failed to call GetEnv: error=%d\n", __FILE__, res);
         return JNI_ERR;
     }
@@ -115,11 +101,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass001_makeRedefinition(JNIEnv *env,
 
 /* filling the structure jvmtiClassDefinition */
     classDef.klass = redefCls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, classBytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, classBytes),
-            NULL);
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(classBytes, NULL);
 
     if (fl == 2) {
         printf(">>>>>>>> Invoke RedefineClasses():\n");
@@ -139,6 +122,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass001_makeRedefinition(JNIEnv *env,
     return PASSED;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass002/redefclass002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass002/redefclass002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -64,8 +51,7 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    if ((res = JNI_ENV_PTR(vm)->GetEnv(JNI_ENV_ARG(vm, (void **) &jvmti),
-            JVMTI_VERSION_1_1)) != JNI_OK) {
+    if ((res = vm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1)) != JNI_OK) {
         printf("%s: Failed to call GetEnv: error=%d\n", __FILE__, res);
         return JNI_ERR;
     }
@@ -155,10 +141,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass002_makeRedefinition(JNIEnv *env, jclas
 
 /* filling the structure jvmtiClassDefinition */
     classDef.klass = redefCls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, classBytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, classBytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(classBytes, NULL);
 
     if (vrb == 1)
         printf(">>>>>>>> Invoke RedefineClasses():\n\tnew class byte count=%d\n",
@@ -175,6 +159,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass002_makeRedefinition(JNIEnv *env, jclas
     return PASSED;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass003/redefclass003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass003/redefclass003.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -66,8 +53,7 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    if ((res = JNI_ENV_PTR(vm)->GetEnv(JNI_ENV_ARG(vm, (void **) &jvmti),
-            JVMTI_VERSION_1_1)) != JNI_OK) {
+    if ((res = vm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1)) != JNI_OK) {
         printf("%s: Failed to call GetEnv: error=%d\n", __FILE__, res);
         return JNI_ERR;
     }
@@ -118,10 +104,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass003_makeRedefinition(JNIEnv *env, jclas
 
 /* filling the structure jvmtiClassDefinition */
     classDef.klass = redefCls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, classBytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, classBytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(classBytes, NULL);
 
     if (vrb == 1)
         printf(">>>>>>>> Invoke RedefineClasses():\n\tnew class byte count=%d\n",
@@ -153,23 +137,19 @@ Java_nsk_jvmti_RedefineClasses_redefclass003_checkNewFields(JNIEnv *env,
     jint intFld;
     jlong longFld;
 
-    if ((fid = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, redefCls),
-        "intComplNewFld", "I")) == NULL) {
+    if ((fid = env->GetStaticFieldID(redefCls, "intComplNewFld", "I")) == NULL) {
         printf("%s: Failed to get the field ID for the static field \"intComplNewFld\"\n",
             __FILE__);
         return STATUS_FAILED;
     }
-    intFld = JNI_ENV_PTR(env)->GetStaticIntField(JNI_ENV_ARG(env, redefCls),
-        fid);
+    intFld = env->GetStaticIntField(redefCls, fid);
 
-    if ((fid = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, redefCls),
-        "longComplNewFld", "J")) == NULL) {
+    if ((fid = env->GetStaticFieldID(redefCls, "longComplNewFld", "J")) == NULL) {
         printf("%s: Failed to get the field ID for the static field \"longComplNewFld\"\n",
             __FILE__);
         return STATUS_FAILED;
     }
-    longFld = JNI_ENV_PTR(env)->GetStaticLongField(JNI_ENV_ARG(env, redefCls),
-        fid);
+    longFld = env->GetStaticLongField(redefCls, fid);
 
     if (intFld != 33 || longFld != 44) {
         printf("Completely new static variable has not assigned its default value:\n");
@@ -184,6 +164,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass003_checkNewFields(JNIEnv *env,
     }
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass004/redefclass004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass004/redefclass004.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -71,8 +58,7 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    if ((res = JNI_ENV_PTR(vm)->GetEnv(JNI_ENV_ARG(vm, (void **) &jvmti),
-            JVMTI_VERSION_1_1)) != JNI_OK) {
+    if ((res = vm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1)) != JNI_OK) {
         printf("%s: Failed to call GetEnv: error=%d\n", __FILE__, res);
         return JNI_ERR;
     }
@@ -123,10 +109,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass004_makeRedefinition(JNIEnv *env,
 
 /* fill the structure jvmtiClassDefinition */
     classDef.klass = redefCls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, classBytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, classBytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(classBytes, NULL);
 
     if (vrb == 1)
         printf(">>>>>>>> Invoke RedefineClasses():\n\tnew class byte count=%d\n",
@@ -154,8 +138,7 @@ Java_nsk_jvmti_RedefineClasses_redefclass004_makeRedefinition(JNIEnv *env,
 JNIEXPORT jint JNICALL
 Java_nsk_jvmti_RedefineClasses_redefclass004_checkNewFields(JNIEnv *env,
         jobject obj, jint vrb, jobject redefObj) {
-    jclass redefCls =
-        JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG(env, redefObj));
+    jclass redefCls = env->GetObjectClass(redefObj);
     jfieldID fid;
     jint intFld;
     jlong longFld;
@@ -163,34 +146,29 @@ Java_nsk_jvmti_RedefineClasses_redefclass004_checkNewFields(JNIEnv *env,
     const char *strFld = NULL;
 
 /* get value of new instance field "intComplNewFld" */
-    if ((fid = JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, redefCls),
-        "intComplNewFld", "I")) == NULL) {
+    if ((fid = env->GetFieldID(redefCls, "intComplNewFld", "I")) == NULL) {
         printf("%s: Failed to get the field ID for the field \"intComplNewFld\"\n",
             __FILE__);
         return STATUS_FAILED;
     }
-    intFld = JNI_ENV_PTR(env)->GetIntField(JNI_ENV_ARG(env, redefObj), fid);
+    intFld = env->GetIntField(redefObj, fid);
 
 /* get value of new instance field "longComplNewFld" */
-    if ((fid = JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, redefCls),
-        "longComplNewFld", "J")) == NULL) {
+    if ((fid = env->GetFieldID(redefCls, "longComplNewFld", "J")) == NULL) {
         printf("%s: Failed to get the field ID for the field \"longComplNewFld\"\n",
             __FILE__);
         return STATUS_FAILED;
     }
-    longFld = JNI_ENV_PTR(env)->GetLongField(JNI_ENV_ARG(env, redefObj), fid);
+    longFld = env->GetLongField(redefObj, fid);
 
 /* get value of new instance field "stringComplNewFld" */
-    if ((fid = JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, redefCls),
-        "stringComplNewFld", "Ljava/lang/String;")) == NULL) {
+    if ((fid = env->GetFieldID(redefCls, "stringComplNewFld", "Ljava/lang/String;")) == NULL) {
         printf("%s: Failed to get the field ID for the field \"stringComplNewFld\"\n",
             __FILE__);
         return STATUS_FAILED;
     }
-    stringObj = (jstring) JNI_ENV_PTR(env)->GetObjectField(JNI_ENV_ARG(env,
-        redefObj), fid);
-    strFld = JNI_ENV_PTR(env)->GetStringUTFChars(JNI_ENV_ARG(env,
-        stringObj), 0);
+    stringObj = (jstring) env->GetObjectField(redefObj, fid);
+    strFld = env->GetStringUTFChars(stringObj, 0);
 
     if (intFld != INTFLD || longFld != LONGFLD ||
         strcmp(strFld, STRFLD) != 0) {
@@ -201,8 +179,7 @@ Java_nsk_jvmti_RedefineClasses_redefclass004_checkNewFields(JNIEnv *env,
         printf(",\texpected %" LL "d\n", LONGFLD);
         printf("\tstringComplNewFld = \"%s\",\texpected \"%s\"\n",
             strFld, STRFLD);
-        JNI_ENV_PTR(env)->ReleaseStringUTFChars(JNI_ENV_ARG(env,
-            stringObj), strFld);
+        env->ReleaseStringUTFChars(stringObj, strFld);
         return STATUS_FAILED;
     } else {
         if (vrb == 1)
@@ -210,12 +187,9 @@ Java_nsk_jvmti_RedefineClasses_redefclass004_checkNewFields(JNIEnv *env,
 \tstringComplNewFld = \"%s\"\n\tintComplNewFld = %d\n\
 \tlongComplNewFld = %" LL "d\n",
                 strFld, intFld, longFld);
-        JNI_ENV_PTR(env)->ReleaseStringUTFChars(JNI_ENV_ARG(env,
-            stringObj), strFld);
+        env->ReleaseStringUTFChars(stringObj, strFld);
         return PASSED;
     }
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass005/redefclass005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass005/redefclass005.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -119,8 +106,7 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    if ((res = JNI_ENV_PTR(vm)->GetEnv(JNI_ENV_ARG(vm, (void **) &jvmti),
-            JVMTI_VERSION_1_1)) != JNI_OK) {
+    if ((res = vm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1)) != JNI_OK) {
         printf("%s: Failed to call GetEnv: error=%d\n", __FILE__, res);
         return JNI_ERR;
     }
@@ -213,10 +199,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass005_makeRedefinition(JNIEnv *env,
 
 /* filling the structure jvmtiClassDefinition */
     classDef.klass = redefCls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, classBytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, classBytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(classBytes, NULL);
 
     set_watch_ev(1); /* watch JVMTI events */
 
@@ -250,6 +234,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass005_makeRedefinition(JNIEnv *env,
     return(result);
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass006/redefclass006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass006/redefclass006.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -64,8 +51,7 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    if ((res = JNI_ENV_PTR(vm)->GetEnv(JNI_ENV_ARG(vm, (void **) &jvmti),
-            JVMTI_VERSION_1_1)) != JNI_OK) {
+    if ((res = vm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1)) != JNI_OK) {
         printf("%s: Failed to call GetEnv: error=%d\n", __FILE__, res);
         return JNI_ERR;
     }
@@ -132,8 +118,7 @@ Java_nsk_jvmti_RedefineClasses_redefclass006_makeRedefinition(JNIEnv *env,
         case 2:
             /* partly fill the structure jvmtiClassDefinition */
             classDef.klass = redefCls;
-            classDef.class_byte_count =
-                JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, classBytes));
+            classDef.class_byte_count = env->GetArrayLength(classBytes);
             classDef.class_bytes = NULL;
             classDefPtr = &classDef;
             break;
@@ -150,6 +135,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass006_makeRedefinition(JNIEnv *env,
     return PASSED;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass008/redefclass008.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass008/redefclass008.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define BP_NUM 5 /* overall number of breakpoints */
 
@@ -90,8 +77,7 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    if ((res = JNI_ENV_PTR(vm)->GetEnv(JNI_ENV_ARG(vm, (void **) &jvmti),
-            JVMTI_VERSION_1_1)) != JNI_OK) {
+    if ((res = vm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1)) != JNI_OK) {
         printf("%s: Failed to call GetEnv: error=%d\n", __FILE__, res);
         return JNI_ERR;
     }
@@ -146,25 +132,24 @@ Java_nsk_jvmti_RedefineClasses_redefclass008_setBreakpoints(JNIEnv *env,
         return PASSED;
     }
 
-    redefCls =
-        JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG(env, redefObj));
+    redefCls = env->GetObjectClass(redefObj);
 
     for (i=0; i<BP_NUM; i++) {
 /* get the JNI method ID for a method with name m_name and
    signature m_sign */
         if (breakpoints[i].inst) { /* an instance method */
-            if ((breakpoints[i].mid =
-                    JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, redefCls),
-                    breakpoints[i].m_name, breakpoints[i].m_sign)) == NULL) {
+            breakpoints[i].mid = env->GetMethodID(
+                redefCls, breakpoints[i].m_name, breakpoints[i].m_sign);
+            if (breakpoints[i].mid == NULL) {
                 printf("%s: Failed to get the method ID for the instance method\
  \"%s\" with signature \"%s\"\n",
                     __FILE__, breakpoints[i].m_name, breakpoints[i].m_sign);
                 return STATUS_FAILED;
             }
         } else {                   /* a static method */
-            if ((breakpoints[i].mid =
-                    JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, redefCls),
-                    breakpoints[i].m_name, breakpoints[i].m_sign)) == NULL) {
+            breakpoints[i].mid = env->GetStaticMethodID(
+                redefCls, breakpoints[i].m_name, breakpoints[i].m_sign);
+            if (breakpoints[i].mid == NULL) {
                 printf("%s: Failed to get the method ID for the static method\
  \"%s\" with signature \"%s\"\n",
                     __FILE__, breakpoints[i].m_name, breakpoints[i].m_sign);
@@ -215,10 +200,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass008_makeRedefinition(JNIEnv *env,
 
 /* fill the structure jvmtiClassDefinition */
     classDef.klass = redefCls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, classBytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, classBytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(classBytes, NULL);
 
     if (vrb == 1)
         printf(">>>>>>>> Invoke RedefineClasses():\n\tnew class byte count=%d\n",
@@ -246,26 +229,25 @@ Java_nsk_jvmti_RedefineClasses_redefclass008_getResult(JNIEnv *env,
         return PASSED;
     }
 
-    redefCls =
-        JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG(env, redefObj));
+    redefCls = env->GetObjectClass(redefObj);
 
 /* all breakpoints should be cleared after the redefinition */
     for (i=0; i<BP_NUM; i++) {
 /* get again the JNI method ID for a method with name m_name and
    signature m_sign */
         if (breakpoints[i].inst) { /* an instance method */
-            if ((breakpoints[i].mid =
-                    JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, redefCls),
-                    breakpoints[i].m_name, breakpoints[i].m_sign)) == NULL) {
+            breakpoints[i].mid = env->GetMethodID(
+                redefCls, breakpoints[i].m_name, breakpoints[i].m_sign);
+            if (breakpoints[i].mid == NULL) {
                 printf("%s: getResult: Failed to get the method ID for the instance method\
  \"%s\" with signature \"%s\"\n",
                     __FILE__, breakpoints[i].m_name, breakpoints[i].m_sign);
                 return STATUS_FAILED;
             }
         } else {                   /* a static method */
-            if ((breakpoints[i].mid =
-                    JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, redefCls),
-                    breakpoints[i].m_name, breakpoints[i].m_sign)) == NULL) {
+            breakpoints[i].mid = env->GetStaticMethodID(
+                redefCls, breakpoints[i].m_name, breakpoints[i].m_sign);
+            if (breakpoints[i].mid == NULL) {
                 printf("%s: getResult: Failed to get the method ID for the static method\
  \"%s\" with signature \"%s\"\n",
                     __FILE__, breakpoints[i].m_name, breakpoints[i].m_sign);
@@ -303,6 +285,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass008_getResult(JNIEnv *env,
     return totRes;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass010/redefclass010.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass010/redefclass010.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define METH_NUM 4 /* overall number of methods */
 
@@ -106,8 +93,7 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    if ((res = JNI_ENV_PTR(vm)->GetEnv(JNI_ENV_ARG(vm, (void **) &jvmti),
-            JVMTI_VERSION_1_1)) != JNI_OK) {
+    if ((res = vm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1)) != JNI_OK) {
         printf("%s: Failed to call GetEnv: error=%d\n", __FILE__, res);
         return JNI_ERR;
     }
@@ -156,16 +142,15 @@ int checkAttr(JNIEnv *env, jclass redefCls, methInfo methodsInfo[], jint vrb) {
     }
 
     for (i=0; i<METH_NUM; i++) {
-/* get the JNI method ID for a method with name m_name and
-   signature m_sign */
-        if (methodsInfo[i].inst) /* an instance method */
-            methodsInfo[i].mid =
-                JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, redefCls),
+        /* get the JNI method ID for a method with name m_name and
+           signature m_sign */
+        if (methodsInfo[i].inst) { /* an instance method */
+            methodsInfo[i].mid = env->GetMethodID(redefCls,
                     methodsInfo[i].m_name, methodsInfo[i].m_sign);
-        else                     /* a static method */
-            methodsInfo[i].mid =
-                JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, redefCls),
+        } else {                   /* a static method */
+            methodsInfo[i].mid = env->GetStaticMethodID(redefCls,
                     methodsInfo[i].m_name, methodsInfo[i].m_sign);
+        }
         if (methodsInfo[i].mid == NULL) {
             printf("%s: Failed to get the method ID for the%s%s method\
  \"%s\", signature \"%s\"\n",
@@ -174,7 +159,7 @@ int checkAttr(JNIEnv *env, jclass redefCls, methInfo methodsInfo[], jint vrb) {
             return STATUS_FAILED;
         }
 
-/* get the LineNumberTable attribute */
+        /* get the LineNumberTable attribute */
         if ((err = (jvmti->GetLineNumberTable(methodsInfo[i].mid,
                 &count, &ln_table))) != JVMTI_ERROR_NONE) {
             printf("%s: Failed to call GetLineNumberTable(): error=%d: %s\n",
@@ -228,9 +213,7 @@ int checkAttr(JNIEnv *env, jclass redefCls, methInfo methodsInfo[], jint vrb) {
 JNIEXPORT jint JNICALL
 Java_nsk_jvmti_RedefineClasses_redefclass010_checkOrigAttr(JNIEnv *env,
         jclass cls, jobject redefObj) {
-    jclass redefCls =
-        JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG(env, redefObj));
-
+    jclass redefCls = env->GetObjectClass(redefObj);
     return checkAttr(env, redefCls, origMethInfo, 2);
 }
 
@@ -249,12 +232,10 @@ Java_nsk_jvmti_RedefineClasses_redefclass010_makeRedefinition(JNIEnv *env,
         return PASSED;
     }
 
-/* fill the structure jvmtiClassDefinition */
+    /* fill the structure jvmtiClassDefinition */
     classDef.klass = redefCls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, classBytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, classBytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(classBytes, NULL);
 
     if (vrb)
         printf("\n>>>>>>>> Invoke RedefineClasses():\n\tnew class byte count=%d\n",
@@ -274,12 +255,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass010_makeRedefinition(JNIEnv *env,
 JNIEXPORT jint JNICALL
 Java_nsk_jvmti_RedefineClasses_redefclass010_getResult(JNIEnv *env,
     jclass cls, jint vrb, jobject redefObj) {
-    jclass redefCls =
-        JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG(env, redefObj));
-
+    jclass redefCls = env->GetObjectClass(redefObj);
     return checkAttr(env, redefCls, redefMethInfo, vrb);
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass011/redefclass011.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass011/redefclass011.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -117,10 +103,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass011_check(JNIEnv *env,
     }
 
     classDef.klass = NULL;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, bytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, bytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(bytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(bytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> invalid class check ...\n");
@@ -142,6 +126,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass011_check(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass012/redefclass012.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass012/redefclass012.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -118,10 +104,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass012_check(JNIEnv *env,
     }
 
     classDef.klass = cls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, jbytes));
-    bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, jbytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(jbytes);
+    bytes = (unsigned char *) env->GetByteArrayElements(jbytes, NULL);
 
     /* put 0,0 into version fields */
     bytes[4] = 0;
@@ -151,6 +135,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass012_check(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass013/redefclass013.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass013/redefclass013.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -118,10 +104,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass013_check(JNIEnv *env,
     }
 
     classDef.klass = cls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, jbytes));
-    bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, jbytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(jbytes);
+    bytes = (unsigned char *) env->GetByteArrayElements(jbytes, NULL);
 
     /* put 0 into magic field */
     bytes[0] = 0;
@@ -151,6 +135,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass013_check(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass014/redefclass014.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass014/redefclass014.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -123,10 +109,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass014_check(JNIEnv *env, jclass cls, jbyt
     }
 
     classDef.klass = cls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, bytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, bytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(bytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(bytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> circularity error check ...\n");
@@ -150,6 +134,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass014_check(JNIEnv *env, jclass cls, jbyt
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass015/redefclass015.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass015/redefclass015.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -117,10 +103,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass015_check(JNIEnv *env, jclass cls,
     }
 
     classDef.klass = clazz;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, bytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, bytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(bytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(bytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> verify error check ...\n");
@@ -142,6 +126,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass015_check(JNIEnv *env, jclass cls,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass016/redefclass016.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass016/redefclass016.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -157,11 +144,8 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
     bpeakpointsCount++;
 
     classDef.klass = klass;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG((JNIEnv *)env, classBytes));
-    bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG((JNIEnv *)env,
-            classBytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
+    bytes = (unsigned char *) env->GetByteArrayElements(classBytes, NULL);
 
     for (i = 0; i < classDef.class_byte_count - 3; i++) {
         if (((jint)bytes[i+3] |
@@ -219,8 +203,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -292,14 +275,14 @@ Java_nsk_jvmti_RedefineClasses_redefclass016_getReady(JNIEnv *env, jclass cls,
         !caps.can_get_line_numbers ||
         !caps.can_access_local_variables) return;
 
-    mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, clazz), "run", "()V");
+    mid = env->GetMethodID(clazz, "run", "()V");
     if (mid == NULL) {
         printf("Cannot find Method ID for method run\n");
         result = STATUS_FAILED;
         return;
     }
 
-    classBytes = (jbyteArray) JNI_ENV_PTR(env)->NewGlobalRef(JNI_ENV_ARG(env, bytes));
+    classBytes = (jbyteArray) env->NewGlobalRef(bytes);
 
     err = jvmti->GetLineNumberTable(mid, &entryCount, &lines);
     if (err != JVMTI_ERROR_NONE) {
@@ -353,6 +336,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass016_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass017/redefclass017.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass017/redefclass017.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -75,11 +62,9 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
     }
 
     classDef.klass = klass;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG((JNIEnv *)env, classBytes));
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
     classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG((JNIEnv *)env,
-            classBytes), NULL);
+        env->GetByteArrayElements(classBytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> bp: about to call RedefineClasses\n");
@@ -112,8 +97,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -173,15 +157,14 @@ Java_nsk_jvmti_RedefineClasses_redefclass017_getReady(JNIEnv *env, jclass cls,
     if (!caps.can_redefine_classes ||
         !caps.can_generate_breakpoint_events) return;
 
-    mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, clazz),
-        "checkPoint", "()V");
+    mid = env->GetMethodID(clazz, "checkPoint", "()V");
     if (mid == NULL) {
         printf("Cannot find Method ID for method run\n");
         result = STATUS_FAILED;
         return;
     }
 
-    classBytes = (jbyteArray) JNI_ENV_PTR(env)->NewGlobalRef(JNI_ENV_ARG(env, bytes));
+    classBytes = (jbyteArray) env->NewGlobalRef(bytes);
 
     err = jvmti->SetBreakpoint(mid, 0);
     if (err != JVMTI_ERROR_NONE) {
@@ -205,6 +188,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass017_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass018/redefclass018.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass018/redefclass018.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -78,11 +65,8 @@ Exception(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
     }
 
     classDef.klass = klass;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG((JNIEnv *)env, classBytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG((JNIEnv *)env,
-            classBytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(classBytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> about to call RedefineClasses\n");
@@ -115,8 +99,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -177,7 +160,7 @@ Java_nsk_jvmti_RedefineClasses_redefclass018_getReady(JNIEnv *env, jclass cls,
     if (!caps.can_redefine_classes ||
         !caps.can_generate_exception_events) return;
 
-    classBytes = (jbyteArray) JNI_ENV_PTR(env)->NewGlobalRef(JNI_ENV_ARG(env, bytes));
+    classBytes = (jbyteArray) env->NewGlobalRef(bytes);
 
     if ((err = (jvmti->GetCurrentThread(&thread))) != JVMTI_ERROR_NONE) {
         printf("Failed to get current thread: %s (%d)\n", TranslateError(err), err);
@@ -199,6 +182,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass018_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass019/redefclass019.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass019/redefclass019.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -316,11 +303,9 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
     }
 
     classDef.klass = klass;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG((JNIEnv *)env, classBytes));
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
     classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG((JNIEnv *)env,
-            classBytes), NULL);
+        env->GetByteArrayElements(classBytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> about to call RedefineClasses\n");
@@ -381,8 +366,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -455,18 +439,16 @@ Java_nsk_jvmti_RedefineClasses_redefclass019_getReady(JNIEnv *env, jclass cls,
         !caps.can_get_line_numbers ||
         !caps.can_access_local_variables) return;
 
-    classBytes = (jbyteArray) JNI_ENV_PTR(env)->NewGlobalRef(JNI_ENV_ARG(env, bytes));
+    classBytes = (jbyteArray) env->NewGlobalRef(bytes);
 
-    midRun = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, clazz),
-         "run", "()V");
+    midRun = env->GetMethodID(clazz, "run", "()V");
     if (midRun == NULL) {
         printf("Cannot find Method ID for method run\n");
         result = STATUS_FAILED;
         return;
     }
 
-    midCheckPoint = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, clazz),
-         "checkPoint", "()V");
+    midCheckPoint = env->GetMethodID(clazz, "checkPoint", "()V");
     if (midCheckPoint == NULL) {
         printf("Cannot find Method ID for method checkPoint\n");
         result = STATUS_FAILED;
@@ -511,6 +493,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass019_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210593](https://bugs.openjdk.java.net/browse/JDK-8210593): Clean up JNI_ENV_ARG and factorize the macros for vmTestbase/jvmti[N-R] tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/645/head:pull/645` \
`$ git checkout pull/645`

Update a local copy of the PR: \
`$ git checkout pull/645` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 645`

View PR using the GUI difftool: \
`$ git pr show -t 645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/645.diff">https://git.openjdk.java.net/jdk11u-dev/pull/645.diff</a>

</details>
