### PR TITLE
8210665: Clean up JNI_ENV_ARG and factorize the macros for vmTestbase/jvmti[R-U] tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass020/redefclass020.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass020/redefclass020.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -117,10 +103,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass020_check(JNIEnv *env, jclass cls,
     }
 
     classDef.klass = clazz;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, bytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, bytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(bytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(bytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> add method capability check ...\n");
@@ -145,6 +129,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass020_check(JNIEnv *env, jclass cls,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass021/redefclass021.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass021/redefclass021.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -117,10 +103,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass021_check(JNIEnv *env, jclass cls,
     }
 
     classDef.klass = clazz;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, bytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, bytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(bytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(bytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> delete method capability check ...\n");
@@ -144,6 +128,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass021_check(JNIEnv *env, jclass cls,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass022/redefclass022.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass022/redefclass022.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -117,10 +103,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass022_check(JNIEnv *env, jclass cls,
     }
 
     classDef.klass = clazz;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, bytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, bytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(bytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(bytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> change fields capability check ...\n");
@@ -145,6 +129,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass022_check(JNIEnv *env, jclass cls,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass023/redefclass023.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass023/redefclass023.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -117,10 +103,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass023_check(JNIEnv *env, jclass cls,
     }
 
     classDef.klass = clazz;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, bytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, bytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(bytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(bytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> change implemented interface capability check ...\n");
@@ -145,6 +129,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass023_check(JNIEnv *env, jclass cls,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass024/redefclass024.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass024/redefclass024.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -117,10 +103,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass024_check(JNIEnv *env, jclass cls,
     }
 
     classDef.klass = clazz;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, bytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, bytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(bytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(bytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> change class modifiers capability check ...\n");
@@ -145,6 +129,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass024_check(JNIEnv *env, jclass cls,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass025/redefclass025.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass025/redefclass025.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -117,10 +103,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass025_check(JNIEnv *env, jclass cls,
     }
 
     classDef.klass = clazz;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, bytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, bytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(bytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(bytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> change method modifiers capability check ...\n");
@@ -145,6 +129,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass025_check(JNIEnv *env, jclass cls,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass026/redefclass026.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass026/redefclass026.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -117,10 +103,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass026_check(JNIEnv *env, jclass cls,
     }
 
     classDef.klass = clazz;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, bytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, bytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(bytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(bytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> changed class name check ...\n");
@@ -142,6 +126,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass026_check(JNIEnv *env, jclass cls,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass027/redefclass027.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass027/redefclass027.cpp
@@ -28,21 +28,8 @@
 #include "JVMTITools.h"
 #include "jni_tools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -311,10 +298,8 @@ void redefine(jvmtiEnv *jvmti_env, JNIEnv *env, jclass cls) {
     jvmtiError err;
 
     classDef.klass = cls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, classBytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, classBytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(classBytes, NULL);
 
     if (printdump == JNI_TRUE) {
         printf(">>> about to call RedefineClasses %d\n", redefinesCount);
@@ -615,8 +600,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -713,24 +697,21 @@ Java_nsk_jvmti_RedefineClasses_redefclass027_getReady(JNIEnv *env, jclass cls,
         !caps.can_get_line_numbers ||
         !caps.can_access_local_variables) return;
 
-    classBytes = (jbyteArray) JNI_ENV_PTR(env)->NewGlobalRef(JNI_ENV_ARG(env, bytes));
+    classBytes = (jbyteArray) env->NewGlobalRef(bytes);
 
-    midRun = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, clazz),
-         "run", "()V");
+    midRun = env->GetMethodID(clazz, "run", "()V");
     if (midRun == NULL) {
         printf("Cannot find Method ID for method run\n");
         result = STATUS_FAILED;
     }
 
-    mid1 = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, clazz),
-         "method1", "(I)V");
+    mid1 = env->GetMethodID(clazz, "method1", "(I)V");
     if (mid1 == NULL) {
         printf("Cannot find Method ID for method1\n");
         result = STATUS_FAILED;
     }
 
-    mid2 = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, clazz),
-         "method2", "(I)V");
+    mid2 = env->GetMethodID(clazz, "method2", "(I)V");
     if (mid2 == NULL) {
         printf("Cannot find Method ID for method2\n");
         result = STATUS_FAILED;
@@ -755,8 +736,7 @@ Java_nsk_jvmti_RedefineClasses_redefclass027_getReady(JNIEnv *env, jclass cls,
         }
     }
 
-    fid1 = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, clazz),
-        "staticInt", "I");
+    fid1 = env->GetStaticFieldID(clazz, "staticInt", "I");
     if (fid1 == NULL) {
         printf("Cannot find Field ID for staticInt\n");
         result = STATUS_FAILED;
@@ -781,8 +761,7 @@ Java_nsk_jvmti_RedefineClasses_redefclass027_getReady(JNIEnv *env, jclass cls,
         }
     }
 
-    fid2 = JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, clazz),
-        "instanceInt", "I");
+    fid2 = env->GetFieldID(clazz, "instanceInt", "I");
     if (fid2 == NULL) {
         printf("Cannot find Field ID for instanceInt\n");
         result = STATUS_FAILED;
@@ -848,6 +827,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass027_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass031/redefclass031.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass031/redefclass031.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -90,8 +77,7 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    if ((res = JNI_ENV_PTR(vm)->GetEnv(JNI_ENV_ARG(vm, (void **) &jvmti),
-            JVMTI_VERSION_1_1)) != JNI_OK) {
+    if ((res = vm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1)) != JNI_OK) {
         printf("%s: Failed to call GetEnv: error=%d\n", __FILE__, res);
         return JNI_ERR;
     }
@@ -163,10 +149,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass031_makeRedefinition(JNIEnv *env,
 
 /* filling the structure jvmtiClassDefinition */
     classDef.klass = redefCls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, classBytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, classBytes), NULL);
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(classBytes, NULL);
 
     set_watch_ev(1); /* watch JVMTI events */
 
@@ -201,6 +185,4 @@ Java_nsk_jvmti_RedefineClasses_redefclass031r_nativeMethod(JNIEnv * pEnv, jclass
 }
 
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RunAgentThread/agentthr001/agentthr001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RunAgentThread/agentthr001/agentthr001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -61,9 +48,9 @@ jthread jthr(JNIEnv *env) {
     jmethodID cid;
     jthread res;
 
-    thrClass = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env, "java/lang/Thread"));
-    cid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, thrClass), "<init>", "()V");
-    res = JNI_ENV_PTR(env)->NewObject(JNI_ENV_ARG(env, thrClass), cid);
+    thrClass = env->FindClass("java/lang/Thread");
+    cid = env->GetMethodID(thrClass, "<init>", "()V");
+    res = env->NewObject(thrClass, cid);
     return res;
 }
 
@@ -257,8 +244,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -337,6 +323,4 @@ Java_nsk_jvmti_RunAgentThread_agentthr001_getRes(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RunAgentThread/agentthr002/agentthr002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RunAgentThread/agentthr002/agentthr002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -69,8 +56,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -172,6 +158,4 @@ Java_nsk_jvmti_RunAgentThread_agentthr002_check(JNIEnv *env, jclass cls, jthread
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RunAgentThread/agentthr003/agentthr003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RunAgentThread/agentthr003/agentthr003.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -145,6 +131,4 @@ Java_nsk_jvmti_RunAgentThread_agentthr003_check(JNIEnv *env, jclass cls, jthread
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetBreakpoint/setbrk002/setbrk002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetBreakpoint/setbrk002/setbrk002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -120,8 +106,7 @@ Java_nsk_jvmti_SetBreakpoint_setbrk002_check(JNIEnv *env, jclass cls) {
         return result;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-         "run", "([Ljava/lang/String;Ljava/io/PrintStream;)I");
+    mid = env->GetStaticMethodID(cls, "run", "([Ljava/lang/String;Ljava/io/PrintStream;)I");
     if (mid == NULL) {
         printf("Cannot find method run\n");
         return STATUS_FAILED;
@@ -157,6 +142,4 @@ Java_nsk_jvmti_SetBreakpoint_setbrk002_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetBreakpoint/setbrk003/setbrk003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetBreakpoint/setbrk003/setbrk003.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -119,8 +105,7 @@ Java_nsk_jvmti_SetBreakpoint_setbrk003_check(JNIEnv *env, jclass cls) {
         return result;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-         "check", "()I");
+    mid = env->GetStaticMethodID(cls, "check", "()I");
     if (mid == NULL) {
         printf("Cannot find method check\n");
         return STATUS_FAILED;
@@ -139,6 +124,4 @@ Java_nsk_jvmti_SetBreakpoint_setbrk003_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetBreakpoint/setbrk005/setbrk005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetBreakpoint/setbrk005/setbrk005.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -119,8 +105,7 @@ Java_nsk_jvmti_SetBreakpoint_setbrk005_check(JNIEnv *env, jclass cls) {
         return result;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-         "trial", "()I");
+    mid = env->GetStaticMethodID(cls, "trial", "()I");
     if (mid == NULL) {
         printf("Cannot find method trial\n");
         return STATUS_FAILED;
@@ -146,6 +131,4 @@ Java_nsk_jvmti_SetBreakpoint_setbrk005_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetBreakpoint/setbrk007/setbrk007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetBreakpoint/setbrk007/setbrk007.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -119,8 +105,7 @@ Java_nsk_jvmti_SetBreakpoint_setbrk007_check(JNIEnv *env, jclass cls) {
         return result;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
+    mid = env->GetStaticMethodID(cls, "checkPoint", "()V");
     if (mid == 0) {
         printf("Cannot find Method ID for method checkPoint\n");
         return STATUS_FAILED;
@@ -143,6 +128,4 @@ Java_nsk_jvmti_SetBreakpoint_setbrk007_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetBreakpoint/setbrk008/setbrk008.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetBreakpoint/setbrk008/setbrk008.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -133,8 +120,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -192,8 +178,7 @@ Java_nsk_jvmti_SetBreakpoint_setbrk008_getReady(JNIEnv *env,
         return;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-         exp_name, exp_sig);
+    mid = env->GetStaticMethodID(cls, exp_name, exp_sig);
     if (mid == NULL) {
         printf("Cannot find Method ID for method checkPoint\n");
         result = STATUS_FAILED;
@@ -234,6 +219,4 @@ Java_nsk_jvmti_SetBreakpoint_setbrk008_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEventNotificationMode/setnotif001/setnotif001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEventNotificationMode/setnotif001/setnotif001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -132,8 +119,7 @@ void setWatches(jvmtiEnv *jvmti_env, JNIEnv *env, jclass cls) {
     jfieldID fid;
     jmethodID mid;
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-        "meth01", "(I)V");
+    mid = env->GetStaticMethodID(cls, "meth01", "(I)V");
     err = jvmti->SetBreakpoint(mid, 0);
     if (err == JVMTI_ERROR_NONE) {
         enable(jvmti_env, JVMTI_EVENT_BREAKPOINT);
@@ -143,7 +129,7 @@ void setWatches(jvmtiEnv *jvmti_env, JNIEnv *env, jclass cls) {
                TranslateError(err), err);
     }
 
-    fid = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls), "fld", "I");
+    fid = env->GetStaticFieldID(cls, "fld", "I");
     if (caps.can_generate_field_access_events) {
         err = jvmti->SetFieldAccessWatch(cls, fid);
         if (err == JVMTI_ERROR_NONE) {
@@ -322,8 +308,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(enbl_scale, 0, SCALE_SIZE);
     memset(ev_scale, 0, SCALE_SIZE);
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -429,6 +414,4 @@ Java_nsk_jvmti_SetEventNotificationMode_setnotif001_getRes(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/setfldw001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/setfldw001.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -74,7 +61,7 @@ void setWatch(JNIEnv *env, jint ind) {
     jclass cls;
     field fld = fields[ind];
 
-    cls = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env, fld.klass));
+    cls = env->FindClass(fld.klass);
     if (cls == NULL) {
         printf("Cannot find class \"%s\"\n", fld.klass);
         result = STATUS_FAILED;
@@ -82,11 +69,9 @@ void setWatch(JNIEnv *env, jint ind) {
     }
     if (fld.fid == NULL) {
         if (fld.stat) {
-            fields[ind].fid = JNI_ENV_PTR(env)->
-                GetStaticFieldID(JNI_ENV_ARG(env, cls), fld.name, fld.sig);
+            fields[ind].fid = env->GetStaticFieldID(cls, fld.name, fld.sig);
         } else {
-            fields[ind].fid = JNI_ENV_PTR(env)->
-                GetFieldID(JNI_ENV_ARG(env, cls), fld.name, fld.sig);
+            fields[ind].fid = env->GetFieldID(cls, fld.name, fld.sig);
         }
     }
 
@@ -147,8 +132,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -210,7 +194,7 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw001_touchfld0(JNIEnv *env,
     jint val;
 
     setWatch(env, (jint)0);
-    val = JNI_ENV_PTR(env)->GetIntField(JNI_ENV_ARG(env, obj), fields[0].fid);
+    val = env->GetIntField(obj, fields[0].fid);
 }
 
 JNIEXPORT void JNICALL
@@ -236,6 +220,4 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw001_getRes(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw002/setfldw002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw002/setfldw002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -71,8 +58,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -127,8 +113,7 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw002_check(JNIEnv *env, jclass cls) {
     jvmtiError err;
     jfieldID fid;
 
-    fid = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-         "fld1", "I");
+    fid = env->GetStaticFieldID(cls, "fld1", "I");
 
     if (!caps.can_generate_field_access_events) {
         err = jvmti->SetFieldAccessWatch(cls, fid);
@@ -170,6 +155,4 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw002_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw003/setfldw003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw003/setfldw003.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -83,8 +70,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -135,12 +121,10 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw003_getReady(JNIEnv *env, jclass cls) 
         return;
     }
 
-    fids[0] = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-        "fld0", "I");
-    fids[1] = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-        "fld1", "I");
-    fids[2] = JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, cls), "fld2", "I");
-    fids[3] = JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, cls), "fld3", "I");
+    fids[0] = env->GetStaticFieldID(cls, "fld0", "I");
+    fids[1] = env->GetStaticFieldID(cls, "fld1", "I");
+    fids[2] = env->GetFieldID(cls, "fld2", "I");
+    fids[3] = env->GetFieldID(cls, "fld3", "I");
     for (i = 0; i < sizeof(fids) / sizeof(jfieldID); i++) {
         if (fids[i] == NULL) {
             printf("Unable to set field access watch on fld%" PRIuPTR ", fieldID=0", i);
@@ -185,6 +169,4 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw003_getRes(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw004/setfldw004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw004/setfldw004.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -83,8 +70,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -141,12 +127,10 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw004_getReady(JNIEnv *env, jclass cls) 
         return;
     }
 
-    fids[0] = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-        "fld0", "I");
-    fids[1] = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-        "fld1", "I");
-    fids[2] = JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, cls), "fld2", "I");
-    fids[3] = JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, cls), "fld3", "I");
+    fids[0] = env->GetStaticFieldID(cls, "fld0", "I");
+    fids[1] = env->GetStaticFieldID(cls, "fld1", "I");
+    fids[2] = env->GetFieldID(cls, "fld2", "I");
+    fids[3] = env->GetFieldID(cls, "fld3", "I");
     for (i = 0; i < sizeof(fids) / sizeof(jfieldID); i++) {
         if (fids[i] == NULL) {
             printf("Unable to set field access watch on fld%" PRIuPTR ", fieldID=0", i);
@@ -191,6 +175,4 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw004_getRes(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw005/setfldw005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw005/setfldw005.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -108,8 +95,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -168,13 +154,11 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw005_getReady(JNIEnv *env, jclass cls) 
 
     for (i = 0; i < sizeof(fields) / sizeof(field); i++) {
         if (fields[i].stat == JNI_TRUE) {
-            fields[i].fid = JNI_ENV_PTR(env)->
-                GetStaticFieldID(JNI_ENV_ARG(env, cls),
-                                 fields[i].name, fields[i].sig);
+            fields[i].fid = env-> GetStaticFieldID(
+                cls, fields[i].name, fields[i].sig);
         } else {
-            fields[i].fid = JNI_ENV_PTR(env)->
-                GetFieldID(JNI_ENV_ARG(env, cls),
-                           fields[i].name, fields[i].sig);
+            fields[i].fid = env->GetFieldID(
+                cls, fields[i].name, fields[i].sig);
         }
         if (fields[i].fid == NULL) {
             printf("Unable to set access watch on %s fld%" PRIuPTR ", fieldID=0",
@@ -220,6 +204,4 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw005_getRes(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw006/setfldw006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw006/setfldw006.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -120,8 +107,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -190,11 +176,11 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw006_getReady(JNIEnv *env,
     }
     for (i = 0; i < sizeof(watches)/sizeof(watch_info); i++) {
         if (watches[i].is_static == JNI_TRUE) {
-            watches[i].fid = JNI_ENV_PTR(env)->GetStaticFieldID(
-                JNI_ENV_ARG(env, cls), watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetStaticFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         } else {
-            watches[i].fid = JNI_ENV_PTR(env)->GetFieldID(
-                JNI_ENV_ARG(env, cls), watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         }
         err = jvmti->SetFieldAccessWatch(cls, watches[i].fid);
         if (err == JVMTI_ERROR_NONE) {
@@ -243,6 +229,4 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw006_check(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/setfmodw001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/setfmodw001.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -73,16 +60,12 @@ void setWatch(JNIEnv *env, jint ind) {
     jclass cls;
     jvmtiError err;
 
-    cls = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env, fields[ind].klass));
+    cls = env->FindClass(fields[ind].klass);
     if (fields[ind].fid == NULL) {
         if (fields[ind].stat) {
-            fields[ind].fid =
-                JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-                    fields[ind].name, fields[ind].sig);
+            fields[ind].fid = env->GetStaticFieldID(cls, fields[ind].name, fields[ind].sig);
         } else {
-            fields[ind].fid =
-                JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, cls),
-                    fields[ind].name, fields[ind].sig);
+            fields[ind].fid = env->GetFieldID(cls, fields[ind].name, fields[ind].sig);
         }
     }
 
@@ -143,8 +126,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -204,7 +186,7 @@ JNIEXPORT void JNICALL
 Java_nsk_jvmti_SetFieldModificationWatch_setfmodw001_touchfld0(JNIEnv *env,
         jclass cls) {
     setWatch(env, (jint)0);
-    JNI_ENV_PTR(env)->SetIntField(JNI_ENV_ARG(env, cls), fields[0].fid, (jint)2000);
+    env->SetIntField(cls, fields[0].fid, (jint)2000);
 }
 
 JNIEXPORT void JNICALL
@@ -231,6 +213,4 @@ Java_nsk_jvmti_SetFieldModificationWatch_setfmodw001_getRes(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw002/setfmodw002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw002/setfmodw002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -71,8 +58,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -128,8 +114,7 @@ Java_nsk_jvmti_SetFieldModificationWatch_setfmodw002_check(JNIEnv *env,
     jvmtiError err;
     jfieldID fid;
 
-    fid = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-         "fld1", "I");
+    fid = env->GetStaticFieldID(cls, "fld1", "I");
 
     if (!caps.can_generate_field_modification_events) {
         err = jvmti->SetFieldModificationWatch(cls, fid);
@@ -171,6 +156,4 @@ Java_nsk_jvmti_SetFieldModificationWatch_setfmodw002_check(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw003/setfmodw003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw003/setfmodw003.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -101,8 +88,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -156,13 +142,9 @@ Java_nsk_jvmti_SetFieldModificationWatch_setfmodw003_getReady(JNIEnv *env,
 
     for (i = 0; i < sizeof(flds) / sizeof(field); i++) {
         if (flds[i].stat == JNI_TRUE) {
-            flds[i].fid =
-                JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-                    flds[i].name, "I");
+            flds[i].fid = env->GetStaticFieldID(cls, flds[i].name, "I");
         } else {
-            flds[i].fid =
-                JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, cls),
-                    flds[i].name, "I");
+            flds[i].fid = env->GetFieldID(cls, flds[i].name, "I");
         }
         if (flds[i].fid == NULL) {
             printf("Unable to set field modif. watch on fld%" PRIuPTR ", fieldID=0", i);
@@ -224,6 +206,4 @@ Java_nsk_jvmti_SetFieldModificationWatch_setfmodw003_getRes(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw004/setfmodw004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw004/setfmodw004.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -101,8 +88,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -154,13 +140,9 @@ JNIEXPORT void JNICALL Java_nsk_jvmti_SetFieldModificationWatch_setfmodw004_getR
 
     for (i = 0; i < sizeof(flds) / sizeof(field); i++) {
         if (flds[i].stat == JNI_TRUE) {
-            flds[i].fid =
-                JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-                    flds[i].name, "I");
+            flds[i].fid = env->GetStaticFieldID(cls, flds[i].name, "I");
         } else {
-            flds[i].fid =
-                JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, cls),
-                    flds[i].name, "I");
+            flds[i].fid = env->GetFieldID(cls, flds[i].name, "I");
         }
         if (flds[i].fid == NULL) {
             printf("Unable to set field modif. watch on fld%" PRIuPTR ", fieldID=0", i);
@@ -222,6 +204,4 @@ Java_nsk_jvmti_SetFieldModificationWatch_setfmodw004_getRes(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw006/setfmodw006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw006/setfmodw006.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -120,8 +107,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -184,13 +170,11 @@ Java_nsk_jvmti_SetFieldModificationWatch_setfmodw006_getReady(JNIEnv *env,
     }
     for (i = 0; i < sizeof(watches)/sizeof(watch_info); i++) {
         if (watches[i].is_static == JNI_TRUE) {
-            watches[i].fid =
-                JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-                    watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetStaticFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         } else {
-            watches[i].fid =
-                JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, cls),
-                    watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         }
         err = jvmti->SetFieldModificationWatch(cls, watches[i].fid);
         if (err == JVMTI_ERROR_NONE) {
@@ -240,6 +224,4 @@ Java_nsk_jvmti_SetFieldModificationWatch_setfmodw006_check(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab002/setjniftab002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab002/setjniftab002.cpp
@@ -27,27 +27,7 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef JNI_ENV_ARG
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG(x, y) y
-    #define JNI_ENV_PTR(x) x
-  #else
-    #define JNI_ENV_ARG(x, y) x, y
-    #define JNI_ENV_PTR(x) (*x)
-  #endif
-#endif
-
-#ifndef JNI_ENV_ARG1
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG1(x)
-  #else
-    #define JNI_ENV_ARG1(x) x
-  #endif
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -98,9 +78,7 @@ Java_nsk_jvmti_SetJNIFunctionTable_setjniftab002_check(JNIEnv *env, jobject obj)
        only since JDK 1.2 */
     if (verbose)
         printf("\nb) Checking the function with the detached thread ...\n\ndetaching the main thread ...\n");
-    if ((res =
-            JNI_ENV_PTR(vm)->DetachCurrentThread(
-                JNI_ENV_ARG1(vm))) != JNI_OK)
+    if ((res = vm->DetachCurrentThread()) != JNI_OK)
         printf("(%s,%d): Warning: DetachCurrentThread() returns: %d\n\
 \tcheck with the detached main thread skipped\n",
             __FILE__, __LINE__, res);
@@ -109,9 +87,7 @@ Java_nsk_jvmti_SetJNIFunctionTable_setjniftab002_check(JNIEnv *env, jobject obj)
 
         if (verbose)
             printf("\nattaching the main thread back ...\n");
-        if ((res =
-                JNI_ENV_PTR(vm)->AttachCurrentThread(
-                    JNI_ENV_ARG(vm, (void **) &nextEnv), (void *) 0)) != JNI_OK) {
+        if ((res = vm->AttachCurrentThread((void **) &nextEnv, (void *) 0)) != JNI_OK) {
             printf("(%s,%d): TEST FAILURE: waitingThread: AttachCurrentThread() returns: %d\n",
                 __FILE__, __LINE__, res);
             return STATUS_FAILED;
@@ -141,8 +117,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (verbose)
         printf("verbose mode on\n");
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("(%s,%d): Failed to call GetEnv\n", __FILE__, __LINE__);
         return JNI_ERR;
@@ -153,6 +128,4 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     return JNI_OK;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal001/setlocal001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal001/setlocal001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -270,8 +257,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if ( res != JNI_OK || jvmti == NULL ) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -330,23 +316,18 @@ Java_nsk_jvmti_SetLocalVariable_setlocal001_getMethReady(JNIEnv *env,
     if (!caps.can_access_local_variables ||
         !caps.can_generate_breakpoint_events) return;
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
-    mid1 = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-        "meth01", "()D");
-    mid2 = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-        "meth02", "(I)V");
-    mid3 = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-        "meth03", "()V");
-    mid4 = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-        "meth04", "(IJSDCFBZ)V");
+    mid = env->GetStaticMethodID(cls, "checkPoint", "()V");
+    mid1 = env->GetMethodID(cls, "meth01", "()D");
+    mid2 = env->GetMethodID(cls, "meth02", "(I)V");
+    mid3 = env->GetStaticMethodID(cls, "meth03", "()V");
+    mid4 = env->GetStaticMethodID(cls, "meth04", "(IJSDCFBZ)V");
     if (mid == 0 || mid1 == 0 || mid2 == 0 || mid3 == 0 || mid4 == 0) {
         printf("Cannot find Method ID for a method\n");
     }
     floatVal = f;
     doubleVal = d;
-    objVal = JNI_ENV_PTR(env)->NewGlobalRef(JNI_ENV_ARG(env, o));
-    arrVal = JNI_ENV_PTR(env)->NewGlobalRef(JNI_ENV_ARG(env, a));
+    objVal = env->NewGlobalRef(o);
+    arrVal = env->NewGlobalRef(a);
 
     err = jvmti->SetBreakpoint(mid, 0);
     if (err != JVMTI_ERROR_NONE) {
@@ -369,6 +350,4 @@ Java_nsk_jvmti_SetLocalVariable_setlocal001_getRes(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal002/setlocal002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal002/setlocal002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -122,8 +108,8 @@ Java_nsk_jvmti_SetLocalVariable_setlocal002_check(JNIEnv *env, jclass cls, jthre
         return result;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-        "run", "([Ljava/lang/String;Ljava/io/PrintStream;)I");
+    mid = env->GetStaticMethodID(
+        cls, "run", "([Ljava/lang/String;Ljava/io/PrintStream;)I");
     if (mid == NULL) {
         printf("Cannot find method \"run\"\n");
         return STATUS_FAILED;
@@ -299,6 +285,4 @@ Java_nsk_jvmti_SetLocalVariable_setlocal002_check(JNIEnv *env, jclass cls, jthre
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal003/setlocal003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal003/setlocal003.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -156,8 +143,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -215,8 +201,7 @@ Java_nsk_jvmti_SetLocalVariable_setlocal003_getReady(JNIEnv *env, jclass cls) {
     if (!caps.can_access_local_variables ||
         !caps.can_generate_breakpoint_events) return;
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
+    mid = env->GetStaticMethodID(cls, "checkPoint", "()V");
     if (mid == NULL) {
         printf("Cannot find Method ID for method checkPoint\n");
         result = STATUS_FAILED;
@@ -244,6 +229,4 @@ Java_nsk_jvmti_SetLocalVariable_setlocal003_getRes(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal004/setlocal004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal004/setlocal004.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -161,8 +148,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -220,8 +206,7 @@ Java_nsk_jvmti_SetLocalVariable_setlocal004_getReady(JNIEnv *env, jclass cls) {
     if (!caps.can_access_local_variables ||
         !caps.can_generate_breakpoint_events) return;
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
+    mid = env->GetStaticMethodID(cls, "checkPoint", "()V");
     if (mid == 0) {
         printf("Cannot find Method ID for method checkPoint\n");
         result = STATUS_FAILED;
@@ -249,6 +234,4 @@ Java_nsk_jvmti_SetLocalVariable_setlocal004_getRes(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/StopThread/stopthrd006/stopthrd006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/StopThread/stopthrd006/stopthrd006.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -144,6 +130,4 @@ Java_nsk_jvmti_StopThread_stopthrd006_check(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadEnd/threadend001/threadend001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadEnd/threadend001/threadend001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -99,8 +86,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -127,7 +113,7 @@ Java_nsk_jvmti_ThreadEnd_threadend001_getReady(JNIEnv *env,
         return;
     }
 
-    prefix = JNI_ENV_PTR(env)->GetStringUTFChars(JNI_ENV_ARG(env, name), NULL);
+    prefix = env->GetStringUTFChars(name, NULL);
     if (prefix == NULL) {
         printf("Failed to copy UTF-8 string!\n");
         result = STATUS_FAILED;
@@ -170,6 +156,4 @@ Java_nsk_jvmti_ThreadEnd_threadend001_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadStart/threadstart001/threadstart001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadStart/threadstart001/threadstart001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -99,8 +86,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -127,7 +113,7 @@ Java_nsk_jvmti_ThreadStart_threadstart001_getReady(JNIEnv *env,
         return;
     }
 
-    prefix = JNI_ENV_PTR(env)->GetStringUTFChars(JNI_ENV_ARG(env, name), NULL);
+    prefix = env->GetStringUTFChars(name, NULL);
     if (prefix == NULL) {
         printf("Failed to copy UTF-8 string!\n");
         result = STATUS_FAILED;
@@ -170,6 +156,4 @@ Java_nsk_jvmti_ThreadStart_threadstart001_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadStart/threadstart003/threadstart003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadStart/threadstart003/threadstart003.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -113,8 +100,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -166,8 +152,7 @@ Java_nsk_jvmti_ThreadStart_threadstart003_check(JNIEnv *env,
         return STATUS_FAILED;
     }
 
-    threadName = JNI_ENV_PTR(env)->GetStringUTFChars(JNI_ENV_ARG(env, name),
-        NULL);
+    threadName = env->GetStringUTFChars(name, NULL);
     if (threadName == NULL) {
         printf("Failed to copy UTF-8 string!\n");
         return STATUS_FAILED;
@@ -288,6 +273,4 @@ Java_nsk_jvmti_ThreadStart_threadstart003_check(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/VMDeath/vmdeath001/vmdeath001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/VMDeath/vmdeath001/vmdeath001.cpp
@@ -33,27 +33,7 @@
 #include "JVMTITools.h"
 #include "jvmti_tools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef JNI_ENV_ARG
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG(x, y) y
-    #define JNI_ENV_PTR(x) x
-  #else
-    #define JNI_ENV_ARG(x, y) x, y
-    #define JNI_ENV_PTR(x) (*x)
-  #endif
-#endif
-
-#ifndef JNI_ENV_ARG1
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG1(x)
-  #else
-    #define JNI_ENV_ARG1(x) x
-  #endif
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -121,6 +101,4 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     return JNI_OK;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/VMInit/vminit001/vminit001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/VMInit/vminit001/vminit001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -149,8 +136,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -197,6 +183,4 @@ Java_nsk_jvmti_VMInit_vminit001_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF06/gf06t001/gf06t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF06/gf06t001/gf06t001.cpp
@@ -28,23 +28,8 @@
 #include "jni_tools.h"
 #include "jvmti_tools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_ARG1(x)
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_ARG1(x) x
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 /* ============================================================================= */
 
@@ -201,8 +186,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     timeout = nsk_jvmti_getWaitTime() * 60 * 1000;
 
     NSK_DISPLAY0("Create first JVMTI env.\n");
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti_1), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti_1, JVMTI_VERSION_1_1);
     if (res < 0) {
         NSK_COMPLAIN0("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -254,6 +238,4 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
 /* ============================================================================= */
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI03/ji03t001/ji03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI03/ji03t001/ji03t001.cpp
@@ -30,27 +30,7 @@
 
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef JNI_ENV_ARG
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG(x, y) y
-    #define JNI_ENV_PTR(x) x
-  #else
-    #define JNI_ENV_ARG(x, y) x, y
-    #define JNI_ENV_PTR(x) (*x)
-  #endif
-#endif
-
-#ifndef JNI_ENV_ARG1
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG1(x)
-  #else
-    #define JNI_ENV_ARG1(x) x
-  #endif
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -70,11 +50,11 @@ int call_count = 0;
 
 jint JNICALL MyGetVersion(JNIEnv *env) {
     call_count++;
-    if (verbose)
+    if (verbose) {
         printf("\nMyGetVersion: the function called successfully: getVer_count=%d\n",
             call_count);
-    return
-        orig_jni_functions->GetVersion(env);
+    }
+    return orig_jni_functions->GetVersion(env);
 }
 
 void doRedirect(JNIEnv *env) {
@@ -87,8 +67,7 @@ void doRedirect(JNIEnv *env) {
             JVMTI_ERROR_NONE) {
         printf("(%s,%d): TEST FAILED: failed to get original JNI function table: %s\n",
             __FILE__, __LINE__, TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to get original JNI function table"));
+        env->FatalError("failed to get original JNI function table");
         result = STATUS_FAILED;
     }
 
@@ -96,8 +75,7 @@ void doRedirect(JNIEnv *env) {
             JVMTI_ERROR_NONE) {
         printf("(%s,%d): TEST FAILED: failed to get redirected JNI function table: %s\n",
             __FILE__, __LINE__, TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to get redirected JNI function table"));
+        env->FatalError("failed to get redirected JNI function table");
         result = STATUS_FAILED;
     }
     if (verbose)
@@ -109,8 +87,7 @@ void doRedirect(JNIEnv *env) {
             JVMTI_ERROR_NONE) {
         printf("(%s,%d): TEST FAILED: failed to set new JNI function table: %s\n",
             __FILE__, __LINE__, TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to set new JNI function table"));
+        env->FatalError("failed to set new JNI function table");
         result = STATUS_FAILED;
     }
 
@@ -127,8 +104,7 @@ void doRestore(JNIEnv *env) {
             JVMTI_ERROR_NONE) {
         printf("(%s,%d): TEST FAILED: failed to restore original JNI function table: %s\n",
             __FILE__, __LINE__, TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to restore original JNI function table"));
+        env->FatalError("failed to restore original JNI function table");
         result = STATUS_FAILED;
     }
     if (verbose)
@@ -148,7 +124,7 @@ Java_nsk_jvmti_scenarios_jni_1interception_JI03_ji03t001_check(JNIEnv *env, jcla
     if (verbose)
         printf("\na) invoking the original function GetVersion() ...\n");
 
-    ver = JNI_ENV_PTR(env)->GetVersion(JNI_ENV_ARG1(env));
+    ver = env->GetVersion();
 
     if (verbose)
         printf("JNIenv version=%d\n", ver);
@@ -158,7 +134,7 @@ Java_nsk_jvmti_scenarios_jni_1interception_JI03_ji03t001_check(JNIEnv *env, jcla
 
     if (verbose)
         printf("\nb) invoking the redirected function GetVersion() ...\n");
-    ver = JNI_ENV_PTR(env)->GetVersion(JNI_ENV_ARG1(env));
+    ver = env->GetVersion();
 
     if (call_count == 1) {
         if (verbose)
@@ -177,7 +153,7 @@ Java_nsk_jvmti_scenarios_jni_1interception_JI03_ji03t001_check(JNIEnv *env, jcla
 
     if (verbose)
         printf("\nc) invoking the restored function GetVersion ...\n");
-    ver = JNI_ENV_PTR(env)->GetVersion(JNI_ENV_ARG1(env));
+    ver = env->GetVersion();
 
     if (call_count == 0) {
         if (verbose)
@@ -213,8 +189,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (verbose)
         printf("verbose mode on\n");
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("(%s,%d): Failed to call GetEnv\n", __FILE__, __LINE__);
         return JNI_ERR;
@@ -223,6 +198,4 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     return JNI_OK;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI03/ji03t003/ji03t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI03/ji03t003/ji03t003.cpp
@@ -31,27 +31,7 @@
 
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef JNI_ENV_ARG
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG(x, y) y
-    #define JNI_ENV_PTR(x) x
-  #else
-    #define JNI_ENV_ARG(x, y) x, y
-    #define JNI_ENV_PTR(x) (*x)
-  #endif
-#endif
-
-#ifndef JNI_ENV_ARG1
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG1(x)
-  #else
-    #define JNI_ENV_ARG1(x) x
-  #endif
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -128,16 +108,14 @@ void doRedirect(JNIEnv *env) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: failed to get original JNI function table: %s\n",
             __FILE__, __LINE__, TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to get original JNI function table"));
+        env->FatalError("failed to get original JNI function table");
     }
     if ((err = jvmti->GetJNIFunctionTable(&redir_jni_functions)) !=
             JVMTI_ERROR_NONE) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: failed to get redirected JNI function table: %s\n",
             __FILE__, __LINE__, TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to get redirected JNI function table"));
+        env->FatalError("failed to get redirected JNI function table");
     }
     if (verbose)
         printf("doRedirect: the JNI function table obtained successfully\n");
@@ -153,8 +131,7 @@ void doRedirect(JNIEnv *env) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: failed to set new JNI function table: %s\n",
             __FILE__, __LINE__, TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to set new JNI function table"));
+        env->FatalError("failed to set new JNI function table");
     }
 
     if (verbose)
@@ -171,8 +148,7 @@ void doRestore(JNIEnv *env) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: failed to restore original JNI function table: %s\n",
             __FILE__, __LINE__, TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to restore original JNI function table"));
+        env->FatalError("failed to restore original JNI function table");
     }
     if (verbose)
         printf("doRestore: the original JNI function table is restored successfully\n");
@@ -181,19 +157,18 @@ void doRestore(JNIEnv *env) {
 void doExc(JNIEnv *env, jthrowable thrw, jclass thrCls, const char *msg) {
     jint res;
 
-    if ((res = JNI_ENV_PTR(env)->ThrowNew(JNI_ENV_ARG(env, thrCls), msg)) != 0) {
+    if ((res = env->ThrowNew(thrCls, msg)) != 0) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: failed to throw new exception\n",
             __FILE__, __LINE__);
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to failed to throw new exception"));
+        env->FatalError("failed to failed to throw new exception");
     }
 
-    if (JNI_ENV_PTR(env)->ExceptionOccurred(JNI_ENV_ARG1(env))) {
+    if (env->ExceptionOccurred()) {
         if (verbose)
             printf("\nCHECK PASSED: exception %s thrown by ThrowNew()\n\tis detected by ExceptionOccurred() successfully\n",
                 msg);
-        JNI_ENV_PTR(env)->ExceptionClear(JNI_ENV_ARG1(env));
+        env->ExceptionClear();
     }
     else {
         result = STATUS_FAILED;
@@ -201,19 +176,18 @@ void doExc(JNIEnv *env, jthrowable thrw, jclass thrCls, const char *msg) {
             __FILE__, __LINE__, msg);
     }
 
-    if ((res = JNI_ENV_PTR(env)->Throw(JNI_ENV_ARG(env, thrw))) != 0) {
+    if ((res = env->Throw(thrw)) != 0) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: failed to throw exception\n",
             __FILE__, __LINE__);
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to failed to throw new exception"));
+        env->FatalError("failed to failed to throw new exception");
     }
 
-    if (JNI_ENV_PTR(env)->ExceptionOccurred(JNI_ENV_ARG1(env))) {
+    if (env->ExceptionOccurred()) {
         if (verbose)
             printf("(%s,%d): CHECK PASSED: exception %s thrown by Throw()\n\tis detected by ExceptionOccurred() successfully\n",
                 __FILE__, __LINE__, msg);
-        JNI_ENV_PTR(env)->ExceptionClear(JNI_ENV_ARG1(env));
+        env->ExceptionClear();
     }
     else {
         result = STATUS_FAILED;
@@ -285,13 +259,12 @@ Java_nsk_jvmti_scenarios_jni_1interception_JI03_ji03t003_check(JNIEnv *env, jobj
         return STATUS_FAILED;
     }
 
-    objCls = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG(env, obj));
+    objCls = env->GetObjectClass(obj);
 
     if (verbose)
        printf("\ncheck: obtaining field ID for \"name=%s signature=%s\"...\n",
            javaField, excClassSig);
-    if ((fid = JNI_ENV_PTR(env)->GetFieldID(
-            JNI_ENV_ARG(env, objCls), javaField, excClassSig)) == 0) {
+    if ((fid = env->GetFieldID(objCls, javaField, excClassSig)) == 0) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: failed to get ID for the field \"%s\"\n",
             __FILE__, __LINE__, javaField);
@@ -301,13 +274,12 @@ Java_nsk_jvmti_scenarios_jni_1interception_JI03_ji03t003_check(JNIEnv *env, jobj
     if (verbose)
        printf("check: obtaining the value of the field \"%s\"...\n",
            javaField);
-    thrwObj = (jthrowable) JNI_ENV_PTR(env)->GetObjectField(
-        JNI_ENV_ARG(env, obj), fid);
+    thrwObj = (jthrowable) env->GetObjectField(obj, fid);
 
     if (verbose)
        printf("check: obtaining the class of the object for \"%s\"...\n",
            javaField);
-    thrw = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG(env, thrwObj));
+    thrw = env->GetObjectClass(thrwObj);
 
     /* 1: check the JNI function table interception */
     if (verbose)
@@ -323,8 +295,8 @@ Java_nsk_jvmti_scenarios_jni_1interception_JI03_ji03t003_check(JNIEnv *env, jobj
     doExc(env, thrwObj, thrw, "restored");
     checkCall(2, 0, 0, 0);
 
-    JNI_ENV_PTR(env)->DeleteLocalRef(JNI_ENV_ARG(env, thrw));
-    JNI_ENV_PTR(env)->DeleteLocalRef(JNI_ENV_ARG(env, thrwObj));
+    env->DeleteLocalRef(thrw);
+    env->DeleteLocalRef(thrwObj);
 
     return result;
 }
@@ -349,8 +321,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (verbose)
         printf("verbose mode on\n");
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("(%s,%d): Failed to call GetEnv\n", __FILE__, __LINE__);
         return JNI_ERR;
@@ -359,6 +330,4 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     return JNI_OK;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI03/ji03t004/ji03t004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI03/ji03t004/ji03t004.cpp
@@ -31,27 +31,7 @@
 
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef JNI_ENV_ARG
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG(x, y) y
-    #define JNI_ENV_PTR(x) x
-  #else
-    #define JNI_ENV_ARG(x, y) x, y
-    #define JNI_ENV_PTR(x) (*x)
-  #endif
-#endif
-
-#ifndef JNI_ENV_ARG1
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG1(x)
-  #else
-    #define JNI_ENV_ARG1(x) x
-  #endif
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -98,21 +78,17 @@ void doRedirect(JNIEnv *env) {
 
     if (verbose)
         printf("\ndoRedirect: obtaining the JNI function table ...\n");
-    if ((err = jvmti->GetJNIFunctionTable(&orig_jni_functions)) !=
-            JVMTI_ERROR_NONE) {
+    if ((err = jvmti->GetJNIFunctionTable(&orig_jni_functions)) != JVMTI_ERROR_NONE) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: failed to get original JNI function table: %s\n",
             __FILE__, __LINE__, TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to get original JNI function table"));
+        env->FatalError("failed to get original JNI function table");
     }
-    if ((err = jvmti->GetJNIFunctionTable(&redir_jni_functions)) !=
-            JVMTI_ERROR_NONE) {
+    if ((err = jvmti->GetJNIFunctionTable(&redir_jni_functions)) != JVMTI_ERROR_NONE) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: failed to get redirected JNI function table: %s\n",
             __FILE__, __LINE__, TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to get redirected JNI function table"));
+        env->FatalError("failed to get redirected JNI function table");
     }
     if (verbose)
         printf("doRedirect: the JNI function table obtained successfully\n");
@@ -127,8 +103,7 @@ void doRedirect(JNIEnv *env) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: failed to set new JNI function table: %s\n",
             __FILE__, __LINE__, TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to set new JNI function table"));
+        env->FatalError("failed to set new JNI function table");
     }
 
     if (verbose)
@@ -140,13 +115,11 @@ void doRestore(JNIEnv *env) {
 
     if (verbose)
         printf("\ndoRestore: restoring the original JNI function table ...\n");
-    if ((err = jvmti->SetJNIFunctionTable(orig_jni_functions)) !=
-            JVMTI_ERROR_NONE) {
+    if ((err = jvmti->SetJNIFunctionTable(orig_jni_functions)) != JVMTI_ERROR_NONE) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: failed to restore original JNI function table: %s\n",
             __FILE__, __LINE__, TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to restore original JNI function table"));
+        env->FatalError("failed to restore original JNI function table");
     }
     if (verbose)
         printf("doRestore: the original JNI function table is restored successfully\n");
@@ -157,42 +130,40 @@ void doExec(JNIEnv *env, jclass allCls, jmethodID ctorId, const char *msg, ...) 
     jobject newObj;
     va_list args;
     va_start(args, msg);
-    if ((allObj = JNI_ENV_PTR(env)->AllocObject(JNI_ENV_ARG(env, allCls)))
+    if ((allObj = env->AllocObject(allCls))
             == NULL) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: failed to call %s AllocObject()\n",
             __FILE__, __LINE__, msg);
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to failed to call AllocObject()"));
+        env->FatalError("failed to failed to call AllocObject()");
     }
 
-    if (JNI_ENV_PTR(env)->ExceptionOccurred(JNI_ENV_ARG1(env))) {
+    if (env->ExceptionOccurred()) {
             result = STATUS_FAILED;
             printf("(%s,%d): TEST FAILED: exception occured during the call of %s AllocObject()\n",
                 __FILE__, __LINE__, msg);
-            JNI_ENV_PTR(env)->ExceptionDescribe(JNI_ENV_ARG1(env));
-            JNI_ENV_PTR(env)->ExceptionClear(JNI_ENV_ARG1(env));
+            env->ExceptionDescribe();
+            env->ExceptionClear();
     }
 
-    newObj = JNI_ENV_PTR(env)->NewObjectV(JNI_ENV_ARG(env, allCls), ctorId, args);
+    newObj = env->NewObjectV(allCls, ctorId, args);
     if (newObj == NULL) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: failed to call %s NewObjectV()\n",
             __FILE__, __LINE__, msg);
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to failed to call NewObjectV()"));
+        env->FatalError("failed to failed to call NewObjectV()");
     }
 
-    if (JNI_ENV_PTR(env)->ExceptionOccurred(JNI_ENV_ARG1(env))) {
+    if (env->ExceptionOccurred()) {
         result = STATUS_FAILED;
         printf("(%s,%d): TEST FAILED: exception occured during the call of %s AllocObject()\n",
             __FILE__, __LINE__, msg);
-        JNI_ENV_PTR(env)->ExceptionDescribe(JNI_ENV_ARG1(env));
-        JNI_ENV_PTR(env)->ExceptionClear(JNI_ENV_ARG1(env));
+        env->ExceptionDescribe();
+        env->ExceptionClear();
     }
     va_end(args);
-    JNI_ENV_PTR(env)->DeleteLocalRef(JNI_ENV_ARG(env, allObj));
-    JNI_ENV_PTR(env)->DeleteLocalRef(JNI_ENV_ARG(env, newObj));
+    env->DeleteLocalRef(allObj);
+    env->DeleteLocalRef(newObj);
 }
 
 void checkCall(int step, int exAllObjCalls, int exNewObjCalls) {
@@ -240,15 +211,13 @@ Java_nsk_jvmti_scenarios_jni_1interception_JI03_ji03t004_check(JNIEnv *env, jobj
         return STATUS_FAILED;
     }
 
-    if ((objCls = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env, classSig)))
-            == NULL) {
+    if ((objCls = env->FindClass(classSig)) == NULL) {
         printf("(%s,%d): TEST FAILED: failed to call FindClass() for \"%s\"\n",
             __FILE__, __LINE__, classSig);
         return STATUS_FAILED;
     }
 
-    if ((ctorId = JNI_ENV_PTR(env)->GetMethodID(
-                JNI_ENV_ARG(env, objCls), "<init>", "()V"))
+    if ((ctorId = env->GetMethodID(objCls, "<init>", "()V"))
             == NULL) {
         printf("(%s,%d): TEST FAILED: failed to call GetMethodID() for a constructor\n",
             __FILE__, __LINE__);
@@ -292,8 +261,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (verbose)
         printf("verbose mode on\n");
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("(%s,%d): Failed to call GetEnv\n", __FILE__, __LINE__);
         return JNI_ERR;
@@ -302,6 +270,4 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     return JNI_OK;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/ji06t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/ji06t001.cpp
@@ -34,27 +34,7 @@
 #include "jvmti_tools.h"
 #include "native_thread.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef JNI_ENV_ARG
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG(x, y) y
-    #define JNI_ENV_PTR(x) x
-  #else
-    #define JNI_ENV_ARG(x, y) x, y
-    #define JNI_ENV_PTR(x) (*x)
-  #endif
-#endif
-
-#ifndef JNI_ENV_ARG1
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG1(x)
-  #else
-    #define JNI_ENV_ARG1(x) x
-  #endif
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -65,7 +45,7 @@ extern "C" {
 // Helper for thread detach and terminate
 #define THREAD_return(status) \
   do { \
-      int res = JNI_ENV_PTR(vm)->DetachCurrentThread(JNI_ENV_ARG1(vm)); \
+      int res = vm->DetachCurrentThread(); \
       if (res != 0) \
           NSK_COMPLAIN1("TEST WARNING: DetachCurrentThread() returns: %d\n", res); \
       else \
@@ -128,17 +108,16 @@ jint JNICALL MyMonitorEnter(JNIEnv *env, jobject obj) {
 static jint enterMonitor(JNIEnv *env, const char *thr) {
     jint result;
 
-    if ((result = JNI_ENV_PTR(env)->
-            MonitorEnter(JNI_ENV_ARG(env, clsObj))) != 0) {
+    if ((result = env->MonitorEnter(clsObj)) != 0) {
         NSK_COMPLAIN2("TEST FAILURE: %s: MonitorEnter() returns: %d\n",
             thr, result);
         return STATUS_FAILED;
     }
-    if (JNI_ENV_PTR(env)->ExceptionOccurred(JNI_ENV_ARG1(env))) {
+    if (env->ExceptionOccurred()) {
         NSK_COMPLAIN1("TEST FAILURE: %s: exception occured\n",
             thr);
-        JNI_ENV_PTR(env)->ExceptionDescribe(JNI_ENV_ARG1(env));
-        JNI_ENV_PTR(env)->ExceptionClear(JNI_ENV_ARG1(env));
+        env->ExceptionDescribe();
+        env->ExceptionClear();
         return STATUS_FAILED;
     }
 
@@ -148,8 +127,7 @@ static jint enterMonitor(JNIEnv *env, const char *thr) {
 static jint exitMonitor(JNIEnv *env, const char *thr) {
     jint result;
 
-    if ((result = JNI_ENV_PTR(env)->
-            MonitorExit(JNI_ENV_ARG(env, clsObj))) != 0) {
+    if ((result = env->MonitorExit(clsObj)) != 0) {
         NSK_COMPLAIN2("TEST FAILURE: %s: MonitorExit() returns: %d\n",
             thr, result);
         return STATUS_FAILED;
@@ -167,16 +145,14 @@ static void doRedirect(JNIEnv *env) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: failed to get original JNI function table: %s\n",
             TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to get original JNI function table"));
+        env->FatalError("failed to get original JNI function table");
     }
     if ((err = jvmti->GetJNIFunctionTable(&redir_jni_functions)) !=
             JVMTI_ERROR_NONE) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: failed to get redirected JNI function table: %s\n",
             TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to get redirected JNI function table"));
+        env->FatalError("failed to get redirected JNI function table");
     }
 
     NSK_DISPLAY0("doRedirect: the JNI function table obtained successfully\n\
@@ -189,8 +165,7 @@ static void doRedirect(JNIEnv *env) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: failed to set new JNI function table: %s\n",
             TranslateError(err));
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to set new JNI function table"));
+        env->FatalError("failed to set new JNI function table");
     }
 
     NSK_DISPLAY0("doRedirect: the functions are overwritten successfully\n");
@@ -222,9 +197,7 @@ static int waitingThread(void *context) {
     NSK_DISPLAY1("waitingThread: thread #%d started\n\
 \tattaching the thread to the VM ...\n",
         indx);
-    if ((res =
-            JNI_ENV_PTR(vm)->AttachCurrentThread(
-                JNI_ENV_ARG(vm, (void **) &env), (void *) 0)) != 0) {
+    if ((res = vm->AttachCurrentThread((void **) &env, (void *) 0)) != 0) {
         NSK_COMPLAIN1("TEST FAILURE: waitingThread: AttachCurrentThread() returns: %d\n",
             res);
         return STATUS_FAILED;
@@ -255,9 +228,7 @@ static int ownerThread(void *context) {
     int tries = 0;
 
     NSK_DISPLAY0("ownerThread: thread started\n\tattaching the thread to the VM ...\n");
-    if ((res =
-            JNI_ENV_PTR(vm)->AttachCurrentThread(
-                JNI_ENV_ARG(vm, (void **) &env), (void *) 0)) != 0) {
+    if ((res = vm->AttachCurrentThread((void **) &env, (void *) 0)) != 0) {
         NSK_COMPLAIN1("TEST FAILURE: ownerThread: AttachCurrentThread() returns: %d\n",
             res);
         return STATUS_FAILED;
@@ -277,8 +248,7 @@ static int ownerThread(void *context) {
         if (tries > TRIES) {
             NSK_COMPLAIN1("TEST FAILED: ownerThread: time exceed after %d attempts\n",
                 TRIES);
-            JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-                "ownerThread: time exceed"));
+            env->FatalError("ownerThread: time exceed");
         }
     } while(releaseMon != 1);
 
@@ -298,9 +268,7 @@ static int redirectorThread(void *context) {
     int tries = 0;
 
     NSK_DISPLAY0("redirectorThread: thread started\n\tattaching the thread to the VM ...\n");
-    if ((res =
-            JNI_ENV_PTR(vm)->AttachCurrentThread(
-                JNI_ENV_ARG(vm, (void **) &env), (void *) 0)) != 0) {
+    if ((res = vm->AttachCurrentThread((void **) &env, (void *) 0)) != 0) {
         NSK_COMPLAIN1("TEST FAILURE: redirectorThread: AttachCurrentThread() returns: %d\n",
             res);
         return STATUS_FAILED;
@@ -320,21 +288,18 @@ static jobject getObjectFromField(JNIEnv *env, jobject obj) {
     jfieldID fid;
     jclass _objCls;
 
-    _objCls = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG(env, obj));
+    _objCls = env->GetObjectClass(obj);
 
     NSK_DISPLAY2("getObjectFromField: obtaining field ID for name=\"%s\" signature=\"%s\"...\n",
         javaField, classSig);
-    if ((fid = JNI_ENV_PTR(env)->GetFieldID(
-            JNI_ENV_ARG(env, _objCls), javaField, classSig)) == 0) {
+    if ((fid = env->GetFieldID(_objCls, javaField, classSig)) == 0) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILURE: failed to get ID for the field \"%s\"\n",
             javaField);
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to get ID for the java field"));
+        env->FatalError("failed to get ID for the java field");
     }
 
-    return JNI_ENV_PTR(env)->GetObjectField(
-        JNI_ENV_ARG(env, obj), fid);
+    return env->GetObjectField(obj, fid);
 }
 
 JNIEXPORT jint JNICALL
@@ -355,12 +320,10 @@ Java_nsk_jvmti_scenarios_jni_1interception_JI06_ji06t001_check(JNIEnv *env, jobj
     }
 
 /* prepare the testing */
-    if ((clsObj = JNI_ENV_PTR(env)->NewGlobalRef(
-            JNI_ENV_ARG(env, getObjectFromField(env, obj)))) == NULL) {
+    if ((clsObj = env->NewGlobalRef(getObjectFromField(env, obj))) == NULL) {
         NSK_COMPLAIN1("TEST FAILURE: cannot create a new global reference of class \"%s\"\n",
             classSig);
-        JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-            "failed to create a new global reference"));
+        env->FatalError("failed to create a new global reference");
     }
 
     NSK_DISPLAY0("starting monitor owner thread ...\n");
@@ -377,8 +340,7 @@ Java_nsk_jvmti_scenarios_jni_1interception_JI06_ji06t001_check(JNIEnv *env, jobj
         if (tries > TRIES) {
             NSK_COMPLAIN1("TEST FAILURE: the monitor is still not entered by the owner thread after %d attempts\n",
                 TRIES);
-            JNI_ENV_PTR(env)->FatalError(JNI_ENV_ARG(env,
-                " the monitor is still not entered by the owner thread"));
+            env->FatalError(" the monitor is still not entered by the owner thread");
         }
     } while(monEntered != 1);
 
@@ -483,7 +445,7 @@ Java_nsk_jvmti_scenarios_jni_1interception_JI06_ji06t001_check(JNIEnv *env, jobj
         free(waitThr[i]);
     }
 
-    JNI_ENV_PTR(env)->DeleteGlobalRef(JNI_ENV_ARG(env, clsObj));
+    env->DeleteGlobalRef(clsObj);
     NSK_DISPLAY0("<<<\n\n");
 
     NSK_DISPLAY0(">>> TEST CASE c) Checking number of the intercepted calls ...\n");
@@ -523,6 +485,4 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     return JNI_OK;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretbase/earlyretbase.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretbase/earlyretbase.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -174,8 +161,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretbase_doForceEarlyReturn(JNIEnv *env
     printf(">>>>>>>> Invoke ForceEarlyReturn()\n");
 
     printf("Before call to GetMethodID(%s, %s)\n", name_exp, sig_exp);
-    midActiveMethod = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, targCls),
-                                                    name_exp, sig_exp);
+    midActiveMethod = env->GetMethodID(targCls, name_exp, sig_exp);
     if (midActiveMethod == NULL) {
         printf("Cannot find Method ID for method %s\n", name_exp);
         RETURN_FAILED;
@@ -211,8 +197,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong error code from a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -288,6 +273,4 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretbase_check(JNIEnv *env, jclass cls)
     return errCode;
 }
 
-#ifdef __cplusplus
 }
-#endif


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210665](https://bugs.openjdk.java.net/browse/JDK-8210665): Clean up JNI_ENV_ARG and factorize the macros for vmTestbase/jvmti[R-U] tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/646/head:pull/646` \
`$ git checkout pull/646`

Update a local copy of the PR: \
`$ git checkout pull/646` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 646`

View PR using the GUI difftool: \
`$ git pr show -t 646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/646.diff">https://git.openjdk.java.net/jdk11u-dev/pull/646.diff</a>

</details>
