### PR TITLE
8210700: Clean up JNI_ENV_ARG and factorize the macros for vmTestbase/jvmti/unit tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretfp/earlyretfp.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretfp/earlyretfp.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -326,8 +313,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong error code from a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -396,29 +382,25 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretfp_getReady(
         return;
     }
 
-    midRun = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "run", "()V");
+    midRun = env->GetMethodID(cls, "run", "()V");
     if (midRun == NULL) {
         printf("Cannot find Method ID for method run\n");
         RETURN_FAILED;
     }
 
-    midCheckPoint = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
+    midCheckPoint = env->GetMethodID(cls, "checkPoint", "()V");
     if (midCheckPoint == NULL) {
         printf("Cannot find Method ID for method checkPoint\n");
         RETURN_FAILED;
     }
 
-    midCountDownFloat = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "countDownFloat", "(I)F");
+    midCountDownFloat = env->GetMethodID(cls, "countDownFloat", "(I)F");
     if (midCountDownFloat == NULL) {
         printf("Cannot find Method ID for method countDownFloat\n");
         RETURN_FAILED;
     }
 
-    midCountDownDouble = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "countDownDouble", "(I)D");
+    midCountDownDouble = env->GetMethodID(cls, "countDownDouble", "(I)D");
     if (midCountDownDouble == NULL) {
         printf("Cannot find Method ID for method countDownDouble\n");
         RETURN_FAILED;
@@ -473,6 +455,4 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretfp_check(JNIEnv *env, jclass cls) {
     return errCode;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretint/earlyretint.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretint/earlyretint.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -332,8 +319,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong error code from a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -401,50 +387,43 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretint_getReady(
         return;
     }
 
-    midRun = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "run", "()V");
+    midRun = env->GetMethodID(cls, "run", "()V");
     if (midRun == NULL) {
         printf("Cannot find Method ID for method run\n");
         RETURN_FAILED;
     }
 
-    midCheckPoint = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
+    midCheckPoint = env->GetMethodID(cls, "checkPoint", "()V");
     if (midCheckPoint == NULL) {
         printf("Cannot find Method ID for method checkPoint\n");
         RETURN_FAILED;
     }
 
-    midCountDownInt = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "countDownInt", "(I)I");
+    midCountDownInt = env->GetMethodID(cls, "countDownInt", "(I)I");
     if (midCheckPoint == NULL) {
         printf("Cannot find Method ID for method countDownInt\n");
         RETURN_FAILED;
     }
 
-    midCountDownShort = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "countDownShort", "(I)S");
+    midCountDownShort = env->GetMethodID(cls, "countDownShort", "(I)S");
     if (midCountDownShort == NULL) {
         printf("Cannot find Method ID for method countDownShort\n");
         RETURN_FAILED;
     }
 
-    midCountDownChar = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "countDownChar", "(I)C");
+    midCountDownChar = env->GetMethodID(cls, "countDownChar", "(I)C");
     if (midCountDownChar == NULL) {
         printf("Cannot find Method ID for method countDownChar\n");
         RETURN_FAILED;
     }
 
-    midCountDownByte = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "countDownByte", "(I)B");
+    midCountDownByte = env->GetMethodID(cls, "countDownByte", "(I)B");
     if (midCountDownByte == NULL) {
         printf("Cannot find Method ID for method countDownByte\n");
         RETURN_FAILED;
     }
 
-    midCountDownBoolean = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "countDownBoolean", "(I)Z");
+    midCountDownBoolean = env->GetMethodID(cls, "countDownBoolean", "(I)Z");
     if (midCountDownBoolean == NULL) {
         printf("Cannot find Method ID for method countDownBoolean\n");
         RETURN_FAILED;
@@ -488,6 +467,4 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretint_check(JNIEnv *env, jclass cls) 
     return errCode;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretlong/earlyretlong.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretlong/earlyretlong.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -313,8 +300,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong error code from a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -383,22 +369,19 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretlong_getReady(
         return;
     }
 
-    midRun = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "run", "()V");
+    midRun = env->GetMethodID(cls, "run", "()V");
     if (midRun == NULL) {
         printf("Cannot find Method ID for method run\n");
         RETURN_FAILED;
     }
 
-    midCheckPoint = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
+    midCheckPoint = env->GetMethodID(cls, "checkPoint", "()V");
     if (midCheckPoint == NULL) {
         printf("Cannot find Method ID for method checkPoint\n");
         RETURN_FAILED;
     }
 
-    midCountDownLong = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "countDownLong", "(I)J");
+    midCountDownLong = env->GetMethodID(cls, "countDownLong", "(I)J");
     if (midCountDownLong == NULL) {
         printf("Cannot find Method ID for method countDownLong\n");
         RETURN_FAILED;
@@ -444,6 +427,4 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretlong_check(JNIEnv *env, jclass cls)
     return errCode;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretobj/earlyretobj.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretobj/earlyretobj.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -277,7 +264,7 @@ void JNICALL MethodExit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
         return;
     }
     if (method == midCountDownObject) {
-        if (!JNI_ENV_PTR(env)->IsSameObject(JNI_ENV_ARG(env, ret_val), val_exp)) {
+        if (!env->IsSameObject(ret_val, val_exp)) {
             printf("Wrong ForceEarlyReturnObject return value: 0x%p\n", ret_val);
             printf("expected: 0x%p\n", val_exp);
             errCode = STATUS_FAILED;
@@ -311,8 +298,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong error code from a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -380,22 +366,19 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretobj_getReady(
         return;
     }
 
-    midRun = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "run", "()V");
+    midRun = env->GetMethodID(cls, "run", "()V");
     if (midRun == NULL) {
         printf("Cannot find Method ID for method run\n");
         RETURN_FAILED;
     }
 
-    midCheckPoint = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
+    midCheckPoint = env->GetMethodID(cls, "checkPoint", "()V");
     if (midCheckPoint == NULL) {
         printf("Cannot find Method ID for method checkPoint\n");
         RETURN_FAILED;
     }
 
-    midCountDownObject = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "countDownObject", sig_exp);
+    midCountDownObject = env->GetMethodID(cls, "countDownObject", sig_exp);
     if (midCountDownObject == NULL) {
         printf("Cannot find Method ID for method countDownObject\n");
         RETURN_FAILED;
@@ -415,7 +398,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretobj_getReady(
                TranslateError(err), err);
         RETURN_FAILED;
     } else {
-        val_exp = JNI_ENV_PTR(env)->NewGlobalRef(JNI_ENV_ARG(env, ret_obj));
+        val_exp = env->NewGlobalRef(ret_obj);
         framesExpected = depth;
     }
 }
@@ -440,6 +423,4 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretobj_printObject(
     return;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretstr/earlyretstr.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretstr/earlyretstr.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -277,8 +264,8 @@ void JNICALL MethodExit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
         return;
     }
     if (method == midCountDownString) {
-      ret_str = JNI_ENV_PTR(env)->GetStringUTFChars(JNI_ENV_ARG(env, ret_val), 0);
-      exp_str = JNI_ENV_PTR(env)->GetStringUTFChars(JNI_ENV_ARG(env, str_exp), 0);
+      ret_str = env->GetStringUTFChars(ret_val, 0);
+      exp_str = env->GetStringUTFChars(str_exp, 0);
       printf("Expected string: \"%s\"\n", exp_str);
       printf("Returned string: \"%s\"\n", ret_str);
       if (was_popped_by_exception) {
@@ -310,8 +297,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong error code of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -379,22 +365,19 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretstr_getReady(
         return;
     }
 
-    midRun = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "run", "()V");
+    midRun = env->GetMethodID(cls, "run", "()V");
     if (midRun == NULL) {
         printf("Cannot find Method ID for method run\n");
         RETURN_FAILED;
     }
 
-    midCheckPoint = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
+    midCheckPoint = env->GetMethodID(cls, "checkPoint", "()V");
     if (midCheckPoint == NULL) {
         printf("Cannot find Method ID for method checkPoint\n");
         RETURN_FAILED;
     }
 
-    midCountDownString = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "countDownString", sig_exp);
+    midCountDownString = env->GetMethodID(cls, "countDownString", sig_exp);
     if (midCountDownString == NULL) {
         printf("Cannot find Method ID for method countDownString\n");
         RETURN_FAILED;
@@ -414,7 +397,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretstr_getReady(
                TranslateError(err), err);
         RETURN_FAILED;
     } else {
-        str_exp = (jstring) JNI_ENV_PTR(env)->NewGlobalRef(JNI_ENV_ARG(env, expected_str));
+        str_exp = (jstring) env->NewGlobalRef(expected_str);
         framesExpected = depth;
     }
 }
@@ -430,6 +413,4 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretstr_check(JNIEnv *env, jclass cls) 
     return errCode;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretvoid/earlyretvoid.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretvoid/earlyretvoid.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -260,8 +247,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong error code from a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -325,15 +311,13 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretvoid_getReady(
         return;
     }
 
-    midRun = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "run", "()V");
+    midRun = env->GetMethodID(cls, "run", "()V");
     if (midRun == NULL) {
         printf("Cannot find Method ID for method run\n");
         RETURN_FAILED;
     }
 
-    midCheckPoint = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
+    midCheckPoint = env->GetMethodID(cls, "checkPoint", "()V");
     if (midCheckPoint == NULL) {
         printf("Cannot find Method ID for method checkPoint\n");
         RETURN_FAILED;
@@ -369,6 +353,4 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretvoid_check(JNIEnv *env, jclass cls)
     return errCode;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetConstantPool/getcpool001/getcpool001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetConstantPool/getcpool001/getcpool001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -114,8 +101,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jvmtiError err;
     jint res;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -176,8 +162,7 @@ Java_nsk_jvmti_unit_GetConstantPool_getcpool001_getReady(
         return;
     }
 
-    midCheckPoint = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
+    midCheckPoint = env->GetMethodID(cls, "checkPoint", "()V");
     if (midCheckPoint == NULL) {
         printf("Cannot find Method ID for method checkPoint\n");
         RETURN_FAILED;
@@ -190,8 +175,7 @@ Java_nsk_jvmti_unit_GetConstantPool_getcpool001_getReady(
         RETURN_FAILED;
     }
 
-    err = jvmti->SetEventNotificationMode(JVMTI_ENABLE,
-        JVMTI_EVENT_BREAKPOINT, NULL);
+    err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL);
     if (err != JVMTI_ERROR_NONE) {
         printf("Failed to enable BREAKPOINT event: %s (%d)\n",
                TranslateError(err), err);
@@ -205,6 +189,4 @@ Java_nsk_jvmti_unit_GetConstantPool_getcpool001_check(JNIEnv *env, jclass cls) {
     return errCode;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetLineNumberTable/linetab004/linetab004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetLineNumberTable/linetab004/linetab004.cpp
@@ -30,21 +30,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -73,8 +60,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -158,15 +144,13 @@ Java_nsk_jvmti_unit_GetLineNumberTable_linetab004_check(JNIEnv *env, jclass cls)
     if (printdump == JNI_TRUE) {
         printf("\n Check methods of interface:\n");
     }
-    interf = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/unit/GetLineNumberTable/Interface004"));
+    interf = env->FindClass("nsk/jvmti/unit/GetLineNumberTable/Interface004");
     if (interf == NULL) {
         printf("Cannot get Interface class!\n");
         return STATUS_FAILED;
     }
 
-    mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-        "instanceMeth0", "()I");
+    mid = env->GetMethodID(cls, "instanceMeth0", "()I");
     if (mid == NULL) {
         printf("Cannot get method ID!\n");
         return STATUS_FAILED;
@@ -174,8 +158,7 @@ Java_nsk_jvmti_unit_GetLineNumberTable_linetab004_check(JNIEnv *env, jclass cls)
     checkGetLineNumberTable(mid, "instanceMeth0", 1,
         JVMTI_ERROR_ABSENT_INFORMATION);
 
-    mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-        "instanceMeth1", "()I");
+    mid = env->GetMethodID(cls, "instanceMeth1", "()I");
     if (mid == NULL) {
         printf("Cannot get method ID!\n");
         return STATUS_FAILED;
@@ -186,14 +169,13 @@ Java_nsk_jvmti_unit_GetLineNumberTable_linetab004_check(JNIEnv *env, jclass cls)
     if (printdump == JNI_TRUE) {
         printf("\n Check methods of abstract class:\n");
     }
-    abstr = JNI_ENV_PTR(env)->GetSuperclass(JNI_ENV_ARG(env, cls));
+    abstr = env->GetSuperclass(cls);
     if (abstr == NULL) {
         printf("Cannot get super class!\n");
         return STATUS_FAILED;
     }
 
-    mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, abstr),
-        "instanceMeth0", "()I");
+    mid = env->GetMethodID(abstr, "instanceMeth0", "()I");
     if (mid == NULL) {
         printf("Cannot get method ID!\n");
         return STATUS_FAILED;
@@ -201,8 +183,7 @@ Java_nsk_jvmti_unit_GetLineNumberTable_linetab004_check(JNIEnv *env, jclass cls)
     checkGetLineNumberTable(mid, "instanceMeth0", 1,
         JVMTI_ERROR_ABSENT_INFORMATION);
 
-    mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, abstr),
-        "instanceMeth1", "()I");
+    mid = env->GetMethodID(abstr, "instanceMeth1", "()I");
     if (mid == NULL) {
         printf("Cannot get method ID!\n");
         return STATUS_FAILED;
@@ -213,8 +194,7 @@ Java_nsk_jvmti_unit_GetLineNumberTable_linetab004_check(JNIEnv *env, jclass cls)
     if (printdump == JNI_TRUE) {
         printf("\n Check methods of regular class:\n");
     }
-    mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-        "instanceMeth0", "()I");
+    mid = env->GetMethodID(cls, "instanceMeth0", "()I");
     if (mid == NULL) {
         printf("Cannot get method ID!\n");
         return STATUS_FAILED;
@@ -222,8 +202,7 @@ Java_nsk_jvmti_unit_GetLineNumberTable_linetab004_check(JNIEnv *env, jclass cls)
     checkGetLineNumberTable(mid, "instanceMeth0", 0,
         JVMTI_ERROR_ABSENT_INFORMATION);
 
-    mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-        "instanceMeth1", "()I");
+    mid = env->GetMethodID(cls, "instanceMeth1", "()I");
     if (mid == NULL) {
         printf("Cannot get method ID!\n");
         return STATUS_FAILED;
@@ -231,8 +210,7 @@ Java_nsk_jvmti_unit_GetLineNumberTable_linetab004_check(JNIEnv *env, jclass cls)
     checkGetLineNumberTable(mid, "instanceMeth1", 0,
         JVMTI_ERROR_ABSENT_INFORMATION);
 
-    mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-        "instanceMeth2", "()I");
+    mid = env->GetMethodID(cls, "instanceMeth2", "()I");
     if (mid == NULL) {
         printf("Cannot get method ID!\n");
         return STATUS_FAILED;
@@ -243,8 +221,7 @@ Java_nsk_jvmti_unit_GetLineNumberTable_linetab004_check(JNIEnv *env, jclass cls)
     if (printdump == JNI_TRUE) {
         printf("\n Check native methods of regular class:\n");
     }
-    mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-        "instanceNativeMeth", "()I");
+    mid = env->GetMethodID(cls, "instanceNativeMeth", "()I");
     if (mid == NULL) {
         printf("Cannot get method ID!\n");
         return STATUS_FAILED;
@@ -252,8 +229,7 @@ Java_nsk_jvmti_unit_GetLineNumberTable_linetab004_check(JNIEnv *env, jclass cls)
     checkGetLineNumberTable(mid, "instanceNativeMeth", 1,
         JVMTI_ERROR_NATIVE_METHOD);
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-        "staticNativeMeth", "()I");
+    mid = env->GetStaticMethodID(cls, "staticNativeMeth", "()I");
     if (mid == NULL) {
         printf("Cannot get method ID!\n");
         return STATUS_FAILED;
@@ -268,6 +244,4 @@ Java_nsk_jvmti_unit_GetLineNumberTable_linetab004_check(JNIEnv *env, jclass cls)
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetLocalVariable/getlocal003/getlocal003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetLocalVariable/getlocal003/getlocal003.cpp
@@ -31,21 +31,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -151,8 +138,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -209,8 +195,7 @@ Java_nsk_jvmti_unit_GetLocalVariable_getlocal003_getMeth(JNIEnv *env, jclass cls
     if (!caps.can_access_local_variables ||
         !caps.can_generate_method_exit_events) return;
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-                                              "staticMeth", "(I)I");
+    mid = env->GetStaticMethodID(cls, "staticMeth", "(I)I");
     if (mid == NULL) {
         printf("Cannot find Method ID for staticMeth\n");
         result = STATUS_FAILED;
@@ -250,8 +235,7 @@ Java_nsk_jvmti_unit_GetLocalVariable_getlocal003_checkLoc(JNIEnv *env,
         return;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-                                              "staticMeth", "(I)I");
+    mid = env->GetStaticMethodID(cls, "staticMeth", "(I)I");
     if (mid == NULL) {
         printf("Cannot find Method ID for staticMeth\n");
         result = STATUS_FAILED;
@@ -324,6 +308,4 @@ Java_nsk_jvmti_unit_GetLocalVariable_getlocal003_getRes(JNIEnv *env, jclass cls)
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetLocalVariable/getlocal004/getlocal004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetLocalVariable/getlocal004/getlocal004.cpp
@@ -31,21 +31,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -82,8 +69,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -128,8 +114,7 @@ Java_nsk_jvmti_unit_GetLocalVariable_getlocal004_getMeth(JNIEnv *env, jclass cls
     if (!caps.can_access_local_variables ||
         !caps.can_generate_method_exit_events) return;
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-                                              "staticMeth", "(I)I");
+    mid = env->GetStaticMethodID(cls, "staticMeth", "(I)I");
     if (mid == NULL) {
         printf("Cannot find Method ID for staticMeth\n");
         result = STATUS_FAILED;
@@ -243,6 +228,4 @@ Java_nsk_jvmti_unit_GetLocalVariable_getlocal004_getRes(JNIEnv *env, jclass cls)
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/IsSynthetic/issynth001/issynth001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/IsSynthetic/issynth001/issynth001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -71,8 +58,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -294,6 +280,4 @@ JNIEXPORT jint JNICALL Java_issynth001_getRes(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/MethodBind/JvmtiTest/JvmtiTest.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/MethodBind/JvmtiTest/JvmtiTest.cpp
@@ -26,27 +26,8 @@
 #include "jvmti.h"
 #include "agent_common.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_ARG1(x)
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_ARG1(x) x
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
-
-#define JVMTI_ENV_ARG JNI_ENV_ARG
-#define JVMTI_ENV_ARG1 JNI_ENV_ARG1
-#define JVMTI_ENV_PTR JNI_ENV_PTR
 
 #define JVMTI_ERROR_CHECK(str,res) if ( res != JVMTI_ERROR_NONE) { printf(str); printf("%d\n",res); return res;}
 #define JVMTI_ERROR_CHECK_EXPECTED_ERROR(str,res,err) if ( res != err) { printf(str); printf("unexpected error %d\n",res); return res;}
@@ -161,8 +142,7 @@ jint Agent_Initialize(JavaVM * jvm, char *options, void *reserved) {
         }
     }
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res < 0) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -170,24 +150,24 @@ jint Agent_Initialize(JavaVM * jvm, char *options, void *reserved) {
 
 
     /* Add capabilities */
-    res = JVMTI_ENV_PTR(jvmti)->GetPotentialCapabilities(JVMTI_ENV_ARG(jvmti, &jvmti_caps));
+    res = jvmti->GetPotentialCapabilities(&jvmti_caps);
     JVMTI_ERROR_CHECK("GetPotentialCapabilities returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->AddCapabilities(JVMTI_ENV_ARG(jvmti, &jvmti_caps));
+    res = jvmti->AddCapabilities(&jvmti_caps);
     JVMTI_ERROR_CHECK("AddCapabilities returned error", res);
 
     /* Enable events */
     init_callbacks();
-    res = JVMTI_ENV_PTR(jvmti)->SetEventCallbacks(JVMTI_ENV_ARG(jvmti, &callbacks), sizeof(callbacks));
+    res = jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks));
     JVMTI_ERROR_CHECK("SetEventCallbacks returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->SetEventNotificationMode(JVMTI_ENV_ARG(jvmti,JVMTI_ENABLE),JVMTI_EVENT_VM_INIT,NULL);
+    res = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL);
     JVMTI_ERROR_CHECK("SetEventNotificationMode for VM_INIT returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->SetEventNotificationMode(JVMTI_ENV_ARG(jvmti,JVMTI_ENABLE),JVMTI_EVENT_VM_DEATH,NULL);
+    res = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL);
     JVMTI_ERROR_CHECK("SetEventNotificationMode for vm death event returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->SetEventNotificationMode(JVMTI_ENV_ARG(jvmti,JVMTI_ENABLE),JVMTI_EVENT_NATIVE_METHOD_BIND,NULL);
+    res = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_NATIVE_METHOD_BIND, NULL);
     JVMTI_ERROR_CHECK("SetEventNotificationMode for native method bind event returned error", res);
 
     return JNI_OK;
@@ -207,7 +187,7 @@ Java_nsk_jvmti_unit_MethodBind_JvmtiTest_CreateRawMonitor(JNIEnv * env, jclass c
 
     sprintf(sz, "Rawmonitor-%d",i);
     debug_printf("jvmti create raw monitor \n");
-    ret = JVMTI_ENV_PTR(jvmti)->CreateRawMonitor(JVMTI_ENV_ARG(jvmti, sz), &jraw_monitor[i]);
+    ret = jvmti->CreateRawMonitor(sz, &jraw_monitor[i]);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: ForceGarbageCollection %d \n", ret);
@@ -220,7 +200,7 @@ Java_nsk_jvmti_unit_MethodBind_JvmtiTest_RawMonitorEnter(JNIEnv * env, jclass cl
     jvmtiError ret;
 
     debug_printf("jvmti Raw monitor enter \n");
-    ret = JVMTI_ENV_PTR(jvmti)->RawMonitorEnter(JVMTI_ENV_ARG(jvmti, jraw_monitor[i]));
+    ret = jvmti->RawMonitorEnter(jraw_monitor[i]);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: Raw monitor enter %d \n", ret);
@@ -233,7 +213,7 @@ Java_nsk_jvmti_unit_MethodBind_JvmtiTest_RawMonitorExit(JNIEnv * env, jclass cls
     jvmtiError ret;
 
     debug_printf("jvmti raw monitor exit \n");
-    ret = JVMTI_ENV_PTR(jvmti)->RawMonitorExit(JVMTI_ENV_ARG(jvmti, jraw_monitor[i]));
+    ret = jvmti->RawMonitorExit(jraw_monitor[i]);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: RawMonitorExit %d \n", ret);
@@ -246,7 +226,7 @@ Java_nsk_jvmti_unit_MethodBind_JvmtiTest_RawMonitorWait(JNIEnv * env, jclass cls
     jvmtiError ret;
 
     debug_printf("jvmti RawMonitorWait \n");
-    ret = JVMTI_ENV_PTR(jvmti)->RawMonitorWait(JVMTI_ENV_ARG(jvmti, jraw_monitor[i]), -1);
+    ret = jvmti->RawMonitorWait(jraw_monitor[i], -1);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: RawMonitorWait %d \n", ret);
@@ -259,7 +239,7 @@ Java_nsk_jvmti_unit_MethodBind_JvmtiTest_RawMonitorNotify(JNIEnv * env, jclass c
     jvmtiError ret;
 
     debug_printf("jvmti RawMonitorNotify \n");
-    ret = JVMTI_ENV_PTR(jvmti)->RawMonitorNotifyAll(JVMTI_ENV_ARG(jvmti, jraw_monitor[i]));
+    ret = jvmti->RawMonitorNotifyAll(jraw_monitor[i]);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: RawMonitorNotify %d \n", ret);
@@ -273,7 +253,7 @@ Java_nsk_jvmti_unit_MethodBind_JvmtiTest_GetFrameCount(JNIEnv * env, jclass cls,
     jint count;
 
     debug_printf("jvmti GetFrameCount \n");
-    ret = JVMTI_ENV_PTR(jvmti)->GetFrameCount(JVMTI_ENV_ARG(jvmti, (jthread)thr),  &count);
+    ret = jvmti->GetFrameCount((jthread) thr,  &count);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: GetFrameCount returned  %d \n", ret);
         iGlobalStatus = 2;
@@ -288,21 +268,21 @@ print_method_name(jmethodID mid) {
     char *mname;
     char *signature;
     char *clname = (char*) "unknown";
-    ret = JVMTI_ENV_PTR(jvmti)->GetMethodDeclaringClass(JVMTI_ENV_ARG(jvmti, mid), &klass);
+    ret = jvmti->GetMethodDeclaringClass(mid, &klass);
     if (ret != JVMTI_ERROR_NONE) {
       printf("Error: GetMethodDeclaringClass %d  \n", ret);
       iGlobalStatus = 2;
       return;
     }
 
-    ret = JVMTI_ENV_PTR(jvmti)->GetClassSignature(JVMTI_ENV_ARG(jvmti, klass), &clname, NULL);
+    ret = jvmti->GetClassSignature(klass, &clname, NULL);
     if (ret != JVMTI_ERROR_NONE) {
       printf("Error: GetClassSignature %d  \n", ret);
       iGlobalStatus = 2;
       return;
     }
 
-    ret = JVMTI_ENV_PTR(jvmti)->GetMethodName(JVMTI_ENV_ARG(jvmti, mid), &mname, &signature, NULL);
+    ret = jvmti->GetMethodName(mid, &mname, &signature, NULL);
     if (ret != JVMTI_ERROR_NONE) {
       printf("Error: GetMethodName %d  \n", ret);
       iGlobalStatus = 2;
@@ -321,19 +301,20 @@ Java_nsk_jvmti_unit_MethodBind_JvmtiTest_GetStackTrace(JNIEnv * env, jclass cls,
     jint count;
 
 
-    ret = JVMTI_ENV_PTR(jvmti)->Allocate(JVMTI_ENV_ARG(jvmti, sizeof(jvmtiFrameInfo) * max_count), (unsigned char**)&stack_buffer);
+    ret = jvmti->Allocate(sizeof(jvmtiFrameInfo) * max_count,
+                          (unsigned char**) &stack_buffer);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: Allocate failed with  %d \n", ret);
         iGlobalStatus = 2;
     }
 
-    ret = JVMTI_ENV_PTR(jvmti)->GetStackTrace(JVMTI_ENV_ARG(jvmti, thr), 0, max_count , stack_buffer, &count);
+    ret = jvmti->GetStackTrace(thr, 0, max_count, stack_buffer, &count);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: GetStackTrace %d \n", ret);
         iGlobalStatus = 2;
     }
 
-    ret = JVMTI_ENV_PTR(jvmti)->Deallocate(JVMTI_ENV_ARG(jvmti, (unsigned char *)stack_buffer));
+    ret = jvmti->Deallocate((unsigned char *) stack_buffer);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: Deallocate failed with  %d \n", ret);
         iGlobalStatus = 2;
@@ -347,6 +328,4 @@ Java_nsk_jvmti_unit_MethodBind_JvmtiTest_SaveThreadInfo(JNIEnv * env, jclass cls
 
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/OnUnload/JvmtiTest/JvmtiTest.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/OnUnload/JvmtiTest/JvmtiTest.cpp
@@ -26,23 +26,8 @@
 #include "jvmti.h"
 #include "agent_common.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_ARG1(x)
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_ARG1(x) x
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 
 jvmtiEnv *jvmti;
@@ -61,8 +46,7 @@ JNIEXPORT jint JNI_OnLoad_JvmtiTest(JavaVM *jvm, char *options, void *reserved) 
 jint Agent_Initialize(JavaVM * jvm, char *options, void *reserved) {
     jint res;
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res < 0) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -83,6 +67,4 @@ Agent_OnUnload(JavaVM *jvm)
 }
 
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/StackTrace/JvmtiTest/JvmtiTest.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/StackTrace/JvmtiTest/JvmtiTest.cpp
@@ -30,27 +30,7 @@
 #include "jvmti.h"
 #include "agent_common.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_ARG1(x)
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_ARG1(x) x
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
-
-#define JVMTI_ENV_ARG JNI_ENV_ARG
-#define JVMTI_ENV_ARG1 JNI_ENV_ARG1
-#define JVMTI_ENV_PTR JNI_ENV_PTR
 
 #define JVMTI_ERROR_CHECK(str,res) if ( res != JVMTI_ERROR_NONE) { printf(str); printf("%d\n",res); return res;}
 #define JVMTI_ERROR_CHECK_EXPECTED_ERROR(str,res,err) if ( res != err) { printf(str); printf("unexpected error %d\n",res); return res;}
@@ -107,8 +87,7 @@ jint Agent_Initialize(JavaVM * jvm, char *options, void *reserved) {
         }
     }
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res < 0) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -116,10 +95,10 @@ jint Agent_Initialize(JavaVM * jvm, char *options, void *reserved) {
 
 
     /* Add capabilities */
-    res = JVMTI_ENV_PTR(jvmti)->GetPotentialCapabilities(JVMTI_ENV_ARG(jvmti, &jvmti_caps));
+    res = jvmti->GetPotentialCapabilities(&jvmti_caps);
     JVMTI_ERROR_CHECK("GetPotentialCapabilities returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->AddCapabilities(JVMTI_ENV_ARG(jvmti, &jvmti_caps));
+    res = jvmti->AddCapabilities(&jvmti_caps);
     JVMTI_ERROR_CHECK("GetPotentialCapabilities returned error", res);
 
     return JNI_OK;
@@ -139,7 +118,7 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_CreateRawMonitor(JNIEnv * env, jclass k
 
     sprintf(sz, "Rawmonitor-%d",i);
     debug_printf("jvmti create raw monitor \n");
-    ret = JVMTI_ENV_PTR(jvmti)->CreateRawMonitor(JVMTI_ENV_ARG(jvmti, sz), &jraw_monitor[i]);
+    ret = jvmti->CreateRawMonitor(sz, &jraw_monitor[i]);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: ForceGarbageCollection %d \n", ret);
@@ -152,7 +131,7 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_RawMonitorEnter(JNIEnv * env, jclass cl
     jvmtiError ret;
 
     debug_printf("jvmti Raw monitor enter \n");
-    ret = JVMTI_ENV_PTR(jvmti)->RawMonitorEnter(JVMTI_ENV_ARG(jvmti, jraw_monitor[i]));
+    ret = jvmti->RawMonitorEnter(jraw_monitor[i]);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: Raw monitor enter %d \n", ret);
@@ -165,7 +144,7 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_RawMonitorExit(JNIEnv * env, jclass cls
     jvmtiError ret;
 
     debug_printf("jvmti raw monitor exit \n");
-    ret = JVMTI_ENV_PTR(jvmti)->RawMonitorExit(JVMTI_ENV_ARG(jvmti, jraw_monitor[i]));
+    ret = jvmti->RawMonitorExit(jraw_monitor[i]);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: RawMonitorExit %d \n", ret);
@@ -178,7 +157,7 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_RawMonitorWait(JNIEnv * env, jclass cls
     jvmtiError ret;
 
     debug_printf("jvmti RawMonitorWait \n");
-    ret = JVMTI_ENV_PTR(jvmti)->RawMonitorWait(JVMTI_ENV_ARG(jvmti, jraw_monitor[i]), -1);
+    ret = jvmti->RawMonitorWait(jraw_monitor[i], -1);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: RawMonitorWait %d \n", ret);
@@ -191,7 +170,7 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_RawMonitorNotify(JNIEnv * env, jclass c
     jvmtiError ret;
 
     debug_printf("jvmti RawMonitorNotify \n");
-    ret = JVMTI_ENV_PTR(jvmti)->RawMonitorNotifyAll(JVMTI_ENV_ARG(jvmti, jraw_monitor[i]));
+    ret = jvmti->RawMonitorNotifyAll(jraw_monitor[i]);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: RawMonitorNotify %d \n", ret);
@@ -205,7 +184,7 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_GetFrameCount(JNIEnv * env, jclass cls,
     jint count;
 
     debug_printf("jvmti GetFrameCount \n");
-    ret = JVMTI_ENV_PTR(jvmti)->GetFrameCount(JVMTI_ENV_ARG(jvmti, (jthread)thr),  &count);
+    ret = jvmti->GetFrameCount((jthread) thr,  &count);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: GetFrameCount returned  %d \n", ret);
         iGlobalStatus = 2;
@@ -230,26 +209,26 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_GetStackTrace(JNIEnv * env, jclass cls,
 
     debug_printf("jvmti GetStackTrace \n");
 
-    ret = JVMTI_ENV_PTR(jvmti)->Allocate(JVMTI_ENV_ARG(jvmti, sizeof(jvmtiFrameInfo) * max_count), (unsigned char**)&stack_buffer);
+    ret = jvmti->Allocate(sizeof(jvmtiFrameInfo) * max_count, (unsigned char**)&stack_buffer);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: Allocate failed with  %d \n", ret);
         iGlobalStatus = 2;
     }
 
-    ret = JVMTI_ENV_PTR(jvmti)->Allocate(JVMTI_ENV_ARG(jvmti, sizeof(jvmtiFrameInfo) * max_count), (unsigned char**)&compare_buffer);
+    ret = jvmti->Allocate(sizeof(jvmtiFrameInfo) * max_count, (unsigned char**)&compare_buffer);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: Allocate failed with  %d \n", ret);
         iGlobalStatus = 2;
     }
 
 
-    ret = JVMTI_ENV_PTR(jvmti)->SuspendThread(JVMTI_ENV_ARG(jvmti, thr));
+    ret = jvmti->SuspendThread(thr);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: SuspendThread failed with  %d \n", ret);
         iGlobalStatus = 2;
     }
 
-    ret = JVMTI_ENV_PTR(jvmti)->GetStackTrace(JVMTI_ENV_ARG(jvmti, thr), 0, max_count , stack_buffer, &count);
+    ret = jvmti->GetStackTrace(thr, 0, max_count, stack_buffer, &count);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: GetStackTrace %d \n", ret);
         iGlobalStatus = 2;
@@ -257,7 +236,7 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_GetStackTrace(JNIEnv * env, jclass cls,
 
     for (i = 1; i < count; ++i) {
       jint res_count = 48343;
-      ret = JVMTI_ENV_PTR(jvmti)->GetStackTrace(JVMTI_ENV_ARG(jvmti, thr), i, max_count , compare_buffer, &res_count);
+      ret = jvmti->GetStackTrace(thr, i, max_count, compare_buffer, &res_count);
       if (ret != JVMTI_ERROR_NONE) {
         printf("Error: GetStackTrace2 %d \n", ret);
         iGlobalStatus = 2;
@@ -276,7 +255,7 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_GetStackTrace(JNIEnv * env, jclass cls,
 
     for (i = 1; i < count; ++i) {
       jint res_count = 48343;
-      ret = JVMTI_ENV_PTR(jvmti)->GetStackTrace(JVMTI_ENV_ARG(jvmti, thr), -i, max_count , compare_buffer, &res_count);
+      ret = jvmti->GetStackTrace(thr, -i, max_count, compare_buffer, &res_count);
       if (ret != JVMTI_ERROR_NONE) {
         printf("Error: GetStackTrace2 %d \n", ret);
         iGlobalStatus = 2;
@@ -296,7 +275,7 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_GetStackTrace(JNIEnv * env, jclass cls,
     debug_printf("Count = %d\n", count);
 
 
-    ret = JVMTI_ENV_PTR(jvmti)->ResumeThread(JVMTI_ENV_ARG(jvmti, thr));
+    ret = jvmti->ResumeThread(thr);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: ResumeThread failed with  %d \n", ret);
         iGlobalStatus = 2;
@@ -305,21 +284,21 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_GetStackTrace(JNIEnv * env, jclass cls,
     debug_printf(" Java Stack trace ---\n");
 
     for (i = 0; i < count; i++) {
-        ret = JVMTI_ENV_PTR(jvmti)->GetMethodDeclaringClass(JVMTI_ENV_ARG(jvmti, stack_buffer[i].method), &klass);
+        ret = jvmti->GetMethodDeclaringClass(stack_buffer[i].method, &klass);
         if (ret != JVMTI_ERROR_NONE) {
             printf("Error: GetMethodDeclaringClass %d  \n", ret);
             iGlobalStatus = 2;
             return;
         }
 
-        ret = JVMTI_ENV_PTR(jvmti)->GetClassSignature(JVMTI_ENV_ARG(jvmti, klass), &clname, NULL);
+        ret = jvmti->GetClassSignature(klass, &clname, NULL);
         if (ret != JVMTI_ERROR_NONE) {
             printf("Error: GetClassSignature %d  \n", ret);
             iGlobalStatus = 2;
             return;
         }
 
-        ret = JVMTI_ENV_PTR(jvmti)->GetMethodName(JVMTI_ENV_ARG(jvmti, stack_buffer[i].method), &mname, &signature, NULL);
+        ret = jvmti->GetMethodName(stack_buffer[i].method, &mname, &signature, NULL);
         if (ret != JVMTI_ERROR_NONE) {
             printf("Error: GetMethodName %d  \n", ret);
             iGlobalStatus = 2;
@@ -332,7 +311,7 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_GetStackTrace(JNIEnv * env, jclass cls,
     }
 
 
-    ret = JVMTI_ENV_PTR(jvmti)->Deallocate(JVMTI_ENV_ARG(jvmti, (unsigned char *)stack_buffer));
+    ret = jvmti->Deallocate((unsigned char *) stack_buffer);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: Deallocate failed with  %d \n", ret);
         iGlobalStatus = 2;
@@ -346,6 +325,4 @@ Java_nsk_jvmti_unit_StackTrace_JvmtiTest_SaveThreadInfo(JNIEnv * env, jclass cls
 
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/agentthr/agentthr.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/agentthr/agentthr.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -60,9 +47,9 @@ jthread jthr(JNIEnv *env) {
     jmethodID cid;
     jthread res;
 
-    thrClass = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env, "java/lang/Thread"));
-    cid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, thrClass), "<init>", "()V");
-    res = JNI_ENV_PTR(env)->NewObject(JNI_ENV_ARG(env, thrClass), cid);
+    thrClass = env->FindClass("java/lang/Thread");
+    cid = env->GetMethodID(thrClass, "<init>", "()V");
+    res = env->NewObject(thrClass, cid);
     return res;
 }
 
@@ -74,8 +61,7 @@ void JNICALL agent_start(jvmtiEnv* jvmti_env, JNIEnv* jni_env, void *p) {
         result = STATUS_FAILED;
     }
 
-    JNI_ENV_PTR(jvm_ins)->GetEnv(JNI_ENV_ARG(jvm_ins, (void **) &env),
-        JNI_VERSION_1_2);
+    jvm_ins->GetEnv((void **) &env, JNI_VERSION_1_2);
     if (jni_env != env) {
         printf("(agent_start) JNI envs don't match\n");
         result = STATUS_FAILED;
@@ -140,8 +126,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     }
 
     jvm_ins = jvm;
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -179,6 +164,4 @@ Java_nsk_jvmti_unit_agentthr_getRes(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/clsldrclss00x/clsldrclss00x.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/clsldrclss00x/clsldrclss00x.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -188,6 +174,4 @@ Java_nsk_jvmti_unit_clsldrclss00x_check(JNIEnv *env, jclass appCls, jclass objCl
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/events/redefineCFLH/JvmtiTest/JvmtiTest.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/events/redefineCFLH/JvmtiTest/JvmtiTest.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define STATUS_FAILED 2
 #define PASSED 0
@@ -123,8 +110,7 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    if ((res = JNI_ENV_PTR(vm)->GetEnv(JNI_ENV_ARG(vm, (void **) &jvmti),
-            JVMTI_VERSION_1_1)) != JNI_OK) {
+    if ((res = vm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1)) != JNI_OK) {
         printf("%s: Failed to call GetEnv: error=%d\n", __FILE__, res);
         return JNI_ERR;
     }
@@ -197,11 +183,8 @@ Java_nsk_jvmti_unit_events_redefineCFLH_JvmtiTest_makeRedefinition(JNIEnv *env,
 
 /* filling the structure jvmtiClassDefinition */
     classDef.klass = redefCls;
-    classDef.class_byte_count =
-        JNI_ENV_PTR(env)->GetArrayLength(JNI_ENV_ARG(env, classBytes));
-    classDef.class_bytes = (unsigned char *)
-        JNI_ENV_PTR(env)->GetByteArrayElements(JNI_ENV_ARG(env, classBytes),
-            NULL);
+    classDef.class_byte_count = env->GetArrayLength(classBytes);
+    classDef.class_bytes = (unsigned char *) env->GetByteArrayElements(classBytes, NULL);
 
     if (fl == 2) {
         printf(">>>>>>>> Invoke RedefineClasses():\n");
@@ -226,6 +209,4 @@ Java_nsk_jvmti_unit_events_redefineCFLH_JvmtiTest_GetResult(JNIEnv *env, jclass 
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/ForceGarbageCollection/gc/gc.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/ForceGarbageCollection/gc/gc.cpp
@@ -26,27 +26,8 @@
 #include "jvmti.h"
 #include "agent_common.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_ARG1(x)
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_ARG1(x) x
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
-
-#define JVMTI_ENV_ARG JNI_ENV_ARG
-#define JVMTI_ENV_ARG1 JNI_ENV_ARG1
-#define JVMTI_ENV_PTR JNI_ENV_PTR
 
 #define JVMTI_ERROR_CHECK(str,res) if ( res != JVMTI_ERROR_NONE) { printf(str); printf("%d\n",res); return res;}
 #define JVMTI_ERROR_CHECK_VOID(str,res) if ( res != JVMTI_ERROR_NONE) { printf(str); printf("%d\n",res); iGlobalStatus = 2; }
@@ -130,40 +111,39 @@ jint Agent_Initialize(JavaVM * jvm, char *options, void *reserved) {
         }
     }
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res < 0) {
         debug_printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
     }
 
     /* Create data access lock */
-    res = JVMTI_ENV_PTR(jvmti)->CreateRawMonitor(JVMTI_ENV_ARG(jvmti,"_access_lock"),&access_lock);
+    res = jvmti->CreateRawMonitor("_access_lock", &access_lock);
     JVMTI_ERROR_CHECK("RawMonitorEnter in monitor_contended_entered failed with error code ", res);
 
 
     /* Add capabilities */
-    res = JVMTI_ENV_PTR(jvmti)->GetPotentialCapabilities(JVMTI_ENV_ARG(jvmti, &jvmti_caps));
+    res = jvmti->GetPotentialCapabilities(&jvmti_caps);
     JVMTI_ERROR_CHECK("SetEventCallbacks returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->AddCapabilities(JVMTI_ENV_ARG(jvmti, &jvmti_caps));
+    res = jvmti->AddCapabilities(&jvmti_caps);
     JVMTI_ERROR_CHECK("SetEventCallbacks returned error", res);
 
     /* Enable events */
     init_callbacks();
-    res = JVMTI_ENV_PTR(jvmti)->SetEventCallbacks(JVMTI_ENV_ARG(jvmti, &callbacks), sizeof(callbacks));
+    res = jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks));
     JVMTI_ERROR_CHECK("SetEventCallbacks returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->SetEventNotificationMode(JVMTI_ENV_ARG(jvmti,JVMTI_ENABLE),JVMTI_EVENT_VM_INIT,NULL);
+    res = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL);
     JVMTI_ERROR_CHECK("SetEventNotificationMode for VM_INIT returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->SetEventNotificationMode(JVMTI_ENV_ARG(jvmti,JVMTI_ENABLE),JVMTI_EVENT_VM_DEATH,NULL);
+    res = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL);
     JVMTI_ERROR_CHECK("SetEventNotificationMode for vm death event returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->SetEventNotificationMode(JVMTI_ENV_ARG(jvmti,JVMTI_ENABLE),JVMTI_EVENT_GARBAGE_COLLECTION_START,NULL);
+    res = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL);
     JVMTI_ERROR_CHECK("SetEventNotificationMode for gc start returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->SetEventNotificationMode(JVMTI_ENV_ARG(jvmti,JVMTI_ENABLE),JVMTI_EVENT_GARBAGE_COLLECTION_FINISH,NULL);
+    res = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH, NULL);
     JVMTI_ERROR_CHECK("SetEventNotificationMode for gc finish returned error", res);
 
     return JNI_OK;
@@ -199,7 +179,7 @@ Java_nsk_jvmti_unit_functions_ForceGarbageCollection_gc_jvmtiForceGC (JNIEnv * e
     jvmtiError ret;
 
     debug_printf("jvmti Force gc requested \n");
-    ret = JVMTI_ENV_PTR(jvmti)->ForceGarbageCollection(JVMTI_ENV_ARG1(jvmti));
+    ret = jvmti->ForceGarbageCollection();
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: ForceGarbageCollection %d \n", ret);
@@ -207,6 +187,4 @@ Java_nsk_jvmti_unit_functions_ForceGarbageCollection_gc_jvmtiForceGC (JNIEnv * e
     }
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/environment/JvmtiTest/JvmtiTest.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/environment/JvmtiTest/JvmtiTest.cpp
@@ -26,27 +26,8 @@
 #include "jvmti.h"
 #include "agent_common.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_ARG1(x)
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_ARG1(x) x
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
-
-#define JVMTI_ENV_ARG JNI_ENV_ARG
-#define JVMTI_ENV_ARG1 JNI_ENV_ARG1
-#define JVMTI_ENV_PTR JNI_ENV_PTR
 
 #define JVMTI_ERROR_CHECK(str,res) if ( res != JVMTI_ERROR_NONE) { printf(str); printf("%d\n",res); return res;}
 #define JVMTI_ERROR_CHECK_EXPECTED_ERROR(str,res,err) if ( res != err) { printf(str); printf("unexpected error %d\n",res); return res;}
@@ -99,8 +80,7 @@ jint Agent_Initialize(JavaVM * jvm, char *options, void *reserved) {
         }
     }
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res < 0) {
         debug_printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -108,26 +88,26 @@ jint Agent_Initialize(JavaVM * jvm, char *options, void *reserved) {
 
 
     /* Add capabilities */
-    res = JVMTI_ENV_PTR(jvmti)->GetPotentialCapabilities(JVMTI_ENV_ARG(jvmti, &jvmti_caps));
+    res = jvmti->GetPotentialCapabilities(&jvmti_caps);
     JVMTI_ERROR_CHECK("GetPotentialCapabilities returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->AddCapabilities(JVMTI_ENV_ARG(jvmti, &jvmti_caps));
+    res = jvmti->AddCapabilities(&jvmti_caps);
     JVMTI_ERROR_CHECK("GetAddCapabilities returned error", res);
 
 
-    res = JVMTI_ENV_PTR(jvmti)->GetSystemProperties(JVMTI_ENV_ARG(jvmti, &count), &properties);
+    res = jvmti->GetSystemProperties(&count, &properties);
 
     JVMTI_ERROR_CHECK("GetSystemProperties returned error", res);
 
     for (i=0; i< count; i++) {
         char *value;
 
-        res = JVMTI_ENV_PTR(jvmti)->GetSystemProperty(JVMTI_ENV_ARG(jvmti, (const char *)properties[i]), &value);
+        res = jvmti->GetSystemProperty((const char *) properties[i], &value);
         JVMTI_ERROR_CHECK("GetSystemProperty returned error", res);
         debug_printf(" %s    %s \n", properties[i], value);
 
         /* Only writeable properties returns JVMTI_ERROR_NONE. */
-        res = JVMTI_ENV_PTR(jvmti)->SetSystemProperty(JVMTI_ENV_ARG(jvmti, (const char *)properties[i]), value);
+        res = jvmti->SetSystemProperty((const char *) properties[i], value);
         debug_printf("SetSystemProperty returned error %d\n", res);
 
      }
@@ -142,6 +122,4 @@ Java_nsk_jvmti_unit_functions_environment_JvmtiTest_GetResult(JNIEnv * env, jcla
 }
 
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/nosuspendMonitorInfo/JvmtiTest/JvmtiTest.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/nosuspendMonitorInfo/JvmtiTest/JvmtiTest.cpp
@@ -26,27 +26,8 @@
 #include "jvmti.h"
 #include "agent_common.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_ARG1(x)
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_ARG1(x) x
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
-
-#define JVMTI_ENV_ARG JNI_ENV_ARG
-#define JVMTI_ENV_ARG1 JNI_ENV_ARG1
-#define JVMTI_ENV_PTR JNI_ENV_PTR
 
 #define JVMTI_ERROR_CHECK(str,res) if ( res != JVMTI_ERROR_NONE) { printf(str); printf("%d\n",res); return res;}
 #define JVMTI_ERROR_CHECK_EXPECTED_ERROR(str,res,err) if ( res != err) { printf(str); printf("unexpected error %d\n",res); return res;}
@@ -134,8 +115,7 @@ jint Agent_Initialize(JavaVM * jvm, char *options, void *reserved) {
         }
     }
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res < 0) {
         debug_printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -143,21 +123,21 @@ jint Agent_Initialize(JavaVM * jvm, char *options, void *reserved) {
 
 
     /* Add capabilities */
-    res = JVMTI_ENV_PTR(jvmti)->GetPotentialCapabilities(JVMTI_ENV_ARG(jvmti, &jvmti_caps));
+    res = jvmti->GetPotentialCapabilities(&jvmti_caps);
     JVMTI_ERROR_CHECK("GetPotentialCapabilities returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->AddCapabilities(JVMTI_ENV_ARG(jvmti, &jvmti_caps));
+    res = jvmti->AddCapabilities(&jvmti_caps);
     JVMTI_ERROR_CHECK("GetPotentialCapabilities returned error", res);
 
     /* Enable events */
     init_callbacks();
-    res = JVMTI_ENV_PTR(jvmti)->SetEventCallbacks(JVMTI_ENV_ARG(jvmti, &callbacks), sizeof(callbacks));
+    res = jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks));
     JVMTI_ERROR_CHECK("SetEventCallbacks returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->SetEventNotificationMode(JVMTI_ENV_ARG(jvmti,JVMTI_ENABLE),JVMTI_EVENT_VM_INIT,NULL);
+    res = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL);
     JVMTI_ERROR_CHECK("SetEventNotificationMode for VM_INIT returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->SetEventNotificationMode(JVMTI_ENV_ARG(jvmti,JVMTI_ENABLE),JVMTI_EVENT_VM_DEATH,NULL);
+    res = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL);
     JVMTI_ERROR_CHECK("SetEventNotificationMode for vm death event returned error", res);
 
     return JNI_OK;
@@ -179,7 +159,7 @@ Java_nsk_jvmti_unit_functions_nosuspendMonitorInfo_JvmtiTest_CheckMonitorInfo(JN
   debug_printf(" jvmti GetMonitorInfo \n");
 
 
-    ret = JVMTI_ENV_PTR(jvmti)->GetOwnedMonitorInfo(JVMTI_ENV_ARG(jvmti, thr), &count , &owned_monitor);
+    ret = jvmti->GetOwnedMonitorInfo(thr, &count, &owned_monitor);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: GetMonitorInfo %d \n", ret);
         iGlobalStatus = 2;
@@ -190,9 +170,9 @@ Java_nsk_jvmti_unit_functions_nosuspendMonitorInfo_JvmtiTest_CheckMonitorInfo(JN
         iGlobalStatus = 2;
     }
 
-    if (expected_count !=0 ) {
+    if (expected_count !=0) {
 
-        ret = JVMTI_ENV_PTR(jvmti)->GetCurrentContendedMonitor(JVMTI_ENV_ARG(jvmti, thr), owned_monitor);
+        ret = jvmti->GetCurrentContendedMonitor(thr, owned_monitor);
         if (ret != JVMTI_ERROR_NONE) {
             printf("Error: GetContendedMonitorInfo %d \n", ret);
             iGlobalStatus = 2;
@@ -201,6 +181,4 @@ Java_nsk_jvmti_unit_functions_nosuspendMonitorInfo_JvmtiTest_CheckMonitorInfo(JN
 
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/nosuspendStackTrace/JvmtiTest/JvmtiTest.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/nosuspendStackTrace/JvmtiTest/JvmtiTest.cpp
@@ -26,27 +26,7 @@
 #include "jvmti.h"
 #include "agent_common.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_ARG1(x)
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_ARG1(x) x
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
-
-#define JVMTI_ENV_ARG JNI_ENV_ARG
-#define JVMTI_ENV_ARG1 JNI_ENV_ARG1
-#define JVMTI_ENV_PTR JNI_ENV_PTR
 
 #define JVMTI_ERROR_CHECK(str,res) if ( res != JVMTI_ERROR_NONE) { printf(str); printf("%d\n",res); return res;}
 #define JVMTI_ERROR_CHECK_EXPECTED_ERROR(str,res,err) if ( res != err) { printf(str); printf("unexpected error %d\n",res); return res;}
@@ -134,8 +114,7 @@ jint Agent_Initialize(JavaVM * jvm, char *options, void *reserved) {
         }
     }
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res < 0) {
         debug_printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -143,21 +122,21 @@ jint Agent_Initialize(JavaVM * jvm, char *options, void *reserved) {
 
 
     /* Add capabilities */
-    res = JVMTI_ENV_PTR(jvmti)->GetPotentialCapabilities(JVMTI_ENV_ARG(jvmti, &jvmti_caps));
+    res = jvmti->GetPotentialCapabilities(&jvmti_caps);
     JVMTI_ERROR_CHECK("GetPotentialCapabilities returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->AddCapabilities(JVMTI_ENV_ARG(jvmti, &jvmti_caps));
+    res = jvmti->AddCapabilities(&jvmti_caps);
     JVMTI_ERROR_CHECK("GetPotentialCapabilities returned error", res);
 
     /* Enable events */
     init_callbacks();
-    res = JVMTI_ENV_PTR(jvmti)->SetEventCallbacks(JVMTI_ENV_ARG(jvmti, &callbacks), sizeof(callbacks));
+    res = jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks));
     JVMTI_ERROR_CHECK("SetEventCallbacks returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->SetEventNotificationMode(JVMTI_ENV_ARG(jvmti,JVMTI_ENABLE),JVMTI_EVENT_VM_INIT,NULL);
+    res = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL);
     JVMTI_ERROR_CHECK("SetEventNotificationMode for VM_INIT returned error", res);
 
-    res = JVMTI_ENV_PTR(jvmti)->SetEventNotificationMode(JVMTI_ENV_ARG(jvmti,JVMTI_ENABLE),JVMTI_EVENT_VM_DEATH,NULL);
+    res = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL);
     JVMTI_ERROR_CHECK("SetEventNotificationMode for vm death event returned error", res);
 
     return JNI_OK;
@@ -177,7 +156,7 @@ Java_nsk_jvmti_unit_functions_nosuspendStackTrace_JvmtiTest_CreateRawMonitor(JNI
 
     sprintf(sz, "Rawmonitor-%d",i);
     debug_printf("jvmti create raw monitor \n");
-    ret = JVMTI_ENV_PTR(jvmti)->CreateRawMonitor(JVMTI_ENV_ARG(jvmti, sz), &jraw_monitor[i]);
+    ret = jvmti->CreateRawMonitor(sz, &jraw_monitor[i]);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: ForceGarbageCollection %d \n", ret);
@@ -190,7 +169,7 @@ Java_nsk_jvmti_unit_functions_nosuspendStackTrace_JvmtiTest_RawMonitorEnter(JNIE
     jvmtiError ret;
 
     debug_printf("jvmti Raw monitor enter \n");
-    ret = JVMTI_ENV_PTR(jvmti)->RawMonitorEnter(JVMTI_ENV_ARG(jvmti, jraw_monitor[i]));
+    ret = jvmti->RawMonitorEnter(jraw_monitor[i]);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: Raw monitor enter %d \n", ret);
@@ -203,7 +182,7 @@ Java_nsk_jvmti_unit_functions_nosuspendStackTrace_JvmtiTest_RawMonitorExit(JNIEn
     jvmtiError ret;
 
     debug_printf("jvmti raw monitor exit \n");
-    ret = JVMTI_ENV_PTR(jvmti)->RawMonitorExit(JVMTI_ENV_ARG(jvmti, jraw_monitor[i]));
+    ret = jvmti->RawMonitorExit(jraw_monitor[i]);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: RawMonitorExit %d \n", ret);
@@ -216,7 +195,7 @@ Java_nsk_jvmti_unit_functions_nosuspendStackTrace_JvmtiTest_RawMonitorWait(JNIEn
     jvmtiError ret;
 
     debug_printf("jvmti RawMonitorWait \n");
-    ret = JVMTI_ENV_PTR(jvmti)->RawMonitorWait(JVMTI_ENV_ARG(jvmti,jraw_monitor[i]),-1);
+    ret = jvmti->RawMonitorWait(jraw_monitor[i], -1);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: RawMonitorWait %d \n", ret);
@@ -229,7 +208,7 @@ Java_nsk_jvmti_unit_functions_nosuspendStackTrace_JvmtiTest_RawMonitorNotify(JNI
     jvmtiError ret;
 
     debug_printf("jvmti RawMonitorNotify \n");
-    ret = JVMTI_ENV_PTR(jvmti)->RawMonitorNotifyAll(JVMTI_ENV_ARG(jvmti,jraw_monitor[i]));
+    ret = jvmti->RawMonitorNotifyAll(jraw_monitor[i]);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: RawMonitorNotify %d \n", ret);
@@ -243,7 +222,7 @@ Java_nsk_jvmti_unit_functions_nosuspendStackTrace_JvmtiTest_GetFrameCount(JNIEnv
     jint count;
 
     debug_printf("jvmti GetFrameCount \n");
-    ret = JVMTI_ENV_PTR(jvmti)->GetFrameCount(JVMTI_ENV_ARG(jvmti, (jthread)thr),  &count);
+    ret = jvmti->GetFrameCount((jthread) thr,  &count);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: GetFrameCount returned  %d \n", ret);
         iGlobalStatus = 2;
@@ -266,14 +245,14 @@ Java_nsk_jvmti_unit_functions_nosuspendStackTrace_JvmtiTest_GetStackTrace(JNIEnv
 
     debug_printf("jvmti GetStackTrace \n");
 
-    ret = JVMTI_ENV_PTR(jvmti)->Allocate(JVMTI_ENV_ARG(jvmti, sizeof(jvmtiFrameInfo) * count), (unsigned char**)&stack_buffer);
+    ret = jvmti->Allocate(sizeof(jvmtiFrameInfo) * count, (unsigned char**)&stack_buffer);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: Allocate failed with  %d \n", ret);
         iGlobalStatus = 2;
     }
 
 
-    ret = JVMTI_ENV_PTR(jvmti)->GetStackTrace(JVMTI_ENV_ARG(jvmti, thr), 0, count , stack_buffer, &count);
+    ret = jvmti->GetStackTrace(thr, 0, count, stack_buffer, &count);
 
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: GetStackTrace %d \n", ret);
@@ -283,21 +262,21 @@ Java_nsk_jvmti_unit_functions_nosuspendStackTrace_JvmtiTest_GetStackTrace(JNIEnv
     debug_printf(" Java Stack trace ---\n");
 
     for (i = 0; i < count; i++) {
-        ret = JVMTI_ENV_PTR(jvmti)->GetMethodDeclaringClass(JVMTI_ENV_ARG(jvmti, stack_buffer[i].method), &klass);
+        ret = jvmti->GetMethodDeclaringClass(stack_buffer[i].method, &klass);
         if (ret != JVMTI_ERROR_NONE) {
             printf("Error: GetMethodDeclaringClass %d  \n", ret);
             iGlobalStatus = 2;
             return;
         }
 
-        ret = JVMTI_ENV_PTR(jvmti)->GetClassSignature(JVMTI_ENV_ARG(jvmti, klass), &clname, &generic);
+        ret = jvmti->GetClassSignature(klass, &clname, &generic);
         if (ret != JVMTI_ERROR_NONE) {
             printf("Error: GetMethodDeclaringClass %d  \n", ret);
             iGlobalStatus = 2;
             return;
         }
 
-        ret = JVMTI_ENV_PTR(jvmti)->GetMethodName(JVMTI_ENV_ARG(jvmti, stack_buffer[i].method), &mname, &signature, &generic);
+        ret = jvmti->GetMethodName(stack_buffer[i].method, &mname, &signature, &generic);
         if (ret != JVMTI_ERROR_NONE) {
             printf("Error: GetMethodDeclaringClass %d  \n", ret);
             iGlobalStatus = 2;
@@ -310,7 +289,7 @@ Java_nsk_jvmti_unit_functions_nosuspendStackTrace_JvmtiTest_GetStackTrace(JNIEnv
     }
 
 
-    ret = JVMTI_ENV_PTR(jvmti)->Deallocate(JVMTI_ENV_ARG(jvmti, (unsigned char *)stack_buffer));
+    ret = jvmti->Deallocate((unsigned char *) stack_buffer);
     if (ret != JVMTI_ERROR_NONE) {
         printf("Error: Deallocate failed with  %d \n", ret);
         iGlobalStatus = 2;
@@ -324,6 +303,4 @@ Java_nsk_jvmti_unit_functions_nosuspendStackTrace_JvmtiTest_SaveThreadInfo(JNIEn
 
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/heapref/heapref.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/heapref/heapref.cpp
@@ -29,21 +29,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -275,8 +262,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     printdump = JNI_TRUE;
   }
 
-  res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-                                 JVMTI_VERSION_1_1);
+  res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti == NULL) {
     printf("Wrong result of a valid call to GetEnv!\n");
     return JNI_ERR;
@@ -487,6 +473,4 @@ Java_nsk_jvmti_unit_heapref_check(JNIEnv *env, jclass cls) {
   return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/refignore/refignore.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/refignore/refignore.cpp
@@ -29,21 +29,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -273,8 +260,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     printdump = JNI_TRUE;
   }
 
-  res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-                                 JVMTI_VERSION_1_1);
+  res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti == NULL) {
     printf("Wrong result of a valid call to GetEnv!\n");
     return JNI_ERR;
@@ -485,6 +471,4 @@ Java_nsk_jvmti_unit_refignore_check(JNIEnv *env, jclass cls) {
   return result;
 }
 
-#ifdef __cplusplus
 }
-#endif


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210700](https://bugs.openjdk.java.net/browse/JDK-8210700): Clean up JNI_ENV_ARG and factorize the macros for vmTestbase/jvmti/unit tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/648/head:pull/648` \
`$ git checkout pull/648`

Update a local copy of the PR: \
`$ git checkout pull/648` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 648`

View PR using the GUI difftool: \
`$ git pr show -t 648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/648.diff">https://git.openjdk.java.net/jdk11u-dev/pull/648.diff</a>

</details>
