### PR TITLE
8210242: [TESTBUG] vmTestbase/nsk/stress/jni/jnistress001.java crashes with EXCEPTION_ACCESS_VIOLATION on windows-x86

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnihelper.h
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnihelper.h
@@ -21,6 +21,16 @@
  * questions.
  */
 
+#include <stdlib.h>
+
+// checked malloc to trap OOM conditions
+static void* c_malloc(JNIEnv* env, size_t size) {
+  void* ret = malloc(size);
+  if (ret == NULL)
+    env->FatalError("malloc failed");
+  return ret;
+}
+
 // Asserts every exception as fatal one
 #define CE {\
     if (env->ExceptionOccurred())\

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress001.cpp
@@ -68,11 +68,11 @@ Java_nsk_stress_jni_JNIter001_jnistress (JNIEnv *env, jobject jobj, jstring jstr
 
     env->MonitorEnter(jobj); CE
     if (!allocs) {
-        element = (CHAR_ARRAY *)malloc(sizeof(CHAR_ARRAY));
-        element->str = (const char **)malloc(nstr*sizeof(const char *));
-        element->checkstr = (char **)malloc(nstr*sizeof(char *));
+        element = (CHAR_ARRAY *)c_malloc(env, sizeof(CHAR_ARRAY));
+        element->str = (const char **)c_malloc(env, nstr*sizeof(const char *));
+        element->checkstr = (char **)c_malloc(env, nstr*sizeof(char *));
         for (j=0;j<nstr;j++)
-            element->checkstr[j] = (char *)malloc(DIGESTLENGTH*sizeof(char));
+            element->checkstr[j] = (char *)c_malloc(env, DIGESTLENGTH*sizeof(char));
     }
     for(j=0;j<DIGESTLENGTH;j++) {
         digest[j]=0;
@@ -150,6 +150,7 @@ Java_nsk_stress_jni_JNIter001_jnistress1(JNIEnv *env, jobject jobj, jstring jstr
     static long len=0;
     static unsigned int equal=1;
     char *elem;
+    int elem_len = -1;
 
     const char *clsName = "nsk/stress/jni/JNIter001";
     const char *name="setpass";
@@ -162,30 +163,32 @@ Java_nsk_stress_jni_JNIter001_jnistress1(JNIEnv *env, jobject jobj, jstring jstr
 
     env->MonitorEnter(jobj); CE
     if (!index) {
-        javachars = (JCHAR_ARRAY *)malloc(sizeof(JCHAR_ARRAY));
-        javachars->str = (const jchar **)malloc(nstr*sizeof(const jchar *));
-        javachars->checkstr = (char **)malloc(nstr*sizeof(char *));
-        javachars->size = (int *)malloc(nstr*sizeof(int));
+        javachars = (JCHAR_ARRAY *)c_malloc(env, sizeof(JCHAR_ARRAY));
+        javachars->str = (const jchar **)c_malloc(env, nstr*sizeof(const jchar *));
+        javachars->checkstr = (char **)c_malloc(env, nstr*sizeof(char *));
+        javachars->size = (int *)c_malloc(env, nstr*sizeof(int));
         for (j=0;j<nstr;j++)
-            javachars->checkstr[j] = (char *)malloc(DIGESTLENGTH*sizeof(char));
+            javachars->checkstr[j] = (char *)c_malloc(env, DIGESTLENGTH*sizeof(char));
     }
     for(j=0;j<DIGESTLENGTH;j++) {
         digest[j]=0;
     }
     javachars->str[index] = env->GetStringChars(jstr,0); CE
     javachars->size[index] = env->GetStringUTFLength(jstr); CE
-    len += javachars->size[index];
-    elem = (char*) malloc(javachars->size[index]*sizeof(char));
-    for (j=0; j < javachars->size[index]; j++) {
+    elem_len = javachars->size[index];
+    len += elem_len;
+    elem = (char*) c_malloc(env, elem_len*sizeof(char));
+    for (j=0; j < elem_len; j++) {
         elem[j] = (char) javachars->str[index][j];
     }
+
     //memcpy(digest, elem, javachars->size[index]);
-    for(j=0;j<javachars->size[index]; j++) {
+    for(j=0;j<elem_len; j++) {
         digest[j % DIGESTLENGTH]+=elem[j];
     }
     memcpy(javachars->checkstr[index++],digest,DIGESTLENGTH);
     if (index%printperiod==0) {
-        printf("Check string sum for thread %s is ",elem);
+        printf("Check string sum for thread %.*s is ", elem_len, elem);
         for (j=0;j<DIGESTLENGTH;j++)
             printf("%02x", digest[j]);
         printf("\n");
@@ -193,9 +196,9 @@ Java_nsk_stress_jni_JNIter001_jnistress1(JNIEnv *env, jobject jobj, jstring jstr
     free(elem);
     if (index==nstr) {
         printf("JNI Unicode strings memory=%ld\n",len);
-        tmpstr=env->NewString(javachars->str[index-1],javachars->size[index-1]); CE
+        tmpstr=env->NewString(javachars->str[index-1],elem_len); CE
         for (j=0; j<nstr; j++) {
-            elem = (char*) malloc(javachars->size[j]*sizeof(char));
+            elem = (char*) c_malloc(env, javachars->size[j]*sizeof(char));
             for (i=0; i < javachars->size[j]; i++) {
                 elem[i] = (char) javachars->str[j][i];
             }
@@ -239,7 +242,7 @@ Java_nsk_stress_jni_JNIter001_jnistress1(JNIEnv *env, jobject jobj, jstring jstr
         return(tmpstr);
     }
     env->MonitorExit(jobj); CE
-    return(env->NewString(javachars->str[index-1],javachars->size[index-1]));
+    return(env->NewString(javachars->str[index-1],elem_len));
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
A clean backport for parity with Oracle 11.0.15. 

The patch fixed potential crash in test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210242](https://bugs.openjdk.java.net/browse/JDK-8210242): [TESTBUG] vmTestbase/nsk/stress/jni/jnistress001.java crashes with EXCEPTION_ACCESS_VIOLATION on windows-x86


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/649/head:pull/649` \
`$ git checkout pull/649`

Update a local copy of the PR: \
`$ git checkout pull/649` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 649`

View PR using the GUI difftool: \
`$ git pr show -t 649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/649.diff">https://git.openjdk.java.net/jdk11u-dev/pull/649.diff</a>

</details>
