### PR TITLE
8277224: sun.security.pkcs.PKCS9Attributes.toString() throws NPE

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attributes.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attributes.java
@@ -277,11 +277,13 @@ public class PKCS9Attributes {
      */
     public PKCS9Attribute[] getAttributes() {
         PKCS9Attribute[] attribs = new PKCS9Attribute[attributes.size()];
-        ObjectIdentifier oid;
 
         int j = 0;
         for (int i=1; i < PKCS9Attribute.PKCS9_OIDS.length &&
                       j < attribs.length; i++) {
+            if (PKCS9Attribute.PKCS9_OIDS[i] == null) {
+                continue;
+            }
             attribs[j] = getAttribute(PKCS9Attribute.PKCS9_OIDS[i]);
 
             if (attribs[j] != null)
@@ -325,11 +327,13 @@ public class PKCS9Attributes {
         StringBuilder sb = new StringBuilder(200);
         sb.append("PKCS9 Attributes: [\n\t");
 
-        ObjectIdentifier oid;
         PKCS9Attribute value;
 
         boolean first = true;
         for (int i = 1; i < PKCS9Attribute.PKCS9_OIDS.length; i++) {
+            if (PKCS9Attribute.PKCS9_OIDS[i] == null) {
+                continue;
+            }
             value = getAttribute(PKCS9Attribute.PKCS9_OIDS[i]);
 
             if (value == null) continue;
@@ -340,7 +344,7 @@ public class PKCS9Attributes {
             else
                 sb.append(";\n\t");
 
-            sb.append(value.toString());
+            sb.append(value);
         }
 
         sb.append("\n\t] (end PKCS9 Attributes)");

--- a/test/jdk/sun/security/x509/AlgorithmId/NonStandardNames.java
+++ b/test/jdk/sun/security/x509/AlgorithmId/NonStandardNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7180907
+ * @bug 7180907 8277224
  * @summary Jarsigner -verify fails if rsa file used sha-256 with authenticated attributes
  * @modules java.base/sun.security.pkcs
  *          java.base/sun.security.tools.keytool
@@ -60,7 +60,12 @@ public class NonStandardNames {
         PKCS9Attributes authed = new PKCS9Attributes(new PKCS9Attribute[]{
             new PKCS9Attribute(PKCS9Attribute.CONTENT_TYPE_OID, ContentInfo.DATA_OID),
             new PKCS9Attribute(PKCS9Attribute.MESSAGE_DIGEST_OID, md.digest(data)),
+            new PKCS9Attribute(PKCS9Attribute.SIGNATURE_TIMESTAMP_TOKEN_OID, "test".getBytes())
         });
+
+        // test PKCS9Attributes.toString(), PKCS9Attributes.getAttributes()
+        System.out.println(authed);
+        authed.getAttributes();
 
         Signature s = Signature.getInstance("SHA256withRSA");
         s.initSign(cakg.getPrivateKey());


### PR DESCRIPTION
Clean backport of JDK-8277224.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277224](https://bugs.openjdk.java.net/browse/JDK-8277224): sun.security.pkcs.PKCS9Attributes.toString() throws NPE


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/651/head:pull/651` \
`$ git checkout pull/651`

Update a local copy of the PR: \
`$ git checkout pull/651` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 651`

View PR using the GUI difftool: \
`$ git pr show -t 651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/651.diff">https://git.openjdk.java.net/jdk11u-dev/pull/651.diff</a>

</details>
