### PR TITLE
8222825: ARM32 SIGILL issue on single core CPU (not supported PLDW instruction)

### DIFF
--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -5317,7 +5317,7 @@ instruct loadConD(regD dst, immD src, iRegP tmp) %{
 // Must be safe to execute with invalid address (cannot fault).
 
 instruct prefetchAlloc_mp( memoryP mem ) %{
-  predicate(os::is_MP());
+  predicate(VM_Version::has_multiprocessing_extensions());
   match( PrefetchAllocation mem );
   ins_cost(MEMORY_REF_COST);
   size(4);
@@ -5334,7 +5334,7 @@ instruct prefetchAlloc_mp( memoryP mem ) %{
 %}
 
 instruct prefetchAlloc_sp( memoryP mem ) %{
-  predicate(!os::is_MP());
+  predicate(!VM_Version::has_multiprocessing_extensions());
   match( PrefetchAllocation mem );
   ins_cost(MEMORY_REF_COST);
   size(4);

--- a/src/hotspot/cpu/arm/assembler_arm_32.hpp
+++ b/src/hotspot/cpu/arm/assembler_arm_32.hpp
@@ -434,7 +434,9 @@ class Assembler : public AbstractAssembler  {
   }
 
   void pldw(Address addr) {
-    assert(VM_Version::arm_arch() >= 7 && os::is_MP(), "no pldw on this processor");
+    assert(!VM_Version::is_initialized() ||
+           (VM_Version::arm_arch() >= 7 && VM_Version::has_multiprocessing_extensions()),
+           "PLDW is available on ARMv7 with Multiprocessing Extensions only");
     emit_int32(0xf510f000 | addr.encoding2());
   }
 

--- a/src/hotspot/cpu/arm/vm_version_arm.hpp
+++ b/src/hotspot/cpu/arm/vm_version_arm.hpp
@@ -54,6 +54,7 @@ class VM_Version: public Abstract_VM_Version {
   static bool has_simd()               { return _has_simd; }
   static bool has_vfp()                { return has_simd(); }
   static bool simd_math_is_compliant() { return true; }
+  static bool has_multiprocessing_extensions() { return true; }
 
   static bool prefer_moves_over_load_literal() { return true; }
 
@@ -64,6 +65,7 @@ class VM_Version: public Abstract_VM_Version {
     vfp = 0,
     vfp3_32 = 1,
     simd = 2,
+    mp_ext = 3
   };
 
   enum Feature_Flag_Set {
@@ -73,6 +75,7 @@ class VM_Version: public Abstract_VM_Version {
     vfp_m     = 1 << vfp,
     vfp3_32_m = 1 << vfp3_32,
     simd_m    = 1 << simd,
+    mp_ext_m  = 1 << mp_ext
   };
 
   // The value stored by "STR PC, [addr]" instruction can be either
@@ -115,6 +118,7 @@ class VM_Version: public Abstract_VM_Version {
   static bool has_vfp()             { return (_features & vfp_m) != 0; }
   static bool has_vfp3_32()         { return (_features & vfp3_32_m) != 0; }
   static bool has_simd()            { return (_features & simd_m) != 0; }
+  static bool has_multiprocessing_extensions() { return (_features & mp_ext_m) != 0; }
 
   static bool simd_math_is_compliant() { return false; }
 

--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
@@ -259,9 +259,11 @@ frame os::current_frame() {
 #ifndef AARCH64
 extern "C" address check_vfp_fault_instr;
 extern "C" address check_vfp3_32_fault_instr;
+extern "C" address check_mp_ext_fault_instr;
 
 address check_vfp_fault_instr = NULL;
 address check_vfp3_32_fault_instr = NULL;
+address check_mp_ext_fault_instr = NULL;
 #endif // !AARCH64
 extern "C" address check_simd_fault_instr;
 address check_simd_fault_instr = NULL;
@@ -283,7 +285,8 @@ extern "C" int JVM_handle_linux_signal(int sig, siginfo_t* info,
   if (sig == SIGILL &&
       ((info->si_addr == (caddr_t)check_simd_fault_instr)
        NOT_AARCH64(|| info->si_addr == (caddr_t)check_vfp_fault_instr)
-       NOT_AARCH64(|| info->si_addr == (caddr_t)check_vfp3_32_fault_instr))) {
+       NOT_AARCH64(|| info->si_addr == (caddr_t)check_vfp3_32_fault_instr)
+       NOT_AARCH64(|| info->si_addr == (caddr_t)check_mp_ext_fault_instr))) {
     // skip faulty instruction + instruction that sets return value to
     // success and set return value to failure.
     os::Linux::ucontext_set_pc(uc, (address)info->si_addr + 8);


### PR DESCRIPTION
This is the request to backport the fix to jdk11u.
The change fixes SIGILL on ARM machines without the Multiprocessing Extensions and brings no risk for other platforms.

The original patch [1] has minor conflicts with os::is_MP [2] and AArch64 Port [3] removal updates.
 [1] https://github.com/openjdk/jdk/commit/989fa190
[2] https://github.com/openjdk/jdk/commit/a3cd6a1a
[3] https://github.com/openjdk/jdk/commit/05027c12

The jtreg tests are Ok.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8222825](https://bugs.openjdk.java.net/browse/JDK-8222825): ARM32 SIGILL issue on single core CPU (not supported PLDW instruction)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/652/head:pull/652` \
`$ git checkout pull/652`

Update a local copy of the PR: \
`$ git checkout pull/652` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 652`

View PR using the GUI difftool: \
`$ git pr show -t 652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/652.diff">https://git.openjdk.java.net/jdk11u-dev/pull/652.diff</a>

</details>
