### PR TITLE
8202142: jfr/event/io/TestInstrumentation is unstable

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -889,7 +889,6 @@ com/sun/jdi/RedefineCrossEvent.java                             8194308    gener
 
 # jdk_jfr
 
-jdk/jfr/event/io/TestInstrumentation.java                       8202142    generic-all
 jdk/jfr/event/sampling/TestNative.java                          8202142    generic-all
 jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java          8228990,8229370    generic-all
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209    generic-all

--- a/test/jdk/jdk/jfr/event/io/IOEvent.java
+++ b/test/jdk/jdk/jfr/event/io/IOEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -197,14 +197,11 @@ public class IOEvent {
             }
             return canonical_path;
         } else {
-            return String.format("%s/%s:%d",
-                                event.getValue("host"),
-                                event.getValue("address"),
-                                event.getValue("port"));
+            return event.getValue("address") + ":"  + event.getValue("port");
         }
     }
 
     private static String getAddress(Socket s) {
-        return s.getInetAddress().toString() + ":" + s.getPort();
+        return s.getInetAddress().getHostAddress() + ":" + s.getPort();
     }
 }

--- a/test/jdk/jdk/jfr/event/io/IOHelper.java
+++ b/test/jdk/jdk/jfr/event/io/IOHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@ package jdk.jfr.event.io;
 import static jdk.test.lib.Asserts.assertEquals;
 import static jdk.test.lib.Asserts.assertTrue;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -41,6 +43,7 @@ import jdk.test.lib.jfr.Events;
 public class IOHelper {
 
     public static void verifyEqualsInOrder(List<RecordedEvent> events, List<IOEvent> expectedEvents) throws Throwable {
+        Collections.sort(events, Comparator.comparing(RecordedEvent::getStartTime));
         List<IOEvent> actualEvents = getTestEvents(events, expectedEvents);
         try {
             assertEquals(actualEvents.size(), expectedEvents.size(), "Wrong number of events.");
@@ -48,6 +51,9 @@ public class IOHelper {
                 assertEquals(actualEvents.get(i), expectedEvents.get(i), "Wrong event at pos " + i);
             }
         } catch (Throwable t) {
+            for (RecordedEvent e: events) {
+                System.out.println(e);
+            }
             logEvents(actualEvents, expectedEvents);
             throw t;
         }

--- a/test/jdk/jdk/jfr/event/io/TestDisabledEvents.java
+++ b/test/jdk/jdk/jfr/event/io/TestDisabledEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,21 +57,22 @@ public class TestDisabledEvents {
     public static void main(String[] args) throws Throwable {
         File tmp = File.createTempFile("TestDisabledEvents", ".tmp", new File("."));
         tmp.deleteOnExit();
-        Recording recording = new Recording();
-        recording.disable(IOEvent.EVENT_FILE_READ);
-        recording.disable(IOEvent.EVENT_FILE_WRITE);
-        recording.start();
+        try (Recording recording = new Recording()) {
+            recording.disable(IOEvent.EVENT_FILE_READ);
+            recording.disable(IOEvent.EVENT_FILE_WRITE);
+            recording.start();
 
-        useRandomAccessFile(tmp);
-        useFileStreams(tmp);
-        useFileChannel(tmp);
+            useRandomAccessFile(tmp);
+            useFileStreams(tmp);
+            useFileChannel(tmp);
 
-        recording.stop();
-        for (RecordedEvent event : Events.fromRecording(recording)) {
-            final String eventName = event.getEventType().getName();
-            System.out.println("Got eventName:" + eventName);
-            assertNotEquals(eventName, IOEvent.EVENT_FILE_READ, "Got disabled read event");
-            assertNotEquals(eventName, IOEvent.EVENT_FILE_WRITE, "Got disabled write event");
+            recording.stop();
+            for (RecordedEvent event : Events.fromRecording(recording)) {
+                final String eventName = event.getEventType().getName();
+                System.out.println("Got eventName:" + eventName);
+                assertNotEquals(eventName, IOEvent.EVENT_FILE_READ, "Got disabled read event");
+                assertNotEquals(eventName, IOEvent.EVENT_FILE_WRITE, "Got disabled write event");
+            }
         }
     }
 

--- a/test/jdk/jdk/jfr/event/io/TestFileChannelEvents.java
+++ b/test/jdk/jdk/jfr/event/io/TestFileChannelEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,74 +50,74 @@ public class TestFileChannelEvents {
     public static void main(String[] args) throws Throwable {
         File tmp = File.createTempFile("TestFileChannelEvents", ".tmp", new File("."));
         tmp.deleteOnExit();
-        Recording recording = new Recording();
-        List<IOEvent> expectedEvents = new ArrayList<>();
+        try (Recording recording = new Recording()) {
+            List<IOEvent> expectedEvents = new ArrayList<>();
+            try (RandomAccessFile rf = new RandomAccessFile(tmp, "rw"); FileChannel ch = rf.getChannel();) {
+                recording.enable(IOEvent.EVENT_FILE_FORCE).withThreshold(Duration.ofMillis(0));
+                recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));
+                recording.enable(IOEvent.EVENT_FILE_WRITE).withThreshold(Duration.ofMillis(0));
+                recording.start();
 
-        try (RandomAccessFile rf = new RandomAccessFile(tmp, "rw"); FileChannel ch = rf.getChannel();) {
-            recording.enable(IOEvent.EVENT_FILE_FORCE).withThreshold(Duration.ofMillis(0));
-            recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));
-            recording.enable(IOEvent.EVENT_FILE_WRITE).withThreshold(Duration.ofMillis(0));
-            recording.start();
+                ByteBuffer bufA = ByteBuffer.allocateDirect(10);
+                ByteBuffer bufB = ByteBuffer.allocateDirect(20);
+                bufA.put("1234567890".getBytes());
+                bufB.put("1234567890".getBytes());
 
-            ByteBuffer bufA = ByteBuffer.allocateDirect(10);
-            ByteBuffer bufB = ByteBuffer.allocateDirect(20);
-            bufA.put("1234567890".getBytes());
-            bufB.put("1234567890".getBytes());
+                // test write(ByteBuffer)
+                bufA.flip();
+                long size = ch.write(bufA);
+                expectedEvents.add(IOEvent.createFileWriteEvent(size, tmp));
 
-            // test write(ByteBuffer)
-            bufA.flip();
-            long size = ch.write(bufA);
-            expectedEvents.add(IOEvent.createFileWriteEvent(size, tmp));
+                // test write(ByteBuffer, long)
+                bufA.flip();
+                size = ch.write(bufA, bufA.capacity() / 2);
+                expectedEvents.add(IOEvent.createFileWriteEvent(size, tmp));
 
-            // test write(ByteBuffer, long)
-            bufA.flip();
-            size = ch.write(bufA, bufA.capacity() / 2);
-            expectedEvents.add(IOEvent.createFileWriteEvent(size, tmp));
+                // test write(ByteBuffer[])
+                bufA.flip();
+                bufA.limit(5);
+                bufB.flip();
+                bufB.limit(5);
+                size = ch.write(new ByteBuffer[] { bufA, bufB });
+                expectedEvents.add(IOEvent.createFileWriteEvent(size, tmp));
 
-            // test write(ByteBuffer[])
-            bufA.flip();
-            bufA.limit(5);
-            bufB.flip();
-            bufB.limit(5);
-            size = ch.write(new ByteBuffer[] { bufA, bufB });
-            expectedEvents.add(IOEvent.createFileWriteEvent(size, tmp));
+                // test force(boolean)
+                ch.force(true);
+                expectedEvents.add(IOEvent.createFileForceEvent(tmp));
 
-            // test force(boolean)
-            ch.force(true);
-            expectedEvents.add(IOEvent.createFileForceEvent(tmp));
+                // reset file
+                ch.position(0);
 
-            // reset file
-            ch.position(0);
+                // test read(ByteBuffer)
+                bufA.clear();
+                size = ch.read(bufA);
+                expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
 
-            // test read(ByteBuffer)
-            bufA.clear();
-            size = ch.read(bufA);
-            expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
+                // test read(ByteBuffer, long)
+                bufA.clear();
+                size = ch.read(bufA, bufA.capacity() / 2);
+                expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
 
-            // test read(ByteBuffer, long)
-            bufA.clear();
-            size = ch.read(bufA, bufA.capacity() / 2);
-            expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
+                // test read(ByteBuffer[])
+                bufA.clear();
+                bufA.limit(5);
+                bufB.clear();
+                bufB.limit(5);
+                size = ch.read(new ByteBuffer[] { bufA, bufB });
+                expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
 
-            // test read(ByteBuffer[])
-            bufA.clear();
-            bufA.limit(5);
-            bufB.clear();
-            bufB.limit(5);
-            size = ch.read(new ByteBuffer[] { bufA, bufB });
-            expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
+                // Read at EOF. Should get size -1 in event.
+                ch.position(ch.size());
+                bufA.clear();
+                size = ch.read(bufA);
+                assertEquals(size, -1L, "Expected size -1 when read at EOF");
+                expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
 
-            // Read at EOF. Should get size -1 in event.
-            ch.position(ch.size());
-            bufA.clear();
-            size = ch.read(bufA);
-            assertEquals(size, -1L, "Expected size -1 when read at EOF");
-            expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
-
-            ch.close();
-            recording.stop();
-            List<RecordedEvent> events = Events.fromRecording(recording);
-            IOHelper.verifyEqualsInOrder(events, expectedEvents);
+                ch.close();
+                recording.stop();
+                List<RecordedEvent> events = Events.fromRecording(recording);
+                IOHelper.verifyEqualsInOrder(events, expectedEvents);
+            }
         }
     }
 }

--- a/test/jdk/jdk/jfr/event/io/TestFileReadOnly.java
+++ b/test/jdk/jdk/jfr/event/io/TestFileReadOnly.java
@@ -58,15 +58,15 @@ public class TestFileReadOnly {
             recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));
             recording.enable(IOEvent.EVENT_FILE_WRITE).withThreshold(Duration.ofMillis(0));
             recording.start();
-    
+
             final byte[] buf = { 1, 2, 3 };
-    
+
             // Create the file.
             try (RandomAccessFile f = new RandomAccessFile(tmp, "rw")) {
                 f.write(buf);
                 expectedEvents.add(IOEvent.createFileWriteEvent(buf.length, tmp));
             }
-    
+
             // Reopen the file as ReadOnly and try to write to it.
             // Should generate an event with bytesWritten = -1.
             try (RandomAccessFile f = new RandomAccessFile(tmp, "r")) {
@@ -78,7 +78,7 @@ public class TestFileReadOnly {
                     expectedEvents.add(IOEvent.createFileWriteEvent(-1, tmp));
                 }
             }
-    
+
             // Try to write to read-only FileChannel.
             try (RandomAccessFile f = new RandomAccessFile(tmp, "r"); FileChannel ch = f.getChannel()) {
                 ByteBuffer writeBuf = ByteBuffer.allocateDirect(buf.length);
@@ -93,7 +93,7 @@ public class TestFileReadOnly {
                     expectedEvents.add(IOEvent.createFileWriteEvent(-1, tmp));
                 }
             }
-    
+
             recording.stop();
             List<RecordedEvent> events = Events.fromRecording(recording);
             IOHelper.verifyEqualsInOrder(events, expectedEvents);

--- a/test/jdk/jdk/jfr/event/io/TestFileReadOnly.java
+++ b/test/jdk/jdk/jfr/event/io/TestFileReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,50 +52,51 @@ public class TestFileReadOnly {
     public static void main(String[] args) throws Throwable {
         File tmp = File.createTempFile("TestFileReadOnly", ".tmp", new File("."));
         tmp.deleteOnExit();
-        Recording recording = new Recording();
-        List<IOEvent> expectedEvents = new ArrayList<>();
+        try (Recording recording = new Recording()) {
+            List<IOEvent> expectedEvents = new ArrayList<>();
 
-        recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));
-        recording.enable(IOEvent.EVENT_FILE_WRITE).withThreshold(Duration.ofMillis(0));
-        recording.start();
-
-        final byte[] buf = { 1, 2, 3 };
-
-        // Create the file.
-        try (RandomAccessFile f = new RandomAccessFile(tmp, "rw")) {
-            f.write(buf);
-            expectedEvents.add(IOEvent.createFileWriteEvent(buf.length, tmp));
-        }
-
-        // Reopen the file as ReadOnly and try to write to it.
-        // Should generate an event with bytesWritten = -1.
-        try (RandomAccessFile f = new RandomAccessFile(tmp, "r")) {
-            try {
+            recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));
+            recording.enable(IOEvent.EVENT_FILE_WRITE).withThreshold(Duration.ofMillis(0));
+            recording.start();
+    
+            final byte[] buf = { 1, 2, 3 };
+    
+            // Create the file.
+            try (RandomAccessFile f = new RandomAccessFile(tmp, "rw")) {
                 f.write(buf);
-                fail("No exception for ReadOnly File");
-            } catch (IOException e) {
-                // Expected exception
-                expectedEvents.add(IOEvent.createFileWriteEvent(-1, tmp));
+                expectedEvents.add(IOEvent.createFileWriteEvent(buf.length, tmp));
             }
-        }
-
-        // Try to write to read-only FileChannel.
-        try (RandomAccessFile f = new RandomAccessFile(tmp, "r"); FileChannel ch = f.getChannel()) {
-            ByteBuffer writeBuf = ByteBuffer.allocateDirect(buf.length);
-            writeBuf.put(buf);
-            writeBuf.flip();
-            ch.position(0);
-            try {
-                ch.write(writeBuf);
-                fail("No exception for ReadOnly FileChannel");
-            } catch (java.nio.channels.NonWritableChannelException e) {
-                // Expected exception
-                expectedEvents.add(IOEvent.createFileWriteEvent(-1, tmp));
+    
+            // Reopen the file as ReadOnly and try to write to it.
+            // Should generate an event with bytesWritten = -1.
+            try (RandomAccessFile f = new RandomAccessFile(tmp, "r")) {
+                try {
+                    f.write(buf);
+                    fail("No exception for ReadOnly File");
+                } catch (IOException e) {
+                    // Expected exception
+                    expectedEvents.add(IOEvent.createFileWriteEvent(-1, tmp));
+                }
             }
+    
+            // Try to write to read-only FileChannel.
+            try (RandomAccessFile f = new RandomAccessFile(tmp, "r"); FileChannel ch = f.getChannel()) {
+                ByteBuffer writeBuf = ByteBuffer.allocateDirect(buf.length);
+                writeBuf.put(buf);
+                writeBuf.flip();
+                ch.position(0);
+                try {
+                    ch.write(writeBuf);
+                    fail("No exception for ReadOnly FileChannel");
+                } catch (java.nio.channels.NonWritableChannelException e) {
+                    // Expected exception
+                    expectedEvents.add(IOEvent.createFileWriteEvent(-1, tmp));
+                }
+            }
+    
+            recording.stop();
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            IOHelper.verifyEqualsInOrder(events, expectedEvents);
         }
-
-        recording.stop();
-        List<RecordedEvent> events = Events.fromRecording(recording);
-        IOHelper.verifyEqualsInOrder(events, expectedEvents);
     }
 }

--- a/test/jdk/jdk/jfr/event/io/TestFileStreamEvents.java
+++ b/test/jdk/jdk/jfr/event/io/TestFileStreamEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,47 +50,47 @@ public class TestFileStreamEvents {
     public static void main(String[] args) throws Throwable {
         File tmp = File.createTempFile("TestFileStreamEvents", ".tmp", new File("."));
         tmp.deleteOnExit();
-        Recording recording = new Recording();
-        List<IOEvent> expectedEvents = new ArrayList<>();
-
-        try(FileOutputStream fos = new FileOutputStream(tmp); FileInputStream fis = new FileInputStream(tmp);) {
-            recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));
-            recording.enable(IOEvent.EVENT_FILE_WRITE).withThreshold(Duration.ofMillis(0));
-            recording.start();
-
-            int writeByte = 47;
-            byte[] writeBuf = {11, 12, 13, 14};
-
-            // Write
-            fos.write(writeByte);
-            expectedEvents.add(IOEvent.createFileWriteEvent(1, tmp));
-            fos.write(writeBuf);
-            expectedEvents.add(IOEvent.createFileWriteEvent(writeBuf.length, tmp));
-            fos.write(writeBuf, 0, 2);
-            expectedEvents.add(IOEvent.createFileWriteEvent(2, tmp));
-
-            // Read
-            int readByte = fis.read();
-            assertEquals(readByte, writeByte, "Wrong byte read");
-            expectedEvents.add(IOEvent.createFileReadEvent(1, tmp));
-
-            byte[] readBuf = new byte[writeBuf.length];
-            long size = fis.read(readBuf);
-            assertEquals(size, (long)writeBuf.length, "Wrong size when reading byte[]");
-            expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
-
-            size = fis.read(readBuf, 0, 2);
-            assertEquals(size, 2L, "Wrong size when reading 2 bytes");
-            expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
-
-            // We are at EOF. Read more and verify we get size -1.
-            size = fis.read(readBuf);
-            assertEquals(size, -1L, "Size should be -1 at EOF");
-            expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
-
-            recording.stop();
-            List<RecordedEvent> events = Events.fromRecording(recording);
-            IOHelper.verifyEqualsInOrder(events, expectedEvents);
+        try (Recording recording = new Recording()) {
+            List<IOEvent> expectedEvents = new ArrayList<>();
+            try(FileOutputStream fos = new FileOutputStream(tmp); FileInputStream fis = new FileInputStream(tmp);) {
+                recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));
+                recording.enable(IOEvent.EVENT_FILE_WRITE).withThreshold(Duration.ofMillis(0));
+                recording.start();
+    
+                int writeByte = 47;
+                byte[] writeBuf = {11, 12, 13, 14};
+    
+                // Write
+                fos.write(writeByte);
+                expectedEvents.add(IOEvent.createFileWriteEvent(1, tmp));
+                fos.write(writeBuf);
+                expectedEvents.add(IOEvent.createFileWriteEvent(writeBuf.length, tmp));
+                fos.write(writeBuf, 0, 2);
+                expectedEvents.add(IOEvent.createFileWriteEvent(2, tmp));
+    
+                // Read
+                int readByte = fis.read();
+                assertEquals(readByte, writeByte, "Wrong byte read");
+                expectedEvents.add(IOEvent.createFileReadEvent(1, tmp));
+    
+                byte[] readBuf = new byte[writeBuf.length];
+                long size = fis.read(readBuf);
+                assertEquals(size, (long)writeBuf.length, "Wrong size when reading byte[]");
+                expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
+    
+                size = fis.read(readBuf, 0, 2);
+                assertEquals(size, 2L, "Wrong size when reading 2 bytes");
+                expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
+    
+                // We are at EOF. Read more and verify we get size -1.
+                size = fis.read(readBuf);
+                assertEquals(size, -1L, "Size should be -1 at EOF");
+                expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
+    
+                recording.stop();
+                List<RecordedEvent> events = Events.fromRecording(recording);
+                IOHelper.verifyEqualsInOrder(events, expectedEvents);
+            }
         }
     }
 }

--- a/test/jdk/jdk/jfr/event/io/TestFileStreamEvents.java
+++ b/test/jdk/jdk/jfr/event/io/TestFileStreamEvents.java
@@ -56,10 +56,10 @@ public class TestFileStreamEvents {
                 recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));
                 recording.enable(IOEvent.EVENT_FILE_WRITE).withThreshold(Duration.ofMillis(0));
                 recording.start();
-    
+
                 int writeByte = 47;
                 byte[] writeBuf = {11, 12, 13, 14};
-    
+
                 // Write
                 fos.write(writeByte);
                 expectedEvents.add(IOEvent.createFileWriteEvent(1, tmp));
@@ -67,26 +67,26 @@ public class TestFileStreamEvents {
                 expectedEvents.add(IOEvent.createFileWriteEvent(writeBuf.length, tmp));
                 fos.write(writeBuf, 0, 2);
                 expectedEvents.add(IOEvent.createFileWriteEvent(2, tmp));
-    
+
                 // Read
                 int readByte = fis.read();
                 assertEquals(readByte, writeByte, "Wrong byte read");
                 expectedEvents.add(IOEvent.createFileReadEvent(1, tmp));
-    
+
                 byte[] readBuf = new byte[writeBuf.length];
                 long size = fis.read(readBuf);
                 assertEquals(size, (long)writeBuf.length, "Wrong size when reading byte[]");
                 expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
-    
+
                 size = fis.read(readBuf, 0, 2);
                 assertEquals(size, 2L, "Wrong size when reading 2 bytes");
                 expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
-    
+
                 // We are at EOF. Read more and verify we get size -1.
                 size = fis.read(readBuf);
                 assertEquals(size, -1L, "Size should be -1 at EOF");
                 expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
-    
+
                 recording.stop();
                 List<RecordedEvent> events = Events.fromRecording(recording);
                 IOHelper.verifyEqualsInOrder(events, expectedEvents);

--- a/test/jdk/jdk/jfr/event/io/TestInstrumentation.java
+++ b/test/jdk/jdk/jfr/event/io/TestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,11 +106,9 @@ public class TestInstrumentation implements ClassFileTransformer {
         "java/io/FileOutputStream::write::([B)V",
         "java/io/FileOutputStream::write::([BII)V",
         "java/net/SocketInputStream::read::()I",
-        "java/net/SocketInputStream::read::([B)I",
         "java/net/SocketInputStream::read::([BII)I",
         "java/net/SocketInputStream::close::()V",
         "java/net/SocketOutputStream::write::(I)V",
-        "java/net/SocketOutputStream::write::([B)V",
         "java/net/SocketOutputStream::write::([BII)V",
         "java/net/SocketOutputStream::close::()V",
         "java/nio/channels/FileChannel::read::([Ljava/nio/ByteBuffer;)J",

--- a/test/jdk/jdk/jfr/event/io/TestRandomAccessFileEvents.java
+++ b/test/jdk/jdk/jfr/event/io/TestRandomAccessFileEvents.java
@@ -55,19 +55,19 @@ public class TestRandomAccessFileEvents {
             recording.enable(IOEvent.EVENT_FILE_WRITE).withThreshold(Duration.ofMillis(0));
             recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));
             recording.start();
-    
+
             RandomAccessFile ras = new RandomAccessFile(tmp, "rw");
             int writeInt = 47;
             byte[] writeBuffer = {10,11,12,13};
-    
+
             // Write an int and a buffer.
             ras.write(writeInt);
             expectedEvents.add(IOEvent.createFileWriteEvent(1, tmp));
             ras.write(writeBuffer);
             expectedEvents.add(IOEvent.createFileWriteEvent(writeBuffer.length, tmp));
-    
+
             ras.seek(0);
-    
+
             // Read int and buffer
             int readInt = ras.read();
             assertEquals(readInt, writeInt, "wrong int read");
@@ -76,31 +76,31 @@ public class TestRandomAccessFileEvents {
             int size = ras.read(readBuffer);
             verifyBufferEquals(readBuffer, writeBuffer);
             expectedEvents.add(IOEvent.createFileReadEvent(readBuffer.length, tmp));
-    
+
             // Read beyond EOF
             readInt = ras.read();
             assertEquals(-1, readInt, "wrong read after EOF");
             expectedEvents.add(IOEvent.createFileReadEvent(-1, tmp));
-    
+
             // Seek to beginning and verify we can read after EOF.
             ras.seek(0);
             readInt = ras.read();
             assertEquals(readInt, writeInt, "wrong int read after seek(0)");
             expectedEvents.add(IOEvent.createFileReadEvent(1, tmp));
-    
+
             // seek beyond EOF and verify we get EOF when reading.
             ras.seek(10);
             readInt = ras.read();
             assertEquals(-1, readInt, "wrong read after seek beyond EOF");
             expectedEvents.add(IOEvent.createFileReadEvent(-1, tmp));
-    
+
             // Read partial buffer.
             int partialSize = writeBuffer.length - 2;
             ras.seek(ras.length()-partialSize);
             size = ras.read(readBuffer);
             assertEquals(size, partialSize, "Wrong size partial buffer read");
             expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
-    
+
             ras.close();
             recording.stop();
             List<RecordedEvent> events = Events.fromRecording(recording);

--- a/test/jdk/jdk/jfr/event/io/TestRandomAccessFileEvents.java
+++ b/test/jdk/jdk/jfr/event/io/TestRandomAccessFileEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,62 +49,63 @@ public class TestRandomAccessFileEvents {
     public static void main(String[] args) throws Throwable {
         File tmp = File.createTempFile("TestRandomAccessFileEvents", ".tmp", new File("."));
         tmp.deleteOnExit();
-        Recording recording = new Recording();
-        List<IOEvent> expectedEvents = new ArrayList<>();
+        try (Recording recording = new Recording()) {
+            List<IOEvent> expectedEvents = new ArrayList<>();
 
-        recording.enable(IOEvent.EVENT_FILE_WRITE).withThreshold(Duration.ofMillis(0));
-        recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));
-        recording.start();
-
-        RandomAccessFile ras = new RandomAccessFile(tmp, "rw");
-        int writeInt = 47;
-        byte[] writeBuffer = {10,11,12,13};
-
-        // Write an int and a buffer.
-        ras.write(writeInt);
-        expectedEvents.add(IOEvent.createFileWriteEvent(1, tmp));
-        ras.write(writeBuffer);
-        expectedEvents.add(IOEvent.createFileWriteEvent(writeBuffer.length, tmp));
-
-        ras.seek(0);
-
-        // Read int and buffer
-        int readInt = ras.read();
-        assertEquals(readInt, writeInt, "wrong int read");
-        expectedEvents.add(IOEvent.createFileReadEvent(1, tmp));
-        byte[] readBuffer = new byte [writeBuffer.length];
-        int size = ras.read(readBuffer);
-        verifyBufferEquals(readBuffer, writeBuffer);
-        expectedEvents.add(IOEvent.createFileReadEvent(readBuffer.length, tmp));
-
-        // Read beyond EOF
-        readInt = ras.read();
-        assertEquals(-1, readInt, "wrong read after EOF");
-        expectedEvents.add(IOEvent.createFileReadEvent(-1, tmp));
-
-        // Seek to beginning and verify we can read after EOF.
-        ras.seek(0);
-        readInt = ras.read();
-        assertEquals(readInt, writeInt, "wrong int read after seek(0)");
-        expectedEvents.add(IOEvent.createFileReadEvent(1, tmp));
-
-        // seek beyond EOF and verify we get EOF when reading.
-        ras.seek(10);
-        readInt = ras.read();
-        assertEquals(-1, readInt, "wrong read after seek beyond EOF");
-        expectedEvents.add(IOEvent.createFileReadEvent(-1, tmp));
-
-        // Read partial buffer.
-        int partialSize = writeBuffer.length - 2;
-        ras.seek(ras.length()-partialSize);
-        size = ras.read(readBuffer);
-        assertEquals(size, partialSize, "Wrong size partial buffer read");
-        expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
-
-        ras.close();
-        recording.stop();
-        List<RecordedEvent> events = Events.fromRecording(recording);
-        IOHelper.verifyEqualsInOrder(events, expectedEvents);
+            recording.enable(IOEvent.EVENT_FILE_WRITE).withThreshold(Duration.ofMillis(0));
+            recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));
+            recording.start();
+    
+            RandomAccessFile ras = new RandomAccessFile(tmp, "rw");
+            int writeInt = 47;
+            byte[] writeBuffer = {10,11,12,13};
+    
+            // Write an int and a buffer.
+            ras.write(writeInt);
+            expectedEvents.add(IOEvent.createFileWriteEvent(1, tmp));
+            ras.write(writeBuffer);
+            expectedEvents.add(IOEvent.createFileWriteEvent(writeBuffer.length, tmp));
+    
+            ras.seek(0);
+    
+            // Read int and buffer
+            int readInt = ras.read();
+            assertEquals(readInt, writeInt, "wrong int read");
+            expectedEvents.add(IOEvent.createFileReadEvent(1, tmp));
+            byte[] readBuffer = new byte [writeBuffer.length];
+            int size = ras.read(readBuffer);
+            verifyBufferEquals(readBuffer, writeBuffer);
+            expectedEvents.add(IOEvent.createFileReadEvent(readBuffer.length, tmp));
+    
+            // Read beyond EOF
+            readInt = ras.read();
+            assertEquals(-1, readInt, "wrong read after EOF");
+            expectedEvents.add(IOEvent.createFileReadEvent(-1, tmp));
+    
+            // Seek to beginning and verify we can read after EOF.
+            ras.seek(0);
+            readInt = ras.read();
+            assertEquals(readInt, writeInt, "wrong int read after seek(0)");
+            expectedEvents.add(IOEvent.createFileReadEvent(1, tmp));
+    
+            // seek beyond EOF and verify we get EOF when reading.
+            ras.seek(10);
+            readInt = ras.read();
+            assertEquals(-1, readInt, "wrong read after seek beyond EOF");
+            expectedEvents.add(IOEvent.createFileReadEvent(-1, tmp));
+    
+            // Read partial buffer.
+            int partialSize = writeBuffer.length - 2;
+            ras.seek(ras.length()-partialSize);
+            size = ras.read(readBuffer);
+            assertEquals(size, partialSize, "Wrong size partial buffer read");
+            expectedEvents.add(IOEvent.createFileReadEvent(size, tmp));
+    
+            ras.close();
+            recording.stop();
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            IOHelper.verifyEqualsInOrder(events, expectedEvents);
+        }
     }
 
     private static void verifyBufferEquals(byte[] a, byte[] b) {

--- a/test/jdk/jdk/jfr/event/io/TestRandomAccessFileThread.java
+++ b/test/jdk/jdk/jfr/event/io/TestRandomAccessFileThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,26 +64,25 @@ public class TestRandomAccessFileThread {
     public static void main(String[] args) throws Throwable {
         File tmp = File.createTempFile("TestRandomAccessFileThread", ".tmp", new File("."));
         tmp.deleteOnExit();
+        try (Recording recording = new Recording()) {
+            recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));
+            recording.enable(IOEvent.EVENT_FILE_WRITE).withThreshold(Duration.ofMillis(0));
+            recording.start();
 
-        Recording recording = new Recording();
-        recording.enable(IOEvent.EVENT_FILE_READ).withThreshold(Duration.ofMillis(0));
-        recording.enable(IOEvent.EVENT_FILE_WRITE).withThreshold(Duration.ofMillis(0));
-        recording.start();
-
-        TestThread writerThread = new TestThread(new XRun() {
-            @Override
-            public void xrun() throws IOException {
-                final byte[] buf = new byte[OP_COUNT];
-                for (int i = 0; i < buf.length; ++i) {
-                    buf[i] = (byte)((i + 'a') % 255);
-                }
-                try (RandomAccessFile raf = new RandomAccessFile(tmp, "rwd")) {
-                    for(int i = 0; i < OP_COUNT; ++i) {
-                        raf.write(buf, 0, i + 1);
-                        writeCount++;
+            TestThread writerThread = new TestThread(new XRun() {
+                @Override
+                public void xrun() throws IOException {
+                    final byte[] buf = new byte[OP_COUNT];
+                    for (int i = 0; i < buf.length; ++i) {
+                        buf[i] = (byte)((i + 'a') % 255);
                     }
-                }
-            }}, "TestWriterThread");
+                    try (RandomAccessFile raf = new RandomAccessFile(tmp, "rwd")) {
+                        for(int i = 0; i < OP_COUNT; ++i) {
+                            raf.write(buf, 0, i + 1);
+                            writeCount++;
+                        }
+                    }
+                }}, "TestWriterThread");
 
             TestThread readerThread = new TestThread(new XRun() {
             @Override
@@ -118,7 +117,7 @@ public class TestRandomAccessFileThread {
                     continue;
                 }
                 logEventSummary(event);
-                if (Events.isEventType(event,IOEvent.EVENT_FILE_READ)) {
+                if (Events.isEventType(event, IOEvent.EVENT_FILE_READ)) {
                     readEvents.add(event);
                 } else {
                     writeEvents.add(event);
@@ -136,6 +135,7 @@ public class TestRandomAccessFileThread {
             Asserts.assertEquals(readEvents.size(), OP_COUNT, "Wrong number of read events");
             Asserts.assertEquals(writeEvents.size(), OP_COUNT, "Wrong number of write events");
         }
+    }
 
         private static void logEventSummary(RecordedEvent event) {
             boolean isRead = Events.isEventType(event, IOEvent.EVENT_FILE_READ);

--- a/test/jdk/jdk/jfr/event/io/TestSocketChannelEvents.java
+++ b/test/jdk/jdk/jfr/event/io/TestSocketChannelEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,7 @@ public class TestSocketChannelEvents {
     private static final int bufSizeB = 20;
 
     private List<IOEvent> expectedEvents = new ArrayList<>();
+
     private synchronized void addExpectedEvent(IOEvent event) {
         expectedEvents.add(event);
     }
@@ -62,69 +63,70 @@ public class TestSocketChannelEvents {
     }
 
     public void test() throws Throwable {
-        Recording recording = new Recording();
+        try (Recording recording = new Recording()) {
+            try (ServerSocketChannel ss = ServerSocketChannel.open()) {
+                recording.enable(IOEvent.EVENT_SOCKET_READ).withThreshold(Duration.ofMillis(0));
+                recording.enable(IOEvent.EVENT_SOCKET_WRITE).withThreshold(Duration.ofMillis(0));
+                recording.start();
 
-        try (ServerSocketChannel ss = ServerSocketChannel.open()) {
-            recording.enable(IOEvent.EVENT_SOCKET_READ).withThreshold(Duration.ofMillis(0));
-            recording.enable(IOEvent.EVENT_SOCKET_WRITE).withThreshold(Duration.ofMillis(0));
-            recording.start();
+                ss.socket().setReuseAddress(true);
+                ss.socket().bind(null);
 
-            ss.socket().setReuseAddress(true);
-            ss.socket().bind(null);
+                TestThread readerThread = new TestThread(new XRun() {
+                    @Override
+                    public void xrun() throws IOException {
+                        ByteBuffer bufA = ByteBuffer.allocate(bufSizeA);
+                        ByteBuffer bufB = ByteBuffer.allocate(bufSizeB);
+                        try (SocketChannel sc = ss.accept()) {
+                            int readSize = sc.read(bufA);
+                            assertEquals(readSize, bufSizeA, "Wrong readSize bufA");
+                            addExpectedEvent(IOEvent.createSocketReadEvent(bufSizeA, sc.socket()));
 
-            TestThread readerThread = new TestThread(new XRun() {
-                @Override
-                public void xrun() throws IOException {
-                    ByteBuffer bufA = ByteBuffer.allocate(bufSizeA);
-                    ByteBuffer bufB = ByteBuffer.allocate(bufSizeB);
-                    try (SocketChannel sc = ss.accept()) {
-                        int readSize = sc.read(bufA);
-                        assertEquals(readSize, bufSizeA, "Wrong readSize bufA");
-                        addExpectedEvent(IOEvent.createSocketReadEvent(bufSizeA, sc.socket()));
+                            bufA.clear();
+                            bufA.limit(1);
+                            readSize = (int) sc.read(new ByteBuffer[] { bufA, bufB });
+                            assertEquals(readSize, 1 + bufSizeB, "Wrong readSize 1+bufB");
+                            addExpectedEvent(IOEvent.createSocketReadEvent(readSize, sc.socket()));
 
-                        bufA.clear();
-                        bufA.limit(1);
-                        readSize = (int)sc.read(new ByteBuffer[] { bufA, bufB });
-                        assertEquals(readSize, 1 + bufSizeB, "Wrong readSize 1+bufB");
-                        addExpectedEvent(IOEvent.createSocketReadEvent(readSize, sc.socket()));
-
-                        // We try to read, but client have closed. Should get EOF.
-                        bufA.clear();
-                        bufA.limit(1);
-                        readSize = sc.read(bufA);
-                        assertEquals(readSize, -1, "Wrong readSize at EOF");
-                        addExpectedEvent(IOEvent.createSocketReadEvent(-1, sc.socket()));
+                            // We try to read, but client have closed. Should
+                            // get EOF.
+                            bufA.clear();
+                            bufA.limit(1);
+                            readSize = sc.read(bufA);
+                            assertEquals(readSize, -1, "Wrong readSize at EOF");
+                            addExpectedEvent(IOEvent.createSocketReadEvent(-1, sc.socket()));
+                        }
                     }
-                }
-            });
-            readerThread.start();
+                });
+                readerThread.start();
 
-            try (SocketChannel sc = SocketChannel.open(ss.socket().getLocalSocketAddress())) {
-                ByteBuffer bufA = ByteBuffer.allocateDirect(bufSizeA);
-                ByteBuffer bufB = ByteBuffer.allocateDirect(bufSizeB);
-                for (int i = 0; i < bufSizeA; ++i) {
-                    bufA.put((byte)('a' + (i % 20)));
-                }
-                for (int i = 0; i < bufSizeB; ++i) {
-                    bufB.put((byte)('A' + (i % 20)));
-                }
-                bufA.flip();
-                bufB.flip();
+                try (SocketChannel sc = SocketChannel.open(ss.socket().getLocalSocketAddress())) {
+                    ByteBuffer bufA = ByteBuffer.allocateDirect(bufSizeA);
+                    ByteBuffer bufB = ByteBuffer.allocateDirect(bufSizeB);
+                    for (int i = 0; i < bufSizeA; ++i) {
+                        bufA.put((byte) ('a' + (i % 20)));
+                    }
+                    for (int i = 0; i < bufSizeB; ++i) {
+                        bufB.put((byte) ('A' + (i % 20)));
+                    }
+                    bufA.flip();
+                    bufB.flip();
 
-                sc.write(bufA);
-                addExpectedEvent(IOEvent.createSocketWriteEvent(bufSizeA, sc.socket()));
+                    sc.write(bufA);
+                    addExpectedEvent(IOEvent.createSocketWriteEvent(bufSizeA, sc.socket()));
 
-                bufA.clear();
-                bufA.limit(1);
-                int bytesWritten = (int)sc.write(new ByteBuffer[] { bufA, bufB });
-                assertEquals(bytesWritten, 1 + bufSizeB, "Wrong bytesWritten 1+bufB");
-                addExpectedEvent(IOEvent.createSocketWriteEvent(bytesWritten, sc.socket()));
+                    bufA.clear();
+                    bufA.limit(1);
+                    int bytesWritten = (int) sc.write(new ByteBuffer[] { bufA, bufB });
+                    assertEquals(bytesWritten, 1 + bufSizeB, "Wrong bytesWritten 1+bufB");
+                    addExpectedEvent(IOEvent.createSocketWriteEvent(bytesWritten, sc.socket()));
+                }
+
+                readerThread.joinAndThrow();
+                recording.stop();
+                List<RecordedEvent> events = Events.fromRecording(recording);
+                IOHelper.verifyEquals(events, expectedEvents);
             }
-
-            readerThread.joinAndThrow();
-            recording.stop();
-            List<RecordedEvent> events= Events.fromRecording(recording);
-            IOHelper.verifyEquals(events, expectedEvents);
         }
     }
 }


### PR DESCRIPTION
Fix jdk/jfr/event/io/TestInstrumentation.java and remove it from ProblemList.txt.

There are only context and copyright conflicts, which have been resolved manually

Test: jdk/jfr/event/io/TestInstrumentation.java passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8202142](https://bugs.openjdk.java.net/browse/JDK-8202142): jfr/event/io/TestInstrumentation is unstable


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/653/head:pull/653` \
`$ git checkout pull/653`

Update a local copy of the PR: \
`$ git checkout pull/653` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 653`

View PR using the GUI difftool: \
`$ git pr show -t 653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/653.diff">https://git.openjdk.java.net/jdk11u-dev/pull/653.diff</a>

</details>
