### PR TITLE
8210726: Fix up a few minor nits forgotten by JDK-8210665

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw005/setfldw005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw005/setfldw005.cpp
@@ -154,11 +154,9 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw005_getReady(JNIEnv *env, jclass cls) 
 
     for (i = 0; i < sizeof(fields) / sizeof(field); i++) {
         if (fields[i].stat == JNI_TRUE) {
-            fields[i].fid = env-> GetStaticFieldID(
-                cls, fields[i].name, fields[i].sig);
+            fields[i].fid = env->GetStaticFieldID(cls, fields[i].name, fields[i].sig);
         } else {
-            fields[i].fid = env->GetFieldID(
-                cls, fields[i].name, fields[i].sig);
+            fields[i].fid = env->GetFieldID(cls, fields[i].name, fields[i].sig);
         }
         if (fields[i].fid == NULL) {
             printf("Unable to set access watch on %s fld%" PRIuPTR ", fieldID=0",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw006/setfldw006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw006/setfldw006.cpp
@@ -176,11 +176,9 @@ Java_nsk_jvmti_SetFieldAccessWatch_setfldw006_getReady(JNIEnv *env,
     }
     for (i = 0; i < sizeof(watches)/sizeof(watch_info); i++) {
         if (watches[i].is_static == JNI_TRUE) {
-            watches[i].fid = env->GetStaticFieldID(
-                cls, watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetStaticFieldID(cls, watches[i].f_name, watches[i].f_sig);
         } else {
-            watches[i].fid = env->GetFieldID(
-                cls, watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetFieldID(cls, watches[i].f_name, watches[i].f_sig);
         }
         err = jvmti->SetFieldAccessWatch(cls, watches[i].fid);
         if (err == JVMTI_ERROR_NONE) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw006/setfmodw006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw006/setfmodw006.cpp
@@ -170,11 +170,9 @@ Java_nsk_jvmti_SetFieldModificationWatch_setfmodw006_getReady(JNIEnv *env,
     }
     for (i = 0; i < sizeof(watches)/sizeof(watch_info); i++) {
         if (watches[i].is_static == JNI_TRUE) {
-            watches[i].fid = env->GetStaticFieldID(
-                cls, watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetStaticFieldID(cls, watches[i].f_name, watches[i].f_sig);
         } else {
-            watches[i].fid = env->GetFieldID(
-                cls, watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetFieldID(cls, watches[i].f_name, watches[i].f_sig);
         }
         err = jvmti->SetFieldModificationWatch(cls, watches[i].fid);
         if (err == JVMTI_ERROR_NONE) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal002/setlocal002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetLocalVariable/setlocal002/setlocal002.cpp
@@ -108,8 +108,7 @@ Java_nsk_jvmti_SetLocalVariable_setlocal002_check(JNIEnv *env, jclass cls, jthre
         return result;
     }
 
-    mid = env->GetStaticMethodID(
-        cls, "run", "([Ljava/lang/String;Ljava/io/PrintStream;)I");
+    mid = env->GetStaticMethodID(cls, "run", "([Ljava/lang/String;Ljava/io/PrintStream;)I");
     if (mid == NULL) {
         printf("Cannot find method \"run\"\n");
         return STATUS_FAILED;


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210726](https://bugs.openjdk.java.net/browse/JDK-8210726): Fix up a few minor nits forgotten by JDK-8210665


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/654/head:pull/654` \
`$ git checkout pull/654`

Update a local copy of the PR: \
`$ git checkout pull/654` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 654`

View PR using the GUI difftool: \
`$ git pr show -t 654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/654.diff">https://git.openjdk.java.net/jdk11u-dev/pull/654.diff</a>

</details>
