### PR TITLE
8210385: Clean up JNI_ENV_ARG and factorize the macros for vmTestbase/jvmti[A-N] tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Allocate/alloc001/alloc001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Allocate/alloc001/alloc001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -75,8 +62,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -185,6 +171,4 @@ Java_nsk_jvmti_Allocate_alloc001_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassPrepare/classprep001/classprep001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassPrepare/classprep001/classprep001.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -257,8 +244,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -333,6 +319,4 @@ Java_nsk_jvmti_ClassPrepare_classprep001_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearBreakpoint/clrbrk001/clrbrk001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearBreakpoint/clrbrk001/clrbrk001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -79,8 +66,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -131,8 +117,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_ClearBreakpoint_clrbrk001_getReady(JNIEnv *env, jclass cls, jint i) {
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-         "trial", "(I)I");
+    mid = env->GetStaticMethodID(cls, "trial", "(I)I");
     if (mid == NULL) {
         printf("Cannot find method \"trial(I)I\"\n");
         result = STATUS_FAILED;
@@ -213,6 +198,4 @@ Java_nsk_jvmti_ClearBreakpoint_clrbrk001_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearBreakpoint/clrbrk002/clrbrk002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearBreakpoint/clrbrk002/clrbrk002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -121,8 +107,7 @@ Java_nsk_jvmti_ClearBreakpoint_clrbrk002_check(JNIEnv *env, jclass cls) {
         return result;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-         "run", "([Ljava/lang/String;Ljava/io/PrintStream;)I");
+    mid = env->GetStaticMethodID(cls, "run", "([Ljava/lang/String;Ljava/io/PrintStream;)I");
     if (mid == NULL) {
         printf("Cannot find method run\n");
         return STATUS_FAILED;
@@ -158,6 +143,4 @@ Java_nsk_jvmti_ClearBreakpoint_clrbrk002_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearBreakpoint/clrbrk005/clrbrk005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearBreakpoint/clrbrk005/clrbrk005.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -119,8 +105,7 @@ Java_nsk_jvmti_ClearBreakpoint_clrbrk005_check(JNIEnv *env, jclass cls) {
         return result;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-         "checkPoint", "()V");
+    mid = env->GetStaticMethodID(cls, "checkPoint", "()V");
     if (mid == 0) {
         printf("Cannot find Method ID for method checkPoint\n");
         return STATUS_FAILED;
@@ -153,6 +138,4 @@ Java_nsk_jvmti_ClearBreakpoint_clrbrk005_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearFieldAccessWatch/clrfldw001/clrfldw001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearFieldAccessWatch/clrfldw001/clrfldw001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -74,14 +61,12 @@ void switchWatch(JNIEnv *env, jint ind, jboolean on) {
     field fld = fields[ind];
     const char *msg;
 
-    cls = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env, fld.klass));
+    cls = env->FindClass(fld.klass);
     if (fld.fid == NULL) {
         if (fld.stat) {
-            fields[ind].fid = JNI_ENV_PTR(env)->
-                    GetStaticFieldID(JNI_ENV_ARG(env, cls), fld.name, fld.sig);
+            fields[ind].fid = env->GetStaticFieldID(cls, fld.name, fld.sig);
         } else {
-            fields[ind].fid = JNI_ENV_PTR(env)->
-                    GetFieldID(JNI_ENV_ARG(env, cls), fld.name, fld.sig);
+            fields[ind].fid = env->GetFieldID(cls, fld.name, fld.sig);
         }
     }
 
@@ -123,8 +108,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -191,7 +175,7 @@ Java_nsk_jvmti_ClearFieldAccessWatch_clrfldw001_touchfld0(JNIEnv *env,
         jobject obj) {
     jint val;
 
-    val = JNI_ENV_PTR(env)->GetIntField(JNI_ENV_ARG(env, obj), fields[0].fid);
+    val = env->GetIntField(obj, fields[0].fid);
 }
 
 JNIEXPORT void JNICALL
@@ -216,6 +200,4 @@ Java_nsk_jvmti_ClearFieldAccessWatch_clrfldw001_getRes(JNIEnv *env, jclass cls) 
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearFieldAccessWatch/clrfldw002/clrfldw002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearFieldAccessWatch/clrfldw002/clrfldw002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -71,8 +58,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -128,10 +114,8 @@ Java_nsk_jvmti_ClearFieldAccessWatch_clrfldw002_check(JNIEnv *env, jclass cls) {
     jvmtiError err;
     jfieldID fid1, fid2;
 
-    fid1 = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-        "fld1", "I");
-    fid2 = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-        "fld2", "I");
+    fid1 = env->GetStaticFieldID(cls, "fld1", "I");
+    fid2 = env->GetStaticFieldID(cls, "fld2", "I");
 
     if (!caps.can_generate_field_access_events) {
         err = jvmti->ClearFieldAccessWatch(cls, fid1);
@@ -169,6 +153,4 @@ Java_nsk_jvmti_ClearFieldAccessWatch_clrfldw002_getRes(JNIEnv *env, jclass cls) 
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearFieldModificationWatch/clrfmodw001/clrfmodw001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearFieldModificationWatch/clrfmodw001/clrfmodw001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -74,14 +61,12 @@ void switchWatch(JNIEnv *env, jint ind, jboolean on) {
     field fld = fields[ind];
     const char *msg;
 
-    cls = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env, fld.klass));
+    cls = env->FindClass(fld.klass);
     if (fld.fid == NULL) {
         if (fld.stat) {
-            fields[ind].fid = JNI_ENV_PTR(env)->
-                GetStaticFieldID(JNI_ENV_ARG(env, cls), fld.name, fld.sig);
+            fields[ind].fid = env->GetStaticFieldID(cls, fld.name, fld.sig);
         } else {
-            fields[ind].fid = JNI_ENV_PTR(env)->
-                GetFieldID(JNI_ENV_ARG(env, cls), fld.name, fld.sig);
+            fields[ind].fid = env->GetFieldID(cls, fld.name, fld.sig);
         }
     }
 
@@ -123,8 +108,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -185,7 +169,7 @@ Java_nsk_jvmti_ClearFieldModificationWatch_clrfmodw001_clearWatch(JNIEnv *env, j
 }
 
 JNIEXPORT void JNICALL Java_nsk_jvmti_ClearFieldModificationWatch_clrfmodw001_touchfld0(JNIEnv *env, jobject obj) {
-    JNI_ENV_PTR(env)->SetIntField(JNI_ENV_ARG(env, obj), fields[0].fid, 2000);
+    env->SetIntField(obj, fields[0].fid, 2000);
 }
 
 JNIEXPORT void JNICALL
@@ -208,6 +192,4 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_ClearFieldModificationWatch_clrfmodw001_ge
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearFieldModificationWatch/clrfmodw002/clrfmodw002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClearFieldModificationWatch/clrfmodw002/clrfmodw002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -72,8 +59,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv !\n");
         return JNI_ERR;
@@ -129,10 +115,8 @@ Java_nsk_jvmti_ClearFieldModificationWatch_clrfmodw002_check(JNIEnv *env,
     jvmtiError err;
     jfieldID fid1, fid2;
 
-    fid1 = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-        "fld1", "I");
-    fid2 = JNI_ENV_PTR(env)->GetStaticFieldID(JNI_ENV_ARG(env, cls),
-        "fld2", "I");
+    fid1 = env->GetStaticFieldID(cls, "fld1", "I");
+    fid2 = env->GetStaticFieldID(cls, "fld2", "I");
 
     if (!caps.can_generate_field_modification_events) {
         printf("Warning: ClearFieldModificationWatch is not implemented\n");
@@ -172,6 +156,4 @@ Java_nsk_jvmti_ClearFieldModificationWatch_clrfmodw002_getRes(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CreateRawMonitor/crrawmon001/crrawmon001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CreateRawMonitor/crrawmon001/crrawmon001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -96,8 +83,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -126,6 +112,4 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_CreateRawMonitor_crrawmon001_check(JNIEnv 
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CreateRawMonitor/crrawmon002/crrawmon002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CreateRawMonitor/crrawmon002/crrawmon002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -111,6 +97,4 @@ Java_nsk_jvmti_CreateRawMonitor_crrawmon002_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Deallocate/dealloc001/dealloc001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Deallocate/dealloc001/dealloc001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED  0
 #define STATUS_FAILED  2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->
-        GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti), JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -103,6 +89,4 @@ Java_nsk_jvmti_Deallocate_dealloc001_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DestroyRawMonitor/drrawmon001/drrawmon001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DestroyRawMonitor/drrawmon001/drrawmon001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -109,8 +96,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -139,6 +125,4 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_DestroyRawMonitor_drrawmon001_check(JNIEnv
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DestroyRawMonitor/drrawmon003/drrawmon003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DestroyRawMonitor/drrawmon003/drrawmon003.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -124,6 +110,4 @@ Java_nsk_jvmti_DestroyRawMonitor_drrawmon003_check(JNIEnv *env, jclass cls) {
     return PASSED;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DestroyRawMonitor/drrawmon004/drrawmon004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DestroyRawMonitor/drrawmon004/drrawmon004.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -105,6 +91,4 @@ Java_nsk_jvmti_DestroyRawMonitor_drrawmon004_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Exception/exception001/exception001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Exception/exception001/exception001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -102,7 +89,7 @@ Exception(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr,
     if (printdump == JNI_TRUE) {
         printf(">>> retrieving Exception info ...\n");
     }
-    cls = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG((JNIEnv *)env, exception));
+    cls = env->GetObjectClass(exception);
     err = jvmti_env->GetClassSignature(cls, &ex.name, &generic);
     if (err != JVMTI_ERROR_NONE) {
         printf("(GetClassSignature) unexpected error: %s (%d)\n",
@@ -204,8 +191,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -263,26 +249,22 @@ Java_nsk_jvmti_Exception_exception001_check(JNIEnv *env, jclass cls) {
         return result;
     }
 
-    clz = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/Exception/exception001c"));
+    clz = env->FindClass("nsk/jvmti/Exception/exception001c");
     if (clz == NULL) {
         printf("Cannot find exception001c class!\n");
         return STATUS_FAILED;
     }
-    clz = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/Exception/exception001b"));
+    clz = env->FindClass("nsk/jvmti/Exception/exception001b");
     if (clz == NULL) {
         printf("Cannot find exception001b class!\n");
         return STATUS_FAILED;
     }
-    clz = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/Exception/exception001a"));
+    clz = env->FindClass("nsk/jvmti/Exception/exception001a");
     if (clz == NULL) {
         printf("Cannot find exception001a class!\n");
         return STATUS_FAILED;
     }
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, clz),
-        "run", "()V");
+    mid = env->GetStaticMethodID(clz, "run", "()V");
     if (mid == NULL) {
         printf("Cannot find method run!\n");
         return STATUS_FAILED;
@@ -304,7 +286,7 @@ Java_nsk_jvmti_Exception_exception001_check(JNIEnv *env, jclass cls) {
         result = STATUS_FAILED;
     }
 
-    JNI_ENV_PTR(env)->CallStaticVoidMethod(JNI_ENV_ARG(env, clz), mid);
+    env->CallStaticVoidMethod(clz, mid);
 
     err = jvmti->SetEventNotificationMode(JVMTI_DISABLE,
             JVMTI_EVENT_EXCEPTION, thread);
@@ -322,6 +304,4 @@ Java_nsk_jvmti_Exception_exception001_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ExceptionCatch/excatch001/excatch001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ExceptionCatch/excatch001/excatch001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -90,7 +77,7 @@ ExceptionCatch(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr,
     if (printdump == JNI_TRUE) {
         printf(">>> retrieving ExceptionCatch info ...\n");
     }
-    cls = JNI_ENV_PTR(env)->GetObjectClass(JNI_ENV_ARG((JNIEnv *)env, exception));
+    cls = env->GetObjectClass(exception);
     err = jvmti_env->GetClassSignature(cls, &ex.name, &generic);
     if (err != JVMTI_ERROR_NONE) {
         printf("(GetClassSignature#e) unexpected error: %s (%d)\n",
@@ -163,8 +150,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -221,26 +207,22 @@ Java_nsk_jvmti_ExceptionCatch_excatch001_check(JNIEnv *env, jclass cls) {
         return result;
     }
 
-    clz = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/ExceptionCatch/excatch001c"));
+    clz = env->FindClass("nsk/jvmti/ExceptionCatch/excatch001c");
     if (clz == NULL) {
         printf("Cannot find excatch001c class!\n");
         return STATUS_FAILED;
     }
-    clz = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/ExceptionCatch/excatch001b"));
+    clz = env->FindClass("nsk/jvmti/ExceptionCatch/excatch001b");
     if (clz == NULL) {
         printf("Cannot find excatch001b class!\n");
         return STATUS_FAILED;
     }
-    clz = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/ExceptionCatch/excatch001a"));
+    clz = env->FindClass("nsk/jvmti/ExceptionCatch/excatch001a");
     if (clz == NULL) {
         printf("Cannot find excatch001a class!\n");
         return STATUS_FAILED;
     }
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, clz),
-        "run", "()V");
+    mid = env->GetStaticMethodID(clz, "run", "()V");
     if (mid == NULL) {
         printf("Cannot find method run!\n");
         return STATUS_FAILED;
@@ -256,7 +238,7 @@ Java_nsk_jvmti_ExceptionCatch_excatch001_check(JNIEnv *env, jclass cls) {
         result = STATUS_FAILED;
     }
 
-    JNI_ENV_PTR(env)->CallStaticVoidMethod(JNI_ENV_ARG(env, clz), mid);
+    env->CallStaticVoidMethod(clz, mid);
 
     err = jvmti->SetEventNotificationMode(JVMTI_DISABLE,
             JVMTI_EVENT_EXCEPTION_CATCH, NULL);
@@ -274,6 +256,4 @@ Java_nsk_jvmti_ExceptionCatch_excatch001_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FieldAccess/fieldacc001/fieldacc001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FieldAccess/fieldacc001/fieldacc001.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -258,8 +245,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -323,8 +309,7 @@ Java_nsk_jvmti_FieldAccess_fieldacc001_getReady(JNIEnv *env, jclass klass) {
     if (printdump == JNI_TRUE) {
         printf(">>> setting field access watches ...\n");
     }
-    cls = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/FieldAccess/fieldacc001a"));
+    cls = env->FindClass("nsk/jvmti/FieldAccess/fieldacc001a");
     if (cls == NULL) {
         printf("Cannot find fieldacc001a class!\n");
         result = STATUS_FAILED;
@@ -332,11 +317,11 @@ Java_nsk_jvmti_FieldAccess_fieldacc001_getReady(JNIEnv *env, jclass klass) {
     }
     for (i = 0; i < sizeof(watches)/sizeof(watch_info); i++) {
         if (watches[i].is_static == JNI_TRUE) {
-            watches[i].fid = JNI_ENV_PTR(env)->GetStaticFieldID(
-                JNI_ENV_ARG(env, cls), watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetStaticFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         } else {
-            watches[i].fid = JNI_ENV_PTR(env)->GetFieldID(
-                JNI_ENV_ARG(env, cls), watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         }
         if (watches[i].fid == NULL) {
             printf("Cannot find field \"%s\"!\n", watches[i].f_name);
@@ -367,6 +352,4 @@ Java_nsk_jvmti_FieldAccess_fieldacc001_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FieldAccess/fieldacc002/fieldacc002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FieldAccess/fieldacc002/fieldacc002.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -257,8 +244,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -321,8 +307,7 @@ JNIEXPORT void JNICALL Java_nsk_jvmti_FieldAccess_fieldacc002_getReady(JNIEnv *e
         printf(">>> setting field access watches ...\n");
     }
 
-    cls = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/FieldAccess/fieldacc002a"));
+    cls = env->FindClass("nsk/jvmti/FieldAccess/fieldacc002a");
     if (cls == NULL) {
         printf("Cannot find fieldacc002a class!\n");
         result = STATUS_FAILED;
@@ -330,11 +315,11 @@ JNIEXPORT void JNICALL Java_nsk_jvmti_FieldAccess_fieldacc002_getReady(JNIEnv *e
     }
     for (i = 0; i < sizeof(watches)/sizeof(watch_info); i++) {
         if (watches[i].is_static == JNI_TRUE) {
-            watches[i].fid = JNI_ENV_PTR(env)->GetStaticFieldID(
-                JNI_ENV_ARG(env, cls), watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetStaticFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         } else {
-            watches[i].fid = JNI_ENV_PTR(env)->GetFieldID(
-                JNI_ENV_ARG(env, cls), watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         }
         if (watches[i].fid == NULL) {
             printf("Cannot find field \"%s\"!\n", watches[i].f_name);
@@ -368,44 +353,33 @@ Java_nsk_jvmti_FieldAccess_fieldacc002_check(JNIEnv *env, jclass clz, jobject ob
         printf(">>> accessing fields ...\n");
     }
 
-    cls = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/FieldAccess/fieldacc002a"));
+    cls = env->FindClass("nsk/jvmti/FieldAccess/fieldacc002a");
     if (cls == NULL) {
         printf("Cannot find fieldacc002a class!\n");
         return STATUS_FAILED;
     }
 
-    JNI_ENV_PTR(env)->GetStaticBooleanField(JNI_ENV_ARG(env, cls),
-        watches[0].fid);
-    JNI_ENV_PTR(env)->GetStaticByteField(JNI_ENV_ARG(env, cls),
-        watches[1].fid);
-    JNI_ENV_PTR(env)->GetStaticShortField(JNI_ENV_ARG(env, cls),
-        watches[2].fid);
-    JNI_ENV_PTR(env)->GetStaticIntField(JNI_ENV_ARG(env, cls),
-        watches[3].fid);
-    JNI_ENV_PTR(env)->GetStaticLongField(JNI_ENV_ARG(env, cls),
-        watches[4].fid);
-    JNI_ENV_PTR(env)->GetStaticFloatField(JNI_ENV_ARG(env, cls),
-        watches[5].fid);
-    JNI_ENV_PTR(env)->GetStaticDoubleField(JNI_ENV_ARG(env, cls),
-        watches[6].fid);
-    JNI_ENV_PTR(env)->GetStaticCharField(JNI_ENV_ARG(env, cls),
-        watches[7].fid);
-    JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG(env, cls),
-        watches[8].fid);
-    JNI_ENV_PTR(env)->GetStaticObjectField(JNI_ENV_ARG(env, cls),
-        watches[9].fid);
+    env->GetStaticBooleanField(cls, watches[0].fid);
+    env->GetStaticByteField(cls, watches[1].fid);
+    env->GetStaticShortField(cls, watches[2].fid);
+    env->GetStaticIntField(cls, watches[3].fid);
+    env->GetStaticLongField(cls, watches[4].fid);
+    env->GetStaticFloatField(cls, watches[5].fid);
+    env->GetStaticDoubleField(cls, watches[6].fid);
+    env->GetStaticCharField(cls, watches[7].fid);
+    env->GetStaticObjectField(cls, watches[8].fid);
+    env->GetStaticObjectField(cls, watches[9].fid);
 
-    JNI_ENV_PTR(env)->GetBooleanField(JNI_ENV_ARG(env, obj), watches[10].fid);
-    JNI_ENV_PTR(env)->GetByteField(JNI_ENV_ARG(env, obj), watches[11].fid);
-    JNI_ENV_PTR(env)->GetShortField(JNI_ENV_ARG(env, obj), watches[12].fid);
-    JNI_ENV_PTR(env)->GetIntField(JNI_ENV_ARG(env, obj), watches[13].fid);
-    JNI_ENV_PTR(env)->GetLongField(JNI_ENV_ARG(env, obj), watches[14].fid);
-    JNI_ENV_PTR(env)->GetFloatField(JNI_ENV_ARG(env, obj), watches[15].fid);
-    JNI_ENV_PTR(env)->GetDoubleField(JNI_ENV_ARG(env, obj), watches[16].fid);
-    JNI_ENV_PTR(env)->GetCharField(JNI_ENV_ARG(env, obj), watches[17].fid);
-    JNI_ENV_PTR(env)->GetObjectField(JNI_ENV_ARG(env, obj), watches[18].fid);
-    JNI_ENV_PTR(env)->GetObjectField(JNI_ENV_ARG(env, obj), watches[19].fid);
+    env->GetBooleanField(obj, watches[10].fid);
+    env->GetByteField(obj, watches[11].fid);
+    env->GetShortField(obj, watches[12].fid);
+    env->GetIntField(obj, watches[13].fid);
+    env->GetLongField(obj, watches[14].fid);
+    env->GetFloatField(obj, watches[15].fid);
+    env->GetDoubleField(obj, watches[16].fid);
+    env->GetCharField(obj, watches[17].fid);
+    env->GetObjectField(obj, watches[18].fid);
+    env->GetObjectField(obj, watches[19].fid);
 
     if (printdump == JNI_TRUE) {
         printf(">>> ... done\n");
@@ -419,6 +393,4 @@ Java_nsk_jvmti_FieldAccess_fieldacc002_check(JNIEnv *env, jclass clz, jobject ob
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FieldAccess/fieldacc003/fieldacc003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FieldAccess/fieldacc003/fieldacc003.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -237,8 +224,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -302,18 +288,18 @@ Java_nsk_jvmti_FieldAccess_fieldacc003_getReady(JNIEnv *env, jclass klass) {
         printf(">>> setting field access watches ...\n");
     }
     for (i = 0; i < sizeof(watches)/sizeof(watch_info); i++) {
-        cls = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env, watches[i].f_cls));
+        cls = env->FindClass(watches[i].f_cls);
         if (cls == NULL) {
             printf("Cannot find %s class!\n", watches[i].f_cls);
             result = STATUS_FAILED;
             return;
         }
         if (watches[i].is_static == JNI_TRUE) {
-            watches[i].fid = JNI_ENV_PTR(env)->GetStaticFieldID(
-                JNI_ENV_ARG(env, cls), watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetStaticFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         } else {
-            watches[i].fid = JNI_ENV_PTR(env)->GetFieldID(
-                JNI_ENV_ARG(env, cls), watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         }
         if (watches[i].fid == NULL) {
             printf("Cannot get field ID for \"%s:%s\"\n",
@@ -345,6 +331,4 @@ Java_nsk_jvmti_FieldAccess_fieldacc003_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FieldAccess/fieldacc004/fieldacc004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FieldAccess/fieldacc004/fieldacc004.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -223,8 +210,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -288,18 +274,18 @@ Java_nsk_jvmti_FieldAccess_fieldacc004_getReady(JNIEnv *env, jclass klass) {
         printf(">>> setting field access watches ...\n");
     }
     for (i = 0; i < sizeof(watches)/sizeof(watch_info); i++) {
-        cls = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env, watches[i].f_cls));
+        cls = env->FindClass(watches[i].f_cls);
         if (cls == NULL) {
             printf("Cannot find %s class!\n", watches[i].f_cls);
             result = STATUS_FAILED;
             return;
         }
         if (watches[i].is_static == JNI_TRUE) {
-            watches[i].fid = JNI_ENV_PTR(env)->GetStaticFieldID(
-                JNI_ENV_ARG(env, cls), watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetStaticFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         } else {
-            watches[i].fid = JNI_ENV_PTR(env)->GetFieldID(
-                JNI_ENV_ARG(env, cls), watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         }
         if (watches[i].fid == NULL) {
             printf("Cannot get field ID for \"%s:%s\"\n",
@@ -331,6 +317,4 @@ Java_nsk_jvmti_FieldAccess_fieldacc004_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FieldModification/fieldmod001/fieldmod001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FieldModification/fieldmod001/fieldmod001.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -170,8 +157,7 @@ int isEqual(JNIEnv *env, char *sig, jvalue v1, jvalue v2) {
         return (v1.d == v2.d);
     case 'L':
     case '[':
-        return (JNI_TRUE ==
-            JNI_ENV_PTR(env)->IsSameObject(JNI_ENV_ARG(env, v1.l), v2.l));
+        return env->IsSameObject(v1.l, v2.l);
     case 'Z':
         return (v1.z == v2.z);
     case 'B':
@@ -335,8 +321,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -400,8 +385,7 @@ Java_nsk_jvmti_FieldModification_fieldmod001_getReady(JNIEnv *env, jclass klass,
     if (printdump == JNI_TRUE) {
         printf(">>> setting field modification watches ...\n");
     }
-    cls = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/FieldModification/fieldmod001a"));
+    cls = env->FindClass("nsk/jvmti/FieldModification/fieldmod001a");
     if (cls == NULL) {
         printf("Cannot find fieldmod001a class!\n");
         result = STATUS_FAILED;
@@ -409,11 +393,11 @@ Java_nsk_jvmti_FieldModification_fieldmod001_getReady(JNIEnv *env, jclass klass,
     }
     for (i = 0; i < sizeof(watches)/sizeof(watch_info); i++) {
         if (watches[i].is_static == JNI_TRUE) {
-            watches[i].fid = JNI_ENV_PTR(env)->GetStaticFieldID(
-                JNI_ENV_ARG(env, cls), watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetStaticFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         } else {
-            watches[i].fid = JNI_ENV_PTR(env)->GetFieldID(
-                JNI_ENV_ARG(env, cls), watches[i].f_name, watches[i].f_sig);
+            watches[i].fid = env->GetFieldID(
+                cls, watches[i].f_name, watches[i].f_sig);
         }
         if (watches[i].fid == NULL) {
             printf("Cannot get field ID for \"%s:%s\"\n",
@@ -468,6 +452,4 @@ Java_nsk_jvmti_FieldModification_fieldmod001_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FramePop/framepop001/framepop001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FramePop/framepop001/framepop001.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -188,8 +175,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -249,8 +235,7 @@ Java_nsk_jvmti_FramePop_framepop001_check(JNIEnv *env, jclass cls) {
         return result;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-         "chain", "()V");
+    mid = env->GetStaticMethodID(cls, "chain", "()V");
     if (mid == 0) {
         printf("Cannot find Method ID for method chain\n");
         return STATUS_FAILED;
@@ -276,20 +261,18 @@ Java_nsk_jvmti_FramePop_framepop001_check(JNIEnv *env, jclass cls) {
         result = STATUS_FAILED;
     }
 
-    clz = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/FramePop/framepop001a"));
+    clz = env->FindClass("nsk/jvmti/FramePop/framepop001a");
     if (clz == NULL) {
         printf("Cannot find framepop001a class!\n");
         result = STATUS_FAILED;
         return STATUS_FAILED;
     }
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, clz),
-        "dummy", "()V");
+    mid = env->GetStaticMethodID(clz, "dummy", "()V");
     if (mid == 0) {
         printf("Cannot find Method ID for method dummy\n");
         return STATUS_FAILED;
     }
-    JNI_ENV_PTR(env)->CallStaticVoidMethod(JNI_ENV_ARG(env, clz), mid);
+    env->CallStaticVoidMethod(clz, mid);
 
     if (eventsCount != eventsExpected) {
         printf("Wrong number of frame pop events: %" PRIuPTR ", expected: %" PRIuPTR "\n",
@@ -300,6 +283,4 @@ Java_nsk_jvmti_FramePop_framepop001_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FramePop/framepop002/framepop002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/FramePop/framepop002/framepop002.cpp
@@ -29,21 +29,8 @@
 #include "JVMTITools.h"
 #include "jvmti_tools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -139,8 +126,7 @@ void pop(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr, jmethodID method, int de
     int i, count = 0;
 
     for (i = 0; i < thr_count; i++) {
-        if (JNI_ENV_PTR(env)->IsSameObject(JNI_ENV_ARG(env, threads[i].thread),
-                thr) == JNI_TRUE) {
+        if (env->IsSameObject(threads[i].thread, thr)) {
             break;
         }
     }
@@ -184,8 +170,7 @@ void push(JNIEnv *env, jthread thr, jmethodID method, int depth) {
     int i;
 
     for (i = 0; i < thr_count; i++) {
-        if (JNI_ENV_PTR(env)->IsSameObject(JNI_ENV_ARG(env, threads[i].thread),
-                thr) == JNI_TRUE) {
+        if (env->IsSameObject(threads[i].thread, thr)) {
             break;
         }
     }
@@ -332,8 +317,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -436,6 +420,4 @@ JNIEXPORT jint JNICALL Java_nsk_jvmti_FramePop_framepop002_check(JNIEnv *env, jc
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetJNIFunctionTable/getjniftab001/getjniftab001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetJNIFunctionTable/getjniftab001/getjniftab001.cpp
@@ -34,15 +34,6 @@
 
 extern "C" {
 
-
-#ifndef JNI_ENV_ARG1
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG1(x)
-  #else
-    #define JNI_ENV_ARG1(x) x
-  #endif
-#endif
-
 #define PASSED  0
 #define STATUS_FAILED  2
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetJNIFunctionTable/getjniftab002/getjniftab002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetJNIFunctionTable/getjniftab002/getjniftab002.cpp
@@ -29,15 +29,6 @@
 
 extern "C" {
 
-
-#ifndef JNI_ENV_ARG1
-  #ifdef __cplusplus
-    #define JNI_ENV_ARG1(x)
-  #else
-    #define JNI_ENV_ARG1(x) x
-  #endif
-#endif
-
 #define PASSED  0
 #define STATUS_FAILED  2
 
@@ -89,7 +80,7 @@ Java_nsk_jvmti_GetJNIFunctionTable_getjniftab002_check(JNIEnv *env, jobject obj)
        only since JDK 1.2 */
     if (verbose)
         printf("\nb) Checking the function with the detached thread ...\n\ndetaching the main thread ...\n");
-    if ((err = vm->DetachCurrentThread(JNI_ENV_ARG1(vm))) != 0)
+    if ((err = vm->DetachCurrentThread()) != 0)
         printf("(%s,%d): Warning: DetachCurrentThread() returns: %d\n\
 \tcheck with the detached main thread skipped\n",
             __FILE__, __LINE__, err);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/InterruptThread/intrpthrd002/intrpthrd002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/InterruptThread/intrpthrd002/intrpthrd002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -65,8 +52,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -124,6 +110,4 @@ Java_nsk_jvmti_InterruptThread_intrpthrd002_getResult (JNIEnv *env, jclass cls) 
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/InterruptThread/intrpthrd003/intrpthrd003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/InterruptThread/intrpthrd003/intrpthrd003.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -66,8 +53,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -140,6 +126,4 @@ Java_nsk_jvmti_InterruptThread_intrpthrd003_isThreadNotAliveError(JNIEnv *env, j
     return JNI_FALSE;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsArrayClass/isarray004/isarray004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsArrayClass/isarray004/isarray004.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -115,6 +101,4 @@ Java_nsk_jvmti_IsArrayClass_isarray004_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsArrayClass/isarray005/isarray005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsArrayClass/isarray005/isarray005.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -125,6 +111,4 @@ Java_nsk_jvmti_IsArrayClass_isarray005_getRes(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsFieldSynthetic/isfldsin002/isfldsin002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsFieldSynthetic/isfldsin002/isfldsin002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -116,7 +102,7 @@ Java_nsk_jvmti_IsFieldSynthetic_isfldsin002_check(JNIEnv *env, jclass cls) {
         return STATUS_FAILED;
     }
 
-    fid = JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, cls), "fld", "I");
+    fid = env->GetFieldID(cls, "fld", "I");
     if (fid == NULL) {
         printf("Cannot get field ID!\n");
         return STATUS_FAILED;
@@ -168,6 +154,4 @@ Java_nsk_jvmti_IsFieldSynthetic_isfldsin002_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsFieldSynthetic/isfldsin003/isfldsin003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsFieldSynthetic/isfldsin003/isfldsin003.cpp
@@ -28,21 +28,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -81,15 +68,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
-    if (res != JNI_OK || jvmti == NULL) {
-        printf("Wrong result of a valid call to GetEnv!\n");
-        return JNI_ERR;
-    }
-
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -141,8 +120,7 @@ Java_nsk_jvmti_IsFieldSynthetic_isfldsin003a_check(JNIEnv *env,
     }
 
     for (i = 0; i < sizeof(fields) / sizeof(field_info); i++) {
-        fid = JNI_ENV_PTR(env)->GetFieldID(JNI_ENV_ARG(env, clazz),
-            fields[i].name, fields[i].sig);
+        fid = env->GetFieldID(clazz, fields[i].name, fields[i].sig);
         if (fid == NULL) {
             printf("(%" PRIuPTR ") cannot get field ID for %s:\"%s\"\n",
                    i, fields[i].name, fields[i].sig);
@@ -175,6 +153,4 @@ Java_nsk_jvmti_IsFieldSynthetic_isfldsin003a_check(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsInterface/isintrf004/isintrf004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsInterface/isintrf004/isintrf004.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -115,6 +101,4 @@ Java_nsk_jvmti_IsInterface_isintrf004_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsInterface/isintrf005/isintrf005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsInterface/isintrf005/isintrf005.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -123,6 +109,4 @@ JNIEXPORT int JNICALL Java_nsk_jvmti_IsInterface_isintrf005_getRes(JNIEnv *env, 
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsMethodNative/isnative001/isnative001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsMethodNative/isnative001/isnative001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -89,9 +75,9 @@ void checkMeth(JNIEnv *env, jclass cl,
     jboolean is_native;
 
     if (stat) {
-        mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cl), name, sig);
+        mid = env->GetStaticMethodID(cl, name, sig);
     } else {
-        mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cl), name, sig);
+        mid = env->GetMethodID(cl, name, sig);
     }
     if (mid == NULL) {
         printf("Cannot find MethodID for \"%s%s\"\n", name, sig);
@@ -129,8 +115,7 @@ Java_nsk_jvmti_IsMethodNative_isnative001_check(JNIEnv *env, jclass cls) {
     checkMeth(env, cls, "nmeth", "()V", 0, JNI_TRUE);
     checkMeth(env, cls, "check", "()I", 1, JNI_TRUE);
 
-    clsId = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/IsMethodNative/isnative001$Inn"));
+    clsId = env->FindClass("nsk/jvmti/IsMethodNative/isnative001$Inn");
     if (clsId == NULL) {
         printf("Cannot find nsk.jvmti.IsMethodNative.isnative001$Inn class!\n");
         return STATUS_FAILED;
@@ -141,6 +126,4 @@ Java_nsk_jvmti_IsMethodNative_isnative001_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsMethodNative/isnative002/isnative002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsMethodNative/isnative002/isnative002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -68,8 +55,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -89,8 +75,7 @@ Java_nsk_jvmti_IsMethodNative_isnative002_check(JNIEnv *env, jclass cls) {
         return STATUS_FAILED;
     }
 
-    mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-        "<init>", "()V");
+    mid = env->GetMethodID(cls, "<init>", "()V");
     if (mid == NULL) {
         printf("Cannot get method ID!\n");
         return STATUS_FAILED;
@@ -123,6 +108,4 @@ Java_nsk_jvmti_IsMethodNative_isnative002_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsMethodSynthetic/issynth001/issynth001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsMethodSynthetic/issynth001/issynth001.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -93,8 +80,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -149,11 +135,9 @@ Java_nsk_jvmti_IsMethodSynthetic_issynth001a_check(JNIEnv *env,
         cl = ((methods[i].class_id == 1) ? cls1 :
                 ((methods[i].class_id == 2) ? cls2 : cls3));
         if (methods[i].is_static == JNI_TRUE) {
-            mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cl),
-                methods[i].name, methods[i].signature);
+            mid = env->GetStaticMethodID(cl, methods[i].name, methods[i].signature);
         } else {
-            mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cl),
-                methods[i].name, methods[i].signature);
+            mid = env->GetMethodID(cl, methods[i].name, methods[i].signature);
         }
         if (mid == NULL) {
             printf("Cannot find MethodID for \"%s%s\"\n",
@@ -190,6 +174,4 @@ JNIEXPORT void JNICALL
 Java_nsk_jvmti_IsMethodSynthetic_issynth001a_nmeth(JNIEnv *env, jclass cls) {
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsMethodSynthetic/issynth002/issynth002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsMethodSynthetic/issynth002/issynth002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -70,8 +57,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -116,8 +102,7 @@ Java_nsk_jvmti_IsMethodSynthetic_issynth002_check(JNIEnv *env, jclass cls) {
         return STATUS_FAILED;
     }
 
-    mid = JNI_ENV_PTR(env)->GetMethodID(JNI_ENV_ARG(env, cls),
-        "<init>", "()V");
+    mid = env->GetMethodID(cls, "<init>", "()V");
     if (mid == NULL) {
         printf("Cannot find method \"<init>()V\"!\n");
         return STATUS_FAILED;
@@ -156,6 +141,4 @@ Java_nsk_jvmti_IsMethodSynthetic_issynth002_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MethodEntry/mentry001/mentry001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MethodEntry/mentry001/mentry001.cpp
@@ -29,21 +29,7 @@
 #include "jni_tools.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -170,8 +156,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -240,14 +225,13 @@ JNIEXPORT jint JNICALL
 Java_nsk_jvmti_MethodEntry_mentry001_check(JNIEnv *env, jclass cls) {
     jmethodID mid;
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-        "dummy", "()V");
+    mid = env->GetStaticMethodID(cls, "dummy", "()V");
     if (mid == NULL) {
         printf("Cannot find metod \"dummy()\"!\n");
         return STATUS_FAILED;
     }
 
-    JNI_ENV_PTR(env)->CallStaticVoidMethod(JNI_ENV_ARG(env, cls), mid);
+    env->CallStaticVoidMethod(cls, mid);
     if (eventsCount != eventsExpected) {
         printf("Wrong number of MethodEntry events: %" PRIuPTR ", expected: %" PRIuPTR "\n",
             eventsCount, eventsExpected);
@@ -279,6 +263,4 @@ Java_nsk_jvmti_MethodEntry_mentry001_chain(JNIEnv *env, jclass cls) {
     }
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MethodEntry/mentry002/mentry002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MethodEntry/mentry002/mentry002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -91,8 +78,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -150,8 +136,7 @@ Java_nsk_jvmti_MethodEntry_mentry002_getReady(JNIEnv *env, jclass cls, jint i) {
         return;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, cls),
-            "emptyMethod", "()V");
+    mid = env->GetStaticMethodID(cls, "emptyMethod", "()V");
     if (mid == NULL) {
         printf("Cannot find Method ID for emptyMethod\n");
         result = STATUS_FAILED;
@@ -198,6 +183,4 @@ Java_nsk_jvmti_MethodEntry_mentry002_check(JNIEnv *env, jclass cls) {
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MethodExit/mexit001/mexit001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MethodExit/mexit001/mexit001.cpp
@@ -29,21 +29,8 @@
 #include "jni_tools.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -172,8 +159,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -252,21 +238,19 @@ Java_nsk_jvmti_MethodExit_mexit001_check(JNIEnv *env, jclass cls) {
         return result;
     }
 
-    clz = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/MethodExit/mexit001a"));
+    clz = env->FindClass("nsk/jvmti/MethodExit/mexit001a");
     if (clz == NULL) {
         printf("Cannot find nsk.jvmti.MethodExit.mexit001a class!\n");
         return STATUS_FAILED;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, clz),
-        "dummy", "()V");
+    mid = env->GetStaticMethodID(clz, "dummy", "()V");
     if (mid == NULL) {
         printf("Cannot find metod \"dummy()\"!\n");
         return STATUS_FAILED;
     }
 
-    JNI_ENV_PTR(env)->CallStaticVoidMethod(JNI_ENV_ARG(env, clz), mid);
+    env->CallStaticVoidMethod(clz, mid);
 
     err = jvmti->SetEventNotificationMode(JVMTI_DISABLE,
             JVMTI_EVENT_METHOD_EXIT, NULL);
@@ -289,6 +273,4 @@ Java_nsk_jvmti_MethodExit_mexit001a_chain(JNIEnv *env, jclass cls) {
     printf("Executing chain()\n");
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MethodExit/mexit002/mexit002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MethodExit/mexit002/mexit002.cpp
@@ -29,21 +29,8 @@
 #include "jni_tools.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -172,8 +159,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printdump = JNI_TRUE;
     }
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -230,15 +216,13 @@ Java_nsk_jvmti_MethodExit_mexit002_check(JNIEnv *env, jclass cls) {
         return result;
     }
 
-    clz = JNI_ENV_PTR(env)->FindClass(JNI_ENV_ARG(env,
-        "nsk/jvmti/MethodExit/mexit002a"));
+    clz = env->FindClass("nsk/jvmti/MethodExit/mexit002a");
     if (clz == NULL) {
         printf("Failed to find class \"mexit002a\"!\n");
         return STATUS_FAILED;
     }
 
-    mid = JNI_ENV_PTR(env)->GetStaticMethodID(JNI_ENV_ARG(env, clz),
-        "dummy", "()V");
+    mid = env->GetStaticMethodID(clz, "dummy", "()V");
     if (mid == NULL) {
         printf("Failed to get method \"dummy\"!\n");
         return STATUS_FAILED;
@@ -254,7 +238,7 @@ Java_nsk_jvmti_MethodExit_mexit002_check(JNIEnv *env, jclass cls) {
         result = STATUS_FAILED;
     }
 
-    JNI_ENV_PTR(env)->CallStaticVoidMethod(JNI_ENV_ARG(env, clz), mid);
+    env->CallStaticVoidMethod(clz, mid);
 
     err = jvmti->SetEventNotificationMode(JVMTI_DISABLE,
             JVMTI_EVENT_METHOD_EXIT, NULL);
@@ -279,6 +263,4 @@ Java_nsk_jvmti_MethodExit_mexit002a_chain(JNIEnv *env, jclass cls) {
     }
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NotifyFramePop/nframepop002/nframepop002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NotifyFramePop/nframepop002/nframepop002.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -65,8 +52,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -123,6 +109,4 @@ Java_nsk_jvmti_NotifyFramePop_nframepop002_check(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NotifyFramePop/nframepop003/nframepop003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NotifyFramePop/nframepop003/nframepop003.cpp
@@ -27,21 +27,8 @@
 #include "agent_common.h"
 #include "JVMTITools.h"
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
-#ifndef JNI_ENV_ARG
-
-#ifdef __cplusplus
-#define JNI_ENV_ARG(x, y) y
-#define JNI_ENV_PTR(x) x
-#else
-#define JNI_ENV_ARG(x,y) x, y
-#define JNI_ENV_PTR(x) (*x)
-#endif
-
-#endif
 
 #define PASSED 0
 #define STATUS_FAILED 2
@@ -65,8 +52,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
     jvmtiError err;
 
-    res = JNI_ENV_PTR(jvm)->GetEnv(JNI_ENV_ARG(jvm, (void **) &jvmti),
-        JVMTI_VERSION_1_1);
+    res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
         return JNI_ERR;
@@ -133,6 +119,4 @@ Java_nsk_jvmti_NotifyFramePop_nframepop003_check(JNIEnv *env,
     return result;
 }
 
-#ifdef __cplusplus
 }
-#endif


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210385](https://bugs.openjdk.java.net/browse/JDK-8210385): Clean up JNI_ENV_ARG and factorize the macros for vmTestbase/jvmti[A-N] tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/655/head:pull/655` \
`$ git checkout pull/655`

Update a local copy of the PR: \
`$ git checkout pull/655` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 655`

View PR using the GUI difftool: \
`$ git pr show -t 655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/655.diff">https://git.openjdk.java.net/jdk11u-dev/pull/655.diff</a>

</details>
