### PR TITLE
8210984: [TESTBUG] hs203t003 fails with "# ERROR: hs203t003.cpp, 218: NSK_CPP_STUB2 ( ResumeThread, jvmti, thread)"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t003/hs203t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t003/hs203t003.cpp
@@ -174,6 +174,23 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     return JNI_OK;
 }
 
+JNIEXPORT jboolean JNICALL
+Java_nsk_jvmti_scenarios_hotswap_HS203_hs203t003_hs203t003_isSuspended(JNIEnv * jni,
+        jclass clas,
+        jthread thread) {
+    jboolean retvalue;
+    jint state;
+    retvalue = JNI_FALSE;
+    if ( ! NSK_JVMTI_VERIFY( NSK_CPP_STUB3(GetThreadState, jvmti, thread, &state) )  ) {
+        nsk_printf(" Agent :: Error while getting thread state.\n");
+        nsk_jvmti_agentFailed();
+    } else {
+        if ( state & JVMTI_THREAD_STATE_SUSPENDED) {
+          retvalue = JNI_TRUE;
+        }
+    }
+    return retvalue;
+}
 
 JNIEXPORT jboolean JNICALL
 Java_nsk_jvmti_scenarios_hotswap_HS203_hs203t003_hs203t003_popThreadFrame(JNIEnv * jni,


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210984](https://bugs.openjdk.java.net/browse/JDK-8210984): [TESTBUG] hs203t003 fails with "# ERROR: hs203t003.cpp, 218: NSK_CPP_STUB2 ( ResumeThread, jvmti, thread)"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/656/head:pull/656` \
`$ git checkout pull/656`

Update a local copy of the PR: \
`$ git checkout pull/656` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 656`

View PR using the GUI difftool: \
`$ git pr show -t 656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/656.diff">https://git.openjdk.java.net/jdk11u-dev/pull/656.diff</a>

</details>
