### PR TITLE
8211261: Remove the NSK_CPP_STUB macros from vmTestbase for jvmti/[A-G]*

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddCapabilities/addcaps001/addcaps001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddCapabilities/addcaps001/addcaps001.cpp
@@ -192,8 +192,7 @@ static int checkCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* initCaps, const
     memset(&caps, 0, sizeof(jvmtiCapabilities));
 
     NSK_DISPLAY0("GetCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps))) {
         return NSK_FALSE;
     }
 
@@ -216,8 +215,7 @@ static int checkCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* initCaps, const
  */
 static int addCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps, const char where[]) {
     NSK_DISPLAY0("AddCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(AddCapabilities, jvmti, caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(caps))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... set\n");
@@ -314,9 +312,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddCapabilities/addcaps002/addcaps002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddCapabilities/addcaps002/addcaps002.cpp
@@ -192,8 +192,7 @@ static int checkCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* initCaps, const
     memset(&caps, 0, sizeof(jvmtiCapabilities));
 
     NSK_DISPLAY0("GetCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps))) {
         return NSK_FALSE;
     }
 
@@ -216,8 +215,7 @@ static int checkCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* initCaps, const
  */
 static int addCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps, const char where[]) {
     NSK_DISPLAY0("AddCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(AddCapabilities, jvmti, caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(caps))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... set\n");
@@ -231,8 +229,7 @@ static int addCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps, const char 
  */
 static int getPotentialCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps) {
     NSK_DISPLAY0("GetPotentialCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(caps))) {
         return NSK_FALSE;
     }
 
@@ -334,9 +331,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddCapabilities/addcaps003/addcaps003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AddCapabilities/addcaps003/addcaps003.cpp
@@ -57,8 +57,7 @@ static int checkCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* initCaps, const
     memset(&caps, 0, sizeof(jvmtiCapabilities));
 
     NSK_DISPLAY0("GetCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps))) {
         return NSK_FALSE;
     }
 
@@ -71,8 +70,7 @@ static int checkCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* initCaps, const
  */
 static int addCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps, const char where[]) {
     NSK_DISPLAY0("AddCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(AddCapabilities, jvmti, caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(caps))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... set\n");
@@ -86,8 +84,7 @@ static int addCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps, const char 
  */
 static int getPotentialCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps) {
     NSK_DISPLAY0("GetPotentialCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(caps))) {
         return NSK_FALSE;
     }
 
@@ -183,9 +180,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002/attach002Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002/attach002Agent00.cpp
@@ -74,12 +74,12 @@ int registerNativeMethods(JNIEnv* jni) {
     jint nativeMethodsNumber = 1;
 
     if (!NSK_JNI_VERIFY(jni, (appClass =
-        NSK_CPP_STUB2(FindClass, jni, ATTACH002_TARGET_APP_CLASS_NAME)) != NULL)) {
+        jni->FindClass(ATTACH002_TARGET_APP_CLASS_NAME)) != NULL)) {
         return NSK_FALSE;
     }
 
     if (!NSK_JNI_VERIFY(jni,
-            (NSK_CPP_STUB4(RegisterNatives, jni, appClass, nativeMethods, nativeMethodsNumber) == 0))) {
+            (jni->RegisterNatives(appClass, nativeMethods, nativeMethodsNumber) == 0))) {
         return NSK_FALSE;
     }
 
@@ -205,7 +205,7 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_all_class_hook_events = 1;
     caps.can_redefine_classes = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)) ) {
         /*
          * If VM is run with -Xshare:on agent can't get required capabilities (see 6718407)
          */
@@ -222,7 +222,7 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
         eventCallbacks.ClassLoad = classLoadHandler;
         eventCallbacks.ClassPrepare = classPrepareHandler;
         eventCallbacks.ClassFileLoadHook = classFileLoadHoockHandler;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/attach002aAgent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach002a/attach002aAgent00.cpp
@@ -106,13 +106,13 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
     memset(&caps, 0, sizeof(caps));
     caps.can_redefine_classes = 1;
     caps.can_generate_vm_object_alloc_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)) ) {
         return JNI_ERR;
     }
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.VMObjectAlloc = vmObjectAllocHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach008/attach008Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach008/attach008Agent00.cpp
@@ -123,14 +123,14 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_monitor_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)) ) {
         return JNI_ERR;
     }
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.MonitorContendedEntered = monitorContentedEnteredHandler;
     eventCallbacks.MonitorContendedEnter = monitorContentedEnterHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach009/attach009Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach009/attach009Agent00.cpp
@@ -82,8 +82,7 @@ classLoadHandler(jvmtiEnv *jvmti,
             return;
         }
 
-        if (!NSK_JVMTI_VERIFY( NSK_CPP_STUB4(
-                SetEventNotificationMode, jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, thread) ) ) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, thread) ) ) {
             NSK_COMPLAIN1("Failed to enable events for thread '%s'\n", mainThreadName);
             nsk_aod_agentFinished(jni, agentName, 0);
             return;
@@ -142,7 +141,7 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ClassLoad = classLoadHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach012/attach012Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach012/attach012Agent00.cpp
@@ -65,7 +65,7 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(vm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)) ) {
         return JNI_ERR;
     }
 
@@ -75,7 +75,7 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
 
     NSK_DISPLAY1("%s: trying to get all potential capabilities:\n", agentName);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach014/attach014Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach014/attach014Agent00.cpp
@@ -62,7 +62,7 @@ classLoadHandler(jvmtiEnv *jvmti,
         if (!nsk_jvmti_aod_disableEvent(jvmti, JVMTI_EVENT_CLASS_LOAD))
             success = 0;
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB1(DisposeEnvironment, jvmti))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->DisposeEnvironment())) {
             success = 0;
             NSK_COMPLAIN1("%s: failed to dispose environment\n", agentName);
         } else {
@@ -104,7 +104,7 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ClassLoad = classLoadHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/attach015Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/attach015Agent00.cpp
@@ -97,7 +97,7 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ClassPrepare = classPrepareHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/attach015Agent01.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/attach015Agent01.cpp
@@ -97,7 +97,7 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ClassLoad = classLoadHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/attach015Target.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach015/attach015Target.cpp
@@ -37,7 +37,7 @@ extern "C" {
  */
 JNIEXPORT jboolean JNICALL
 Java_nsk_jvmti_AttachOnDemand_attach015_attach015Target_loadClassFromNative(JNIEnv * jni, jclass klass) {
-    return NSK_CPP_STUB2(FindClass, jni, LOADED_CLASS_NAME) ? JNI_TRUE : JNI_FALSE;
+    return jni->FindClass(LOADED_CLASS_NAME) ? JNI_TRUE : JNI_FALSE;
 }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach020/attach020Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach020/attach020Agent00.cpp
@@ -71,17 +71,15 @@ void JNICALL garbageCollectionFinishHandler(jvmtiEnv *jvmti) {
         success = 0;
     }
 
-    if (NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-            RawMonitorEnter, jvmti, gcFinishMonitor))) {
+    if (NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(gcFinishMonitor))) {
 
         gcFinishEventReceived = 1;
 
-        if (NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                RawMonitorNotify, jvmti, gcFinishMonitor))) {
+        if (NSK_JVMTI_VERIFY(jvmti->RawMonitorNotify(gcFinishMonitor))) {
             auxiliaryThreadNotified = 1;
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, gcFinishMonitor))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(gcFinishMonitor))) {
             success = 0;
         }
     } else {
@@ -96,17 +94,15 @@ void JNICALL garbageCollectionFinishHandler(jvmtiEnv *jvmti) {
 void JNICALL auxiliaryThreadFunction(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     NSK_DISPLAY1("%s: auxiliary thread is running\n", agentName);
 
-    if (NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-            RawMonitorEnter, jvmti, gcFinishMonitor))) {
+    if (NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(gcFinishMonitor))) {
 
         if (!gcFinishEventReceived) {
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(
-                    RawMonitorWait, jvmti, gcFinishMonitor, 0))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorWait(gcFinishMonitor, 0))) {
                 success = 0;
             }
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, gcFinishMonitor))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(gcFinishMonitor))) {
             success = 0;
         }
     } else {
@@ -122,8 +118,7 @@ int startAuxiliaryThread(jvmtiEnv* jvmti, JNIEnv* jni) {
     if (!NSK_VERIFY((thread = nsk_jvmti_aod_createThread(jni)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(
-            RunAgentThread, jvmti, thread, auxiliaryThreadFunction, NULL, JVMTI_THREAD_NORM_PRIORITY ))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RunAgentThread(thread, auxiliaryThreadFunction, NULL, JVMTI_THREAD_NORM_PRIORITY ))) {
         return NSK_FALSE;
     }
 
@@ -161,7 +156,7 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(vm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor, jvmti, "GCFinishMonitor", &gcFinishMonitor))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("GCFinishMonitor", &gcFinishMonitor))) {
         return JNI_ERR;
     }
 
@@ -170,14 +165,14 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_garbage_collection_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)) ) {
         return JNI_ERR;
     }
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.GarbageCollectionStart  = garbageCollectionStartHandler;
     eventCallbacks.GarbageCollectionFinish = garbageCollectionFinishHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach021/attach021Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach021/attach021Agent00.cpp
@@ -56,7 +56,7 @@ volatile int success = 0;
 JNIEXPORT jboolean JNICALL
 Java_nsk_jvmti_AttachOnDemand_attach021_attach021Target_setTagFor(JNIEnv * jni,
         jclass klass, jobject obj) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, obj, TAG_VALUE))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(obj, TAG_VALUE))) {
         return JNI_FALSE;
     }
 
@@ -95,12 +95,12 @@ int registerNativeMethods(JNIEnv* jni) {
     jint nativeMethodsNumber = 2;
 
     if (!NSK_JNI_VERIFY(jni, (appClass =
-        NSK_CPP_STUB2(FindClass, jni, ATTACH021_TARGET_APP_CLASS_NAME)) != NULL)) {
+        jni->FindClass(ATTACH021_TARGET_APP_CLASS_NAME)) != NULL)) {
         return NSK_FALSE;
     }
 
     if (!NSK_JNI_VERIFY(jni,
-            (NSK_CPP_STUB4(RegisterNatives, jni, appClass, nativeMethods, nativeMethodsNumber) == 0))) {
+            (jni->RegisterNatives(appClass, nativeMethods, nativeMethodsNumber) == 0))) {
         return NSK_FALSE;
     }
 
@@ -142,13 +142,13 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
     memset(&caps, 0, sizeof(caps));
     caps.can_tag_objects = 1;
     caps.can_generate_object_free_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)) ) {
         return JNI_ERR;
     }
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ObjectFree = objectFreeHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach022/attach022Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach022/attach022Agent00.cpp
@@ -84,12 +84,10 @@ Java_nsk_jvmti_AttachOnDemand_attach022_attach022Target_shutdownAgent(JNIEnv * j
 void JNICALL objectFreeHandler(jvmtiEnv *jvmti, jlong tag) {
     NSK_DISPLAY2("%s: ObjectFree event received (object tag: %ld)\n", agentName, tag);
 
-    if (NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-            RawMonitorEnter, jvmti, objectFreeMonitor))) {
-
+    if (NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(objectFreeMonitor))) {
         freedObjectsCounter++;
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, objectFreeMonitor))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(objectFreeMonitor))) {
             success = 0;
         }
     } else {
@@ -107,12 +105,12 @@ int registerNativeMethods(JNIEnv* jni) {
     jint nativeMethodsNumber = 1;
 
     if (!NSK_JNI_VERIFY(jni, (appClass =
-        NSK_CPP_STUB2(FindClass, jni, ATTACH022_TARGET_APP_CLASS_NAME)) != NULL)) {
+        jni->FindClass(ATTACH022_TARGET_APP_CLASS_NAME)) != NULL)) {
         return NSK_FALSE;
     }
 
     if (!NSK_JNI_VERIFY(jni,
-            (NSK_CPP_STUB4(RegisterNatives, jni, appClass, nativeMethods, nativeMethodsNumber) == 0))) {
+            (jni->RegisterNatives(appClass, nativeMethods, nativeMethodsNumber) == 0))) {
         return NSK_FALSE;
     }
 
@@ -136,12 +134,10 @@ void JNICALL vmObjectAllocHandler(jvmtiEnv * jvmti,
     NSK_DISPLAY2("%s: ObjectAlloc event received (object class: %s)\n", agentName, className);
 
     if (!strcmp(className, OBJECTS_FOR_ALLOCATION_TEST_CLASS_NAME)) {
-        if (NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                RawMonitorEnter, jvmti, objectTagMonitor))) {
+        if (NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(objectTagMonitor))) {
             jlong tagValue = taggedObjectsCounter + 1;
 
-
-            if (!NSK_JVMTI_VERIFY( NSK_CPP_STUB3(SetTag, jvmti, object, tagValue))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->SetTag(object, tagValue))) {
                 NSK_COMPLAIN1("%s: failed to set tag\n", agentName);
                 success = 0;
             } else {
@@ -149,7 +145,7 @@ void JNICALL vmObjectAllocHandler(jvmtiEnv * jvmti,
                 taggedObjectsCounter++;
             }
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, objectTagMonitor))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(objectTagMonitor))) {
                 success = 0;
             }
         } else {
@@ -195,11 +191,11 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor, jvmti, "ObjectTagMonitor", &objectTagMonitor))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("ObjectTagMonitor", &objectTagMonitor))) {
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor, jvmti, "ObjectFreeMonitor", &objectFreeMonitor))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("ObjectFreeMonitor", &objectFreeMonitor))) {
         return JNI_ERR;
     }
 
@@ -207,14 +203,14 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
     caps.can_tag_objects = 1;
     caps.can_generate_object_free_events = 1;
     caps.can_generate_vm_object_alloc_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)) ) {
         return JNI_ERR;
     }
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ObjectFree = objectFreeHandler;
     eventCallbacks.VMObjectAlloc = vmObjectAllocHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach037/attach037Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach037/attach037Agent00.cpp
@@ -122,14 +122,14 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_monitor_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)) ) {
         return JNI_ERR;
     }
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.MonitorWaited = monitorWaitedHandler;
     eventCallbacks.MonitorWait = monitorWaitHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach038/attach038Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach038/attach038Agent00.cpp
@@ -119,7 +119,7 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ThreadEnd = threadEndHandler;
     eventCallbacks.ThreadStart = threadStartHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach039/attach039Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach039/attach039Agent00.cpp
@@ -68,8 +68,7 @@ int startNewThread(jvmtiEnv* jvmti, JNIEnv* jni) {
     if (!NSK_VERIFY((thread = nsk_jvmti_aod_createThreadWithName(jni, STARTED_THREAD_NAME)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(
-            RunAgentThread, jvmti, thread, startedThreadFunction, NULL, JVMTI_THREAD_NORM_PRIORITY ))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RunAgentThread(thread, startedThreadFunction, NULL, JVMTI_THREAD_NORM_PRIORITY ))) {
         return NSK_FALSE;
     }
 
@@ -155,7 +154,7 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ThreadEnd = threadEndHandler;
     eventCallbacks.ThreadStart = threadStartHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach040/attach040Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach040/attach040Agent00.cpp
@@ -66,7 +66,7 @@ void JNICALL threadStartHandler(jvmtiEnv *jvmti,
 
     NSK_DISPLAY2("%s: ThreadStart event was received for thread '%s'\n", agentName, startedThreadName);
 
-    if (NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetAllThreads, jvmti, &threadsCount, &threads))) {
+    if (NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threadsCount, &threads))) {
         int startedThreadWasFound = 0;
 
         for (i = 0; i < threadsCount; i++) {
@@ -94,8 +94,7 @@ void JNICALL threadStartHandler(jvmtiEnv *jvmti,
     }
 
     if (strstr(startedThreadName, TEST_THREAD_NAME_PREFIX)) {
-        if (NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                RawMonitorEnter, jvmti, threadsCounterMonitor))) {
+        if (NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(threadsCounterMonitor))) {
 
             testThreadsCounter++;
 
@@ -103,7 +102,7 @@ void JNICALL threadStartHandler(jvmtiEnv *jvmti,
                 nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_THREAD_START, success, jvmti, jni);
             }
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, threadsCounterMonitor))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(threadsCounterMonitor))) {
                 success = 0;
             }
         } else {
@@ -145,13 +144,13 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(vm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor, jvmti, "threadsCounterMonitor", &threadsCounterMonitor))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("threadsCounterMonitor", &threadsCounterMonitor))) {
         return JNI_ERR;
     }
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ThreadStart = threadStartHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach041/attach041Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach041/attach041Agent00.cpp
@@ -52,7 +52,7 @@ int tryFindThread(jvmtiEnv *jvmti, jthreadGroup group, const char* threadNameToF
     int i;
     char threadGroupName[MAX_STRING_LENGTH];
 
-    if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadGroupInfo, jvmti, group, &groupInfo))) {
+    if(!NSK_JVMTI_VERIFY(jvmti->GetThreadGroupInfo(group, &groupInfo))) {
         return 0;
     }
 
@@ -61,7 +61,7 @@ int tryFindThread(jvmtiEnv *jvmti, jthreadGroup group, const char* threadNameToF
 
     NSK_DISPLAY3("%s: trying to find thread '%s' in group '%s'\n", agentName, threadNameToFind, threadGroupName);
 
-    if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB6(GetThreadGroupChildren, jvmti, group, &threadsCount, &threads, &groupsCount, &groups))) {
+    if(!NSK_JVMTI_VERIFY(jvmti->GetThreadGroupChildren(group, &threadsCount, &threads, &groupsCount, &groups))) {
         return 0;
     }
 
@@ -118,7 +118,7 @@ void JNICALL threadStartHandler(jvmtiEnv *jvmti,
         jthreadGroup *topGroups;
         int i;
 
-        if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetTopThreadGroups, jvmti, &groupsCount, &topGroups))) {
+        if(!NSK_JVMTI_VERIFY(jvmti->GetTopThreadGroups(&groupsCount, &topGroups))) {
             NSK_COMPLAIN1("%s: failed to get top thread groups\n", agentName);
             nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_THREAD_START, 0, jvmti, jni);
             return;
@@ -172,7 +172,7 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ThreadStart = threadStartHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach042/attach042Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach042/attach042Agent00.cpp
@@ -62,7 +62,7 @@ void JNICALL threadStartHandler(jvmtiEnv *jvmti,
         int i;
         int startedThreadWasFound = 0;
 
-        if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetAllThreads, jvmti, &threadsCount, &threads))) {
+        if(!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threadsCount, &threads))) {
             NSK_COMPLAIN1("%s: failed to get all threads\n", agentName);
             nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_THREAD_START, 0, jvmti, jni);
             return;
@@ -85,7 +85,7 @@ void JNICALL threadStartHandler(jvmtiEnv *jvmti,
                 startedThreadWasFound = 1;
             }
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadState, jvmti, threads[i], &threadState))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(threads[i], &threadState))) {
                 NSK_COMPLAIN2("%s: failed to get status of thread '%s'\n", agentName, threadName);
                 nsk_jvmti_aod_deallocate(jvmti, (unsigned char*)threads);
                 nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_THREAD_START, 0, jvmti, jni);
@@ -136,7 +136,7 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ThreadStart = threadStartHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent00.cpp
@@ -57,8 +57,7 @@ void JNICALL classLoadHandler(
         return;
     }
 
-    if (NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-            RawMonitorEnter, jvmti, eventsCounterMonitor))) {
+    if (NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(eventsCounterMonitor))) {
 
         eventsCounter++;
 
@@ -69,7 +68,7 @@ void JNICALL classLoadHandler(
             nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_CLASS_LOAD, success, jvmti, jni);
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, eventsCounterMonitor))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(eventsCounterMonitor))) {
             success = 0;
         }
     } else {
@@ -109,13 +108,13 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(vm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor, jvmti, "attach045-agent00-eventsCounterMonitor", &eventsCounterMonitor))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("attach045-agent00-eventsCounterMonitor", &eventsCounterMonitor))) {
         return JNI_ERR;
     }
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ClassLoad = classLoadHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent01.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent01.cpp
@@ -59,7 +59,7 @@ void JNICALL classPrepareHandler(
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetLoadedClasses, jvmti, &loadedClassesCount, &loadedClasses))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetLoadedClasses(&loadedClassesCount, &loadedClasses))) {
         NSK_COMPLAIN1("%s: failed to get loaded classes\n", agentName);
         nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_CLASS_PREPARE, 0, jvmti, jni);
         return;
@@ -67,8 +67,7 @@ void JNICALL classPrepareHandler(
 
     nsk_jvmti_aod_deallocate(jvmti, (unsigned char*)loadedClasses);
 
-    if (NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-            RawMonitorEnter, jvmti, eventsCounterMonitor))) {
+    if (NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(eventsCounterMonitor))) {
 
         eventsCounter++;
 
@@ -80,7 +79,7 @@ void JNICALL classPrepareHandler(
             nsk_jvmti_aod_disableEventAndFinish(agentName, JVMTI_EVENT_CLASS_PREPARE, success, jvmti, jni);
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, eventsCounterMonitor))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(eventsCounterMonitor))) {
             success = 0;
         }
     } else {
@@ -120,13 +119,13 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(vm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor, jvmti, "attach045-agent01-eventsCounterMonitor", &eventsCounterMonitor))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("attach045-agent01-eventsCounterMonitor", &eventsCounterMonitor))) {
         return JNI_ERR;
     }
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ClassPrepare = classPrepareHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent02.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent02.cpp
@@ -62,7 +62,7 @@ void eventHandler(jvmtiEnv *jvmti,
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetAllThreads, jvmti, &threadsCount, &threads))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threadsCount, &threads))) {
         NSK_COMPLAIN1("%s: failed to get all threads\n", agentName);
         nsk_jvmti_aod_disableEventsAndFinish(agentName, testEvents, testEventsNumber, 0, jvmti, jni);
         return;
@@ -70,8 +70,7 @@ void eventHandler(jvmtiEnv *jvmti,
 
     nsk_jvmti_aod_deallocate(jvmti, (unsigned char*)threads);
 
-    if (NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-            RawMonitorEnter, jvmti, eventsCounterMonitor))) {
+    if (NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(eventsCounterMonitor))) {
 
         eventsCounter++;
 
@@ -86,7 +85,7 @@ void eventHandler(jvmtiEnv *jvmti,
             nsk_jvmti_aod_disableEventsAndFinish(agentName, testEvents, testEventsNumber, success, jvmti, jni);
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, eventsCounterMonitor))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(eventsCounterMonitor))) {
             success = 0;
         }
     } else {
@@ -140,14 +139,14 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(vm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor, jvmti, "attach045-agent02-eventsCounterMonitor", &eventsCounterMonitor))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("attach045-agent02-eventsCounterMonitor", &eventsCounterMonitor))) {
         return JNI_ERR;
     }
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ThreadStart = threadStartHandler;
     eventCallbacks.ThreadEnd = threadEndHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent03.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach045/attach045Agent03.cpp
@@ -68,8 +68,7 @@ VMObjectAllocHandler(jvmtiEnv *jvmti,
         return;
     }
 
-    if (NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-            RawMonitorEnter, jvmti, eventsCounterMonitor))) {
+    if (NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(eventsCounterMonitor))) {
 
         eventsCounter++;
 
@@ -79,7 +78,7 @@ VMObjectAllocHandler(jvmtiEnv *jvmti,
         if ((eventsCounter % 10) == 0) {
             NSK_DISPLAY1("%s: force garbage collection\n", agentName);
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB1(ForceGarbageCollection, jvmti)))
+            if (!NSK_JVMTI_VERIFY(jvmti->ForceGarbageCollection()))
                 success = 0;
         }
 
@@ -89,7 +88,7 @@ VMObjectAllocHandler(jvmtiEnv *jvmti,
             nsk_jvmti_aod_disableEventsAndFinish(agentName, testEvents, testEventsNumber, success, jvmti, jni);
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, eventsCounterMonitor))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(eventsCounterMonitor))) {
             success = 0;
         }
     } else {
@@ -130,19 +129,19 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(vm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor, jvmti, "attach045-agent03-eventsCounterMonitor", &eventsCounterMonitor))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("attach045-agent03-eventsCounterMonitor", &eventsCounterMonitor))) {
         return JNI_ERR;
     }
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_vm_object_alloc_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)) ) {
         return JNI_ERR;
     }
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.VMObjectAlloc = VMObjectAllocHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach046/attach046Agent00.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/AttachOnDemand/attach046/attach046Agent00.cpp
@@ -113,13 +113,13 @@ Agent_OnAttach(JavaVM *vm, char *optionsString, void *reserved)
 
     memset(&caps, 0, sizeof(caps));
     caps.can_redefine_classes = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)) ) {
         return JNI_ERR;
     }
 
     memset(&eventCallbacks,0, sizeof(eventCallbacks));
     eventCallbacks.ClassLoad = classLoadHandler;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &eventCallbacks, sizeof(eventCallbacks))) ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))) ) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Breakpoint/breakpoint001/breakpoint001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Breakpoint/breakpoint001/breakpoint001.cpp
@@ -67,15 +67,11 @@ static void setBP(jvmtiEnv *jvmti_env, JNIEnv *env, jclass klass) {
     int i;
 
     for (i=0; i<METH_NUM; i++) {
-        if (!NSK_JNI_VERIFY(env, (mid = NSK_CPP_STUB4(GetMethodID,
-                env, klass, METHODS[i][0], METHODS[i][1])) != NULL))
-            NSK_CPP_STUB2(FatalError, env,
-                "failed to get ID for the java method\n");
+        if (!NSK_JNI_VERIFY(env, (mid = env->GetMethodID(klass, METHODS[i][0], METHODS[i][1])) != NULL))
+            env->FatalError("failed to get ID for the java method\n");
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetBreakpoint,
-                jvmti_env, mid, 0)))
-            NSK_CPP_STUB2(FatalError, env,
-                "failed to set breakpoint\n");
+        if (!NSK_JVMTI_VERIFY(jvmti_env->SetBreakpoint(mid, 0)))
+            env->FatalError("failed to set breakpoint\n");
     }
 }
 
@@ -88,10 +84,8 @@ ClassLoad(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread, jclass klass) {
 
     if (vm_started) {
         // GetClassSignature may be called only during the start or the live phase
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-                                            jvmti_env, klass, &sig, &generic)))
-            NSK_CPP_STUB2(FatalError, env,
-                          "failed to obtain a class signature\n");
+        if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &sig, &generic)))
+            env->FatalError("failed to obtain a class signature\n");
 
         if (sig != NULL && (strcmp(sig, CLASS_SIG) == 0)) {
             NSK_DISPLAY1("ClassLoad event received for the class \"%s\"\n\
@@ -116,8 +110,7 @@ Breakpoint(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
     NSK_DISPLAY0(">>>> Breakpoint event received\n");
 
     /* checking thread info */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo,
-            jvmti_env, thread, &thr_info))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &thr_info))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to get thread info during Breakpoint callback\n\n");
         return;
@@ -146,14 +139,12 @@ Breakpoint(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
             (long) location);
 
     /* checking method info */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-            jvmti_env, method, &klass))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(method, &klass))) {
         result = checkStatus = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to get method declaring class during Breakpoint callback\n\n");
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-            jvmti_env, klass, &clsSig, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &clsSig, &generic))) {
         result = checkStatus = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to obtain a class signature during Breakpoint callback\n\n");
         return;
@@ -169,8 +160,7 @@ Breakpoint(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         NSK_DISPLAY1("CHECK PASSED: class signature: \"%s\"\n",
             clsSig);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &methNam, &methSig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &methNam, &methSig, NULL))) {
         result = checkStatus = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to get method name during Breakpoint callback\n\n");
         return;
@@ -186,13 +176,11 @@ Breakpoint(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
             break;
         }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) methNam))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methNam))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method name\n\n");
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) methSig))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methSig))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method signature\n\n");
     }
@@ -260,12 +248,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     /* add capability to generate compiled method events */
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_breakpoint_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_single_step_events)
@@ -277,20 +263,16 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.ClassLoad = &ClassLoad;
     callbacks.Breakpoint = &Breakpoint;
     callbacks.VMStart = &VMStart;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_START, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_START, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk001/classfloadhk001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk001/classfloadhk001.cpp
@@ -93,13 +93,11 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("setting event callbacks ...\n");
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.ClassFileLoadHook = &ClassFileLoadHook;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling ClassFileLoadHook event ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling ClassFileLoadHook event done\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk002/classfloadhk002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk002/classfloadhk002.cpp
@@ -122,7 +122,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Find static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls, fieldName, fieldSig)) != NULL)) {
+            jni->GetStaticFieldID(cls, fieldName, fieldSig)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -130,14 +130,13 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Get classfile bytes array from static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (array = (jbyteArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fieldID)) != NULL)) {
+            jni->GetStaticObjectField(cls, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got array object: 0x%p\n", (void*)array);
 
-    if (!NSK_JNI_VERIFY(jni, (*size =
-            NSK_CPP_STUB2(GetArrayLength, jni, array)) > 0)) {
+    if (!NSK_JNI_VERIFY(jni, (*size = jni->GetArrayLength(array)) > 0)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -145,17 +144,14 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     {
         jboolean isCopy;
-        if (!NSK_JNI_VERIFY(jni, (elements =
-                NSK_CPP_STUB3(GetByteArrayElements, jni, array,
-                                                            &isCopy)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni, (elements = jni->GetByteArrayElements(array, &isCopy)) != NULL)) {
             nsk_jvmti_setFailStatus();
         return NSK_FALSE;
         }
     }
     NSK_DISPLAY1("  ... got elements list: 0x%p\n", (void*)elements);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, *size, bytes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(*size, bytes))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -167,7 +163,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
     NSK_DISPLAY1("  ... copied bytecode: %d bytes\n", (int)*size);
 
     NSK_DISPLAY1("Release elements list: 0x%p\n", (void*)elements);
-    NSK_TRACE(NSK_CPP_STUB4(ReleaseByteArrayElements, jni, array, elements, JNI_ABORT));
+    NSK_TRACE(jni->ReleaseByteArrayElements(array, elements, JNI_ABORT));
     NSK_DISPLAY0("  ... released\n");
 
     return NSK_TRUE;
@@ -190,7 +186,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
             if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-                    NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+                    jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -240,8 +236,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Clean used data\n");
         {
             NSK_DISPLAY1("Deallocate bytecode array: 0x%p\n", (void*)origClassBytes);
-            if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(Deallocate, jvmti, origClassBytes))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate(origClassBytes))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -318,8 +313,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_generate_all_class_hook_events = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -332,8 +326,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ClassFileLoadHook = callbackClassFileLoadHook;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, size))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, size))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk003/classfloadhk003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk003/classfloadhk003.cpp
@@ -127,7 +127,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Find static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls, fieldName, fieldSig)) != NULL)) {
+            jni->GetStaticFieldID(cls, fieldName, fieldSig)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -135,14 +135,13 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Get classfile bytes array from static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (array = (jbyteArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fieldID)) != NULL)) {
+            jni->GetStaticObjectField(cls, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got array object: 0x%p\n", (void*)array);
 
-    if (!NSK_JNI_VERIFY(jni, (*size =
-            NSK_CPP_STUB2(GetArrayLength, jni, array)) > 0)) {
+    if (!NSK_JNI_VERIFY(jni, (*size = jni->GetArrayLength(array)) > 0)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -150,17 +149,14 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     {
         jboolean isCopy;
-        if (!NSK_JNI_VERIFY(jni, (elements =
-                NSK_CPP_STUB3(GetByteArrayElements, jni, array,
-                                                            &isCopy)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni, (elements = jni->GetByteArrayElements(array, &isCopy)) != NULL)) {
             nsk_jvmti_setFailStatus();
         return NSK_FALSE;
         }
     }
     NSK_DISPLAY1("  ... got elements list: 0x%p\n", (void*)elements);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, *size, bytes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(*size, bytes))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -172,7 +168,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
     NSK_DISPLAY1("  ... copied bytecode: %d bytes\n", (int)*size);
 
     NSK_DISPLAY1("Release elements list: 0x%p\n", (void*)elements);
-    NSK_TRACE(NSK_CPP_STUB4(ReleaseByteArrayElements, jni, array, elements, JNI_ABORT));
+    NSK_TRACE(jni->ReleaseByteArrayElements(array, elements, JNI_ABORT));
     NSK_DISPLAY0("  ... released\n");
 
     return NSK_TRUE;
@@ -187,23 +183,21 @@ static jobject getObject(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Find static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls, fieldName, fieldSig)) != NULL)) {
+            jni->GetStaticFieldID(cls, fieldName, fieldSig)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
     NSK_DISPLAY1("  ... got fieldID: 0x%p\n", (void*)fieldID);
 
     NSK_DISPLAY1("Get object from static field: %s\n", fieldName);
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fieldID)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->GetStaticObjectField(cls, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
     NSK_DISPLAY1("  ... got object: 0x%p\n", (void*)obj);
 
     NSK_DISPLAY1("Make global reference to object: 0x%p\n", obj);
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB2(NewGlobalRef, jni, obj)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->NewGlobalRef(obj)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
@@ -229,7 +223,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             NSK_DISPLAY0(">>> Obtain debuggee class\n");
             NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
             if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-                    NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+                    jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -286,11 +280,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Clean used data\n");
         {
             NSK_DISPLAY1("Delete global reference to classloader object: 0x%p\n", (void*)classLoader);
-            NSK_CPP_STUB2(DeleteGlobalRef, jni, classLoader);
+            jni->DeleteGlobalRef(classLoader);
 
             NSK_DISPLAY1("Deallocate classfile bytes array: 0x%p\n", (void*)origClassBytes);
-            if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(Deallocate, jvmti, origClassBytes))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate(origClassBytes))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -331,7 +324,7 @@ callbackClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
             NSK_COMPLAIN1("Unexpected NULL classloader in CLASS_FILE_LOAD_HOOK: 0x%p\n",
                                                     (void*)loader);
             nsk_jvmti_setFailStatus();
-        } else if (!NSK_CPP_STUB3(IsSameObject, jni, loader, classLoader)) {
+        } else if (!jni->IsSameObject(loader, classLoader)) {
             NSK_COMPLAIN2("Unexpected classloader in CLASS_FILE_LOAD_HOOK for tested class:\n"
                           "#   got classloder:   0x%p\n"
                           "#   expected same as: 0x%p\n",
@@ -380,8 +373,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_generate_all_class_hook_events = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -394,8 +386,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ClassFileLoadHook = callbackClassFileLoadHook;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, size))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, size))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk004/classfloadhk004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk004/classfloadhk004.cpp
@@ -61,7 +61,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Find static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls, fieldName, fieldSig)) != NULL)) {
+            jni->GetStaticFieldID(cls, fieldName, fieldSig)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -69,14 +69,13 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Get classfile bytes array from static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (array = (jbyteArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fieldID)) != NULL)) {
+            jni->GetStaticObjectField(cls, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got array object: 0x%p\n", (void*)array);
 
-    if (!NSK_JNI_VERIFY(jni, (*size =
-            NSK_CPP_STUB2(GetArrayLength, jni, array)) > 0)) {
+    if (!NSK_JNI_VERIFY(jni, (*size = jni->GetArrayLength(array)) > 0)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -84,17 +83,14 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     {
         jboolean isCopy;
-        if (!NSK_JNI_VERIFY(jni, (elements =
-                NSK_CPP_STUB3(GetByteArrayElements, jni, array,
-                                                            &isCopy)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni, (elements = jni->GetByteArrayElements(array, &isCopy)) != NULL)) {
             nsk_jvmti_setFailStatus();
         return NSK_FALSE;
         }
     }
     NSK_DISPLAY1("  ... got elements list: 0x%p\n", (void*)elements);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, *size, bytes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(*size, bytes))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -106,7 +102,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
     NSK_DISPLAY1("  ... copied bytecode: %d bytes\n", (int)*size);
 
     NSK_DISPLAY1("Release elements list: 0x%p\n", (void*)elements);
-    NSK_TRACE(NSK_CPP_STUB4(ReleaseByteArrayElements, jni, array, elements, JNI_ABORT));
+    NSK_TRACE(jni->ReleaseByteArrayElements(array, elements, JNI_ABORT));
     NSK_DISPLAY0("  ... released\n");
 
     return NSK_TRUE;
@@ -129,7 +125,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
             if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-                    NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+                    jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -271,8 +267,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_generate_all_class_hook_events = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -285,8 +280,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ClassFileLoadHook = callbackClassFileLoadHook;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, size))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, size))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk005/classfloadhk005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk005/classfloadhk005.cpp
@@ -123,7 +123,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Find static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls, fieldName, fieldSig)) != NULL)) {
+            jni->GetStaticFieldID(cls, fieldName, fieldSig)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -131,14 +131,13 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Get classfile bytes array from static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (array = (jbyteArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fieldID)) != NULL)) {
+            jni->GetStaticObjectField(cls, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got array object: 0x%p\n", (void*)array);
 
-    if (!NSK_JNI_VERIFY(jni, (*size =
-            NSK_CPP_STUB2(GetArrayLength, jni, array)) > 0)) {
+    if (!NSK_JNI_VERIFY(jni, (*size = jni->GetArrayLength(array)) > 0)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -146,17 +145,14 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     {
         jboolean isCopy;
-        if (!NSK_JNI_VERIFY(jni, (elements =
-                NSK_CPP_STUB3(GetByteArrayElements, jni, array,
-                                                            &isCopy)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni, (elements = jni->GetByteArrayElements(array, &isCopy)) != NULL)) {
             nsk_jvmti_setFailStatus();
         return NSK_FALSE;
         }
     }
     NSK_DISPLAY1("  ... got elements list: 0x%p\n", (void*)elements);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, *size, bytes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(*size, bytes))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -168,7 +164,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
     NSK_DISPLAY1("  ... copied bytecode: %d bytes\n", (int)*size);
 
     NSK_DISPLAY1("Release elements list: 0x%p\n", (void*)elements);
-    NSK_TRACE(NSK_CPP_STUB4(ReleaseByteArrayElements, jni, array, elements, JNI_ABORT));
+    NSK_TRACE(jni->ReleaseByteArrayElements(array, elements, JNI_ABORT));
     NSK_DISPLAY0("  ... released\n");
 
     return NSK_TRUE;
@@ -191,7 +187,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
             if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-                    NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+                    jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -333,8 +329,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_generate_all_class_hook_events = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -347,8 +342,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ClassFileLoadHook = callbackClassFileLoadHook;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, size))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, size))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk006/classfloadhk006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk006/classfloadhk006.cpp
@@ -128,7 +128,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Find static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls, fieldName, fieldSig)) != NULL)) {
+            jni->GetStaticFieldID(cls, fieldName, fieldSig)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -136,14 +136,13 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Get classfile bytes array from static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (array = (jbyteArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fieldID)) != NULL)) {
+            jni->GetStaticObjectField(cls, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got array object: 0x%p\n", (void*)array);
 
-    if (!NSK_JNI_VERIFY(jni, (*size =
-            NSK_CPP_STUB2(GetArrayLength, jni, array)) > 0)) {
+    if (!NSK_JNI_VERIFY(jni, (*size = jni->GetArrayLength(array)) > 0)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -151,17 +150,14 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     {
         jboolean isCopy;
-        if (!NSK_JNI_VERIFY(jni, (elements =
-                NSK_CPP_STUB3(GetByteArrayElements, jni, array,
-                                                            &isCopy)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni, (elements = jni->GetByteArrayElements(array, &isCopy)) != NULL)) {
             nsk_jvmti_setFailStatus();
         return NSK_FALSE;
         }
     }
     NSK_DISPLAY1("  ... got elements list: 0x%p\n", (void*)elements);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, *size, bytes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(*size, bytes))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -173,7 +169,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
     NSK_DISPLAY1("  ... copied bytecode: %d bytes\n", (int)*size);
 
     NSK_DISPLAY1("Release elements list: 0x%p\n", (void*)elements);
-    NSK_TRACE(NSK_CPP_STUB4(ReleaseByteArrayElements, jni, array, elements, JNI_ABORT));
+    NSK_TRACE(jni->ReleaseByteArrayElements(array, elements, JNI_ABORT));
     NSK_DISPLAY0("  ... released\n");
 
     return NSK_TRUE;
@@ -188,23 +184,21 @@ static jobject getObject(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Find static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls, fieldName, fieldSig)) != NULL)) {
+            jni->GetStaticFieldID(cls, fieldName, fieldSig)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
     NSK_DISPLAY1("  ... got fieldID: 0x%p\n", (void*)fieldID);
 
     NSK_DISPLAY1("Get object from static field: %s\n", fieldName);
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fieldID)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->GetStaticObjectField(cls, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
     NSK_DISPLAY1("  ... got object: 0x%p\n", (void*)obj);
 
     NSK_DISPLAY1("Make global reference to object: 0x%p\n", obj);
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB2(NewGlobalRef, jni, obj)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->NewGlobalRef(obj)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
@@ -223,8 +217,7 @@ static int redefineClass(jvmtiEnv* jvmti, jclass klass, const char className[],
     classDef.class_bytes = bytes;
 
     NSK_DISPLAY1("Redefine class: %s\n", className);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &classDef))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &classDef))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -250,7 +243,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             NSK_DISPLAY0(">>> Obtain debuggee class\n");
             NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
             if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-                    NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+                    jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -309,11 +302,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Clean used data\n");
         {
             NSK_DISPLAY1("Delete global reference to tested class object: 0x%p\n", (void*)testedClass);
-            NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass);
+            jni->DeleteGlobalRef(testedClass);
 
             NSK_DISPLAY1("Deallocate redefined bytecode array: 0x%p\n", (void*)redefClassBytes);
-            if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(Deallocate, jvmti, redefClassBytes))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate(redefClassBytes))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -347,7 +339,7 @@ callbackClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
             NSK_COMPLAIN1("Unexpected NULL class_being_redefined in CLASS_FILE_LOAD_HOOK: 0x%p\n",
                                                     (void*)class_being_redefined);
             nsk_jvmti_setFailStatus();
-        } else if (!NSK_CPP_STUB3(IsSameObject, jni, class_being_redefined, testedClass)) {
+        } else if (!jni->IsSameObject(class_being_redefined, testedClass)) {
             NSK_COMPLAIN2("Unexpected class_being_redefined in CLASS_FILE_LOAD_HOOK:\n"
                           "#   got class:        0x%p\n"
                           "#   expected same as: 0x%p\n",
@@ -397,8 +389,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_generate_all_class_hook_events = 1;
         caps.can_redefine_classes = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -411,8 +402,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ClassFileLoadHook = callbackClassFileLoadHook;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, size))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, size))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk007/classfloadhk007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk007/classfloadhk007.cpp
@@ -132,7 +132,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Find static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls, fieldName, fieldSig)) != NULL)) {
+            jni->GetStaticFieldID(cls, fieldName, fieldSig)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -140,14 +140,13 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Get classfile bytes array from static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (array = (jbyteArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fieldID)) != NULL)) {
+            jni->GetStaticObjectField(cls, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got array object: 0x%p\n", (void*)array);
 
-    if (!NSK_JNI_VERIFY(jni, (*size =
-            NSK_CPP_STUB2(GetArrayLength, jni, array)) > 0)) {
+    if (!NSK_JNI_VERIFY(jni, (*size = jni->GetArrayLength(array)) > 0)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -155,17 +154,14 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     {
         jboolean isCopy;
-        if (!NSK_JNI_VERIFY(jni, (elements =
-                NSK_CPP_STUB3(GetByteArrayElements, jni, array,
-                                                            &isCopy)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni, (elements = jni->GetByteArrayElements(array, &isCopy)) != NULL)) {
             nsk_jvmti_setFailStatus();
         return NSK_FALSE;
         }
     }
     NSK_DISPLAY1("  ... got elements list: 0x%p\n", (void*)elements);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, *size, bytes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(*size, bytes))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -177,7 +173,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
     NSK_DISPLAY1("  ... copied bytecode: %d bytes\n", (int)*size);
 
     NSK_DISPLAY1("Release elements list: 0x%p\n", (void*)elements);
-    NSK_TRACE(NSK_CPP_STUB4(ReleaseByteArrayElements, jni, array, elements, JNI_ABORT));
+    NSK_TRACE(jni->ReleaseByteArrayElements(array, elements, JNI_ABORT));
     NSK_DISPLAY0("  ... released\n");
 
     return NSK_TRUE;
@@ -192,23 +188,21 @@ static jobject getObject(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Find static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls, fieldName, fieldSig)) != NULL)) {
+            jni->GetStaticFieldID(cls, fieldName, fieldSig)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
     NSK_DISPLAY1("  ... got fieldID: 0x%p\n", (void*)fieldID);
 
     NSK_DISPLAY1("Get object from static field: %s\n", fieldName);
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fieldID)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->GetStaticObjectField(cls, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
     NSK_DISPLAY1("  ... got object: 0x%p\n", (void*)obj);
 
     NSK_DISPLAY1("Make global reference to object: 0x%p\n", obj);
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB2(NewGlobalRef, jni, obj)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->NewGlobalRef(obj)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
@@ -227,8 +221,7 @@ static int redefineClass(jvmtiEnv* jvmti, jclass klass, const char className[],
     classDef.class_bytes = bytes;
 
     NSK_DISPLAY1("Redefine class: %s\n", className);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &classDef))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &classDef))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -254,7 +247,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             NSK_DISPLAY0(">>> Obtain debuggee class\n");
             NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
             if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-                    NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+                    jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -319,14 +312,13 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Clean used data\n");
         {
             NSK_DISPLAY1("Delete global reference to classloader object: 0x%p\n", (void*)classLoader);
-            NSK_CPP_STUB2(DeleteGlobalRef, jni, classLoader);
+            jni->DeleteGlobalRef(classLoader);
 
             NSK_DISPLAY1("Delete global reference to tested class object: 0x%p\n", (void*)testedClass);
-            NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass);
+            jni->DeleteGlobalRef(testedClass);
 
             NSK_DISPLAY1("Deallocate redefined bytecode array: 0x%p\n", (void*)redefClassBytes);
-            if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(Deallocate, jvmti, redefClassBytes))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate(redefClassBytes))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -360,7 +352,7 @@ callbackClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
             NSK_COMPLAIN1("Unexpected NULL classloader in CLASS_FILE_LOAD_HOOK: 0x%p\n",
                                                     (void*)loader);
             nsk_jvmti_setFailStatus();
-        } else if (!NSK_CPP_STUB3(IsSameObject, jni, loader, classLoader)) {
+        } else if (!jni->IsSameObject(loader, classLoader)) {
             NSK_COMPLAIN2("Unexpected classloader in CLASS_FILE_LOAD_HOOK:\n"
                           "#   got classloder:   0x%p\n"
                           "#   expected same as: 0x%p\n",
@@ -373,7 +365,7 @@ callbackClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
             NSK_COMPLAIN1("Unexpected NULL class_being_redefined in CLASS_FILE_LOAD_HOOK: 0x%p\n",
                                                     (void*)class_being_redefined);
             nsk_jvmti_setFailStatus();
-        } else if (!NSK_CPP_STUB3(IsSameObject, jni, class_being_redefined, testedClass)) {
+        } else if (!jni->IsSameObject(class_being_redefined, testedClass)) {
             NSK_COMPLAIN2("Unexpected class_being_redefined in CLASS_FILE_LOAD_HOOK:\n"
                           "#   got class:        0x%p\n"
                           "#   expected same as: 0x%p\n",
@@ -423,8 +415,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_generate_all_class_hook_events = 1;
         caps.can_redefine_classes = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -437,8 +428,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ClassFileLoadHook = callbackClassFileLoadHook;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, size))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, size))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk008/classfloadhk008.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk008/classfloadhk008.cpp
@@ -70,7 +70,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Find static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls, fieldName, fieldSig)) != NULL)) {
+            jni->GetStaticFieldID(cls, fieldName, fieldSig)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -78,14 +78,13 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Get classfile bytes array from static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (array = (jbyteArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fieldID)) != NULL)) {
+            jni->GetStaticObjectField(cls, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got array object: 0x%p\n", (void*)array);
 
-    if (!NSK_JNI_VERIFY(jni, (*size =
-            NSK_CPP_STUB2(GetArrayLength, jni, array)) > 0)) {
+    if (!NSK_JNI_VERIFY(jni, (*size = jni->GetArrayLength(array)) > 0)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -93,17 +92,14 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     {
         jboolean isCopy;
-        if (!NSK_JNI_VERIFY(jni, (elements =
-                NSK_CPP_STUB3(GetByteArrayElements, jni, array,
-                                                            &isCopy)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni, (elements = jni->GetByteArrayElements(array, &isCopy)) != NULL)) {
             nsk_jvmti_setFailStatus();
         return NSK_FALSE;
         }
     }
     NSK_DISPLAY1("  ... got elements list: 0x%p\n", (void*)elements);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, *size, bytes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(*size, bytes))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -115,7 +111,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
     NSK_DISPLAY1("  ... copied bytecode: %d bytes\n", (int)*size);
 
     NSK_DISPLAY1("Release elements list: 0x%p\n", (void*)elements);
-    NSK_TRACE(NSK_CPP_STUB4(ReleaseByteArrayElements, jni, array, elements, JNI_ABORT));
+    NSK_TRACE(jni->ReleaseByteArrayElements(array, elements, JNI_ABORT));
     NSK_DISPLAY0("  ... released\n");
 
     return NSK_TRUE;
@@ -130,23 +126,21 @@ static jobject getObject(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Find static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls, fieldName, fieldSig)) != NULL)) {
+            jni->GetStaticFieldID(cls, fieldName, fieldSig)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
     NSK_DISPLAY1("  ... got fieldID: 0x%p\n", (void*)fieldID);
 
     NSK_DISPLAY1("Get object from static field: %s\n", fieldName);
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fieldID)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->GetStaticObjectField(cls, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
     NSK_DISPLAY1("  ... got object: 0x%p\n", (void*)obj);
 
     NSK_DISPLAY1("Make global reference to object: 0x%p\n", obj);
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB2(NewGlobalRef, jni, obj)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->NewGlobalRef(obj)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
@@ -165,8 +159,7 @@ static int redefineClass(jvmtiEnv* jvmti, jclass klass, const char className[],
     classDef.class_bytes = bytes;
 
     NSK_DISPLAY1("Redefine class: %s\n", className);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &classDef))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &classDef))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -192,7 +185,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             NSK_DISPLAY0(">>> Obtain debuggee class\n");
             NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
             if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-                    NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+                    jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -258,11 +251,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Clean used data\n");
         {
             NSK_DISPLAY1("Delete global reference to tested class object: 0x%p\n", (void*)testedClass);
-            NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass);
+            jni->DeleteGlobalRef(testedClass);
 
             NSK_DISPLAY1("Deallocate redefined bytecode array: 0x%p\n", (void*)redefClassBytes);
-            if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(Deallocate, jvmti, redefClassBytes))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate(redefClassBytes))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -359,8 +351,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_generate_all_class_hook_events = 1;
         caps.can_redefine_classes = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -373,8 +364,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ClassFileLoadHook = callbackClassFileLoadHook;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, size))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, size))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk009/classfloadhk009.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassFileLoadHook/classfloadhk009/classfloadhk009.cpp
@@ -70,7 +70,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Find static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls, fieldName, fieldSig)) != NULL)) {
+            jni->GetStaticFieldID(cls, fieldName, fieldSig)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -78,14 +78,13 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Get classfile bytes array from static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (array = (jbyteArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fieldID)) != NULL)) {
+            jni->GetStaticObjectField(cls, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got array object: 0x%p\n", (void*)array);
 
-    if (!NSK_JNI_VERIFY(jni, (*size =
-            NSK_CPP_STUB2(GetArrayLength, jni, array)) > 0)) {
+    if (!NSK_JNI_VERIFY(jni, (*size = jni->GetArrayLength(array)) > 0)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -93,17 +92,14 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     {
         jboolean isCopy;
-        if (!NSK_JNI_VERIFY(jni, (elements =
-                NSK_CPP_STUB3(GetByteArrayElements, jni, array,
-                                                            &isCopy)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni, (elements = jni->GetByteArrayElements(array, &isCopy)) != NULL)) {
             nsk_jvmti_setFailStatus();
         return NSK_FALSE;
         }
     }
     NSK_DISPLAY1("  ... got elements list: 0x%p\n", (void*)elements);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, *size, bytes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(*size, bytes))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -115,7 +111,7 @@ static int getBytecode(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
     NSK_DISPLAY1("  ... copied bytecode: %d bytes\n", (int)*size);
 
     NSK_DISPLAY1("Release elements list: 0x%p\n", (void*)elements);
-    NSK_TRACE(NSK_CPP_STUB4(ReleaseByteArrayElements, jni, array, elements, JNI_ABORT));
+    NSK_TRACE(jni->ReleaseByteArrayElements(array, elements, JNI_ABORT));
     NSK_DISPLAY0("  ... released\n");
 
     return NSK_TRUE;
@@ -130,23 +126,21 @@ static jobject getObject(jvmtiEnv* jvmti, JNIEnv* jni, jclass cls,
 
     NSK_DISPLAY1("Find static field: %s\n", fieldName);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls, fieldName, fieldSig)) != NULL)) {
+            jni->GetStaticFieldID(cls, fieldName, fieldSig)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
     NSK_DISPLAY1("  ... got fieldID: 0x%p\n", (void*)fieldID);
 
     NSK_DISPLAY1("Get object from static field: %s\n", fieldName);
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fieldID)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->GetStaticObjectField(cls, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
     NSK_DISPLAY1("  ... got object: 0x%p\n", (void*)obj);
 
     NSK_DISPLAY1("Make global reference to object: 0x%p\n", obj);
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB2(NewGlobalRef, jni, obj)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->NewGlobalRef(obj)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
@@ -165,8 +159,7 @@ static int redefineClass(jvmtiEnv* jvmti, jclass klass, const char className[],
     classDef.class_bytes = bytes;
 
     NSK_DISPLAY1("Redefine class: %s\n", className);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &classDef))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &classDef))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -192,7 +185,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             NSK_DISPLAY0(">>> Obtain debuggee class\n");
             NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
             if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-                    NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+                    jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -258,11 +251,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Clean used data\n");
         {
             NSK_DISPLAY1("Delete global reference to tested class object: 0x%p\n", (void*)testedClass);
-            NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass);
+            jni->DeleteGlobalRef(testedClass);
 
             NSK_DISPLAY1("Deallocate redefined bytecode array: 0x%p\n", (void*)redefClassBytes);
-            if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(Deallocate, jvmti, redefClassBytes))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate(redefClassBytes))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -359,8 +351,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_generate_all_class_hook_events = 1;
         caps.can_redefine_classes = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -373,8 +364,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ClassFileLoadHook = callbackClassFileLoadHook;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, size))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, size))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassLoad/classload001/classload001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassLoad/classload001/classload001.cpp
@@ -98,17 +98,13 @@ static int findSig(char *sig, int expected) {
 }
 
 static void lock(jvmtiEnv *jvmti_env, JNIEnv *jni_env) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter,
-            jvmti_env, countLock)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-                "failed to enter a raw monitor\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(countLock)))
+        jni_env->FatalError("failed to enter a raw monitor\n");
 }
 
 static void unlock(jvmtiEnv *jvmti_env, JNIEnv *jni_env) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit,
-        jvmti_env, countLock)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-                "failed to exit a raw monitor\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(countLock)))
+        jni_env->FatalError("failed to exit a raw monitor\n");
 }
 
 /** callback functions **/
@@ -119,8 +115,7 @@ ClassLoad(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread, jclass klass) {
 
     lock(jvmti_env, env);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-            jvmti_env, klass, &sig, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &sig, &generic))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILURE: unable to obtain a class signature\n");
     }
@@ -184,20 +179,17 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     initCounters();
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor,
-            jvmti, "_counter_lock", &countLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_counter_lock", &countLock)))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks ...\n");
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.ClassLoad = &ClassLoad;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling ClassLoad event ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("the event enabled\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CompiledMethodLoad/compmethload001/compmethload001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CompiledMethodLoad/compmethload001/compmethload001.cpp
@@ -45,8 +45,7 @@ void JNICALL
 VMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr) {
     NSK_DISPLAY0("VMInit event received\n\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GenerateEvents,
-            jvmti_env, JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
         NSK_COMPLAIN0("TEST FAILED: unable to generate events to represent the current state of the VM\n");
         result = STATUS_FAILED;
     }
@@ -63,8 +62,7 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method, jint code_size,
 
     NSK_DISPLAY0("CompiledMethodLoad event received for:\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &sig, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sig, &generic))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILURE: unable to obtain method info\n");
         return;
@@ -72,8 +70,7 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method, jint code_size,
     NSK_DISPLAY4("\tmethod: name=\"%s\" signature=\"%s\"\n\tcompiled code size=%d\n\tnumber of address location map entries=%d\n",
         name, sig, code_size, map_length);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase,
-            jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILURE: unable to obtain phase of the VM execution\n");
         return;
@@ -122,12 +119,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     /* add capability to generate compiled method events */
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_compiled_method_load_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_compiled_method_load_events)
@@ -138,16 +133,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.VMInit = &VMInit;
     callbacks.CompiledMethodLoad = &CompiledMethodLoad;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling VMInit, CompiledMethodLoad event ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CompiledMethodUnload/compmethunload001/compmethunload001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/CompiledMethodUnload/compmethunload001/compmethunload001.cpp
@@ -47,8 +47,7 @@ void JNICALL
 VMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr) {
     NSK_DISPLAY0("VMInit event received\n\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GenerateEvents,
-            jvmti_env, JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
         NSK_COMPLAIN0("TEST FAILED: unable to generate events to represent the current state of the VM\n");
         result = STATUS_FAILED;
     }
@@ -64,8 +63,7 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method, jint code_size,
 
     NSK_DISPLAY0("CompiledMethodLoad event received for:\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &sig, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sig, &generic))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILURE: unable to obtain method info\n\n");
         return;
@@ -94,8 +92,8 @@ CompiledMethodUnload(jvmtiEnv *jvmti_env, jmethodID method,
     if (err == JVMTI_ERROR_NONE) {
         NSK_DISPLAY3("for: \tmethod: name=\"%s\" signature=\"%s\"\n\tnative address=0x%p\n",
           name, sig, code_addr);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)sig);
+        jvmti_env->Deallocate((unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)sig);
     } else {
         // The class metadata has been completely unloaded so the name is not available.
         NSK_DISPLAY0("for: \tmethod: name=<not available>\n");
@@ -104,8 +102,7 @@ CompiledMethodUnload(jvmtiEnv *jvmti_env, jmethodID method,
     // Count unloaded events
     class_unloaded++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase,
-            jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILURE: unable to obtain phase of the VM execution\n");
         return;
@@ -166,12 +163,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     /* add capability to generate compiled method events */
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_compiled_method_load_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_compiled_method_load_events)
@@ -183,19 +178,15 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.VMInit = &VMInit;
     callbacks.CompiledMethodLoad = &CompiledMethodLoad;
     callbacks.CompiledMethodUnload = &CompiledMethodUnload;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_UNLOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_UNLOAD, NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DataDumpRequest/datadumpreq001/datadumpreq001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DataDumpRequest/datadumpreq001/datadumpreq001.cpp
@@ -118,13 +118,11 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("setting event callbacks ...\n");
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.DataDumpRequest = &DataDumpRequest;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_DATA_DUMP_REQUEST, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_DATA_DUMP_REQUEST, NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DisposeEnvironment/disposeenv001/disposeenv001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DisposeEnvironment/disposeenv001/disposeenv001.cpp
@@ -54,8 +54,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
     NSK_DISPLAY0(">>> Testcase #1: Dispose JVMTI environment in Agent_OnLoad()\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB1(DisposeEnvironment, jvmti))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->DisposeEnvironment())) {
         return JNI_ERR;
     }
     NSK_DISPLAY0("  ... disposed\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DisposeEnvironment/disposeenv002/disposeenv002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DisposeEnvironment/disposeenv002/disposeenv002.cpp
@@ -45,16 +45,14 @@ callbackVMDeath(jvmtiEnv* jvmti, JNIEnv* jni) {
 
     NSK_DISPLAY0("Disable VM_DEATH event in VM_DEATH callback\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                                JVMTI_EVENT_VM_DEATH, NULL))) {
+            jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_VM_DEATH, NULL))) {
         success = NSK_FALSE;
     } else {
         NSK_DISPLAY0("  ... disabled\n");
     }
 
     NSK_DISPLAY0(">>> Testcase #1: Dispose JVMTI environment in VM_DEATH callback\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB1(DisposeEnvironment, jvmti))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->DisposeEnvironment())) {
         success = NSK_FALSE;
     } else {
         NSK_DISPLAY0("  ... disposed\n");
@@ -95,16 +93,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMDeath = callbackVMDeath;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 
         NSK_DISPLAY0("Enable VM_DEATH event in JVM_OnLoad()\n");
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                                    JVMTI_EVENT_VM_DEATH, NULL))) {
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL))) {
             return JNI_ERR;
         }
         NSK_DISPLAY0("  ... enabled\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DynamicCodeGenerated/dyncodgen001/dyncodgen001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/DynamicCodeGenerated/dyncodgen001/dyncodgen001.cpp
@@ -116,15 +116,12 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.DynamicCodeGenerated = &DynamicCodeGenerated;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* enable DynamicCodeGenerated event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_DYNAMIC_CODE_GENERATED, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_DYNAMIC_CODE_GENERATED, NULL)))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceEarlyReturn/ForceEarlyReturn001/ForceEarlyReturn001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceEarlyReturn/ForceEarlyReturn001/ForceEarlyReturn001.cpp
@@ -45,11 +45,7 @@ Java_nsk_jvmti_ForceEarlyReturn_ForceEarlyReturn001_suspendThread (
         )
 {
     if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    SuspendThread
-                    , jvmti
-                    , earlyReturnThread
-                )
+                jvmti                    ->SuspendThread                    (earlyReturnThread                )
             )
         )
          return JNI_FALSE;
@@ -67,11 +63,7 @@ Java_nsk_jvmti_ForceEarlyReturn_ForceEarlyReturn001_resumeThread (
         )
 {
     if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    ResumeThread
-                    , jvmti
-                    , earlyReturnThread
-                )
+                jvmti                    ->ResumeThread                    (earlyReturnThread                )
             )
         )
          return JNI_FALSE;
@@ -90,12 +82,7 @@ Java_nsk_jvmti_ForceEarlyReturn_ForceEarlyReturn001_doForceEarlyReturnObject (
         )
 {
     if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    ForceEarlyReturnObject
-                    , jvmti
-                    , earlyReturnThread
-                    , valueToReturn
-                    )
+                jvmti                    ->ForceEarlyReturnObject                    (earlyReturnThread                    , valueToReturn                    )
                 )
        )
         return JNI_FALSE;
@@ -114,12 +101,7 @@ Java_nsk_jvmti_ForceEarlyReturn_ForceEarlyReturn001_doForceEarlyReturnInt(
         )
 {
     if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    ForceEarlyReturnInt
-                    , jvmti
-                    , earlyReturnThread
-                    , valueToReturn
-                    )
+                jvmti                    ->ForceEarlyReturnInt                    (earlyReturnThread                    , valueToReturn                    )
                 )
        )
         return JNI_FALSE;
@@ -138,12 +120,7 @@ Java_nsk_jvmti_ForceEarlyReturn_ForceEarlyReturn001_doForceEarlyReturnLong (
         )
 {
     if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    ForceEarlyReturnLong
-                    , jvmti
-                    , earlyReturnThread
-                    , valueToReturn
-                    )
+                jvmti                    ->ForceEarlyReturnLong                    (earlyReturnThread                    , valueToReturn                    )
                 )
        )
         return JNI_FALSE;
@@ -162,12 +139,7 @@ Java_nsk_jvmti_ForceEarlyReturn_ForceEarlyReturn001_doForceEarlyReturnFloat (
         )
 {
     if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    ForceEarlyReturnFloat
-                    , jvmti
-                    , earlyReturnThread
-                    , valueToReturn
-                    )
+                jvmti                    ->ForceEarlyReturnFloat                    (earlyReturnThread                    , valueToReturn                    )
                 )
        )
         return JNI_FALSE;
@@ -186,12 +158,7 @@ Java_nsk_jvmti_ForceEarlyReturn_ForceEarlyReturn001_doForceEarlyReturnDouble (
         )
 {
     if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    ForceEarlyReturnDouble
-                    , jvmti
-                    , earlyReturnThread
-                    , valueToReturn
-                    )
+                jvmti                    ->ForceEarlyReturnDouble                    (earlyReturnThread                    , valueToReturn                    )
                 )
        )
         return JNI_FALSE;
@@ -209,11 +176,7 @@ Java_nsk_jvmti_ForceEarlyReturn_ForceEarlyReturn001_doForceEarlyReturnVoid (
         )
 {
     if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    ForceEarlyReturnVoid
-                    , jvmti
-                    , earlyReturnThread
-                    )
+                jvmti                    ->ForceEarlyReturnVoid                    (earlyReturnThread                    )
                 )
        )
         return JNI_FALSE;
@@ -245,11 +208,7 @@ jint Agent_Initialize(JavaVM *vm, char *options, void *reserved)
        )
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    GetCapabilities
-                    , jvmti
-                    , &caps)
+    if (!NSK_JVMTI_VERIFY(jvmti                    ->GetCapabilities                    (&caps)
                 )
        )
         return JNI_ERR;
@@ -258,11 +217,7 @@ jint Agent_Initialize(JavaVM *vm, char *options, void *reserved)
     caps.can_force_early_return = 1;
     caps.can_suspend = 1;
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    AddCapabilities
-                    , jvmti
-                    , &caps)
+    if (!NSK_JVMTI_VERIFY(jvmti                    ->AddCapabilities                    (&caps)
                 )
        )
         return JNI_ERR;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc001/forcegc001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc001/forcegc001.cpp
@@ -45,8 +45,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     NSK_DISPLAY0(">>> Testcase #1: force GC to collect sofly reachable objects\n");
     {
         NSK_DISPLAY0("Call ForceGarbageCollection()\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB1(ForceGarbageCollection, jvmti))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->ForceGarbageCollection())) {
             nsk_jvmti_setFailStatus();
             return;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc002/forcegc002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ForceGarbageCollection/forcegc002/forcegc002.cpp
@@ -54,8 +54,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY0("Call ForceGarbageCollection()\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB1(ForceGarbageCollection, jvmti))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->ForceGarbageCollection())) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -114,7 +113,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities caps;
         memset(&caps, 0, sizeof(caps));
         caps.can_generate_garbage_collection_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 
@@ -122,9 +121,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiEventCallbacks eventCallbacks;
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.GarbageCollectionStart = callbackGarbageCollectionStart;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GarbageCollectionFinish/gcfinish001/gcfinish001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GarbageCollectionFinish/gcfinish001/gcfinish001.cpp
@@ -51,8 +51,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: creating a raw monitor ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor,
-            jvmti_env, "_lock", &_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->CreateRawMonitor("_lock", &_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to create a raw monitor\n\n",
             msg);
@@ -63,8 +62,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: entering the raw monitor ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter,
-            jvmti_env, _lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to enter the raw monitor\n\n",
             msg);
@@ -75,8 +73,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
         NSK_DISPLAY1("%s: waiting the raw monitor ...\n",
             msg);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RawMonitorWait,
-                jvmti_env, _lock, (jlong)10))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorWait(_lock, (jlong)10))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: %s: unable to wait the raw monitor\n\n",
                 msg);
@@ -87,8 +84,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
         NSK_DISPLAY1("%s: notifying a single thread waiting on the raw monitor ...\n",
             msg);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorNotify,
-                jvmti_env, _lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorNotify(_lock))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: %s: unable to notify single thread\n\n",
                 msg);
@@ -99,8 +95,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
         NSK_DISPLAY1("%s: notifying all threads waiting on the raw monitor ...\n",
             msg);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorNotifyAll,
-                jvmti_env, _lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorNotifyAll(_lock))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: %s: unable to notify all threads\n\n",
                 msg);
@@ -111,8 +106,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
         NSK_DISPLAY1("%s: exiting the raw monitor ...\n",
             msg);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit,
-                jvmti_env, _lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(_lock))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: %s: unable to exit the raw monitor\n\n",
                 msg);
@@ -123,8 +117,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: destroying the raw monitor ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(DestroyRawMonitor,
-            jvmti_env, _lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->DestroyRawMonitor(_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to destroy a raw monitor\n",
             msg);
@@ -137,8 +130,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 static void memoryFunc(jvmtiEnv *jvmti_env, const char *msg) {
     NSK_DISPLAY1("%s: allocating memory ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate,
-            jvmti_env, MEM_SIZE, &mem))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Allocate(MEM_SIZE, &mem))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to allocate memory\n\n",
             msg);
@@ -150,8 +142,7 @@ static void memoryFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: deallocating memory ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, mem))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate(mem))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to deallocate memory\n\n",
             msg);
@@ -209,12 +200,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     /* add capability to generate compiled method events */
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_garbage_collection_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_garbage_collection_events)
@@ -225,16 +214,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.VMDeath = &VMDeath;
     callbacks.GarbageCollectionFinish = &GarbageCollectionFinish;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH, NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GarbageCollectionStart/gcstart001/gcstart001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GarbageCollectionStart/gcstart001/gcstart001.cpp
@@ -117,12 +117,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     /* add capability to generate compiled method events */
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_garbage_collection_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_garbage_collection_events)
@@ -134,19 +132,15 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.VMDeath = &VMDeath;
     callbacks.GarbageCollectionStart = &GarbageCollectionStart;
     callbacks.GarbageCollectionFinish = &GarbageCollectionFinish;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH, NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GarbageCollectionStart/gcstart002/gcstart002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GarbageCollectionStart/gcstart002/gcstart002.cpp
@@ -51,8 +51,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: creating a raw monitor ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor,
-            jvmti_env, "_lock", &_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->CreateRawMonitor("_lock", &_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to create a raw monitor\n\n",
             msg);
@@ -63,8 +62,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: entering the raw monitor ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter,
-            jvmti_env, _lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to enter the raw monitor\n\n",
             msg);
@@ -76,8 +74,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
         NSK_DISPLAY1("%s: waiting the raw monitor ...\n",
             msg);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RawMonitorWait,
-                jvmti_env, _lock, (jlong)10))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorWait(_lock, (jlong)10))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: %s: unable to wait the raw monitor\n\n",
                 msg);
@@ -88,8 +85,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
         NSK_DISPLAY1("%s: notifying a single thread waiting on the raw monitor ...\n",
             msg);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorNotify,
-                jvmti_env, _lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorNotify(_lock))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: %s: unable to notify single thread\n\n",
                 msg);
@@ -100,8 +96,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
         NSK_DISPLAY1("%s: notifying all threads waiting on the raw monitor ...\n",
             msg);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorNotifyAll,
-                jvmti_env, _lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorNotifyAll(_lock))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: %s: unable to notify all threads\n\n",
                 msg);
@@ -112,8 +107,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
         NSK_DISPLAY1("%s: exiting the raw monitor ...\n",
             msg);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit,
-                jvmti_env, _lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(_lock))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: %s: unable to exit the raw monitor\n\n",
                 msg);
@@ -124,8 +118,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: destroying the raw monitor ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(DestroyRawMonitor,
-            jvmti_env, _lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->DestroyRawMonitor(_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to destroy a raw monitor\n",
             msg);
@@ -138,8 +131,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 static void memoryFunc(jvmtiEnv *jvmti_env, const char *msg) {
     NSK_DISPLAY1("%s: allocating memory ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate,
-            jvmti_env, MEM_SIZE, &mem))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Allocate(MEM_SIZE, &mem))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to allocate memory\n\n",
             msg);
@@ -151,8 +143,7 @@ static void memoryFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: deallocating memory ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, mem))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate(mem))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to deallocate memory\n\n",
             msg);
@@ -210,12 +201,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     /* add capability to generate compiled method events */
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_garbage_collection_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_garbage_collection_events)
@@ -226,16 +215,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.VMDeath = &VMDeath;
     callbacks.GarbageCollectionStart = &GarbageCollectionStart;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GenerateEvents/genevents001/genevents001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GenerateEvents/genevents001/genevents001.cpp
@@ -99,13 +99,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
 
         NSK_DISPLAY0("Call GenerateEvents() to send missed events\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(GenerateEvents, jvmti, JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
             nsk_jvmti_setFailStatus();
         }
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(GenerateEvents, jvmti, JVMTI_EVENT_DYNAMIC_CODE_GENERATED))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GenerateEvents(JVMTI_EVENT_DYNAMIC_CODE_GENERATED))) {
             nsk_jvmti_setFailStatus();
         }
 
@@ -195,8 +193,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities caps;
         memset(&caps, 0, sizeof(caps));
         caps.can_generate_compiled_method_load_events = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 
@@ -207,9 +204,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.CompiledMethodLoad = callbackCompiledMethodLoad;
         eventCallbacks.CompiledMethodUnload = callbackCompiledMethodUnload;
         eventCallbacks.DynamicCodeGenerated = callbackDynamicCodeGenerated;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211261](https://bugs.openjdk.java.net/browse/JDK-8211261): Remove the NSK_CPP_STUB macros from vmTestbase for jvmti/[A-G]*


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/657/head:pull/657` \
`$ git checkout pull/657`

Update a local copy of the PR: \
`$ git checkout pull/657` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 657`

View PR using the GUI difftool: \
`$ git pr show -t 657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/657.diff">https://git.openjdk.java.net/jdk11u-dev/pull/657.diff</a>

</details>
