### PR TITLE
8211131: Remove the NSK_CPP_STUB macros from vmTestbase for jvmti/[G-I]*

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetAvailableProcessors/getavailproc001/getavailproc001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetAvailableProcessors/getavailproc001/getavailproc001.cpp
@@ -53,8 +53,7 @@ static int checkProcessors(jvmtiEnv* jvmti, const char where[]) {
     jint processors = 0;
 
     NSK_DISPLAY0("GetAvailableProcessors() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetAvailableProcessors, jvmti, &processors))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAvailableProcessors(&processors))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got processors: %d\n", (int)processors);
@@ -157,9 +156,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCapabilities/getcaps002/getcaps002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCapabilities/getcaps002/getcaps002.cpp
@@ -190,8 +190,7 @@ static int checkCapabilities(jvmtiEnv* jvmti, const char where[]) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
 
     NSK_DISPLAY0("GetCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps))) {
         return NSK_FALSE;
     }
 
@@ -297,9 +296,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassLoaderClasses/clsldrclss002/clsldrclss002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassLoaderClasses/clsldrclss002/clsldrclss002.cpp
@@ -58,18 +58,15 @@ static int prepare(JNIEnv* jni) {
     NSK_DISPLAY0("Obtain tested object from a static field of debugee class\n");
 
     NSK_DISPLAY1("Find class: %s\n", CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (testedClass =
-            NSK_CPP_STUB2(FindClass, jni, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = jni->FindClass(CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, testedClass)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass) jni->NewGlobalRef(testedClass)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY2("Find field: %s:%s\n", FIELD_NAME, FIELD_SIGNATURE);
     if (!NSK_JNI_VERIFY(jni, (testedFieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, testedClass,
-                FIELD_NAME, FIELD_SIGNATURE)) != NULL))
+            jni->GetStaticFieldID(testedClass, FIELD_NAME, FIELD_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -82,8 +79,7 @@ static int lookup(jvmtiEnv* jvmti,
     jint i;
 
     for (i = 0; i < classCount && !found; i++) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti,
-                classes[i], &signature, &generic)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetClassSignature(classes[i], &signature, &generic)))
             break;
 
         if (signature != NULL && strcmp(signature, exp_sig) == 0) {
@@ -92,10 +88,10 @@ static int lookup(jvmtiEnv* jvmti,
         }
 
         if (signature != NULL)
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)signature);
+            jvmti->Deallocate((unsigned char*)signature);
 
         if (generic != NULL)
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)generic);
+            jvmti->Deallocate((unsigned char*)generic);
     }
 
     return found;
@@ -119,13 +115,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
     NSK_DISPLAY0("Testcase #1: check on default classloader\n");
     if (!NSK_JNI_VERIFY(jni, (testedClassLoader =
-            NSK_CPP_STUB3(GetStaticObjectField, jni,
-                testedClass, testedFieldID)) != NULL)) {
+            jni->GetStaticObjectField(testedClass, testedFieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassLoaderClasses, jvmti,
-            testedClassLoader, &classCount, &classes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetClassLoaderClasses(testedClassLoader, &classCount, &classes))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -143,7 +137,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
     }
     if (classes != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)classes);
+        jvmti->Deallocate((unsigned char*)classes);
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -152,13 +146,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
     NSK_DISPLAY0("Testcase #2: check on custom classloader\n");
     if (!NSK_JNI_VERIFY(jni, (testedClassLoader =
-            NSK_CPP_STUB3(GetStaticObjectField, jni,
-                testedClass, testedFieldID)) != NULL)) {
+            jni->GetStaticObjectField(testedClass, testedFieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassLoaderClasses, jvmti,
-            testedClassLoader, &classCount, &classes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetClassLoaderClasses(testedClassLoader, &classCount, &classes))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -183,9 +175,9 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         nsk_jvmti_setFailStatus();
     }
     if (classes != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)classes);
+        jvmti->Deallocate((unsigned char*)classes);
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass));
+    NSK_TRACE(jni->DeleteGlobalRef(testedClass));
 
     if (!nsk_jvmti_resumeSync())
         return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassSignature/getclsig006/getclsig006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassSignature/getclsig006/getclsig006.cpp
@@ -58,8 +58,7 @@ static int checkSig(JNIEnv *jni_env, jclass testedCls, int idx) {
     char *sign;
     char *gen_sign;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-            jvmti, testedCls, &sign, &gen_sign))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetClassSignature(testedCls, &sign, &gen_sign))) {
         NSK_COMPLAIN1("TEST FAILED: unable to get class signature for \"%s\"\n\n",
             class_sig[idx][0]);
         return STATUS_FAILED;
@@ -81,13 +80,11 @@ has\n\tsignature: \"%s\"\n\tgeneric signature: \"%s\"\n\n\tExpected: \"%s\"\n\t\
                 sign, (gen_sign==NULL)?"NULL":gen_sign);
 
         NSK_DISPLAY0("Deallocating the signature array\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti, (unsigned char*) sign))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*) sign))) {
             totRes = STATUS_FAILED;
         }
         if (gen_sign!=NULL)
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                    jvmti, (unsigned char*) gen_sign))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*) gen_sign))) {
                 totRes = STATUS_FAILED;
             }
 
@@ -104,8 +101,7 @@ Java_nsk_jvmti_GetClassSignature_getclsig006_check(
     jclass testedCls;
 
     for (i=0; i<CLS_NUM; i++) {
-        if (!NSK_JNI_VERIFY(jni, (testedCls = NSK_CPP_STUB2(
-                FindClass, jni, class_sig[i][1])) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni, (testedCls = jni->FindClass(class_sig[i][1])) != NULL)) {
             NSK_COMPLAIN1("TEST FAILURE: unable to find class \"%s\"\n\n",
                 class_sig[i][0]);
             res = STATUS_FAILED;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/curthrcputime001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentThreadCpuTime/curthrcputime001/curthrcputime001.cpp
@@ -70,8 +70,7 @@ static int checkCpuTime(jvmtiEnv* jvmti, jthread thread, julong* time,
     int success = NSK_TRUE;
 
     NSK_DISPLAY1("GetCurrentThreadCpuTime() for current thread: 0x%p\n", (void*)thread);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, (jlong *)time))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCurrentThreadCpuTime((jlong *)time))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got cpu time: %s\n", julong_to_string(*time, buf));
@@ -260,8 +259,7 @@ callbackThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 
     jvmtiThreadInfo threadInfo;
     {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, thread, &threadInfo))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(thread, &threadInfo))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -284,8 +282,7 @@ callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 
     jvmtiThreadInfo threadInfo;
     {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, thread, &threadInfo))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(thread, &threadInfo))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -337,8 +334,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_get_current_thread_cpu_time = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -353,9 +349,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.VMDeath = callbackVMDeath;
         eventCallbacks.ThreadStart = callbackThreadStart;
         eventCallbacks.ThreadEnd = callbackThreadEnd;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentThreadCpuTimerInfo/curthrtimerinfo001/curthrtimerinfo001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentThreadCpuTimerInfo/curthrtimerinfo001/curthrtimerinfo001.cpp
@@ -66,7 +66,7 @@ static int checkTimerInfo(jvmtiEnv* jvmti, jvmtiTimerInfo* info,
 
     NSK_DISPLAY0("GetCurrentThreadCpuTimerInfo() for current JVMTI env\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, info))) {
+            jvmti->GetCurrentThreadCpuTimerInfo(info))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("Got timer info:\n");
@@ -260,7 +260,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_get_current_thread_cpu_time = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -276,8 +276,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.ThreadStart = callbackThreadStart;
         eventCallbacks.ThreadEnd = callbackThreadEnd;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+                jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetEnv/GetEnv001/GetEnv001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetEnv/GetEnv001/GetEnv001.cpp
@@ -87,64 +87,29 @@ jint Agent_Initialize(JavaVM *vm, char *options, void *reserved)
         return JNI_ERR;
     }
 
-    if (NSK_CPP_STUB3(
-            GetEnv
-            , vm
-            , (void **) &jvmti
-            , JVMTI_VERSION_1_1
-            ) != JNI_OK || jvmti == NULL)
-    {
+    if (vm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1) != JNI_OK || jvmti == NULL) {
         NSK_COMPLAIN0("JVMTI_VERSION_1_1 isn't supported.");
         return JNI_OK;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    GetCapabilities
-                    , jvmti
-                    , &caps)
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     caps.can_retransform_classes = 1;
 
     // Register all necessary JVM capabilities
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    AddCapabilities
-                    , jvmti
-                    , &caps)
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     // Register all necessary event callbacks
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.ClassFileLoadHook = &ClassFileLoadHook;
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    SetEventCallbacks
-                    , jvmti
-                    , &callbacks
-                    , sizeof(callbacks)
-                    )
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     // Enable class retransformation
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(
-                    SetEventNotificationMode
-                    , jvmti
-                    , JVMTI_ENABLE
-                    , JVMTI_EVENT_CLASS_FILE_LOAD_HOOK
-                    , NULL
-                    )
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetEnvironmentLocalStorage/getenvstor001/getenvstor001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetEnvironmentLocalStorage/getenvstor001/getenvstor001.cpp
@@ -53,8 +53,7 @@ static int checkEnvStorage(jvmtiEnv* jvmti, const char where[]) {
     void* storage = NULL;
 
     NSK_DISPLAY0("GetEnvironmentLocalStorage() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetEnvironmentLocalStorage, jvmti, &storage))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetEnvironmentLocalStorage(&storage))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got storage: 0x%p\n", (void*)storage);
@@ -158,9 +157,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetErrorName/geterrname001/geterrname001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetErrorName/geterrname001/geterrname001.cpp
@@ -152,15 +152,14 @@ static int checkGetErrorName(jvmtiEnv *jvmti) {
 
     for (i = 0; i < sizeof(errors)/sizeof(error_info); i++) {
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetErrorName, jvmti, errors[i].err, &name)))
+                jvmti->GetErrorName(errors[i].err, &name)))
             return NSK_FALSE;
         if (strcmp(name, errors[i].name) != 0) {
             NSK_COMPLAIN2("Error: function returns \"%s\", expected \"%s\"\n",
                 name, errors[i].name);
             return_value = NSK_FALSE;
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)name)))
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)name)))
             return NSK_FALSE;
     }
 
@@ -172,7 +171,7 @@ static int checkGetErrorName(jvmtiEnv *jvmti) {
 void JNICALL
 VMInit(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY1("Phase: %s\n", TranslatePhase(phase));
@@ -194,10 +193,10 @@ ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
                   unsigned char** new_class_data) {
     jvmtiPhase curr_phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(access_lock)))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &curr_phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&curr_phase)))
         nsk_jvmti_setFailStatus();
 
     if (phase != curr_phase) {
@@ -210,7 +209,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
             nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(access_lock)))
         nsk_jvmti_setFailStatus();
 }
 
@@ -224,7 +223,7 @@ agentProc(jvmtiEnv *jvmti, JNIEnv* jni, void* arg) {
     if (!nsk_jvmti_waitForSync(timeout))
         return;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY1("Phase: %s\n", TranslatePhase(phase));
@@ -270,12 +269,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
     /* Create data access lock */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti,
-                "_access_lock", &access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_access_lock", &access_lock)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         return JNI_ERR;
 
     NSK_DISPLAY1("Phase: %s\n", TranslatePhase(phase));
@@ -288,21 +285,17 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.VMInit = &VMInit;
     callbacks.ClassFileLoadHook = &ClassFileLoadHook;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* enable VMInit event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_VM_INIT, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
         return JNI_ERR;
 
     /* enable ClassFileLoadHook event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetErrorName/geterrname002/geterrname002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetErrorName/geterrname002/geterrname002.cpp
@@ -48,12 +48,12 @@ agentProc(jvmtiEnv *jvmti, JNIEnv* jni, void* arg) {
 
     NSK_DISPLAY0("Testcase #1: check on JVMTI_ERROR_ILLEGAL_ARGUMENT\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_ILLEGAL_ARGUMENT,
-            NSK_CPP_STUB3(GetErrorName, jvmti, (jvmtiError)(-1), &name)))
+                               jvmti->GetErrorName((jvmtiError)(-1), &name)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY0("Testcase #2: check on JVMTI_ERROR_NULL_POINTER\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_NULL_POINTER,
-            NSK_CPP_STUB3(GetErrorName, jvmti, JVMTI_ERROR_NONE, NULL)))
+                               jvmti->GetErrorName(JVMTI_ERROR_NONE, NULL)))
         nsk_jvmti_setFailStatus();
 
     /* resume debugee after last sync */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetExtensionEvents/extevents001/extevents001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetExtensionEvents/extevents001/extevents001.cpp
@@ -54,8 +54,7 @@ static int checkExtensions(jvmtiEnv* jvmti, const char phase[]) {
     int i;
 
     NSK_DISPLAY0("Get extension events list\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetExtensionEvents, jvmti, &extCount, &extList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetExtensionEvents(&extCount, &extList))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got count: %d\n", (int)extCount);
@@ -219,8 +218,7 @@ static int checkExtensions(jvmtiEnv* jvmti, const char phase[]) {
     }
 
     NSK_DISPLAY1("Deallocate extension events list: 0x%p\n", (void*)extList);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)extList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)extList))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... deallocated\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetExtensionFunctions/extfuncs001/extfuncs001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetExtensionFunctions/extfuncs001/extfuncs001.cpp
@@ -53,8 +53,7 @@ static int checkExtensions(jvmtiEnv* jvmti, const char phase[]) {
     int i;
 
     NSK_DISPLAY0("Get extension functions list\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetExtensionFunctions, jvmti, &extCount, &extList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetExtensionFunctions(&extCount, &extList))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got count: %d\n", (int)extCount);
@@ -230,8 +229,7 @@ static int checkExtensions(jvmtiEnv* jvmti, const char phase[]) {
     }
 
     NSK_DISPLAY1("Deallocate extension functions list: 0x%p\n", (void*)extList);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)extList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)extList))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... deallocated\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetFieldName/getfldnm005/getfldnm005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetFieldName/getfldnm005/getfldnm005.cpp
@@ -92,8 +92,7 @@ static int checkSig(JNIEnv *jni_env, jclass testedCls,
     char *sign;
     char *gen_sign;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB6(GetFieldName,
-            jvmti, testedCls, testedFld, &name, &sign, &gen_sign))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetFieldName(testedCls, testedFld, &name, &sign, &gen_sign))) {
         NSK_COMPLAIN1("TEST FAILED: unable to get field name & signature for \"%s\"\n\n",
             fld_sig[idx][0]);
         return STATUS_FAILED;
@@ -116,15 +115,12 @@ has\n\tsignature: \"%s\"\n\tgeneric signature: \"%s\"\n\n\tExpected: \"%s\"\n\t\
                 sign, (gen_sign==NULL)?"NULL":gen_sign);
 
         NSK_DISPLAY0("Deallocating name & signature arrays\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti, (unsigned char*) name)))
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*) name)))
             totRes = STATUS_FAILED;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti, (unsigned char*) sign)))
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*) sign)))
             totRes = STATUS_FAILED;
         if (gen_sign!=NULL)
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                    jvmti, (unsigned char*) gen_sign)))
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*) gen_sign)))
                 totRes = STATUS_FAILED;
     }
 
@@ -136,8 +132,7 @@ Java_nsk_jvmti_GetFieldName_getfldnm005_check(
         JNIEnv *jni, jobject obj) {
     int res = PASSED, i, instance;
     jfieldID testedFld = NULL;
-    jclass objCls = NSK_CPP_STUB2(GetObjectClass,
-        jni, obj);
+    jclass objCls = jni->GetObjectClass(obj);
 
     for (i=0; i<FLDS_NUM; i++) {
         instance = strcmp(fld_sig[i][1], "instance");
@@ -146,9 +141,7 @@ Java_nsk_jvmti_GetFieldName_getfldnm005_check(
             (instance==0)?"instance":"static",
              fld_sig[i][0]);
         if (instance==0) {
-            if (!NSK_JNI_VERIFY(jni, (testedFld = NSK_CPP_STUB4(
-                    GetFieldID, jni, objCls,
-                    fld_sig[i][0], fld_sig[i][2])) != NULL)) {
+            if (!NSK_JNI_VERIFY(jni, (testedFld = jni->GetFieldID(objCls, fld_sig[i][0], fld_sig[i][2])) != NULL)) {
                 NSK_COMPLAIN1("TEST FAILERE: unable to get field ID for \"%s\"\n\n",
                     fld_sig[i][0]);
                 res = STATUS_FAILED;
@@ -156,9 +149,7 @@ Java_nsk_jvmti_GetFieldName_getfldnm005_check(
             }
         }
         else
-            if (!NSK_JNI_VERIFY(jni, (testedFld = NSK_CPP_STUB4(
-                    GetStaticFieldID, jni, objCls,
-                    fld_sig[i][0], fld_sig[i][2])) != NULL)) {
+            if (!NSK_JNI_VERIFY(jni, (testedFld = jni->GetStaticFieldID(objCls, fld_sig[i][0], fld_sig[i][2])) != NULL)) {
                 NSK_COMPLAIN1("TEST FAILERE: unable to get field ID for \"%s\"\n\n",
                     fld_sig[i][0]);
                 res = STATUS_FAILED;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetJLocationFormat/getjlocfmt001/getjlocfmt001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetJLocationFormat/getjlocfmt001/getjlocfmt001.cpp
@@ -57,14 +57,14 @@ void JNICALL
 VMInit(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread) {
     jvmtiJlocationFormat format;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY1("Phase: %s\n", TranslatePhase(phase));
 
     /* testcase #3: check GetJLocationFormat in VMInit */
     NSK_DISPLAY0("Testcase #3: check GetJLocationFormat in VMInit\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetJLocationFormat, jvmti, &format)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetJLocationFormat(&format)))
         nsk_jvmti_setFailStatus();
     if (!NSK_VERIFY((format == JVMTI_JLOCATION_JVMBCI)
                  || (format == JVMTI_JLOCATION_MACHINEPC)
@@ -85,10 +85,10 @@ ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
     jvmtiJlocationFormat format;
     jvmtiPhase curr_phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(access_lock)))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &curr_phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&curr_phase)))
         nsk_jvmti_setFailStatus();
 
     if (phase != curr_phase) {
@@ -97,7 +97,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
 
         /* testcase #2: check GetJLocationFormat in ClassFileLoadHook */
         NSK_DISPLAY0("Testcase #2: check GetJLocationFormat in ClassFileLoadHook\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetJLocationFormat, jvmti, &format)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetJLocationFormat(&format)))
             nsk_jvmti_setFailStatus();
         if (!NSK_VERIFY((format == JVMTI_JLOCATION_JVMBCI)
                      || (format == JVMTI_JLOCATION_MACHINEPC)
@@ -106,7 +106,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
         NSK_DISPLAY1("JlocationFormat: %s\n", TranslateJlocationFormat(format));
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(access_lock)))
         nsk_jvmti_setFailStatus();
 }
 
@@ -121,14 +121,14 @@ agentProc(jvmtiEnv *jvmti, JNIEnv* jni, void* arg) {
     if (!nsk_jvmti_waitForSync(timeout))
         return;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY1("Phase: %s\n", TranslatePhase(phase));
 
     /* testcase #4: check GetJLocationFormat in agentProc */
     NSK_DISPLAY0("Testcase #4: check GetJLocationFormat in agentProc\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetJLocationFormat, jvmti, &format)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetJLocationFormat(&format)))
         nsk_jvmti_setFailStatus();
     if (!NSK_VERIFY((format == JVMTI_JLOCATION_JVMBCI)
                  || (format == JVMTI_JLOCATION_MACHINEPC)
@@ -173,19 +173,17 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
     /* Create data access lock */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti,
-                "_access_lock", &access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_access_lock", &access_lock)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         return JNI_ERR;
 
     NSK_DISPLAY1("Phase: %s\n", TranslatePhase(phase));
 
     /* testcase #1: check GetJLocationFormat in Agent_OnLoad */
     NSK_DISPLAY0("Testcase #1: check GetJLocationFormat in Agent_OnLoad\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetJLocationFormat, jvmti, &format)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetJLocationFormat(&format)))
         nsk_jvmti_setFailStatus();
     if (!NSK_VERIFY((format == JVMTI_JLOCATION_JVMBCI)
                  || (format == JVMTI_JLOCATION_MACHINEPC)
@@ -196,21 +194,17 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.VMInit = &VMInit;
     callbacks.ClassFileLoadHook = &ClassFileLoadHook;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* enable VMInit event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_VM_INIT, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
         return JNI_ERR;
 
     /* enable ClassFileLoadHook event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetJLocationFormat/getjlocfmt002/getjlocfmt002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetJLocationFormat/getjlocfmt002/getjlocfmt002.cpp
@@ -46,8 +46,7 @@ agentProc(jvmtiEnv *jvmti, JNIEnv* jni, void* arg) {
         return;
 
     NSK_DISPLAY0("Check if GetJLocationFormat(NULL) returns JVMTI_ERROR_NULL_POINTER\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_NULL_POINTER,
-            NSK_CPP_STUB2(GetJLocationFormat, jvmti, NULL)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_NULL_POINTER, jvmti->GetJLocationFormat(NULL)))
         nsk_jvmti_setFailStatus();
 
     /* resume debugee after last sync */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetLoadedClasses/loadedclss002/loadedclss002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetLoadedClasses/loadedclss002/loadedclss002.cpp
@@ -60,8 +60,7 @@ static int lookup(jvmtiEnv* jvmti,
     jint i;
 
     for (i = 0; i < classCount && !found; i++) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti,
-                classes[i], &signature, &generic)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetClassSignature(classes[i], &signature, &generic)))
             break;
 
         if (signature != NULL && strcmp(signature, exp_sig) == 0) {
@@ -70,10 +69,10 @@ static int lookup(jvmtiEnv* jvmti,
         }
 
         if (signature != NULL)
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)signature);
+            jvmti->Deallocate((unsigned char*)signature);
 
         if (generic != NULL)
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)generic);
+            jvmti->Deallocate((unsigned char*)generic);
     }
 
     return found;
@@ -91,8 +90,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!nsk_jvmti_waitForSync(timeout))
         return;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetLoadedClasses, jvmti,
-            &classCount, &classes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetLoadedClasses(&classCount, &classes))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -124,7 +122,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     if (classes != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)classes);
+        jvmti->Deallocate((unsigned char*)classes);
 
     if (!nsk_jvmti_resumeSync())
         return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetLocalVariableTable/localtab004/localtab004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetLocalVariableTable/localtab004/localtab004.cpp
@@ -99,13 +99,9 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
 /* get the JNI method ID for a method with name m_name and
    signature m_sign */
         if (methInfo[i].inst) /* an instance method */
-            methInfo[i].mid = NSK_CPP_STUB4(GetMethodID,
-                jni_env, testedCls,
-                methInfo[i].m_name, methInfo[i].m_sign);
+            methInfo[i].mid = jni_env->GetMethodID(testedCls, methInfo[i].m_name, methInfo[i].m_sign);
         else                   /* a static method */
-            methInfo[i].mid = NSK_CPP_STUB4(GetStaticMethodID,
-                jni_env, testedCls,
-                methInfo[i].m_name, methInfo[i].m_sign);
+            methInfo[i].mid = jni_env->GetStaticMethodID(testedCls, methInfo[i].m_name, methInfo[i].m_sign);
         if (methInfo[i].mid == NULL) {
             NSK_COMPLAIN3("TEST FAILURE: unable to get the method ID for the %s method\
  \"%s\", signature \"%s\"\n\n",
@@ -115,8 +111,7 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
         }
 
 /* get the LocalVariableTable attribute */
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetLocalVariableTable,
-                jvmti, methInfo[i].mid, &count, &lv_table))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetLocalVariableTable(methInfo[i].mid, &count, &lv_table))) {
             NSK_COMPLAIN3("TEST FAILED: unable to get local variable table\n\tfor the %s method \"%s\", signature \"%s\"\n\n",
                 methInfo[i].inst?"instance":"static",
                 methInfo[i].m_name, methInfo[i].m_sign);
@@ -172,8 +167,7 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
 JNIEXPORT jint JNICALL
 Java_nsk_jvmti_GetLocalVariableTable_localtab004_check(
         JNIEnv *env, jobject obj, jobject testedObj) {
-    jclass testedCls = NSK_CPP_STUB2(GetObjectClass,
-        env, testedObj);
+    jclass testedCls = env->GetObjectClass(testedObj);
 
     if (!caps.can_access_local_variables)
         return PASSED;
@@ -205,12 +199,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     /* add capability to access local variables */
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_access_local_variables = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_access_local_variables)

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetLocalVariableTable/localtab005/localtab005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetLocalVariableTable/localtab005/localtab005.cpp
@@ -107,13 +107,9 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
 /* get the JNI method ID for a method with name m_name and
    signature m_sign */
         if (methInfo[i].inst) /* an instance method */
-            methInfo[i].mid = NSK_CPP_STUB4(GetMethodID,
-                jni_env, testedCls,
-                methInfo[i].m_name, methInfo[i].m_sign);
+            methInfo[i].mid = jni_env->GetMethodID(testedCls, methInfo[i].m_name, methInfo[i].m_sign);
         else                   /* a static method */
-            methInfo[i].mid = NSK_CPP_STUB4(GetStaticMethodID,
-                jni_env, testedCls,
-                methInfo[i].m_name, methInfo[i].m_sign);
+            methInfo[i].mid = jni_env->GetStaticMethodID(testedCls, methInfo[i].m_name, methInfo[i].m_sign);
         if (methInfo[i].mid == NULL) {
             NSK_COMPLAIN3("TEST FAILURE: unable to get the method ID for the %s method\
  \"%s\", signature \"%s\"\n\n",
@@ -123,8 +119,7 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
         }
 
 /* get the LocalVariableTable attribute */
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetLocalVariableTable,
-                jvmti, methInfo[i].mid, &count, &lv_table))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetLocalVariableTable(methInfo[i].mid, &count, &lv_table))) {
             NSK_COMPLAIN3("TEST FAILED: unable to get local variable table\n\tfor the %s method \"%s\", signature \"%s\"\n\n",
                 methInfo[i].inst?"instance":"static",
                 methInfo[i].m_name, methInfo[i].m_sign);
@@ -178,8 +173,7 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
                 }
             }
             NSK_DISPLAY0("Deallocating the local variable table entries\n");
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                    jvmti, (unsigned char*) lv_table))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*) lv_table))) {
                 totRes = STATUS_FAILED;
             }
 
@@ -193,8 +187,7 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
 JNIEXPORT jint JNICALL
 Java_nsk_jvmti_GetLocalVariableTable_localtab005_check(
         JNIEnv *env, jobject obj, jobject testedObj) {
-    jclass testedCls = NSK_CPP_STUB2(GetObjectClass,
-        env, testedObj);
+    jclass testedCls = env->GetObjectClass(testedObj);
 
     if (!caps.can_access_local_variables)
         return PASSED;
@@ -226,12 +219,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     /* add capability to access local variables */
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_access_local_variables = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_access_local_variables)

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetMethodName/methname003/methname003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetMethodName/methname003/methname003.cpp
@@ -89,8 +89,7 @@ static int checkSig(JNIEnv *jni_env, jmethodID testedMeth,
     char *sign;
     char *gen_sign;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti, testedMeth, &name, &sign, &gen_sign))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetMethodName(testedMeth, &name, &sign, &gen_sign))) {
         NSK_COMPLAIN1("TEST FAILED: unable to get class signature for \"%s\"\n\n",
             meth_sig[clsIdx][methIdx][0]);
         return STATUS_FAILED;
@@ -112,17 +111,14 @@ has\n\tsignature: \"%s\"\n\tgeneric signature: \"%s\"\n\n\tExpected: \"%s\"\n\t\
                 sign, (gen_sign==NULL)?"NULL":gen_sign);
 
         NSK_DISPLAY0("Deallocating name & signature arrays\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti, (unsigned char*) name))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*) name))) {
             totRes = STATUS_FAILED;
         }
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti, (unsigned char*) sign))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*) sign))) {
             totRes = STATUS_FAILED;
         }
         if (gen_sign!=NULL)
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                    jvmti, (unsigned char*) gen_sign))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*) gen_sign))) {
                 totRes = STATUS_FAILED;
             }
     }
@@ -135,8 +131,7 @@ Java_nsk_jvmti_GetMethodName_methname003_check(
         JNIEnv *jni, jobject obj, jobject testedObj, jint clsIdx) {
     int res = PASSED, i, instance;
     jmethodID testedMeth = NULL;
-    jclass objCls = NSK_CPP_STUB2(GetObjectClass,
-        jni, testedObj);
+    jclass objCls = jni->GetObjectClass(testedObj);
 
     for (i=0; i<METH_NUM; i++) {
         instance = strcmp(meth_sig[clsIdx][i][1], "instance");
@@ -145,9 +140,7 @@ Java_nsk_jvmti_GetMethodName_methname003_check(
             (instance==0)?"instance":"static",
              meth_sig[clsIdx][i][0]);
         if (instance==0) {
-            if (!NSK_JNI_VERIFY(jni, (testedMeth = NSK_CPP_STUB4(GetMethodID,
-                    jni, objCls, meth_sig[clsIdx][i][0],
-                    meth_sig[clsIdx][i][2])) != NULL)) {
+            if (!NSK_JNI_VERIFY(jni, (testedMeth = jni->GetMethodID(objCls, meth_sig[clsIdx][i][0], meth_sig[clsIdx][i][2])) != NULL)) {
                 NSK_COMPLAIN2("TEST FAILERE: unable to get method ID for \"%s\" \"%s\"\n\n",
                     meth_sig[clsIdx][i][0], meth_sig[clsIdx][i][2]);
                 res = STATUS_FAILED;
@@ -155,9 +148,7 @@ Java_nsk_jvmti_GetMethodName_methname003_check(
             }
         }
         else
-            if (!NSK_JNI_VERIFY(jni, (testedMeth = NSK_CPP_STUB4(GetStaticMethodID,
-                    jni, objCls, meth_sig[clsIdx][i][0],
-                    meth_sig[clsIdx][i][2])) != NULL)) {
+            if (!NSK_JNI_VERIFY(jni, (testedMeth = jni->GetStaticMethodID(objCls, meth_sig[clsIdx][i][0], meth_sig[clsIdx][i][2])) != NULL)) {
                 NSK_COMPLAIN2("TEST FAILERE: unable to get method ID for \"%s\" \"%s\"\n\n",
                     meth_sig[clsIdx][i][0], meth_sig[clsIdx][i][2]);
                 res = STATUS_FAILED;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectHashCode/objhashcode001/objhashcode001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectHashCode/objhashcode001/objhashcode001.cpp
@@ -60,8 +60,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             jfieldID objectField = NULL;
 
             NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
-            if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-                    NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+            if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -69,8 +68,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Find static field: %s\n", OBJECT_FIELD_NAME);
             if (!NSK_JNI_VERIFY(jni, (objectField =
-                    NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                                    OBJECT_FIELD_NAME, OBJECT_CLASS_SIG)) != NULL)) {
+                    jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, OBJECT_CLASS_SIG)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -78,16 +76,14 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Get object from static field: %s\n", OBJECT_FIELD_NAME);
             if (!NSK_JNI_VERIFY(jni, (testedObject =
-                    NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                            objectField)) != NULL)) {
+                    jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
             NSK_DISPLAY1("  ... got object: %p\n", (void*)testedObject);
 
             NSK_DISPLAY1("Create global reference for object: %p\n", (void*)testedObject);
-            if (!NSK_JNI_VERIFY(jni, (testedObject =
-                    NSK_CPP_STUB2(NewGlobalRef, jni, testedObject)) != NULL)) {
+            if (!NSK_JNI_VERIFY(jni, (testedObject = jni->NewGlobalRef(testedObject)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -97,8 +93,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Testcase #1: get initial hash code of the object\n");
         {
             NSK_DISPLAY1("Get hashcode for object: %p\n", (void*)testedObject);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetObjectHashCode, jvmti, testedObject, &objectHashCode))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetObjectHashCode(testedObject, &objectHashCode))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -110,8 +105,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             jint hashCode = 0;
 
             NSK_DISPLAY1("Get hashcode for object: %p\n", (void*)testedObject);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetObjectHashCode, jvmti, testedObject, &hashCode))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetObjectHashCode(testedObject, &hashCode))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -141,7 +135,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Get hashcode for object: %p\n", (void*)testedObject);
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetObjectHashCode, jvmti, testedObject, &hashCode))) {
+                    jvmti->GetObjectHashCode(testedObject, &hashCode))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -162,7 +156,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Clean used data\n");
         {
             NSK_DISPLAY1("Delete object reference: %p\n", (void*)testedObject);
-            NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedObject));
+            NSK_TRACE(jni->DeleteGlobalRef(testedObject));
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectSize/objsize001/objsize001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectSize/objsize001/objsize001.cpp
@@ -57,8 +57,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             jfieldID objectField = NULL;
 
             NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
-            if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-                    NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+            if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -66,8 +65,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Find static field: %s\n", OBJECT_FIELD_NAME);
             if (!NSK_JNI_VERIFY(jni, (objectField =
-                    NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                                    OBJECT_FIELD_NAME, OBJECT_CLASS_SIG)) != NULL)) {
+                    jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, OBJECT_CLASS_SIG)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -75,16 +73,14 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Get object from static field: %s\n", OBJECT_FIELD_NAME);
             if (!NSK_JNI_VERIFY(jni, (testedObject =
-                    NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                            objectField)) != NULL)) {
+                    jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
             NSK_DISPLAY1("  ... got object: 0x%p\n", (void*)testedObject);
 
             NSK_DISPLAY1("Create global reference for object: 0x%p\n", (void*)testedObject);
-            if (!NSK_JNI_VERIFY(jni, (testedObject =
-                    NSK_CPP_STUB2(NewGlobalRef, jni, testedObject)) != NULL)) {
+            if (!NSK_JNI_VERIFY(jni, (testedObject = jni->NewGlobalRef(testedObject)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -94,8 +90,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Testcase #1: get initial size of the object\n");
         {
             NSK_DISPLAY1("Get size for object: 0x%p\n", (void*)testedObject);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetObjectSize, jvmti, testedObject, &objectSize))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetObjectSize(testedObject, &objectSize))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -113,8 +108,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             jlong size = 0;
 
             NSK_DISPLAY1("Get size for object: 0x%p\n", (void*)testedObject);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetObjectSize, jvmti, testedObject, &size))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetObjectSize(testedObject, &size))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -142,8 +136,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
                 return;
 
             NSK_DISPLAY1("Get size for object: 0x%p\n", (void*)testedObject);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetObjectSize, jvmti, testedObject, &size))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetObjectSize(testedObject, &size))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -163,7 +156,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Clean used data\n");
         {
             NSK_DISPLAY1("Delete object reference: 0x%p\n", (void*)testedObject);
-            NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedObject));
+            NSK_TRACE(jni->DeleteGlobalRef(testedObject));
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectsWithTags/objwithtags001/objwithtags001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectsWithTags/objwithtags001/objwithtags001.cpp
@@ -63,17 +63,13 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int tagsCount, int obj
 
     NSK_DISPLAY2("Allocate memory for lists: %d objects for %d tags\n",
                                                             objectsCount, tagsCount);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (size * sizeof(jobject)),
-                                                    (unsigned char**)objects))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((size * sizeof(jobject)), (unsigned char**)objects))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... allocated objects list: 0x%p\n", (void*)objects);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (tagsCount * sizeof(jlong)),
-                                                    (unsigned char**)tags))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((tagsCount * sizeof(jlong)), (unsigned char**)tags))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -91,8 +87,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int tagsCount, int obj
     }
 
     NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -100,8 +95,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int tagsCount, int obj
 
     NSK_DISPLAY1("Find static field: %s\n", OBJECTS_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (objectField =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                            OBJECTS_FIELD_NAME, OBJECTS_FIELD_SIG)) != NULL)) {
+            jni->GetStaticFieldID(debugeeClass, OBJECTS_FIELD_NAME, OBJECTS_FIELD_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -109,8 +103,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int tagsCount, int obj
 
     NSK_DISPLAY1("Get objects array from static field: %s\n", OBJECTS_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (arrayObject = (jobjectArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                    objectField)) != NULL)) {
+            jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -120,8 +113,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int tagsCount, int obj
         jsize arrayLen = 0;
         jsize k;
 
-        if (!NSK_JNI_VERIFY(jni, (arrayLen =
-                NSK_CPP_STUB2(GetArrayLength, jni, arrayObject)) == size)) {
+        if (!NSK_JNI_VERIFY(jni, (arrayLen = jni->GetArrayLength(arrayObject)) == size)) {
             NSK_DISPLAY1("  ... got array length: %d\n", (int)size);
             nsk_jvmti_setFailStatus();
             return NSK_FALSE;
@@ -131,13 +123,11 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int tagsCount, int obj
         for (k = 0; k < size; k++) {
             jobject object = NULL;
 
-            if (!NSK_JNI_VERIFY(jni, (object =
-                NSK_CPP_STUB3(GetObjectArrayElement, jni, arrayObject, k)) != NULL)) {
+            if (!NSK_JNI_VERIFY(jni, (object = jni->GetObjectArrayElement(arrayObject, k)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return NSK_FALSE;
             }
-            if (!NSK_JNI_VERIFY(jni, (object =
-                NSK_CPP_STUB2(NewGlobalRef, jni, object)) != NULL)) {
+            if (!NSK_JNI_VERIFY(jni, (object = jni->NewGlobalRef(object)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return NSK_FALSE;
             }
@@ -162,14 +152,14 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int tagsCount, int
     NSK_DISPLAY1("Release objects references: %d objects\n", size);
     for (k = 0; k < size; k++) {
         if (objects[k] != NULL) {
-            NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, objects[k]));
+            NSK_TRACE(jni->DeleteGlobalRef(objects[k]));
         }
     }
     NSK_DISPLAY1("  ... object references released: %d objects\n", size);
 
     NSK_DISPLAY1("Deallocate objects list: 0x%p\n", (void*)objects);
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objects))) {
+            jvmti->Deallocate((unsigned char*)objects))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -178,7 +168,7 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int tagsCount, int
 
     NSK_DISPLAY1("Deallocate tags list: 0x%p\n", (void*)tags);
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)tags))) {
+            jvmti->Deallocate((unsigned char*)tags))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -197,8 +187,7 @@ static int checkTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int tagsCount, int o
 
     NSK_DISPLAY1("Get tagged objects: %d tags\n", tagsCount);
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, tagsCount, tags,
-                &taggedObjectsCount, &taggedObjectsList, &taggedObjectsTags))) {
+            jvmti->GetObjectsWithTags(tagsCount, tags, &taggedObjectsCount, &taggedObjectsList, &taggedObjectsTags))) {
         nsk_jvmti_setFailStatus();
         return NSK_TRUE;
     }
@@ -258,7 +247,7 @@ static int checkTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int tagsCount, int o
             for (j = 0; j < objectsCount; j++) {
                 jobject foundObject = ITEM(objects, i, j);
 
-                if (NSK_CPP_STUB3(IsSameObject, jni, object, foundObject)) {
+                if (jni->IsSameObject(object, foundObject)) {
                     objectsFound++;
 
                     if (expectedCount > 0)
@@ -295,12 +284,12 @@ static int checkTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int tagsCount, int o
 
     NSK_DISPLAY1("Deallocate got objects list: 0x%p\n", (void*)taggedObjectsList);
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)taggedObjectsList))) {
+            jvmti->Deallocate((unsigned char*)taggedObjectsList))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY1("Deallocate got tags list: 0x%p\n", (void*)taggedObjectsTags);
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)taggedObjectsTags))) {
+            jvmti->Deallocate((unsigned char*)taggedObjectsTags))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -338,8 +327,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
                     NSK_DISPLAY3("    #%d: object: 0x%p, tag: %ld\n",
                                             j, (void*)object, (long)tags[i]);
-                    if (!NSK_JVMTI_VERIFY(
-                            NSK_CPP_STUB3(SetTag, jvmti, object, tags[i]))) {
+                    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(object, tags[i]))) {
                         nsk_jvmti_setFailStatus();
                         return;
                     }
@@ -384,8 +372,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
                     NSK_DISPLAY3("    #%d: object: 0x%p, tag: %ld\n",
                                             j, (void*)object, (long)tag);
-                    if (!NSK_JVMTI_VERIFY(
-                            NSK_CPP_STUB3(SetTag, jvmti, object, tag))) {
+                    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(object, tag))) {
                         nsk_jvmti_setFailStatus();
                         return;
                     }
@@ -455,8 +442,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetPhase/getphase001/getphase001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetPhase/getphase001/getphase001.cpp
@@ -45,14 +45,14 @@ static void JNICALL
 VMStart(jvmtiEnv *jvmti, JNIEnv* jni) {
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(access_lock)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY0("VMStart\n");
 
     /* testcase #2: check JVMTI_PHASE_START */
     NSK_DISPLAY0("Testcase #2: check if GetPhase returns JVMTI_PHASE_START\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         nsk_jvmti_setFailStatus();
 
     if (!NSK_VERIFY(phase == JVMTI_PHASE_START))
@@ -60,7 +60,7 @@ VMStart(jvmtiEnv *jvmti, JNIEnv* jni) {
 
     was_VMStart = JNI_TRUE;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(access_lock)))
         nsk_jvmti_setFailStatus();
 }
 
@@ -68,14 +68,14 @@ static void JNICALL
 VMInit(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread) {
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(access_lock)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY0("VMInit\n");
 
     /* testcase #3: check JVMTI_PHASE_LIVE */
     NSK_DISPLAY0("Testcase #3: check if GetPhase returns JVMTI_PHASE_LIVE\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         nsk_jvmti_setFailStatus();
 
     if (!NSK_VERIFY(phase == JVMTI_PHASE_LIVE))
@@ -83,7 +83,7 @@ VMInit(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread) {
 
     was_VMInit = JNI_TRUE;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(access_lock)))
         nsk_jvmti_setFailStatus();
 }
 
@@ -93,7 +93,7 @@ NativeMethodBind(jvmtiEnv* jvmti, JNIEnv *jni,
                  void* address, void** new_address_ptr) {
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(access_lock)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY0("NativeMethodBind\n");
@@ -102,7 +102,7 @@ NativeMethodBind(jvmtiEnv* jvmti, JNIEnv *jni,
 
         /* testcase #5: check JVMTI_PHASE_PRIMORDIAL */
         NSK_DISPLAY0("Testcase #2: check if GetPhase returns JVMTI_PHASE_PRIMORDIAL\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
             nsk_jvmti_setFailStatus();
 
         if (!NSK_VERIFY(phase == JVMTI_PHASE_PRIMORDIAL))
@@ -112,7 +112,7 @@ NativeMethodBind(jvmtiEnv* jvmti, JNIEnv *jni,
 
         /* testcase #2: check JVMTI_PHASE_START */
         NSK_DISPLAY0("Testcase #2: check if GetPhase returns JVMTI_PHASE_START\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
             nsk_jvmti_setFailStatus();
 
         if (!NSK_VERIFY(phase == JVMTI_PHASE_START))
@@ -122,7 +122,7 @@ NativeMethodBind(jvmtiEnv* jvmti, JNIEnv *jni,
 
         /* testcase #3: check JVMTI_PHASE_LIVE */
         NSK_DISPLAY0("Testcase #3: check if GetPhase returns JVMTI_PHASE_LIVE\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
             nsk_jvmti_setFailStatus();
 
         if (!NSK_VERIFY(phase == JVMTI_PHASE_LIVE))
@@ -132,14 +132,14 @@ NativeMethodBind(jvmtiEnv* jvmti, JNIEnv *jni,
 
         /* testcase #4: check JVMTI_PHASE_DEAD */
         NSK_DISPLAY0("Testcase #4: check if GetPhase returns JVMTI_PHASE_DEAD\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
             nsk_jvmti_setFailStatus();
 
         if (!NSK_VERIFY(phase == JVMTI_PHASE_DEAD))
             nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(access_lock)))
         nsk_jvmti_setFailStatus();
 }
 
@@ -154,7 +154,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
                   unsigned char** new_class_data) {
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(access_lock)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY1("ClassFileLoadHook: %s\n", name);
@@ -163,7 +163,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
 
         /* testcase #5: check JVMTI_PHASE_PRIMORDIAL */
         NSK_DISPLAY0("Testcase #2: check if GetPhase returns JVMTI_PHASE_PRIMORDIAL\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
             nsk_jvmti_setFailStatus();
 
         if (!NSK_VERIFY(phase == JVMTI_PHASE_PRIMORDIAL))
@@ -173,7 +173,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
 
         /* testcase #2: check JVMTI_PHASE_START */
         NSK_DISPLAY0("Testcase #2: check if GetPhase returns JVMTI_PHASE_START\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
             nsk_jvmti_setFailStatus();
 
         if (!NSK_VERIFY(phase == JVMTI_PHASE_START))
@@ -183,7 +183,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
 
         /* testcase #3: check JVMTI_PHASE_LIVE */
         NSK_DISPLAY0("Testcase #3: check if GetPhase returns JVMTI_PHASE_LIVE\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
             nsk_jvmti_setFailStatus();
 
         if (!NSK_VERIFY(phase == JVMTI_PHASE_LIVE))
@@ -193,14 +193,14 @@ ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
 
         /* testcase #4: check JVMTI_PHASE_DEAD */
         NSK_DISPLAY0("Testcase #4: check if GetPhase returns JVMTI_PHASE_DEAD\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
             nsk_jvmti_setFailStatus();
 
         if (!NSK_VERIFY(phase == JVMTI_PHASE_DEAD))
             nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(access_lock)))
         nsk_jvmti_setFailStatus();
 }
 
@@ -208,14 +208,14 @@ static void JNICALL
 VMDeath(jvmtiEnv *jvmti, JNIEnv* jni) {
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(access_lock)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY0("VMDeath\n");
 
     /* testcase #3: check JVMTI_PHASE_LIVE */
     NSK_DISPLAY0("Testcase #3: check if GetPhase returns JVMTI_PHASE_LIVE\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         nsk_jvmti_setFailStatus();
 
     if (!NSK_VERIFY(phase == JVMTI_PHASE_LIVE))
@@ -223,7 +223,7 @@ VMDeath(jvmtiEnv *jvmti, JNIEnv* jni) {
 
     was_VMDeath = JNI_TRUE;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(access_lock)))
         nsk_jvmti_setFailStatus();
 }
 
@@ -242,7 +242,7 @@ agentProc(jvmtiEnv *jvmti, JNIEnv* jni, void* arg) {
 
     /* testcase #3: check JVMTI_PHASE_LIVE */
     NSK_DISPLAY0("Testcase #3: check if GetPhase returns JVMTI_PHASE_LIVE\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         nsk_jvmti_setFailStatus();
 
     if (!NSK_VERIFY(phase == JVMTI_PHASE_LIVE))
@@ -289,13 +289,12 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* Create data access lock */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti,
-                "_access_lock", &access_lock)))
+            jvmti->CreateRawMonitor("_access_lock", &access_lock)))
         return JNI_ERR;
 
     /* testcase #1: check JVMTI_PHASE_ONLOAD */
     NSK_DISPLAY0("Testcase #1: check if GetPhase returns JVMTI_PHASE_ONLOAD\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         nsk_jvmti_setFailStatus();
 
     if (!NSK_VERIFY(phase == JVMTI_PHASE_ONLOAD))
@@ -305,7 +304,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_all_class_hook_events = 1;
     caps.can_generate_native_method_bind_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     memset(&callbacks, 0, sizeof(callbacks));
@@ -315,38 +314,32 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.NativeMethodBind = &NativeMethodBind;
     callbacks.ClassFileLoadHook = &ClassFileLoadHook;
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                &callbacks, sizeof(callbacks))))
+            jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* enable VMStart event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_VM_START, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_START, NULL)))
         return JNI_ERR;
 
     /* enable VMInit event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_VM_INIT, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
         return JNI_ERR;
 
     /* enable NativeMethodBind event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_NATIVE_METHOD_BIND, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_NATIVE_METHOD_BIND, NULL)))
         return JNI_ERR;
 
     /* enable ClassFileLoadHook event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
 
     /* enable VMDeath event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_VM_DEATH, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
         return JNI_ERR;
 
     /* register agent proc and arg */
@@ -373,7 +366,7 @@ Agent_OnUnload(JavaVM *jvm)
 
     /* testcase #4: check JVMTI_PHASE_DEAD */
     NSK_DISPLAY0("Testcase #4: check if GetPhase returns JVMTI_PHASE_DEAD\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         exit(97);
 
     if (!NSK_VERIFY(phase == JVMTI_PHASE_DEAD))

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetPhase/getphase002/getphase002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetPhase/getphase002/getphase002.cpp
@@ -47,7 +47,7 @@ agentProc(jvmtiEnv *jvmti, JNIEnv* jni, void* arg) {
 
     NSK_DISPLAY0("Check if GetPhase(NULL) returns JVMTI_ERROR_NULL_POINTER\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_NULL_POINTER,
-            NSK_CPP_STUB2(GetPhase, jvmti, NULL)))
+            jvmti->GetPhase(NULL)))
         nsk_jvmti_setFailStatus();
 
     /* resume debugee after last sync */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetPotentialCapabilities/getpotcaps001/getpotcaps001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetPotentialCapabilities/getpotcaps001/getpotcaps001.cpp
@@ -130,7 +130,7 @@ static int checkCapabilities(jvmtiEnv* jvmti, const char where[]) {
 
     NSK_DISPLAY0("GetPotentialCapabilities() for current JVMTI env\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps))) {
+            jvmti->GetPotentialCapabilities(&caps))) {
         return NSK_FALSE;
     }
 
@@ -233,8 +233,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+                jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops001/getsysprops001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops001/getsysprops001.cpp
@@ -42,7 +42,7 @@ static int checkProperties(jvmtiEnv* jvmti, const char phase[]) {
 
     NSK_DISPLAY0("Invoke GetSystemProperties()\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetSystemProperties, jvmti, &count, &properties))) {
+            jvmti->GetSystemProperties(&count, &properties))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -75,7 +75,7 @@ static int checkProperties(jvmtiEnv* jvmti, const char phase[]) {
     }
     NSK_DISPLAY0("Deallocate properties list\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)properties))) {
+            jvmti->Deallocate((unsigned char*)properties))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... deallocated\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops002/getsysprops002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperties/getsysprops002/getsysprops002.cpp
@@ -56,7 +56,7 @@ static int checkProperties (jvmtiEnv* jvmti, const char phase[]) {
 
     NSK_DISPLAY0("Get system properties list\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetSystemProperties, jvmti, &count, &properties))) {
+            jvmti->GetSystemProperties(&count, &properties))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got properties: %d\n", (int)count);
@@ -108,7 +108,7 @@ static int checkProperties (jvmtiEnv* jvmti, const char phase[]) {
 
     NSK_DISPLAY0("Deallocate properties list\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)properties))) {
+            jvmti->Deallocate((unsigned char*)properties))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... deallocated\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop001/getsysprop001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop001/getsysprop001.cpp
@@ -42,7 +42,7 @@ static int checkProperties(jvmtiEnv* jvmti, const char phase[]) {
 
     NSK_DISPLAY0("Get system properties names\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetSystemProperties, jvmti, &count, &properties))) {
+            jvmti->GetSystemProperties(&count, &properties))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got properties: %d\n", (int)count);
@@ -65,7 +65,7 @@ static int checkProperties(jvmtiEnv* jvmti, const char phase[]) {
             }
 
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetSystemProperty, jvmti, properties[i], &value))) {
+                    jvmti->GetSystemProperty(properties[i], &value))) {
                 success = NSK_FALSE;
                 continue;
             }
@@ -81,7 +81,7 @@ static int checkProperties(jvmtiEnv* jvmti, const char phase[]) {
             }
 
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)value))) {
+                    jvmti->Deallocate((unsigned char*)value))) {
                 success = NSK_FALSE;
             }
         }
@@ -90,7 +90,7 @@ static int checkProperties(jvmtiEnv* jvmti, const char phase[]) {
 
     NSK_DISPLAY0("Deallocate properties list\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)properties))) {
+            jvmti->Deallocate((unsigned char*)properties))) {
         success = NSK_FALSE;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop002/getsysprop002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetSystemProperty/getsysprop002/getsysprop002.cpp
@@ -53,7 +53,7 @@ static int checkProperty(jvmtiEnv* jvmti, const char phase[], PropertyDesc* desc
 
     NSK_DISPLAY1("Get value of tested property: %s\n", desc->name);
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetSystemProperty, jvmti, desc->name, &value))) {
+            jvmti->GetSystemProperty(desc->name, &value))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got value: \"%s\"\n", nsk_null_string(value));
@@ -73,7 +73,7 @@ static int checkProperty(jvmtiEnv* jvmti, const char phase[], PropertyDesc* desc
     }
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)value))) {
+            jvmti->Deallocate((unsigned char*)value))) {
         success = NSK_FALSE;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetTag/gettag001/gettag001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetTag/gettag001/gettag001.cpp
@@ -61,7 +61,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
             if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-                    NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+                    jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -69,8 +69,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Find static field: %s\n", OBJECT_FIELD_NAME);
             if (!NSK_JNI_VERIFY(jni, (objectField =
-                    NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                                    OBJECT_FIELD_NAME, OBJECT_CLASS_SIG)) != NULL)) {
+                    jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, OBJECT_CLASS_SIG)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -78,8 +77,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Get object from static field: %s\n", OBJECT_FIELD_NAME);
             if (!NSK_JNI_VERIFY(jni, (testedObject =
-                    NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                            objectField)) != NULL)) {
+                    jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -87,7 +85,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Create global reference for object: 0x%p\n", (void*)testedObject);
             if (!NSK_JNI_VERIFY(jni, (testedObject =
-                    NSK_CPP_STUB2(NewGlobalRef, jni, testedObject)) != NULL)) {
+                    jni->NewGlobalRef(testedObject)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -100,7 +98,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Get tag for object: 0x%p\n", (void*)testedObject);
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetTag, jvmti, testedObject, &objectTag))) {
+                    jvmti->GetTag(testedObject, &objectTag))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -120,7 +118,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Clean used data\n");
         {
             NSK_DISPLAY1("Delete object reference: 0x%p\n", (void*)testedObject);
-            NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedObject));
+            NSK_TRACE(jni->DeleteGlobalRef(testedObject));
         }
     }
 
@@ -164,7 +162,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime001/thrcputime001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime001/thrcputime001.cpp
@@ -71,7 +71,7 @@ static int checkCpuTime(jvmtiEnv* jvmti, jthread thread, julong* time,
 
     NSK_DISPLAY1("GetThreadCpuTime() for current thread (passing NULL): 0x%p\n", (void*)thread);
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, NULL, (jlong *)time))) {
+            jvmti->GetThreadCpuTime(NULL, (jlong *)time))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got cpu time: %s\n", julong_to_string(*time, buf));
@@ -261,7 +261,7 @@ callbackThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     jvmtiThreadInfo threadInfo;
     {
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, thread, &threadInfo))) {
+                jvmti->GetThreadInfo(thread, &threadInfo))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -285,7 +285,7 @@ callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     jvmtiThreadInfo threadInfo;
     {
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, thread, &threadInfo))) {
+                jvmti->GetThreadInfo(thread, &threadInfo))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -338,7 +338,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_get_thread_cpu_time = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -354,8 +354,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.ThreadStart = callbackThreadStart;
         eventCallbacks.ThreadEnd = callbackThreadEnd;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+                jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/thrcputime002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTime/thrcputime002/thrcputime002.cpp
@@ -73,8 +73,7 @@ static int checkCpuTime(jvmtiEnv* jvmti, jthread thread, julong* time,
     int success = NSK_TRUE;
 
     NSK_DISPLAY1("GetThreadCpuTime() for thread: 0x%p\n", (void*)thread);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, (jlong *)time))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetThreadCpuTime(thread, (jlong *)time))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got cpu time: %s\n", julong_to_string(*time, buf));
@@ -265,8 +264,7 @@ callbackThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 
     jvmtiThreadInfo threadInfo;
     {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, thread, &threadInfo))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(thread, &threadInfo))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -282,8 +280,7 @@ callbackThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     }
 
     if (threadInfo.name != NULL && strcmp(threadInfo.name, TESTED_THREAD_NAME) == 0) {
-        if (!NSK_JNI_VERIFY(jni, (testedThread =
-                NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni, (testedThread = jni->NewGlobalRef(thread)) != NULL)) {
             nsk_jvmti_setFailStatus();
         }
 
@@ -302,8 +299,7 @@ callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 
     jvmtiThreadInfo threadInfo;
     {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, thread, &threadInfo))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(thread, &threadInfo))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -324,7 +320,7 @@ callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
         if (!checkCpuTime(jvmti, thread, &time, &prevTestedThreadTime, "THREAD_END callback")) {
             nsk_jvmti_setFailStatus();
         }
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedThread));
+        NSK_TRACE(jni->DeleteGlobalRef(testedThread));
         testedThread = NULL;
     }
 }
@@ -365,8 +361,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_get_thread_cpu_time = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -381,9 +376,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.VMDeath = callbackVMDeath;
         eventCallbacks.ThreadStart = callbackThreadStart;
         eventCallbacks.ThreadEnd = callbackThreadEnd;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTimerInfo/thrtimerinfo001/thrtimerinfo001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadCpuTimerInfo/thrtimerinfo001/thrtimerinfo001.cpp
@@ -66,7 +66,7 @@ static int checkTimerInfo(jvmtiEnv* jvmti, jvmtiTimerInfo* info,
 
     NSK_DISPLAY0("GetThreadCpuTimerInfo() for current JVMTI env\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, info))) {
+            jvmti->GetThreadCpuTimerInfo(info))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("Got timer info:\n");
@@ -260,7 +260,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_get_thread_cpu_time = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -276,8 +276,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.ThreadStart = callbackThreadStart;
         eventCallbacks.ThreadEnd = callbackThreadEnd;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+                jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/getthrdgrpchld001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadGroupChildren/getthrdgrpchld001/getthrdgrpchld001.cpp
@@ -81,7 +81,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY0("Get top level thread groups\n");
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetTopThreadGroups, jvmti, &topGroupsCount, &topGroups))) {
+                    jvmti->GetTopThreadGroups(&topGroupsCount, &topGroups))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -110,8 +110,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Get children of root thread group: %p\n", (void*)rootGroup);
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB6(GetThreadGroupChildren, jvmti, rootGroup,
-                                    &threadsCount, &threads, &groupsCount, &groups))) {
+                    jvmti->GetThreadGroupChildren(rootGroup, &threadsCount, &threads, &groupsCount, &groups))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -142,7 +141,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
                     jvmtiThreadGroupInfo info;
 
                     if (!NSK_JVMTI_VERIFY(
-                            NSK_CPP_STUB3(GetThreadGroupInfo, jvmti, groups[i], &info))) {
+                            jvmti->GetThreadGroupInfo(groups[i], &info))) {
                         nsk_jvmti_setFailStatus();
                         continue;
                     }
@@ -221,11 +220,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             /* deallocate arrays */
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)groups))) {
+                    jvmti->Deallocate((unsigned char*)groups))) {
                 nsk_jvmti_setFailStatus();
             }
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads))) {
+                    jvmti->Deallocate((unsigned char*)threads))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -258,8 +257,7 @@ static int checkThreadGroup(jvmtiEnv* jvmti, JNIEnv* jni,
         jthreadGroup* groups = NULL;
 
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB6(GetThreadGroupChildren, jvmti, group,
-                                &threadsCount, &threads, &groupsCount, &groups))) {
+                jvmti->GetThreadGroupChildren(group, &threadsCount, &threads, &groupsCount, &groups))) {
             nsk_jvmti_setFailStatus();
             return NSK_FALSE;
         }
@@ -290,7 +288,7 @@ static int checkThreadGroup(jvmtiEnv* jvmti, JNIEnv* jni,
                 jvmtiThreadInfo info;
 
                 if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info))) {
+                        jvmti->GetThreadInfo(threads[i], &info))) {
                     nsk_jvmti_setFailStatus();
                     continue;
                 }
@@ -314,11 +312,11 @@ static int checkThreadGroup(jvmtiEnv* jvmti, JNIEnv* jni,
 
         /* deallocate arrays */
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)groups))) {
+                jvmti->Deallocate((unsigned char*)groups))) {
             nsk_jvmti_setFailStatus();
         }
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads))) {
+                jvmti->Deallocate((unsigned char*)threads))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -339,8 +337,7 @@ static jthreadGroup findThreadGroupByName(jvmtiEnv* jvmti, JNIEnv* jni, const ch
         jthreadGroup * groups = NULL;
 
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB6(GetThreadGroupChildren, jvmti, groupsList[i],
-                                &threadsCount, &threads, &groupsCount, &groups))) {
+                jvmti->GetThreadGroupChildren(groupsList[i], &threadsCount, &threads, &groupsCount, &groups))) {
             nsk_jvmti_setFailStatus();
             return NULL;
         }
@@ -357,7 +354,7 @@ static jthreadGroup findThreadGroupByName(jvmtiEnv* jvmti, JNIEnv* jni, const ch
                 if (groups[i] != NULL) {
 
                     if (!NSK_JVMTI_VERIFY(
-                            NSK_CPP_STUB3(GetThreadGroupInfo, jvmti, groups[i], &info))) {
+                            jvmti->GetThreadGroupInfo(groups[i], &info))) {
                         nsk_jvmti_setFailStatus();
                         continue;
                     }
@@ -376,11 +373,11 @@ static jthreadGroup findThreadGroupByName(jvmtiEnv* jvmti, JNIEnv* jni, const ch
 
         /* deallocate arrays */
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)groups))) {
+                jvmti->Deallocate((unsigned char*)groups))) {
             nsk_jvmti_setFailStatus();
         }
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads))) {
+                jvmti->Deallocate((unsigned char*)threads))) {
             nsk_jvmti_setFailStatus();
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadLocalStorage/getthrdstor001/getthrdstor001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetThreadLocalStorage/getthrdstor001/getthrdstor001.cpp
@@ -59,7 +59,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
         NSK_DISPLAY1("GetThreadLocalStorage() for tested thread: %p\n", (void*)testedThread);
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadLocalStorage, jvmti, testedThread, &storage))) {
+                jvmti->GetThreadLocalStorage(testedThread, &storage))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -76,7 +76,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
         NSK_DISPLAY0("GetThreadLocalStorage() for current agent thread\n");
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadLocalStorage, jvmti, NULL, &storage))) {
+                jvmti->GetThreadLocalStorage(NULL, &storage))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -91,7 +91,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
 
         NSK_DISPLAY0("Delete thread reference\n");
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedThread));
+        NSK_TRACE(jni->DeleteGlobalRef(testedThread));
     }
 
     NSK_DISPLAY0("Let debugee to finish\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetTime/gettime001/gettime001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetTime/gettime001/gettime001.cpp
@@ -59,7 +59,7 @@ static int checkTime(jvmtiEnv* jvmti, julong* time,
 
     NSK_DISPLAY0("GetTime() for current JVMTI env\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetTime, jvmti, (jlong *)time))) {
+            jvmti->GetTime((jlong *)time))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got time: %s\n", julong_to_string(*time, buf));
@@ -186,8 +186,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+                jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetTimerInfo/timerinfo001/timerinfo001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetTimerInfo/timerinfo001/timerinfo001.cpp
@@ -59,7 +59,7 @@ static int checkTimerInfo(jvmtiEnv* jvmti, jvmtiTimerInfo* info,
 
     NSK_DISPLAY0("GetTimerInfo() for current JVMTI env\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetTimerInfo, jvmti, info))) {
+            jvmti->GetTimerInfo(info))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("Got timer info:\n");
@@ -203,8 +203,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+                jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/InterruptThread/intrpthrd001/intrpthrd001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/InterruptThread/intrpthrd001/intrpthrd001.cpp
@@ -57,7 +57,7 @@ static int prepare(jvmtiEnv* jvmti) {
 
     /* get all live threads */
     if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+           jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -70,7 +70,7 @@ static int prepare(jvmtiEnv* jvmti) {
 
         /* get thread information */
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+                jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -89,7 +89,7 @@ static int prepare(jvmtiEnv* jvmti) {
 
     /* deallocate threads list */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+            jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -112,8 +112,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!NSK_VERIFY(runningThread != NULL)) {
         nsk_jvmti_setFailStatus();
     } else {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(InterruptThread,
-                jvmti, runningThread)))
+        if (!NSK_JVMTI_VERIFY(jvmti->InterruptThread(runningThread)))
             nsk_jvmti_setFailStatus();
     }
 
@@ -121,8 +120,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!NSK_VERIFY(waitingThread != NULL)) {
         nsk_jvmti_setFailStatus();
     } else {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(InterruptThread,
-                jvmti, waitingThread)))
+        if (!NSK_JVMTI_VERIFY(jvmti->InterruptThread(waitingThread)))
             nsk_jvmti_setFailStatus();
     }
 
@@ -130,8 +128,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!NSK_VERIFY(sleepingThread != NULL)) {
         nsk_jvmti_setFailStatus();
     } else {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(InterruptThread,
-                jvmti, sleepingThread)))
+        if (!NSK_JVMTI_VERIFY(jvmti->InterruptThread(sleepingThread)))
             nsk_jvmti_setFailStatus();
     }
 
@@ -173,7 +170,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_signal_thread = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsMethodObsolete/isobsolete001/isobsolete001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IsMethodObsolete/isobsolete001/isobsolete001.cpp
@@ -60,7 +60,7 @@ static void checkMethodObsolete(jvmtiEnv* jvmti, jmethodID method, const char na
 
     NSK_DISPLAY3("Call IsObsolete() for %s method: %p (%s)\n", kind, (void*)method, name);
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(IsMethodObsolete, jvmti, method, &obsolete))) {
+            jvmti->IsMethodObsolete(method, &obsolete))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY1("  ... got obsolete: %d\n", (int)obsolete);
@@ -83,8 +83,7 @@ static void checkStackMethodsObsolete(jvmtiEnv* jvmti, jthread thread,
 
     NSK_DISPLAY1("Get stack frames for thread: %p\n", (void*)thread);
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB6(GetStackTrace, jvmti, thread, 0, MAX_STACK_DEPTH,
-                                                    frameStack, &frameCount))) {
+            jvmti->GetStackTrace(thread, 0, MAX_STACK_DEPTH, frameStack, &frameCount))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -104,8 +103,7 @@ static void checkStackMethodsObsolete(jvmtiEnv* jvmti, jthread thread,
             NSK_DISPLAY1("  frame #%i:\n", i);
             NSK_DISPLAY1("     methodID:  %p\n", (void*)frameStack[i].method);
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB5(GetMethodName, jvmti, frameStack[i].method,
-                                                        &name, &signature, &generic))) {
+                    jvmti->GetMethodName(frameStack[i].method, &name, &signature, &generic))) {
                 nsk_jvmti_setFailStatus();
                 continue;
             }
@@ -122,15 +120,15 @@ static void checkStackMethodsObsolete(jvmtiEnv* jvmti, jthread thread,
             }
 
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)name))) {
+                    jvmti->Deallocate((unsigned char*)name))) {
                 nsk_jvmti_setFailStatus();
             }
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)signature))) {
+                    jvmti->Deallocate((unsigned char*)signature))) {
                 nsk_jvmti_setFailStatus();
             }
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)generic))) {
+                    jvmti->Deallocate((unsigned char*)generic))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -156,7 +154,7 @@ static int redefineClass(jvmtiEnv* jvmti, jclass klass, const char className[],
 
     NSK_DISPLAY1("Redefine class: %s\n", className);
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &classDef))) {
+            jvmti->RedefineClasses(1, &classDef))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -176,7 +174,7 @@ static int getClassfileBytes(JNIEnv* jni, jvmtiEnv* jvmti,
 
     NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+            jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -184,8 +182,7 @@ static int getClassfileBytes(JNIEnv* jni, jvmtiEnv* jvmti,
 
     NSK_DISPLAY1("Find static field: %s\n", CLASSFILE_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                            CLASSFILE_FIELD_NAME, CLASSFILE_FIELD_SIG)) != NULL)) {
+            jni->GetStaticFieldID(debugeeClass, CLASSFILE_FIELD_NAME, CLASSFILE_FIELD_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -193,15 +190,14 @@ static int getClassfileBytes(JNIEnv* jni, jvmtiEnv* jvmti,
 
     NSK_DISPLAY1("Get classfile bytes array from static field: %s\n", CLASSFILE_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (array = (jbyteArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                    fieldID)) != NULL)) {
+            jni->GetStaticObjectField(debugeeClass, fieldID)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got array object: %p\n", (void*)array);
 
     if (!NSK_JNI_VERIFY(jni, (*size =
-            NSK_CPP_STUB2(GetArrayLength, jni, array)) > 0)) {
+            jni->GetArrayLength(array)) > 0)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -210,8 +206,7 @@ static int getClassfileBytes(JNIEnv* jni, jvmtiEnv* jvmti,
     {
         jboolean isCopy;
         if (!NSK_JNI_VERIFY(jni, (elements =
-                NSK_CPP_STUB3(GetByteArrayElements, jni, array,
-                                                            &isCopy)) != NULL)) {
+                jni->GetByteArrayElements(array, &isCopy)) != NULL)) {
             nsk_jvmti_setFailStatus();
         return NSK_FALSE;
         }
@@ -219,7 +214,7 @@ static int getClassfileBytes(JNIEnv* jni, jvmtiEnv* jvmti,
     NSK_DISPLAY1("  ... got elements list: %p\n", (void*)elements);
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, *size, bytes))) {
+            jvmti->Allocate(*size, bytes))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -231,7 +226,7 @@ static int getClassfileBytes(JNIEnv* jni, jvmtiEnv* jvmti,
     NSK_DISPLAY1("  ... copied bytecode: %d bytes\n", (int)*size);
 
     NSK_DISPLAY1("Release elements list: %p\n", (void*)elements);
-    NSK_TRACE(NSK_CPP_STUB4(ReleaseByteArrayElements, jni, array, elements, JNI_ABORT));
+    NSK_TRACE(jni->ReleaseByteArrayElements(array, elements, JNI_ABORT));
     NSK_DISPLAY0("  ... released\n");
 
     return NSK_TRUE;
@@ -264,7 +259,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         {
             NSK_DISPLAY1("Find tested class: %s\n", TESTED_CLASS_NAME);
             if (!NSK_JNI_VERIFY(jni, (testedClass =
-                    NSK_CPP_STUB2(FindClass, jni, TESTED_CLASS_NAME)) != NULL)) {
+                    jni->FindClass(TESTED_CLASS_NAME)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -272,7 +267,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Make global reference for class object: %p\n", (void*)testedClass);
             if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass)
-                    NSK_CPP_STUB2(NewGlobalRef, jni, testedClass)) != NULL)) {
+                    jni->NewGlobalRef(testedClass)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -280,8 +275,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Get static methodID: %s\n", STATIC_METHOD_NAME);
             if (!NSK_JNI_VERIFY(jni, (staticMethodID =
-                    NSK_CPP_STUB4(GetStaticMethodID, jni, testedClass,
-                                    STATIC_METHOD_NAME, STATIC_METHOD_SIG)) != NULL)) {
+                    jni->GetStaticMethodID(testedClass, STATIC_METHOD_NAME, STATIC_METHOD_SIG)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -289,8 +283,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Get instance methodID: %s\n", INSTANCE_METHOD_NAME);
             if (!NSK_JNI_VERIFY(jni, (instanceMethodID =
-                    NSK_CPP_STUB4(GetMethodID, jni, testedClass,
-                                    INSTANCE_METHOD_NAME, INSTANCE_METHOD_SIG)) != NULL)) {
+                    jni->GetMethodID(testedClass, INSTANCE_METHOD_NAME, INSTANCE_METHOD_SIG)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -342,15 +335,15 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         {
             NSK_DISPLAY1("Deallocate classfile bytes array: %p\n", (void*)classfileBytes);
             if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(Deallocate, jvmti, classfileBytes))) {
+                        jvmti->Deallocate(classfileBytes))) {
                 nsk_jvmti_setFailStatus();
             }
 
             NSK_DISPLAY1("Delete global eference to thread: %p\n", (void*)testedThread);
-            NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedThread));
+            NSK_TRACE(jni->DeleteGlobalRef(testedThread));
 
             NSK_DISPLAY1("Delete global reference to class: %p\n", (void*)testedClass);
-            NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass));
+            NSK_TRACE(jni->DeleteGlobalRef(testedClass));
         }
     }
 
@@ -394,7 +387,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_redefine_classes = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap001/iterheap001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap001/iterheap001.cpp
@@ -92,14 +92,14 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
     tag++;
 
     if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetObjectField, jni, firstObject, firstField)) != NULL)) {
+            jni->GetObjectField(firstObject, firstField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
     objectDescList[count].tag = objTag;
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, obj, objTag))) {
+            jvmti->SetTag(obj, objTag))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -111,7 +111,7 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
         return NSK_FALSE;
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteLocalRef, jni, obj));
+    NSK_TRACE(jni->DeleteLocalRef(obj));
     return success;
 }
 
@@ -134,9 +134,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     *objectsCount = 2 * chainLength;
 
     NSK_DISPLAY1("Allocate memory for objects list: %d objects\n", *objectsCount);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (*objectsCount * sizeof(ObjectDesc)),
-                                                    (unsigned char**)objectDescList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)), (unsigned char**)objectDescList))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -153,7 +151,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+            jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -161,7 +159,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find root object class: %s\n", ROOT_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (rootObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, ROOT_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -169,7 +167,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find chain object class: %s\n", CHAIN_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (chainObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -177,8 +175,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find static field in debugee class: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (objectField =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                            OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -186,8 +183,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", REACHABLE_CHAIN_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (reachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -195,8 +191,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", UNREACHABLE_CHAIN_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (unreachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -204,8 +199,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in chain object class: %s\n", TAIL_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (tailField =
-            NSK_CPP_STUB4(GetFieldID, jni, chainObjectClass,
-                            TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(chainObjectClass, TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -213,8 +207,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Get root object from static field: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (rootObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                    objectField)) != NULL)) {
+            jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -312,7 +305,7 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     if (objectDescList != NULL) {
         NSK_DISPLAY1("Deallocate objects list: 0x%p\n", (void*)objectDescList);
         if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescList))) {
+            jvmti->Deallocate((unsigned char*)objectDescList))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -430,9 +423,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Iterate over all object in heap with filter JVMTI_HEAP_OBJECT_EITHER\n");
         {
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(IterateOverHeap, jvmti,
-                        JVMTI_HEAP_OBJECT_EITHER, heapObjectCallback,
-                        &fakeUserData))) {
+                    jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_EITHER, heapObjectCallback, &fakeUserData))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -542,7 +533,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         caps.can_tag_objects = 1;
         caps.can_generate_object_free_events = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -552,8 +543,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ObjectFree = callbackObjectFree;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+                jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap002/iterheap002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap002/iterheap002.cpp
@@ -92,14 +92,14 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
     tag++;
 
     if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetObjectField, jni, firstObject, firstField)) != NULL)) {
+            jni->GetObjectField(firstObject, firstField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
     objectDescList[count].tag = objTag;
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, obj, objTag))) {
+            jvmti->SetTag(obj, objTag))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -111,7 +111,7 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
         return NSK_FALSE;
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteLocalRef, jni, obj));
+    NSK_TRACE(jni->DeleteLocalRef(obj));
     return success;
 }
 
@@ -134,9 +134,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     *objectsCount = 2 * chainLength;
 
     NSK_DISPLAY1("Allocate memory for objects list: %d objects\n", *objectsCount);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (*objectsCount * sizeof(ObjectDesc)),
-                                                    (unsigned char**)objectDescList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)), (unsigned char**)objectDescList))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -153,7 +151,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+            jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -161,7 +159,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find root object class: %s\n", ROOT_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (rootObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, ROOT_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -169,7 +167,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find chain object class: %s\n", CHAIN_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (chainObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -177,8 +175,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find static field in debugee class: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (objectField =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                            OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -186,8 +183,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", REACHABLE_CHAIN_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (reachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -195,8 +191,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", UNREACHABLE_CHAIN_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (unreachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -204,8 +199,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in chain object class: %s\n", TAIL_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (tailField =
-            NSK_CPP_STUB4(GetFieldID, jni, chainObjectClass,
-                            TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(chainObjectClass, TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -213,8 +207,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Get root object from static field: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (rootObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                    objectField)) != NULL)) {
+            jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -312,7 +305,7 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     if (objectDescList != NULL) {
         NSK_DISPLAY1("Deallocate objects list: 0x%p\n", (void*)objectDescList);
         if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescList))) {
+            jvmti->Deallocate((unsigned char*)objectDescList))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -438,9 +431,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Iterate over all object in heap with filter JVMTI_HEAP_OBJECT_TAGGED\n");
         {
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(IterateOverHeap, jvmti,
-                        JVMTI_HEAP_OBJECT_TAGGED, heapObjectCallback,
-                        &fakeUserData))) {
+                    jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, heapObjectCallback, &fakeUserData))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -550,7 +541,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         caps.can_tag_objects = 1;
         caps.can_generate_object_free_events = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -560,8 +551,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ObjectFree = callbackObjectFree;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+                jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap003/iterheap003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap003/iterheap003.cpp
@@ -92,14 +92,14 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
     tag++;
 
     if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetObjectField, jni, firstObject, firstField)) != NULL)) {
+            jni->GetObjectField(firstObject, firstField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
     objectDescList[count].tag = objTag;
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, obj, objTag))) {
+            jvmti->SetTag(obj, objTag))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -111,7 +111,7 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
         return NSK_FALSE;
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteLocalRef, jni, obj));
+    NSK_TRACE(jni->DeleteLocalRef(obj));
     return success;
 }
 
@@ -134,9 +134,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     *objectsCount = 2 * chainLength;
 
     NSK_DISPLAY1("Allocate memory for objects list: %d objects\n", *objectsCount);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (*objectsCount * sizeof(ObjectDesc)),
-                                                    (unsigned char**)objectDescList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)), (unsigned char**)objectDescList))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -153,7 +151,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+            jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -161,7 +159,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find root object class: %s\n", ROOT_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (rootObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, ROOT_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -169,7 +167,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find chain object class: %s\n", CHAIN_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (chainObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -177,8 +175,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find static field in debugee class: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (objectField =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                            OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -186,8 +183,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", REACHABLE_CHAIN_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (reachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -195,8 +191,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", UNREACHABLE_CHAIN_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (unreachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -204,8 +199,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in chain object class: %s\n", TAIL_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (tailField =
-            NSK_CPP_STUB4(GetFieldID, jni, chainObjectClass,
-                            TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(chainObjectClass, TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -213,8 +207,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Get root object from static field: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (rootObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                    objectField)) != NULL)) {
+            jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -312,7 +305,7 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     if (objectDescList != NULL) {
         NSK_DISPLAY1("Deallocate objects list: 0x%p\n", (void*)objectDescList);
         if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescList))) {
+            jvmti->Deallocate((unsigned char*)objectDescList))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -439,9 +432,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Iterate over all object in heap with filter JVMTI_HEAP_OBJECT_UNTAGGED\n");
         {
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(IterateOverHeap, jvmti,
-                        JVMTI_HEAP_OBJECT_UNTAGGED, heapObjectCallback,
-                        &fakeUserData))) {
+                    jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_UNTAGGED, heapObjectCallback, &fakeUserData))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -551,7 +542,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         caps.can_tag_objects = 1;
         caps.can_generate_object_free_events = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -561,8 +552,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ObjectFree = callbackObjectFree;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+                jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap004/iterheap004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap004/iterheap004.cpp
@@ -65,9 +65,7 @@ heapObjectCallbackForFirstIteration(jlong class_tag,
     *tag_ptr = (jlong)++objectDescCount;
 
     /* Allocate memory for next list element*/
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (sizeof(ObjectDesc)),
-                                               (unsigned char**)&objectDescBuf))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((sizeof(ObjectDesc)), (unsigned char**)&objectDescBuf))) {
         nsk_jvmti_setFailStatus();
         callbackAborted = 1;
         NSK_COMPLAIN0("heapObjectCallbackForFirstIteration: Allocation failed. Iteration aborted.\n");
@@ -97,7 +95,7 @@ heapObjectCallbackForSecondIteration(jlong class_tag,
 
     /* Deallocate memory of list element*/
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescArr[ind]))) {
+            jvmti->Deallocate((unsigned char*)objectDescArr[ind]))) {
         nsk_jvmti_setFailStatus();
         callbackAborted = 1;
         NSK_COMPLAIN0("heapObjectCallbackForSecondIteration: Deallocation failed. Iteration aborted.\n");
@@ -133,9 +131,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             NSK_DISPLAY0("Calling IterateOverHeap with filter JVMTI_HEAP_OBJECT_UNTAGGED\n");
             {
                 if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB4(IterateOverHeap, jvmti,
-                            JVMTI_HEAP_OBJECT_UNTAGGED, heapObjectCallbackForFirstIteration,
-                            &fakeUserData))) {
+                        jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_UNTAGGED, heapObjectCallbackForFirstIteration, &fakeUserData))) {
                     nsk_jvmti_setFailStatus();
                     break;
                 }
@@ -151,17 +147,13 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             }
 
             /* Allocate memory for array to save pointers to ObjectDescList elements */
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(Allocate, jvmti, (objectDescCount * sizeof(ObjectDesc*)),
-                                      (unsigned char**)&objectDescArr))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Allocate((objectDescCount * sizeof(ObjectDesc*)), (unsigned char**)&objectDescArr))) {
                 nsk_jvmti_setFailStatus();
                 break;
             }
 
             /* Allocate memory for flags array and fill with false values */
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(Allocate, jvmti, (objectDescCount * sizeof(unsigned char)),
-                                      &deallocatedFlagsArr))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Allocate((objectDescCount * sizeof(unsigned char)), &deallocatedFlagsArr))) {
                 nsk_jvmti_setFailStatus();
                 break;
             }
@@ -186,9 +178,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             NSK_DISPLAY0("Calling IterateOverHeap with filter JVMTI_HEAP_OBJECT_TAGGED\n");
             {
                 if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB4(IterateOverHeap, jvmti,
-                            JVMTI_HEAP_OBJECT_TAGGED, heapObjectCallbackForSecondIteration,
-                            &fakeUserData))) {
+                        jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, heapObjectCallbackForSecondIteration, &fakeUserData))) {
                     nsk_jvmti_setFailStatus();
                 }
             }
@@ -202,7 +192,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             for (ind = 0; ind < objectDescCount; ind++) {
                 if (!deallocatedFlagsArr[ind]) {
                     if (!NSK_JVMTI_VERIFY(
-                           NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescArr[ind]))) {
+                           jvmti->Deallocate((unsigned char*)objectDescArr[ind]))) {
                         NSK_COMPLAIN1("Unable to deallocate descriptor. Index = %d \n", ind);
                         nsk_jvmti_setFailStatus();
                         return;
@@ -211,12 +201,12 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             }
 
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescArr))) {
+                    jvmti->Deallocate((unsigned char*)objectDescArr))) {
                 nsk_jvmti_setFailStatus();
             }
 
          if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)deallocatedFlagsArr))) {
+                    jvmti->Deallocate((unsigned char*)deallocatedFlagsArr))) {
                 nsk_jvmti_setFailStatus();
          }
 
@@ -258,12 +248,11 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(caps));
     caps.can_tag_objects = 1;
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+            jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_tag_objects)

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap005/iterheap005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap005/iterheap005.cpp
@@ -51,54 +51,54 @@ heapObjectCallback(jlong class_tag,
     objCounter++;
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, st_jvmti, name, &monitor_ptr))) {
+            st_jvmti->CreateRawMonitor(name, &monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, st_jvmti, monitor_ptr))) {
+            st_jvmti->RawMonitorEnter(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     /* Enter second time */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, st_jvmti, monitor_ptr))) {
+            st_jvmti->RawMonitorEnter(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RawMonitorWait, st_jvmti, monitor_ptr, (jlong)100))) {
+            st_jvmti->RawMonitorWait(monitor_ptr, (jlong)100))) {
         nsk_jvmti_setFailStatus();
     }
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorNotify, st_jvmti, monitor_ptr))) {
+            st_jvmti->RawMonitorNotify(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorNotifyAll, st_jvmti, monitor_ptr))) {
+            st_jvmti->RawMonitorNotifyAll(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, st_jvmti, monitor_ptr))) {
+            st_jvmti->RawMonitorExit(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     /* Exit second time */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, st_jvmti, monitor_ptr))) {
+            st_jvmti->RawMonitorExit(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, st_jvmti, monitor_ptr))) {
+            st_jvmti->DestroyRawMonitor(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -119,11 +119,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0("Calling IterateOverHeap with filter JVMTI_HEAP_OBJECT_EITHER\n");
         {
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(IterateOverHeap,
-                        jvmti,
-                        JVMTI_HEAP_OBJECT_EITHER,
-                        heapObjectCallback,
-                        &fakeUserData))) {
+                    jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_EITHER, heapObjectCallback, &fakeUserData))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -174,7 +170,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap006/iterheap006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap006/iterheap006.cpp
@@ -46,12 +46,12 @@ heapObjectCallback(jlong class_tag,
                    void* storage_data) {
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(SetEnvironmentLocalStorage, st_jvmti, storage_data ))) {
+            st_jvmti->SetEnvironmentLocalStorage(storage_data ))) {
         nsk_jvmti_setFailStatus();
     }
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetEnvironmentLocalStorage, st_jvmti, &storage_ptr))) {
+            st_jvmti->GetEnvironmentLocalStorage(&storage_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -73,11 +73,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0("Calling IterateOverHeap with filter JVMTI_HEAP_OBJECT_EITHER\n");
         {
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(IterateOverHeap,
-                        jvmti,
-                        JVMTI_HEAP_OBJECT_EITHER,
-                        heapObjectCallback,
-                        (void *)storage_data))) {
+                    jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_EITHER, heapObjectCallback, (void *)storage_data))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -135,7 +131,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap007/iterheap007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverHeap/iterheap007/iterheap007.cpp
@@ -46,7 +46,7 @@ heapObjectCallback(jlong class_tag,
                    void* user_data) {
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, st_jvmti, &timer_info1 ))) {
+            st_jvmti->GetCurrentThreadCpuTimerInfo(&timer_info1 ))) {
         nsk_jvmti_setFailStatus();
     }
     /* Check the returned jvmtiTimerInfo structure */
@@ -65,13 +65,13 @@ heapObjectCallback(jlong class_tag,
     /* ---------------------------------------------------------------------- */
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, st_jvmti, &nanos ))) {
+            st_jvmti->GetCurrentThreadCpuTime(&nanos ))) {
         nsk_jvmti_setFailStatus();
     }
     /* ---------------------------------------------------------------------- */
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetTimerInfo, st_jvmti, &timer_info2 ))) {
+            st_jvmti->GetTimerInfo(&timer_info2 ))) {
         nsk_jvmti_setFailStatus();
     }
     /* Check the returned jvmtiTimerInfo structure */
@@ -91,7 +91,7 @@ heapObjectCallback(jlong class_tag,
 
     nanos = 0;
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetTime, st_jvmti, &nanos ))) {
+            st_jvmti->GetTime(&nanos ))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -113,11 +113,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0("Calling IterateOverHeap with filter JVMTI_HEAP_OBJECT_EITHER\n");
         {
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(IterateOverHeap,
-                        jvmti,
-                        JVMTI_HEAP_OBJECT_EITHER,
-                        heapObjectCallback,
-                        (void *)user_data))) {
+                    jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_EITHER, heapObjectCallback, (void *)user_data))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -164,7 +160,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         caps.can_get_current_thread_cpu_time = 1;
 
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls001/iterinstcls001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls001/iterinstcls001.cpp
@@ -92,14 +92,14 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
     tag++;
 
     if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetObjectField, jni, firstObject, firstField)) != NULL)) {
+            jni->GetObjectField(firstObject, firstField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
     objectDescList[count].tag = objTag;
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, obj, objTag))) {
+            jvmti->SetTag(obj, objTag))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -111,7 +111,7 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
         return NSK_FALSE;
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteLocalRef, jni, obj));
+    NSK_TRACE(jni->DeleteLocalRef(obj));
     return success;
 }
 
@@ -136,9 +136,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     *objectsCount = 2 * chainLength;
 
     NSK_DISPLAY1("Allocate memory for objects list: %d objects\n", *objectsCount);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (*objectsCount * sizeof(ObjectDesc)),
-                                                    (unsigned char**)objectDescList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)), (unsigned char**)objectDescList))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -155,7 +153,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+            jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -163,7 +161,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find root object class: %s\n", ROOT_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (rootObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, ROOT_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -171,7 +169,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find chain object class: %s\n", CHAIN_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (chainObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -179,7 +177,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Create global ref to tested class: 0x%p\n", chainObjectClass);
     if (!NSK_JNI_VERIFY(jni, (*testedClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, chainObjectClass)) != NULL)) {
+            jni->NewGlobalRef(chainObjectClass)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -187,8 +185,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find static field in debugee class: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (objectField =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                            OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -196,8 +193,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", REACHABLE_CHAIN_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (reachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -205,8 +201,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", UNREACHABLE_CHAIN_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (unreachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -214,8 +209,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in chain object class: %s\n", TAIL_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (tailField =
-            NSK_CPP_STUB4(GetFieldID, jni, chainObjectClass,
-                            TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(chainObjectClass, TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -223,8 +217,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Get root object from static field: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (rootObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                    objectField)) != NULL)) {
+            jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -234,7 +227,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY0("    tested class object:\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, *testedClass, testedClassTag))) {
+            jvmti->SetTag(*testedClass, testedClassTag))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -329,13 +322,13 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
                                         ObjectDesc* objectDescList, jclass testedClass) {
     if (testedClass != NULL) {
         NSK_DISPLAY1("Release object reference to tested class: 0x%p\n", testedClass);
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass));
+        NSK_TRACE(jni->DeleteGlobalRef(testedClass));
     }
 
     if (objectDescList != NULL) {
         NSK_DISPLAY1("Deallocate objects list: 0x%p\n", (void*)objectDescList);
         if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescList))) {
+            jvmti->Deallocate((unsigned char*)objectDescList))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -450,9 +443,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Iterate over instances of tested class with filter JVMTI_HEAP_OBJECT_EITHER\n");
         {
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-                        testedClass, JVMTI_HEAP_OBJECT_EITHER,
-                        heapObjectCallback, &fakeUserData))) {
+                    jvmti->IterateOverInstancesOfClass(testedClass, JVMTI_HEAP_OBJECT_EITHER, heapObjectCallback, &fakeUserData))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -561,7 +552,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         caps.can_tag_objects = 1;
         caps.can_generate_object_free_events = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -571,8 +562,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ObjectFree = callbackObjectFree;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+                jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls002/iterinstcls002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls002/iterinstcls002.cpp
@@ -92,14 +92,14 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
     tag++;
 
     if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetObjectField, jni, firstObject, firstField)) != NULL)) {
+            jni->GetObjectField(firstObject, firstField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
     objectDescList[count].tag = objTag;
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, obj, objTag))) {
+            jvmti->SetTag(obj, objTag))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -111,7 +111,7 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
         return NSK_FALSE;
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteLocalRef, jni, obj));
+    NSK_TRACE(jni->DeleteLocalRef(obj));
     return success;
 }
 
@@ -136,9 +136,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     *objectsCount = 2 * chainLength;
 
     NSK_DISPLAY1("Allocate memory for objects list: %d objects\n", *objectsCount);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (*objectsCount * sizeof(ObjectDesc)),
-                                                    (unsigned char**)objectDescList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)), (unsigned char**)objectDescList))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -155,7 +153,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+            jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -163,7 +161,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find root object class: %s\n", ROOT_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (rootObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, ROOT_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -171,7 +169,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find chain object class: %s\n", CHAIN_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (chainObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -179,7 +177,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Create global ref to tested class: 0x%p\n", chainObjectClass);
     if (!NSK_JNI_VERIFY(jni, (*testedClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, chainObjectClass)) != NULL)) {
+            jni->NewGlobalRef(chainObjectClass)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -187,8 +185,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find static field in debugee class: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (objectField =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                            OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -196,8 +193,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", REACHABLE_CHAIN_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (reachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -205,8 +201,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", UNREACHABLE_CHAIN_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (unreachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -214,8 +209,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in chain object class: %s\n", TAIL_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (tailField =
-            NSK_CPP_STUB4(GetFieldID, jni, chainObjectClass,
-                            TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(chainObjectClass, TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -223,8 +217,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Get root object from static field: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (rootObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                    objectField)) != NULL)) {
+            jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -234,7 +227,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY0("    tested class object:\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, *testedClass, testedClassTag))) {
+            jvmti->SetTag(*testedClass, testedClassTag))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -329,13 +322,13 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
                                         ObjectDesc* objectDescList, jclass testedClass) {
     if (testedClass != NULL) {
         NSK_DISPLAY1("Release object reference to tested class: 0x%p\n", testedClass);
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass));
+        NSK_TRACE(jni->DeleteGlobalRef(testedClass));
     }
 
     if (objectDescList != NULL) {
         NSK_DISPLAY1("Deallocate objects list: 0x%p\n", (void*)objectDescList);
         if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescList))) {
+            jvmti->Deallocate((unsigned char*)objectDescList))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -458,9 +451,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Iterate over instances of tested class with filter JVMTI_HEAP_OBJECT_TAGGED\n");
         {
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-                        testedClass, JVMTI_HEAP_OBJECT_TAGGED,
-                        heapObjectCallback, &fakeUserData))) {
+                    jvmti->IterateOverInstancesOfClass(testedClass, JVMTI_HEAP_OBJECT_TAGGED, heapObjectCallback, &fakeUserData))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -569,7 +560,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         caps.can_tag_objects = 1;
         caps.can_generate_object_free_events = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -579,8 +570,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ObjectFree = callbackObjectFree;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+                jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls003/iterinstcls003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls003/iterinstcls003.cpp
@@ -92,14 +92,14 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
     tag++;
 
     if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetObjectField, jni, firstObject, firstField)) != NULL)) {
+            jni->GetObjectField(firstObject, firstField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
     objectDescList[count].tag = objTag;
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, obj, objTag))) {
+            jvmti->SetTag(obj, objTag))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -111,7 +111,7 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
         return NSK_FALSE;
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteLocalRef, jni, obj));
+    NSK_TRACE(jni->DeleteLocalRef(obj));
     return success;
 }
 
@@ -136,9 +136,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     *objectsCount = 2 * chainLength;
 
     NSK_DISPLAY1("Allocate memory for objects list: %d objects\n", *objectsCount);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (*objectsCount * sizeof(ObjectDesc)),
-                                                    (unsigned char**)objectDescList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)), (unsigned char**)objectDescList))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -155,7 +153,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+            jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -163,7 +161,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find root object class: %s\n", ROOT_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (rootObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, ROOT_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -171,7 +169,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find chain object class: %s\n", CHAIN_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (chainObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -179,7 +177,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Create global ref to tested class: 0x%p\n", chainObjectClass);
     if (!NSK_JNI_VERIFY(jni, (*testedClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, chainObjectClass)) != NULL)) {
+            jni->NewGlobalRef(chainObjectClass)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -187,8 +185,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find static field in debugee class: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (objectField =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                            OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -196,8 +193,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", REACHABLE_CHAIN_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (reachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -205,8 +201,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", UNREACHABLE_CHAIN_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (unreachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -214,8 +209,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in chain object class: %s\n", TAIL_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (tailField =
-            NSK_CPP_STUB4(GetFieldID, jni, chainObjectClass,
-                            TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(chainObjectClass, TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -223,8 +217,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Get root object from static field: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (rootObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                    objectField)) != NULL)) {
+            jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -234,7 +227,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY0("    tested class object:\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, *testedClass, testedClassTag))) {
+            jvmti->SetTag(*testedClass, testedClassTag))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -329,13 +322,13 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
                                         ObjectDesc* objectDescList, jclass testedClass) {
     if (testedClass != NULL) {
         NSK_DISPLAY1("Release object reference to tested class: 0x%p\n", testedClass);
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass));
+        NSK_TRACE(jni->DeleteGlobalRef(testedClass));
     }
 
     if (objectDescList != NULL) {
         NSK_DISPLAY1("Deallocate objects list: 0x%p\n", (void*)objectDescList);
         if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescList))) {
+            jvmti->Deallocate((unsigned char*)objectDescList))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -459,9 +452,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Iterate over instances of tested class with filter JVMTI_HEAP_OBJECT_UNTAGGED\n");
         {
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-                        testedClass, JVMTI_HEAP_OBJECT_UNTAGGED,
-                        heapObjectCallback, &fakeUserData))) {
+                    jvmti->IterateOverInstancesOfClass(testedClass, JVMTI_HEAP_OBJECT_UNTAGGED, heapObjectCallback, &fakeUserData))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -570,7 +561,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         caps.can_tag_objects = 1;
         caps.can_generate_object_free_events = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }
@@ -580,8 +571,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ObjectFree = callbackObjectFree;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+                jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls004/iterinstcls004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls004/iterinstcls004.cpp
@@ -61,9 +61,7 @@ heapObjectCallback1(jlong class_tag,
     /* Set tag */
     *tag_ptr = objectCount;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, st_jvmti, (sizeof(ObjectDesc)),
-                             (unsigned char**)&objectDescBuf))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->Allocate((sizeof(ObjectDesc)), (unsigned char**)&objectDescBuf))) {
         nsk_jvmti_setFailStatus();
         allocationError = 1;
     }
@@ -83,8 +81,7 @@ heapObjectCallback2(jlong class_tag,
 
     objectCount--;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, st_jvmti, (unsigned char*)objectDescBuf))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->Deallocate((unsigned char*)objectDescBuf))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -115,12 +112,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             NSK_DISPLAY0("Calling IterateOverInstancesOfClass with filter JVMTI_HEAP_OBJECT_UNTAGGED\n");
             {
                 if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB5(IterateOverInstancesOfClass,
-                            jvmti,
-                            debugeeClass,
-                            JVMTI_HEAP_OBJECT_UNTAGGED,
-                            heapObjectCallback1,
-                            &userData))) {
+                        jvmti->IterateOverInstancesOfClass(debugeeClass, JVMTI_HEAP_OBJECT_UNTAGGED, heapObjectCallback1, &userData))) {
                     nsk_jvmti_setFailStatus();
                     break;
                 }
@@ -139,12 +131,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             NSK_DISPLAY0("Calling IterateOverInstancesOfClass with filter JVMTI_HEAP_OBJECT_TAGGED\n");
             {
                 if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB5(IterateOverInstancesOfClass,
-                            jvmti,
-                            debugeeClass,
-                            JVMTI_HEAP_OBJECT_TAGGED,
-                            heapObjectCallback2,
-                            &userData))) {
+                        jvmti->IterateOverInstancesOfClass(debugeeClass, JVMTI_HEAP_OBJECT_TAGGED, heapObjectCallback2, &userData))) {
                     nsk_jvmti_setFailStatus();
                     break;
                 }
@@ -200,7 +187,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+                jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211131](https://bugs.openjdk.java.net/browse/JDK-8211131): Remove the NSK_CPP_STUB macros from vmTestbase for jvmti/[G-I]*


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/658/head:pull/658` \
`$ git checkout pull/658`

Update a local copy of the PR: \
`$ git checkout pull/658` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 658`

View PR using the GUI difftool: \
`$ git pr show -t 658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/658.diff">https://git.openjdk.java.net/jdk11u-dev/pull/658.diff</a>

</details>
