### PR TITLE
8211905: Remove multiple casts for EM06 file

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM06/em06t001/em06t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM06/em06t001/em06t001.cpp
@@ -73,8 +73,7 @@ handler(jvmtiEvent event, jvmtiEnv* jvmti, JNIEnv* jni_env,
         return;
     }
 
-    jclassName = (jstring) (jstring) (jstring) (jstring) (jstring) (jstring) (jstring) (jstring) (jstring) NSK_CPP_STUB3(CallObjectMethod, jni_env, klass,
-                        methodID);
+    jclassName = (jstring) NSK_CPP_STUB3(CallObjectMethod, jni_env, klass, methodID);
 
     className = NSK_CPP_STUB3(GetStringUTFChars, jni_env, jclassName, 0);
 


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211905](https://bugs.openjdk.java.net/browse/JDK-8211905): Remove multiple casts for EM06 file


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/659/head:pull/659` \
`$ git checkout pull/659`

Update a local copy of the PR: \
`$ git checkout pull/659` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 659`

View PR using the GUI difftool: \
`$ git pr show -t 659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/659.diff">https://git.openjdk.java.net/jdk11u-dev/pull/659.diff</a>

</details>
