### PR TITLE
8211801: Remove the NSK_CPP_STUB macros from vmTestbase for jvmti/scenarios/[A-E]

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP06/ap06t001/ap06t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP06/ap06t001/ap06t001.cpp
@@ -124,7 +124,7 @@ objectReferenceCallback( jvmtiObjectReferenceKind reference_kind,
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_scenarios_allocation_AP06_ap06t001Thread_setTag( JNIEnv* jni, jobject obj) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, obj, threadTag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(obj, threadTag))) {
         nsk_jvmti_setFailStatus();
     } else {
         NSK_DISPLAY0("setTag: the tag was set for checked thread.");
@@ -153,34 +153,26 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
 
         if (!NSK_JNI_VERIFY(jni, (fid =
-                NSK_CPP_STUB4(GetStaticFieldID, jni,
-                                                debugeeClass,
-                                                "thread",
-                                                THREAD_CLS_SIGNATURE)) != NULL )) {
+                jni->GetStaticFieldID(debugeeClass, "thread", THREAD_CLS_SIGNATURE)) != NULL)) {
             nsk_jvmti_setFailStatus();
             break;
         }
 
         if (!NSK_JNI_VERIFY(jni, (localRefThread =
-                NSK_CPP_STUB3(GetStaticObjectField, jni,
-                                                    debugeeClass,
-                                                    fid )) != NULL )) {
+                jni->GetStaticObjectField(debugeeClass, fid)) != NULL)) {
             NSK_COMPLAIN0("GetStaticObjectField returned NULL for 'thread' field value\n\n");
             nsk_jvmti_setFailStatus();
             break;
         }
 
-        if (!NSK_JNI_VERIFY(jni, (globalRefThread =
-                 NSK_CPP_STUB2(NewGlobalRef, jni, localRefThread)) != NULL))
+        if (!NSK_JNI_VERIFY(jni, (globalRefThread = jni->NewGlobalRef(localRefThread)) != NULL))
             return;
 
         NSK_DISPLAY0("Calling IterateOverReachableObjects\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                                                           heapRootCallback,
-                                                           stackReferenceCallback,
-                                                           objectReferenceCallback,
-                                                           NULL /*user_data*/))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(heapRootCallback,
+                                                                 stackReferenceCallback,
+                                                                 objectReferenceCallback,
+                                                                 NULL /*user_data*/))) {
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -234,12 +226,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_tag_objects = 1;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_tag_objects)

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP07/ap07t001/ap07t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP07/ap07t001/ap07t001.cpp
@@ -111,15 +111,14 @@ Java_nsk_jvmti_scenarios_allocation_AP07_ap07t001_setTag( JNIEnv* jni,
                                                           jobject target,
                                                           jlong   tag ) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, target, tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(target, tag))) {
         nsk_jvmti_setFailStatus();
     }
 }
 
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_scenarios_allocation_AP07_ap07t001_setRoot( JNIEnv* jni, jobject obj) {
-    if (!NSK_JNI_VERIFY(jni, (root =
-            NSK_CPP_STUB2(NewGlobalRef, jni, obj)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (root = jni->NewGlobalRef(obj)) != NULL))
         nsk_jvmti_setFailStatus();
 }
 
@@ -135,30 +134,24 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     do {
 
         NSK_DISPLAY0("Calling IterateOverReachableObjects\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                                                           heapRootCallback,
-                                                           stackReferenceCallback,
-                                                           objectReferenceCallback,
-                                                           NULL /*user_data*/))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(heapRootCallback,
+                                                                 stackReferenceCallback,
+                                                                 objectReferenceCallback,
+                                                                 NULL /*user_data*/))) {
             nsk_jvmti_setFailStatus();
             break;
         }
 
         NSK_DISPLAY0("Calling IterateOverObjectsReachableFromObject\n");
         {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(IterateOverObjectsReachableFromObject,
-                        jvmti,
-                        root,
-                        objectReferenceCallback,
-                        NULL /*user_data*/))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(
+                    root, objectReferenceCallback, NULL /*user_data*/))) {
                 nsk_jvmti_setFailStatus();
                 break;
             }
         }
 
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, root));
+        NSK_TRACE(jni->DeleteGlobalRef(root));
 
     } while (0);
 
@@ -191,12 +184,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_tag_objects = 1;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_tag_objects)

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP07/ap07t002/ap07t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP07/ap07t002/ap07t002.cpp
@@ -111,7 +111,7 @@ Java_nsk_jvmti_scenarios_allocation_AP07_ap07t002_setTag( JNIEnv* jni,
                                                           jobject target,
                                                           jlong   tag ) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, target, tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(target, tag))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -128,12 +128,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     do {
 
         NSK_DISPLAY0("Calling IterateOverReachableObjects\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                                                           heapRootCallback,
-                                                           stackReferenceCallback,
-                                                           objectReferenceCallback,
-                                                           NULL /*user_data*/))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(heapRootCallback,
+                                                                 stackReferenceCallback,
+                                                                 objectReferenceCallback,
+                                                                 NULL /*user_data*/))) {
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -169,12 +167,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_tag_objects = 1;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_tag_objects)

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP09/ap09t001/ap09t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP09/ap09t001/ap09t001.cpp
@@ -132,15 +132,14 @@ Java_nsk_jvmti_scenarios_allocation_AP09_ap09t001_setTag( JNIEnv* jni,
                                                           jobject target,
                                                           jlong   tag ) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, target, tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(target, tag))) {
         nsk_jvmti_setFailStatus();
     }
 }
 
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_scenarios_allocation_AP09_ap09t001_setReferrer( JNIEnv* jni, jclass klass, jobject ref) {
-    if (!NSK_JNI_VERIFY(jni, (referrer =
-            NSK_CPP_STUB2(NewGlobalRef, jni, ref)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (referrer = jni->NewGlobalRef(ref)) != NULL))
         nsk_jvmti_setFailStatus();
 }
 
@@ -155,12 +154,9 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
     do {
         NSK_DISPLAY0("\nCalling IterateOverObjectsReachableFromObject\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(IterateOverObjectsReachableFromObject,
-                    jvmti,
-                    referrer,
-                    objectReferenceCallback,
-                    NULL /*user_data*/))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(referrer,
+                                                                           objectReferenceCallback,
+                                                                           NULL /*user_data*/))) {
             nsk_jvmti_setFailStatus();
         }
         if (!classFound) {
@@ -192,7 +188,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             nsk_jvmti_setFailStatus();
         }
 
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, referrer));
+        NSK_TRACE(jni->DeleteGlobalRef(referrer));
     } while (0);
 
     NSK_DISPLAY0("Let debugee to finish\n");
@@ -224,12 +220,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_tag_objects = 1;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_tag_objects) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP10/ap10t001/ap10t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP10/ap10t001/ap10t001.cpp
@@ -61,8 +61,7 @@ static void envStorageFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY2("%s: setting an environment local storage 0x%p ...\n",
         msg, (void*) &stor);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(SetEnvironmentLocalStorage,
-            jvmti_env, (const void*) &stor))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->SetEnvironmentLocalStorage((const void*) &stor))) {
         nsk_jvmti_setFailStatus();
         NSK_COMPLAIN1("%s: unable to set an environment local storage\n\n",
             msg);
@@ -71,8 +70,7 @@ static void envStorageFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: getting an environment local storage ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetEnvironmentLocalStorage,
-            jvmti_env, (void**) &obtainedData))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetEnvironmentLocalStorage((void**) &obtainedData))) {
         nsk_jvmti_setFailStatus();
         NSK_COMPLAIN1("%s: unable to get an environment local storage\n\n",
             msg);
@@ -89,8 +87,7 @@ got: 0x%p\texpected: 0x%p\n\n",
 }
 
 static void timerFunc(jvmtiEnv *jvmti_env, const char *msg) {
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti_env, &timer_info1 ))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetCurrentThreadCpuTimerInfo(&timer_info1))) {
         nsk_jvmti_setFailStatus();
         NSK_COMPLAIN1("%s: GetCurrentThreadCpuTimerInfo returned unexpected error code\n\n",
             msg);
@@ -113,8 +110,7 @@ static void timerFunc(jvmtiEnv *jvmti_env, const char *msg) {
     }
     /* ---------------------------------------------------------------------- */
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti_env, &nanos ))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetCurrentThreadCpuTime(&nanos))) {
         nsk_jvmti_setFailStatus();
         NSK_COMPLAIN1("%s: GetCurrentThreadCpuTime returned unexpected error code\n\n",
             msg);
@@ -122,8 +118,7 @@ static void timerFunc(jvmtiEnv *jvmti_env, const char *msg) {
     /* ---------------------------------------------------------------------- */
 
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetTimerInfo, jvmti_env, &timer_info2 ))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetTimerInfo(&timer_info2))) {
         nsk_jvmti_setFailStatus();
         NSK_COMPLAIN1("%s: GetTimerInfo returned unexpected error code\n\n",
             msg);
@@ -147,8 +142,7 @@ static void timerFunc(jvmtiEnv *jvmti_env, const char *msg) {
     /* ---------------------------------------------------------------------- */
 
     nanos = 0;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetTime, jvmti_env, &nanos ))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetTime(&nanos))) {
         nsk_jvmti_setFailStatus();
         NSK_COMPLAIN1("%s: GetTime returned unexpected error code\n\n",
             msg);
@@ -222,10 +216,9 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
     NSK_DISPLAY0("Call IterateOverHeap to tag random objects for ObjectFree evnts\n\n");
     {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(IterateOverHeap, jvmti,
-                    JVMTI_HEAP_OBJECT_UNTAGGED, heapObjectCallback,
-                    &user_data))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_UNTAGGED,
+                                                     heapObjectCallback,
+                                                     &user_data))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -275,12 +268,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     caps.can_get_thread_cpu_time = 1;
     caps.can_generate_object_free_events = 1;
     caps.can_generate_garbage_collection_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_garbage_collection_events)
@@ -298,19 +289,21 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.GarbageCollectionFinish = &GarbageCollectionFinish;
     callbacks.ObjectFree = &ObjectFree;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_GARBAGE_COLLECTION_START,
+                                                          NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_GARBAGE_COLLECTION_FINISH,
+                                                          NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_OBJECT_FREE,
+                                                          NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP11/ap11t001/ap11t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP11/ap11t001/ap11t001.cpp
@@ -43,8 +43,7 @@ static int lookup(jvmtiEnv* jvmti,
     jint i;
 
     for (i = 0; i < classCount && !found; i++) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti,
-                classes[i], &signature, &generic)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetClassSignature(classes[i], &signature, &generic)))
             break;
 
         if (signature != NULL && strcmp(signature, exp_sig) == 0) {
@@ -52,10 +51,10 @@ static int lookup(jvmtiEnv* jvmti,
         }
 
         if (signature != NULL)
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)signature);
+            jvmti->Deallocate((unsigned char*)signature);
 
         if (generic != NULL)
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)generic);
+            jvmti->Deallocate((unsigned char*)generic);
     }
 
     return found;
@@ -74,7 +73,7 @@ VMObjectAlloc(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread, jobject object,
     */
     {
         jvmtiPhase phase;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase ))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -85,14 +84,12 @@ VMObjectAlloc(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread, jobject object,
     }
 
     do {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti,
-                object_klass, &signature, &generic))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetClassSignature(object_klass, &signature, &generic))) {
             nsk_jvmti_setFailStatus();
             break;
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti,
-                thread, &threadInfo))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(thread, &threadInfo))) {
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -108,14 +105,13 @@ VMObjectAlloc(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread, jobject object,
         jint i;
         jboolean found = JNI_FALSE;
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetAllThreads, jvmti,
-                 &threadCount, &threads))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threadCount, &threads))) {
             nsk_jvmti_setFailStatus();
             break;
         }
 
         for (i = 0; i < threadCount && !found; i++) {
-            found = NSK_CPP_STUB3(IsSameObject, jni, threads[i], thread);
+            found = jni->IsSameObject(threads[i], thread);
             if (found == JNI_TRUE) {
                 break;
             }
@@ -134,8 +130,7 @@ VMObjectAlloc(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread, jobject object,
         jint classCount;
         jclass *classes;
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetLoadedClasses, jvmti,
-                 &classCount, &classes))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetLoadedClasses(&classCount, &classes))) {
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -147,7 +142,7 @@ VMObjectAlloc(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread, jobject object,
         }
 
         if (classes != NULL)
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)classes);
+            jvmti->Deallocate((unsigned char*)classes);
     } while(0);
 
 
@@ -155,8 +150,8 @@ VMObjectAlloc(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread, jobject object,
     */
     {
         jclass klass;
-        klass = NSK_CPP_STUB2(GetObjectClass, jni, object);
-        if (!(NSK_CPP_STUB3(IsSameObject, jni, object_klass, klass))) {
+        klass = jni->GetObjectClass(object);
+        if (!(jni->IsSameObject(object_klass, klass))) {
             nsk_jvmti_setFailStatus();
             NSK_COMPLAIN1("VMObjectAlloc: unexpected object_klass : \"%s\"\n\n", signature);
         }
@@ -167,8 +162,7 @@ VMObjectAlloc(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread, jobject object,
 
     do {
         jlong objSize;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetObjectSize, jvmti,
-                 object, &objSize))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetObjectSize(object, &objSize))) {
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -181,10 +175,10 @@ VMObjectAlloc(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread, jobject object,
     } while(0);
 
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)signature);
+        jvmti->Deallocate((unsigned char*)signature);
 
     if (generic != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)generic);
+        jvmti->Deallocate((unsigned char*)generic);
 }
 
 /* ========================================================================== */
@@ -234,21 +228,18 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_vm_object_alloc_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.VMObjectAlloc= &VMObjectAlloc;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* enable VMObjectAlloc event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_VM_OBJECT_ALLOC, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_OBJECT_ALLOC, NULL)))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP12/ap12t001/ap12t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP12/ap12t001/ap12t001.cpp
@@ -77,8 +77,7 @@ expected number: %d", obj_free, EXP_OBJ_FREE);
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_scenarios_allocation_AP12_ap12t001_setTag( JNIEnv* jni, jobject obj, jlong tag) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag,
-         jvmti, obj, tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(obj, tag))) {
          nsk_jvmti_setFailStatus();
     }
 }
@@ -127,12 +126,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_object_free_events = 1;
     caps.can_tag_objects = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_object_free_events)
@@ -147,16 +144,17 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.ObjectFree = &ObjectFree;
     callbacks.VMDeath = &VMDeath;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_OBJECT_FREE,
+                                                          NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_VM_DEATH,
+                                                          NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI01/bi01t001/bi01t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI01/bi01t001/bi01t001.cpp
@@ -52,23 +52,20 @@ Java_nsk_jvmti_scenarios_bcinstr_BI01_bi01t001_setNewByteCode(JNIEnv *jni_env,
     jbyte* elements;
     jboolean isCopy;
 
-    if (!NSK_JNI_VERIFY(jni_env, (newClassSize =
-            NSK_CPP_STUB2(GetArrayLength, jni_env, byteCode)) > 0)) {
+    if (!NSK_JNI_VERIFY(jni_env, (newClassSize = jni_env->GetArrayLength(byteCode)) > 0)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("\t... got array size: %d\n", newClassSize);
 
     if (!NSK_JNI_VERIFY(jni_env, (elements =
-            NSK_CPP_STUB3(GetByteArrayElements, jni_env, byteCode,
-                                                        &isCopy)) != NULL)) {
+            jni_env->GetByteArrayElements(byteCode, &isCopy)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("\t... got elements list: 0x%p\n", (void*)elements);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate, jvmti,
-                                newClassSize, &newClassBytes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(newClassSize, &newClassBytes))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -82,7 +79,7 @@ Java_nsk_jvmti_scenarios_bcinstr_BI01_bi01t001_setNewByteCode(JNIEnv *jni_env,
     NSK_DISPLAY1("\t... copied bytecode: %d bytes\n", (int)newClassSize);
 
     NSK_DISPLAY1("\t... release elements list: 0x%p\n", (void*)elements);
-    NSK_TRACE(NSK_CPP_STUB4(ReleaseByteArrayElements, jni_env, byteCode, elements, JNI_ABORT));
+    NSK_TRACE(jni_env->ReleaseByteArrayElements(byteCode, elements, JNI_ABORT));
     NSK_DISPLAY0("\t... released\n");
     return NSK_TRUE;
 }
@@ -98,7 +95,7 @@ Java_nsk_jvmti_scenarios_bcinstr_BI01_bi01t001_setClass(JNIEnv *jni_env,
                         jobject o, jclass cls) {
 
     if (!NSK_JNI_VERIFY(jni_env, (oldClassDef.klass = (jclass)
-             NSK_CPP_STUB2(NewGlobalRef, jni_env, cls)) != NULL)) {
+             jni_env->NewGlobalRef(cls)) != NULL)) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -129,9 +126,7 @@ cbClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
         unsigned char *arr;
 
         oldClassDef.class_byte_count = class_data_len;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti_env, class_data_len,
-                                &arr))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Allocate(class_data_len, &arr))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -181,9 +176,9 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
         return;
 
     NSK_DISPLAY0("Notification disabled for CLASS_FILE_LOAD_HOOK event\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                                JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_DISABLE,
+                                                          JVMTI_EVENT_CLASS_FILE_LOAD_HOOK,
+                                                          NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -205,8 +200,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
         nsk_printHexBytes("   ", 16, oldClassDef.class_byte_count,
                                 oldClassDef.class_bytes);
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &oldClassDef))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &oldClassDef))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -219,7 +213,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
     if (!nsk_jvmti_waitForSync(timeout))
         return;
 
-    NSK_CPP_STUB2(DeleteGlobalRef, agentJNI, oldClassDef.klass);
+    agentJNI->DeleteGlobalRef(oldClassDef.klass);
 
     NSK_DISPLAY0("Let debuggee to finish\n");
     if (!nsk_jvmti_resumeSync())
@@ -256,7 +250,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
 
         caps.can_redefine_classes = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 
@@ -267,16 +261,15 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&callbacks, 0, size);
         callbacks.ClassFileLoadHook = cbClassFileLoadHook;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, size))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, size))) {
             return JNI_ERR;
         }
     }
 
     NSK_DISPLAY0("Set notification enabled for CLASS_FILE_LOAD_HOOK event\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                                JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_CLASS_FILE_LOAD_HOOK,
+                                                          NULL))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI01/bi01t002/bi01t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI01/bi01t002/bi01t002.cpp
@@ -54,23 +54,20 @@ Java_nsk_jvmti_scenarios_bcinstr_BI01_bi01t002_setNewByteCode(JNIEnv *jni_env,
     jbyte* elements;
     jboolean isCopy;
 
-    if (!NSK_JNI_VERIFY(jni_env, (newClassSize[ind] =
-            NSK_CPP_STUB2(GetArrayLength, jni_env, byteCode)) > 0)) {
+    if (!NSK_JNI_VERIFY(jni_env, (newClassSize[ind] = jni_env->GetArrayLength(byteCode)) > 0)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("\t... got array size: %d\n", newClassSize[ind]);
 
     if (!NSK_JNI_VERIFY(jni_env, (elements =
-            NSK_CPP_STUB3(GetByteArrayElements, jni_env, byteCode,
-                                                        &isCopy)) != NULL)) {
+            jni_env->GetByteArrayElements(byteCode, &isCopy)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("\t... got elements list: 0x%p\n", (void*)elements);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate, jvmti,
-                                newClassSize[ind], &newClassBytes[ind]))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(newClassSize[ind], &newClassBytes[ind]))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -84,7 +81,7 @@ Java_nsk_jvmti_scenarios_bcinstr_BI01_bi01t002_setNewByteCode(JNIEnv *jni_env,
     NSK_DISPLAY1("\t... copied bytecode: %d bytes\n", (int)newClassSize[ind]);
 
     NSK_DISPLAY1("\t... release elements list: 0x%p\n", (void*)elements);
-    NSK_TRACE(NSK_CPP_STUB4(ReleaseByteArrayElements, jni_env, byteCode, elements, JNI_ABORT));
+    NSK_TRACE(jni_env->ReleaseByteArrayElements(byteCode, elements, JNI_ABORT));
     NSK_DISPLAY0("\t... released\n");
     return NSK_TRUE;
 }
@@ -100,7 +97,7 @@ Java_nsk_jvmti_scenarios_bcinstr_BI01_bi01t002_setClass(JNIEnv *jni_env,
                         jobject o, jint ind, jclass cls) {
 
     if (!NSK_JNI_VERIFY(jni_env, (oldClassDef[ind].klass = (jclass)
-             NSK_CPP_STUB2(NewGlobalRef, jni_env, cls)) != NULL)) {
+             jni_env->NewGlobalRef(cls)) != NULL)) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -131,9 +128,7 @@ cbClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
         unsigned char *arr;
 
         oldClassDef[clsLoadedIdx].class_byte_count = class_data_len;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti_env, class_data_len,
-                                &arr))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Allocate(class_data_len, &arr))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -189,9 +184,9 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
         return;
 
     NSK_DISPLAY0("Notification disabled for CLASS_FILE_LOAD_HOOK event\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                                JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_DISABLE,
+                                                          JVMTI_EVENT_CLASS_FILE_LOAD_HOOK,
+                                                          NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -216,9 +211,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
                                     oldClassDef[i].class_bytes);
         }
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RedefineClasses, jvmti, TOTAL_INSTRUMENTED_CLASSES,
-                            oldClassDef))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(TOTAL_INSTRUMENTED_CLASSES, oldClassDef))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -232,7 +225,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
         return;
 
     for (i = 0; i < TOTAL_INSTRUMENTED_CLASSES; i++) {
-        NSK_CPP_STUB2(DeleteGlobalRef, agentJNI, oldClassDef[i].klass);
+        agentJNI->DeleteGlobalRef(oldClassDef[i].klass);
     }
 
     NSK_DISPLAY0("Let debuggee to finish\n");
@@ -270,7 +263,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
 
         caps.can_redefine_classes = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 
@@ -281,16 +274,15 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&callbacks, 0, size);
         callbacks.ClassFileLoadHook = cbClassFileLoadHook;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, size))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, size))) {
             return JNI_ERR;
         }
     }
 
     NSK_DISPLAY0("Set notification enabled for CLASS_FILE_LOAD_HOOK event\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                                JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_CLASS_FILE_LOAD_HOOK,
+                                                          NULL))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI02/bi02t002/bi02t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI02/bi02t002/bi02t002.cpp
@@ -52,35 +52,29 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     jfieldID field = NULL;
 
     NSK_DISPLAY1("Find class: %s\n", DEBUGEE_CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, debugeeClass)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = (jclass)jni->NewGlobalRef(debugeeClass)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                "newClassBytes", "[B")) != NULL))
+            jni->GetStaticFieldID(debugeeClass, "newClassBytes", "[B")) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (classBytes = (jbyteArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass, field))
+            jni->GetStaticObjectField(debugeeClass, field))
                 != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (classBytes = (jbyteArray)
-            NSK_CPP_STUB2(NewGlobalRef, jni, classBytes)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (classBytes = (jbyteArray)jni->NewGlobalRef(classBytes)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY1("Find class: %s\n", CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (testedClass =
-            NSK_CPP_STUB2(FindClass, jni, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = jni->FindClass(CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, testedClass)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass)jni->NewGlobalRef(testedClass)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -93,17 +87,16 @@ static int redefine(jvmtiEnv* jvmti, JNIEnv* jni) {
 
     NSK_DISPLAY0("Redefining ...\n");
 
-    if (!NSK_JNI_VERIFY(jni, (class_def.class_byte_count =
-            NSK_CPP_STUB2(GetArrayLength, jni, classBytes)) > 0))
+    if (!NSK_JNI_VERIFY(jni, (class_def.class_byte_count = jni->GetArrayLength(classBytes)) > 0))
         return NSK_TRUE;
 
     if (!NSK_JNI_VERIFY(jni, (class_def.class_bytes = (unsigned char*)
-            NSK_CPP_STUB3(GetByteArrayElements, jni, classBytes, NULL))
+            jni->GetByteArrayElements(classBytes, NULL))
                 != NULL))
         return NSK_TRUE;
 
     class_def.klass = testedClass;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -132,9 +125,9 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!nsk_jvmti_waitForSync(timeout))
         return;
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, debugeeClass));
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, classBytes));
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass));
+    NSK_TRACE(jni->DeleteGlobalRef(debugeeClass));
+    NSK_TRACE(jni->DeleteGlobalRef(classBytes));
+    NSK_TRACE(jni->DeleteGlobalRef(testedClass));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -171,7 +164,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_redefine_classes = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     if (!NSK_VERIFY(nsk_jvmti_setAgentProc(agentProc, NULL)))

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI03/bi03t002/bi03t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI03/bi03t002/bi03t002.cpp
@@ -52,35 +52,29 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     jfieldID field = NULL;
 
     NSK_DISPLAY1("Find class: %s\n", DEBUGEE_CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, debugeeClass)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = (jclass)jni->NewGlobalRef(debugeeClass)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                "newClassBytes", "[B")) != NULL))
+            jni->GetStaticFieldID(debugeeClass, "newClassBytes", "[B")) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (classBytes = (jbyteArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass, field))
+            jni->GetStaticObjectField(debugeeClass, field))
                 != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (classBytes = (jbyteArray)
-            NSK_CPP_STUB2(NewGlobalRef, jni, classBytes)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (classBytes = (jbyteArray)jni->NewGlobalRef(classBytes)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY1("Find class: %s\n", CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (testedClass =
-            NSK_CPP_STUB2(FindClass, jni, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = jni->FindClass(CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, testedClass)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass)jni->NewGlobalRef(testedClass)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -93,17 +87,16 @@ static int redefine(jvmtiEnv* jvmti, JNIEnv* jni) {
 
     NSK_DISPLAY0("Redefining ...\n");
 
-    if (!NSK_JNI_VERIFY(jni, (class_def.class_byte_count =
-            NSK_CPP_STUB2(GetArrayLength, jni, classBytes)) > 0))
+    if (!NSK_JNI_VERIFY(jni, (class_def.class_byte_count = jni->GetArrayLength(classBytes)) > 0))
         return NSK_TRUE;
 
     if (!NSK_JNI_VERIFY(jni, (class_def.class_bytes = (unsigned char*)
-            NSK_CPP_STUB3(GetByteArrayElements, jni, classBytes, NULL))
+            jni->GetByteArrayElements(classBytes, NULL))
                 != NULL))
         return NSK_TRUE;
 
     class_def.klass = testedClass;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -132,9 +125,9 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!nsk_jvmti_waitForSync(timeout))
         return;
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, debugeeClass));
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, classBytes));
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass));
+    NSK_TRACE(jni->DeleteGlobalRef(debugeeClass));
+    NSK_TRACE(jni->DeleteGlobalRef(classBytes));
+    NSK_TRACE(jni->DeleteGlobalRef(testedClass));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -171,7 +164,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_redefine_classes = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     if (!NSK_VERIFY(nsk_jvmti_setAgentProc(agentProc, NULL)))

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI04/bi04t002/bi04t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/bcinstr/BI04/bi04t002/bi04t002.cpp
@@ -69,9 +69,7 @@ int readNewBytecode(jvmtiEnv* jvmti) {
     classDef.class_byte_count = ftell(bytecode);
     rewind(bytecode);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate, jvmti,
-                                classDef.class_byte_count,
-                                &newClassBytes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(classDef.class_byte_count, &newClassBytes))) {
         NSK_COMPLAIN0("buffer couldn't be allocated\n");
         return NSK_FALSE;
     }
@@ -99,14 +97,13 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
 
     NSK_DISPLAY1("Find class: %s\n", TESTED_CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (classDef.klass =
-            NSK_CPP_STUB2(FindClass, jni, TESTED_CLASS_NAME)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (classDef.klass = jni->FindClass(TESTED_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
 
     if (!NSK_JNI_VERIFY(jni, (classDef.klass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, classDef.klass)) != NULL)) {
+            jni->NewGlobalRef(classDef.klass)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -120,13 +117,12 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         nsk_printHexBytes("   ", 16, classDef.class_byte_count,
                                 classDef.class_bytes);
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &classDef))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &classDef))) {
         nsk_jvmti_setFailStatus();
         return;
     }
 
-    NSK_CPP_STUB2(DeleteGlobalRef, jni, classDef.klass);
+    jni->DeleteGlobalRef(classDef.klass);
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -163,7 +159,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         caps.can_redefine_classes = 1;
         caps.can_redefine_any_class = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t001/cm01t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t001/cm01t001.cpp
@@ -79,8 +79,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -92,8 +91,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -105,24 +103,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -136,23 +130,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -168,27 +160,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -202,7 +190,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -215,7 +203,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -225,8 +213,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -269,44 +256,36 @@ static int checkHeapFunctions() {
     jint dummy_user_data = 0;
 
     NSK_DISPLAY0("Checking positive: SetTag\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: GetTag\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: GetObjectsWithTags\n");
     tag = TAG_VALUE;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: IterateOverInstancesOfClass\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(
+            klass, JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: IterateOverObjectsReachableFromObject\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(
+            thread, ObjectReference, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: IterateOverReachableObjects\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(
+            HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -325,58 +304,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -391,18 +369,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -418,7 +395,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -431,7 +408,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -444,12 +421,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -463,7 +440,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -477,12 +454,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -496,12 +473,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -597,7 +574,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -609,13 +586,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -627,13 +604,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -645,10 +622,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t002/cm01t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t002/cm01t002.cpp
@@ -72,8 +72,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -85,8 +84,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -98,24 +96,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -129,23 +123,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -161,27 +153,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -195,7 +183,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -208,7 +196,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -218,8 +206,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -263,43 +250,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -318,58 +307,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -384,18 +372,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -411,7 +398,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -424,7 +411,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -437,12 +424,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -455,10 +442,9 @@ static int checkGetBytecodes() {
     unsigned char *bytecodes;
 
     NSK_DISPLAY0("Checking positive: GetBytecodes\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, jvmti, bytecodes)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate(bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -472,12 +458,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -491,12 +477,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -592,7 +578,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -604,13 +590,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -622,13 +608,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -640,10 +626,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t003/cm01t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t003/cm01t003.cpp
@@ -74,8 +74,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -87,8 +86,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -100,24 +98,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -131,23 +125,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -163,27 +155,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -197,7 +185,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -210,7 +198,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -220,8 +208,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -265,43 +252,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -320,58 +309,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -386,18 +374,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -413,7 +400,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -426,7 +413,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -438,13 +425,11 @@ static int checkIsSyntheticFunctions() {
     jboolean is_synthetic;
 
     NSK_DISPLAY0("Checking positive: IsFieldSynthetic\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+    if (!NSK_JVMTI_VERIFY(jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: IsMethodSynthetic\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+    if (!NSK_JVMTI_VERIFY(jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -458,7 +443,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -472,12 +457,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -491,12 +476,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -592,7 +577,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -604,13 +589,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -622,13 +607,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -640,10 +625,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t004/cm01t004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t004/cm01t004.cpp
@@ -72,8 +72,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -85,8 +84,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -98,24 +96,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -129,23 +123,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -161,27 +153,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -194,8 +182,7 @@ static int checkGetOwnedMonitorInfo() {
     jobject *monitors = NULL;
 
     NSK_DISPLAY0("Checking positive: GetOwnedMonitorInfo\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -208,7 +195,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -218,8 +205,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -263,43 +249,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -318,58 +306,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -384,18 +371,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -411,7 +397,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -424,7 +410,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -437,12 +423,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -456,7 +442,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -470,12 +456,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -489,12 +475,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: checkGetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -590,7 +576,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -602,13 +588,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -620,13 +606,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -638,10 +624,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t005/cm01t005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t005/cm01t005.cpp
@@ -72,8 +72,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -85,8 +84,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -98,24 +96,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -129,23 +123,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -161,27 +153,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -195,7 +183,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -207,8 +195,7 @@ static int checkGetCurrentContendedMonitor() {
     jobject monitor = NULL;
 
     NSK_DISPLAY0("Checking positive: GetCurrentContendedMonitor\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -218,8 +205,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -263,43 +249,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -318,58 +306,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -384,18 +371,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -411,7 +397,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -424,7 +410,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -437,12 +423,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -456,7 +442,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -470,12 +456,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -489,12 +475,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -590,7 +576,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -602,13 +588,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -620,13 +606,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -638,10 +624,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t006/cm01t006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t006/cm01t006.cpp
@@ -72,8 +72,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -85,8 +84,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -98,24 +96,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -129,23 +123,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -161,27 +153,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -195,7 +183,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -208,7 +196,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -218,8 +206,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -263,43 +250,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -318,58 +307,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -384,18 +372,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -411,7 +398,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -423,8 +410,7 @@ static int checkGetObjectMonitorUsage() {
     jvmtiMonitorUsage monitor_info;
 
     NSK_DISPLAY0("Checking positive: GetObjectMonitorUsage\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -437,12 +423,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -456,7 +442,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -470,12 +456,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -489,12 +475,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -590,7 +576,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -602,13 +588,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -620,13 +606,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -638,10 +624,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t007/cm01t007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t007/cm01t007.cpp
@@ -72,8 +72,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -85,8 +84,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -98,23 +96,19 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingFlag' */
-    if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass, "waitingFlag", "Z")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (field = jni->GetFieldID(klass, "waitingFlag", "Z")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -128,23 +122,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -160,27 +152,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -194,7 +182,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -207,7 +195,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -223,23 +211,23 @@ static int checkPopFrame() {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_suspend = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     // PopFrame is allowed to fail with JVMTI_ERROR_OPAQUE_FRAME.
     // That will happen if we are in a native function, for example while waiting for a Condition.
     // See JCK-5020108.
-    err = NSK_CPP_STUB2(PopFrame, jvmti, thread);
+    err = jvmti->PopFrame(thread);
     if (err != JVMTI_ERROR_NONE && err != JVMTI_ERROR_OPAQUE_FRAME) {
       NSK_DISPLAY1("jvmti error from PopFrame: %d\n", err);
       return NSK_FALSE;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(thread)))
         return NSK_FALSE;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     return NSK_TRUE;
@@ -283,43 +271,47 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED,
+                                   HeapObject,
+                                   &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -338,58 +330,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -404,18 +395,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -431,7 +421,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -444,7 +434,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -457,12 +447,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -476,7 +466,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -490,12 +480,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -509,12 +499,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -610,7 +600,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -622,13 +612,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -640,13 +630,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -658,10 +648,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t008/cm01t008.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t008/cm01t008.cpp
@@ -76,8 +76,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -89,8 +88,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -102,24 +100,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -133,23 +127,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -165,27 +157,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -199,7 +187,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -212,7 +200,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -222,8 +210,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -267,43 +254,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -322,58 +311,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -388,18 +376,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -415,12 +402,11 @@ static int checkRedefineClasses() {
     class_def.klass = klass;
     class_def.class_byte_count = klass_byte_count;
     class_def.class_bytes = klass_bytes;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: IsMethodObsolete\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(IsMethodObsolete, jvmti, method, &is_obsolete)))
+    if (!NSK_JVMTI_VERIFY(jvmti->IsMethodObsolete(method, &is_obsolete)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -433,7 +419,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -446,12 +432,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -465,7 +451,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -479,12 +465,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -498,12 +484,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -521,15 +507,14 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *env, jclass class_beeing_redefine
 
     if (name != NULL && (strcmp(name, CLASS_NAME) == 0)) {
         NSK_DISPLAY1("ClassFileLoadHook: %s\n", name);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate,
-            jvmti, class_data_len, &klass_bytes)))
+        if (!NSK_JVMTI_VERIFY(jvmti->Allocate(class_data_len, &klass_bytes)))
             nsk_jvmti_setFailStatus();
         else {
             memcpy(klass_bytes, class_data, class_data_len);
             klass_byte_count = class_data_len;
         }
-        NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL));
+        NSK_JVMTI_VERIFY(
+            jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL));
     }
 }
 
@@ -624,7 +609,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -636,13 +621,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -654,13 +639,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -672,10 +657,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -686,11 +671,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     /* activate ClassFileLoadHook to get class file data */
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.ClassFileLoadHook = &ClassFileLoadHook;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+    if (!NSK_JVMTI_VERIFY(
+        jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t009/cm01t009.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t009/cm01t009.cpp
@@ -74,8 +74,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -87,8 +86,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -100,24 +98,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -131,23 +125,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -163,25 +155,22 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: StopThread\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+    if (!NSK_JVMTI_VERIFY(jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -195,7 +184,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -208,7 +197,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -218,8 +207,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -263,43 +251,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -318,58 +308,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -384,18 +373,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -411,7 +399,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -424,7 +412,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -437,12 +425,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -456,7 +444,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -470,12 +458,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -489,12 +477,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -590,7 +578,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -602,13 +590,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -620,13 +608,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -638,10 +626,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t010/cm01t010.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t010/cm01t010.cpp
@@ -73,8 +73,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -86,8 +85,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -99,24 +97,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -130,23 +124,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -162,27 +154,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -196,7 +184,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -209,7 +197,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -219,8 +207,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -264,43 +251,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -319,58 +308,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -384,19 +372,17 @@ static int checkSourceInfoFunctions() {
     jvmtiLineNumberEntry *line_number_table = NULL;
 
     NSK_DISPLAY0("Checking positive: GetSourceFileName\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -412,7 +398,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -425,7 +411,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -438,12 +424,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -457,7 +443,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -471,12 +457,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -490,12 +476,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -591,7 +577,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -603,13 +589,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -621,13 +607,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -639,10 +625,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t012/cm01t012.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t012/cm01t012.cpp
@@ -76,8 +76,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -89,8 +88,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -102,24 +100,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -133,21 +127,19 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking positive: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: SuspendThreadList\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: ResumeThreadList\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+    if (!NSK_JVMTI_VERIFY(jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -163,27 +155,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -197,7 +185,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -210,7 +198,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -220,8 +208,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -265,43 +252,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -320,58 +309,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -386,18 +374,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -413,7 +400,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -426,7 +413,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -439,12 +426,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -458,7 +445,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -472,12 +459,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -491,12 +478,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -592,7 +579,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -604,13 +591,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -622,13 +609,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -640,10 +627,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t013/cm01t013.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t013/cm01t013.cpp
@@ -73,8 +73,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -86,8 +85,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -99,24 +97,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -130,23 +124,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -162,27 +154,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -196,7 +184,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -209,7 +197,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -219,8 +207,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -264,43 +251,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -319,58 +308,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -385,18 +373,16 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: GetLineNumberTable\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -412,7 +398,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -425,7 +411,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -438,12 +424,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -457,7 +443,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -471,12 +457,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -490,12 +476,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -591,7 +577,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -603,13 +589,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -621,13 +607,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -639,10 +625,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t014/cm01t014.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t014/cm01t014.cpp
@@ -74,8 +74,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -87,8 +86,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -100,24 +98,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -130,7 +124,7 @@ static int prepare() {
 static int checkGetPotentialCapabilities() {
     jvmtiCapabilities caps;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return NSK_FALSE;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -148,7 +142,7 @@ static int checkAddCapabilities() {
 
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -160,7 +154,7 @@ static int checkGetCapabilities(int owe) {
     jvmtiCapabilities caps;
 
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return NSK_FALSE;
     if (owe && !caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -182,7 +176,7 @@ static int checkRelinquishCapabilities() {
 
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -196,23 +190,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -228,27 +220,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -262,7 +250,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -275,7 +263,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -285,8 +273,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -330,43 +317,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -385,58 +374,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -451,18 +439,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -478,7 +465,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -491,7 +478,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -504,12 +491,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -523,15 +510,14 @@ static int checkGetBytecodes(int positive) {
 
     if (positive) {
         NSK_DISPLAY0("Checking positive: GetBytecodes\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetBytecodes(method, &count, &bytecodes)))
             return NSK_FALSE;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, jvmti, bytecodes)))
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate(bytecodes)))
             return NSK_FALSE;
     } else {
         NSK_DISPLAY0("Checking negative: GetBytecodes\n");
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+                jvmti->GetBytecodes(method, &count, &bytecodes)))
             return NSK_FALSE;
     }
 
@@ -546,12 +532,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -565,12 +551,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t015/cm01t015.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t015/cm01t015.cpp
@@ -76,8 +76,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -89,8 +88,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -102,24 +100,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -132,7 +126,7 @@ static int prepare() {
 static int checkGetPotentialCapabilities() {
     jvmtiCapabilities caps;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return NSK_FALSE;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -150,7 +144,7 @@ static int checkAddCapabilities() {
 
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -162,7 +156,7 @@ static int checkGetCapabilities(int owe) {
     jvmtiCapabilities caps;
 
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return NSK_FALSE;
     if (owe && !caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -184,7 +178,7 @@ static int checkRelinquishCapabilities() {
 
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -198,23 +192,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -230,27 +222,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -264,7 +252,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -277,7 +265,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -287,8 +275,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -332,43 +319,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -387,58 +376,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -453,18 +441,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -480,7 +467,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -493,7 +480,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -506,23 +493,21 @@ static int checkIsSyntheticFunctions(int positive) {
 
     if (positive) {
         NSK_DISPLAY0("Checking positive: IsFieldSynthetic\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+        if (!NSK_JVMTI_VERIFY(jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
             return NSK_FALSE;
 
         NSK_DISPLAY0("Checking positive: IsMethodSynthetic\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+        if (!NSK_JVMTI_VERIFY(jvmti->IsMethodSynthetic(method, &is_synthetic)))
             return NSK_FALSE;
     } else {
         NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+                jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
             return NSK_FALSE;
 
         NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+                jvmti->IsMethodSynthetic(method, &is_synthetic)))
             return NSK_FALSE;
     }
 
@@ -537,7 +522,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -551,12 +536,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -570,12 +555,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t016/cm01t016.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t016/cm01t016.cpp
@@ -74,8 +74,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -87,8 +86,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -100,24 +98,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -130,7 +124,7 @@ static int prepare() {
 static int checkGetPotentialCapabilities() {
     jvmtiCapabilities caps;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return NSK_FALSE;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -148,7 +142,7 @@ static int checkAddCapabilities() {
 
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -160,7 +154,7 @@ static int checkGetCapabilities(int owe) {
     jvmtiCapabilities caps;
 
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return NSK_FALSE;
     if (owe && !caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -182,7 +176,7 @@ static int checkRelinquishCapabilities() {
 
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -196,23 +190,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -228,27 +220,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -262,7 +250,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -275,7 +263,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -285,8 +273,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -330,43 +317,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -385,58 +374,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -451,18 +439,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -478,7 +465,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -491,14 +478,12 @@ static int checkGetObjectMonitorUsage(int positive) {
 
     if (positive) {
         NSK_DISPLAY0("Checking positive: GetObjectMonitorUsage\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti,
-                thread, &monitor_info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
             return NSK_FALSE;
     } else {
         NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti,
-                    thread, &monitor_info)))
+                jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
             return NSK_FALSE;
     }
 
@@ -512,12 +497,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -531,7 +516,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -545,12 +530,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -564,12 +549,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t017/cm01t017.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t017/cm01t017.cpp
@@ -76,8 +76,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -89,8 +88,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -102,24 +100,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -132,7 +126,7 @@ static int prepare() {
 static int checkGetPotentialCapabilities() {
     jvmtiCapabilities caps;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return NSK_FALSE;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -150,7 +144,7 @@ static int checkAddCapabilities() {
 
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -162,7 +156,7 @@ static int checkGetCapabilities(int owe) {
     jvmtiCapabilities caps;
 
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return NSK_FALSE;
     if (owe && !caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -184,7 +178,7 @@ static int checkRelinquishCapabilities() {
 
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -198,23 +192,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -230,37 +222,33 @@ static int checkSignalThread(int positive) {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     if (positive) {
         NSK_DISPLAY0("Checking positive: InterruptThread\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+        if (!NSK_JVMTI_VERIFY(jvmti->InterruptThread(thread)))
             return NSK_FALSE;
 
         NSK_DISPLAY0("Checking positive: StopThread\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(StopThread, jvmti,
-                thread, exception)))
+        if (!NSK_JVMTI_VERIFY(jvmti->StopThread(thread, exception)))
             return NSK_FALSE;
     } else {
         NSK_DISPLAY0("Checking negative: StopThread\n");
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+                jvmti->StopThread(thread, exception)))
             return NSK_FALSE;
 
         NSK_DISPLAY0("Checking negative: InterruptThread\n");
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+                jvmti->InterruptThread(thread)))
             return NSK_FALSE;
     }
 
@@ -275,7 +263,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -288,7 +276,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -298,8 +286,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -343,43 +330,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -398,58 +387,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -464,18 +452,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -491,7 +478,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -504,7 +491,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -517,12 +504,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -536,7 +523,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -550,12 +537,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -569,12 +556,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t018/cm01t018.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t018/cm01t018.cpp
@@ -78,8 +78,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -91,8 +90,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -104,24 +102,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -134,7 +128,7 @@ static int prepare() {
 static int checkGetPotentialCapabilities() {
     jvmtiCapabilities caps;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return NSK_FALSE;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -152,7 +146,7 @@ static int checkAddCapabilities() {
 
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -164,7 +158,7 @@ static int checkGetCapabilities(int owe) {
     jvmtiCapabilities caps;
 
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return NSK_FALSE;
     if (owe && !caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -186,7 +180,7 @@ static int checkRelinquishCapabilities() {
 
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -201,41 +195,39 @@ static int checkSuspend(int positive) {
 
     if (positive) {
         NSK_DISPLAY0("Checking positive: SuspendThread\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+        if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(thread)))
             return NSK_FALSE;
 
         NSK_DISPLAY0("Checking positive: ResumeThread\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(thread)))
             return NSK_FALSE;
 
         NSK_DISPLAY0("Checking positive: SuspendThreadList\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+        if (!NSK_JVMTI_VERIFY(jvmti->SuspendThreadList(1, &thread, &err)))
             return NSK_FALSE;
 
         NSK_DISPLAY0("Checking positive: ResumeThreadList\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThreadList(1, &thread, &err)))
             return NSK_FALSE;
     } else {
         NSK_DISPLAY0("Checking negative: SuspendThread\n");
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+                jvmti->SuspendThread(thread)))
             return NSK_FALSE;
 
         NSK_DISPLAY0("Checking negative: ResumeThread\n");
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+                jvmti->ResumeThread(thread)))
             return NSK_FALSE;
 
         NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+                jvmti->SuspendThreadList(1, &thread, &err)))
             return NSK_FALSE;
 
         NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+                jvmti->ResumeThreadList(1, &thread, &err)))
             return NSK_FALSE;
     }
 
@@ -252,27 +244,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -286,7 +274,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -299,7 +287,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -309,8 +297,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -354,43 +341,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -409,58 +398,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -475,18 +463,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -502,7 +489,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -515,7 +502,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -528,12 +515,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -547,7 +534,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -561,12 +548,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -580,12 +567,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t019/cm01t019.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t019/cm01t019.cpp
@@ -73,8 +73,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -86,8 +85,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -99,24 +97,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -130,23 +124,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -162,27 +154,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -196,7 +184,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -209,7 +197,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -219,8 +207,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -264,43 +251,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -319,58 +308,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -385,18 +373,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_ABSENT_INFORMATION,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -412,7 +399,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -425,7 +412,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -438,12 +425,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -457,7 +444,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -471,12 +458,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -490,12 +477,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -591,7 +578,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -603,13 +590,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -621,13 +608,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -639,10 +626,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t020/cm01t020.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t020/cm01t020.cpp
@@ -74,8 +74,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -87,8 +86,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -100,24 +98,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -131,23 +125,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -163,27 +155,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -197,7 +185,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -210,7 +198,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -220,8 +208,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -265,43 +252,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -320,58 +309,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -386,18 +374,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -413,7 +400,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -426,7 +413,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -439,12 +426,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -458,7 +445,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -471,13 +458,11 @@ static int checkGetCurrentThreadCpuTime() {
     jlong nanos;
 
     NSK_DISPLAY0("Checking positive: GetCurrentThreadCpuTimerInfo\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: GetCurrentThreadCpuTime\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -491,12 +476,12 @@ static int checkGetThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: checkGetThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+            jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -592,7 +577,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -604,13 +589,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -622,13 +607,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -640,10 +625,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t021/cm01t021.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM01/cm01t021/cm01t021.cpp
@@ -74,8 +74,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -87,8 +86,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -100,24 +98,20 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'run' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "run", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "run", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -131,23 +125,21 @@ static int checkSuspend() {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking negative: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SuspendThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+            jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: ResumeThreadList\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+            jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -163,27 +155,23 @@ static int checkSignalThread() {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: StopThread\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+            jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -197,7 +185,7 @@ static int checkGetOwnedMonitorInfo() {
 
     NSK_DISPLAY0("Checking negative: GetOwnedMonitorInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+            jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -210,7 +198,7 @@ static int checkGetCurrentContendedMonitor() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentContendedMonitor\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+            jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -220,8 +208,7 @@ static int checkGetCurrentContendedMonitor() {
  */
 static int checkPopFrame() {
     NSK_DISPLAY0("Checking negative: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(PopFrame, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->PopFrame(thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -265,43 +252,45 @@ static int checkHeapFunctions() {
 
     NSK_DISPLAY0("Checking negative: SetTag\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+            jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetTag\n");
-    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY, jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetObjectsWithTags\n");
     tag = TAG_VALUE;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+            jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -320,58 +309,57 @@ static int checkLocalVariableFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetLocalVariableTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+            jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalObject, jvmti, thread, 0, 0, &object_value)))
+            jvmti->GetLocalObject(thread, 0, 0, &object_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalInt, jvmti, thread, 0, 0, &int_value)))
+            jvmti->GetLocalInt(thread, 0, 0, &int_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalLong, jvmti, thread, 0, 0, &long_value)))
+            jvmti->GetLocalLong(thread, 0, 0, &long_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalFloat, jvmti, thread, 0, 0, &float_value)))
+            jvmti->GetLocalFloat(thread, 0, 0, &float_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(GetLocalDouble, jvmti, thread, 0, 0, &double_value)))
+            jvmti->GetLocalDouble(thread, 0, 0, &double_value)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalObject\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalObject, jvmti, thread, 0, 0, thread)))
+            jvmti->SetLocalObject(thread, 0, 0, thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalInt\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalInt, jvmti, thread, 0, 0, (jint)0)))
+            jvmti->SetLocalInt(thread, 0, 0, (jint)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalLong\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalLong, jvmti, thread, 0, 0, (jlong)0)))
+            jvmti->SetLocalLong(thread, 0, 0, (jlong)0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalFloat\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalFloat, jvmti, thread, 0, 0, (jfloat)0.0)))
+            jvmti->SetLocalFloat(thread, 0, 0, (jfloat)0.0)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: SetLocalDouble\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB5(SetLocalDouble, jvmti, thread, 0, 0, (jdouble)0.0)))
+            jvmti->SetLocalDouble(thread, 0, 0, (jdouble)0.0)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -386,18 +374,17 @@ static int checkSourceInfoFunctions() {
 
     NSK_DISPLAY0("Checking negative: GetSourceFileName\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+            jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetLineNumberTable\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+            jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -413,7 +400,7 @@ static int checkRedefineClasses() {
     class_def.class_byte_count = 0;
     class_def.class_bytes = NULL;
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+            jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -426,7 +413,7 @@ static int checkGetObjectMonitorUsage() {
 
     NSK_DISPLAY0("Checking negative: GetObjectMonitorUsage\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+            jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -439,12 +426,12 @@ static int checkIsSyntheticFunctions() {
 
     NSK_DISPLAY0("Checking negative: IsFieldSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+            jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: IsMethodSynthetic\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+            jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -458,7 +445,7 @@ static int checkGetBytecodes() {
 
     NSK_DISPLAY0("Checking negative: GetBytecodes\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+            jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -472,12 +459,12 @@ static int checkGetCurrentThreadCpuTime() {
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTimerInfo\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+            jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking negative: GetCurrentThreadCpuTime\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+            jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -490,13 +477,11 @@ static int checkGetThreadCpuTime() {
     jlong nanos;
 
     NSK_DISPLAY0("Checking positive: GetThreadCpuTimerInfo\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: checkGetThreadCpuTime\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -592,7 +577,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     /* testcase #1: check GetPotentialCapabilities */
     NSK_DISPLAY0("Testcase #1: check if GetPotentialCapabilities returns the capability\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetPotentialCapabilities does not return \"%s\" capability\n",
@@ -604,13 +589,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #2: add the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #3: check if GetCapabilities returns the capability */
     NSK_DISPLAY0("Testcase #3: check if GetCapabilities returns the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",
@@ -622,13 +607,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #4: relinquish the capability during Onload phase\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RelinquishCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(&caps)))
         return JNI_ERR;
 
     /* testcase #5: check if GetCapabilities does not return the capability */
     NSK_DISPLAY0("Testcase #5: check if GetCapabilities does not return the capability\n");
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities returns relinquished \"%s\" capability\n",
@@ -640,10 +625,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("Testcase #6: add back the capability and check with GetCapabilities\n");
     memset(&caps, 0, sizeof(caps));
     caps.CAPABILITY = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.CAPABILITY) {
         NSK_COMPLAIN1("GetCapabilities does not return \"%s\" capability\n",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM02/cm02t001/cm02t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM02/cm02t001/cm02t001.cpp
@@ -99,17 +99,16 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method,
 
     CompiledMethodLoadEventsCount++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY3("CompiledMethodLoad event: %s%s (0x%p)\n",
         name, signature, code_addr);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 static void JNICALL
@@ -126,8 +125,8 @@ CompiledMethodUnload(jvmtiEnv *jvmti_env, jmethodID method,
     if (err == JVMTI_ERROR_NONE) {
         NSK_DISPLAY3("for: \tmethod: name=\"%s\" signature=\"%s\"\n\tnative address=0x%p\n",
           name, sig, code_addr);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)sig);
+        jvmti_env->Deallocate((unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)sig);
     }
 }
 
@@ -139,8 +138,7 @@ MonitorContendedEnter(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
     MonitorContendedEnterEventsCount++;
 
     /* get thread information */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti_env,
-            thread, &info))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -156,8 +154,7 @@ MonitorContendedEntered(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
     MonitorContendedEnteredEventsCount++;
 
     /* get thread information */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti_env,
-            thread, &info))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -173,8 +170,7 @@ MonitorWait(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
     MonitorWaitEventsCount++;
 
     /* get thread information */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti_env,
-            thread, &info))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -190,8 +186,7 @@ MonitorWaited(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
     MonitorWaitedEventsCount++;
 
     /* get thread information */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti_env,
-            thread, &info))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -207,14 +202,13 @@ VMObjectAlloc(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
 
     VMObjectAllocEventsCount++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti_env,
-            object_klass, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(object_klass, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("VMObjectAlloc: \"%s\", size=%d\n", signature, size);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 static void JNICALL
@@ -226,7 +220,7 @@ NativeMethodBind(jvmtiEnv* jvmti_env, JNIEnv *jni_env,
 
     NativeMethodBindEventsCount++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -234,8 +228,7 @@ NativeMethodBind(jvmtiEnv* jvmti_env, JNIEnv *jni_env,
     if (phase != JVMTI_PHASE_START && phase != JVMTI_PHASE_LIVE)
         return;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -243,9 +236,9 @@ NativeMethodBind(jvmtiEnv* jvmti_env, JNIEnv *jni_env,
     NSK_DISPLAY2("NativeMethodBind event: %s%s\n", name, signature);
 
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 static void JNICALL
@@ -280,8 +273,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -293,8 +285,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -305,18 +296,15 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         }
     }
 
-    if (!NSK_JNI_VERIFY(jni, (thread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL))
         return NSK_FALSE;
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -330,7 +318,7 @@ static int checkGetCapabilities(jvmtiEnv* jvmti) {
     jvmtiCapabilities caps;
 
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return NSK_FALSE;
     if (!NSK_VERIFY(caps.can_tag_objects))
         return NSK_FALSE;
@@ -373,8 +361,7 @@ static int checkGetOwnedMonitorInfo(jvmtiEnv* jvmti) {
     jobject *monitors = NULL;
 
     NSK_DISPLAY0("Checking positive: GetOwnedMonitorInfo\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetOwnedMonitorInfo, jvmti, thread, &count, &monitors)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetOwnedMonitorInfo(thread, &count, &monitors)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -386,8 +373,7 @@ static int checkGetCurrentContendedMonitor(jvmtiEnv* jvmti) {
     jobject monitor = NULL;
 
     NSK_DISPLAY0("Checking positive: GetCurrentContendedMonitor\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetCurrentContendedMonitor, jvmti, thread, &monitor)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCurrentContendedMonitor(thread, &monitor)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -439,44 +425,44 @@ static int checkHeapFunctions(jvmtiEnv* jvmti) {
     jint dummy_user_data = 0;
 
     NSK_DISPLAY0("Checking positive: SetTag\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, thread, TAG_VALUE)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(thread, TAG_VALUE)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: GetTag\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetTag, jvmti, thread, &tag)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetTag(thread, &tag)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: GetObjectsWithTags\n");
     tag = TAG_VALUE;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB6(GetObjectsWithTags, jvmti, 1, &tag,
-                &count, &res_objects, &res_tags)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetObjectsWithTags(1, &tag, &count, &res_objects, &res_tags)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: IterateOverHeap\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IterateOverHeap, jvmti, JVMTI_HEAP_OBJECT_TAGGED,
-                HeapObject, &dummy_user_data)))
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, HeapObject, &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: IterateOverInstancesOfClass\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti, klass,
-                JVMTI_HEAP_OBJECT_UNTAGGED, HeapObject, &dummy_user_data)))
+            jvmti->IterateOverInstancesOfClass(klass,
+                                               JVMTI_HEAP_OBJECT_UNTAGGED,
+                                               HeapObject,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: IterateOverObjectsReachableFromObject\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti, thread,
-                ThreadObjectReference, &dummy_user_data)))
+            jvmti->IterateOverObjectsReachableFromObject(thread,
+                                                         ThreadObjectReference,
+                                                         &dummy_user_data)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: IterateOverReachableObjects\n");
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                HeapRoot, StackReference, ObjectReference, &dummy_user_data)))
+            jvmti->IterateOverReachableObjects(HeapRoot,
+                                               StackReference,
+                                               ObjectReference,
+                                               &dummy_user_data)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -488,8 +474,7 @@ static int checkGetObjectMonitorUsage(jvmtiEnv* jvmti) {
     jvmtiMonitorUsage monitor_info;
 
     NSK_DISPLAY0("Checking positive: GetObjectMonitorUsage\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetObjectMonitorUsage, jvmti, thread, &monitor_info)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetObjectMonitorUsage(thread, &monitor_info)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -502,13 +487,11 @@ static int checkGetCurrentThreadCpuTime(jvmtiEnv* jvmti) {
     jlong nanos;
 
     NSK_DISPLAY0("Checking positive: GetCurrentThreadCpuTimerInfo\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, jvmti, &info)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCurrentThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: GetCurrentThreadCpuTime\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, jvmti, &nanos)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCurrentThreadCpuTime(&nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -521,13 +504,11 @@ static int checkGetThreadCpuTime(jvmtiEnv* jvmti) {
     jlong nanos;
 
     NSK_DISPLAY0("Checking positive: GetThreadCpuTimerInfo\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetThreadCpuTimerInfo, jvmti, &info)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetThreadCpuTimerInfo(&info)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: checkGetThreadCpuTime\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetThreadCpuTime, jvmti, thread, &nanos)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetThreadCpuTime(thread, &nanos)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -641,7 +622,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!checkGetThreadCpuTime(jvmti))
         nsk_jvmti_setFailStatus();
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, thread));
+    NSK_TRACE(jni->DeleteGlobalRef(thread));
 
     /* resume debugee and wait for sync */
     if (!nsk_jvmti_resumeSync())
@@ -706,7 +687,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     caps.can_generate_native_method_bind_events = 1;
     caps.can_generate_garbage_collection_events = 1;
     caps.can_generate_object_free_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* set event callbacks */
@@ -723,46 +704,45 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.GarbageCollectionStart = &GarbageCollectionStart;
     callbacks.GarbageCollectionFinish = &GarbageCollectionFinish;
     callbacks.ObjectFree = &ObjectFree;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* enable events */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(
+            JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(
+            JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_UNLOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(
+            JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_UNLOAD, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(
+            JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(
+            JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAIT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(
+            JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAIT, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAITED, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(
+            JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAITED, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_OBJECT_ALLOC, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(
+            JVMTI_ENABLE, JVMTI_EVENT_VM_OBJECT_ALLOC, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_NATIVE_METHOD_BIND, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(
+            JVMTI_ENABLE, JVMTI_EVENT_NATIVE_METHOD_BIND, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(
+            JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(
+            JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(
+            JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/cm03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/cm03t001.cpp
@@ -95,15 +95,15 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
 
     if (name != NULL && (strcmp(name, CLASS_NAME) == 0)) {
         NSK_DISPLAY1("ClassFileLoadHook: %s\n", name);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate,
-                jvmti_env, class_data_len, &klass_bytes)))
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Allocate(class_data_len, &klass_bytes)))
             nsk_jvmti_setFailStatus();
         else {
             memcpy(klass_bytes, class_data, class_data_len);
             klass_byte_count = class_data_len;
         }
-        NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti_env, JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL));
+        NSK_JVMTI_VERIFY(
+            jvmti_env->SetEventNotificationMode(
+                JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL));
     }
 }
 
@@ -116,20 +116,18 @@ FieldAccess(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
 
     FieldAccessEventsCount++;
 
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(ClearFieldAccessWatch, jvmti_env, klass, field)))
+    if (!NSK_JVMTI_VERIFY(jvmti_env->ClearFieldAccessWatch(klass, field)))
         return;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB6(GetFieldName,
-            jvmti_env, field_klass, field, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetFieldName(field_klass, field, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("FieldAccess event: %s:%s\n", name, signature);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 static void JNICALL
@@ -142,16 +140,15 @@ FieldModification(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
 
     FieldModificationEventsCount++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB6(GetFieldName,
-            jvmti_env, field_klass, field, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetFieldName(field_klass, field, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("FieldModification event: %s:%s\n", name, signature);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 static void JNICALL
@@ -162,19 +159,19 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     SingleStepEventsCount++;
 
-    NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-        jvmti_env, JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, NULL));
+    NSK_JVMTI_VERIFY(
+        jvmti_env->SetEventNotificationMode(
+            JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, NULL));
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("SingleStep event: %s%s\n", name, signature);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 static void JNICALL
@@ -186,19 +183,17 @@ Exception(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread,
 
     ExceptionEventsCount++;
 
-    if (!NSK_JNI_VERIFY(jni_env, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, exception)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(exception)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti_env,
-            klass, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY1("Exception event: %s\n", signature);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 void JNICALL
@@ -209,19 +204,17 @@ ExceptionCatch(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread,
 
     ExceptionCatchEventsCount++;
 
-    if (!NSK_JNI_VERIFY(jni_env, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, exception)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(exception)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti_env,
-            klass, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY1("ExceptionCatch event: %s\n", signature);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 static void JNICALL
@@ -231,18 +224,17 @@ Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     char *signature = NULL;
 
     BreakpointEventsCount++;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("Breakpoint event: %s%s\n", name, signature);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 
-    NSK_CPP_STUB3(NotifyFramePop, jvmti_env, thread, 0);
+    jvmti_env->NotifyFramePop(thread, 0);
 }
 
 static void JNICALL
@@ -253,16 +245,15 @@ FramePop(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     char *signature = NULL;
 
     FramePopEventsCount++;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("FramePop event: %s%s\n", name, signature);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 static void JNICALL
@@ -272,16 +263,15 @@ MethodEntry(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     char *signature = NULL;
 
     MethodEntryEventsCount++;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("MethodEntry event: %s%s\n", name, signature);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 static void JNICALL
@@ -292,16 +282,15 @@ MethodExit(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     char *signature = NULL;
 
     MethodExitEventsCount++;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("MethodExit event: %s%s\n", name, signature);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 /* ========================================================================== */
@@ -316,8 +305,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -329,8 +317,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -341,28 +328,23 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         }
     }
 
-    if (!NSK_JNI_VERIFY(jni, (thread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL))
         return NSK_FALSE;
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'delay' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "delay", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "delay", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingFlag' */
-    if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass, "waitingFlag", "Z")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (field = jni->GetFieldID(klass, "waitingFlag", "Z")) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -372,41 +354,37 @@ static int prepareEvents(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare events ...\n");
 
     /* get tested thread method 'letItGo' */
-    if (!NSK_JNI_VERIFY(jni, (method =
-            NSK_CPP_STUB4(GetMethodID, jni, klass, "letItGo", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "letItGo", "()V")) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingFlag' */
-    if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass, "waitingFlag", "Z")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (field = jni->GetFieldID(klass, "waitingFlag", "Z")) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(SetFieldAccessWatch, jvmti, klass, field)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetFieldAccessWatch(klass, field)))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(SetFieldModificationWatch, jvmti, klass, field)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetFieldModificationWatch(klass, field)))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetBreakpoint, jvmti, method, 0)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetBreakpoint(method, 0)))
         return NSK_FALSE;
 
     /* enable events */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, NULL)))
+    if (!NSK_JVMTI_VERIFY(
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION, NULL)))
+    if (!NSK_JVMTI_VERIFY(
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION_CATCH, NULL)))
+    if (!NSK_JVMTI_VERIFY(
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION_CATCH, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, thread)))
+    if (!NSK_JVMTI_VERIFY(
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, thread)))
         return NSK_FALSE;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_METHOD_EXIT, thread)))
+    if (!NSK_JVMTI_VERIFY(
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_EXIT, thread)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -420,7 +398,7 @@ static int checkGetCapabilities(jvmtiEnv* jvmti) {
     jvmtiCapabilities caps;
 
     memset(&caps, 0, sizeof(caps));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return NSK_FALSE;
     if (!NSK_VERIFY(caps.can_get_bytecodes))
         return NSK_FALSE;
@@ -471,10 +449,9 @@ static int checkGetBytecodes(jvmtiEnv* jvmti) {
     unsigned char *bytecodes;
 
     NSK_DISPLAY0("Checking positive: GetBytecodes\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetBytecodes, jvmti, method, &count, &bytecodes)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetBytecodes(method, &count, &bytecodes)))
         return NSK_FALSE;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, jvmti, bytecodes)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate(bytecodes)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -486,13 +463,11 @@ static int checkIsSyntheticFunctions(jvmtiEnv* jvmti) {
     jboolean is_synthetic;
 
     NSK_DISPLAY0("Checking positive: IsFieldSynthetic\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IsFieldSynthetic, jvmti, klass, field, &is_synthetic)))
+    if (!NSK_JVMTI_VERIFY(jvmti->IsFieldSynthetic(klass, field, &is_synthetic)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: IsMethodSynthetic\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(IsMethodSynthetic, jvmti, method, &is_synthetic)))
+    if (!NSK_JVMTI_VERIFY(jvmti->IsMethodSynthetic(method, &is_synthetic)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -511,12 +486,11 @@ static int checkRedefineClasses(jvmtiEnv* jvmti) {
     class_def.klass = klass;
     class_def.class_byte_count = klass_byte_count;
     class_def.class_bytes = klass_bytes;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: IsMethodObsolete\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(IsMethodObsolete, jvmti, method, &is_obsolete)))
+    if (!NSK_JVMTI_VERIFY(jvmti->IsMethodObsolete(method, &is_obsolete)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -528,8 +502,7 @@ static int checkGetSourceFileName(jvmtiEnv* jvmti) {
     char *name;
 
     NSK_DISPLAY0("Checking positive: GetSourceFileName\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetSourceFileName, jvmti, klass, &name)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetSourceFileName(klass, &name)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -542,9 +515,7 @@ static int checkGetLineNumberTable(jvmtiEnv* jvmti) {
     jvmtiLineNumberEntry *line_number_table = NULL;
 
     NSK_DISPLAY0("Checking positive: GetLineNumberTable\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetLineNumberTable, jvmti, method, &count,
-                &line_number_table)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetLineNumberTable(method, &count, &line_number_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -557,7 +528,7 @@ static int checkGetSourceDebugExtension(jvmtiEnv* jvmti) {
 
     NSK_DISPLAY0("Checking positive: GetSourceDebugExtension\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_ABSENT_INFORMATION,
-            NSK_CPP_STUB3(GetSourceDebugExtension, jvmti, klass, &name)))
+            jvmti->GetSourceDebugExtension(klass, &name)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -576,77 +547,74 @@ static int checkLocalVariableFunctions(jvmtiEnv* jvmti) {
     int i;
 
     NSK_DISPLAY0("Checking positive: GetLocalVariableTable\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetLocalVariableTable, jvmti, method, &count,
-                &local_variable_table)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetLocalVariableTable(method, &count, &local_variable_table)))
         return NSK_FALSE;
 
 /* DEBUG -- while 4913796 bug not fixed thread should be suspended
  */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     for (i = 0; i < count; i++) {
         if (strcmp(local_variable_table[i].name, "o") ==0) {
             NSK_DISPLAY0("Checking positive: GetLocalObject\n");
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetLocalObject, jvmti,
-                    thread, 1, local_variable_table[i].slot, &object_value)))
+            if (!NSK_JVMTI_VERIFY(
+                    jvmti->GetLocalObject(thread, 1, local_variable_table[i].slot, &object_value)))
                 return NSK_FALSE;
 
             NSK_DISPLAY0("Checking positive: SetLocalObject\n");
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(SetLocalObject, jvmti,
-                    thread, 1, local_variable_table[i].slot, object_value)))
+            if (!NSK_JVMTI_VERIFY(
+                    jvmti->SetLocalObject(thread, 1, local_variable_table[i].slot, object_value)))
                 return NSK_FALSE;
         } else if (strcmp(local_variable_table[i].name, "i") ==0) {
             NSK_DISPLAY0("Checking positive: GetLocalInt\n");
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetLocalInt, jvmti,
-                    thread, 1, local_variable_table[i].slot, &int_value)))
+            if (!NSK_JVMTI_VERIFY(
+                    jvmti->GetLocalInt(thread, 1, local_variable_table[i].slot, &int_value)))
                 return NSK_FALSE;
 
             NSK_DISPLAY0("Checking positive: SetLocalInt\n");
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(SetLocalInt, jvmti,
-                    thread, 1, local_variable_table[i].slot, int_value)))
+            if (!NSK_JVMTI_VERIFY(
+                    jvmti->SetLocalInt(thread, 1, local_variable_table[i].slot, int_value)))
                 return NSK_FALSE;
         } else if (strcmp(local_variable_table[i].name, "l") ==0) {
             NSK_DISPLAY0("Checking positive: GetLocalLong\n");
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetLocalLong, jvmti,
-                    thread, 1, local_variable_table[i].slot, &long_value)))
+            if (!NSK_JVMTI_VERIFY(
+                    jvmti->GetLocalLong(thread, 1, local_variable_table[i].slot, &long_value)))
                 return NSK_FALSE;
 
             NSK_DISPLAY0("Checking positive: SetLocalLong\n");
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(SetLocalLong, jvmti,
-                    thread, 1, local_variable_table[i].slot, long_value)))
+            if (!NSK_JVMTI_VERIFY(
+                    jvmti->SetLocalLong(thread, 1, local_variable_table[i].slot, long_value)))
                 return NSK_FALSE;
         } else if (strcmp(local_variable_table[i].name, "f") ==0) {
             NSK_DISPLAY0("Checking positive: GetLocalFloat\n");
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetLocalFloat, jvmti,
-                    thread, 1, local_variable_table[i].slot, &float_value)))
+            if (!NSK_JVMTI_VERIFY(
+                    jvmti->GetLocalFloat(thread, 1, local_variable_table[i].slot, &float_value)))
                 return NSK_FALSE;
 
             NSK_DISPLAY0("Checking positive: SetLocalFloat\n");
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(SetLocalFloat, jvmti,
-                    thread, 1, local_variable_table[i].slot, float_value)))
+            if (!NSK_JVMTI_VERIFY(
+                    jvmti->SetLocalFloat(thread, 1, local_variable_table[i].slot, float_value)))
                 return NSK_FALSE;
         } else if (strcmp(local_variable_table[i].name, "d") ==0) {
             NSK_DISPLAY0("Checking positive: GetLocalDouble\n");
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetLocalDouble, jvmti,
-                    thread, 1, local_variable_table[i].slot, &double_value)))
+            if (!NSK_JVMTI_VERIFY(
+                    jvmti->GetLocalDouble(thread, 1, local_variable_table[i].slot, &double_value)))
                 return NSK_FALSE;
 
             NSK_DISPLAY0("Checking positive: SetLocalDouble\n");
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(SetLocalDouble, jvmti,
-                    thread, 1, local_variable_table[i].slot, double_value)))
+            if (!NSK_JVMTI_VERIFY(
+                    jvmti->SetLocalDouble(thread, 1, local_variable_table[i].slot, double_value)))
                 return NSK_FALSE;
         }
     }
 
 /* DEBUG -- while 4913796 bug not fixed thread should be suspended
  */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, jvmti,
-            (unsigned char*)local_variable_table)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)local_variable_table)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -658,21 +626,19 @@ static int checkSuspend(jvmtiEnv* jvmti) {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking positive: SuspendThread\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: ResumeThread\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: SuspendThreadList\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SuspendThreadList, jvmti, 1, &thread, &err)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SuspendThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: ResumeThreadList\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(ResumeThreadList, jvmti, 1, &thread, &err)))
+    if (!NSK_JVMTI_VERIFY(jvmti->ResumeThreadList(1, &thread, &err)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -685,20 +651,20 @@ static int checkPopFrame(jvmtiEnv* jvmti) {
     jvmtiError err;
 
     NSK_DISPLAY0("Checking positive: PopFrame\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(SuspendThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(thread)))
         return NSK_FALSE;
 
     // PopFrame is allowed to fail with JVMTI_ERROR_OPAQUE_FRAME.
     // That will happen if we are in a native function,
     // for example while waiting for a Condition.
     // See JCK-5020108.
-    err = NSK_CPP_STUB2(PopFrame, jvmti, thread);
+    err = jvmti->PopFrame(thread);
     if (err != JVMTI_ERROR_NONE && err != JVMTI_ERROR_OPAQUE_FRAME) {
       result = NSK_FALSE;
       NSK_DISPLAY1("jvmti error from PopFrame: %d\n", err);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(ResumeThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(thread)))
         result = NSK_FALSE;
 
     return result;
@@ -714,25 +680,22 @@ static int checkSignalThread(jvmtiEnv* jvmti, JNIEnv* jni) {
     jmethodID ctor = NULL;
     jobject exception = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (exception =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (exception = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: InterruptThread\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(InterruptThread, jvmti, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->InterruptThread(thread)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Checking positive: StopThread\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(StopThread, jvmti, thread, exception)))
+    if (!NSK_JVMTI_VERIFY(jvmti->StopThread(thread, exception)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -847,7 +810,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!checkSignalThread(jvmti, jni))
         nsk_jvmti_setFailStatus();
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, thread));
+    NSK_TRACE(jni->DeleteGlobalRef(thread));
 
     /* resume debugee and wait for sync */
     if (!nsk_jvmti_resumeSync())
@@ -916,7 +879,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     caps.can_generate_breakpoint_events = 1;
     caps.can_generate_method_entry_events = 1;
     caps.can_generate_method_exit_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* set event callbacks */
@@ -931,25 +894,24 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.FramePop = &FramePop;
     callbacks.MethodEntry = &MethodEntry;
     callbacks.MethodExit = &MethodExit;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* enable events */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+    if (!NSK_JVMTI_VERIFY(
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_FIELD_ACCESS, NULL)))
+    if (!NSK_JVMTI_VERIFY(
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_FIELD_ACCESS, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_FIELD_MODIFICATION, NULL)))
+    if (!NSK_JVMTI_VERIFY(
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_FIELD_MODIFICATION, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL)))
+    if (!NSK_JVMTI_VERIFY(
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_FRAME_POP, NULL)))
+    if (!NSK_JVMTI_VERIFY(
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_FRAME_POP, NULL)))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/contention/TC01/tc01t001/tc01t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/contention/TC01/tc01t001/tc01t001.cpp
@@ -54,8 +54,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -67,8 +66,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -79,38 +77,31 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         }
 
         if (info.name != NULL) {
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                    Deallocate, jvmti, (unsigned char*)info.name)))
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)info.name)))
                 return NSK_FALSE;
         }
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'M1' */
-    if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass, "M1", FIELD_SIG)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (field = jni->GetFieldID(klass, "M1", FIELD_SIG)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (object_M1 =
-            NSK_CPP_STUB3(GetObjectField, jni, thread, field)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object_M1 = jni->GetObjectField(thread, field)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'M2' */
-    if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass, "M2", FIELD_SIG)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (field = jni->GetFieldID(klass, "M2", FIELD_SIG)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (object_M2 =
-            NSK_CPP_STUB3(GetObjectField, jni, thread, field)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object_M2 = jni->GetObjectField(thread, field)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -126,22 +117,19 @@ static int checkGetObjectMonitorUsage(jvmtiEnv* jvmti, JNIEnv* jni,
     int i;
 
     NSK_DISPLAY1("Checking GetObjectMonitorUsage for 0x%p\n", object);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(
-            GetObjectMonitorUsage, jvmti, object, &inf)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetObjectMonitorUsage(object, &inf)))
         return NSK_FALSE;
 
     if (nsk_getVerboseMode()) {
         if (inf.owner == NULL) {
             NSK_DISPLAY0("\towner: none (0x0)\n");
         } else {
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(
-                    GetThreadInfo, jvmti, inf.owner, &tinf))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(inf.owner, &tinf))) {
                 result = NSK_FALSE;
             } else {
                 NSK_DISPLAY2("\towner: %s (0x%p)\n", tinf.name, inf.owner);
                 if (tinf.name != NULL) {
-                    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                            Deallocate, jvmti, (unsigned char*)tinf.name)))
+                    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)tinf.name)))
                         result = NSK_FALSE;
                 }
             }
@@ -152,15 +140,13 @@ static int checkGetObjectMonitorUsage(jvmtiEnv* jvmti, JNIEnv* jni,
         if (inf.waiter_count > 0) {
             NSK_DISPLAY0("\twaiters:\n");
             for (i = 0; i < inf.waiter_count; i++) {
-                if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(
-                        GetThreadInfo, jvmti, inf.waiters[i], &tinf))) {
+                if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(inf.waiters[i], &tinf))) {
                     result = NSK_FALSE;
                 } else {
                     NSK_DISPLAY3("\t\t%2d: %s (0x%p)\n",
                         i, tinf.name, inf.waiters[i]);
                     if (tinf.name != NULL) {
-                        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                                Deallocate, jvmti, (unsigned char*)tinf.name)))
+                        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)tinf.name)))
                             result = NSK_FALSE;
                     }
                 }
@@ -171,15 +157,13 @@ static int checkGetObjectMonitorUsage(jvmtiEnv* jvmti, JNIEnv* jni,
         if (inf.notify_waiter_count > 0) {
             NSK_DISPLAY0("\tnotify_waiters:\n");
             for (i = 0; i < inf.notify_waiter_count; i++) {
-                if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(
-                        GetThreadInfo, jvmti, inf.notify_waiters[i], &tinf))) {
+                if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(inf.notify_waiters[i], &tinf))) {
                     result = NSK_FALSE;
                 } else {
                     NSK_DISPLAY3("\t\t%2d: %s (0x%p)\n",
                         i, tinf.name, inf.notify_waiters[i]);
                     if (tinf.name != NULL) {
-                        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                                Deallocate, jvmti, (unsigned char*)tinf.name)))
+                        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)tinf.name)))
                             result = NSK_FALSE;
                     }
                 }
@@ -188,8 +172,7 @@ static int checkGetObjectMonitorUsage(jvmtiEnv* jvmti, JNIEnv* jni,
     }
 
     /* check owner to be debugee thread */
-    if (!NSK_JNI_VERIFY(jni, (NSK_CPP_STUB3(
-            IsSameObject, jni, inf.owner, thread)) == JNI_TRUE))
+    if (!NSK_JNI_VERIFY(jni, (jni->IsSameObject(inf.owner, thread)) == JNI_TRUE))
         result = NSK_FALSE;
 
     if (!NSK_VERIFY(inf.entry_count == 2))
@@ -203,13 +186,11 @@ static int checkGetObjectMonitorUsage(jvmtiEnv* jvmti, JNIEnv* jni,
 
     /* deallocate monitor waiters arrays */
     if (inf.waiters != NULL) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                Deallocate, jvmti, (unsigned char*)inf.waiters)))
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)inf.waiters)))
             result = NSK_FALSE;
     }
     if (inf.notify_waiters != NULL) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                Deallocate, jvmti, (unsigned char*)inf.notify_waiters)))
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)inf.notify_waiters)))
             result = NSK_FALSE;
     }
 
@@ -279,7 +260,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     /* add capabilities */
     memset(&caps, 0, sizeof(caps));
     caps.can_get_monitor_info = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/contention/TC02/tc02t001/tc02t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/contention/TC02/tc02t001/tc02t001.cpp
@@ -52,8 +52,7 @@ static jint findLineNumber(jvmtiEnv *jvmti, jthread thread) {
     jint line = 0;
     int i;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(
-            GetFrameLocation, jvmti, thread, 0, &method, &location)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetFrameLocation(thread, 0, &method, &location)))
         return 0;
 
     if (!NSK_VERIFY(method != NULL))
@@ -62,8 +61,7 @@ static jint findLineNumber(jvmtiEnv *jvmti, jthread thread) {
     if (!NSK_VERIFY(location != -1))
         return 0;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(
-            GetLineNumberTable, jvmti, method, &count, &table)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetLineNumberTable(method, &count, &table)))
         return 0;
 
     if (!NSK_VERIFY(table != NULL))
@@ -81,8 +79,7 @@ static jint findLineNumber(jvmtiEnv *jvmti, jthread thread) {
     line = table[i-1].line_number;
 
     if (table != NULL) {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)table)))
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)table)))
             return 0;
     }
 
@@ -108,8 +105,8 @@ MonitorContendedEnter(jvmtiEnv *jvmti, JNIEnv* jni, jthread thr, jobject obj) {
     }
 
     /* check if event is for tested thread and object */
-    if (NSK_CPP_STUB3(IsSameObject, jni, thread, thr) &&
-            NSK_CPP_STUB3(IsSameObject, jni, object_M, obj)) {
+    if (jni->IsSameObject(thread, thr) &&
+            jni->IsSameObject(object_M, obj)) {
 
         if (!(line = findLineNumber(jvmti, thread))) {
             nsk_jvmti_setFailStatus();
@@ -152,8 +149,8 @@ MonitorContendedEntered(jvmtiEnv *jvmti, JNIEnv* jni, jthread thr, jobject obj) 
     }
 
     /* check if event is for tested thread and object */
-    if (NSK_CPP_STUB3(IsSameObject, jni, thread, thr) &&
-            NSK_CPP_STUB3(IsSameObject, jni, object_M, obj)) {
+    if (jni->IsSameObject(thread, thr) &&
+            jni->IsSameObject(object_M, obj)) {
 
         if (!(line = findLineNumber(jvmti, thread))) {
             nsk_jvmti_setFailStatus();
@@ -194,8 +191,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -207,8 +203,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -219,15 +214,13 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         }
 
         if (info.name != NULL) {
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                    Deallocate, jvmti, (unsigned char*)info.name)))
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)info.name)))
                 return NSK_FALSE;
         }
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     if (thread == NULL) {
@@ -236,39 +229,34 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     }
 
     /* make thread accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (thread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'M' */
-    if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass, "M", FIELD_SIG)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (field = jni->GetFieldID(klass, "M", FIELD_SIG)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (object_M =
-            NSK_CPP_STUB3(GetObjectField, jni, thread, field)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object_M = jni->GetObjectField(thread, field)) != NULL))
         return NSK_FALSE;
 
     /* make object accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (object_M =
-            NSK_CPP_STUB2(NewGlobalRef, jni, object_M)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object_M = jni->NewGlobalRef(object_M)) != NULL))
         return NSK_FALSE;
 
     /* enable MonitorContendedEntered event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
+            jvmti->SetEventNotificationMode(
+                JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
         return NSK_FALSE;
 
     /* enable MonitorContendedEntered event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
+            jvmti->SetEventNotificationMode(
+                JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -278,8 +266,8 @@ static int clean(jvmtiEnv* jvmti, JNIEnv* jni) {
 
     /* disable MonitorContendedEntered event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
+            jvmti->SetEventNotificationMode(
+                JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
         nsk_jvmti_setFailStatus();
 
     return NSK_TRUE;
@@ -364,15 +352,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_monitor_events = 1;
     caps.can_get_line_numbers = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.MonitorContendedEnter = &MonitorContendedEnter;
     callbacks.MonitorContendedEntered = &MonitorContendedEntered;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/contention/TC04/tc04t001/tc04t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/contention/TC04/tc04t001/tc04t001.cpp
@@ -44,14 +44,14 @@ static jrawMonitorID syncLock = NULL;
 
 
 static jboolean lockSyncLock(jvmtiEnv* jvmti) {
-    jboolean status = NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock));
+    jboolean status = NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock));
     if (!status)
         nsk_jvmti_setFailStatus();
     return status;
 }
 
 static void unlockSyncLock(jvmtiEnv* jvmti) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 }
 
@@ -73,7 +73,7 @@ MonitorWait(jvmtiEnv *jvmti, JNIEnv* jni,
     }
 
     /* check if event is for tested object */
-    if (NSK_CPP_STUB3(IsInstanceOf, jni, obj, object_M)) {
+    if (jni->IsInstanceOf(obj, object_M)) {
         if (lockSyncLock(jvmti)) {
             waitEventsCount++;
             unlockSyncLock(jvmti);
@@ -96,7 +96,7 @@ MonitorWaited(jvmtiEnv *jvmti, JNIEnv* jni,
     }
 
     /* check if event is for tested object */
-    if (NSK_CPP_STUB3(IsInstanceOf, jni, obj, object_M)) {
+    if (jni->IsInstanceOf(obj, object_M)) {
         if (lockSyncLock(jvmti)) {
             waitedEventsCount++;
             unlockSyncLock(jvmti);
@@ -118,7 +118,7 @@ MonitorContendedEnter(jvmtiEnv *jvmti, JNIEnv* jni, jthread thr, jobject obj) {
     }
 
     /* check if event is for tested object */
-    if (NSK_CPP_STUB3(IsSameObject, jni, object_M, obj)) {
+    if (jni->IsSameObject(object_M, obj)) {
         jvmtiMonitorUsage usageInfo;
 
         if (lockSyncLock(jvmti)) {
@@ -126,12 +126,10 @@ MonitorContendedEnter(jvmtiEnv *jvmti, JNIEnv* jni, jthread thr, jobject obj) {
             unlockSyncLock(jvmti);
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetObjectMonitorUsage,
-                jvmti, obj, &usageInfo))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetObjectMonitorUsage(obj, &usageInfo))) {
             nsk_jvmti_setFailStatus();
         } else if (usageInfo.owner != NULL) {
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                    InterruptThread, jvmti, usageInfo.owner)))
+            if (!NSK_JVMTI_VERIFY(jvmti->InterruptThread(usageInfo.owner)))
                 nsk_jvmti_setFailStatus();
         }
     }
@@ -151,7 +149,7 @@ MonitorContendedEntered(jvmtiEnv *jvmti, JNIEnv* jni, jthread thr, jobject obj) 
     }
 
     /* check if event is for tested object */
-    if (NSK_CPP_STUB3(IsSameObject, jni, object_M, obj)) {
+    if (jni->IsSameObject(object_M, obj)) {
         if (lockSyncLock(jvmti)) {
             enteredEventsCount++;
             unlockSyncLock(jvmti);
@@ -166,40 +164,35 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
 
     NSK_DISPLAY0("Obtain tested object from debugee thread class\n");
 
-    if (!NSK_JNI_VERIFY(jni, (object_M =
-            NSK_CPP_STUB2(FindClass, jni, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object_M = jni->FindClass(CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (object_M = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, object_M)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object_M = (jclass)jni->NewGlobalRef(object_M)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock)))
         return NSK_FALSE;
 
     /* enable MonitorWait event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_MONITOR_WAIT, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAIT, NULL)))
         nsk_jvmti_setFailStatus();
 
     /* enable MonitorWaited event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_MONITOR_WAITED, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAITED, NULL)))
         nsk_jvmti_setFailStatus();
 
     /* enable MonitorContendedEnter event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
+            jvmti->SetEventNotificationMode(
+                JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
         nsk_jvmti_setFailStatus();
 
     /* enable MonitorContendedEntered event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
+            jvmti->SetEventNotificationMode(
+                JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
         nsk_jvmti_setFailStatus();
 
     return NSK_TRUE;
@@ -209,30 +202,27 @@ static int clean(jvmtiEnv* jvmti, JNIEnv* jni) {
 
     /* disable MonitorWait event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                JVMTI_EVENT_MONITOR_WAIT, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_WAIT, NULL)))
         nsk_jvmti_setFailStatus();
 
     /* disable MonitorWaited event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                JVMTI_EVENT_MONITOR_WAITED, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_WAITED, NULL)))
         nsk_jvmti_setFailStatus();
 
     /* disable MonitorContendedEnter event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
+            jvmti->SetEventNotificationMode(
+                JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
         nsk_jvmti_setFailStatus();
 
     /* disable MonitorContendedEntered event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
+            jvmti->SetEventNotificationMode(
+                JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
     return NSK_TRUE;
@@ -336,7 +326,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     caps.can_generate_monitor_events = 1;
     caps.can_get_monitor_info = 1;
     caps.can_signal_thread = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     memset(&callbacks, 0, sizeof(callbacks));
@@ -344,8 +334,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.MonitorWaited = &MonitorWaited;
     callbacks.MonitorContendedEnter = &MonitorContendedEnter;
     callbacks.MonitorContendedEntered = &MonitorContendedEntered;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-            &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/contention/TC05/tc05t001/tc05t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/contention/TC05/tc05t001/tc05t001.cpp
@@ -72,14 +72,12 @@ MonitorWait(jvmtiEnv *jvmti, JNIEnv* jni,
     }
 
     /* check if event is for tested thread and object */
-    if (NSK_CPP_STUB3(IsSameObject, jni, thread, thr) &&
-            NSK_CPP_STUB3(IsSameObject, jni, object_M, obj)) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(
-                GetThreadCpuTime, jvmti, thr, &waitThreadCpuTime))) {
+    if (jni->IsSameObject(thread, thr) &&
+            jni->IsSameObject(object_M, obj)) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadCpuTime(thr, &waitThreadCpuTime))) {
             nsk_jvmti_setFailStatus();
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(GetTime, jvmti, &waitTime))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetTime(&waitTime))) {
             nsk_jvmti_setFailStatus();
         }
         waitEventsCount++;
@@ -113,14 +111,12 @@ MonitorWaited(jvmtiEnv *jvmti, JNIEnv* jni,
     }
 
     /* check if event is for tested thread and object */
-    if (NSK_CPP_STUB3(IsSameObject, jni, thread, thr) &&
-            NSK_CPP_STUB3(IsSameObject, jni, object_M, obj)) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(
-                GetThreadCpuTime, jvmti, thr, &waitedThreadCpuTime))) {
+    if (jni->IsSameObject(thread, thr) &&
+            jni->IsSameObject(object_M, obj)) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadCpuTime(thr, &waitedThreadCpuTime))) {
             nsk_jvmti_setFailStatus();
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(GetTime, jvmti, &waitedTime))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetTime(&waitedTime))) {
             nsk_jvmti_setFailStatus();
         }
         waitedEventsCount++;
@@ -149,8 +145,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -162,8 +157,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -174,15 +168,13 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         }
 
         if (info.name != NULL) {
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                    Deallocate, jvmti, (unsigned char*)info.name)))
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)info.name)))
                 return NSK_FALSE;
         }
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     if (thread == NULL) {
@@ -191,39 +183,32 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     }
 
     /* make thread accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (thread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'M' */
-    if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass, "M", FIELD_SIG)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (field = jni->GetFieldID(klass, "M", FIELD_SIG)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (object_M =
-            NSK_CPP_STUB3(GetObjectField, jni, thread, field)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object_M = jni->GetObjectField(thread, field)) != NULL))
         return NSK_FALSE;
 
     /* make object accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (object_M =
-            NSK_CPP_STUB2(NewGlobalRef, jni, object_M)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object_M = jni->NewGlobalRef(object_M)) != NULL))
         return NSK_FALSE;
 
     /* enable MonitorWait event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_MONITOR_WAIT, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAIT, NULL)))
         return NSK_FALSE;
 
     /* enable MonitorWaited event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_MONITOR_WAITED, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAITED, NULL)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -233,14 +218,12 @@ static int clean(jvmtiEnv* jvmti, JNIEnv* jni) {
 
     /* disable MonitorWait event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                JVMTI_EVENT_MONITOR_WAIT, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_WAIT, NULL)))
         nsk_jvmti_setFailStatus();
 
     /* disable MonitorWaited event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                JVMTI_EVENT_MONITOR_WAITED, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_WAITED, NULL)))
         nsk_jvmti_setFailStatus();
 
     return NSK_TRUE;
@@ -343,14 +326,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_monitor_events = 1;
     caps.can_get_thread_cpu_time = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.MonitorWait = &MonitorWait;
     callbacks.MonitorWaited = &MonitorWaited;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-            &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t001/em01t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t001/em01t001.cpp
@@ -54,12 +54,12 @@ static jvmtiPhase currentPhase;
 static void
 changeCount(jvmtiEvent event) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     eventCount[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -92,9 +92,7 @@ classEventsHandler(jvmtiEvent event, jvmtiEnv* jvmti_env, JNIEnv* jni_env,
     char *generic;
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetClassSignature, jvmti_env, klass,
-                                &className, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &className, &generic))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -107,7 +105,7 @@ classEventsHandler(jvmtiEvent event, jvmtiEnv* jvmti_env, JNIEnv* jni_env,
                             className);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -125,13 +123,11 @@ classEventsHandler(jvmtiEvent event, jvmtiEnv* jvmti_env, JNIEnv* jni_env,
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)className))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)className))) {
         nsk_jvmti_setFailStatus();
     }
     if (generic != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)generic))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)generic))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -145,15 +141,12 @@ threadEventHandler(jvmtiEvent event, jvmtiEnv* jvmti_env, JNIEnv* jni_env,
     jvmtiPhase phase;
 
 
-    if (!NSK_JNI_VERIFY(jni_env, (classObject =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, thread)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (classObject = jni_env->GetObjectClass(thread)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetClassSignature, jvmti_env, classObject,
-                                &className, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(classObject, &className, &generic))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -166,7 +159,7 @@ threadEventHandler(jvmtiEvent event, jvmtiEnv* jvmti_env, JNIEnv* jni_env,
                             className);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -184,13 +177,11 @@ threadEventHandler(jvmtiEvent event, jvmtiEnv* jvmti_env, JNIEnv* jni_env,
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)className))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)className))) {
         nsk_jvmti_setFailStatus();
     }
     if (generic != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)generic))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)generic))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -200,7 +191,7 @@ cbVMStart(jvmtiEnv* jvmti_env, JNIEnv* jni_env) {
 
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -221,7 +212,7 @@ cbVMInit(jvmtiEnv* jvmti_env, JNIEnv* jni_env, jthread thread) {
 
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -242,7 +233,7 @@ cbVMDeath(jvmtiEnv* jvmti_env, JNIEnv* jni_env) {
 
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -257,8 +248,7 @@ cbVMDeath(jvmtiEnv* jvmti_env, JNIEnv* jni_env) {
     currentPhase = JVMTI_PHASE_DEAD;
     changeCount(JVMTI_EVENT_VM_DEATH);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -294,9 +284,7 @@ cbThreadEnd(jvmtiEnv* jvmti_env, JNIEnv* jni_env, jthread thread) {
 static int
 enableEvent(jvmtiEventMode enable, jvmtiEvent event) {
     NSK_DISPLAY1("enabling %s\n", TranslateEvent(event));
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, enable,
-                                            event, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(enable, event, NULL))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -369,10 +357,7 @@ setCallBacks() {
     eventCallbacks.ThreadStart  = cbThreadStart;
     eventCallbacks.ThreadEnd    = cbThreadEnd;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -446,8 +431,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t002/em01t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM01/em01t002/em01t002.cpp
@@ -65,22 +65,20 @@ Java_nsk_jvmti_scenarios_events_EM01_em01t002_loadClass(JNIEnv *jni_env,
     jmethodID methodID;
     jclass loadedClass;
 
-    if (!NSK_JNI_VERIFY(jni_env, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, loader)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(loader)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
 
-    if (!NSK_JNI_VERIFY(jni_env, (methodID =
-            NSK_CPP_STUB4(GetMethodID, jni_env, klass, "loadClass",
-                        "(Ljava/lang/String;)Ljava/lang/Class;")) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env,
+            (methodID = jni_env->GetMethodID(
+                klass, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;")) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
 
     if (!NSK_JNI_VERIFY(jni_env, (loadedClass = (jclass)
-            NSK_CPP_STUB4(CallObjectMethod, jni_env, loader, methodID,
-                                    className)) != NULL)) {
+            jni_env->CallObjectMethod(loader, methodID, className)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NULL;
     }
@@ -99,8 +97,7 @@ Java_nsk_jvmti_scenarios_events_EM01_em01t002_prepareClass(JNIEnv *jni_env,
     jfieldID fieldID;
 
     if (!NSK_JNI_VERIFY(jni_env, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni_env, klass,
-                        "toProvokePreparation", "I")) != NULL)) {
+            jni_env->GetStaticFieldID(klass, "toProvokePreparation", "I")) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -119,20 +116,18 @@ Java_nsk_jvmti_scenarios_events_EM01_em01t002_startThread(JNIEnv *jni_env,
     jclass klass;
     jmethodID methodID;
 
-    if (!NSK_JNI_VERIFY(jni_env, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, thread)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(thread)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
     if (!NSK_JNI_VERIFY(jni_env, (methodID =
-            NSK_CPP_STUB4(GetMethodID, jni_env, klass, "start", "()V")) != NULL)) {
+            jni_env->GetMethodID(klass, "start", "()V")) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
-    if (!NSK_JNI_VERIFY_VOID(jni_env,
-            NSK_CPP_STUB3(CallVoidMethod, jni_env, thread, methodID)) ) {
+    if (!NSK_JNI_VERIFY_VOID(jni_env,jni_env->CallVoidMethod(thread, methodID)) ) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -146,12 +141,12 @@ Java_nsk_jvmti_scenarios_events_EM01_em01t002_startThread(JNIEnv *jni_env,
 static void
 changeCount(jvmtiEvent event) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     eventCount[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -184,9 +179,7 @@ classEventsHandler(jvmtiEvent event, jvmtiEnv* jvmti_env, JNIEnv* jni_env,
     char *generic;
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetClassSignature, jvmti_env, klass,
-                                &className, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &className, &generic))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -199,7 +192,7 @@ classEventsHandler(jvmtiEvent event, jvmtiEnv* jvmti_env, JNIEnv* jni_env,
                             className);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -217,13 +210,11 @@ classEventsHandler(jvmtiEvent event, jvmtiEnv* jvmti_env, JNIEnv* jni_env,
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)className))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)className))) {
         nsk_jvmti_setFailStatus();
     }
     if (generic != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)generic))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)generic))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -237,15 +228,12 @@ threadEventHandler(jvmtiEvent event, jvmtiEnv* jvmti_env, JNIEnv* jni_env,
     jvmtiPhase phase;
 
 
-    if (!NSK_JNI_VERIFY(jni_env, (classObject =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, thread)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (classObject = jni_env->GetObjectClass(thread)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetClassSignature, jvmti_env, classObject,
-                                &className, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(classObject, &className, &generic))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -258,7 +246,7 @@ threadEventHandler(jvmtiEvent event, jvmtiEnv* jvmti_env, JNIEnv* jni_env,
                             className);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -276,13 +264,11 @@ threadEventHandler(jvmtiEvent event, jvmtiEnv* jvmti_env, JNIEnv* jni_env,
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)className))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)className))) {
         nsk_jvmti_setFailStatus();
     }
     if (generic != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)generic))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)generic))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -292,7 +278,7 @@ cbVMStart(jvmtiEnv* jvmti_env, JNIEnv* jni_env) {
 
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -313,7 +299,7 @@ cbVMInit(jvmtiEnv* jvmti_env, JNIEnv* jni_env, jthread thread) {
 
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -334,7 +320,7 @@ cbVMDeath(jvmtiEnv* jvmti_env, JNIEnv* jni_env) {
 
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -349,8 +335,7 @@ cbVMDeath(jvmtiEnv* jvmti_env, JNIEnv* jni_env) {
     currentPhase = JVMTI_PHASE_DEAD;
     changeCount(JVMTI_EVENT_VM_DEATH);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -393,9 +378,7 @@ enableEvent(jvmtiEventMode enable, jvmtiEvent event) {
     }
 
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, enable,
-                                            event, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(enable, event, NULL))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -468,10 +451,7 @@ setCallBacks() {
     eventCallbacks.ThreadStart  = cbThreadStart;
     eventCallbacks.ThreadEnd    = cbThreadEnd;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -544,8 +524,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t001/em02t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t001/em02t001.cpp
@@ -68,8 +68,7 @@ findThread(const char *threadName) {
     int i;
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NULL;
 
     if (!NSK_VERIFY(threads != NULL))
@@ -81,8 +80,7 @@ findThread(const char *threadName) {
             break;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             break;
 
         /* find by name */
@@ -92,8 +90,7 @@ findThread(const char *threadName) {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NULL;
 
     return returnValue;
@@ -108,16 +105,14 @@ getStaticObjField(const char* className, const char* objFieldName,
     jfieldID fieldID;
     jclass klass = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(FindClass, jni, className)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->FindClass(className)) != NULL))
         return NULL;
 
     if (!NSK_JNI_VERIFY(jni, (fieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, klass, objFieldName,
-                                signature)) != NULL))
+            jni->GetStaticFieldID(klass, objFieldName, signature)) != NULL))
         return NULL;
 
-    return NSK_CPP_STUB3(GetStaticObjectField, jni, klass, fieldID);
+    return jni->GetStaticObjectField(klass, fieldID);
 }
 
 /* ============================================================================= */
@@ -130,8 +125,7 @@ static int prepare() {
     }
 
     /* make thread accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (mainThread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, mainThread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (mainThread = jni->NewGlobalRef(mainThread)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_VERIFY((startObject =
@@ -140,8 +134,7 @@ static int prepare() {
         return NSK_FALSE;
 
     /*make object accessable for a long time*/
-    if (!NSK_JNI_VERIFY(jni, (startObject =
-            NSK_CPP_STUB2(NewGlobalRef, jni, startObject)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (startObject = jni->NewGlobalRef(startObject)) != NULL))
         return NSK_FALSE;
 
 
@@ -151,8 +144,7 @@ static int prepare() {
         return NSK_FALSE;
 
     /*make object accessable for a long time*/
-    if (!NSK_JNI_VERIFY(jni, (endObject =
-            NSK_CPP_STUB2(NewGlobalRef, jni, endObject)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (endObject = jni->NewGlobalRef(endObject)) != NULL))
         return NSK_FALSE;
 
 
@@ -162,8 +154,7 @@ static int prepare() {
         return NSK_FALSE;
 
     /* make thread accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (debuggeeThread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, debuggeeThread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (debuggeeThread = jni->NewGlobalRef(debuggeeThread)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -176,15 +167,15 @@ clean() {
 
     /* disable MonitorContendedEnter event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
+            jvmti->SetEventNotificationMode(
+                JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
         nsk_jvmti_setFailStatus();
 
     /* dispose global references */
-    NSK_CPP_STUB2(DeleteGlobalRef, jni, startObject);
-    NSK_CPP_STUB2(DeleteGlobalRef, jni, endObject);
-    NSK_CPP_STUB2(DeleteGlobalRef, jni, debuggeeThread);
-    NSK_CPP_STUB2(DeleteGlobalRef, jni, mainThread);
+    jni->DeleteGlobalRef(startObject);
+    jni->DeleteGlobalRef(endObject);
+    jni->DeleteGlobalRef(debuggeeThread);
+    jni->DeleteGlobalRef(mainThread);
 
     startObject = NULL;
     endObject = NULL;
@@ -219,8 +210,7 @@ showEventStatistics(int step /*int *currentCounts*/) {
 static void
 showThreadInfo(jthread thread) {
     jvmtiThreadInfo info;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetThreadInfo, jvmti, thread, &info)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(thread, &info)))
         return;
 
     NSK_DISPLAY2("\tthread (%s): %p\n", info.name, thread);
@@ -231,12 +221,12 @@ showThreadInfo(jthread thread) {
 static void
 changeCount(jvmtiEvent event, int *currentCounts) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     currentCounts[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -327,8 +317,7 @@ cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -420,13 +409,13 @@ handlerMC1(jvmtiEvent event, jvmtiEnv* jvmti, JNIEnv* jni_env,
         return;
 
     /* check if event is for tested thread and for tested object */
-    if (NSK_CPP_STUB3(IsSameObject, jni_env, expectedThread, thread) &&
-            NSK_CPP_STUB3(IsSameObject, jni_env, expectedObject, object)) {
+    if (jni_env->IsSameObject(expectedThread, thread) &&
+            jni_env->IsSameObject(expectedObject, object)) {
 
         NSK_DISPLAY1("--->%-40s is received\n", TranslateEvent(event));
 
         showThreadInfo(thread);
-        if (NSK_CPP_STUB3(IsSameObject, jni_env, expectedObject, endObject))
+        if (jni_env->IsSameObject(expectedObject, endObject))
             NSK_DISPLAY0("\tobject: 'endingMonitor'\n");
         else
             NSK_DISPLAY0("\tobject: 'startingMonitor'\n");
@@ -506,13 +495,13 @@ handlerMC2(jvmtiEvent event, jvmtiEnv* jvmti, JNIEnv* jni_env,
         return;
 
     /* check if event is for tested thread and for tested object */
-    if (NSK_CPP_STUB3(IsSameObject, jni_env, expectedThread, thread) &&
-            NSK_CPP_STUB3(IsSameObject, jni_env, expectedObject, object)) {
+    if (jni_env->IsSameObject(expectedThread, thread) &&
+            jni_env->IsSameObject(expectedObject, object)) {
 
         NSK_DISPLAY1("--->%-40s is received (new callbacks)\n", TranslateEvent(event));
 
         showThreadInfo(thread);
-        if (NSK_CPP_STUB3(IsSameObject, jni_env, expectedObject, endObject))
+        if (jni_env->IsSameObject(expectedObject, endObject))
             NSK_DISPLAY0("\tobject: 'endingMonitor'\n");
         else
             NSK_DISPLAY0("\tobject: 'startingMonitor'\n");
@@ -572,16 +561,13 @@ static int enableEvent(jvmtiEvent event) {
             && (event != JVMTI_EVENT_MONITOR_WAIT)
             && (event != JVMTI_EVENT_MONITOR_WAITED)) {
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
         }
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
@@ -679,10 +665,7 @@ setCallBacks(int step) {
             break;
 
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -771,8 +754,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }
@@ -782,7 +764,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
 
         caps.can_generate_monitor_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t002/em02t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t002/em02t002.cpp
@@ -150,12 +150,12 @@ int checkEvents(int step) {
 static void
 changeCount(jvmtiEvent event, int *currentCounts) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     currentCounts[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -177,8 +177,7 @@ cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
     if (!checkEvents(STEP_AMOUNT))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -345,16 +344,13 @@ static int enableEvent(jvmtiEvent event) {
             && (event != JVMTI_EVENT_GARBAGE_COLLECTION_START)
             && (event != JVMTI_EVENT_GARBAGE_COLLECTION_FINISH)) {
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
         }
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
@@ -450,10 +446,7 @@ setCallBacks(int step) {
             break;
 
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -519,8 +512,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }
@@ -530,7 +522,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
 
         caps.can_generate_garbage_collection_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t003/em02t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t003/em02t003.cpp
@@ -134,12 +134,12 @@ int checkEvents(int step) {
 static void
 changeCount(jvmtiEvent event, int *currentCounts) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     currentCounts[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -159,8 +159,7 @@ cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
     if (!checkEvents(STEP_AMOUNT))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -265,9 +264,7 @@ handlerMC1(jvmtiEvent event, jvmtiEnv* jvmti, jmethodID method) {
     char *sign;
     char *genc;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(
-                GetMethodName, jvmti, method, &name, &sign, &genc))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetMethodName(method, &name, &sign, &genc))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -277,17 +274,14 @@ handlerMC1(jvmtiEvent event, jvmtiEnv* jvmti, jmethodID method) {
         changeCount(event, &eventCount[0]);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti, (unsigned char*)name))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)name))) {
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti, (unsigned char*)sign))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)sign))) {
         nsk_jvmti_setFailStatus();
     }
     if (genc != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti, (unsigned char*)genc))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)genc))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -338,9 +332,7 @@ handlerMC2(jvmtiEvent event, jvmtiEnv* jvmti, jmethodID method) {
     char *sign;
     char *genc;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(
-                GetMethodName, jvmti, method, &name, &sign, &genc))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetMethodName(method, &name, &sign, &genc))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -348,17 +340,14 @@ handlerMC2(jvmtiEvent event, jvmtiEnv* jvmti, jmethodID method) {
     NSK_DISPLAY2("\tMethod: %s, signature: %s\n", name, sign);
     changeCount(event, &newEventCount[0]);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti, (unsigned char*)name))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)name))) {
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti, (unsigned char*)sign))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)sign))) {
         nsk_jvmti_setFailStatus();
     }
     if (genc != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti, (unsigned char*)genc))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)genc))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -389,16 +378,13 @@ static int enableEvent(jvmtiEvent event) {
             && (event != JVMTI_EVENT_COMPILED_METHOD_LOAD)
             && (event != JVMTI_EVENT_COMPILED_METHOD_UNLOAD)) {
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
         }
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
@@ -498,10 +484,7 @@ setCallBacks(int step) {
             break;
 
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -568,8 +551,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }
@@ -579,7 +561,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
 
         caps.can_generate_compiled_method_load_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t004/em02t004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t004/em02t004.cpp
@@ -146,12 +146,12 @@ int checkEvents(int step) {
 static void
 changeCount(jvmtiEvent event, int *currentCounts) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     currentCounts[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -171,8 +171,7 @@ cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
     if (!checkEvents(STEP_AMOUNT))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -310,7 +309,7 @@ cbNativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env,jthread thread,
     char *genc;
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -318,9 +317,7 @@ cbNativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env,jthread thread,
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(
-                GetMethodName, jvmti_env, method, &name, &sign, &genc))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sign, &genc))) {
         return;
     }
 
@@ -331,17 +328,14 @@ cbNativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env,jthread thread,
         changeCount(JVMTI_EVENT_NATIVE_METHOD_BIND, &eventCount[0]);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)name))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)name))) {
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)sign))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)sign))) {
         nsk_jvmti_setFailStatus();
     }
     if (genc != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)genc))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)genc))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -355,7 +349,7 @@ cbNewNativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env,jthread thread,
 
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -363,9 +357,7 @@ cbNewNativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env,jthread thread,
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(
-                GetMethodName, jvmti_env, method, &name, &sign, &genc))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sign, &genc))) {
         return;
     }
 
@@ -376,17 +368,14 @@ cbNewNativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env,jthread thread,
         changeCount(JVMTI_EVENT_NATIVE_METHOD_BIND, &newEventCount[0]);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)name))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)name))) {
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)sign))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)sign))) {
         nsk_jvmti_setFailStatus();
     }
     if (genc != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)genc))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)genc))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -398,16 +387,13 @@ static int enableEvent(jvmtiEvent event) {
     if (nsk_jvmti_isOptionalEvent(event)
             && (event != JVMTI_EVENT_NATIVE_METHOD_BIND)) {
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
         }
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
@@ -505,10 +491,7 @@ setCallBacks(int step) {
             break;
 
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -574,8 +557,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }
@@ -585,7 +567,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
 
         caps.can_generate_native_method_bind_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t005/em02t005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t005/em02t005.cpp
@@ -133,12 +133,12 @@ int checkEvents(int step) {
 static void
 changeCount(jvmtiEvent event, int *currentCounts) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     currentCounts[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -158,8 +158,7 @@ cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
     if (!checkEvents(STEP_NUMBER))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -302,9 +301,7 @@ cbVMObjectAlloc(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetClassSignature, jvmti_env, object_klass,
-                                &sign_ptr, &gen_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(object_klass, &sign_ptr, &gen_ptr))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -313,7 +310,7 @@ cbVMObjectAlloc(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         changeCount(JVMTI_EVENT_VM_OBJECT_ALLOC, &eventCount[0]);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -326,13 +323,11 @@ cbVMObjectAlloc(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)sign_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)sign_ptr))) {
         nsk_jvmti_setFailStatus();
     }
     if (gen_ptr != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)gen_ptr))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)gen_ptr))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -346,9 +341,7 @@ cbNewVMObjectAlloc(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetClassSignature, jvmti_env, object_klass,
-                                &sign_ptr, &gen_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(object_klass, &sign_ptr, &gen_ptr))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -357,7 +350,7 @@ cbNewVMObjectAlloc(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         changeCount(JVMTI_EVENT_VM_OBJECT_ALLOC, &newEventCount[0]);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -370,13 +363,11 @@ cbNewVMObjectAlloc(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)sign_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)sign_ptr))) {
         nsk_jvmti_setFailStatus();
     }
     if (gen_ptr != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)gen_ptr))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)gen_ptr))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -388,16 +379,13 @@ static int enableEvent(jvmtiEvent event) {
     if (nsk_jvmti_isOptionalEvent(event)
             && (event != JVMTI_EVENT_VM_OBJECT_ALLOC)) {
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
         }
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
@@ -490,10 +478,7 @@ setCallBacks(int step) {
             break;
 
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -553,8 +538,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }
@@ -564,7 +548,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
 
         caps.can_generate_vm_object_alloc_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211801](https://bugs.openjdk.java.net/browse/JDK-8211801): Remove the NSK_CPP_STUB macros from vmTestbase for jvmti/scenarios/[A-E]


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/660/head:pull/660` \
`$ git checkout pull/660`

Update a local copy of the PR: \
`$ git checkout pull/660` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 660`

View PR using the GUI difftool: \
`$ git pr show -t 660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/660.diff">https://git.openjdk.java.net/jdk11u-dev/pull/660.diff</a>

</details>
