### PR TITLE
8210689: Remove the multi-line old C style for string literals

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Breakpoint/breakpoint001/breakpoint001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Breakpoint/breakpoint001/breakpoint001.cpp
@@ -94,9 +94,10 @@ ClassLoad(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread, jclass klass) {
                           "failed to obtain a class signature\n");
 
         if (sig != NULL && (strcmp(sig, CLASS_SIG) == 0)) {
-            NSK_DISPLAY1("ClassLoad event received for the class \"%s\"\n\
-\tsetting breakpoints ...\n",
-                         sig);
+            NSK_DISPLAY1(
+                "ClassLoad event received for the class \"%s\"\n"
+                "\tsetting breakpoints ...\n",
+                sig);
             setBP(jvmti_env, env, klass);
         }
     }
@@ -126,8 +127,9 @@ Breakpoint(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
             strcmp(thr_info.name,THREAD_NAME) != 0 ||
             thr_info.is_daemon==JNI_TRUE) {
         result = checkStatus = STATUS_FAILED;
-        NSK_COMPLAIN2("TEST FAILED: Breakpoint event with unexpected thread info:\n\
-\tname: \"%s\"\ttype: %s thread\n\n",
+        NSK_COMPLAIN2(
+            "TEST FAILED: Breakpoint event with unexpected thread info:\n"
+            "\tname: \"%s\"\ttype: %s thread\n\n",
             (thr_info.name == NULL)?"NULL":thr_info.name,
             (thr_info.is_daemon==JNI_TRUE)?"deamon":"user");
     }
@@ -161,9 +163,10 @@ Breakpoint(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
     if (clsSig == NULL ||
             strcmp(clsSig,CLASS_SIG) != 0) {
         result = checkStatus = STATUS_FAILED;
-        NSK_COMPLAIN1("TEST FAILED: Breakpoint event with unexpected class signature:\n\
-\t\"%s\"\n\n",
-            (clsSig == NULL)?"NULL":clsSig);
+        NSK_COMPLAIN1(
+            "TEST FAILED: Breakpoint event with unexpected class signature:\n"
+            "\t\"%s\"\n\n",
+            (clsSig == NULL) ? "NULL" : clsSig);
     }
     else
         NSK_DISPLAY1("CHECK PASSED: class signature: \"%s\"\n",
@@ -220,8 +223,10 @@ Java_nsk_jvmti_Breakpoint_breakpoint001_check(
     for (i=0; i<METH_NUM; i++) {
         if (bpEvents[i] != 1) {
             result = STATUS_FAILED;
-            NSK_COMPLAIN3("TEST FAILED: wrong number of Breakpoint events\n\
-\tfor the method \"%s %s\":\n\t\tgot: %d\texpected: 1\n",
+            NSK_COMPLAIN3(
+                "TEST FAILED: wrong number of Breakpoint events\n"
+                "\tfor the method \"%s %s\":\n"
+                "\t\tgot: %d\texpected: 1\n",
                 METHODS[i][0], METHODS[i][1], bpEvents[i]);
         }
         else

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassLoad/classload001/classload001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ClassLoad/classload001/classload001.cpp
@@ -133,8 +133,9 @@ ClassLoad(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread, jclass klass) {
     else if ((i = findSig(sig, 0)) != -1) {
         result = STATUS_FAILED;
         primClsEvents[i]++;
-        NSK_COMPLAIN1("TEST FAILED: JVMTI_EVENT_CLASS_LOAD event received for\n\
-\t a primitive class/array of primitive types with the signature \"%s\"\n",
+        NSK_COMPLAIN1(
+            "TEST FAILED: JVMTI_EVENT_CLASS_LOAD event received for\n"
+            "\t a primitive class/array of primitive types with the signature \"%s\"\n",
             sig);
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GarbageCollectionStart/gcstart001/gcstart001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GarbageCollectionStart/gcstart001/gcstart001.cpp
@@ -52,8 +52,9 @@ GarbageCollectionStart(jvmtiEnv *jvmti_env) {
 
     if (gcstart != (gcfinish+1)) {
         result = STATUS_FAILED;
-        NSK_COMPLAIN2("TEST FAILED: GarbageCollectionStart event has no a matched pair GarbageCollectionFinish:\n\
-\t%d GarbageCollectionStart events\t%d GarbageCollectionFinish events\n\n",
+        NSK_COMPLAIN2(
+            "TEST FAILED: GarbageCollectionStart event has no a matched pair GarbageCollectionFinish:\n"
+            "\t%d GarbageCollectionStart events\t%d GarbageCollectionFinish events\n\n",
             gcstart, gcfinish);
     }
     else
@@ -68,8 +69,9 @@ GarbageCollectionFinish(jvmtiEnv *jvmti_env) {
 
     if (gcstart != gcfinish) {
         result = STATUS_FAILED;
-        NSK_COMPLAIN2("TEST FAILED: GarbageCollectionFinish event has no a matched pair GarbageCollectionStart:\n\
-\t%d GarbageCollectionStart events\t%d GarbageCollectionFinish events\n\n",
+        NSK_COMPLAIN2(
+            "TEST FAILED: GarbageCollectionFinish event has no a matched pair GarbageCollectionStart:\n"
+            "\t%d GarbageCollectionStart events\t%d GarbageCollectionFinish events\n\n",
             gcstart, gcfinish);
     }
     else
@@ -81,8 +83,9 @@ VMDeath(jvmtiEnv *jvmti_env, JNIEnv *env) {
     NSK_DISPLAY0("VMDeath event received\n");
 
     if (gcstart != gcfinish || result == STATUS_FAILED) {
-        NSK_COMPLAIN2("TEST FAILED: some GarbageCollectionFinish events have no a matched pair GarbageCollectionStart:\n\
-\t%d GarbageCollectionStart events\t%d GarbageCollectionFinish events\n\n",
+        NSK_COMPLAIN2(
+            "TEST FAILED: some GarbageCollectionFinish events have no a matched pair GarbageCollectionStart:\n"
+            "\t%d GarbageCollectionStart events\t%d GarbageCollectionFinish events\n\n",
             gcstart, gcfinish);
 
         exit(95 + STATUS_FAILED);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassSignature/getclsig006/getclsig006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassSignature/getclsig006/getclsig006.cpp
@@ -69,8 +69,12 @@ static int checkSig(JNIEnv *jni_env, jclass testedCls, int idx) {
 
         if (strcmp(class_sig[idx][1], sign) != 0 ||
                 strcmp(class_sig[idx][2], (gen_sign==NULL)?"NULL":gen_sign) != 0) {
-            NSK_COMPLAIN5("TEST FAILED: class: \"%s\" \
-has\n\tsignature: \"%s\"\n\tgeneric signature: \"%s\"\n\n\tExpected: \"%s\"\n\t\"%s\"\n\n",
+            NSK_COMPLAIN5(
+                "TEST FAILED: class: \"%s\" has\n"
+                "\tsignature: \"%s\"\n"
+                "\tgeneric signature: \"%s\"\n\n"
+                "\tExpected: \"%s\"\n"
+                "\t\"%s\"\n\n",
                 class_sig[idx][0],
                 sign, (gen_sign==NULL)?"NULL":gen_sign,
                 class_sig[idx][1], class_sig[idx][2]);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetFieldName/getfldnm005/getfldnm005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetFieldName/getfldnm005/getfldnm005.cpp
@@ -103,8 +103,12 @@ static int checkSig(JNIEnv *jni_env, jclass testedCls,
 
         if (strcmp(fld_sig[idx][2], sign) != 0 ||
                 strcmp(fld_sig[idx][3], (gen_sign==NULL)?"NULL":gen_sign) != 0) {
-            NSK_COMPLAIN6("TEST FAILED: %s field \"%s\" \
-has\n\tsignature: \"%s\"\n\tgeneric signature: \"%s\"\n\n\tExpected: \"%s\"\n\t\t\"%s\"\n\n",
+            NSK_COMPLAIN6(
+                "TEST FAILED: %s field \"%s\" has\n"
+                "\tsignature: \"%s\"\n"
+                "\tgeneric signature: \"%s\"\n\n"
+                "\tExpected: \"%s\"\n"
+                "\t\t\"%s\"\n\n",
                (instance==0)?"instance":"static",
                 fld_sig[idx][0],
                 sign, (gen_sign==NULL)?"NULL":gen_sign,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetJNIFunctionTable/getjniftab002/getjniftab002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetJNIFunctionTable/getjniftab002/getjniftab002.cpp
@@ -80,11 +80,12 @@ Java_nsk_jvmti_GetJNIFunctionTable_getjniftab002_check(JNIEnv *env, jobject obj)
        only since JDK 1.2 */
     if (verbose)
         printf("\nb) Checking the function with the detached thread ...\n\ndetaching the main thread ...\n");
-    if ((err = vm->DetachCurrentThread()) != 0)
-        printf("(%s,%d): Warning: DetachCurrentThread() returns: %d\n\
-\tcheck with the detached main thread skipped\n",
+    if ((err = vm->DetachCurrentThread()) != 0) {
+        printf(
+            "(%s,%d): Warning: DetachCurrentThread() returns: %d\n"
+            "\tcheck with the detached main thread skipped\n",
             __FILE__, __LINE__, err);
-    else {
+    } else {
         redirect(env, JVMTI_ERROR_UNATTACHED_THREAD);
 
         if (verbose)

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetLocalVariableTable/localtab004/localtab004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetLocalVariableTable/localtab004/localtab004.cpp
@@ -107,8 +107,7 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
                 jni_env, testedCls,
                 methInfo[i].m_name, methInfo[i].m_sign);
         if (methInfo[i].mid == NULL) {
-            NSK_COMPLAIN3("TEST FAILURE: unable to get the method ID for the %s method\
- \"%s\", signature \"%s\"\n\n",
+            NSK_COMPLAIN3("TEST FAILURE: unable to get the method ID for the %s method \"%s\", signature \"%s\"\n\n",
                 methInfo[i].inst?"instance":"static",
                 methInfo[i].m_name, methInfo[i].m_sign);
             return STATUS_FAILED;
@@ -124,8 +123,9 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
         } else {
             if (count != methInfo[i].vcount) {
                 totRes = STATUS_FAILED;
-                NSK_COMPLAIN5("TEST FAILED: %s method \"%s\", signature \"%s\":\
- found %d vars in the LocalVariableTable, expected %d\n\tHere are the found vars:\n",
+                NSK_COMPLAIN5(
+                    "TEST FAILED: %s method \"%s\", signature \"%s\": found %d vars in the LocalVariableTable, expected %d\n"
+                    "\tHere are the found vars:\n",
                     methInfo[i].inst?"instance":"static",
                     methInfo[i].m_name, methInfo[i].m_sign,
                     count, methInfo[i].vcount);
@@ -136,18 +136,21 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
 
                 continue;
             }
-            else
-                NSK_DISPLAY4("Checking vars in the LocalVariableTable of the %s method \"%s\",\
- signature \"%s\" ...\n\tfound %d local vars as expected\n",
+            else {
+                NSK_DISPLAY4(
+                    "Checking vars in the LocalVariableTable of the %s method \"%s\", signature \"%s\" ...\n"
+                    "\tfound %d local vars as expected\n",
                     methInfo[i].inst?"instance":"static",
                     methInfo[i].m_name, methInfo[i].m_sign, count);
+            }
 
             for (j=0; j<count; j++) {
                 for (k=0; k<count; k++) {
                     if (strcmp(lv_table[j].name, methInfo[i].vars[k].v_name) == 0) {
                         if (strcmp(lv_table[j].signature, methInfo[i].vars[k].v_sign) != 0) {
-                            NSK_COMPLAIN6("TEST FAILED: %s method: \"%s\", signature: \"%s\": var \"%s\"\
- has signature \"%s\" in the LocalVariableTable, expected \"%s\"\n\n",
+                            NSK_COMPLAIN6(
+                                "TEST FAILED: %s method: \"%s\", signature: \"%s\": var \"%s\" "
+                                "has signature \"%s\" in the LocalVariableTable, expected \"%s\"\n\n",
                                 methInfo[i].inst?"instance":"static",
                                 methInfo[i].m_name, methInfo[i].m_sign,
                                 lv_table[j].name, lv_table[j].signature,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetLocalVariableTable/localtab005/localtab005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetLocalVariableTable/localtab005/localtab005.cpp
@@ -115,8 +115,7 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
                 jni_env, testedCls,
                 methInfo[i].m_name, methInfo[i].m_sign);
         if (methInfo[i].mid == NULL) {
-            NSK_COMPLAIN3("TEST FAILURE: unable to get the method ID for the %s method\
- \"%s\", signature \"%s\"\n\n",
+            NSK_COMPLAIN3("TEST FAILURE: unable to get the method ID for the %s method \"%s\", signature \"%s\"\n\n",
                 methInfo[i].inst?"instance":"static",
                 methInfo[i].m_name, methInfo[i].m_sign);
             return STATUS_FAILED;
@@ -132,8 +131,10 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
         } else {
             if (count != methInfo[i].vcount) {
                 totRes = STATUS_FAILED;
-                NSK_COMPLAIN5("TEST FAILED: %s method \"%s\", signature \"%s\":\
- found %d vars in the LocalVariableTable, expected %d\n\tHere are the found vars:\n",
+                NSK_COMPLAIN5(
+                    "TEST FAILED: %s method \"%s\", signature \"%s\":"
+                    "found %d vars in the LocalVariableTable, expected %d\n"
+                    "\tHere are the found vars:\n",
                     methInfo[i].inst?"instance":"static",
                     methInfo[i].m_name, methInfo[i].m_sign,
                     count, methInfo[i].vcount);
@@ -146,11 +147,14 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
 
                 continue;
             }
-            else
-                NSK_DISPLAY4(">>> Checking vars in the LocalVariableTable of the %s method \"%s\",\
- signature \"%s\" ...\n\t%d local vars as expected\n",
+            else {
+                NSK_DISPLAY4(
+                    ">>> Checking vars in the LocalVariableTable of the %s method \"%s\","
+                    "signature \"%s\" ...\n"
+                    "\t%d local vars as expected\n",
                     methInfo[i].inst?"instance":"static",
                     methInfo[i].m_name, methInfo[i].m_sign, count);
+            }
 
             for (j=0; j<count; j++) {
                 for (k=0; k<count; k++) {
@@ -158,8 +162,11 @@ static int checkAttr(JNIEnv *jni_env, jclass testedCls) {
                         if ((strcmp(lv_table[j].signature, methInfo[i].vars[k].v_sign) != 0) ||
                             (strcmp((lv_table[j].generic_signature==NULL)?"NULL":lv_table[j].generic_signature,
                                 methInfo[i].vars[k].v_gen_sign) != 0)) {
-                            NSK_COMPLAIN8("TEST FAILED: %s method: \"%s\" \"%s\":\n\tvar \"%s\"\
- has signature \"%s\",\n\tgeneric signature \"%s\"\n\n\tExpected: \"%s\"\n\t\t\"%s\"\n\n",
+                            NSK_COMPLAIN8(
+                                "TEST FAILED: %s method: \"%s\" \"%s\":\n"
+                                "\tvar \"%s\" has signature \"%s\",\n"
+                                "\tgeneric signature \"%s\"\n\n"
+                                "\tExpected: \"%s\"\n\t\t\"%s\"\n\n",
                                 methInfo[i].inst?"instance":"static",
                                 methInfo[i].m_name, methInfo[i].m_sign,
                                 lv_table[j].name, lv_table[j].signature,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind001/nativemethbind001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind001/nativemethbind001.cpp
@@ -110,8 +110,9 @@ NativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
                 (strcmp(methSig,METHODS[i][1]) == 0)) {
             bindEv[i][0]++;
 
-            NSK_DISPLAY1("CHECK PASSED: NativeMethodBind event received for the method:\n\
-\t\"%s\" as expected\n",
+            NSK_DISPLAY1(
+                "CHECK PASSED: NativeMethodBind event received for the method:\n"
+                "\t\"%s\" as expected\n",
                 methNam);
             break;
         }
@@ -163,8 +164,8 @@ Java_nsk_jvmti_NativeMethodBind_nativemethbind001_nativeMethod(
         meth.signature = (char *) METHODS[1][1];
         meth.fnPtr = (void *) &anotherNativeMethod;
 
-        NSK_DISPLAY3("Calling RegisterNatives() with \"%s %s\"\n\
-\tfor class \"%s\" ...\n",
+        NSK_DISPLAY3("Calling RegisterNatives() with \"%s %s\"\n"
+                     "\tfor class \"%s\" ...\n",
             METHODS[1][0], METHODS[1][1], CLASS_SIG);
         if (!NSK_JNI_VERIFY_VOID(env, (NSK_CPP_STUB4(RegisterNatives,
                 env, testedCls, &meth, 1)) != 0)) {
@@ -187,8 +188,9 @@ Java_nsk_jvmti_NativeMethodBind_nativemethbind001_check(
         }
         else {
             result = STATUS_FAILED;
-            NSK_COMPLAIN3("TEST FAILED: wrong number of NativeMethodBind events for the method \"%s\":\n\
-got: %d\texpected: %d\n\n",
+            NSK_COMPLAIN3(
+                "TEST FAILED: wrong number of NativeMethodBind events for the method \"%s\":\n"
+                "got: %d\texpected: %d\n\n",
                 METHODS[i][0], bindEv[i][0], bindEv[i][1]);
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind002/nativemethbind002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind002/nativemethbind002.cpp
@@ -67,8 +67,9 @@ NativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
     if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase,
             jvmti_env, &phase))) {
         result = STATUS_FAILED;
-        NSK_COMPLAIN0("TEST FAILED: unable to obtain phase of the VM execution\n\
-\tduring NativeMethodBind callback\n\n");
+        NSK_COMPLAIN0(
+            "TEST FAILED: unable to obtain phase of the VM execution\n"
+            "\tduring NativeMethodBind callback\n\n");
         unlock(jvmti_env, jni_env);
         return;
     }
@@ -103,10 +104,12 @@ void JNICALL
 VMDeath(jvmtiEnv *jvmti_env, JNIEnv *env) {
     NSK_DISPLAY0("VMDeath event received\n");
 
-    if (wrongBindEv != 0)
-        NSK_COMPLAIN1("TEST FAILED: there are %d NativeMethodBind events\n\
-sent during non-start or non-live phase of the VM execution\n",
+    if (wrongBindEv != 0) {
+        NSK_COMPLAIN1(
+            "TEST FAILED: there are %d NativeMethodBind events\n"
+            "sent during non-start or non-live phase of the VM execution\n",
             wrongBindEv);
+    }
 
     if (result == STATUS_FAILED)
         exit(95 + STATUS_FAILED);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind003/nativemethbind003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind003/nativemethbind003.cpp
@@ -124,14 +124,18 @@ VMDeath(jvmtiEnv *jvmti_env, JNIEnv *env) {
 
     if (bindEv[0] != bindEv[1]) {
         result = STATUS_FAILED;
-        NSK_COMPLAIN5("TEST FAILED: wrong NativeMethodBind events\n\
-\tfor tested method \"%s %s\" bound with \"%s\":\n\
-\tgot: %d\texpected: %d\n\n",
+        NSK_COMPLAIN5(
+            "TEST FAILED: wrong NativeMethodBind events\n"
+            "\tfor tested method \"%s %s\" bound with \"%s\":\n"
+            "\tgot: %d\texpected: %d\n\n",
             METHODS[0], METHODS[1], CLASS_SIG, bindEv[0], bindEv[1]);
-    } else
-        NSK_DISPLAY4("CHECK PASSED: %d NativeMethodBind event(s)\n\
-\tfor tested method \"%s %s\" bound with \"%s\"\n\tas expected\n",
+    } else {
+        NSK_DISPLAY4(
+            "CHECK PASSED: %d NativeMethodBind event(s)\n"
+            "\tfor tested method \"%s %s\" bound with \"%s\"\n"
+            "\tas expected\n",
             bindEv[0], METHODS[0], METHODS[1], CLASS_SIG);
+    }
 
     if (result == STATUS_FAILED)
         exit(95 + STATUS_FAILED);
@@ -151,8 +155,9 @@ Java_nsk_jvmti_NativeMethodBind_nativemethbind003_registerNative(
     jclass testedCls = NULL;
     JNINativeMethod meth;
 
-    NSK_DISPLAY1("Inside the registerNative()\n\
-Finding class \"%s\" ...\n", CLASS_SIG);
+    NSK_DISPLAY1("Inside the registerNative()\n"
+                 "Finding class \"%s\" ...\n",
+                 CLASS_SIG);
     if (!NSK_JNI_VERIFY(env, (testedCls =
             NSK_CPP_STUB2(FindClass, env, CLASS_SIG)) != NULL)) {
         result = STATUS_FAILED;
@@ -165,8 +170,9 @@ Finding class \"%s\" ...\n", CLASS_SIG);
     meth.signature = (char*) METHODS[1];
     meth.fnPtr = (void*) nativeMethod;
 
-    NSK_DISPLAY3("Calling RegisterNatives() with \"%s %s\"\n\
-\tfor class \"%s\" ...\n",
+    NSK_DISPLAY3(
+        "Calling RegisterNatives() with \"%s %s\"\n"
+        "\tfor class \"%s\" ...\n",
         METHODS[0], METHODS[1], CLASS_SIG);
     if (!NSK_JNI_VERIFY_VOID(env, (NSK_CPP_STUB4(RegisterNatives,
             env, testedCls, &meth, 1)) != 0)) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind004/nativemethbind004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind004/nativemethbind004.cpp
@@ -138,22 +138,29 @@ JNIEXPORT jint JNICALL
 Java_nsk_jvmti_NativeMethodBind_nativemethbind004_check(
         JNIEnv *env, jobject obj) {
 
-    if (origCalls == 0)
-        NSK_DISPLAY0("CHECK PASSED: original nativeMethod() to be redirected\n\
-\thas not been invoked as expected\n");
-    else {
+    if (origCalls == 0) {
+        NSK_DISPLAY0(
+            "CHECK PASSED: original nativeMethod() to be redirected\n"
+            "\thas not been invoked as expected\n");
+    } else {
         result = STATUS_FAILED;
-        NSK_COMPLAIN1("TEST FAILED: nativeMethod() has not been redirected by the NativeMethodBind:\n\
-\t%d calls\texpected: 0\n\n", origCalls);
+        NSK_COMPLAIN1(
+            "TEST FAILED: nativeMethod() has not been redirected by the NativeMethodBind:\n"
+            "\t%d calls\texpected: 0\n\n",
+            origCalls);
     }
 
-    if (redirCalls == 1)
-        NSK_DISPLAY1("CHECK PASSED: nativeMethod() has been redirected by the NativeMethodBind:\n\
-\t%d calls of redirected method as expected\n", redirCalls);
-    else {
+    if (redirCalls == 1) {
+        NSK_DISPLAY1(
+            "CHECK PASSED: nativeMethod() has been redirected by the NativeMethodBind:\n"
+            "\t%d calls of redirected method as expected\n",
+            redirCalls);
+    } else {
         result = STATUS_FAILED;
-        NSK_COMPLAIN1("TEST FAILED: nativeMethod() has not been redirected by the NativeMethodBind:\n\
-\t%d calls of redirected method\texpected: 1\n\n", redirCalls);
+        NSK_COMPLAIN1(
+            "TEST FAILED: nativeMethod() has not been redirected by the NativeMethodBind:\n"
+            "\t%d calls of redirected method\texpected: 1\n\n",
+            redirCalls);
     }
 
     return result;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree001/objfree001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree001/objfree001.cpp
@@ -165,8 +165,9 @@ static void envStorageFunc(jvmtiEnv *jvmti_env, const char *msg) {
     else {
         if (obtainedData != storedData) {
             result = STATUS_FAILED;
-            NSK_COMPLAIN3("TEST FAILED: %s: obtained an environment local storage has unexpected pointer:\n\
-got: 0x%p\texpected: 0x%p\n\n",
+            NSK_COMPLAIN3(
+                "TEST FAILED: %s: obtained an environment local storage has unexpected pointer:\n"
+                "got: 0x%p\texpected: 0x%p\n\n",
                 msg, (void*) obtainedData, (void*) storedData);
         }
         else
@@ -203,18 +204,23 @@ VMDeath(jvmtiEnv *jvmti_env, JNIEnv *env) {
     NSK_DISPLAY0("VMDeath event received\n");
 
     if (clsUnloaded == JNI_TRUE) {
-        if (objfree == 0)
-            NSK_DISPLAY1("Warning: no ObjectFree events for a tagged object\n\
-\twhich class \"%s\" has been detected for unloading\n\n",
+        if (objfree == 0) {
+            NSK_DISPLAY1(
+                "Warning: no ObjectFree events for a tagged object\n"
+                "\twhich class \"%s\" has been detected for unloading\n\n",
                 CLASS_SIG);
-        else
-            NSK_DISPLAY2("CHECK PASSED: %d ObjectFree event(s) received for a tagged object\n\
-\twhich class \"%s\" has been detected for unloading\n\n",
+        } else {
+            NSK_DISPLAY2(
+                "CHECK PASSED: %d ObjectFree event(s) received for a tagged object\n"
+                "\twhich class \"%s\" has been detected for unloading\n\n",
                 objfree, CLASS_SIG);
-    } else
-        NSK_DISPLAY1("Warning: unloading of the tested class \"%s\" has not been detected,\n\
-\tso the test has no results\n",
-            CLASS_SIG);
+        }
+    } else {
+         NSK_DISPLAY1(
+             "Warning: unloading of the tested class \"%s\" has not been detected,\n"
+             "\tso the test has no results\n",
+             CLASS_SIG);
+    }
 
     if (result == STATUS_FAILED)
         exit(95 + STATUS_FAILED);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree002/objfree002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree002/objfree002.cpp
@@ -198,8 +198,9 @@ static void envStorageFunc(jvmtiEnv *jvmti_env, const char *msg) {
     else {
         if (obtainedData != storedData) {
             result = STATUS_FAILED;
-            NSK_COMPLAIN3("TEST FAILED: %s: obtained an environment local storage has unexpected pointer:\n\
-got: 0x%p\texpected: 0x%p\n\n",
+            NSK_COMPLAIN3(
+                "TEST FAILED: %s: obtained an environment local storage has unexpected pointer:\n"
+                "got: 0x%p\texpected: 0x%p\n\n",
                 msg, (void*) obtainedData, (void*) storedData);
         }
         else

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass003/redefclass003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass003/redefclass003.cpp
@@ -112,8 +112,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass003_makeRedefinition(JNIEnv *env, jclas
             classDef.class_byte_count);
     if ((err = (jvmti->RedefineClasses(1, &classDef))) != JVMTI_ERROR_NONE) {
         if (err == JVMTI_ERROR_UNSUPPORTED_REDEFINITION_SCHEMA_CHANGED) {
-            printf("Warning: unrestrictedly redefinition of classes is not implemented,\n\
-\tso the test has no results.\n");
+            printf("Warning: unrestrictedly redefinition of classes is not implemented,\n"
+                   "\tso the test has no results.\n");
             no_results = 1;
         }
         else {
@@ -157,9 +157,13 @@ Java_nsk_jvmti_RedefineClasses_redefclass003_checkNewFields(JNIEnv *env,
         printf("\tlongComplNewFld = %" LL "d, expected 44\n", longFld);
         return STATUS_FAILED;
     } else {
-        if (vrb == 1)
-            printf("Completely new static variables:\n\
-\tintComplNewFld = %d\n\tlongComplNewFld = %" LL "d\n", intFld, longFld);
+        if (vrb == 1) {
+            printf(
+                "Completely new static variables:\n"
+                "\tintComplNewFld = %d\n"
+                "\tlongComplNewFld = %" LL "d\n",
+                intFld, longFld);
+        }
         return PASSED;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass004/redefclass004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass004/redefclass004.cpp
@@ -117,8 +117,9 @@ Java_nsk_jvmti_RedefineClasses_redefclass004_makeRedefinition(JNIEnv *env,
             classDef.class_byte_count);
     if ((err = (jvmti->RedefineClasses(1, &classDef))) != JVMTI_ERROR_NONE) {
         if (err == JVMTI_ERROR_UNSUPPORTED_REDEFINITION_SCHEMA_CHANGED) {
-            printf("Warning: unrestrictedly redefinition of classes is not implemented,\n\
-\tso the test has no results.\n");
+            printf(
+                "Warning: unrestrictedly redefinition of classes is not implemented,\n"
+                "\tso the test has no results.\n");
             no_results = 1;
         }
         else {
@@ -182,11 +183,14 @@ Java_nsk_jvmti_RedefineClasses_redefclass004_checkNewFields(JNIEnv *env,
         env->ReleaseStringUTFChars(stringObj, strFld);
         return STATUS_FAILED;
     } else {
-        if (vrb == 1)
-            printf("Completely new fields:\n\
-\tstringComplNewFld = \"%s\"\n\tintComplNewFld = %d\n\
-\tlongComplNewFld = %" LL "d\n",
+        if (vrb == 1) {
+            printf(
+                "Completely new fields:\n"
+                "\tstringComplNewFld = \"%s\"\n"
+                "\tintComplNewFld = %d\n"
+                "\tlongComplNewFld = %" LL "d\n",
                 strFld, intFld, longFld);
+        }
         env->ReleaseStringUTFChars(stringObj, strFld);
         return PASSED;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass008/redefclass008.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass008/redefclass008.cpp
@@ -141,8 +141,8 @@ Java_nsk_jvmti_RedefineClasses_redefclass008_setBreakpoints(JNIEnv *env,
             breakpoints[i].mid = env->GetMethodID(
                 redefCls, breakpoints[i].m_name, breakpoints[i].m_sign);
             if (breakpoints[i].mid == NULL) {
-                printf("%s: Failed to get the method ID for the instance method\
- \"%s\" with signature \"%s\"\n",
+                printf(
+                    "%s: Failed to get the method ID for the instance method \"%s\" with signature \"%s\"\n",
                     __FILE__, breakpoints[i].m_name, breakpoints[i].m_sign);
                 return STATUS_FAILED;
             }
@@ -150,18 +150,22 @@ Java_nsk_jvmti_RedefineClasses_redefclass008_setBreakpoints(JNIEnv *env,
             breakpoints[i].mid = env->GetStaticMethodID(
                 redefCls, breakpoints[i].m_name, breakpoints[i].m_sign);
             if (breakpoints[i].mid == NULL) {
-                printf("%s: Failed to get the method ID for the static method\
- \"%s\" with signature \"%s\"\n",
+                printf(
+                    "%s: Failed to get the method ID for the static method \"%s\" with signature \"%s\"\n",
                     __FILE__, breakpoints[i].m_name, breakpoints[i].m_sign);
                 return STATUS_FAILED;
             }
         }
 
-        if (vrb == 1)
-            printf(">>>>>>>> #%d Invoke SetBreakpoint():\n\tbreakpoint in the %s\
- method: name=\"%s\"; signature=\"%s\"; location=%d\n",
+        if (vrb == 1) {
+            printf(
+                ">>>>>>>> #%d Invoke SetBreakpoint():\n"
+                "\tbreakpoint in the %s method: name=\"%s\"; "
+                "signature=\"%s\"; location=%d\n",
                 i, breakpoints[i].inst?"instance":"static",
                 breakpoints[i].m_name, breakpoints[i].m_sign, breakpoints[i].loc);
+        }
+
         if ((err = (jvmti->SetBreakpoint(breakpoints[i].mid,
                 breakpoints[i].loc))) != JVMTI_ERROR_NONE) {
             printf("%s: Failed to call SetBreakpoint(): error=%d: %s\n",
@@ -239,8 +243,9 @@ Java_nsk_jvmti_RedefineClasses_redefclass008_getResult(JNIEnv *env,
             breakpoints[i].mid = env->GetMethodID(
                 redefCls, breakpoints[i].m_name, breakpoints[i].m_sign);
             if (breakpoints[i].mid == NULL) {
-                printf("%s: getResult: Failed to get the method ID for the instance method\
- \"%s\" with signature \"%s\"\n",
+                printf(
+                    "%s: getResult: Failed to get the method ID for the instance method"
+                    "\"%s\" with signature \"%s\"\n",
                     __FILE__, breakpoints[i].m_name, breakpoints[i].m_sign);
                 return STATUS_FAILED;
             }
@@ -248,8 +253,9 @@ Java_nsk_jvmti_RedefineClasses_redefclass008_getResult(JNIEnv *env,
             breakpoints[i].mid = env->GetStaticMethodID(
                 redefCls, breakpoints[i].m_name, breakpoints[i].m_sign);
             if (breakpoints[i].mid == NULL) {
-                printf("%s: getResult: Failed to get the method ID for the static method\
- \"%s\" with signature \"%s\"\n",
+                printf(
+                    "%s: getResult: Failed to get the method ID for the static method"
+                    "\"%s\" with signature \"%s\"\n",
                     __FILE__, breakpoints[i].m_name, breakpoints[i].m_sign);
                 return STATUS_FAILED;
             }
@@ -257,25 +263,30 @@ Java_nsk_jvmti_RedefineClasses_redefclass008_getResult(JNIEnv *env,
 
         if ((err = (jvmti->ClearBreakpoint(breakpoints[i].mid,
                 breakpoints[i].loc))) != JVMTI_ERROR_NOT_FOUND) {
-            printf("TEST FAILED: Breakpoint #%d in the %s method:\n\
-\tname=\"%s\"; signature=\"%s\"; location=%d was not cleared:\n\
-\tClearBreakpoint() returned the error %d: %s\n\n",
+            printf(
+                "TEST FAILED: Breakpoint #%d in the %s method:\n"
+                "\tname=\"%s\"; signature=\"%s\"; location=%d was not cleared:\n"
+                "\tClearBreakpoint() returned the error %d: %s\n\n",
                 i, breakpoints[i].inst?"instance":"static",
                 breakpoints[i].m_name, breakpoints[i].m_sign,
                 breakpoints[i].loc, err, TranslateError(err));
             totRes = STATUS_FAILED;
         } else {
-            if (vrb == 1)
-                printf("Check #%d PASSED: Breakpoint in the %s method:\n\
-\tname=\"%s\"; signature=\"%s\"; location=%d was cleared:\n\
-\tClearBreakpoint() returned the error %d: %s\n\n",
+            if (vrb == 1) {
+                printf(
+                    "Check #%d PASSED: Breakpoint in the %s method:\n"
+                    "\tname=\"%s\"; signature=\"%s\"; location=%d was cleared:\n"
+                    "\tClearBreakpoint() returned the error %d: %s\n\n",
                     i, breakpoints[i].inst?"instance":"static",
                     breakpoints[i].m_name, breakpoints[i].m_sign,
                     breakpoints[i].loc, err, TranslateError(err));
+            }
+
             if ((err = (jvmti->SetBreakpoint(breakpoints[i].mid,
                     breakpoints[i].loc))) == JVMTI_ERROR_DUPLICATE) {
-                printf("TEST FAILED: the function SetBreakpoint() returned the error %d: %s\n\
-\ti.e. the breakpoint #%d has not been really cleared.\n\n",
+                printf(
+                    "TEST FAILED: the function SetBreakpoint() returned the error %d: %s\n"
+                    "\ti.e. the breakpoint #%d has not been really cleared.\n\n",
                     err, TranslateError(err), i);
                 totRes = STATUS_FAILED;
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass009/redefclass009.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass009/redefclass009.cpp
@@ -174,8 +174,7 @@ int checkAttr(JNIEnv *env, jclass redefCls, methInfo methodsInfo[],
                 methodsInfo[i].m_name, methodsInfo[i].m_sign);
         }
         if (methodsInfo[i].mid == NULL) {
-            printf("%s: Failed to get the method ID for the%s%s method\
- \"%s\", signature \"%s\"\n",
+            printf("%s: Failed to get the method ID for the%s%s method \"%s\", signature \"%s\"\n",
                 __FILE__, full?" ":" original ", methodsInfo[i].inst?"instance":"static",
                 methodsInfo[i].m_name, methodsInfo[i].m_sign);
             return STATUS_FAILED;
@@ -192,8 +191,9 @@ int checkAttr(JNIEnv *env, jclass redefCls, methInfo methodsInfo[],
             return STATUS_FAILED;
         } else {
             if (count != methodsInfo[i].vcount) {
-                printf("TEST FAILED: %s%s method \"%s\", signature \"%s\":\
- found %d vars in the LocalVariableTable, expected %d\n",
+                printf(
+                    "TEST FAILED: %s%s method \"%s\", signature \"%s\": "
+                    "found %d vars in the LocalVariableTable, expected %d\n",
                     full?" ":" original ", methodsInfo[i].inst?"instance":"static",
                     methodsInfo[i].m_name, methodsInfo[i].m_sign,
                     count, methodsInfo[i].vcount);
@@ -201,8 +201,10 @@ int checkAttr(JNIEnv *env, jclass redefCls, methInfo methodsInfo[],
                 continue;
             }
             else if (vrb)
-                printf("\nChecking vars in the LocalVariableTable of the %s method \"%s\",\
- signature \"%s\" ...\n\tfound %d local vars as expected\n",
+                printf(
+                    "\nChecking vars in the LocalVariableTable of the %s method \"%s\", "
+                    "signature \"%s\" ...\n"
+                    "\tfound %d local vars as expected\n",
                     methodsInfo[i].inst?"instance":"static",
                     methodsInfo[i].m_name, methodsInfo[i].m_sign, count);
 
@@ -211,8 +213,9 @@ int checkAttr(JNIEnv *env, jclass redefCls, methInfo methodsInfo[],
                     for (k=0; k<count; k++) {
                         if (strcmp(lv_table[j].name, methodsInfo[i].vars[k].v_name) == 0) {
                             if (strcmp(lv_table[j].signature, methodsInfo[i].vars[k].v_sign) != 0) {
-                                printf("TEST FAILED: %s method \"%s\", signature \"%s\": var \"%s\"\
- has signature \"%s\" in the LocalVariableTable, expected \"%s\"\n",
+                                printf(
+                                    "TEST FAILED: %s method \"%s\", signature \"%s\": var \"%s\" "
+                                    "has signature \"%s\" in the LocalVariableTable, expected \"%s\"\n",
                                     methodsInfo[i].inst?"instance":"static",
                                     methodsInfo[i].m_name, methodsInfo[i].m_sign,
                                     lv_table[j].name, lv_table[j].signature,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass010/redefclass010.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass010/redefclass010.cpp
@@ -152,8 +152,7 @@ int checkAttr(JNIEnv *env, jclass redefCls, methInfo methodsInfo[], jint vrb) {
                     methodsInfo[i].m_name, methodsInfo[i].m_sign);
         }
         if (methodsInfo[i].mid == NULL) {
-            printf("%s: Failed to get the method ID for the%s%s method\
- \"%s\", signature \"%s\"\n",
+            printf("%s: Failed to get the method ID for the%s%s method \"%s\", signature \"%s\"\n",
                 __FILE__, (vrb==2)?" original ":" ", methodsInfo[i].inst?"instance":"static",
                 methodsInfo[i].m_name, methodsInfo[i].m_sign);
             return STATUS_FAILED;
@@ -170,8 +169,8 @@ int checkAttr(JNIEnv *env, jclass redefCls, methInfo methodsInfo[], jint vrb) {
             return STATUS_FAILED;
         } else {
             if (count != methodsInfo[i].lcount) {
-                printf("TEST %s %s method \"%s\", signature \"%s\":\
- found %d lines in the LineNumberTable, expected %d\n",
+                printf(
+                    "TEST %s %s method \"%s\", signature \"%s\": found %d lines in the LineNumberTable, expected %d\n",
                     (vrb==2)?"BUG: original ":"FAILED:",
                     methodsInfo[i].inst?"instance":"static",
                     methodsInfo[i].m_name, methodsInfo[i].m_sign,
@@ -180,8 +179,9 @@ int checkAttr(JNIEnv *env, jclass redefCls, methInfo methodsInfo[], jint vrb) {
                 continue;
             }
             else if (vrb == 1)
-                printf("\nChecking line numbers in the LineNumberTable of the %s method\
- \"%s\", signature \"%s\" ...\n\toverall number of lines: %d as expected\n",
+                printf(
+                    "\nChecking line numbers in the LineNumberTable of the %s method \"%s\", signature \"%s\" ...\n"
+                    "\toverall number of lines: %d as expected\n",
                     methodsInfo[i].inst?"instance":"static",
                     methodsInfo[i].m_name, methodsInfo[i].m_sign, count);
 
@@ -192,8 +192,9 @@ int checkAttr(JNIEnv *env, jclass redefCls, methInfo methodsInfo[], jint vrb) {
                     chkval = redf_ln[i][j];
 
                 if (ln_table[j].line_number != chkval) {
-                    printf("TEST %s %s method \"%s\", signature \"%s\": entry #%d\
- has value %d in the LineNumberTable, expected %d\n",
+                    printf(
+                        "TEST %s %s method \"%s\", signature \"%s\": "
+                        "entry #%d has value %d in the LineNumberTable, expected %d\n",
                         (vrb==2)?"BUG: original":"FAILED:",
                         methodsInfo[i].inst?"instance":"static",
                         methodsInfo[i].m_name, methodsInfo[i].m_sign,

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab001/setjniftab001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab001/setjniftab001.cpp
@@ -351,11 +351,12 @@ Java_nsk_jvmti_SetJNIFunctionTable_setjniftab001_check(JNIEnv *env, jobject obj)
     if (verbose)
         printf("\nb) Checking the assertion inside main thread detached and attached again ...\n\ndetaching the main thread ...\n");
 
-    if ((res = vm->DetachCurrentThread()) != 0)
-        printf("(%s,%d): Warning: DetachCurrentThread() returns: %d\n\
-\tcheck with the detached main thread skipped\n",
+    if ((res = vm->DetachCurrentThread()) != 0) {
+        printf(
+            "(%s,%d): Warning: DetachCurrentThread() returns: %d\n"
+            "\tcheck with the detached main thread skipped\n",
             __FILE__, __LINE__, res);
-    else {
+    } else {
         if (verbose)
             printf("\nattaching the main thread again ...\n");
         if ((res = vm->AttachCurrentThread((void **) &nextEnv, (void *) 0)) != 0) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab002/setjniftab002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab002/setjniftab002.cpp
@@ -78,11 +78,12 @@ Java_nsk_jvmti_SetJNIFunctionTable_setjniftab002_check(JNIEnv *env, jobject obj)
        only since JDK 1.2 */
     if (verbose)
         printf("\nb) Checking the function with the detached thread ...\n\ndetaching the main thread ...\n");
-    if ((res = vm->DetachCurrentThread()) != JNI_OK)
-        printf("(%s,%d): Warning: DetachCurrentThread() returns: %d\n\
-\tcheck with the detached main thread skipped\n",
+    if ((res = vm->DetachCurrentThread()) != JNI_OK) {
+        printf(
+            "(%s,%d): Warning: DetachCurrentThread() returns: %d\n"
+            "\tcheck with the detached main thread skipped\n",
             __FILE__, __LINE__, res);
-    else {
+    } else {
         redirect(env, JVMTI_ERROR_UNATTACHED_THREAD);
 
         if (verbose)

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SingleStep/singlestep001/singlestep001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SingleStep/singlestep001/singlestep001.cpp
@@ -88,9 +88,10 @@ ClassLoad(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread, jclass klass) {
                           "failed to obtain a class signature\n");
 
         if (sig != NULL && (strcmp(sig, CLASS_SIG) == 0)) {
-            NSK_DISPLAY1("ClassLoad event received for the class \"%s\"\n\
-\tsetting breakpoint ...\n",
-                         sig);
+            NSK_DISPLAY1(
+                "ClassLoad event received for the class \"%s\"\n"
+                "\tsetting breakpoint ...\n",
+                sig);
             setBP(jvmti_env, env, klass);
         }
     }
@@ -161,9 +162,11 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
     }
 
     if (sig != NULL) {
-        NSK_DISPLAY3("\tmethod name: \"%s\"\n\tsignature: \"%s\"\n\
-\tmethod declaring class: \"%s\"\n",
-                methNam, methSig, sig);
+        NSK_DISPLAY3(
+            "\tmethod name: \"%s\"\n"
+            "\tsignature: \"%s\"\n"
+            "\tmethod declaring class: \"%s\"\n",
+            methNam, methSig, sig);
 
         if (stepEv[1] == 1) {
             result = STATUS_FAILED;
@@ -180,8 +183,9 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
                 (strcmp(methSig,METHOD_SIGS[1]) == 0) &&
                 (strcmp(sig,CLASS_SIG) == 0)) {
             stepEv[1]++;
-            NSK_DISPLAY1("CHECK PASSED: SingleStep event received for the method \"%s\" as expected\n\
-\tdisabling the event generation\n",
+            NSK_DISPLAY1(
+                "CHECK PASSED: SingleStep event received for the method \"%s\" as expected\n"
+                "\tdisabling the event generation\n",
                 methNam);
             if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
                     jvmti_env, JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, thread))) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SingleStep/singlestep002/singlestep002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SingleStep/singlestep002/singlestep002.cpp
@@ -69,10 +69,12 @@ void JNICALL
 VMDeath(jvmtiEnv *jvmti_env, JNIEnv *env) {
     NSK_DISPLAY0("VMDeath event received\n");
 
-    if (wrongStepEv != 0)
-        NSK_COMPLAIN1("TEST FAILED: there are %d SingleStep events\n\
-sent during non-live phase of the VM execution\n",
+    if (wrongStepEv != 0) {
+        NSK_COMPLAIN1(
+            "TEST FAILED: there are %d SingleStep events\n"
+            "sent during non-live phase of the VM execution\n",
             wrongStepEv);
+    }
 
     if (result == STATUS_FAILED)
         exit(95 + STATUS_FAILED);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SingleStep/singlestep003/singlestep003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SingleStep/singlestep003/singlestep003.cpp
@@ -86,10 +86,11 @@ ClassLoad(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread, jclass klass) {
             "failed to obtain a class signature\n");
 
     if (sig != NULL && (strcmp(sig, CLASS_SIG) == 0)) {
-            NSK_DISPLAY1("ClassLoad event received for the class \"%s\"\n\
-\tsetting breakpoint ...\n",
-                sig);
-            setBP(jvmti_env, env, klass);
+        NSK_DISPLAY1(
+            "ClassLoad event received for the class \"%s\"\n"
+            "\tsetting breakpoint ...\n",
+            sig);
+        setBP(jvmti_env, env, klass);
     }
 }
 
@@ -169,15 +170,18 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
                     (strcmp(sig,CLASS_SIG) == 0)) {
                 stepEv[i][0]++;
 
-                if (stepEv[i][1] == 1)
-                    NSK_DISPLAY3("CHECK PASSED: SingleStep event received for the method:\n\
-\t \"%s %s\" of class \"%s\"\n\tas expected\n",
+                if (stepEv[i][1] == 1) {
+                    NSK_DISPLAY3(
+                        "CHECK PASSED: SingleStep event received for the method:\n"
+                        "\t \"%s %s\" of class \"%s\"\n"
+                        "\tas expected\n",
                         methNam, methSig, sig);
-                else {
+                } else {
                     result = STATUS_FAILED;
-                    NSK_COMPLAIN3("TEST FAILED: SingleStep event received for the method:\n\
-\t \"%s %s\" of class \"%s\"\n",
-                    methNam, methSig, sig);
+                    NSK_COMPLAIN3(
+                        "TEST FAILED: SingleStep event received for the method:\n"
+                        "\t \"%s %s\" of class \"%s\"\n",
+                        methNam, methSig, sig);
                 }
 
                 if (i == (METH_NUM-1)) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP01/ap01t001/ap01t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP01/ap01t001/ap01t001.cpp
@@ -64,8 +64,10 @@ VMDeath(jvmtiEnv *jvmti_env, JNIEnv *env) {
     NSK_DISPLAY0("VMDeath event received\n");
 
     if (obj_free != (EXP_OBJ_NUMBER - 1) ) {
-        NSK_COMPLAIN2("Received unexpected number of ObjectFree events: %d\n\t\
-expected number: %d", obj_free, (EXP_OBJ_NUMBER - 1));
+        NSK_COMPLAIN2(
+            "Received unexpected number of ObjectFree events: %d\n"
+            "\texpected number: %d\n",
+            obj_free, (EXP_OBJ_NUMBER - 1));
         exit(95 + STATUS_FAILED);
     }
 
@@ -247,8 +249,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
     if (obj_count != EXP_OBJ_NUMBER) {
         nsk_jvmti_setFailStatus();
-        NSK_COMPLAIN2("IterateOverInstancesOfClass found unexpected number of objects: %d\n\t\
-expected number: %d\n\n",  obj_count, EXP_OBJ_NUMBER);
+        NSK_COMPLAIN2(
+            "IterateOverInstancesOfClass found unexpected number of objects: %d\n"
+            "\texpected number: %d\n\n",
+            obj_count, EXP_OBJ_NUMBER);
+
     } else {
         NSK_DISPLAY1("Number of objects IterateOverInstancesOfClass has found: %d\n\n", obj_count);
     }
@@ -267,8 +272,10 @@ expected number: %d\n\n",  obj_count, EXP_OBJ_NUMBER);
 
     if (obj_count != EXP_OBJ_NUMBER) {
         nsk_jvmti_setFailStatus();
-        NSK_COMPLAIN2("IterateOverHeap found unexpected number of objects: %d\n\t\
-expected number: %d\n\n",  obj_count, EXP_OBJ_NUMBER);
+        NSK_COMPLAIN2(
+            "IterateOverHeap found unexpected number of objects: %d\n"
+            "\texpected number: %d\n\n",
+            obj_count, EXP_OBJ_NUMBER);
     } else {
         NSK_DISPLAY1("Number of objects IterateOverHeap has found: %d\n\n", obj_count);
     }
@@ -287,8 +294,10 @@ expected number: %d\n\n",  obj_count, EXP_OBJ_NUMBER);
 
     if (obj_count != EXP_OBJ_NUMBER) {
         nsk_jvmti_setFailStatus();
-        NSK_COMPLAIN2("IterateOverReachableObjects found unexpected number of objects: %d\n\t\
-expected number: %d\n\n",  obj_count, EXP_OBJ_NUMBER);
+        NSK_COMPLAIN2(
+            "IterateOverReachableObjects found unexpected number of objects: %d\n"
+            "\texpected number: %d\n\n",
+            obj_count, EXP_OBJ_NUMBER);
     } else {
         NSK_DISPLAY1("Number of objects IterateOverReachableObjects has found: %d\n\n", obj_count);
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP02/ap02t001/ap02t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP02/ap02t001/ap02t001.cpp
@@ -118,8 +118,10 @@ static void runIterations (jvmtiEnv* jvmti, jclass testedClass, jint exp_count) 
 
     if (obj_count != exp_count) {
         nsk_jvmti_setFailStatus();
-        NSK_COMPLAIN3("IterateOverInstancesOfClass found unexpected number of %s objects: %d\n\t\
-expected number: %d\n\n", TESTED_CLASS, obj_count, exp_count);
+        NSK_COMPLAIN3(
+            "IterateOverInstancesOfClass found unexpected number of %s objects: %d\n"
+            "\texpected number: %d\n\n",
+            TESTED_CLASS, obj_count, exp_count);
     } else {
         NSK_DISPLAY2("Number of %s objects IterateOverInstancesOfClass has found: %d\n\n", TESTED_CLASS,
             obj_count);
@@ -139,8 +141,10 @@ expected number: %d\n\n", TESTED_CLASS, obj_count, exp_count);
 
     if (obj_count != exp_count) {
         nsk_jvmti_setFailStatus();
-        NSK_COMPLAIN3("IterateOverHeap found unexpected number of %s objects: %d\n\t\
-expected number: %d\n\n", TESTED_CLASS, obj_count, exp_count);
+        NSK_COMPLAIN3(
+            "IterateOverHeap found unexpected number of %s objects: %d\n"
+            "\texpected number: %d\n\n",
+            TESTED_CLASS, obj_count, exp_count);
     } else {
         NSK_DISPLAY2("Number of %s objects IterateOverHeap has found: %d\n\n", TESTED_CLASS, obj_count);
     }
@@ -159,8 +163,10 @@ expected number: %d\n\n", TESTED_CLASS, obj_count, exp_count);
 
     if (obj_count != exp_count) {
         nsk_jvmti_setFailStatus();
-        NSK_COMPLAIN3("IterateOverReachableObjects found unexpected number of %s objects: %d\n\t\
-expected number: %d\n\n", TESTED_CLASS, obj_count, exp_count);
+        NSK_COMPLAIN3(
+            "IterateOverReachableObjects found unexpected number of %s objects: %d\n"
+            "\texpected number: %d\n\n",
+            TESTED_CLASS, obj_count, exp_count);
     } else {
         NSK_DISPLAY2("Number of %s objects IterateOverReachableObjects has found: %d\n\n", TESTED_CLASS,
             obj_count);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001/ap03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001/ap03t001.cpp
@@ -140,8 +140,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
         if (obj_count != EXP_OBJ_NUMBER) {
             nsk_jvmti_setFailStatus();
-            NSK_COMPLAIN2("IterateOverInstancesOfClass found unexpected number of objects: %d\n\t\
-expected number: %d\n\n",  obj_count, EXP_OBJ_NUMBER);
+            NSK_COMPLAIN2(
+                "IterateOverInstancesOfClass found unexpected number of objects: %d\n"
+                "\texpected number: %d\n\n",
+                obj_count, EXP_OBJ_NUMBER);
         } else {
             NSK_DISPLAY1("Number of objects IterateOverInstancesOfClass has found: %d\n\n", obj_count);
         }
@@ -160,8 +162,10 @@ expected number: %d\n\n",  obj_count, EXP_OBJ_NUMBER);
 
         if (obj_count != EXP_OBJ_NUMBER) {
             nsk_jvmti_setFailStatus();
-            NSK_COMPLAIN2("IterateOverHeap found unexpected number of objects: %d\n\t\
-expected number: %d\n\n",  obj_count, EXP_OBJ_NUMBER);
+            NSK_COMPLAIN2(
+                "IterateOverHeap found unexpected number of objects: %d\n"
+                "\texpected number: %d\n\n",
+                obj_count, EXP_OBJ_NUMBER);
         } else {
             NSK_DISPLAY1("Number of objects IterateOverHeap has found: %d\n\n", obj_count);
         }
@@ -197,8 +201,10 @@ expected number: %d\n\n",  obj_count, EXP_OBJ_NUMBER);
 
         if (obj_count != EXP_OBJ_NUMBER) {
             nsk_jvmti_setFailStatus();
-            NSK_COMPLAIN2("IterateOverObjectsReachableFromObject found unexpected number of objects: %d\n\t\
-expected number: %d\n\n",  obj_count, EXP_OBJ_NUMBER);
+            NSK_COMPLAIN2(
+                "IterateOverObjectsReachableFromObject found unexpected number of objects: %d\n"
+                "\texpected number: %d\n\n",
+                obj_count, EXP_OBJ_NUMBER);
         } else {
             NSK_DISPLAY1("Number of objects IterateOverObjectsReachableFromObject has found: %d\n\n", obj_count);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP10/ap10t001/ap10t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP10/ap10t001/ap10t001.cpp
@@ -81,8 +81,9 @@ static void envStorageFunc(jvmtiEnv *jvmti_env, const char *msg) {
     else {
         if (obtainedData != storedData) {
             nsk_jvmti_setFailStatus();
-            NSK_COMPLAIN3("%s: obtained an environment local storage has unexpected pointer:\n\
-got: 0x%p\texpected: 0x%p\n\n",
+            NSK_COMPLAIN3(
+                "%s: obtained an environment local storage has unexpected pointer:\n"
+                "got: 0x%p\texpected: 0x%p\n\n",
                 msg, (void*) obtainedData, (void*) storedData);
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP12/ap12t001/ap12t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP12/ap12t001/ap12t001.cpp
@@ -64,8 +64,10 @@ VMDeath(jvmtiEnv *jvmti_env, JNIEnv *env) {
     NSK_DISPLAY0("VMDeath event received\n");
 
     if (obj_free != EXP_OBJ_FREE) {
-        NSK_COMPLAIN2("Received unexpected number of ObjectFree events: %d\n\t\
-expected number: %d", obj_free, EXP_OBJ_FREE);
+        NSK_COMPLAIN2(
+            "Received unexpected number of ObjectFree events: %d\n"
+            "\texpected number: %d\n",
+            obj_free, EXP_OBJ_FREE);
         exit(95 + STATUS_FAILED);
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t003/hs201t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t003/hs201t003.cpp
@@ -80,12 +80,12 @@ static int expectedMeth(jvmtiEnv *jvmti_env, const char *event,
         return 0;
     }
 
-    if ((strcmp(name, expMeth) == 0) &&
-            (strcmp(sig, expSig) == 0)) {
-        NSK_DISPLAY4("===== %s event received for the tested method:\n\
-\tID=0x%p name=\"%s\" signature=\"%s\"\n",
+    if ((strcmp(name, expMeth) == 0) && (strcmp(sig, expSig) == 0)) {
+        NSK_DISPLAY4(
+            "===== %s event received for the tested method:\n"
+            "\tID=0x%p name=\"%s\" signature=\"%s\"\n",
             event, (void*) method, name, sig);
-         methFound = 1;
+        methFound = 1;
     }
     else
         methFound = 0;
@@ -129,8 +129,9 @@ static void doHotSwap(jvmtiEnv *jvmti_env,
     classDef.class_byte_count = bytesCount;
     classDef.class_bytes = (unsigned char*) clsBytes;
 
-    NSK_DISPLAY2("[%s] >>>>> Invoke RedefineClasses():\n\
-\tnew class byte count=%d\n",
+    NSK_DISPLAY2(
+        "[%s] >>>>> Invoke RedefineClasses():\n"
+        "\tnew class byte count=%d\n",
         event, classDef.class_byte_count);
     if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RedefineClasses,
             jvmti, 1, &classDef))) {
@@ -162,8 +163,9 @@ static void doChecks(jvmtiEnv *jvmti_env,
         nsk_jvmti_setFailStatus();
         return;
     }
-    NSK_DISPLAY3("[%s] method bytes count=%d\n\
-\tbytes count of the redefined method=%d\n",
+    NSK_DISPLAY3(
+        "[%s] method bytes count=%d\n"
+        "\tbytes count of the redefined method=%d\n",
         event, methBytesCount, redefMethBytesCount);
     if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
            jvmti_env, (unsigned char*) methBytes)))

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI05/ji05t001/ji05t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI05/ji05t001/ji05t001.cpp
@@ -112,9 +112,10 @@ static void doRedirect(JNIEnv *env, jvmtiEnv *jvmti, int indx) {
         env->FatalError("failed to get redirected JNI function table");
     }
 
-    NSK_DISPLAY1("%s JVMTI env: doRedirect: the JNI function table obtained successfully\n\
-\toverwriting the function GetVersion() ...\n",
-        (indx==0)?"first":"second");
+    NSK_DISPLAY1(
+        "%s JVMTI env: doRedirect: the JNI function table obtained successfully\n"
+        "\toverwriting the function GetVersion() ...\n",
+        (indx == 0) ? "first" : "second");
     redir_jni_functions[indx]->GetVersion =
         (indx==0)?MyGetVersionA:MyGetVersionB;
 
@@ -139,8 +140,9 @@ static void provokeIntercept(JNIEnv *env, const char *name) {
 
 static int checkIntercept(int indx, int env_num, int exCalls) {
     if (redir_calls[indx] == exCalls) {
-        NSK_DISPLAY5("\nCHECK PASSED: GetVersion() interception set in the %s JVMTI env %s properly:\n\
-\t%d interception(s) with the%s%s JVMTI env as expected\n",
+        NSK_DISPLAY5(
+            "\nCHECK PASSED: GetVersion() interception set in the %s JVMTI env %s properly:\n"
+            "\t%d interception(s) with the%s%s JVMTI env as expected\n",
             (indx==0)?"first":"second",
             (exCalls==0)?"overwritten by another environment":"works",
             redir_calls[indx],
@@ -149,8 +151,9 @@ static int checkIntercept(int indx, int env_num, int exCalls) {
     }
     else {
         result = STATUS_FAILED;
-        NSK_COMPLAIN6("\nTEST FAILED: GetVersion() interception set in the %s JVMTI env doesn't %s properly:\n\
-\t%d interception(s) with the%s%s JVMTI env instead of %d as expected\n",
+        NSK_COMPLAIN6(
+            "\nTEST FAILED: GetVersion() interception set in the %s JVMTI env doesn't %s properly:\n"
+            "\t%d interception(s) with the%s%s JVMTI env instead of %d as expected\n",
             (indx==0)?"first":"second",
             (exCalls==0)?"overwritten by another environment":"work",
             redir_calls[indx],
@@ -259,8 +262,9 @@ static int agentA(void *context) {
 
     /* intercept the JNI function table */
     /* check the interception set in another JVMTI env */
-    NSK_DISPLAY0("\n>>> TEST CASE #1) First JVMTI env: checking the redirection set in the same env ...\n\
-\nagent A (first JVMTI env): redirecting the function table ...\n");
+    NSK_DISPLAY0(
+        "\n>>> TEST CASE #1) First JVMTI env: checking the redirection set in the same env ...\n"
+        "\nagent A (first JVMTI env): redirecting the function table ...\n");
     doRedirect(env, jvmti[0], 0);
 
     /* check that the interception has been set properly */
@@ -343,8 +347,9 @@ static int agentB(void *context) {
     NSK_DISPLAY0("\n<<< TEST CASE #2) done\n");
 
     /* intercept the JNI function table */
-    NSK_DISPLAY0("\n>>> TEST CASE #3) Second JVMTI env: checking the redirection set in the same env ...\n\
-\nagent B (second JVMTI env): redirecting the function table ...\n");
+    NSK_DISPLAY0(
+        "\n>>> TEST CASE #3) Second JVMTI env: checking the redirection set in the same env ...\n"
+        "\nagent B (second JVMTI env): redirecting the function table ...\n");
     doRedirect(env, jvmti[1], 1);
 
     for (i=0; i<AGENTS; i++) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/ji06t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/ji06t001.cpp
@@ -155,8 +155,8 @@ static void doRedirect(JNIEnv *env) {
         env->FatalError("failed to get redirected JNI function table");
     }
 
-    NSK_DISPLAY0("doRedirect: the JNI function table obtained successfully\n\
-\toverwriting the function MonitorEnter ...\n");
+    NSK_DISPLAY0("doRedirect: the JNI function table obtained successfully\n"
+                 "\toverwriting the function MonitorEnter ...\n");
 
     redir_jni_functions->MonitorEnter = MyMonitorEnter;
 
@@ -173,14 +173,16 @@ static void doRedirect(JNIEnv *env) {
 
 static void checkCall(int exMonEntCalls) {
     if (monent_calls >= exMonEntCalls) {
-        NSK_DISPLAY1("CHECK PASSED: the tested JNI function MonitorEnter() has been redirected:\n\
-\tat least %d intercepted call(s) as expected",
+        NSK_DISPLAY1(
+            "CHECK PASSED: the tested JNI function MonitorEnter() has been redirected:\n"
+            "\tat least %d intercepted call(s) as expected",
             monent_calls);
     }
     else {
         result = STATUS_FAILED;
-        NSK_COMPLAIN2("TEST FAILED: the tested JNI function MonitorEnter() has not been redirected properly:\n\
-\tonly %d intercepted call(s) instead of at least %d as expected\n",
+        NSK_COMPLAIN2(
+            "TEST FAILED: the tested JNI function MonitorEnter() has not been redirected properly:\n"
+            "\tonly %d intercepted call(s) instead of at least %d as expected\n",
             monent_calls, exMonEntCalls);
     }
 }
@@ -194,8 +196,9 @@ static int waitingThread(void *context) {
     /* 4932877 fix in accordance with ANSI C: thread context of type void* -> int* -> int */
     int indx = *((int *) context);
 
-    NSK_DISPLAY1("waitingThread: thread #%d started\n\
-\tattaching the thread to the VM ...\n",
+    NSK_DISPLAY1(
+        "waitingThread: thread #%d started\n"
+        "\tattaching the thread to the VM ...\n",
         indx);
     if ((res = vm->AttachCurrentThread((void **) &env, (void *) 0)) != 0) {
         NSK_COMPLAIN1("TEST FAILURE: waitingThread: AttachCurrentThread() returns: %d\n",
@@ -239,8 +242,9 @@ static int ownerThread(void *context) {
         THREAD_return(STATUS_FAILED);
 
     monEntered = 1; /* the monitor has been entered */
-    NSK_DISPLAY1("ownerThread: entered the monitor: monEntered=%d\n\
-\twaiting ...\n",
+    NSK_DISPLAY1(
+        "ownerThread: entered the monitor: monEntered=%d\n"
+        "\twaiting ...\n",
         monEntered);
     do {
         THREAD_sleep(1);
@@ -372,8 +376,8 @@ Java_nsk_jvmti_scenarios_jni_1interception_JI06_ji06t001_check(JNIEnv *env, jobj
     }
 
 /* begin the testing */
-    NSK_DISPLAY0(">>> TEST CASE a) Trying to redirect the JNI function ...\n\
-\nstarting redirector thread ...\n");
+    NSK_DISPLAY0(">>> TEST CASE a) Trying to redirect the JNI function ...\n\n"
+                 "starting redirector thread ...\n");
     redirThr = THREAD_new(redirectorThread, redirContext);
     if (THREAD_start(redirThr) == NULL) {
         NSK_COMPLAIN0("TEST FAILURE: cannot start redirector thread\n");
@@ -408,8 +412,8 @@ Java_nsk_jvmti_scenarios_jni_1interception_JI06_ji06t001_check(JNIEnv *env, jobj
     NSK_DISPLAY0("<<<\n\n");
 
 /*  verification of the interception */
-    NSK_DISPLAY0(">>> TEST CASE b) Exercising the interception ...\n\
-\nmain thread: trying to enter the monitor ...\n");
+    NSK_DISPLAY0(">>> TEST CASE b) Exercising the interception ...\n\n"
+                 "main thread: trying to enter the monitor ...\n");
     if (enterMonitor(env, "mainThread") == STATUS_FAILED)
         exitCode = STATUS_FAILED;
     NSK_DISPLAY0("main thread: entered the monitor\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/JVMTIagent.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/JVMTIagent.cpp
@@ -167,12 +167,13 @@ ClassLoad(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread, jclass klass) {
         else {
             if (shortTestName != NULL) {
                 if (strstr((const char*) cls_sig, shortTestName) != NULL) {
-                    display(0, "#### JVMTIagent: found test class matched with \"%s\"\n\
-<JVMTIagent>\tsignature=%s\n",
-                        shortTestName, cls_sig);
+                    display(0,
+                            "#### JVMTIagent: found test class matched with \"%s\"\n"
+                            "<JVMTIagent>\tsignature=%s\n",
+                            shortTestName, cls_sig);
                     clsByteCount = allocClsInfo(jni_env, cls_sig, klass);
                     display(0, "#### JVMTIagent: %d bytes defining the class have been successfully loaded\n",
-                        clsByteCount);
+                            clsByteCount);
                 }
             }
         }
@@ -534,33 +535,38 @@ Java_nsk_share_RASagent_setHotSwapMode(JNIEnv *jni_env, jclass cls,
             return 0;
         case HOTSWAP_EVERY_METHOD_ENTRY:
             stress_lev = 2;
-            display(0, "#### JVMTIagent: hotswapping class in every method entry event enabled ####\n\
-<JVMTIagent>\tHotSwap stress level: %d\n",
-                stress_lev);
+            display(0,
+                    "#### JVMTIagent: hotswapping class in every method entry event enabled ####\n"
+                    "<JVMTIagent>\tHotSwap stress level: %d\n",
+                    stress_lev);
             break;
         case HOTSWAP_EVERY_METHOD_ENTRY_FOR_EVERY_CLASS:
             stress_lev = 2;
-            display(0, "#### JVMTIagent: hotswapping class in every method entry event for every class enabled ####\n\
-<JVMTIagent>\tHotSwap stress level: %d\n",
-                stress_lev);
+            display(0,
+                    "#### JVMTIagent: hotswapping class in every method entry event for every class enabled ####\n"
+                    "<JVMTIagent>\tHotSwap stress level: %d\n",
+                    stress_lev);
             break;
         case HOTSWAP_EVERY_SINGLE_STEP:
             stress_lev = 3;
-            display(0, "#### JVMTIagent: hotswapping class in every single step event enabled ####\n\
-<JVMTIagent>\tHotSwap stress level: %d\n",
-                stress_lev);
+            display(0,
+                    "#### JVMTIagent: hotswapping class in every single step event enabled ####\n"
+                    "<JVMTIagent>\tHotSwap stress level: %d\n",
+                    stress_lev);
             break;
         case HOTSWAP_EVERY_EXCEPTION:
             stress_lev = 4;
-            display(0, "#### JVMTIagent: hotswapping class in every exception event enabled ####\n\
-<JVMTIagent>\tHotSwap stress level: %d\n",
-                stress_lev);
+            display(0,
+                    "#### JVMTIagent: hotswapping class in every exception event enabled ####\n"
+                    "<JVMTIagent>\tHotSwap stress level: %d\n",
+                    stress_lev);
             break;
         case HOTSWAP_EVERY_EXCEPTION_FOR_EVERY_CLASS:
             stress_lev = 40;
-            display(0, "#### JVMTIagent: hotswapping class in every exception event for every class enabled ####\n\
-<JVMTIagent>\tHotSwap stress level: %d\n",
-                stress_lev);
+            display(0,
+                    "#### JVMTIagent: hotswapping class in every exception event for every class enabled ####\n"
+                    "<JVMTIagent>\tHotSwap stress level: %d\n",
+                    stress_lev);
             break;
         default:
             printf("ERROR(%s,%d): JVMTIagent: unknown value of HotSwap stress level: \"%d\"\n",
@@ -741,9 +747,10 @@ static int doHotSwap(JNIEnv *jni_env, jclass redefCls, jint bCount,
     classDef.class_byte_count = bCount;
     classDef.class_bytes = (unsigned char*) classBytes;
 
-    display(0, "#### JVMTIagent: >>>>>>>> Invoke RedefineClasses():\n\
-<JVMTIagent>\tnew class byte count=%d\n",
-        classDef.class_byte_count);
+    display(0,
+            "#### JVMTIagent: >>>>>>>> Invoke RedefineClasses():\n"
+            "<JVMTIagent>\tnew class byte count=%d\n",
+            classDef.class_byte_count);
     if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RedefineClasses,
             jvmti, 1, &classDef)))
         return 1;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/aod.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/aod.cpp
@@ -236,16 +236,19 @@ int nsk_aod_agentFinished(JNIEnv* jni, const char* agentName, int success) {
     jstring agentNameString;
 
     if (!targetAppClass) {
-        NSK_COMPLAIN1("%s: TEST LOGIC ERROR: method 'agentFinished' was called before "\
-                "targetAppClass was initialized\n", agentName);
+        NSK_COMPLAIN1(
+            "%s: TEST LOGIC ERROR: method 'agentFinished' was called before "
+            "targetAppClass was initialized\n",
+            agentName);
         return NSK_FALSE;
     }
 
     if (internalError && success) {
         success = 0;
-        NSK_COMPLAIN1("Status of agent '%s' is 'passed', but some error happened during test execution "\
-                "(see log for details), change agent status to 'failed'\n",
-                agentName);
+        NSK_COMPLAIN1(
+            "Status of agent '%s' is 'passed', but some error happened during test execution "
+            "(see log for details), change agent status to 'failed'\n",
+            agentName);
     }
 
     NSK_DISPLAY2("Agent %s finished (success: %d)\n", agentName, success);


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210689](https://bugs.openjdk.java.net/browse/JDK-8210689): Remove the multi-line old C style for string literals


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/661/head:pull/661` \
`$ git checkout pull/661`

Update a local copy of the PR: \
`$ git checkout pull/661` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 661`

View PR using the GUI difftool: \
`$ git pr show -t 661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/661.diff">https://git.openjdk.java.net/jdk11u-dev/pull/661.diff</a>

</details>
