### PR TITLE
8277815: Fix mistakes in legal header backports

### DIFF
--- a/src/java.base/share/classes/sun/security/util/math/intpoly/header.txt
+++ b/src/java.base/share/classes/sun/security/util/math/intpoly/header.txt
@@ -4,7 +4,9 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/X509CertificateEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/X509CertificateEvent.java
@@ -4,7 +4,9 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
This corrects the copyright header issues, introduced by the backports of JDK-8213263 and JDK-8213328.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277815](https://bugs.openjdk.java.net/browse/JDK-8277815): Fix mistakes in legal header backports


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/663/head:pull/663` \
`$ git checkout pull/663`

Update a local copy of the PR: \
`$ git checkout pull/663` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 663`

View PR using the GUI difftool: \
`$ git pr show -t 663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/663.diff">https://git.openjdk.java.net/jdk11u-dev/pull/663.diff</a>

</details>
