### PR TITLE
8211036: Remove the NSK_STUB macros from vmTestbase for non jvmti

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/StackTraceController.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/StackTraceController.cpp
@@ -29,31 +29,27 @@ extern "C" {
 
 #define GET_OBJECT_CLASS(_class, _obj)\
     if (!NSK_JNI_VERIFY(env, (_class = \
-            NSK_CPP_STUB2(GetObjectClass, env, _obj)) != NULL))\
+            env->GetObjectClass(_obj)) != NULL))\
         return 2
 
 #define CALL_STATIC_VOID_NOPARAM(_class, _methodName)\
     GET_STATIC_METHOD_ID(method, _class, _methodName, "()V");\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB3(CallStaticVoidMethod, env,\
-                            _class, method)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallStaticVoidMethod(_class, method)))\
         return 2
 
 #define GET_STATIC_METHOD_ID(_methodID, _class, _methodName, _sig)\
     if (!NSK_JNI_VERIFY(env, (_methodID = \
-            NSK_CPP_STUB4(GetStaticMethodID, env, _class,\
-                _methodName, _sig)) != NULL))\
+            env->GetStaticMethodID(_class, _methodName, _sig)) != NULL))\
         return 2
 
 #define GET_METHOD_ID(_methodID, _class, _methodName, _sig)\
     if (!NSK_JNI_VERIFY(env, (_methodID = \
-            NSK_CPP_STUB4(GetMethodID, env, _class,\
-                _methodName, _sig)) != NULL))\
+            env->GetMethodID(_class, _methodName, _sig)) != NULL))\
         return 2
 
 #define CALL_VOID_NOPARAM(_obj, _class, _methodName)\
     GET_METHOD_ID(method, _class, _methodName, "()V");\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB3(CallVoidMethod, env, _obj,\
-                                                    method)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallVoidMethod(_obj, method)))\
         return 2
 
 JNIEXPORT jint JNICALL
@@ -71,18 +67,13 @@ Java_nsk_monitoring_stress_thread_RunningThread_recursionNative(JNIEnv *env,
         if (returnToJava) {
             GET_METHOD_ID(method, threadClass, "recursionJava", "(II)V");
             if (!NSK_JNI_VERIFY_VOID(env,
-                                     NSK_CPP_STUB5(CallIntMethod, env, obj,
-                                                   method, maxDepth,
-                                                   currentDepth))) {
+                                     env->CallIntMethod(obj, method, maxDepth, currentDepth))) {
                 return 1;
             }
         } else {
             GET_METHOD_ID(method, threadClass, "recursionNative", "(IIZ)I");
             if (!NSK_JNI_VERIFY_VOID(env,
-                                     NSK_CPP_STUB6(CallIntMethod, env, obj,
-                                                   method, maxDepth,
-                                                   currentDepth,
-                                                   returnToJava))) {
+                                     env->CallIntMethod(obj, method, maxDepth, currentDepth, returnToJava))) {
                 return 1;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadController.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadController.cpp
@@ -31,131 +31,121 @@ extern "C" {
 
 #define FIND_CLASS(_class, _className)\
     if (!NSK_JNI_VERIFY(env, (_class = \
-            NSK_CPP_STUB2(FindClass, env, _className)) != NULL))\
+            env->FindClass(_className)) != NULL))\
         return
 
 #define GET_OBJECT_CLASS(_class, _obj)\
     if (!NSK_JNI_VERIFY(env, (_class = \
-            NSK_CPP_STUB2(GetObjectClass, env, _obj)) != NULL))\
+            env->GetObjectClass(_obj)) != NULL))\
         return
 
 #define GET_STATIC_FIELD_ID(_fieldID, _class, _fieldName, _fieldSig)\
     if (!NSK_JNI_VERIFY(env, (_fieldID = \
-            NSK_CPP_STUB4(GetStaticFieldID, env, _class,\
-                _fieldName, _fieldSig)) != NULL))\
+            env->GetStaticFieldID(_class, _fieldName, _fieldSig)) != NULL))\
         return
 
 #define GET_STATIC_OBJ_FIELD(_value, _class, _fieldName, _fieldSig)\
     GET_STATIC_FIELD_ID(field, _class, _fieldName, _fieldSig);\
-    _value = NSK_CPP_STUB3(GetStaticObjectField, env, _class, \
-                                field)
+    _value = env->GetStaticObjectField(_class, field)
 
 #define GET_STATIC_BOOL_FIELD(_value, _class, _fieldName)\
     GET_STATIC_FIELD_ID(field, _class, _fieldName, "Z");\
-    _value = NSK_CPP_STUB3(GetStaticBooleanField, env, _class, field)
+    _value = env->GetStaticBooleanField(_class, field)
 
 #define GET_FIELD_ID(_fieldID, _class, _fieldName, _fieldSig)\
     if (!NSK_JNI_VERIFY(env, (_fieldID = \
-            NSK_CPP_STUB4(GetFieldID, env, _class,\
-                _fieldName, _fieldSig)) != NULL))\
+            env->GetFieldID(_class, _fieldName, _fieldSig)) != NULL))\
         return
 
 #define GET_INT_FIELD(_value, _obj, _class, _fieldName)\
     GET_FIELD_ID(field, _class, _fieldName, "I");\
-    _value = NSK_CPP_STUB3(GetIntField, env, _obj, field)
+    _value = env->GetIntField(_obj, field)
 
 #define GET_BOOL_FIELD(_value, _obj, _class, _fieldName)\
     GET_FIELD_ID(field, _class, _fieldName, "Z");\
-    _value = NSK_CPP_STUB3(GetBooleanField, env, _obj, field)
+    _value = env->GetBooleanField(_obj, field)
 
 #define GET_LONG_FIELD(_value, _obj, _class, _fieldName)\
     GET_FIELD_ID(field, _class, _fieldName, "J");\
-    _value = NSK_CPP_STUB3(GetLongField, env, _obj, field)
+    _value = env->GetLongField(_obj, field)
 
 #define GET_STATIC_INT_FIELD(_value, _class, _fieldName)\
     GET_STATIC_FIELD_ID(field, _class, _fieldName, "I");\
-    _value = NSK_CPP_STUB3(GetStaticIntField, env, _class, field)
+    _value = env->GetStaticIntField(_class, field)
 
 #define SET_INT_FIELD(_obj, _class, _fieldName, _newValue)\
     GET_FIELD_ID(field, _class, _fieldName, "I");\
-    NSK_CPP_STUB4(SetIntField, env, _obj, field, _newValue)
+    env->SetIntField(_obj, field, _newValue)
 
 #define GET_OBJ_FIELD(_value, _obj, _class, _fieldName, _fieldSig)\
     GET_FIELD_ID(field, _class, _fieldName, _fieldSig);\
-    _value = NSK_CPP_STUB3(GetObjectField, env, _obj, field)
+    _value = env->GetObjectField(_obj, field)
 
 
 #define GET_ARR_ELEMENT(_arr, _index)\
-    NSK_CPP_STUB3(GetObjectArrayElement, env, _arr, _index)
+    env->GetObjectArrayElement(_arr, _index)
 
 #define SET_ARR_ELEMENT(_arr, _index, _newValue)\
-    NSK_CPP_STUB4(SetObjectArrayElement, env, _arr, _index, _newValue)
+    env->SetObjectArrayElement(_arr, _index, _newValue)
 
 #define GET_STATIC_METHOD_ID(_methodID, _class, _methodName, _sig)\
     if (!NSK_JNI_VERIFY(env, (_methodID = \
-            NSK_CPP_STUB4(GetStaticMethodID, env, _class,\
-                _methodName, _sig)) != NULL))\
+            env->GetStaticMethodID(_class, _methodName, _sig)) != NULL))\
         return
 
 #define GET_METHOD_ID(_methodID, _class, _methodName, _sig)\
     if (!NSK_JNI_VERIFY(env, (_methodID = \
-            NSK_CPP_STUB4(GetMethodID, env, _class,\
-                _methodName, _sig)) != NULL))\
+            env->GetMethodID(_class, _methodName, _sig)) != NULL))\
         return
 
 #define CALL_STATIC_VOID_NOPARAM(_class, _methodName)\
     GET_STATIC_METHOD_ID(method, _class, _methodName, "()V");\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB3(CallStaticVoidMethod, env,\
-                            _class, method)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallStaticVoidMethod(_class, method)))\
         return
 
 #define CALL_STATIC_VOID(_class, _methodName, _sig, _param)\
     GET_STATIC_METHOD_ID(method, _class, _methodName, _sig);\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB4(CallStaticVoidMethod, env,\
-                                                    _class, method, _param)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallStaticVoidMethod(_class, method, _param)))\
         return
 
 #define CALL_STATIC_OBJ(_value, _class, _methodName, _sig, _param)\
     GET_STATIC_METHOD_ID(method, _class, _methodName, _sig);\
-    _value = NSK_CPP_STUB4(CallStaticObjectMethod, env, _class, method, _param)
+    _value = env->CallStaticObjectMethod(_class, method, _param)
 
 #define CALL_VOID_NOPARAM(_obj, _class, _methodName)\
     GET_METHOD_ID(method, _class, _methodName, "()V");\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB3(CallVoidMethod, env, _obj,\
-                                                    method)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallVoidMethod(_obj, method)))\
         return
 
 #define CALL_VOID(_obj, _class, _methodName, _sig, _param)\
     GET_METHOD_ID(method, _class, _methodName, "()V");\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB4(CallVoidMethod, env, _obj,\
-                                                    method, _param)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallVoidMethod(_obj, method, _param)))\
         return
 
 #define CALL_VOID2(_obj, _class, _methodName, _sig, _param1, _param2)\
     GET_METHOD_ID(method, _class, _methodName, _sig);\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB5(CallVoidMethod, env, _obj, \
-                                                    method, _param1, _param2)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallVoidMethod(_obj, method, _param1, _param2)))\
         return
 
 #define CALL_INT_NOPARAM(_value, _obj, _class, _methodName)\
     GET_METHOD_ID(method, _class, _methodName, "()I");\
-    _value = NSK_CPP_STUB3(CallIntMethod, env, _obj, method)
+    _value = env->CallIntMethod(_obj, method)
 
 #define NEW_OBJ(_obj, _class, _constructorName, _sig, _params)\
     GET_METHOD_ID(method, _class, _constructorName, _sig);\
     if (!NSK_JNI_VERIFY(env, (_obj = \
-            NSK_CPP_STUB4(NewObject, env, _class, method, _params)) != NULL))\
+            env->NewObject(_class, method, _params)) != NULL))\
         return
 
 #define MONITOR_ENTER(x) \
-    NSK_JNI_VERIFY(env, NSK_CPP_STUB2(MonitorEnter, env, x) == 0)
+    NSK_JNI_VERIFY(env, env->MonitorEnter(x) == 0)
 
 #define MONITOR_EXIT(x) \
-    NSK_JNI_VERIFY(env, NSK_CPP_STUB2(MonitorExit, env, x) == 0)
+    NSK_JNI_VERIFY(env, env->MonitorExit(x) == 0)
 
 #define TRACE(msg)\
    GET_OBJ_FIELD(logger, obj, threadClass, "logger", "Lnsk/share/Log$Logger;");\
-   jmsg = NSK_CPP_STUB2(NewStringUTF, env, msg);\
+   jmsg = env->NewStringUTF(msg);\
    CALL_VOID2(logger, loggerClass, "trace",\
                            "(ILjava/lang/String;)V", 50, jmsg)
 
@@ -497,29 +487,29 @@ extern "C" {
         jint state;
 
         if(!NSK_VERIFY(
-             NSK_CPP_STUB2(GetJavaVM, env, &vm) == 0)) {
+             env->GetJavaVM(&vm) == 0)) {
             return NULL;
         }
 
         if(!NSK_VERIFY(
-             NSK_CPP_STUB3(GetEnv, vm, (void **)&jvmti, JVMTI_VERSION_1)
+             vm->GetEnv((void **)&jvmti, JVMTI_VERSION_1)
                     == JNI_OK)) {
             return NULL;
         }
 
         if(!NSK_VERIFY(
-             NSK_CPP_STUB3(GetThreadState, jvmti, (jthread)thread, &state)
+             jvmti->GetThreadState((jthread)thread, &state)
              == JVMTI_ERROR_NONE)) {
             return NULL;
         }
 
         stateName = getStateName(env, state);
-        if (!NSK_JNI_VERIFY(env, (ThreadState = NSK_CPP_STUB2(FindClass, env, "java/lang/Thread$State")) != NULL))
+        if (!NSK_JNI_VERIFY(env, (ThreadState = env->FindClass("java/lang/Thread$State")) != NULL))
             return NULL;
 
-        if (!NSK_JNI_VERIFY(env, (method = NSK_CPP_STUB4(GetStaticMethodID, env, ThreadState, "valueOf", "(Ljava/lang/String;)Ljava/lang/Thread$State;")) != NULL))
+        if (!NSK_JNI_VERIFY(env, (method = env->GetStaticMethodID(ThreadState, "valueOf", "(Ljava/lang/String;)Ljava/lang/Thread$State;")) != NULL))
             return NULL;
-        threadState = NSK_CPP_STUB4(CallStaticObjectMethod, env, ThreadState, method, stateName);
+        threadState = env->CallStaticObjectMethod(ThreadState, method, stateName);
 
         return threadState;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/Deadlock.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/Deadlock.cpp
@@ -27,34 +27,31 @@ extern "C" {
 
 #define FIND_CLASS(_class, _className)\
         if (!NSK_JNI_VERIFY(env, (_class = \
-             NSK_CPP_STUB2(FindClass, env, _className)) != NULL))\
+             env->FindClass(_className)) != NULL))\
                 return
 
 #define GET_OBJECT_CLASS(_class, _obj)\
         if (!NSK_JNI_VERIFY(env, (_class = \
-             NSK_CPP_STUB2(GetObjectClass, env, _obj)) != NULL))\
+             env->GetObjectClass(_obj)) != NULL))\
                 return
 
 #define GET_OBJ_FIELD(_value, _obj, _class, _fieldName, _fieldSig)\
         GET_FIELD_ID(field, _class, _fieldName, _fieldSig);\
-        _value = NSK_CPP_STUB3(GetObjectField, env, _obj, field)
+        _value = env->GetObjectField(_obj, field)
 
 #define GET_FIELD_ID(_fieldID, _class, _fieldName, _fieldSig)\
         if (!NSK_JNI_VERIFY(env, (_fieldID = \
-             NSK_CPP_STUB4(GetFieldID, env, _class,\
-             _fieldName, _fieldSig)) != NULL))\
+             env->GetFieldID(_class, _fieldName, _fieldSig)) != NULL))\
                 return
 
 #define GET_METHOD_ID(_methodID, _class, _methodName, _sig)\
         if (!NSK_JNI_VERIFY(env, (_methodID = \
-             NSK_CPP_STUB4(GetMethodID, env, _class,\
-             _methodName, _sig)) != NULL)) \
+             env->GetMethodID(_class, _methodName, _sig)) != NULL)) \
                 return
 
 #define CALL_VOID_NOPARAM(_obj, _class, _methodName)\
             GET_METHOD_ID(method, _class, _methodName, "()V");\
-        if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB3(CallVoidMethod, env, _obj,\
-             method))) \
+        if (!NSK_JNI_VERIFY_VOID(env, env->CallVoidMethod(_obj, method))) \
                 return
 
 /*

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/LockingThreads.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/LockingThreads.cpp
@@ -27,34 +27,31 @@ extern "C" {
 
 #define FIND_CLASS(_class, _className)\
         if (!NSK_JNI_VERIFY(env, (_class = \
-             NSK_CPP_STUB2(FindClass, env, _className)) != NULL))\
+             env->FindClass(_className)) != NULL))\
                 return
 
 #define GET_OBJECT_CLASS(_class, _obj)\
         if (!NSK_JNI_VERIFY(env, (_class = \
-             NSK_CPP_STUB2(GetObjectClass, env, _obj)) != NULL))\
+             env->GetObjectClass(_obj)) != NULL))\
                 return
 
 #define GET_OBJ_FIELD(_value, _obj, _class, _fieldName, _fieldSig)\
         GET_FIELD_ID(field, _class, _fieldName, _fieldSig);\
-        _value = NSK_CPP_STUB3(GetObjectField, env, _obj, field)
+        _value = env->GetObjectField(_obj, field)
 
 #define GET_FIELD_ID(_fieldID, _class, _fieldName, _fieldSig)\
         if (!NSK_JNI_VERIFY(env, (_fieldID = \
-             NSK_CPP_STUB4(GetFieldID, env, _class,\
-             _fieldName, _fieldSig)) != NULL))\
+             env->GetFieldID(_class, _fieldName, _fieldSig)) != NULL))\
                 return
 
 #define GET_METHOD_ID(_methodID, _class, _methodName, _sig)\
         if (!NSK_JNI_VERIFY(env, (_methodID = \
-             NSK_CPP_STUB4(GetMethodID, env, _class,\
-             _methodName, _sig)) != NULL))\
+             env->GetMethodID(_class, _methodName, _sig)) != NULL))\
                 return
 
 #define CALL_VOID_NOPARAM(_obj, _class, _methodName)\
             GET_METHOD_ID(method, _class, _methodName, "()V");\
-        if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB3(CallVoidMethod, env, _obj,\
-             method)))\
+        if (!NSK_JNI_VERIFY_VOID(env, env->CallVoidMethod(_obj, method)))\
                 return
 /*
  * Class:     nsk_monitoring_share_thread_LockingThreads_Thread1

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/RecursiveMonitoringThread.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/RecursiveMonitoringThread.cpp
@@ -29,123 +29,113 @@ extern "C" {
 
 #define FIND_CLASS(_class, _className)\
     if (!NSK_JNI_VERIFY(env, (_class = \
-            NSK_CPP_STUB2(FindClass, env, _className)) != NULL))\
+            env->FindClass(_className)) != NULL))\
         return
 
 #define GET_OBJECT_CLASS(_class, _obj)\
     if (!NSK_JNI_VERIFY(env, (_class = \
-            NSK_CPP_STUB2(GetObjectClass, env, _obj)) != NULL))\
+            env->GetObjectClass(_obj)) != NULL))\
         return
 
 #define GET_STATIC_FIELD_ID(_fieldID, _class, _fieldName, _fieldSig)\
     if (!NSK_JNI_VERIFY(env, (_fieldID = \
-            NSK_CPP_STUB4(GetStaticFieldID, env, _class,\
-                _fieldName, _fieldSig)) != NULL))\
+            env->GetStaticFieldID(_class, _fieldName, _fieldSig)) != NULL))\
         return
 
 #define GET_STATIC_OBJ_FIELD(_value, _class, _fieldName, _fieldSig)\
     GET_STATIC_FIELD_ID(field, _class, _fieldName, _fieldSig);\
-    _value = NSK_CPP_STUB3(GetStaticObjectField, env, _class, \
-                                field)
+    _value = env->GetStaticObjectField(_class, field)
 
 #define GET_STATIC_BOOL_FIELD(_value, _class, _fieldName)\
     GET_STATIC_FIELD_ID(field, _class, _fieldName, "Z");\
-    _value = NSK_CPP_STUB3(GetStaticBooleanField, env, _class, field)
+    _value = env->GetStaticBooleanField(_class, field)
 
 #define GET_FIELD_ID(_fieldID, _class, _fieldName, _fieldSig)\
     if (!NSK_JNI_VERIFY(env, (_fieldID = \
-            NSK_CPP_STUB4(GetFieldID, env, _class,\
-                _fieldName, _fieldSig)) != NULL))\
+            env->GetFieldID(_class, _fieldName, _fieldSig)) != NULL))\
         return
 
 #define GET_INT_FIELD(_value, _obj, _class, _fieldName)\
     GET_FIELD_ID(field, _class, _fieldName, "I");\
-    _value = NSK_CPP_STUB3(GetIntField, env, _obj, field)
+    _value = env->GetIntField(_obj, field)
 
 #define GET_LONG_FIELD(_value, _obj, _class, _fieldName)\
     GET_FIELD_ID(field, _class, _fieldName, "J");\
-    _value = NSK_CPP_STUB3(GetLongField, env, _obj, field)
+    _value = env->GetLongField(_obj, field)
 
 #define GET_STATIC_INT_FIELD(_value, _class, _fieldName)\
     GET_STATIC_FIELD_ID(field, _class, _fieldName, "I");\
-    _value = NSK_CPP_STUB3(GetStaticIntField, env, _class, field)
+    _value = env->GetStaticIntField(_class, field)
 
 #define SET_INT_FIELD(_obj, _class, _fieldName, _newValue)\
     GET_FIELD_ID(field, _class, _fieldName, "I");\
-    NSK_CPP_STUB4(SetIntField, env, _obj, field, _newValue)
+    env->SetIntField(_obj, field, _newValue)
 
 #define GET_OBJ_FIELD(_value, _obj, _class, _fieldName, _fieldSig)\
     GET_FIELD_ID(field, _class, _fieldName, _fieldSig);\
-    _value = NSK_CPP_STUB3(GetObjectField, env, _obj, field)
+    _value = env->GetObjectField(_obj, field)
 
 
 #define GET_ARR_ELEMENT(_arr, _index)\
-    NSK_CPP_STUB3(GetObjectArrayElement, env, _arr, _index)
+    env->GetObjectArrayElement(_arr, _index)
 
 #define SET_ARR_ELEMENT(_arr, _index, _newValue)\
-    NSK_CPP_STUB4(SetObjectArrayElement, env, _arr, _index, _newValue)
+    env->SetObjectArrayElement(_arr, _index, _newValue)
 
 #define GET_STATIC_METHOD_ID(_methodID, _class, _methodName, _sig)\
     if (!NSK_JNI_VERIFY(env, (_methodID = \
-            NSK_CPP_STUB4(GetStaticMethodID, env, _class,\
-                _methodName, _sig)) != NULL))\
+            env->GetStaticMethodID(_class, _methodName, _sig)) != NULL))\
         return
 
 #define GET_METHOD_ID(_methodID, _class, _methodName, _sig)\
     if (!NSK_JNI_VERIFY(env, (_methodID = \
-            NSK_CPP_STUB4(GetMethodID, env, _class,\
-                _methodName, _sig)) != NULL))\
+            env->GetMethodID(_class, _methodName, _sig)) != NULL))\
         return
 
 #define CALL_STATIC_VOID_NOPARAM(_class, _methodName)\
     GET_STATIC_METHOD_ID(method, _class, _methodName, "()V");\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB3(CallStaticVoidMethod, env,\
-                            _class, method)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallStaticVoidMethod(_class, method)))\
         return
 
 #define CALL_STATIC_VOID(_class, _methodName, _sig, _param)\
     GET_STATIC_METHOD_ID(method, _class, _methodName, _sig);\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB4(CallStaticVoidMethod, env,\
-                                                    _class, method, _param)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallStaticVoidMethod(_class, method, _param)))\
         return
 
 #define CALL_VOID_NOPARAM(_obj, _class, _methodName)\
     GET_METHOD_ID(method, _class, _methodName, "()V");\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB3(CallVoidMethod, env, _obj,\
-                                                    method)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallVoidMethod(_obj, method)))\
         return
 
 #define CALL_VOID(_obj, _class, _methodName, _sig, _param)\
     GET_METHOD_ID(method, _class, _methodName, _sig);\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB4(CallVoidMethod, env, _obj,\
-                                                    method, _param)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallVoidMethod(_obj, method, _param)))\
         return
 
 #define CALL_VOID2(_obj, _class, _methodName, _sig, _param1, _param2)\
     GET_METHOD_ID(method, _class, _methodName, _sig);\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB5(CallVoidMethod, env, _obj, \
-                                                    method, _param1, _param2)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallVoidMethod(_obj, method, _param1, _param2)))\
         return
 
 #define CALL_INT_NOPARAM(_value, _obj, _class, _methodName)\
     GET_METHOD_ID(method, _class, _methodName, "()I");\
-    _value = NSK_CPP_STUB3(CallIntMethod, env, _obj, method)
+    _value = env->CallIntMethod(_obj, method)
 
 #define NEW_OBJ(_obj, _class, _constructorName, _sig, _params)\
     GET_METHOD_ID(method, _class, _constructorName, _sig);\
     if (!NSK_JNI_VERIFY(env, (_obj = \
-            NSK_CPP_STUB4(NewObject, env, _class, method, _params)) != NULL))\
+            env->NewObject(_class, method, _params)) != NULL))\
         return
 
 #define MONITOR_ENTER(x) \
-    NSK_JNI_VERIFY(env, NSK_CPP_STUB2(MonitorEnter, env, x) == 0)
+    NSK_JNI_VERIFY(env, env->MonitorEnter(x) == 0)
 
 #define MONITOR_EXIT(x) \
-    NSK_JNI_VERIFY(env, NSK_CPP_STUB2(MonitorExit, env, x) == 0)
+    NSK_JNI_VERIFY(env, env->MonitorExit(x) == 0)
 
 #define TRACE(msg)\
    GET_OBJ_FIELD(logger, obj, threadClass, "logger", "Lnsk/share/Log$Logger;");\
-   jmsg = NSK_CPP_STUB2(NewStringUTF, env, msg);\
+   jmsg = env->NewStringUTF(msg);\
    CALL_VOID2(logger, loggerClass, "trace",\
                            "(ILjava/lang/String;)V", 50, jmsg)
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/JVMTIagent.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/JVMTIagent.cpp
@@ -160,10 +160,8 @@ ClassLoad(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread, jclass klass) {
         lock(jni_env);
         display(0, "#### JVMTIagent: ClassLoad: >>>>>>>> entered the raw monitor \"eventLock\" ####\n");
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-                jvmti_env, klass, &cls_sig, /*&generic*/NULL)))
-            NSK_CPP_STUB2(FatalError, jni_env,
-                "JVMTIagent: failed to get class signature\n");
+        if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &cls_sig, /*&generic*/NULL)))
+            jni_env->FatalError("JVMTIagent: failed to get class signature\n");
         else {
             if (shortTestName != NULL) {
                 if (strstr((const char*) cls_sig, shortTestName) != NULL) {
@@ -245,14 +243,11 @@ Exception(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thr,
 
     if (hotswap == HOTSWAP_EVERY_EXCEPTION ||
             hotswap == HOTSWAP_EVERY_EXCEPTION_FOR_EVERY_CLASS) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-                jvmti_env, method, &decl_clazz)))
-            NSK_CPP_STUB2(FatalError, jni_env,
-                "JVMTIagent: failed to get method declaring class\n");
+        if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(method, &decl_clazz)))
+            jni_env->FatalError("JVMTIagent: failed to get method declaring class\n");
 
         if (findAndHotSwap(jni_env, decl_clazz) != 0)
-            NSK_CPP_STUB2(FatalError, jni_env,
-                "JVMTIagent: failed to hotswap class\n");
+            jni_env->FatalError("JVMTIagent: failed to hotswap class\n");
     }
 }
 
@@ -419,14 +414,11 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
     getVerdict(jni_env, "SingleStep");
 
     if (hotswap == HOTSWAP_EVERY_SINGLE_STEP) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-                jvmti_env, method, &decl_clazz)))
-            NSK_CPP_STUB2(FatalError, jni_env,
-                "JVMTIagent: failed to get method declaring class\n");
+        if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(method, &decl_clazz)))
+            jni_env->FatalError("JVMTIagent: failed to get method declaring class\n");
 
         if (findAndHotSwap(jni_env, decl_clazz) != 0)
-            NSK_CPP_STUB2(FatalError, jni_env,
-                "JVMTIagent: failed to hotswap class\n");
+            jni_env->FatalError("JVMTIagent: failed to hotswap class\n");
     }
 }
 
@@ -443,14 +435,11 @@ MethodEntry(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
 
     if (hotswap == HOTSWAP_EVERY_METHOD_ENTRY ||
             hotswap == HOTSWAP_EVERY_METHOD_ENTRY_FOR_EVERY_CLASS) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-                jvmti_env, method, &decl_clazz)))
-            NSK_CPP_STUB2(FatalError, jni_env,
-                "JVMTIagent: failed to get method declaring class\n");
+        if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(method, &decl_clazz)))
+            jni_env->FatalError("JVMTIagent: failed to get method declaring class\n");
 
         if (findAndHotSwap(jni_env, decl_clazz) != 0)
-            NSK_CPP_STUB2(FatalError, jni_env,
-                "JVMTIagent: failed to hotswap class\n");
+            jni_env->FatalError("JVMTIagent: failed to hotswap class\n");
     }
 }
 
@@ -477,30 +466,23 @@ ExceptionCatch(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thr,
 
     if (hotswap == HOTSWAP_EVERY_EXCEPTION ||
             hotswap == HOTSWAP_EVERY_EXCEPTION_FOR_EVERY_CLASS) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-                jvmti_env, method, &decl_clazz)))
-            NSK_CPP_STUB2(FatalError, jni_env,
-                "JVMTIagent: failed to get method declaring class\n");
+        if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(method, &decl_clazz)))
+            jni_env->FatalError("JVMTIagent: failed to get method declaring class\n");
 
         if (findAndHotSwap(jni_env, decl_clazz) != 0)
-            NSK_CPP_STUB2(FatalError, jni_env,
-                "JVMTIagent: failed to hotswap class\n");
+            jni_env->FatalError("JVMTIagent: failed to hotswap class\n");
     }
 }
 /************************/
 
 static void lock(JNIEnv *jni_env) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter,
-            jvmti, eventLock)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "JVMTIagent: failed to enter a raw monitor\n");
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(eventLock)))
+        jni_env->FatalError("JVMTIagent: failed to enter a raw monitor\n");
 }
 
 static void unlock(JNIEnv *jni_env) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit,
-            jvmti, eventLock)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "JVMTIagent: failed to exit a raw monitor\n");
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(eventLock)))
+        jni_env->FatalError("JVMTIagent: failed to exit a raw monitor\n");
 }
 
 JNIEXPORT jint JNICALL
@@ -516,10 +498,8 @@ Java_nsk_share_RASagent_setHotSwapMode(JNIEnv *jni_env, jclass cls,
     }
 
     /* get supported JVMTI capabilities */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &capabil)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "JVMTIagent: failed to get capabilities\n");
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&capabil)))
+        jni_env->FatalError("JVMTIagent: failed to get capabilities\n");
     if (capabil.can_redefine_classes != 1) { /* ???????????? */
         printf("ERROR: JVMTIagent: Class File Redefinition (HotSwap) is not implemented in this VM\n");
         return 1;
@@ -574,16 +554,14 @@ Java_nsk_share_RASagent_setHotSwapMode(JNIEnv *jni_env, jclass cls,
             return 1;
     }
 
-    if (!NSK_JNI_VERIFY(jni_env, (shortTestName = NSK_CPP_STUB3(GetStringUTFChars,
-            jni_env, shortName, NULL)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (shortTestName = jni_env->GetStringUTFChars(shortName, NULL)) != NULL)) {
         printf("ERROR: JVMTIagent: unable to get UTF-8 characters of the string\n");
         return 1;
     }
     display(0, "#### JVMTIagent: short name of current test is \"%s\"\n",
         shortTestName);
 
-    if (!NSK_JNI_VERIFY(jni_env, (rasCls = NSK_CPP_STUB2(NewGlobalRef,
-            jni_env, cls)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (rasCls = jni_env->NewGlobalRef(cls)) != NULL)) {
         printf("ERROR JVMTIagent: unable to create a new global reference of the class \"RASagent\"\n");
         return 1;
     }
@@ -605,37 +583,31 @@ static jint allocClsInfo(JNIEnv *jni_env, char *cls_sig, jclass clazz) {
 
     if ((_clsInfo = (class_info*)
             malloc(sizeof(class_info))) == NULL)
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "JVMTIagent: cannot allocate memory for class_info\n");
+        jni_env->FatalError("JVMTIagent: cannot allocate memory for class_info\n");
 
     /* fill the structure class_info */
     _clsInfo->clazzsig = cls_sig;
 
-    if (!NSK_JNI_VERIFY(jni_env, ((*_clsInfo).cls = NSK_CPP_STUB2(NewGlobalRef,
-            jni_env, clazz)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, ((*_clsInfo).cls = jni_env->NewGlobalRef(clazz)) != NULL)) {
         printf("ERROR: JVMTIagent: unable to create a new global reference of class \"%s\"\n",
             _clsInfo->clazzsig);
         free(_clsInfo);
         deallocClsInfo(jni_env);
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "JVMTIagent: unable to create a new global reference of class\n");
+        jni_env->FatalError("JVMTIagent: unable to create a new global reference of class\n");
     }
 
     if (!NSK_JNI_VERIFY(jni_env, (mid =
-        NSK_CPP_STUB4(GetStaticMethodID, jni_env, rasCls,
-            "loadFromClassFile", "(Ljava/lang/String;)[B")) != NULL))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "JVMTIagent: unable to get ID of the method \"loadFromClassFile\"\n");
+        jni_env->GetStaticMethodID(rasCls, "loadFromClassFile", "(Ljava/lang/String;)[B")) != NULL))
+        jni_env->FatalError("JVMTIagent: unable to get ID of the method \"loadFromClassFile\"\n");
 
-    classBytes = (jbyteArray) NSK_CPP_STUB4(CallStaticObjectMethod,
-        jni_env, rasCls, mid, NSK_CPP_STUB2(NewStringUTF, jni_env, cls_sig));
+    classBytes = (jbyteArray) jni_env->CallStaticObjectMethod(rasCls, mid, jni_env->NewStringUTF(cls_sig));
 
     clearJavaException(jni_env);
 
-    (*_clsInfo).bCount = NSK_CPP_STUB2(GetArrayLength, jni_env, classBytes);
+    (*_clsInfo).bCount = jni_env->GetArrayLength(classBytes);
 
     (*_clsInfo).clsBytes =
-        NSK_CPP_STUB3(GetByteArrayElements, jni_env, classBytes, &isCopy);
+        jni_env->GetByteArrayElements(classBytes, &isCopy);
 
     _clsInfo->next = NULL;
 
@@ -653,17 +625,15 @@ static jint allocClsInfo(JNIEnv *jni_env, char *cls_sig, jclass clazz) {
 static void deallocClsInfo(JNIEnv *jni_env) {
     class_info *clsInfoCurr = clsInfoFst;
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni_env, rasCls));
+    NSK_TRACE(jni_env->DeleteGlobalRef(rasCls));
 
     while(clsInfoCurr != NULL) {
         class_info *_clsInfo = clsInfoCurr;
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti, (unsigned char*) clsInfoCurr->clazzsig)))
-            NSK_CPP_STUB2(FatalError, jni_env,
-                "JVMTIagent: failed to deallocate memory for clazzsig\n");
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*) clsInfoCurr->clazzsig)))
+            jni_env->FatalError("JVMTIagent: failed to deallocate memory for clazzsig\n");
 
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni_env, clsInfoCurr->cls));
+        NSK_TRACE(jni_env->DeleteGlobalRef(clsInfoCurr->cls));
 
         clsInfoCurr = (class_info*) clsInfoCurr->next;
 
@@ -679,10 +649,8 @@ static int findAndHotSwap(JNIEnv *jni_env, jclass clazz) {
     class_info *clsInfoCurr = clsInfoFst;
 
     display(1, "\n#### JVMTIagent: findAndHotSwap: obtaining class signature of class to be hotswap ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-            jvmti, clazz, &clazzsig, /*&generic*/NULL)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "JVMTIagent: findAndHotSwap: failed to get class signature\n");
+    if (!NSK_JVMTI_VERIFY(jvmti->GetClassSignature(clazz, &clazzsig, /*&generic*/NULL)))
+        jni_env->FatalError("JVMTIagent: findAndHotSwap: failed to get class signature\n");
     else {
         display(1, "#### JVMTIagent: findAndHotSwap: ... class signature obtained: \"%s\"\n",
             clazzsig);
@@ -696,10 +664,8 @@ static int findAndHotSwap(JNIEnv *jni_env, jclass clazz) {
                     hotswap == HOTSWAP_EVERY_EXCEPTION_FOR_EVERY_CLASS) {
                 display(1, "\n#### JVMTIagent: findAndHotSwap: going to hotswap tested class \"%s\" during execution of class \"%s\" ...\n",
                     clsInfoCurr->clazzsig, clazzsig);
-                if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                        jvmti, (unsigned char*) clazzsig)))
-                    NSK_CPP_STUB2(FatalError, jni_env,
-                        "JVMTIagent: findAndHotSwap: failed to deallocate memory for clazzsig\n");
+                if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*) clazzsig)))
+                    jni_env->FatalError("JVMTIagent: findAndHotSwap: failed to deallocate memory for clazzsig\n");
 
                 if (doHotSwap(jni_env, clsInfoCurr->cls,
                         clsInfoCurr->bCount, clsInfoCurr->clsBytes) != 0) {
@@ -712,10 +678,8 @@ static int findAndHotSwap(JNIEnv *jni_env, jclass clazz) {
                     display(0, "\n#### JVMTIagent: findAndHotSwap: tested class found \"%s\" ...\n",
                         clazzsig);
 
-                    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                            jvmti, (unsigned char*) clazzsig)))
-                        NSK_CPP_STUB2(FatalError, jni_env,
-                            "JVMTIagent: findAndHotSwap: failed to deallocate memory for clazzsig\n");
+                    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*) clazzsig)))
+                        jni_env->FatalError("JVMTIagent: findAndHotSwap: failed to deallocate memory for clazzsig\n");
 
                     display(0, "\n#### JVMTIagent: findAndHotSwap: going to hotswap tested class \"%s\" ...\n",
                         clsInfoCurr->clazzsig);
@@ -751,8 +715,7 @@ static int doHotSwap(JNIEnv *jni_env, jclass redefCls, jint bCount,
             "#### JVMTIagent: >>>>>>>> Invoke RedefineClasses():\n"
             "<JVMTIagent>\tnew class byte count=%d\n",
             classDef.class_byte_count);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RedefineClasses,
-            jvmti, 1, &classDef)))
+    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(jvmti->RedefineClasses(1, &classDef)))
         return 1;
 
     display(0, "#### JVMTIagent: <<<<<<<< RedefineClasses() is successfully done ####\n");
@@ -772,8 +735,7 @@ static int addStressEvents() {
 
             callbacks.SingleStep = &SingleStep;
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-                    jvmti, JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, NULL)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, NULL)))
                 return JNI_ERR;
 
             stepEventSet = JNI_TRUE;
@@ -789,8 +751,7 @@ static int addStressEvents() {
 
             callbacks.MethodEntry = &MethodEntry;
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-                    jvmti, JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, NULL)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, NULL)))
                 return JNI_ERR;
 
             display(0, "#### JVMTIagent: ... setting MethodEntry events done\n");
@@ -800,8 +761,7 @@ static int addStressEvents() {
 
             callbacks.MethodExit = &MethodExit;
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-                    jvmti, JVMTI_ENABLE, JVMTI_EVENT_METHOD_EXIT, NULL)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_EXIT, NULL)))
                 return JNI_ERR;
 
             display(0, "#### JVMTIagent: ... setting MethodExit events done\n");
@@ -817,8 +777,7 @@ static int addStressEvents() {
 
             callbacks.ExceptionCatch = &ExceptionCatch;
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-                    jvmti, JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION_CATCH, NULL)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION_CATCH, NULL)))
                 return JNI_ERR;
 
             excCatchEventSet = JNI_TRUE;
@@ -827,8 +786,7 @@ static int addStressEvents() {
         }
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
     else
         return 0;
@@ -856,8 +814,7 @@ static int enableEventsCaps() {
     caps.can_generate_native_method_bind_events = 1;
     caps.can_generate_object_free_events = 1;
     caps.can_generate_vm_object_alloc_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* Breakpoint events */
@@ -865,8 +822,7 @@ static int enableEventsCaps() {
 
     callbacks.Breakpoint = &Breakpoint;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting Breakpoint events done\n");
 
@@ -875,8 +831,7 @@ static int enableEventsCaps() {
 
     callbacks.ClassFileLoadHook = &ClassFileLoadHook;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting ClassFileLoadHook events done\n");
 
@@ -885,8 +840,7 @@ static int enableEventsCaps() {
 
     callbacks.ClassLoad = &ClassLoad;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting ClassLoad events done\n");
 
@@ -895,8 +849,7 @@ static int enableEventsCaps() {
 
     callbacks.ClassPrepare = &ClassPrepare;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_PREPARE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_PREPARE, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting ClassPrepare events done\n");
 
@@ -905,8 +858,7 @@ static int enableEventsCaps() {
 
     callbacks.CompiledMethodLoad = &CompiledMethodLoad;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting CompiledMethodLoad events done\n");
 
@@ -915,8 +867,7 @@ static int enableEventsCaps() {
 
     callbacks.CompiledMethodUnload = &CompiledMethodUnload;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_UNLOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_UNLOAD, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting CompiledMethodUnload events done\n");
 
@@ -925,8 +876,7 @@ static int enableEventsCaps() {
 
     callbacks.DataDumpRequest = &DataDumpRequest;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_DATA_DUMP_REQUEST, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_DATA_DUMP_REQUEST, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting DataDumpRequest events done\n");
 
@@ -935,8 +885,7 @@ static int enableEventsCaps() {
 
     callbacks.DynamicCodeGenerated = &DynamicCodeGenerated;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_DYNAMIC_CODE_GENERATED, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_DYNAMIC_CODE_GENERATED, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting DynamicCodeGenerated events done\n");
 
@@ -945,8 +894,7 @@ static int enableEventsCaps() {
 
     callbacks.Exception = &Exception;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting Exception events done\n");
 
@@ -955,8 +903,7 @@ static int enableEventsCaps() {
 
     callbacks.FieldAccess = &FieldAccess;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_FIELD_ACCESS, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_FIELD_ACCESS, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting FieldAccess events done\n");
 
@@ -965,8 +912,7 @@ static int enableEventsCaps() {
 
     callbacks.FieldModification = &FieldModification;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_FIELD_MODIFICATION, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_FIELD_MODIFICATION, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting FieldModification events done\n");
 
@@ -975,8 +921,7 @@ static int enableEventsCaps() {
 
     callbacks.FramePop = &FramePop;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_FRAME_POP, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_FRAME_POP, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting FramePop events done\n");
 
@@ -985,8 +930,7 @@ static int enableEventsCaps() {
 
     callbacks.GarbageCollectionFinish = &GarbageCollectionFinish;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting GarbageCollectionFinish events done\n");
 
@@ -995,8 +939,7 @@ static int enableEventsCaps() {
 
     callbacks.GarbageCollectionStart = &GarbageCollectionStart;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting GarbageCollectionStart events done\n");
 
@@ -1005,8 +948,7 @@ static int enableEventsCaps() {
 
     callbacks.MonitorContendedEnter = &MonitorContendedEnter;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting MonitorContendedEnter events done\n");
 
@@ -1015,8 +957,7 @@ static int enableEventsCaps() {
 
     callbacks.MonitorContendedEntered = &MonitorContendedEntered;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting MonitorContendedEntered events done\n");
 
@@ -1025,8 +966,7 @@ static int enableEventsCaps() {
 
     callbacks.MonitorWait = &MonitorWait;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAIT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAIT, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting MonitorWait events done\n");
 
@@ -1035,8 +975,7 @@ static int enableEventsCaps() {
 
     callbacks.MonitorWaited = &MonitorWaited;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAITED, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAITED, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting MonitorWaited events done\n");
 
@@ -1045,8 +984,7 @@ static int enableEventsCaps() {
 
     callbacks.NativeMethodBind = &NativeMethodBind;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_NATIVE_METHOD_BIND, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_NATIVE_METHOD_BIND, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting NativeMethodBind events done\n");
 
@@ -1055,8 +993,7 @@ static int enableEventsCaps() {
 
     callbacks.ObjectFree = &ObjectFree;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting ObjectFree events done\n");
 
@@ -1065,8 +1002,7 @@ static int enableEventsCaps() {
 
     callbacks.ThreadEnd = &ThreadEnd;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_THREAD_END, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_THREAD_END, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting ThreadEnd events done\n");
 
@@ -1075,8 +1011,7 @@ static int enableEventsCaps() {
 
     callbacks.ThreadStart = &ThreadStart;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_THREAD_START, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_THREAD_START, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting ThreadStart events done\n");
 
@@ -1085,8 +1020,7 @@ static int enableEventsCaps() {
 
     callbacks.VMDeath = &VMDeath;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting VMDeath events done\n");
 
@@ -1095,8 +1029,7 @@ static int enableEventsCaps() {
 
     callbacks.VMInit = &VMInit;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting VMInit events done\n");
 
@@ -1105,8 +1038,7 @@ static int enableEventsCaps() {
 
     callbacks.VMStart = &VMStart;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_START, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_START, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting VMStart events done\n");
 
@@ -1115,26 +1047,23 @@ static int enableEventsCaps() {
 
     callbacks.VMObjectAlloc = &VMObjectAlloc;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_OBJECT_ALLOC, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_OBJECT_ALLOC, NULL)))
         return JNI_ERR;
     display(0, "#### JVMTIagent: ... setting VMObjectAlloc events done\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     return 0;
 }
 
 static void clearJavaException(JNIEnv* jni_env) {
-    if (NSK_CPP_STUB1(ExceptionOccurred, jni_env)) {
+    if (jni_env->ExceptionOccurred()) {
 
-        NSK_CPP_STUB1(ExceptionDescribe, jni_env);
-        NSK_CPP_STUB1(ExceptionClear, jni_env);
+        jni_env->ExceptionDescribe();
+        jni_env->ExceptionClear();
 
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "JVMTIagent: exception occurred in java code, aborting\n");
+        jni_env->FatalError("JVMTIagent: exception occurred in java code, aborting\n");
     }
 }
 
@@ -1229,7 +1158,7 @@ static void getVerdict(JNIEnv *jni_env, const char *evnt) {
             exit(97);
         }
         else
-            NSK_CPP_STUB2(FatalError, jni_env, error_msg);
+            jni_env->FatalError(error_msg);
     }
 }
 
@@ -1257,8 +1186,7 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
 
     doSetup(options);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor,
-            jvmti, "_event_lock", &eventLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_event_lock", &eventLock)))
         return JNI_ERR;
 
     if (enableEventsCaps() == 0 && addStressEvents() == 0) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/aod.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/aod.cpp
@@ -205,28 +205,27 @@ int nsk_aod_agentLoaded(JNIEnv* jni, const char* agentName) {
          */
         jclass localTargetAppClass;
         if (!NSK_JNI_VERIFY(jni, (localTargetAppClass =
-            NSK_CPP_STUB2(FindClass, jni, TARGET_APP_CLASS_NAME)) != NULL)) {
+            jni->FindClass(TARGET_APP_CLASS_NAME)) != NULL)) {
             return NSK_FALSE;
         }
 
         if (!NSK_JNI_VERIFY(jni, (targetAppClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, localTargetAppClass)) != NULL)) {
+            jni->NewGlobalRef(localTargetAppClass)) != NULL)) {
             return NSK_FALSE;
         }
     }
 
     if (agentLoadedMethod == NULL) {
         if (!NSK_JNI_VERIFY(jni, (agentLoadedMethod =
-            NSK_CPP_STUB4(GetStaticMethodID, jni, targetAppClass,
-                    AGENT_LOADED_METHOD_NAME, AGENT_LOADED_METHOD_SIGNATURE)) != NULL))
+            jni->GetStaticMethodID(targetAppClass, AGENT_LOADED_METHOD_NAME, AGENT_LOADED_METHOD_SIGNATURE)) != NULL))
             return NSK_FALSE;
     }
 
     if (!NSK_JNI_VERIFY(jni, (agentNameString =
-        NSK_CPP_STUB2(NewStringUTF, jni, agentName)) != NULL))
+        jni->NewStringUTF(agentName)) != NULL))
         return NSK_FALSE;
 
-    NSK_CPP_STUB4(CallStaticVoidMethod, jni, targetAppClass, agentLoadedMethod, agentNameString);
+    jni->CallStaticVoidMethod(targetAppClass, agentLoadedMethod, agentNameString);
 
     return NSK_TRUE;
 }
@@ -255,16 +254,14 @@ int nsk_aod_agentFinished(JNIEnv* jni, const char* agentName, int success) {
 
     if (agentFinishedMethod == NULL) {
         if (!NSK_JNI_VERIFY(jni, (agentFinishedMethod =
-            NSK_CPP_STUB4(GetStaticMethodID, jni, targetAppClass,
-                    AGENT_FINISHED_METHOD_NAME, AGENT_FINISHED_METHOD_SIGNATURE)) != NULL))
+            jni->GetStaticMethodID(targetAppClass, AGENT_FINISHED_METHOD_NAME, AGENT_FINISHED_METHOD_SIGNATURE)) != NULL))
             return NSK_FALSE;
     }
 
-    if (!NSK_JNI_VERIFY(jni, (agentNameString = NSK_CPP_STUB2(NewStringUTF, jni, agentName)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (agentNameString = jni->NewStringUTF(agentName)) != NULL))
         return NSK_FALSE;
 
-    NSK_CPP_STUB5(CallStaticVoidMethod, jni, targetAppClass,
-            agentFinishedMethod, agentNameString, success ? JNI_TRUE : JNI_FALSE);
+    jni->CallStaticVoidMethod(targetAppClass, agentFinishedMethod, agentNameString, success ? JNI_TRUE : JNI_FALSE);
 
     return NSK_TRUE;
 }
@@ -277,7 +274,7 @@ int nsk_aod_agentFinished(JNIEnv* jni, const char* agentName, int success) {
 
 JNIEnv* nsk_aod_createJNIEnv(JavaVM* vm) {
     JNIEnv* jni;
-    NSK_CPP_STUB3(GetEnv, vm, (void**)&jni, JNI_VERSION_1_2);
+    vm->GetEnv((void**)&jni, JNI_VERSION_1_2);
 
     NSK_VERIFY(jni != NULL);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jni/README
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jni/README
@@ -47,7 +47,7 @@ for invokation of JNI functions:
 
     // jni->FindClass(jni, class_name)
     if (!NSK_JNI_VERIFY(jni,
-            NSK_CPP_STUB2(FindClass, jni, class_name) != NULL)) {
+            jni->FindClass(class_name) != NULL)) {
         return JNI_ERR;
     }
 
@@ -55,7 +55,7 @@ or with saving obtained data:
 
     // cls = jni->FindClass(jni, class_name)
     if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, class_name)) != NULL)) {
+            jni->FindClass(class_name)) != NULL)) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jni/jni_tools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jni/jni_tools.cpp
@@ -53,11 +53,11 @@ int nsk_jni_check_exception(JNIEnv* jni, const char file[], int line)
 {
     jthrowable throwable;
 
-    NSK_TRACE(throwable = NSK_CPP_STUB1(ExceptionOccurred, jni));
+    NSK_TRACE(throwable = jni->ExceptionOccurred());
     if (throwable != NULL) {
         nsk_lcomplain(file, line, "Exception in JNI call (cleared):\n");
-        NSK_TRACE(NSK_CPP_STUB1(ExceptionDescribe, jni));
-        NSK_TRACE(NSK_CPP_STUB1(ExceptionClear, jni));
+        NSK_TRACE(jni->ExceptionDescribe());
+        NSK_TRACE(jni->ExceptionClear());
         return NSK_TRUE;
     }
     return NSK_FALSE;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/README
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/README
@@ -95,7 +95,7 @@ for accesing JVM native environment:
 
     // jvm->GetEnv(jvm, &env, version)
     if (!NSK_VERIFY(
-            NSK_CPP_STUB3(GetEnv, jvm, &env, JNI_VERSION_1_2) == JNI_OK)) {
+            jvm->GetEnv(&env, JNI_VERSION_1_2) == JNI_OK)) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/nsk_strace.h
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/nsk_strace.h
@@ -29,16 +29,15 @@
 
 #define JNI_VERSION JNI_VERSION_1_1
 
-#define EXCEPTION_CLEAR NSK_CPP_STUB1(ExceptionClear, env)
-#define EXCEPTION_OCCURRED NSK_CPP_STUB1(ExceptionOccurred, env)
+#define EXCEPTION_CLEAR env->ExceptionClear()
+#define EXCEPTION_OCCURRED env->ExceptionOccurred()
 
 // Check for pending exception of the specified type
 // If it's present, then clear it
 #define EXCEPTION_CHECK(exceptionClass, recurDepth) \
         if (EXCEPTION_OCCURRED != NULL) { \
             jobject exception = EXCEPTION_OCCURRED; \
-            if (NSK_CPP_STUB3(IsInstanceOf, env, exception, \
-                        exceptionClass) == JNI_TRUE) { \
+            if (env->IsInstanceOf(exception, exceptionClass) == JNI_TRUE) { \
                 EXCEPTION_CLEAR; \
                 NSK_DISPLAY1("StackOverflowError occurred at depth %d\n", recurDepth); \
             } \
@@ -46,95 +45,86 @@
 
 #define FIND_CLASS(_class, _className)\
     if (!NSK_JNI_VERIFY(env, (_class = \
-            NSK_CPP_STUB2(FindClass, env, _className)) != NULL))\
+            env->FindClass(_className)) != NULL))\
         exit(1)
 
 #define GET_OBJECT_CLASS(_class, _obj)\
     if (!NSK_JNI_VERIFY(env, (_class = \
-            NSK_CPP_STUB2(GetObjectClass, env, _obj)) != NULL))\
+            env->GetObjectClass(_obj)) != NULL))\
         exit(1)
 
 #define GET_FIELD_ID(_fieldID, _class, _fieldName, _fieldSig)\
     if (!NSK_JNI_VERIFY(env, (_fieldID = \
-            NSK_CPP_STUB4(GetFieldID, env, _class,\
-                _fieldName, _fieldSig)) != NULL))\
+            env->GetFieldID(_class, _fieldName, _fieldSig)) != NULL))\
         exit(1)
 
 #define GET_STATIC_FIELD_ID(_fieldID, _class, _fieldName, _fieldSig)\
     if (!NSK_JNI_VERIFY(env, (_fieldID = \
-            NSK_CPP_STUB4(GetStaticFieldID, env, _class,\
-                _fieldName, _fieldSig)) != NULL))\
+            env->GetStaticFieldID(_class, _fieldName, _fieldSig)) != NULL))\
         exit(1)
 
 #define GET_STATIC_BOOL_FIELD(_value, _class, _fieldName)\
     GET_STATIC_FIELD_ID(field, _class, _fieldName, "Z");\
-    _value = NSK_CPP_STUB3(GetStaticBooleanField, env, _class, field)
+    _value = env->GetStaticBooleanField(_class, field)
 
 #define GET_STATIC_INT_FIELD(_value, _class, _fieldName)\
     GET_STATIC_FIELD_ID(field, _class, _fieldName, "I");\
-    _value = NSK_CPP_STUB3(GetStaticIntField, env, _class, field)
+    _value = env->GetStaticIntField(_class, field)
 
 #define GET_STATIC_OBJ_FIELD(_value, _class, _fieldName, _fieldSig)\
     GET_STATIC_FIELD_ID(field, _class, _fieldName, _fieldSig);\
-    _value = NSK_CPP_STUB3(GetStaticObjectField, env, _class, \
-                                field)
+    _value = env->GetStaticObjectField(_class, field)
 
 #define GET_INT_FIELD(_value, _obj, _class, _fieldName)\
     GET_FIELD_ID(field, _class, _fieldName, "I");\
-    _value = NSK_CPP_STUB3(GetIntField, env, _obj, field)
+    _value = env->GetIntField(_obj, field)
 
 #define SET_INT_FIELD(_obj, _class, _fieldName, _newValue)\
     GET_FIELD_ID(field, _class, _fieldName, "I");\
-    NSK_CPP_STUB4(SetIntField, env, _obj, field, _newValue)
+    env->SetIntField(_obj, field, _newValue)
 
 #define SET_STATIC_INT_FIELD(_class, _fieldName, _newValue)\
     GET_STATIC_FIELD_ID(field, _class, _fieldName, "I");\
-    NSK_CPP_STUB4(SetStaticIntField, env, _class, field, _newValue)
+    env->SetStaticIntField(_class, field, _newValue)
 
 #define GET_OBJ_FIELD(_value, _obj, _class, _fieldName, _fieldSig)\
     GET_FIELD_ID(field, _class, _fieldName, _fieldSig);\
-    _value = NSK_CPP_STUB3(GetObjectField, env, _obj, field)
+    _value = env->GetObjectField(_obj, field)
 
 #define GET_STATIC_METHOD_ID(_methodID, _class, _methodName, _sig)\
     if (!NSK_JNI_VERIFY(env, (_methodID = \
-            NSK_CPP_STUB4(GetStaticMethodID, env, _class,\
-                _methodName, _sig)) != NULL))\
+            env->GetStaticMethodID(_class, _methodName, _sig)) != NULL))\
         exit(1)
 
 #define GET_METHOD_ID(_methodID, _class, _methodName, _sig)\
     if (!NSK_JNI_VERIFY(env, (_methodID = \
-            NSK_CPP_STUB4(GetMethodID, env, _class,\
-                _methodName, _sig)) != NULL))\
+            env->GetMethodID(_class, _methodName, _sig)) != NULL))\
         exit(1)
 
 #define CALL_STATIC_VOID_NOPARAM(_class, _methodName)\
     GET_STATIC_METHOD_ID(method, _class, _methodName, "()V");\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB3(CallStaticVoidMethod, env,\
-                            _class, method)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallStaticVoidMethod(_class, method)))\
         exit(1)
 
 #define CALL_STATIC_VOID(_class, _methodName, _sig, _param)\
     GET_STATIC_METHOD_ID(method, _class, _methodName, _sig);\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB4(CallStaticVoidMethod, env,\
-                                                    _class, method, _param)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallStaticVoidMethod(_class, method, _param)))\
         exit(1)
 
 #define CALL_VOID_NOPARAM(_obj, _class, _methodName)\
     GET_METHOD_ID(method, _class, _methodName, "()V");\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB3(CallVoidMethod, env, _obj,\
-                                                    method)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallVoidMethod(_obj, method)))\
         exit(1)
 
 #define CALL_VOID(_obj, _class, _methodName, _sig, _param)\
     GET_METHOD_ID(method, _class, _methodName, _sig);\
-    if (!NSK_JNI_VERIFY_VOID(env, NSK_CPP_STUB4(CallVoidMethod, env, _obj,\
-                                                    method, _param)))\
+    if (!NSK_JNI_VERIFY_VOID(env, env->CallVoidMethod(_obj, method, _param)))\
         exit(1)
 
 #define MONITOR_ENTER(x) \
-    NSK_JNI_VERIFY(env, NSK_CPP_STUB2(MonitorEnter, env, x) == 0)
+    NSK_JNI_VERIFY(env, env->MonitorEnter(x) == 0)
 
 #define MONITOR_EXIT(x) \
-    NSK_JNI_VERIFY(env, NSK_CPP_STUB2(MonitorExit, env, x) == 0)
+    NSK_JNI_VERIFY(env, env->MonitorExit(x) == 0)
 
 #endif /* _IS_NSK_STRACE_DEFINED_ */

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace005.cpp
@@ -87,11 +87,11 @@ Java_nsk_stress_strace_strace005Thread_recursiveMethod2(JNIEnv *env, jobject obj
     if (maxDepth - currDepth > 0)
     {
         GET_STATIC_METHOD_ID(method, threadClass, "yield", "()V");
-        NSK_CPP_STUB3(CallStaticVoidMethod, env, threadClass, method);
+        env->CallStaticVoidMethod(threadClass, method);
         EXCEPTION_CHECK(stackOverflowErrorClass, currDepth);
 
         GET_METHOD_ID(method, threadClass, "recursiveMethod1", "()V");
-        NSK_CPP_STUB3(CallVoidMethod, env, obj, method);
+        env->CallVoidMethod(obj, method);
         EXCEPTION_CHECK(stackOverflowErrorClass, currDepth);
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace006.cpp
@@ -88,11 +88,11 @@ Java_nsk_stress_strace_strace006Thread_recursiveMethod2(JNIEnv *env, jobject obj
     if (maxDepth - currDepth > 0)
     {
         GET_STATIC_METHOD_ID(method, threadClass, "yield", "()V");
-        NSK_CPP_STUB3(CallStaticVoidMethod, env, threadClass, method);
+        env->CallStaticVoidMethod(threadClass, method);
         EXCEPTION_CHECK(stackOverflowErrorClass, currDepth);
 
         GET_METHOD_ID(method, threadClass, "recursiveMethod1", "()V");
-        NSK_CPP_STUB3(CallVoidMethod, env, obj, method);
+        env->CallVoidMethod(obj, method);
         EXCEPTION_CHECK(stackOverflowErrorClass, currDepth);
     }
 

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/jni/nativeAndMH/nativeAndMH.cpp
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/jni/nativeAndMH/nativeAndMH.cpp
@@ -48,27 +48,25 @@ Java_vm_mlvm_meth_stress_jni_nativeAndMH_Test_native01(
     jobjectArray arguments;
     jobject result;
 
-    if ( ! NSK_JNI_VERIFY(pEnv, (mhClass = NSK_CPP_STUB2(GetObjectClass, pEnv, mhToCall)) != NULL) )
+    if ( ! NSK_JNI_VERIFY(pEnv, (mhClass = pEnv->GetObjectClass(mhToCall)) != NULL) )
         return NULL;
 
-    if ( ! NSK_JNI_VERIFY(pEnv, NULL != (mid = NSK_CPP_STUB4(GetMethodID, pEnv, mhClass,
-            "invokeWithArguments",
-            "([Ljava/lang/Object;)Ljava/lang/Object;"))) )
+    if ( ! NSK_JNI_VERIFY(pEnv, NULL != (mid = pEnv->GetMethodID(mhClass, "invokeWithArguments", "([Ljava/lang/Object;)Ljava/lang/Object;"))) )
         return NULL;
 
-    NSK_JNI_VERIFY(pEnv, NULL != (objectClass = NSK_CPP_STUB2(FindClass, pEnv, "java/lang/Object")));
+    NSK_JNI_VERIFY(pEnv, NULL != (objectClass = pEnv->FindClass("java/lang/Object")));
 
-    NSK_JNI_VERIFY(pEnv, NULL != (arguments = NSK_CPP_STUB4(NewObjectArray, pEnv, ARGS_COUNT, objectClass, NULL)));
+    NSK_JNI_VERIFY(pEnv, NULL != (arguments = pEnv->NewObjectArray(ARGS_COUNT, objectClass, NULL)));
 
-    NSK_JNI_VERIFY_VOID(pEnv, NSK_CPP_STUB4(SetObjectArrayElement, pEnv, arguments, 0, a1));
-    NSK_JNI_VERIFY_VOID(pEnv, NSK_CPP_STUB4(SetObjectArrayElement, pEnv, arguments, 1, a2));
-    NSK_JNI_VERIFY_VOID(pEnv, NSK_CPP_STUB4(SetObjectArrayElement, pEnv, arguments, 2, a3));
-    NSK_JNI_VERIFY_VOID(pEnv, NSK_CPP_STUB4(SetObjectArrayElement, pEnv, arguments, 3, a4));
-    NSK_JNI_VERIFY_VOID(pEnv, NSK_CPP_STUB4(SetObjectArrayElement, pEnv, arguments, 4, a5));
-    NSK_JNI_VERIFY_VOID(pEnv, NSK_CPP_STUB4(SetObjectArrayElement, pEnv, arguments, 5, a6));
+    NSK_JNI_VERIFY_VOID(pEnv, pEnv->SetObjectArrayElement(arguments, 0, a1));
+    NSK_JNI_VERIFY_VOID(pEnv, pEnv->SetObjectArrayElement(arguments, 1, a2));
+    NSK_JNI_VERIFY_VOID(pEnv, pEnv->SetObjectArrayElement(arguments, 2, a3));
+    NSK_JNI_VERIFY_VOID(pEnv, pEnv->SetObjectArrayElement(arguments, 3, a4));
+    NSK_JNI_VERIFY_VOID(pEnv, pEnv->SetObjectArrayElement(arguments, 4, a5));
+    NSK_JNI_VERIFY_VOID(pEnv, pEnv->SetObjectArrayElement(arguments, 5, a6));
 
     // Swap arguments
-    NSK_JNI_VERIFY(pEnv, NULL != (result = NSK_CPP_STUB4(CallObjectMethod, pEnv, mhToCall, mid, arguments)));
+    NSK_JNI_VERIFY(pEnv, NULL != (result = pEnv->CallObjectMethod(mhToCall, mid, arguments)));
     return result;
 }
 

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/mlvmJvmtiUtils.cpp
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/mlvmJvmtiUtils.cpp
@@ -36,15 +36,15 @@ void copyFromJString(JNIEnv * pEnv, jstring src, char ** dst) {
     const char * pStr;
         jsize len;
 
-    if ( ! NSK_VERIFY((pStr = NSK_CPP_STUB3(GetStringUTFChars, pEnv, src, NULL)) != NULL) ) {
+    if ( ! NSK_VERIFY((pStr = pEnv->GetStringUTFChars(src, NULL)) != NULL) ) {
         return;
     }
 
-    len = NSK_CPP_STUB2(GetStringUTFLength, pEnv, src) + 1;
+    len = pEnv->GetStringUTFLength(src) + 1;
     *dst = (char*) malloc(len);
     strncpy(*dst, pStr, len);
 
-    NSK_CPP_STUB3(ReleaseStringUTFChars, pEnv, src, pStr);
+    pEnv->ReleaseStringUTFChars(src, pStr);
 }
 
 struct MethodName * getMethodName(jvmtiEnv * pJvmtiEnv, jmethodID method) {
@@ -53,17 +53,17 @@ struct MethodName * getMethodName(jvmtiEnv * pJvmtiEnv, jmethodID method) {
     jclass clazz;
     struct MethodName * mn;
 
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName, pJvmtiEnv, method, &szName, NULL, NULL)) ) {
+    if ( ! NSK_JVMTI_VERIFY(pJvmtiEnv->GetMethodName(method, &szName, NULL, NULL)) ) {
         return NULL;
     }
 
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass, pJvmtiEnv, method, &clazz)) ) {
-        NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, pJvmtiEnv, (unsigned char*) szName));
+    if ( ! NSK_JVMTI_VERIFY(pJvmtiEnv->GetMethodDeclaringClass(method, &clazz)) ) {
+        NSK_JVMTI_VERIFY(pJvmtiEnv->Deallocate((unsigned char*) szName));
         return NULL;
     }
 
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, pJvmtiEnv, clazz, &szSignature, NULL)) ) {
-        NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, pJvmtiEnv, (unsigned char*) szName));
+    if ( ! NSK_JVMTI_VERIFY(pJvmtiEnv->GetClassSignature(clazz, &szSignature, NULL)) ) {
+        NSK_JVMTI_VERIFY(pJvmtiEnv->Deallocate((unsigned char*) szName));
         return NULL;
     }
 
@@ -75,8 +75,8 @@ struct MethodName * getMethodName(jvmtiEnv * pJvmtiEnv, jmethodID method) {
     strncpy(mn->classSig, szSignature, sizeof(mn->classSig) - 1);
     mn->classSig[sizeof(mn->classSig) - 1] = '\0';
 
-    NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, pJvmtiEnv, (unsigned char*) szName));
-    NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, pJvmtiEnv, (unsigned char*) szSignature));
+    NSK_JVMTI_VERIFY(pJvmtiEnv->Deallocate((unsigned char*) szName));
+    NSK_JVMTI_VERIFY(pJvmtiEnv->Deallocate((unsigned char*) szSignature));
     return mn;
 }
 
@@ -111,7 +111,7 @@ char * locationToString(jvmtiEnv * pJvmtiEnv, jmethodID method, jlocation locati
 
 void * getTLS(jvmtiEnv * pJvmtiEnv, jthread thread, jsize sizeToAllocate) {
     void * tls;
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadLocalStorage, pJvmtiEnv, thread, &tls)) )
+    if ( ! NSK_JVMTI_VERIFY(pJvmtiEnv->GetThreadLocalStorage(thread, &tls)) )
         return NULL;
 
     if ( ! tls) {
@@ -120,7 +120,7 @@ void * getTLS(jvmtiEnv * pJvmtiEnv, jthread thread, jsize sizeToAllocate) {
 
         memset(tls, 0, sizeToAllocate);
 
-        if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetThreadLocalStorage, pJvmtiEnv, thread, tls)) )
+        if ( ! NSK_JVMTI_VERIFY(pJvmtiEnv->SetThreadLocalStorage(thread, tls)) )
             return NULL;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/vm/runtime/defmeth/shared/redefineClasses.cpp
+++ b/test/hotspot/jtreg/vmTestbase/vm/runtime/defmeth/shared/redefineClasses.cpp
@@ -56,23 +56,23 @@ Java_vm_runtime_defmeth_shared_Util_redefineClassIntl(JNIEnv *env, jclass clazz,
 
     classDef.klass = clazzToRedefine;
     if (!NSK_JNI_VERIFY(env,
-            (classDef.class_byte_count = /* jsize */ NSK_CPP_STUB2(GetArrayLength, env, bytecodeArray)) > 0)) {
+            (classDef.class_byte_count = /* jsize */ env->GetArrayLength(bytecodeArray)) > 0)) {
         return JNI_FALSE;
     }
 
     if (!NSK_JNI_VERIFY(env,
-            (classDef.class_bytes = (const unsigned char *) /* jbyte* */ NSK_CPP_STUB3(GetByteArrayElements, env, bytecodeArray, NULL)) != NULL)) {
+            (classDef.class_bytes = (const unsigned char *) /* jbyte* */ env->GetByteArrayElements(bytecodeArray, NULL)) != NULL)) {
         return JNI_FALSE;
     }
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RedefineClasses, test_jvmti, 1, &classDef))) {
+            test_jvmti->RedefineClasses(1, &classDef))) {
         result = JNI_FALSE;
     }
 
     // Need to cleanup reference to byte[] whether RedefineClasses succeeded or not
     if (!NSK_JNI_VERIFY_VOID(env,
-            NSK_CPP_STUB4(ReleaseByteArrayElements, env, bytecodeArray, (jbyte*)classDef.class_bytes, JNI_ABORT))) {
+            env->ReleaseByteArrayElements(bytecodeArray, (jbyte*)classDef.class_bytes, JNI_ABORT))) {
         return JNI_FALSE;
     }
 
@@ -91,12 +91,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_redefine_classes = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            test_jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(test_jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            test_jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(test_jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_redefine_classes)


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211036](https://bugs.openjdk.java.net/browse/JDK-8211036): Remove the NSK_STUB macros from vmTestbase for non jvmti


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/664/head:pull/664` \
`$ git checkout pull/664`

Update a local copy of the PR: \
`$ git checkout pull/664` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 664`

View PR using the GUI difftool: \
`$ git pr show -t 664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/664.diff">https://git.openjdk.java.net/jdk11u-dev/pull/664.diff</a>

</details>
