### PR TITLE
8211782: Remove the NSK_CPP_STUB macros from vmTestbase for jvmti/[I-S]*

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls005/iterinstcls005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls005/iterinstcls005.cpp
@@ -49,55 +49,46 @@ heapObjectCallback(jlong class_tag,
 
     objCounter++;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, st_jvmti, name, &monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->CreateRawMonitor(name, &monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorEnter(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     /* Enter second time */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorEnter(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RawMonitorWait, st_jvmti, monitor_ptr, (jlong)100))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorWait(monitor_ptr, (jlong)100))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorNotify, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorNotify(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorNotifyAll, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorNotifyAll(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorExit(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     /* Exit second time */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorExit(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->DestroyRawMonitor(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -127,12 +118,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0("Calling IterateOverInstancesOfClass with filter JVMTI_HEAP_OBJECT_EITHER\n");
         {
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB5(IterateOverInstancesOfClass,
-                        jvmti,
-                        debugeeClass,
-                        JVMTI_HEAP_OBJECT_EITHER,
-                        heapObjectCallback,
-                        &fakeUserData))) {
+                    jvmti->IterateOverInstancesOfClass(debugeeClass,
+                                                       JVMTI_HEAP_OBJECT_EITHER,
+                                                       heapObjectCallback,
+                                                       &fakeUserData))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -182,8 +171,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls006/iterinstcls006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls006/iterinstcls006.cpp
@@ -45,13 +45,11 @@ heapObjectCallback(jlong class_tag,
                    jlong* tag_ptr,
                    void* storage_data) {
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(SetEnvironmentLocalStorage, st_jvmti, storage_data ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->SetEnvironmentLocalStorage(storage_data))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetEnvironmentLocalStorage, st_jvmti, &storage_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetEnvironmentLocalStorage(&storage_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -82,12 +80,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0("Calling IterateOverInstancesOfClass with filter JVMTI_HEAP_OBJECT_EITHER\n");
         {
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB5(IterateOverInstancesOfClass,
-                        jvmti,
-                        debugeeClass,
-                        JVMTI_HEAP_OBJECT_EITHER,
-                        heapObjectCallback,
-                        (void *)storage_data))) {
+                    jvmti->IterateOverInstancesOfClass(debugeeClass,
+                                                       JVMTI_HEAP_OBJECT_EITHER,
+                                                       heapObjectCallback,
+                                                       (void *) storage_data))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -144,8 +140,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls007/iterinstcls007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverInstancesOfClass/iterinstcls007/iterinstcls007.cpp
@@ -46,8 +46,7 @@ heapObjectCallback(jlong class_tag,
                    jlong* tag_ptr,
                    void* user_data) {
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, st_jvmti, &timer_info1 ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetCurrentThreadCpuTimerInfo(&timer_info1))) {
         nsk_jvmti_setFailStatus();
     }
     /* Check the returned jvmtiTimerInfo structure */
@@ -65,14 +64,12 @@ heapObjectCallback(jlong class_tag,
     }
     /* ---------------------------------------------------------------------- */
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, st_jvmti, &nanos ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetCurrentThreadCpuTime(&nanos))) {
         nsk_jvmti_setFailStatus();
     }
     /* ---------------------------------------------------------------------- */
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetTimerInfo, st_jvmti, &timer_info2 ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetTimerInfo(&timer_info2))) {
         nsk_jvmti_setFailStatus();
     }
     /* Check the returned jvmtiTimerInfo structure */
@@ -91,8 +88,7 @@ heapObjectCallback(jlong class_tag,
     /* ---------------------------------------------------------------------- */
 
     nanos = 0;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetTime, st_jvmti, &nanos ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetTime(&nanos))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -123,12 +119,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             }
 
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB5(IterateOverInstancesOfClass,
-                        jvmti,
-                        debugeeClass,
-                        JVMTI_HEAP_OBJECT_EITHER,
-                        heapObjectCallback,
-                        (void *)user_data))) {
+                    jvmti->IterateOverInstancesOfClass(debugeeClass,
+                                                       JVMTI_HEAP_OBJECT_EITHER,
+                                                       heapObjectCallback,
+                                                       (void *) user_data))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -174,8 +168,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         caps.can_tag_objects = 1;
         caps.can_get_current_thread_cpu_time = 1;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj001/iterobjreachobj001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj001/iterobjreachobj001.cpp
@@ -85,15 +85,13 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
     count--;
     tag++;
 
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetObjectField, jni, firstObject, firstField)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->GetObjectField(firstObject, firstField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
     objectDescList[count].tag = objTag;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, obj, objTag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(obj, objTag))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY2("        tag=%-5ld object=0x%p\n", (long)objTag, (void*)obj);
@@ -104,7 +102,7 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
         return NSK_FALSE;
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteLocalRef, jni, obj));
+    NSK_TRACE(jni->DeleteLocalRef(obj));
     return NSK_TRUE;
 }
 
@@ -127,9 +125,8 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     *objectsCount = 1 + 2 * chainLength;
 
     NSK_DISPLAY1("Allocate memory for objects list: %d objects\n", *objectsCount);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (*objectsCount * sizeof(ObjectDesc)),
-                                                    (unsigned char**)objectDescList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)),
+                                          (unsigned char**)objectDescList))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -144,16 +141,14 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     }
 
     NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... found class: 0x%p\n", (void*)debugeeClass);
 
     NSK_DISPLAY1("Find root object class: %s\n", ROOT_OBJECT_CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (rootObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, ROOT_OBJECT_CLASS_NAME)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (rootObjectClass = jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -161,34 +156,31 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find chain object class: %s\n", CHAIN_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (chainObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... found class: 0x%p\n", (void*)chainObjectClass);
 
     NSK_DISPLAY1("Find static field in debugee class: %s\n", OBJECT_FIELD_NAME);
-    if (!NSK_JNI_VERIFY(jni, (objectField =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                            OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (objectField = jni->GetStaticFieldID(
+            debugeeClass, OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got fieldID: 0x%p\n", (void*)objectField);
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", REACHABLE_CHAIN_FIELD_NAME);
-    if (!NSK_JNI_VERIFY(jni, (reachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (reachableChainField = jni->GetFieldID(
+            rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got fieldID: 0x%p\n", (void*)reachableChainField);
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", UNREACHABLE_CHAIN_FIELD_NAME);
-    if (!NSK_JNI_VERIFY(jni, (unreachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (unreachableChainField = jni->GetFieldID(
+            rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -196,8 +188,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in chain object class: %s\n", TAIL_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (tailField =
-            NSK_CPP_STUB4(GetFieldID, jni, chainObjectClass,
-                            TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(chainObjectClass, TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -205,15 +196,13 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Get root object from static field: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (*rootObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                    objectField)) != NULL)) {
+            jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got object: 0x%p\n", (void*)*rootObject);
 
-    if (!NSK_JNI_VERIFY(jni, (*rootObject =
-            NSK_CPP_STUB2(NewGlobalRef, jni, *rootObject)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (*rootObject = jni->NewGlobalRef(*rootObject)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -222,8 +211,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     NSK_DISPLAY0("Obtain and tag chain objects:\n");
 
     NSK_DISPLAY0("    root tested object:\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, *rootObject, rootObjectTag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(*rootObject, rootObjectTag))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY2("        tag=%-5ld object=0x%p\n", (long)rootObjectTag, (void*)*rootObject);
@@ -304,13 +292,12 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
                                         ObjectDesc* objectDescList, jobject rootObject) {
     if (rootObject != NULL) {
         NSK_DISPLAY1("Release object reference to root tested object: 0x%p\n", rootObject);
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, rootObject));
+        NSK_TRACE(jni->DeleteGlobalRef(rootObject));
     }
 
     if (objectDescList != NULL) {
         NSK_DISPLAY1("Deallocate objects list: 0x%p\n", (void*)objectDescList);
-        if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescList))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)objectDescList))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -445,7 +432,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Start iteration for root tested object\n");
         {
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti,
+                    jvmti->IterateOverObjectsReachableFromObject(
                         rootObject, objectReferenceCallback, &fakeUserData))) {
                 nsk_jvmti_setFailStatus();
                 return;
@@ -529,8 +516,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj002/iterobjreachobj002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj002/iterobjreachobj002.cpp
@@ -66,9 +66,8 @@ objectReferenceCallback1( jvmtiObjectReferenceKind reference_kind,
     /* Set tag */
     *tag_ptr = objectCount;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, st_jvmti, (sizeof(ObjectDesc)),
-                             (unsigned char**)&objectDescBuf))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->Allocate((sizeof(ObjectDesc)),
+                                             (unsigned char**)&objectDescBuf))) {
         nsk_jvmti_setFailStatus();
         allocationError = 1;
     }
@@ -91,8 +90,7 @@ objectReferenceCallback2( jvmtiObjectReferenceKind reference_kind,
 
     objectCount--;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, st_jvmti, (unsigned char*)objectDescBuf))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->Deallocate((unsigned char*)objectDescBuf))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -123,29 +121,23 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             }
 
             NSK_DISPLAY1("Find static field in debugee class: %s\n", objectFieldName);
-            if (!NSK_JNI_VERIFY(jni, (objectField =
-                    NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                                     objectFieldName, debugeeClassSignature)) != NULL)) {
+            if (!NSK_JNI_VERIFY(jni, (objectField = jni->GetStaticFieldID(
+                    debugeeClass, objectFieldName, debugeeClassSignature)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 break;
             }
 
             NSK_DISPLAY1("Find value of static field in debugee class: %s\n", objectFieldName);
             if (!NSK_JNI_VERIFY(jni, (object =
-                    NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                     objectField)) != NULL)) {
+                    jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 break;
             }
 
             NSK_DISPLAY0("Calling IterateOverObjectsReachableFromObject with allocation\n");
             {
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB4(IterateOverObjectsReachableFromObject,
-                            jvmti,
-                            object,
-                            objectReferenceCallback1,
-                            &userData))) {
+                if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(
+                        object, objectReferenceCallback1, &userData))) {
                     nsk_jvmti_setFailStatus();
                     break;
                 }
@@ -161,12 +153,8 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY0("Calling IterateOverObjectsReachableFromObject with deallocation\n");
             {
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB4(IterateOverObjectsReachableFromObject,
-                            jvmti,
-                            object,
-                            objectReferenceCallback2,
-                            &userData))) {
+                if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(
+                        object, objectReferenceCallback2, &userData))) {
                     nsk_jvmti_setFailStatus();
                     break;
                 }
@@ -221,8 +209,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj003/iterobjreachobj003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj003/iterobjreachobj003.cpp
@@ -53,55 +53,46 @@ objectReferenceCallback( jvmtiObjectReferenceKind reference_kind,
 
     objCounter++;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, st_jvmti, name, &monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->CreateRawMonitor(name, &monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorEnter(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     /* Enter second time */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorEnter(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RawMonitorWait, st_jvmti, monitor_ptr, (jlong)100))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorWait(monitor_ptr, (jlong)100))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorNotify, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorNotify(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorNotifyAll, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorNotifyAll(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorExit(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     /* Exit second time */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorExit(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->DestroyRawMonitor(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -131,29 +122,23 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
 
         NSK_DISPLAY1("Find static field in debugee class: %s\n", objectFieldName);
-        if (!NSK_JNI_VERIFY(jni, (objectField =
-                NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                                 objectFieldName, debugeeClassSignature)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni, (objectField = jni->GetStaticFieldID(
+                debugeeClass, objectFieldName, debugeeClassSignature)) != NULL)) {
             nsk_jvmti_setFailStatus();
             break;
         }
 
         NSK_DISPLAY1("Find value of static field in debugee class: %s\n", objectFieldName);
         if (!NSK_JNI_VERIFY(jni, (object =
-                NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                 objectField)) != NULL)) {
+                jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
             nsk_jvmti_setFailStatus();
             break;
         }
 
         NSK_DISPLAY0("Calling IterateOverObjectsReachableFromObject with filter JVMTI_HEAP_OBJECT_EITHER\n");
         {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(IterateOverObjectsReachableFromObject,
-                        jvmti,
-                        object,
-                        objectReferenceCallback,
-                        &fakeUserData))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(
+                    object, objectReferenceCallback, &fakeUserData))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -203,8 +188,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj004/iterobjreachobj004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj004/iterobjreachobj004.cpp
@@ -52,13 +52,11 @@ objectReferenceCallback( jvmtiObjectReferenceKind reference_kind,
 
     objCounter++;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(SetEnvironmentLocalStorage, st_jvmti, storage_data ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->SetEnvironmentLocalStorage(storage_data))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetEnvironmentLocalStorage, st_jvmti, &storage_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetEnvironmentLocalStorage(&storage_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -89,29 +87,23 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
 
         NSK_DISPLAY1("Find static field in debugee class: %s\n", objectFieldName);
-        if (!NSK_JNI_VERIFY(jni, (objectField =
-                NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                                 objectFieldName, debugeeClassSignature)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni, (objectField = jni->GetStaticFieldID(
+                debugeeClass, objectFieldName, debugeeClassSignature)) != NULL)) {
             nsk_jvmti_setFailStatus();
             break;
         }
 
         NSK_DISPLAY1("Find value of static field in debugee class: %s\n", objectFieldName);
         if (!NSK_JNI_VERIFY(jni, (object =
-                NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                 objectField)) != NULL)) {
+                jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
             nsk_jvmti_setFailStatus();
             break;
         }
 
         NSK_DISPLAY0("Calling IterateOverObjectsReachableFromObject with filter JVMTI_HEAP_OBJECT_EITHER\n");
         {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(IterateOverObjectsReachableFromObject,
-                        jvmti,
-                        object,
-                        objectReferenceCallback,
-                        &fakeUserData))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(
+                  object, objectReferenceCallback, &fakeUserData))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -173,8 +165,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj005/iterobjreachobj005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverObjectsReachableFromObject/iterobjreachobj005/iterobjreachobj005.cpp
@@ -52,8 +52,7 @@ objectReferenceCallback( jvmtiObjectReferenceKind reference_kind,
 
     objCounter++;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, st_jvmti, &timer_info1 ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetCurrentThreadCpuTimerInfo(&timer_info1))) {
         nsk_jvmti_setFailStatus();
     }
     /* Check the returned jvmtiTimerInfo structure */
@@ -71,14 +70,12 @@ objectReferenceCallback( jvmtiObjectReferenceKind reference_kind,
     }
     /* ---------------------------------------------------------------------- */
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, st_jvmti, &nanos ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetCurrentThreadCpuTime(&nanos))) {
         nsk_jvmti_setFailStatus();
     }
     /* ---------------------------------------------------------------------- */
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetTimerInfo, st_jvmti, &timer_info2 ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetTimerInfo(&timer_info2))) {
         nsk_jvmti_setFailStatus();
     }
     /* Check the returned jvmtiTimerInfo structure */
@@ -97,8 +94,7 @@ objectReferenceCallback( jvmtiObjectReferenceKind reference_kind,
     /* ---------------------------------------------------------------------- */
 
     nanos = 0;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetTime, st_jvmti, &nanos ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetTime(&nanos))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -131,29 +127,23 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             }
 
             NSK_DISPLAY1("Find static field in debugee class: %s\n", objectFieldName);
-            if (!NSK_JNI_VERIFY(jni, (objectField =
-                    NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                                     objectFieldName, debugeeClassSignature)) != NULL)) {
+            if (!NSK_JNI_VERIFY(jni, (objectField = jni->GetStaticFieldID(
+                    debugeeClass, objectFieldName, debugeeClassSignature)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 break;
             }
 
             NSK_DISPLAY1("Find value of static field in debugee class: %s\n", objectFieldName);
             if (!NSK_JNI_VERIFY(jni, (object =
-                    NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                     objectField)) != NULL)) {
+                    jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 break;
             }
 
             NSK_DISPLAY0("Calling IterateOverObjectsReachableFromObject with filter JVMTI_HEAP_OBJECT_EITHER\n");
             {
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB4(IterateOverObjectsReachableFromObject,
-                            jvmti,
-                            object,
-                            objectReferenceCallback,
-                            &user_data))) {
+                if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(
+                        object, objectReferenceCallback, &user_data))) {
                     nsk_jvmti_setFailStatus();
                 }
             }
@@ -205,8 +195,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         caps.can_tag_objects = 1;
         caps.can_get_current_thread_cpu_time = 1;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj001/iterreachobj001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj001/iterreachobj001.cpp
@@ -87,15 +87,13 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
     count--;
     tag++;
 
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetObjectField, jni, firstObject, firstField)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->GetObjectField(firstObject, firstField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
     objectDescList[count].tag = objTag;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti, obj, objTag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(obj, objTag))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -107,7 +105,7 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
         return NSK_FALSE;
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteLocalRef, jni, obj));
+    NSK_TRACE(jni->DeleteLocalRef(obj));
     return success;
 }
 
@@ -131,9 +129,8 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     *objectsCount = 2 * chainLength;
 
     NSK_DISPLAY1("Allocate memory for objects list: %d objects\n", *objectsCount);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (*objectsCount * sizeof(ObjectDesc)),
-                                                    (unsigned char**)objectDescList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)),
+                                          (unsigned char**)objectDescList))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -148,16 +145,14 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     }
 
     NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... found class: 0x%p\n", (void*)debugeeClass);
 
     NSK_DISPLAY1("Find root object class: %s\n", ROOT_OBJECT_CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (rootObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, ROOT_OBJECT_CLASS_NAME)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (rootObjectClass = jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -165,34 +160,31 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find chain object class: %s\n", CHAIN_OBJECT_CLASS_NAME);
     if (!NSK_JNI_VERIFY(jni, (chainObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... found class: 0x%p\n", (void*)chainObjectClass);
 
     NSK_DISPLAY1("Find static field in debugee class: %s\n", OBJECT_FIELD_NAME);
-    if (!NSK_JNI_VERIFY(jni, (objectField =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                            OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (objectField = jni->GetStaticFieldID(
+            debugeeClass, OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got fieldID: 0x%p\n", (void*)objectField);
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", REACHABLE_CHAIN_FIELD_NAME);
-    if (!NSK_JNI_VERIFY(jni, (reachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (reachableChainField = jni->GetFieldID(
+            rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got fieldID: 0x%p\n", (void*)reachableChainField);
 
     NSK_DISPLAY1("Find instance field in root object class: %s\n", UNREACHABLE_CHAIN_FIELD_NAME);
-    if (!NSK_JNI_VERIFY(jni, (unreachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (unreachableChainField = jni->GetFieldID(
+            rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -200,8 +192,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Find instance field in chain object class: %s\n", TAIL_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (tailField =
-            NSK_CPP_STUB4(GetFieldID, jni, chainObjectClass,
-                            TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(chainObjectClass, TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -209,8 +200,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     NSK_DISPLAY1("Get root object from static field: %s\n", OBJECT_FIELD_NAME);
     if (!NSK_JNI_VERIFY(jni, (rootObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                    objectField)) != NULL)) {
+            jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -288,8 +278,7 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
                                                         ObjectDesc* objectDescList) {
     if (objectDescList != NULL) {
         NSK_DISPLAY1("Deallocate objects list: 0x%p\n", (void*)objectDescList);
-        if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescList))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)objectDescList))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -638,9 +627,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Start iteration over reachable objects\n");
         {
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                                  heapRootCallback, stackReferenceCallback,
-                                  objectReferenceCallback, &fakeUserData))) {
+                    jvmti->IterateOverReachableObjects(heapRootCallback,
+                                                       stackReferenceCallback,
+                                                       objectReferenceCallback,
+                                                       &fakeUserData))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -722,8 +712,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/iterreachobj002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj002/iterreachobj002.cpp
@@ -75,9 +75,7 @@ heapRootCallbackForFirstObjectsIteration( jvmtiHeapRootKind root_kind,
     /* Set tag */
     *tag_ptr = (jlong)++objectCount;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (sizeof(ObjectDesc)),
-                             (unsigned char**)&objectDescBuf))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((sizeof(ObjectDesc)), (unsigned char**)&objectDescBuf))) {
         nsk_jvmti_setFailStatus();
         callbackAborted = 1;
         NSK_COMPLAIN0("heapRootCallbackForFirstObjectsIteration: Allocation failed. Iteration aborted.\n");
@@ -121,8 +119,7 @@ heapRootCallbackForSecondObjectsIteration( jvmtiHeapRootKind root_kind,
                      (long)*tag_ptr, (long)tag, objectCount);
 */
     /* Deallocate memory of list element*/
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescArr[ind]))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)objectDescArr[ind]))) {
         nsk_jvmti_setFailStatus();
         callbackAborted = 1;
         NSK_COMPLAIN0("heapRootCallbackForSecondObjectsIteration: Deallocation failed. Iteration aborted.\n");
@@ -156,9 +153,7 @@ stackReferenceCallbackForFirstObjectsIteration( jvmtiHeapRootKind root_kind,
     /* Set tag */
     *tag_ptr = (jlong)++objectCount;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (sizeof(ObjectDesc)),
-                             (unsigned char**)&objectDescBuf))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((sizeof(ObjectDesc)), (unsigned char**)&objectDescBuf))) {
         nsk_jvmti_setFailStatus();
         callbackAborted = 1;
         NSK_COMPLAIN0("stackReferenceCallbackForFirstObjectsIteration: Allocation failed. Iteration aborted.\n");
@@ -206,8 +201,7 @@ stackReferenceCallbackForSecondObjectsIteration( jvmtiHeapRootKind root_kind,
                      (long)*tag_ptr, (long)tag, objectCount);
 */
     /* Deallocate memory of list element*/
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescArr[ind]))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)objectDescArr[ind]))) {
         nsk_jvmti_setFailStatus();
         callbackAborted = 1;
         NSK_COMPLAIN0("stackReferenceCallbackForSecondObjectsIteration: Deallocation failed. Iteration aborted.\n");
@@ -239,9 +233,7 @@ objectReferenceCallbackForFirstObjectsIteration( jvmtiObjectReferenceKind refere
     /* Set tag */
     *tag_ptr = (jlong)++objectCount;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (sizeof(ObjectDesc)),
-                             (unsigned char**)&objectDescBuf))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((sizeof(ObjectDesc)), (unsigned char**)&objectDescBuf))) {
         nsk_jvmti_setFailStatus();
         callbackAborted = 1;
         NSK_COMPLAIN0("objectReferenceCallbackForFirstObjectsIteration: Allocation failed. Iteration aborted.\n");
@@ -287,8 +279,7 @@ objectReferenceCallbackForSecondObjectsIteration( jvmtiObjectReferenceKind refer
                      (long)*tag_ptr, (long)tag, objectCount);
 */
     /* Deallocate memory of list element*/
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescArr[ind]))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)objectDescArr[ind]))) {
         nsk_jvmti_setFailStatus();
         callbackAborted = 1;
         NSK_COMPLAIN0("objectReferenceCallbackForSecondObjectsIteration: Deallocation failed. Iteration aborted.\n");
@@ -320,9 +311,8 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     {
         do {
             /* Allocate memory for first element of objectList */
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(Allocate, jvmti, (sizeof(ObjectDesc)),
-                                      (unsigned char**)&objectDescBuf))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Allocate((sizeof(ObjectDesc)),
+                                                  (unsigned char**)&objectDescBuf))) {
                 nsk_jvmti_setFailStatus();
                 break;
             }
@@ -331,13 +321,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY0("Calling IterateOverReachableObjects with allocating object descriptors\n");
             {
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB5(IterateOverReachableObjects,
-                                      jvmti,
-                                      heapRootCallbackForFirstObjectsIteration,
-                                      stackReferenceCallbackForFirstObjectsIteration,
-                                      objectReferenceCallbackForFirstObjectsIteration,
-                                      &userData))) {
+                if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(
+                        heapRootCallbackForFirstObjectsIteration,
+                        stackReferenceCallbackForFirstObjectsIteration,
+                        objectReferenceCallbackForFirstObjectsIteration,
+                        &userData))) {
                     nsk_jvmti_setFailStatus();
                     break;
                 }
@@ -357,25 +345,22 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             objectCountMax = objectCount;
 
             /* Deallocate last unnecessary descriptor */
-            if (!NSK_JVMTI_VERIFY(
-                   NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescList))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)objectDescList))) {
                 NSK_COMPLAIN0("Unable to deallocate last unnecessary descriptor. \n");
                 nsk_jvmti_setFailStatus();
                 break;
             }
 
             /* Allocate memory for array to save pointers to ObjectDescList elements */
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(Allocate, jvmti, (objectCount * sizeof(ObjectDesc*)),
-                                      (unsigned char**)&objectDescArr))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Allocate((objectCount * sizeof(ObjectDesc*)),
+                                                  (unsigned char**)&objectDescArr))) {
                 nsk_jvmti_setFailStatus();
                 break;
             }
 
             /* Allocate memory for flags array and fill with false values */
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(Allocate, jvmti, (objectCountMax * sizeof(short)),
-                                      (unsigned char**)&deallocatedFlagsArr))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Allocate((objectCountMax * sizeof(short)),
+                                                  (unsigned char**)&deallocatedFlagsArr))) {
                 nsk_jvmti_setFailStatus();
                 break;
             }
@@ -395,13 +380,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY0("Calling IterateOverReachableObjects with deallocating object descriptors\n");
             {
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB5(IterateOverReachableObjects,
-                                      jvmti,
-                                      heapRootCallbackForSecondObjectsIteration,
-                                      stackReferenceCallbackForSecondObjectsIteration,
-                                      objectReferenceCallbackForSecondObjectsIteration,
-                                      &userData))) {
+                if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(
+                    heapRootCallbackForSecondObjectsIteration,
+                    stackReferenceCallbackForSecondObjectsIteration,
+                    objectReferenceCallbackForSecondObjectsIteration,
+                    &userData))) {
                     nsk_jvmti_setFailStatus();
                     break;
                 }
@@ -415,8 +398,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             for (ind = 0; ind < objectCountMax; ind++) {
                 if (!deallocatedFlagsArr[ind]) {
-                    if (!NSK_JVMTI_VERIFY(
-                           NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescArr[ind]))) {
+                    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)objectDescArr[ind]))) {
                         NSK_COMPLAIN1("Unable to deallocate descriptor. Index = %d \n", ind);
                         nsk_jvmti_setFailStatus();
                         return;
@@ -424,13 +406,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
                 }
             }
 
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescArr))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)objectDescArr))) {
                 nsk_jvmti_setFailStatus();
             }
 
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)deallocatedFlagsArr))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)deallocatedFlagsArr))) {
                 nsk_jvmti_setFailStatus();
             }
 
@@ -472,13 +452,11 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(caps));
     caps.can_tag_objects = 1;
     caps.can_generate_object_free_events = 1;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_tag_objects)
@@ -491,15 +469,15 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     (void) memset(&callbacks, 0, sizeof(callbacks));
 
     callbacks.ObjectFree = &ObjectFree;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done.\n");
 
     NSK_DISPLAY0("enabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_OBJECT_FREE,
+                                                          NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done.\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj003/iterreachobj003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj003/iterreachobj003.cpp
@@ -54,55 +54,46 @@ heapRootCallback( jvmtiHeapRootKind root_kind,
 
     *tag_ptr = (jlong)++objCounter;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, st_jvmti, "heapRootMonitor", &monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->CreateRawMonitor("heapRootMonitor", &monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorEnter(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     /* Enter second time */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorEnter(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RawMonitorWait, st_jvmti, monitor_ptr, (jlong)1))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorWait(monitor_ptr, (jlong)1))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorNotify, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorNotify(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorNotifyAll, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorNotifyAll(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorExit(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     /* Exit second time */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorExit(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->DestroyRawMonitor(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 /*
@@ -127,55 +118,46 @@ stackReferenceCallback( jvmtiHeapRootKind root_kind,
 
     *tag_ptr = (jlong)++objCounter;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, st_jvmti, "stackRefMonitor", &monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->CreateRawMonitor("stackRefMonitor", &monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorEnter(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     /* Enter second time */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorEnter(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RawMonitorWait, st_jvmti, monitor_ptr, (jlong)1))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorWait(monitor_ptr, (jlong)1))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorNotify, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorNotify(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorNotifyAll, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorNotifyAll(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorExit(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     /* Exit second time */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorExit(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->DestroyRawMonitor(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 /*
@@ -199,55 +181,46 @@ objectReferenceCallback( jvmtiObjectReferenceKind reference_kind,
 
     *tag_ptr = (jlong)++objCounter;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, st_jvmti, "objRefMonitor", &monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->CreateRawMonitor("objRefMonitor", &monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorEnter(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     /* Enter second time */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorEnter(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RawMonitorWait, st_jvmti, monitor_ptr, (jlong)1))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorWait(monitor_ptr, (jlong)1))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorNotify, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorNotify(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorNotifyAll, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorNotifyAll(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorExit(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
     /* Exit second time */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->RawMonitorExit(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, st_jvmti, monitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->DestroyRawMonitor(monitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -270,12 +243,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             NSK_DISPLAY0("Calling IterateOverReachableObjects\n");
             {
                 if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB5(IterateOverReachableObjects,
-                                      jvmti,
-                                      heapRootCallback,
-                                      stackReferenceCallback,
-                                      objectReferenceCallback,
-                                      &userData))) {
+                        jvmti->IterateOverReachableObjects(heapRootCallback,
+                                                           stackReferenceCallback,
+                                                           objectReferenceCallback,
+                                                           &userData))) {
                     nsk_jvmti_setFailStatus();
                     break;
                 }
@@ -333,8 +304,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj004/iterreachobj004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj004/iterreachobj004.cpp
@@ -54,14 +54,12 @@ heapRootCallback( jvmtiHeapRootKind root_kind,
 
     *tag_ptr = (jlong)++objCounter;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(SetEnvironmentLocalStorage, st_jvmti, storage_data ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->SetEnvironmentLocalStorage(storage_data))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetEnvironmentLocalStorage, st_jvmti, &storage_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetEnvironmentLocalStorage(&storage_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
@@ -100,14 +98,12 @@ stackReferenceCallback( jvmtiHeapRootKind root_kind,
 
     *tag_ptr = (jlong)++objCounter;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(SetEnvironmentLocalStorage, st_jvmti, storage_data ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->SetEnvironmentLocalStorage(storage_data))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetEnvironmentLocalStorage, st_jvmti, &storage_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetEnvironmentLocalStorage(&storage_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
@@ -145,14 +141,12 @@ objectReferenceCallback( jvmtiObjectReferenceKind reference_kind,
 
     *tag_ptr = (jlong)++objCounter;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(SetEnvironmentLocalStorage, st_jvmti, storage_data ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->SetEnvironmentLocalStorage(storage_data))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetEnvironmentLocalStorage, st_jvmti, &storage_ptr))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetEnvironmentLocalStorage(&storage_ptr))) {
         nsk_jvmti_setFailStatus();
         return JVMTI_ITERATION_ABORT;
     }
@@ -190,12 +184,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             NSK_DISPLAY0("Calling IterateOverReachableObjects\n");
             {
                 if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB5(IterateOverReachableObjects,
-                                      jvmti,
-                                      heapRootCallback,
-                                      stackReferenceCallback,
-                                      objectReferenceCallback,
-                                      &userData))) {
+                        jvmti->IterateOverReachableObjects(heapRootCallback,
+                                                           stackReferenceCallback,
+                                                           objectReferenceCallback,
+                                                           &userData))) {
                     nsk_jvmti_setFailStatus();
                     break;
                 }
@@ -253,8 +245,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj005/iterreachobj005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateOverReachableObjects/iterreachobj005/iterreachobj005.cpp
@@ -53,8 +53,7 @@ heapRootCallback( jvmtiHeapRootKind root_kind,
 
     if (!nsk_jvmti_isFailStatus()) {
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, st_jvmti, &timer_info1 ))) {
+        if (!NSK_JVMTI_VERIFY(st_jvmti->GetCurrentThreadCpuTimerInfo(&timer_info1))) {
             nsk_jvmti_setFailStatus();
         }
         /* Check the returned jvmtiTimerInfo structure */
@@ -72,14 +71,12 @@ heapRootCallback( jvmtiHeapRootKind root_kind,
         }
         /* ---------------------------------------------------------------------- */
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(GetCurrentThreadCpuTime, st_jvmti, &nanos ))) {
+        if (!NSK_JVMTI_VERIFY(st_jvmti->GetCurrentThreadCpuTime(&nanos))) {
             nsk_jvmti_setFailStatus();
         }
         /* ---------------------------------------------------------------------- */
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(GetTimerInfo, st_jvmti, &timer_info2 ))) {
+        if (!NSK_JVMTI_VERIFY(st_jvmti->GetTimerInfo(&timer_info2))) {
             nsk_jvmti_setFailStatus();
         }
         /* Check the returned jvmtiTimerInfo structure */
@@ -98,8 +95,7 @@ heapRootCallback( jvmtiHeapRootKind root_kind,
         /* ---------------------------------------------------------------------- */
 
         nanos = 0;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(GetTime, st_jvmti, &nanos ))) {
+        if (!NSK_JVMTI_VERIFY(st_jvmti->GetTime(&nanos))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -126,8 +122,7 @@ stackReferenceCallback( jvmtiHeapRootKind root_kind,
 
     if (!nsk_jvmti_isFailStatus()) {
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, st_jvmti, &timer_info1 ))) {
+        if (!NSK_JVMTI_VERIFY(st_jvmti->GetCurrentThreadCpuTimerInfo(&timer_info1))) {
             nsk_jvmti_setFailStatus();
         }
         /* Check the returned jvmtiTimerInfo structure */
@@ -145,14 +140,12 @@ stackReferenceCallback( jvmtiHeapRootKind root_kind,
         }
         /* ---------------------------------------------------------------------- */
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(GetCurrentThreadCpuTime, st_jvmti, &nanos ))) {
+        if (!NSK_JVMTI_VERIFY(st_jvmti->GetCurrentThreadCpuTime(&nanos))) {
             nsk_jvmti_setFailStatus();
         }
         /* ---------------------------------------------------------------------- */
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(GetTimerInfo, st_jvmti, &timer_info2 ))) {
+        if (!NSK_JVMTI_VERIFY(st_jvmti->GetTimerInfo(&timer_info2))) {
             nsk_jvmti_setFailStatus();
         }
         /* Check the returned jvmtiTimerInfo structure */
@@ -171,8 +164,7 @@ stackReferenceCallback( jvmtiHeapRootKind root_kind,
         /* ---------------------------------------------------------------------- */
 
         nanos = 0;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(GetTime, st_jvmti, &nanos ))) {
+        if (!NSK_JVMTI_VERIFY(st_jvmti->GetTime(&nanos))) {
             nsk_jvmti_setFailStatus();
         }
    }
@@ -196,8 +188,7 @@ objectReferenceCallback( jvmtiObjectReferenceKind reference_kind,
 
     *tag_ptr = (jlong)++objCounter;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTimerInfo, st_jvmti, &timer_info1 ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetCurrentThreadCpuTimerInfo(&timer_info1))) {
         nsk_jvmti_setFailStatus();
     }
     /* Check the returned jvmtiTimerInfo structure */
@@ -215,15 +206,13 @@ objectReferenceCallback( jvmtiObjectReferenceKind reference_kind,
     }
     /* ---------------------------------------------------------------------- */
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCurrentThreadCpuTime, st_jvmti, &nanos ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetCurrentThreadCpuTime(&nanos))) {
         nsk_jvmti_setFailStatus();
     }
     /* ---------------------------------------------------------------------- */
 
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetTimerInfo, st_jvmti, &timer_info2 ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetTimerInfo(&timer_info2))) {
         nsk_jvmti_setFailStatus();
     }
     /* Check the returned jvmtiTimerInfo structure */
@@ -242,8 +231,7 @@ objectReferenceCallback( jvmtiObjectReferenceKind reference_kind,
     /* ---------------------------------------------------------------------- */
 
     nanos = 0;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetTime, st_jvmti, &nanos ))) {
+    if (!NSK_JVMTI_VERIFY(st_jvmti->GetTime(&nanos))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -265,13 +253,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         do {
             NSK_DISPLAY0("Calling IterateOverReachableObjects\n");
             {
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB5(IterateOverReachableObjects,
-                                      jvmti,
-                                      heapRootCallback,
-                                      stackReferenceCallback,
-                                      objectReferenceCallback,
-                                      &userData))) {
+                if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(heapRootCallback,
+                                                                         stackReferenceCallback,
+                                                                         objectReferenceCallback,
+                                                                         &userData))) {
                     nsk_jvmti_setFailStatus();
                     break;
                 }
@@ -330,8 +315,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
         caps.can_get_current_thread_cpu_time = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/abort/Abort.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/abort/Abort.cpp
@@ -95,8 +95,7 @@ agent(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
   primitive_callbacks.heap_iteration_callback = &heap_callback;
 
   NSK_DISPLAY0("Iterating over reachable objects.\n");
-  if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(IterateThroughHeap, jvmti,
-                                     0, NULL, &primitive_callbacks, &invocations))) {
+  if(!NSK_JVMTI_VERIFY(jvmti->IterateThroughHeap(0, NULL, &primitive_callbacks, &invocations))) {
     nsk_jvmti_setFailStatus();
     return;
   }
@@ -139,14 +138,12 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
   caps.can_tag_objects = 1;
   caps.can_generate_object_free_events = 1;
 
-  if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+  if(!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
     return JNI_ERR;
   }
 
   memset(&event_callbacks, 0, sizeof(jvmtiEventCallbacks));
-  if(!NSK_JVMTI_VERIFY(
-                       NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                     &event_callbacks, sizeof(jvmtiEventCallbacks)))) {
+  if(!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&event_callbacks, sizeof(jvmtiEventCallbacks)))) {
     return JNI_ERR;
   }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/concrete-klass-filter/ConcreteKlassFilter.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/concrete-klass-filter/ConcreteKlassFilter.cpp
@@ -152,36 +152,26 @@ int tag_objects(jvmtiEnv *jvmti, JNIEnv *jni) {
   jobject testObject;
   jclass testObjectClass;
 
-  if(!NSK_VERIFY(NULL !=
-                 (debugee = NSK_CPP_STUB2(FindClass, jni, className))))
+  if(!NSK_VERIFY(NULL != (debugee = jni->FindClass(className))))
     return JNI_ERR;
 
-  if(!NSK_VERIFY(NULL !=
-                 (testObjectField = NSK_CPP_STUB4(GetStaticFieldID,
-                                                   jni, debugee,
-                                                   fieldName,
-                                                   fieldSig))))
+  if(!NSK_VERIFY(NULL != (testObjectField = jni->GetStaticFieldID(debugee, fieldName, fieldSig))))
     return JNI_ERR;
 
-  if(!NSK_VERIFY(NULL !=
-                 (testObject = (NSK_CPP_STUB3(GetStaticObjectField,
-                                               jni, debugee,
-                                               testObjectField)))))
+  if(!NSK_VERIFY(NULL != (testObject = (jni->GetStaticObjectField(debugee, testObjectField)))))
     return JNI_ERR;
 
-  if(!NSK_VERIFY(NULL !=
-                 (testObjectClass = (NSK_CPP_STUB2(GetObjectClass,
-                                                   jni, testObject)))))
+  if(!NSK_VERIFY(NULL != (testObjectClass = (jni->GetObjectClass(testObject)))))
     return JNI_ERR;
 
   // tag class and it's instance to pass this tag into primitive field callback
-  if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, testObject, TEST_OBJECT_TAG)))
+  if(!NSK_JVMTI_VERIFY(jvmti->SetTag(testObject, TEST_OBJECT_TAG)))
     return JNI_ERR;
-  if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, testObjectClass, TEST_OBJECT_TAG)))
+  if(!NSK_JVMTI_VERIFY(jvmti->SetTag(testObjectClass, TEST_OBJECT_TAG)))
     return JNI_ERR;
 
-  NSK_CPP_STUB2(DeleteLocalRef, jni, testObjectClass);
-  NSK_CPP_STUB2(DeleteLocalRef, jni, testObject);
+  jni->DeleteLocalRef(testObjectClass);
+  jni->DeleteLocalRef(testObject);
 
   return JNI_OK;
 }
@@ -207,7 +197,7 @@ agent(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
   jvmtiHeapCallbacks primitive_callbacks;
   jclass klass;
 
-  if(!NSK_VERIFY(NULL != (klass = NSK_CPP_STUB2(FindClass,jni,testClassName)))) {
+  if(!NSK_VERIFY(NULL != (klass = jni->FindClass(testClassName)))) {
     NSK_COMPLAIN1("Can't find class %s.\n",testClassName);
     nsk_jvmti_setFailStatus();
     return;
@@ -233,8 +223,7 @@ agent(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
   primitive_callbacks.heap_iteration_callback = &heap_callback;
 
   NSK_DISPLAY0("Iterating over reachable objects.\n");
-  if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(IterateThroughHeap, jvmti,
-                                     0, klass, &primitive_callbacks, NULL))) {
+  if(!NSK_JVMTI_VERIFY(jvmti->IterateThroughHeap(0, klass, &primitive_callbacks, NULL))) {
     nsk_jvmti_setFailStatus();
     return;
   }
@@ -251,8 +240,7 @@ agent(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
   }
 
   NSK_DISPLAY0("Iterating over unreachable objects.\n");
-  if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(IterateThroughHeap, jvmti,
-                                     0, klass, &primitive_callbacks, NULL))) {
+  if(!NSK_JVMTI_VERIFY(jvmti->IterateThroughHeap(0, klass, &primitive_callbacks, NULL))) {
     nsk_jvmti_setFailStatus();
     return;
   }
@@ -292,15 +280,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
   caps.can_tag_objects = 1;
   caps.can_generate_object_free_events = 1;
 
-  if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+  if(!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
     return JNI_ERR;
   }
 
   memset(&event_callbacks, 0, sizeof(jvmtiEventCallbacks));
   event_callbacks.ObjectFree = &object_free_callback;
-  if(!NSK_JVMTI_VERIFY(
-                       NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                     &event_callbacks, sizeof(jvmtiEventCallbacks)))) {
+  if(!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&event_callbacks, sizeof(jvmtiEventCallbacks)))) {
     return JNI_ERR;
   }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/non-concrete-klass-filter/NonConcreteKlassFilter.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/non-concrete-klass-filter/NonConcreteKlassFilter.cpp
@@ -156,14 +156,13 @@ agent(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
   phase = ZERO_INVOCATIONS_PHASE;
   for(i = 0; i < FILTER_COUNT; i++) {
-    if(!NSK_VERIFY(NULL != (klass = NSK_CPP_STUB2(FindClass, jni, types[i])))) {
+    if(!NSK_VERIFY(NULL != (klass = jni->FindClass(types[i])))) {
       NSK_COMPLAIN1("Can't find class %s.\n",types[i]);
       nsk_jvmti_setFailStatus();
       return;
     }
     NSK_DISPLAY1("Iterating through heap with klass-filter '%s'.\n",types[i]);
-    if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(IterateThroughHeap, jvmti,
-                                       0, klass, &primitive_callbacks, NULL))) {
+    if(!NSK_JVMTI_VERIFY(jvmti->IterateThroughHeap(0, klass, &primitive_callbacks, NULL))) {
       nsk_jvmti_setFailStatus();
       return;
     }
@@ -171,13 +170,12 @@ agent(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
   phase = STATIC_FIELDS_FINDING_PHASE;
   NSK_DISPLAY0("Iterating through heap with klass-filter 'java/lang/Class'.\n");
-  if(!NSK_VERIFY(NULL != (klass = NSK_CPP_STUB2(FindClass, jni, "java/lang/Class")))) {
+  if(!NSK_VERIFY(NULL != (klass = jni->FindClass("java/lang/Class")))) {
     NSK_COMPLAIN0("Can't find class java/lang/Class.\n");
     nsk_jvmti_setFailStatus();
     return;
   }
-  if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(IterateThroughHeap, jvmti,
-                                     0, klass, &primitive_callbacks, NULL))) {
+  if(!NSK_JVMTI_VERIFY(jvmti->IterateThroughHeap(0, klass, &primitive_callbacks, NULL))) {
     nsk_jvmti_setFailStatus();
     return;
   }
@@ -222,14 +220,12 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
   caps.can_tag_objects = 1;
   caps.can_generate_object_free_events = 1;
 
-  if(!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+  if(!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
     return JNI_ERR;
   }
 
   memset(&event_callbacks, 0, sizeof(jvmtiEventCallbacks));
-  if(!NSK_JVMTI_VERIFY(
-                       NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                     &event_callbacks, sizeof(jvmtiEventCallbacks)))) {
+  if(!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&event_callbacks, sizeof(jvmtiEventCallbacks)))) {
     return JNI_ERR;
   }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MonitorContendedEnter/mcontenter001/mcontenter001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MonitorContendedEnter/mcontenter001/mcontenter001.cpp
@@ -55,8 +55,8 @@ MonitorContendedEnter(jvmtiEnv *jvmti, JNIEnv* jni, jthread thr, jobject obj) {
     }
 
     /* check if event is for tested thread and for tested object */
-    if (NSK_CPP_STUB3(IsSameObject, jni, thread, thr) &&
-        NSK_CPP_STUB3(IsSameObject, jni, object, obj))
+    if (jni->IsSameObject(thread, thr) &&
+        jni->IsSameObject(object, obj))
             eventsCount++;
 }
 
@@ -74,8 +74,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -87,8 +86,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -100,8 +98,7 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     if (thread == NULL) {
@@ -110,35 +107,30 @@ static int prepare() {
     }
 
     /* make thread accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (thread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'endingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "endingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "endingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     /* get 'endingMonitor' object */
-    if (!NSK_JNI_VERIFY(jni, (object =
-            NSK_CPP_STUB3(GetObjectField, jni, thread, field)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object = jni->GetObjectField(thread, field)) != NULL))
         return NSK_FALSE;
 
     /* make object accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (object =
-            NSK_CPP_STUB2(NewGlobalRef, jni, object)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object = jni->NewGlobalRef(object)) != NULL))
         return NSK_FALSE;
 
     /* enable MonitorContendedEnter event */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_MONITOR_CONTENDED_ENTER,
+                                                          NULL)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -147,9 +139,9 @@ static int prepare() {
 static int clean() {
 
     /* disable MonitorContendedEnter event */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_DISABLE,
+                                                          JVMTI_EVENT_MONITOR_CONTENDED_ENTER,
+                                                          NULL)))
         nsk_jvmti_setFailStatus();
 
     return NSK_TRUE;
@@ -228,14 +220,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
             nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetPotentialCapabilities, jvmti,&caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!NSK_VERIFY(caps.can_generate_monitor_events))
@@ -243,9 +234,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.MonitorContendedEnter = &MonitorContendedEnter;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MonitorContendedEntered/mcontentered001/mcontentered001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MonitorContendedEntered/mcontentered001/mcontentered001.cpp
@@ -57,8 +57,8 @@ MonitorContendedEntered(jvmtiEnv *jvmti, JNIEnv* jni, jthread thr, jobject obj) 
     }
 
     /* check if event is for tested thread and for tested object */
-    if (NSK_CPP_STUB3(IsSameObject, jni, thread, thr) &&
-        NSK_CPP_STUB3(IsSameObject, jni, object, obj))
+    if (jni->IsSameObject(thread, thr) &&
+        jni->IsSameObject(object, obj))
             eventsCount++;
 }
 
@@ -74,8 +74,8 @@ MonitorContendedEnter(jvmtiEnv *jvmti, JNIEnv* jni, jthread thr, jobject obj) {
     }
 
     /* check if event is for tested thread and for tested object */
-    if (NSK_CPP_STUB3(IsSameObject, jni, thread, thr) &&
-        NSK_CPP_STUB3(IsSameObject, jni, object, obj))
+    if (jni->IsSameObject(thread, thr) &&
+        jni->IsSameObject(object, obj))
             eventsCount++;
 }
 
@@ -94,8 +94,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -107,8 +106,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -120,8 +118,7 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     if (thread == NULL) {
@@ -130,41 +127,36 @@ static int prepare() {
     }
 
     /* make thread accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (thread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'endingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "endingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "endingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     /* get 'endingMonitor' object */
-    if (!NSK_JNI_VERIFY(jni, (object =
-            NSK_CPP_STUB3(GetObjectField, jni, thread, field)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object = jni->GetObjectField(thread, field)) != NULL))
         return NSK_FALSE;
 
     /* make object accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (object =
-            NSK_CPP_STUB2(NewGlobalRef, jni, object)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object = jni->NewGlobalRef(object)) != NULL))
         return NSK_FALSE;
 
     /* enable MonitorContendedEntered event */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_MONITOR_CONTENDED_ENTERED,
+                                                          NULL)))
         return NSK_FALSE;
 
     /* enable MonitorContendedEnter event */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_MONITOR_CONTENDED_ENTER,
+                                                          NULL)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -173,9 +165,9 @@ static int prepare() {
 static int clean() {
 
     /* disable MonitorContendedEntered event */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_DISABLE,
+                                                          JVMTI_EVENT_MONITOR_CONTENDED_ENTERED,
+                                                          NULL)))
         nsk_jvmti_setFailStatus();
 
     return NSK_TRUE;
@@ -254,14 +246,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
             nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetPotentialCapabilities, jvmti,&caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!NSK_VERIFY(caps.can_generate_monitor_events))
@@ -271,9 +262,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.MonitorContendedEntered = &MonitorContendedEntered;
     callbacks.MonitorContendedEnter = &MonitorContendedEnter;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MonitorWait/monitorwait001/monitorwait001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MonitorWait/monitorwait001/monitorwait001.cpp
@@ -55,8 +55,8 @@ MonitorWait(jvmtiEnv *jvmti, JNIEnv* jni, jthread thr, jobject obj, jlong tout) 
     }
 
     /* check if event is for tested thread and for tested object */
-    if (NSK_CPP_STUB3(IsSameObject, jni, thread, thr) &&
-            NSK_CPP_STUB3(IsSameObject, jni, object, obj)) {
+    if (jni->IsSameObject(thread, thr) &&
+            jni->IsSameObject(object, obj)) {
         eventsCount++;
         if (tout != timeout) {
             NSK_COMPLAIN1("Unexpected timeout value: %d\n", (int)tout);
@@ -79,8 +79,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -92,8 +91,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -105,8 +103,7 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     if (thread == NULL) {
@@ -115,35 +112,29 @@ static int prepare() {
     }
 
     /* make thread accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (thread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     /* get 'waitingMonitor' object */
-    if (!NSK_JNI_VERIFY(jni, (object =
-            NSK_CPP_STUB3(GetObjectField, jni, thread, field)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object = jni->GetObjectField(thread, field)) != NULL))
         return NSK_FALSE;
 
     /* make object accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (object =
-            NSK_CPP_STUB2(NewGlobalRef, jni, object)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object = jni->NewGlobalRef(object)) != NULL))
         return NSK_FALSE;
 
     /* enable MonitorWait event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_MONITOR_WAIT, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAIT, NULL)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -153,8 +144,7 @@ static int clean() {
 
     /* disable MonitorWait event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                JVMTI_EVENT_MONITOR_WAIT, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_WAIT, NULL)))
         nsk_jvmti_setFailStatus();
 
     return NSK_TRUE;
@@ -233,14 +223,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
             nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetPotentialCapabilities, jvmti,&caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!NSK_VERIFY(caps.can_generate_monitor_events))
@@ -248,9 +237,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.MonitorWait = &MonitorWait;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MonitorWaited/monitorwaited001/monitorwaited001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/MonitorWaited/monitorwaited001/monitorwaited001.cpp
@@ -56,8 +56,8 @@ MonitorWaited(jvmtiEnv *jvmti, JNIEnv* jni,
     }
 
     /* check if event is for tested thread and for tested object */
-    if (NSK_CPP_STUB3(IsSameObject, jni, thread, thr) &&
-            NSK_CPP_STUB3(IsSameObject, jni, object, obj)) {
+    if (jni->IsSameObject(thread, thr) &&
+            jni->IsSameObject(object, obj)) {
         eventsCount++;
         if (timed_out == JNI_TRUE) {
             NSK_COMPLAIN0("Unexpected timed_out value: true\n");
@@ -80,8 +80,7 @@ static int prepare() {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -93,8 +92,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -106,8 +104,7 @@ static int prepare() {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     if (thread == NULL) {
@@ -116,35 +113,29 @@ static int prepare() {
     }
 
     /* make thread accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (thread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread field 'waitingMonitor' */
     if (!NSK_JNI_VERIFY(jni, (field =
-            NSK_CPP_STUB4(GetFieldID, jni, klass,
-                "waitingMonitor", "Ljava/lang/Object;")) != NULL))
+            jni->GetFieldID(klass, "waitingMonitor", "Ljava/lang/Object;")) != NULL))
         return NSK_FALSE;
 
     /* get 'waitingMonitor' object */
-    if (!NSK_JNI_VERIFY(jni, (object =
-            NSK_CPP_STUB3(GetObjectField, jni, thread, field)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object = jni->GetObjectField(thread, field)) != NULL))
         return NSK_FALSE;
 
     /* make object accessable for a long time */
-    if (!NSK_JNI_VERIFY(jni, (object =
-            NSK_CPP_STUB2(NewGlobalRef, jni, object)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (object = jni->NewGlobalRef(object)) != NULL))
         return NSK_FALSE;
 
     /* enable MonitorWaited event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_MONITOR_WAITED, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAITED, NULL)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -154,8 +145,7 @@ static int clean() {
 
     /* disable MonitorWaited event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                JVMTI_EVENT_MONITOR_WAITED, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_WAITED, NULL)))
         nsk_jvmti_setFailStatus();
 
     return NSK_TRUE;
@@ -234,14 +224,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
             nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetPotentialCapabilities, jvmti,&caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!NSK_VERIFY(caps.can_generate_monitor_events))
@@ -249,9 +238,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.MonitorWaited = &MonitorWaited;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind001/nativemethbind001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind001/nativemethbind001.cpp
@@ -59,17 +59,13 @@ static jvmtiEventCallbacks callbacks;
 static jrawMonitorID countLock;
 
 static void lock(jvmtiEnv *jvmti_env, JNIEnv *jni_env) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter,
-            jvmti_env, countLock)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "failed to enter a raw monitor\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(countLock)))
+        jni_env->FatalError("failed to enter a raw monitor\n");
 }
 
 static void unlock(jvmtiEnv *jvmti_env, JNIEnv *jni_env) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit,
-            jvmti_env, countLock)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "failed to exit a raw monitor\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(countLock)))
+        jni_env->FatalError("failed to exit a raw monitor\n");
 }
 
 /** callback functions **/
@@ -84,7 +80,7 @@ NativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     NSK_DISPLAY0(">>>> NativeMethodBind event received\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         result = STATUS_FAILED;
         unlock(jvmti_env, jni_env);
         return;
@@ -95,8 +91,7 @@ NativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &methNam, &methSig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &methNam, &methSig, NULL))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to get method name during NativeMethodBind callback\n\n");
         unlock(jvmti_env, jni_env);
@@ -118,13 +113,11 @@ NativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         }
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) methNam))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methNam))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method name\n\n");
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) methSig))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methSig))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method signature\n\n");
     }
@@ -152,8 +145,7 @@ Java_nsk_jvmti_NativeMethodBind_nativemethbind001_nativeMethod(
 
     if (registerNative == JNI_TRUE) {
         NSK_DISPLAY1("Finding class \"%s\" ...\n", CLASS_SIG);
-        if (!NSK_JNI_VERIFY(env, (testedCls =
-                NSK_CPP_STUB2(FindClass, env, CLASS_SIG)) != NULL)) {
+        if (!NSK_JNI_VERIFY(env, (testedCls = env->FindClass(CLASS_SIG)) != NULL)) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILURE: unable to find class \"%s\"\n\n",
                 CLASS_SIG);
@@ -167,8 +159,7 @@ Java_nsk_jvmti_NativeMethodBind_nativemethbind001_nativeMethod(
         NSK_DISPLAY3("Calling RegisterNatives() with \"%s %s\"\n"
                      "\tfor class \"%s\" ...\n",
             METHODS[1][0], METHODS[1][1], CLASS_SIG);
-        if (!NSK_JNI_VERIFY_VOID(env, (NSK_CPP_STUB4(RegisterNatives,
-                env, testedCls, &meth, 1)) != 0)) {
+        if (!NSK_JNI_VERIFY_VOID(env, (env->RegisterNatives(testedCls, &meth, 1)) != 0)) {
             result = STATUS_FAILED;
             NSK_COMPLAIN3("TEST FAILURE: unable to RegisterNatives() \"%s %s\" for class \"%s\"\n\n",
                 METHODS[1][0], METHODS[1][1], CLASS_SIG);
@@ -221,19 +212,16 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
     /* create a raw monitor */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor,
-            jvmti, "_counter_lock", &countLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_counter_lock", &countLock)))
         return JNI_ERR;
 
     /* add capability to generate compiled method events */
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_native_method_bind_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.can_generate_native_method_bind_events)
         NSK_DISPLAY0("Warning: generation of native method bind events is not implemented\n");
@@ -242,13 +230,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("setting event callbacks ...\n");
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.NativeMethodBind = &NativeMethodBind;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_NATIVE_METHOD_BIND, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_NATIVE_METHOD_BIND,
+                                                          NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind002/nativemethbind002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind002/nativemethbind002.cpp
@@ -42,17 +42,13 @@ static jvmtiEventCallbacks callbacks;
 static jrawMonitorID countLock;
 
 static void lock(jvmtiEnv *jvmti_env, JNIEnv *jni_env) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter,
-            jvmti_env, countLock)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "failed to enter a raw monitor\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(countLock)))
+        jni_env->FatalError("failed to enter a raw monitor\n");
 }
 
 static void unlock(jvmtiEnv *jvmti_env, JNIEnv *jni_env) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit,
-            jvmti_env, countLock)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "failed to exit a raw monitor\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(countLock)))
+        jni_env->FatalError("failed to exit a raw monitor\n");
 }
 
 /** callback functions **/
@@ -64,8 +60,7 @@ NativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     lock(jvmti_env, jni_env);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase,
-            jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0(
             "TEST FAILED: unable to obtain phase of the VM execution\n"
@@ -79,8 +74,7 @@ NativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &methNam, &methSig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &methNam, &methSig, NULL))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to get method name during NativeMethodBind callback\n\n");
     }
@@ -89,12 +83,10 @@ NativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
             methNam, methSig);
 
     if (!(methNam==NULL))
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*) methNam)))
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methNam)))
             NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method name\n\n");
     if (!(methSig==NULL))
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*) methSig)))
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methSig)))
             NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method signature\n\n");
 
     unlock(jvmti_env, jni_env);
@@ -149,19 +141,16 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
     /* create a raw monitor */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor,
-            jvmti, "_counter_lock", &countLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_counter_lock", &countLock)))
         return JNI_ERR;
 
     /* add capability to generate compiled method events */
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_native_method_bind_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.can_generate_native_method_bind_events)
         NSK_DISPLAY0("Warning: generation of native method bind events is not implemented\n");
@@ -171,16 +160,17 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.NativeMethodBind = &NativeMethodBind;
     callbacks.VMDeath = &VMDeath;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_NATIVE_METHOD_BIND, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_NATIVE_METHOD_BIND,
+                                                          NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_VM_DEATH,
+                                                          NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind004/nativemethbind004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeMethodBind/nativemethbind004/nativemethbind004.cpp
@@ -67,17 +67,13 @@ redirNativeMethod(JNIEnv *env, jobject obj) {
 }
 
 static void lock(jvmtiEnv *jvmti_env, JNIEnv *jni_env) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter,
-            jvmti_env, countLock)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "failed to enter a raw monitor\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(countLock)))
+        jni_env->FatalError("failed to enter a raw monitor\n");
 }
 
 static void unlock(jvmtiEnv *jvmti_env, JNIEnv *jni_env) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit,
-            jvmti_env, countLock)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "failed to exit a raw monitor\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(countLock)))
+        jni_env->FatalError("failed to exit a raw monitor\n");
 }
 
 /** callback functions **/
@@ -90,7 +86,7 @@ NativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     NSK_DISPLAY0(">>>> NativeMethodBind event received\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         result = STATUS_FAILED;
         unlock(jvmti_env, jni_env);
         return;
@@ -101,8 +97,7 @@ NativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &methNam, &methSig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &methNam, &methSig, NULL))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to get method name during NativeMethodBind callback\n\n");
         unlock(jvmti_env, jni_env);
@@ -117,13 +112,11 @@ NativeMethodBind(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         *new_addr = (void*) redirNativeMethod;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) methNam))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methNam))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory storing method name\n\n");
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) methSig))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methSig))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory storing method signature\n\n");
     }
@@ -190,19 +183,16 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
     /* create a raw monitor */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor,
-            jvmti, "_counter_lock", &countLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_counter_lock", &countLock)))
         return JNI_ERR;
 
     /* add capability to generate compiled method events */
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_native_method_bind_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.can_generate_native_method_bind_events)
         NSK_DISPLAY0("Warning: generation of native method bind events is not implemented\n");
@@ -211,13 +201,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("setting event callbacks ...\n");
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.NativeMethodBind = &NativeMethodBind;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_NATIVE_METHOD_BIND, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_NATIVE_METHOD_BIND,
+                                                          NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree001/objfree001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree001/objfree001.cpp
@@ -62,8 +62,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: creating a raw monitor ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor,
-            jvmti_env, "_lock", &_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->CreateRawMonitor("_lock", &_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to create a raw monitor\n\n",
             msg);
@@ -74,8 +73,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: entering the raw monitor ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter,
-            jvmti_env, _lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to enter the raw monitor\n\n",
             msg);
@@ -86,8 +84,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
         NSK_DISPLAY1("%s: exiting the raw monitor ...\n",
             msg);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit,
-                jvmti_env, _lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(_lock))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: %s: unable to exit the raw monitor\n\n",
                 msg);
@@ -98,8 +95,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: destroying the raw monitor ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(DestroyRawMonitor,
-            jvmti_env, _lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->DestroyRawMonitor(_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to destroy a raw monitor\n",
             msg);
@@ -112,8 +108,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 static void memoryFunc(jvmtiEnv *jvmti_env, const char *msg) {
     NSK_DISPLAY1("%s: allocating memory ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate,
-            jvmti_env, MEM_SIZE, &mem))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Allocate(MEM_SIZE, &mem))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to allocate memory\n\n",
             msg);
@@ -125,8 +120,7 @@ static void memoryFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: deallocating memory ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, mem))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate(mem))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to deallocate memory\n\n",
             msg);
@@ -142,8 +136,7 @@ static void envStorageFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY2("%s: setting an environment local storage 0x%p ...\n",
         msg, (void*) &stor);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(SetEnvironmentLocalStorage,
-            jvmti_env, (const void*) &stor))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->SetEnvironmentLocalStorage((const void*) &stor))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to set an environment local storage\n\n",
             msg);
@@ -155,8 +148,7 @@ static void envStorageFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: getting an environment local storage ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetEnvironmentLocalStorage,
-            jvmti_env, (void**) &obtainedData))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetEnvironmentLocalStorage((void**) &obtainedData))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to get an environment local storage\n\n",
             msg);
@@ -229,8 +221,7 @@ VMDeath(jvmtiEnv *jvmti_env, JNIEnv *env) {
 
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_ObjectFree_objfree001_setTag(JNIEnv *jni_env, jobject obj, jobject objToTag) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag,
-            jvmti, objToTag, (jlong) 1))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(objToTag, (jlong) 1))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to set tag for a tested object\n");
     }
@@ -269,12 +260,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_object_free_events = 1;
     caps.can_tag_objects = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_object_free_events)
@@ -287,16 +276,17 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.VMDeath = &VMDeath;
     callbacks.ObjectFree = &ObjectFree;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_VM_DEATH,
+                                                          NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_OBJECT_FREE,
+                                                          NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree002/objfree002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ObjectFree/objfree002/objfree002.cpp
@@ -59,8 +59,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: creating a raw monitor ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor,
-            jvmti_env, "_lock", &_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->CreateRawMonitor("_lock", &_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to create a raw monitor\n\n",
             msg);
@@ -71,8 +70,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: entering the raw monitor ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter,
-            jvmti_env, _lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to enter the raw monitor\n\n",
             msg);
@@ -83,8 +81,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
         NSK_DISPLAY1("%s: waiting the raw monitor ...\n",
             msg);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RawMonitorWait,
-                jvmti_env, _lock, (jlong)10))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorWait(_lock, (jlong)10))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: %s: unable to wait the raw monitor\n\n",
                 msg);
@@ -95,8 +92,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
         NSK_DISPLAY1("%s: notifying a single thread waiting on the raw monitor ...\n",
             msg);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorNotify,
-                jvmti_env, _lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorNotify(_lock))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: %s: unable to notify single thread\n\n",
                 msg);
@@ -107,8 +103,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
         NSK_DISPLAY1("%s: notifying all threads waiting on the raw monitor ...\n",
             msg);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorNotifyAll,
-                jvmti_env, _lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorNotifyAll(_lock))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: %s: unable to notify all threads\n\n",
                 msg);
@@ -119,8 +114,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
         NSK_DISPLAY1("%s: exiting the raw monitor ...\n",
             msg);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit,
-                jvmti_env, _lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(_lock))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: %s: unable to exit the raw monitor\n\n",
                 msg);
@@ -131,8 +125,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: destroying the raw monitor ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(DestroyRawMonitor,
-            jvmti_env, _lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->DestroyRawMonitor(_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to destroy a raw monitor\n",
             msg);
@@ -145,8 +138,7 @@ static void rawMonitorFunc(jvmtiEnv *jvmti_env, const char *msg) {
 static void memoryFunc(jvmtiEnv *jvmti_env, const char *msg) {
     NSK_DISPLAY1("%s: allocating memory ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate,
-            jvmti_env, MEM_SIZE, &mem))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Allocate(MEM_SIZE, &mem))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to allocate memory\n\n",
             msg);
@@ -158,8 +150,7 @@ static void memoryFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: deallocating memory ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, mem))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate(mem))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to deallocate memory\n\n",
             msg);
@@ -175,8 +166,7 @@ static void envStorageFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY2("%s: setting an environment local storage 0x%p ...\n",
         msg, (void*) &stor);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(SetEnvironmentLocalStorage,
-            jvmti_env, (const void*) &stor))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->SetEnvironmentLocalStorage((const void*) &stor))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to set an environment local storage\n\n",
             msg);
@@ -188,8 +178,7 @@ static void envStorageFunc(jvmtiEnv *jvmti_env, const char *msg) {
 
     NSK_DISPLAY1("%s: getting an environment local storage ...\n",
         msg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetEnvironmentLocalStorage,
-            jvmti_env, (void**) &obtainedData))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetEnvironmentLocalStorage((void**) &obtainedData))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN1("TEST FAILED: %s: unable to get an environment local storage\n\n",
             msg);
@@ -249,8 +238,7 @@ Java_nsk_jvmti_ObjectFree_objfree002_setTag(
     if ((num % 2) == 0) {
         NSK_DISPLAY2("Setting the tag \"%ld\" for object #%d\n",
             (long) num, num);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag,
-                jvmti, objToTag, (jlong) num))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetTag(objToTag, (jlong) num))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN1("TEST FAILED: unable to set tag for object #%d\n",
                 num);
@@ -292,12 +280,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_object_free_events = 1;
     caps.can_tag_objects = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_object_free_events)
@@ -310,16 +296,17 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.VMDeath = &VMDeath;
     callbacks.ObjectFree = &ObjectFree;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_VM_DEATH,
+                                                          NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_OBJECT_FREE,
+                                                          NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe005/popframe005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/PopFrame/popframe005/popframe005.cpp
@@ -33,12 +33,7 @@ extern "C" {
 // Deallocate memory region allocated by VM
 #define DEALLOCATE(p) \
     if (p != NULL)                 \
-        if (!NSK_JVMTI_VERIFY(     \
-                    NSK_CPP_STUB2( \
-                        Deallocate \
-                        , jvmti    \
-                        , p        \
-                        )))        \
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate(p)))        \
         {                          \
             NSK_COMPLAIN0("Failed to deallocate: ##p##\n"); \
         }
@@ -101,49 +96,22 @@ MethodExit(
         int failure = 1;
 
         do {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(
-                        GetThreadInfo
-                        , jvmti
-                        , thread
-                        , &thr_info
-                        )))
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(thread, &thr_info)))
             {
                 break;
             }
 
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(
-                        GetMethodDeclaringClass
-                        , jvmti
-                        , method
-                        , &klass
-                        )))
+            if (!NSK_JVMTI_VERIFY(jvmti->GetMethodDeclaringClass(method, &klass)))
             {
                 break;
             }
 
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(
-                        GetClassSignature
-                        , jvmti
-                        , klass
-                        , &class_signature
-                        , NULL
-                        )))
+            if (!NSK_JVMTI_VERIFY(jvmti->GetClassSignature(klass, &class_signature, NULL)))
             {
                 break;
             }
 
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB5(
-                        GetMethodName
-                        , jvmti
-                        , method
-                        , &entry_name
-                        , &entry_sig
-                        , NULL
-                        )))
+            if (!NSK_JVMTI_VERIFY(jvmti->GetMethodName(method, &entry_name, &entry_sig, NULL)))
             {
                 break;
             }
@@ -181,12 +149,7 @@ jboolean suspendThread(jobject suspendedThread) {
 
     NSK_DISPLAY0(">>>>>>>> Invoke SuspendThread()\n");
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(
-                SuspendThread
-                , jvmti
-                , suspendedThread
-                )))
+    if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(suspendedThread)))
     {
         return JNI_FALSE;
     }
@@ -203,12 +166,7 @@ jboolean resThread(jobject suspendedThread) {
 
     NSK_DISPLAY0(">>>>>>>> Invoke ResumeThread()\n");
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(
-                ResumeThread
-                , jvmti
-                , suspendedThread
-                )))
+    if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(suspendedThread)))
     {
         return JNI_FALSE;
     }
@@ -234,25 +192,13 @@ Java_nsk_jvmti_PopFrame_popframe005_doPopFrame(
     }
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(
-                SetEventNotificationMode
-                , jvmti
-                , JVMTI_ENABLE
-                , JVMTI_EVENT_METHOD_EXIT
-                , frameThr
-                )))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_EXIT, frameThr)))
     {
         result = JNI_FALSE;
     }
 
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(
-                SetEventNotificationMode
-                , jvmti
-                , JVMTI_ENABLE
-                , JVMTI_EVENT_FRAME_POP
-                , frameThr
-                )))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_FRAME_POP, frameThr)))
     {
         result = JNI_FALSE;
     }
@@ -261,12 +207,7 @@ Java_nsk_jvmti_PopFrame_popframe005_doPopFrame(
 
     set_watch_jvmti_events(1); /* watch JVMTI events */
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(
-                PopFrame
-                , jvmti
-                , frameThr
-                )))
+    if (!NSK_JVMTI_VERIFY(jvmti->PopFrame(frameThr)))
     {
         result = JNI_FALSE;
     } else {
@@ -319,32 +260,17 @@ jint Agent_Initialize(JavaVM *vm, char *options, void *reserved)
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(
-                GetPotentialCapabilities
-                , jvmti
-                , &caps
-                )))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps)))
     {
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(
-                AddCapabilities
-                , jvmti
-                , &caps
-                )))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
     {
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(
-                GetCapabilities
-                , jvmti
-                , &caps
-                )))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
     {
         return JNI_ERR;
     }
@@ -365,12 +291,7 @@ jint Agent_Initialize(JavaVM *vm, char *options, void *reserved)
         callbacks.MethodExit = &MethodExit;
         callbacks.FramePop = &FramePop;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    SetEventCallbacks
-                    , jvmti
-                    , &callbacks
-                    , sizeof(callbacks)
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks)
                     )))
         {
             return JNI_ERR;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass028/redefclass028.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass028/redefclass028.cpp
@@ -86,9 +86,9 @@ JNIEXPORT void JNICALL Java_nsk_jvmti_RedefineClasses_redefclass028_storeClassBy
         (JNIEnv *jni_env, jclass cls, jbyteArray classBytes) {
     jboolean isCopy;
 
-    bytesCount = NSK_CPP_STUB2(GetArrayLength, jni_env, classBytes);
+    bytesCount = jni_env->GetArrayLength(classBytes);
     clsBytes =
-        NSK_CPP_STUB3(GetByteArrayElements, jni_env, classBytes, &isCopy);
+        jni_env->GetByteArrayElements(classBytes, &isCopy);
 }
 
 /** callback functions **/
@@ -100,8 +100,7 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method, jint code_size,
     char *sig;
 
     NSK_DISPLAY0("CompiledMethodLoad event received for:\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &sig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sig, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -138,8 +137,8 @@ CompiledMethodUnload(jvmtiEnv* jvmti_env, jmethodID method,
     if (err == JVMTI_ERROR_NONE) {
         NSK_DISPLAY3("for: \tmethod: name=\"%s\" signature=\"%s\"\n\tnative address=0x%p\n",
           name, sig, code_addr);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)sig);
+        jvmti_env->Deallocate((unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)sig);
     }
 }
 /************************/
@@ -163,8 +162,7 @@ agentProc(jvmtiEnv* jvmti_env, JNIEnv* jni_env, void* arg) {
 
     /* at first, send all generated CompiledMethodLoad events */
     NSK_DISPLAY0("agentProc: sending all generated CompiledMethodLoad events ...\n\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GenerateEvents, jvmti, JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
         nsk_jvmti_setFailStatus();
         nsk_jvmti_resumeSync();
         return;
@@ -185,14 +183,12 @@ agentProc(jvmtiEnv* jvmti_env, JNIEnv* jni_env, void* arg) {
 
     NSK_DISPLAY0("agentProc: hotspot method compiled\n\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-                                        jvmti_env, hsMethodID, &decl_cls))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(hsMethodID, &decl_cls))) {
         nsk_jvmti_setFailStatus();
         nsk_jvmti_resumeSync();
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-                                        jvmti_env, decl_cls, &cls_sig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(decl_cls, &cls_sig, NULL))) {
         nsk_jvmti_setFailStatus();
         nsk_jvmti_resumeSync();
         return;
@@ -209,8 +205,7 @@ agentProc(jvmtiEnv* jvmti_env, JNIEnv* jni_env, void* arg) {
     NSK_DISPLAY1("agentProc: >>>>>>>> Invoke RedefineClasses():\n"
                  "\tnew class byte count=%d\n",
                  classDef.class_byte_count);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RedefineClasses,
-                                        jvmti, 1, &classDef))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &classDef))) {
         nsk_jvmti_setFailStatus();
         nsk_jvmti_resumeSync();
         return;
@@ -261,8 +256,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_compiled_method_load_events = 1;
     caps.can_redefine_classes = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* set event callback */
@@ -270,8 +264,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.CompiledMethodLoad = &CompiledMethodLoad;
     callbacks.CompiledMethodUnload = &CompiledMethodUnload;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling events ...\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass029/redefclass029.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass029/redefclass029.cpp
@@ -85,9 +85,9 @@ JNIEXPORT void JNICALL Java_nsk_jvmti_RedefineClasses_redefclass029_storeClassBy
         (JNIEnv *jni_env, jclass cls, jbyteArray classBytes) {
     jboolean isCopy;
 
-    bytesCount = NSK_CPP_STUB2(GetArrayLength, jni_env, classBytes);
+    bytesCount = jni_env->GetArrayLength(classBytes);
     clsBytes =
-        NSK_CPP_STUB3(GetByteArrayElements, jni_env, classBytes, &isCopy);
+        jni_env->GetByteArrayElements(classBytes, &isCopy);
 }
 
 /** callback functions **/
@@ -99,8 +99,7 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method, jint code_size,
     char *sig;
 
     NSK_DISPLAY0("CompiledMethodLoad event received for:\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &sig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sig, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -137,8 +136,8 @@ CompiledMethodUnload(jvmtiEnv* jvmti_env, jmethodID method,
     if (err == JVMTI_ERROR_NONE) {
         NSK_DISPLAY3("for: \tmethod: name=\"%s\" signature=\"%s\"\n\tnative address=0x%p\n",
           name, sig, code_addr);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)sig);
+        jvmti_env->Deallocate((unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)sig);
     }
 }
 /************************/
@@ -162,8 +161,7 @@ agentProc(jvmtiEnv* jvmti_env, JNIEnv* jni_env, void* arg) {
 
     /* at first, send all generated CompiledMethodLoad events */
     NSK_DISPLAY0("agentProc: sending all generated CompiledMethodLoad events ...\n\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GenerateEvents, jvmti, JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
         nsk_jvmti_setFailStatus();
         nsk_jvmti_resumeSync();
         return;
@@ -184,14 +182,12 @@ agentProc(jvmtiEnv* jvmti_env, JNIEnv* jni_env, void* arg) {
 
     NSK_DISPLAY0("agentProc: hotspot method compiled\n\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-                                        jvmti_env, hsMethodID, &decl_cls))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(hsMethodID, &decl_cls))) {
         nsk_jvmti_setFailStatus();
         nsk_jvmti_resumeSync();
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-                                        jvmti_env, decl_cls, &cls_sig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(decl_cls, &cls_sig, NULL))) {
         nsk_jvmti_setFailStatus();
         nsk_jvmti_resumeSync();
         return;
@@ -208,8 +204,7 @@ agentProc(jvmtiEnv* jvmti_env, JNIEnv* jni_env, void* arg) {
     NSK_DISPLAY1("agentProc: >>>>>>>> Invoke RedefineClasses():\n"
                  "\tnew class byte count=%d\n",
                  classDef.class_byte_count);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RedefineClasses,
-                                        jvmti, 1, &classDef))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &classDef))) {
       nsk_jvmti_setFailStatus();
       nsk_jvmti_resumeSync();
       return;
@@ -260,8 +255,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_compiled_method_load_events = 1;
     caps.can_redefine_classes = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* set event callback */
@@ -269,8 +263,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.CompiledMethodLoad = &CompiledMethodLoad;
     callbacks.CompiledMethodUnload = &CompiledMethodUnload;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling events ...\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass030/redefclass030.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass030/redefclass030.cpp
@@ -86,9 +86,9 @@ JNIEXPORT void JNICALL Java_nsk_jvmti_RedefineClasses_redefclass030_storeClassBy
         (JNIEnv *jni_env, jclass cls, jbyteArray classBytes) {
     jboolean isCopy;
 
-    bytesCount = NSK_CPP_STUB2(GetArrayLength, jni_env, classBytes);
+    bytesCount = jni_env->GetArrayLength(classBytes);
     clsBytes =
-        NSK_CPP_STUB3(GetByteArrayElements, jni_env, classBytes, &isCopy);
+        jni_env->GetByteArrayElements(classBytes, &isCopy);
 }
 
 /** callback functions **/
@@ -100,8 +100,7 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method, jint code_size,
     char *sig;
 
     NSK_DISPLAY0("CompiledMethodLoad event received for:\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &sig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sig, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -138,8 +137,8 @@ CompiledMethodUnload(jvmtiEnv* jvmti_env, jmethodID method,
     if (err == JVMTI_ERROR_NONE) {
         NSK_DISPLAY3("for: \tmethod: name=\"%s\" signature=\"%s\"\n\tnative address=0x%p\n",
           name, sig, code_addr);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)sig);
+        jvmti_env->Deallocate((unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)sig);
     }
 }
 /************************/
@@ -163,8 +162,7 @@ agentProc(jvmtiEnv* jvmti_env, JNIEnv* jni_env, void* arg) {
 
     /* at first, send all generated CompiledMethodLoad events */
     NSK_DISPLAY0("agentProc: sending all generated CompiledMethodLoad events ...\n\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GenerateEvents, jvmti, JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
         nsk_jvmti_setFailStatus();
         nsk_jvmti_resumeSync();
         return;
@@ -185,14 +183,12 @@ agentProc(jvmtiEnv* jvmti_env, JNIEnv* jni_env, void* arg) {
 
     NSK_DISPLAY0("agentProc: hotspot method compiled\n\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-                                        jvmti_env, hsMethodID, &decl_cls))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(hsMethodID, &decl_cls))) {
         nsk_jvmti_setFailStatus();
         nsk_jvmti_resumeSync();
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-                                        jvmti_env, decl_cls, &cls_sig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(decl_cls, &cls_sig, NULL))) {
         nsk_jvmti_setFailStatus();
         nsk_jvmti_resumeSync();
         return;
@@ -209,8 +205,7 @@ agentProc(jvmtiEnv* jvmti_env, JNIEnv* jni_env, void* arg) {
     NSK_DISPLAY1("agentProc: >>>>>>>> Invoke RedefineClasses():\n"
                  "\tnew class byte count=%d\n",
                  classDef.class_byte_count);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RedefineClasses,
-                                        jvmti, 1, &classDef))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &classDef))) {
       nsk_jvmti_setFailStatus();
       nsk_jvmti_resumeSync();
       return;
@@ -261,8 +256,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_compiled_method_load_events = 1;
     caps.can_redefine_classes = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* set event callback */
@@ -270,8 +264,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.CompiledMethodLoad = &CompiledMethodLoad;
     callbacks.CompiledMethodUnload = &CompiledMethodUnload;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling events ...\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RelinquishCapabilities/relcaps001/relcaps001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RelinquishCapabilities/relcaps001/relcaps001.cpp
@@ -193,8 +193,7 @@ static int checkCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* initCaps, const
     memset(&caps, 0, sizeof(jvmtiCapabilities));
 
     NSK_DISPLAY0("GetCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps))) {
         return NSK_FALSE;
     }
 
@@ -217,8 +216,7 @@ static int checkCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* initCaps, const
  */
 static int addCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps) {
     NSK_DISPLAY0("AddCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(AddCapabilities, jvmti, caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(caps))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... set\n");
@@ -232,8 +230,7 @@ static int addCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps) {
  */
 static int removeCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps, const char where[]) {
     NSK_DISPLAY0("RelinquishCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RelinquishCapabilities, jvmti, caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(caps))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... relinguished\n");
@@ -247,8 +244,7 @@ static int removeCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps, const ch
  */
 static int getPotentialCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps) {
     NSK_DISPLAY0("GetPotentialCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(caps))) {
         return NSK_FALSE;
     }
 
@@ -350,9 +346,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RelinquishCapabilities/relcaps002/relcaps002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RelinquishCapabilities/relcaps002/relcaps002.cpp
@@ -193,8 +193,7 @@ static int checkCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* initCaps, const
     memset(&caps, 0, sizeof(jvmtiCapabilities));
 
     NSK_DISPLAY0("GetCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps))) {
         return NSK_FALSE;
     }
 
@@ -217,8 +216,7 @@ static int checkCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* initCaps, const
  */
 static int addCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps) {
     NSK_DISPLAY0("AddCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(AddCapabilities, jvmti, caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(caps))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... set\n");
@@ -232,8 +230,7 @@ static int addCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps) {
  */
 static int removeCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps, const char where[]) {
     NSK_DISPLAY0("RelinquishCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RelinquishCapabilities, jvmti, caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RelinquishCapabilities(caps))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... relinguished\n");
@@ -247,8 +244,7 @@ static int removeCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps, const ch
  */
 static int getPotentialCapabilities(jvmtiEnv* jvmti, jvmtiCapabilities* caps) {
     NSK_DISPLAY0("GetPotentialCapabilities() for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(caps))) {
         return NSK_FALSE;
     }
 
@@ -349,9 +345,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted.cpp
@@ -86,15 +86,17 @@ jint Agent_Initialize(JavaVM *vm, char *options, void *reserved)
     memset(&capabilities, 0, sizeof(jvmtiCapabilities));
     capabilities.can_generate_resource_exhaustion_heap_events = 1;
     capabilities.can_generate_resource_exhaustion_threads_events = 1;
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, gJvmti, &capabilities)) )
+    if ( ! NSK_JVMTI_VERIFY(gJvmti->AddCapabilities(&capabilities)) )
         return JNI_ERR;
 
     memset((void *)&callbacks, 0, sizeof(jvmtiEventCallbacks));
     callbacks.ResourceExhausted = resourceExhausted;
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, gJvmti, &callbacks, sizeof(callbacks))) )
+    if ( ! NSK_JVMTI_VERIFY(gJvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))) )
         return JNI_ERR;
 
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode, gJvmti, JVMTI_ENABLE, JVMTI_EVENT_RESOURCE_EXHAUSTED, NULL) ) )
+    if ( ! NSK_JVMTI_VERIFY(gJvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                             JVMTI_EVENT_RESOURCE_EXHAUSTED,
+                                                             NULL) ) )
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThread/resumethrd001/resumethrd001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThread/resumethrd001/resumethrd001.cpp
@@ -58,15 +58,13 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY1("  ... found thread: %p\n", (void*)testedThread);
 
         NSK_DISPLAY1("Suspend thread: %p\n", (void*)testedThread);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(SuspendThread, jvmti, testedThread))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(testedThread))) {
             nsk_jvmti_setFailStatus();
             return;
         }
 
         NSK_DISPLAY1("Resume thread: %p\n", (void*)testedThread);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(ResumeThread, jvmti, testedThread))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(testedThread))) {
             nsk_jvmti_setFailStatus();
         }
 
@@ -74,8 +72,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         {
             jint state = 0;
 
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetThreadState, jvmti, testedThread, &state))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(testedThread, &state))) {
                 nsk_jvmti_setFailStatus();
             }
             NSK_DISPLAY2("  ... got state vector: %s (%d)\n",
@@ -98,7 +95,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY0("Delete thread reference\n");
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedThread));
+        NSK_TRACE(jni->DeleteGlobalRef(testedThread));
     }
 
     NSK_DISPLAY0("Let debugee to finish\n");
@@ -139,8 +136,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThread/resumethrd002/resumethrd002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThread/resumethrd002/resumethrd002.cpp
@@ -72,8 +72,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY1("Suspend thread: %p\n", (void*)testedThread);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(SuspendThread, jvmti, testedThread))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(testedThread))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -83,8 +82,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY1("Resume thread: %p\n", (void*)testedThread);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(ResumeThread, jvmti, testedThread))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(testedThread))) {
             nsk_jvmti_setFailStatus();
         }
 
@@ -112,7 +110,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY0("Delete thread reference\n");
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedThread));
+        NSK_TRACE(jni->DeleteGlobalRef(testedThread));
     }
 
     NSK_DISPLAY0("Let debugee to finish\n");
@@ -127,7 +125,7 @@ JNIEXPORT void JNICALL
 callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     /* check if event is for tested thread */
     if (thread != NULL &&
-                NSK_CPP_STUB3(IsSameObject, jni, testedThread, thread)) {
+                jni->IsSameObject(testedThread, thread)) {
         NSK_DISPLAY1("  ... received THREAD_END event for tested thread: %p\n", (void*)thread);
         eventsReceived++;
     } else {
@@ -168,8 +166,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 
@@ -178,8 +175,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiEventCallbacks callbacks;
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ThreadEnd = callbackThreadEnd;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, sizeof(callbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst001/resumethrdlst001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst001/resumethrdlst001.cpp
@@ -62,18 +62,16 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         int i;
 
         NSK_DISPLAY1("Allocate threads array: %d threads\n", threadsCount);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti, (threadsCount * sizeof(jthread)),
-                                                (unsigned char**)&threads))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Allocate((threadsCount * sizeof(jthread)),
+                                              (unsigned char**)&threads))) {
             nsk_jvmti_setFailStatus();
             return;
         }
         NSK_DISPLAY1("  ... allocated array: %p\n", (void*)threads);
 
         NSK_DISPLAY1("Allocate results array: %d threads\n", threadsCount);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti, (threadsCount * sizeof(jvmtiError)),
-                                                (unsigned char**)&results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Allocate((threadsCount * sizeof(jvmtiError)),
+                                              (unsigned char**)&results))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -84,8 +82,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY0("Suspend threads list\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SuspendThreadList, jvmti, threadsCount, threads, results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SuspendThreadList(threadsCount, threads, results))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -99,8 +96,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
 
         NSK_DISPLAY0("Resume threads list\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(ResumeThreadList, jvmti, threadsCount, threads, results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThreadList(threadsCount, threads, results))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -118,8 +114,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             jint state = 0;
 
             NSK_DISPLAY2("  thread #%d (%p):\n", i, (void*)threads[i]);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetThreadState, jvmti, threads[i], &state))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(threads[i], &state))) {
                 nsk_jvmti_setFailStatus();
             }
             NSK_DISPLAY2("  ... got state vector: %s (%d)\n",
@@ -144,18 +139,16 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0("Delete threads references\n");
         for (i = 0; i < threadsCount; i++) {
             if (threads[i] != NULL)
-                NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threads[i]));
+                NSK_TRACE(jni->DeleteGlobalRef(threads[i]));
         }
 
         NSK_DISPLAY1("Deallocate threads array: %p\n", (void*)threads);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads))) {
             nsk_jvmti_setFailStatus();
         }
 
         NSK_DISPLAY1("Deallocate results array: %p\n", (void*)results);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)results))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -181,8 +174,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
         foundThreads[i] = NULL;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &count, &threads))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&count, &threads))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -191,8 +183,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
     for (i = 0; i < count; i++) {
         jvmtiThreadInfo info;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info))) {
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -207,8 +198,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
 
     }
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -226,7 +216,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
     NSK_DISPLAY1("Make global references for threads: %d threads\n", foundCount);
     for (i = 0; i < foundCount; i++) {
         if (!NSK_JNI_VERIFY(jni, (foundThreads[i] = (jthread)
-                    NSK_CPP_STUB2(NewGlobalRef, jni, foundThreads[i])) != NULL)) {
+                    jni->NewGlobalRef(foundThreads[i])) != NULL)) {
             nsk_jvmti_setFailStatus();
             return NSK_FALSE;
         }
@@ -274,8 +264,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst002/resumethrdlst002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResumeThreadList/resumethrdlst002/resumethrdlst002.cpp
@@ -71,18 +71,16 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         int i;
 
         NSK_DISPLAY1("Allocate threads array: %d threads\n", threadsCount);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti, (threadsCount * sizeof(jthread)),
-                                                (unsigned char**)&threads))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Allocate((threadsCount * sizeof(jthread)),
+                                              (unsigned char**)&threads))) {
             nsk_jvmti_setFailStatus();
             return;
         }
         NSK_DISPLAY1("  ... allocated array: %p\n", (void*)threads);
 
         NSK_DISPLAY1("Allocate results array: %d threads\n", threadsCount);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti, (threadsCount * sizeof(jvmtiError)),
-                                                (unsigned char**)&results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Allocate((threadsCount * sizeof(jvmtiError)),
+                                              (unsigned char**)&results))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -93,8 +91,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY0("Suspend threads list\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SuspendThreadList, jvmti, threadsCount, threads, results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SuspendThreadList(threadsCount, threads, results))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -117,8 +114,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY0("Resume threads list\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(ResumeThreadList, jvmti, threadsCount, threads, results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThreadList(threadsCount, threads, results))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -159,18 +155,16 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0("Delete threads references\n");
         for (i = 0; i < threadsCount; i++) {
             if (threads[i] != NULL)
-                NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threads[i]));
+                NSK_TRACE(jni->DeleteGlobalRef(threads[i]));
         }
 
         NSK_DISPLAY1("Deallocate threads array: %p\n", (void*)threads);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads))) {
             nsk_jvmti_setFailStatus();
         }
 
         NSK_DISPLAY1("Deallocate results array: %p\n", (void*)results);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)results))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -196,8 +190,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
         foundThreads[i] = NULL;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &count, &threads))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&count, &threads))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -206,8 +199,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
     for (i = 0; i < count; i++) {
         jvmtiThreadInfo info;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info))) {
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -222,8 +214,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
 
     }
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -241,7 +232,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
     NSK_DISPLAY1("Make global references for threads: %d threads\n", foundCount);
     for (i = 0; i < foundCount; i++) {
         if (!NSK_JNI_VERIFY(jni, (foundThreads[i] = (jthread)
-                    NSK_CPP_STUB2(NewGlobalRef, jni, foundThreads[i])) != NULL)) {
+                    jni->NewGlobalRef(foundThreads[i])) != NULL)) {
             nsk_jvmti_setFailStatus();
             return NSK_FALSE;
         }
@@ -258,7 +249,7 @@ JNIEXPORT void JNICALL
 callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     int i = 0;
 
-    jvmtiError e = NSK_CPP_STUB2(RawMonitorEnter, jvmti, eventsReceivedMtx);
+    jvmtiError e = jvmti->RawMonitorEnter(eventsReceivedMtx);
     if ( !NSK_JVMTI_VERIFY(e) ) {
         NSK_DISPLAY1("  ... ERROR entering raw monitor for thread %p\n", (void *) thread);
         return;
@@ -267,15 +258,15 @@ callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     /* check if event is for tested thread */
     for (i = 0; i < threadsCount; i++) {
         if (thread != NULL &&
-                NSK_CPP_STUB3(IsSameObject, jni, threads[i], thread)) {
+                jni->IsSameObject(threads[i], thread)) {
             NSK_DISPLAY2("  ... received THREAD_END event for thread #%d: %p\n",
                                                                     i, (void*)thread);
             eventsReceived++;
-            NSK_CPP_STUB2(RawMonitorExit, jvmti, eventsReceivedMtx);
+            jvmti->RawMonitorExit(eventsReceivedMtx);
             return;
         }
     }
-    NSK_CPP_STUB2(RawMonitorExit, jvmti, eventsReceivedMtx);
+    jvmti->RawMonitorExit(eventsReceivedMtx);
     NSK_DISPLAY1("  ... received THREAD_END event for unknown thread: %p\n", (void*)thread);
 }
 
@@ -317,8 +308,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 
@@ -327,15 +317,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiEventCallbacks callbacks;
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ThreadEnd = callbackThreadEnd;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, sizeof(callbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
     }
 
     /* create a mutex for the eventsReceived variable */
     {
-        if ( ! NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(CreateRawMonitor, jvmti, "eventsReceived", &eventsReceivedMtx))) {
+        if ( ! NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("eventsReceived", &eventsReceivedMtx))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform002/retransform002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform002/retransform002.cpp
@@ -49,15 +49,7 @@ Java_nsk_jvmti_RetransformClasses_retransform002_forceLoadedClassesRetransformat
         )
 {
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    RetransformClasses
-                    , jvmti
-                    , 1
-                    , &class_for_retransformation
-                    )
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->RetransformClasses(1, &class_for_retransformation)))
         return JNI_FALSE;
 
     return JNI_TRUE;
@@ -114,53 +106,26 @@ jint Agent_Initialize(JavaVM *vm, char *options, void *reserved)
        )
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    GetCapabilities
-                    , jvmti
-                    , &caps)
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     caps.can_retransform_classes = 1;
 
     // Register all necessary JVM capabilities
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    AddCapabilities
-                    , jvmti
-                    , &caps)
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     // Register all necessary event callbacks
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.ClassFileLoadHook = &ClassFileLoadHook;
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    SetEventCallbacks
-                    , jvmti
-                    , &callbacks
-                    , sizeof(callbacks)
-                    )
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     // Enable class retransformation
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(
-                    SetEventNotificationMode
-                    , jvmti
-                    , JVMTI_ENABLE
-                    , JVMTI_EVENT_CLASS_FILE_LOAD_HOOK
-                    , NULL
-                    )
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_CLASS_FILE_LOAD_HOOK,
+                                                          NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform003/retransform003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform003/retransform003.cpp
@@ -63,15 +63,7 @@ Java_nsk_jvmti_RetransformClasses_retransform003_forceLoadedClassesRetransformat
         , jclass class_for_retransformation
         )
 {
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    RetransformClasses
-                    , jvmti
-                    , 1
-                    , &class_for_retransformation
-                    )
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->RetransformClasses(1, &class_for_retransformation)))
         return JNI_FALSE;
 
     return JNI_TRUE;
@@ -107,88 +99,28 @@ ClassFileLoadHook (
     }
 
     // Get ant the invoke callback function
-    if (!NSK_VERIFY(
-                (loader_class = NSK_CPP_STUB2(
-                    GetObjectClass
-                    , jni
-                    , loader
-                    )
-                ) != NULL
-            )
-       )
+    if (!NSK_VERIFY((loader_class = jni->GetObjectClass(loader)) != NULL))
         return;
 
-    if (!NSK_VERIFY(
-                (method_id = NSK_CPP_STUB4(
-                    GetMethodID
-                    , jni
-                    , loader_class
-                    , "loadClass"
-                    , "(Ljava/lang/String;)Ljava/lang/Class;"
-                    )
-                ) != NULL
-            )
-       )
+    if (!NSK_VERIFY((method_id = jni->GetMethodID(
+            loader_class, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;")) != NULL))
         return;
 
-    if (!NSK_VERIFY(
-                (class_name_string =
-                 NSK_CPP_STUB2(
-                     NewStringUTF
-                     , jni
-                     , CALLBACK_CLASS_NAME
-                     )
-                ) != NULL
-            )
-       )
+    if (!NSK_VERIFY((class_name_string = jni->NewStringUTF(CALLBACK_CLASS_NAME)) != NULL))
         return;
 
-    if (!NSK_VERIFY(
-                (callback_class = (jclass) NSK_CPP_STUB4(
-                        CallObjectMethod
-                        , jni
-                        , loader
-                        , method_id
-                        , class_name_string
-                        )
-                ) != NULL
-            )
-       )
+    if (!NSK_VERIFY((callback_class = (jclass) jni->CallObjectMethod(
+            loader, method_id, class_name_string)) != NULL))
         return;
 
-    if (!NSK_VERIFY(
-                (method_id = NSK_CPP_STUB4(
-                    GetStaticMethodID
-                    , jni
-                    , callback_class
-                    , "callback"
-                    , "(Ljava/lang/String;I)V"
-                    )
-                ) != NULL
-            )
-       )
+    if (!NSK_VERIFY((method_id = jni->GetStaticMethodID(
+            callback_class, "callback", "(Ljava/lang/String;I)V")) != NULL))
         return;
 
-    if (!NSK_VERIFY(
-                (class_name_string =
-                 NSK_CPP_STUB2(
-                     NewStringUTF
-                     , jni
-                     , name
-                     )
-                ) != NULL
-            )
-       )
+    if (!NSK_VERIFY((class_name_string = jni->NewStringUTF(name)) != NULL))
         return;
 
-    NSK_CPP_STUB5(
-        CallStaticObjectMethod
-        , jni
-        , callback_class
-        , method_id
-        , class_name_string
-        , agent_id
-        );
+    jni->CallStaticObjectMethod(callback_class, method_id, class_name_string, agent_id);
 }
 
 
@@ -219,19 +151,10 @@ jint Agent_Initialize(JavaVM *vm, char *options, void *reserved)
 
     agent_id= nsk_jvmti_findOptionIntValue("id", -1);
 
-    if (!NSK_VERIFY(
-                (jvmti = nsk_jvmti_createJVMTIEnv(vm, reserved)) != NULL
-                )
-       )
+    if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(vm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    GetCapabilities
-                    , jvmti
-                    , &caps)
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if(nsk_jvmti_findOptionIntValue("can_retransform_classes", 1)) {
@@ -242,41 +165,21 @@ jint Agent_Initialize(JavaVM *vm, char *options, void *reserved)
 
 
     // Register all necessary JVM capabilities
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    AddCapabilities
-                    , jvmti
-                    , &caps)
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     // Register all necessary event callbacks
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.ClassFileLoadHook = &ClassFileLoadHook;
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    SetEventCallbacks
-                    , jvmti
-                    , &callbacks
-                    , sizeof(callbacks)
-                    )
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     // Enable class retransformation
     if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(
-                    SetEventNotificationMode
-                    , jvmti
-                    , JVMTI_ENABLE
-                    , JVMTI_EVENT_CLASS_FILE_LOAD_HOOK
-                    , NULL
-                    )
-                )
-       )
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                JVMTI_EVENT_CLASS_FILE_LOAD_HOOK,
+                                                NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform004/retransform004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform004/retransform004.cpp
@@ -52,15 +52,7 @@ Java_nsk_jvmti_RetransformClasses_retransform004_forceLoadedClassesRetransformat
         , jclass class_for_retransformation
         )
 {
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    RetransformClasses
-                    , jvmti
-                    , 1
-                    , &class_for_retransformation
-                    )
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->RetransformClasses(1, &class_for_retransformation)))
         return JNI_FALSE;
 
     return JNI_TRUE;
@@ -85,15 +77,7 @@ ClassFileLoadHook (
         )
 {
     // Allocate space for "retransformed" class version
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    Allocate
-                    , jvmti
-                    , class_data_len
-                    , new_class_data
-                    )
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(class_data_len, new_class_data)))
         return;
 
     // Copy old code
@@ -127,53 +111,27 @@ jint Agent_Initialize(JavaVM *vm, char *options, void *reserved)
        )
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    GetCapabilities
-                    , jvmti
-                    , &caps)
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     caps.can_retransform_classes = 1;
 
     // Register all necessary JVM capabilities
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    AddCapabilities
-                    , jvmti
-                    , &caps)
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     // Register all necessary event callbacks
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.ClassFileLoadHook = &ClassFileLoadHook;
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(
-                    SetEventCallbacks
-                    , jvmti
-                    , &callbacks
-                    , sizeof(callbacks)
-                    )
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     // Enable class retransformation
     if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(
-                    SetEventNotificationMode
-                    , jvmti
-                    , JVMTI_ENABLE
-                    , JVMTI_EVENT_CLASS_FILE_LOAD_HOOK
-                    , NULL
-                    )
-                )
-       )
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                JVMTI_EVENT_CLASS_FILE_LOAD_HOOK,
+                                                NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP01/ap01t001/ap01t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP01/ap01t001/ap01t001.cpp
@@ -146,20 +146,13 @@ Java_nsk_jvmti_scenarios_allocation_AP01_ap01t001_newObject( JNIEnv* jni, jclass
     jmethodID cid;
     jobject result;
 
-    if (!NSK_JNI_VERIFY(jni, (cid =
-            NSK_CPP_STUB4(GetMethodID, jni,
-                                       cls,
-                                       "<init>",
-                                       "()V" )) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (cid = jni->GetMethodID(cls, "<init>", "()V" )) != NULL)) {
          NSK_COMPLAIN0("newObject: GetMethodID returned NULL\n\n");
          nsk_jvmti_setFailStatus();
          return NULL;
     }
 
-    if (!NSK_JNI_VERIFY(jni, ( result =
-            NSK_CPP_STUB3(NewObject, jni,
-                                     cls,
-                                     cid )) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, ( result = jni->NewObject(cls, cid)) != NULL)) {
 
          NSK_COMPLAIN0("newObject: NewObject returned NULL\n\n");
          nsk_jvmti_setFailStatus();
@@ -174,31 +167,21 @@ Java_nsk_jvmti_scenarios_allocation_AP01_ap01t001_allocObject( JNIEnv* jni, jcla
     jmethodID cid;
     jobject result;
 
-    if (!NSK_JNI_VERIFY(jni, ( cid =
-            NSK_CPP_STUB4(GetMethodID, jni,
-                                       cls,
-                                       "<init>",
-                                       "()V" )) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, ( cid = jni->GetMethodID(cls, "<init>", "()V" )) != NULL)) {
 
          NSK_COMPLAIN0("allocObject: GetMethodID returned NULL\n\n");
          nsk_jvmti_setFailStatus();
          return NULL;
     }
 
-    if (!NSK_JNI_VERIFY(jni, ( result =
-            NSK_CPP_STUB2(AllocObject, jni,
-                                       cls )) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, ( result = jni->AllocObject(cls)) != NULL)) {
 
          NSK_COMPLAIN0("allocObject: AllocObject returned NULL\n\n");
          nsk_jvmti_setFailStatus();
          return NULL;
     }
 
-    if (!NSK_JNI_VERIFY_VOID(jni,
-            NSK_CPP_STUB4(CallNonvirtualVoidMethod, jni,
-                                                    result,
-                                                    cls,
-                                                    cid))) {
+    if (!NSK_JNI_VERIFY_VOID(jni,jni->CallNonvirtualVoidMethod(result, cls, cid))) {
 
          NSK_COMPLAIN0("newObject: CallNonvirtualVoidMethod failed\n\n");
          nsk_jvmti_setFailStatus();
@@ -225,10 +208,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     NSK_DISPLAY0("Set tag for debugee class\n\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti,
-                                  debugeeClass,
-                                  DEBUGEE_CLASS_TAG ))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(debugeeClass, DEBUGEE_CLASS_TAG))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -236,13 +216,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
     NSK_DISPLAY0("Calling IterateOverInstancesOfClass with filter JVMTI_HEAP_OBJECT_UNTAGGED\n");
     obj_count = 0;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverInstancesOfClass,
-                              jvmti,
-                              debugeeClass,
-                              JVMTI_HEAP_OBJECT_UNTAGGED,
-                              heapObjectCallback,
-                              &user_data))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(debugeeClass,
+                                                             JVMTI_HEAP_OBJECT_UNTAGGED,
+                                                             heapObjectCallback,
+                                                             &user_data))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -261,11 +238,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     NSK_DISPLAY0("Calling IterateOverHeap with filter JVMTI_HEAP_OBJECT_UNTAGGED\n");
     obj_count = 0;
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IterateOverHeap,
-                              jvmti,
-                              JVMTI_HEAP_OBJECT_UNTAGGED,
-                              heapObjectCallback,
-                              &user_data))) {
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_UNTAGGED, heapObjectCallback, &user_data))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -282,12 +255,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
     NSK_DISPLAY0("Calling IterateOverReachableObjects\n");
     obj_count = 0;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                                                       heapRootCallback,
-                                                       stackReferenceCallback,
-                                                       objectReferenceCallback,
-                                                       &user_data))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(heapRootCallback,
+                                                             stackReferenceCallback,
+                                                             objectReferenceCallback,
+                                                             &user_data))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -338,12 +309,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_object_free_events = 1;
     caps.can_tag_objects = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_object_free_events)
@@ -358,16 +327,17 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.ObjectFree = &ObjectFree;
     callbacks.VMDeath = &VMDeath;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_OBJECT_FREE,
+                                                          NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_VM_DEATH,
+                                                          NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP02/ap02t001/ap02t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP02/ap02t001/ap02t001.cpp
@@ -91,9 +91,7 @@ Java_nsk_jvmti_scenarios_allocation_AP02_ap02t001_throwException( JNIEnv* jni,
                                                                   jclass exception_cls ) {
     jint result;
 
-    result = NSK_CPP_STUB3(ThrowNew, jni,
-                                     exception_cls,
-                                     "Got expected exception thrown from native code" );
+    result = jni->ThrowNew(exception_cls, "Got expected exception thrown from native code" );
     if (result != 0) {
         NSK_COMPLAIN1("throwException: Unable to throw exception in native code: %d\n\n", result );
         nsk_jvmti_setFailStatus();
@@ -105,13 +103,10 @@ Java_nsk_jvmti_scenarios_allocation_AP02_ap02t001_throwException( JNIEnv* jni,
 static void runIterations (jvmtiEnv* jvmti, jclass testedClass, jint exp_count) {
     NSK_DISPLAY0("Calling IterateOverInstancesOfClass with filter JVMTI_HEAP_OBJECT_EITHER\n");
     obj_count = 0;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverInstancesOfClass,
-                              jvmti,
-                              testedClass,
-                              JVMTI_HEAP_OBJECT_EITHER,
-                              heapObjectCallback,
-                              &user_data))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(testedClass,
+                                                             JVMTI_HEAP_OBJECT_EITHER,
+                                                             heapObjectCallback,
+                                                             &user_data))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -130,11 +125,7 @@ static void runIterations (jvmtiEnv* jvmti, jclass testedClass, jint exp_count) 
     NSK_DISPLAY0("Calling IterateOverHeap with filter JVMTI_HEAP_OBJECT_EITHER\n");
     obj_count = 0;
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IterateOverHeap,
-                              jvmti,
-                              JVMTI_HEAP_OBJECT_EITHER,
-                              heapObjectCallback,
-                              &user_data))) {
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_EITHER, heapObjectCallback, &user_data))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -151,12 +142,10 @@ static void runIterations (jvmtiEnv* jvmti, jclass testedClass, jint exp_count) 
 
     NSK_DISPLAY0("Calling IterateOverReachableObjects\n");
     obj_count = 0;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                                                       NULL /*heapRootCallback*/,
-                                                       stackReferenceCallback,
-                                                       NULL /*objectReferenceCallback*/,
-                                                       &user_data))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(NULL /*heapRootCallback*/,
+                                                             stackReferenceCallback,
+                                                             NULL /*objectReferenceCallback*/,
+                                                             &user_data))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -189,15 +178,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
     }
 
-    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, testedClass)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass)jni->NewGlobalRef(testedClass)) != NULL))
         return;
 
     NSK_DISPLAY0("Set tag for tested class\n\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetTag, jvmti,
-                                  testedClass,
-                                  TESTED_CLASS_TAG ))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(testedClass, TESTED_CLASS_TAG))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -212,7 +197,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
     runIterations (jvmti, testedClass, 2);
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass));
+    NSK_TRACE(jni->DeleteGlobalRef(testedClass));
 
     NSK_DISPLAY0("Let debugee to finish\n");
     if (!NSK_VERIFY(nsk_jvmti_resumeSync()))
@@ -242,12 +227,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_tag_objects = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_tag_objects)

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001/ap03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP03/ap03t001/ap03t001.cpp
@@ -90,8 +90,7 @@ objectReferenceCallback( jvmtiObjectReferenceKind reference_kind,
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_scenarios_allocation_AP03_ap03t001_setTag( JNIEnv* jni, jobject obj, jlong tag) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag,
-         jvmti, obj, tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(obj, tag))) {
          nsk_jvmti_setFailStatus();
     }
 }
@@ -117,23 +116,17 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
 
         NSK_DISPLAY0("Set tag for debugee class\n\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetTag, jvmti,
-                                      debugeeClass,
-                                      DEBUGEE_CLASS_TAG ))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetTag(debugeeClass, DEBUGEE_CLASS_TAG))) {
             nsk_jvmti_setFailStatus();
             break;
         }
 
         NSK_DISPLAY0("Calling IterateOverInstancesOfClass with filter JVMTI_HEAP_OBJECT_TAGGED\n");
         obj_count = 0;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB5(IterateOverInstancesOfClass,
-                                  jvmti,
-                                  debugeeClass,
-                                  JVMTI_HEAP_OBJECT_TAGGED,
-                                  heapObjectCallback,
-                                  &user_data))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(debugeeClass,
+                                                                 JVMTI_HEAP_OBJECT_TAGGED,
+                                                                 heapObjectCallback,
+                                                                 &user_data))) {
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -151,11 +144,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0("Calling IterateOverHeap with filter JVMTI_HEAP_OBJECT_TAGGED\n");
         obj_count = 0;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(IterateOverHeap,
-                                  jvmti,
-                                  JVMTI_HEAP_OBJECT_TAGGED,
-                                  heapObjectCallback,
-                                  &user_data))) {
+                jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, heapObjectCallback, &user_data))) {
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -171,18 +160,13 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
 
         if (!NSK_JNI_VERIFY(jni, (fid =
-                NSK_CPP_STUB4(GetStaticFieldID, jni,
-                                                debugeeClass,
-                                                "catcher",
-                                                DEBUGEE_SIGNATURE)) != NULL )) {
+                jni->GetStaticFieldID(debugeeClass, "catcher", DEBUGEE_SIGNATURE)) != NULL )) {
             nsk_jvmti_setFailStatus();
             break;
         }
 
         if (!NSK_JNI_VERIFY(jni, (catcher =
-                NSK_CPP_STUB3(GetStaticObjectField, jni,
-                                                    debugeeClass,
-                                                    fid )) != NULL )) {
+                jni->GetStaticObjectField(debugeeClass, fid)) != NULL )) {
             NSK_COMPLAIN0("GetStaticObjectField returned NULL for 'catcher' field value\n\n");
             nsk_jvmti_setFailStatus();
             break;
@@ -190,11 +174,9 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
         NSK_DISPLAY0("Calling IterateOverObjectsReachableFromObject\n");
         obj_count = 0;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti,
-                                                                     catcher,
-                                                                     objectReferenceCallback,
-                                                                     &user_data))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(catcher,
+                                                                           objectReferenceCallback,
+                                                                           &user_data))) {
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -239,12 +221,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_object_free_events = 1;
     caps.can_tag_objects = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_object_free_events)
@@ -258,13 +238,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     callbacks.ObjectFree = &ObjectFree;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_OBJECT_FREE,
+                                                          NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t001/ap04t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t001/ap04t001.cpp
@@ -66,30 +66,26 @@ static jrawMonitorID counterMonitor_ptr = NULL;
 
 static void increaseCounter(volatile int* counterPtr) {
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
     (*counterPtr)++;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 }
 
 static void setCounter(volatile int* counterPtr, int value) {
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
     *counterPtr = value;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -97,15 +93,13 @@ static void setCounter(volatile int* counterPtr, int value) {
 static int getCounter(volatile int* counterPtr) {
     int result;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
     result = *counterPtr;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -248,7 +242,7 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t001_setTag( JNIEnv* jni,
                                                           jobject target, /* object to be tagged */
                                                           jlong   tag ) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, target, tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(target, tag))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -258,7 +252,7 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t001_forceGC( JNIEnv* jni,
                                                           jclass  klass) {
 
 NSK_DISPLAY0("  run: ForceGarbageCollection\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB1(ForceGarbageCollection, jvmti))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->ForceGarbageCollection())) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -273,11 +267,9 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t001_runIterateOverHeap( JNIEnv* jn
     setCounter(&iterationCount, 0);
 
     NSK_DISPLAY0("Calling IterateOverHeap...\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IterateOverHeap, jvmti,
-                                           JVMTI_HEAP_OBJECT_TAGGED,
-                                           heapObjectCallback,
-                                           NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED,
+                                                 heapObjectCallback,
+                                                 NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY0("IterateOverHeap finished.\n");
@@ -303,12 +295,10 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t001_runIterateOverReachableObjects
     setCounter(&iterationCount, 0);
 
     NSK_DISPLAY0("Calling IterateOverReachableObjects...\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                                                       heapRootCallback,
-                                                       stackReferenceCallback,
-                                                       objectReferenceCallback,
-                                                       NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(heapRootCallback,
+                                                             stackReferenceCallback,
+                                                             objectReferenceCallback,
+                                                             NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY0("IterateOverReachableObjects finished.\n");
@@ -334,12 +324,10 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t001_runIterateOverInstancesOfClass
     setCounter(&iterationCount, 0);
 
     NSK_DISPLAY0("Calling IterateOverInstancesOfClass...\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-                                                       debugeeClass,
-                                                       JVMTI_HEAP_OBJECT_TAGGED,
-                                                       heapObjectCallback,
-                                                       NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(debugeeClass,
+                                                             JVMTI_HEAP_OBJECT_TAGGED,
+                                                             heapObjectCallback,
+                                                             NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY0("IterateOverInstancesOfClass finished.\n");
@@ -363,27 +351,23 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t001_runIterateOverObjectsReachable
     int count = 0;
 
     if (!NSK_JNI_VERIFY(jni, (root =
-            NSK_CPP_STUB3(GetStaticObjectField, jni,
-                                                debugeeClass,
-                                                rootFieldID )) != NULL )) {
+            jni->GetStaticObjectField(debugeeClass, rootFieldID)) != NULL )) {
         NSK_COMPLAIN0("GetStaticObjectField returned NULL for 'root' field value\n\n");
         nsk_jvmti_setFailStatus();
         return;
     }
 
     // release secondary lock
-    NSK_CPP_STUB3(CallStaticVoidMethod, jni, debugeeClass, unlockSecondaryID);
+    jni->CallStaticVoidMethod(debugeeClass, unlockSecondaryID);
 
     setCounter(&errorCount, 0);
     setCounter(&eventCount, 0);
     setCounter(&iterationCount, 0);
 
     NSK_DISPLAY0("Calling IterateOverObjectsReachableFromObject...\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti,
-                                                                 root,
-                                                                 objectReferenceCallback,
-                                                                 NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(root,
+                                                                       objectReferenceCallback,
+                                                                       NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY0("IterateOverObjectsReachableFromObject finished.\n");
@@ -413,26 +397,19 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
     }
 
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, debugeeClass)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = (jclass)jni->NewGlobalRef(debugeeClass)) != NULL))
         return;
 
     NSK_DISPLAY1("Find ID of 'root' field: %s\n", ROOT_SIGNATURE);
     if (!NSK_JNI_VERIFY(jni, (rootFieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni,
-                                            debugeeClass,
-                                            "root",
-                                            ROOT_SIGNATURE)) != NULL )) {
+            jni->GetStaticFieldID(debugeeClass, "root", ROOT_SIGNATURE)) != NULL )) {
         nsk_jvmti_setFailStatus();
         return;
     }
 
     NSK_DISPLAY1("Find ID of 'unlockSecondary' method: %s\n", ROOT_SIGNATURE);
     if (!NSK_JNI_VERIFY(jni, (unlockSecondaryID =
-            NSK_CPP_STUB4(GetStaticMethodID, jni,
-                                            debugeeClass,
-                                            "unlockSecondary",
-                                            "()V")) != NULL )) {
+            jni->GetStaticMethodID(debugeeClass, "unlockSecondary", "()V")) != NULL )) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -448,8 +425,8 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
     nsk_jvmti_enableEvents(JVMTI_DISABLE, eventsCount, events, NULL);
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, debugeeClass));
-    NSK_TRACE(NSK_CPP_STUB2(DestroyRawMonitor, jvmti, counterMonitor_ptr));
+    NSK_TRACE(jni->DeleteGlobalRef(debugeeClass));
+    NSK_TRACE(jvmti->DestroyRawMonitor(counterMonitor_ptr));
 
     NSK_DISPLAY0("Let debugee to finish\n");
     if (!NSK_VERIFY(nsk_jvmti_resumeSync()))
@@ -477,8 +454,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
             nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "counterMonitor", &counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("counterMonitor", &counterMonitor_ptr))) {
         return JNI_ERR;
     }
 
@@ -487,12 +463,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     caps.can_generate_object_free_events = 1;
     caps.can_generate_garbage_collection_events = 1;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_tag_objects)
@@ -509,8 +483,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.ObjectFree = &ObjectFree;
     callbacks.GarbageCollectionStart = &GarbageCollectionStart;
     callbacks.GarbageCollectionFinish = &GarbageCollectionFinish;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done.\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t002/ap04t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t002/ap04t002.cpp
@@ -59,30 +59,26 @@ static jrawMonitorID counterMonitor_ptr = NULL;
 
 static void increaseCounter(volatile int* counterPtr) {
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
     (*counterPtr)++;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 }
 
 static void setCounter(volatile int* counterPtr, int value) {
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
     *counterPtr = value;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -90,15 +86,13 @@ static void setCounter(volatile int* counterPtr, int value) {
 static int getCounter(volatile int* counterPtr) {
     int result;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
     result = *counterPtr;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -238,7 +232,7 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t002_setTag( JNIEnv* jni,
                                                           jobject target, /* object to be tagged */
                                                           jlong   tag ) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, target, tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(target, tag))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -253,11 +247,9 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t002_runIterateOverHeap( JNIEnv* jn
     setCounter(&iterationCount, 0);
 
     NSK_DISPLAY0("Calling IterateOverHeap...\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IterateOverHeap, jvmti,
-                                           JVMTI_HEAP_OBJECT_TAGGED,
-                                           heapObjectCallback,
-                                           NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED,
+                                                 heapObjectCallback,
+                                                 NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY0("IterateOverHeap finished.\n");
@@ -284,12 +276,10 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t002_runIterateOverReachableObjects
     setCounter(&iterationCount, 0);
 
     NSK_DISPLAY0("Calling IterateOverReachableObjects...\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                                                       heapRootCallback,
-                                                       stackReferenceCallback,
-                                                       objectReferenceCallback,
-                                                       NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(heapRootCallback,
+                                                             stackReferenceCallback,
+                                                             objectReferenceCallback,
+                                                             NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY0("IterateOverReachableObjects finished.\n");
@@ -316,12 +306,10 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t002_runIterateOverInstancesOfClass
     setCounter(&iterationCount, 0);
 
     NSK_DISPLAY0("Calling IterateOverInstancesOfClass...\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-                                                       debugeeClass,
-                                                       JVMTI_HEAP_OBJECT_TAGGED,
-                                                       heapObjectCallback,
-                                                       NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(debugeeClass,
+                                                             JVMTI_HEAP_OBJECT_TAGGED,
+                                                             heapObjectCallback,
+                                                             NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY0("IterateOverInstancesOfClass finished.\n");
@@ -345,9 +333,7 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t002_runIterateOverObjectsReachable
     int count = 0;
 
     if (!NSK_JNI_VERIFY(jni, (root =
-                NSK_CPP_STUB3(GetStaticObjectField, jni,
-                                                    debugeeClass,
-                                                    rootFieldID )) != NULL )) {
+                jni->GetStaticObjectField(debugeeClass, rootFieldID)) != NULL )) {
         NSK_COMPLAIN0("GetStaticObjectField returned NULL for 'root' field value\n\n");
         nsk_jvmti_setFailStatus();
         return;
@@ -358,11 +344,9 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t002_runIterateOverObjectsReachable
     setCounter(&iterationCount, 0);
 
     NSK_DISPLAY0("Calling IterateOverObjectsReachableFromObject...\n");
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti,
-                                                                     root,
-                                                                     objectReferenceCallback,
-                                                                     NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(root,
+                                                                       objectReferenceCallback,
+                                                                       NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY0("IterateOverObjectsReachableFromObject finished.\n");
@@ -393,35 +377,25 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
     }
 
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, debugeeClass)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = (jclass)jni->NewGlobalRef(debugeeClass)) != NULL))
         return;
 
     NSK_DISPLAY1("Find ID of 'root' field: %s\n", ROOT_SIGNATURE);
     if (!NSK_JNI_VERIFY(jni, (rootFieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni,
-                                            debugeeClass,
-                                            "root",
-                                            ROOT_SIGNATURE)) != NULL )) {
+            jni->GetStaticFieldID(debugeeClass, "root", ROOT_SIGNATURE)) != NULL )) {
         nsk_jvmti_setFailStatus();
         return;
     }
 
     NSK_DISPLAY0("Find ID of 'modified' field\n");
     if (!NSK_JNI_VERIFY(jni, (modifiedFieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni,
-                                            debugeeClass,
-                                            "modified",
-                                            "I")) != NULL )) {
+            jni->GetStaticFieldID(debugeeClass, "modified", "I")) != NULL )) {
         nsk_jvmti_setFailStatus();
         return;
     }
 
     NSK_DISPLAY0("Set FieldModification watchpoint for 'modified' field\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetFieldModificationWatch, jvmti,
-                                                     debugeeClass,
-                                                     modifiedFieldID))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetFieldModificationWatch(debugeeClass, modifiedFieldID))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -434,8 +408,8 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!NSK_VERIFY(nsk_jvmti_waitForSync(timeout)))
         return;
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, debugeeClass));
-    NSK_TRACE(NSK_CPP_STUB2(DestroyRawMonitor, jvmti, counterMonitor_ptr));
+    NSK_TRACE(jni->DeleteGlobalRef(debugeeClass));
+    NSK_TRACE(jvmti->DestroyRawMonitor(counterMonitor_ptr));
 
     NSK_DISPLAY0("Let debugee to finish\n");
     if (!NSK_VERIFY(nsk_jvmti_resumeSync()))
@@ -463,8 +437,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
             nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "counterMonitor", &counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("counterMonitor", &counterMonitor_ptr))) {
         return JNI_ERR;
     }
 
@@ -472,12 +445,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     caps.can_tag_objects = 1;
     caps.can_generate_field_modification_events = 1;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_tag_objects)
@@ -490,18 +461,15 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     (void) memset(&callbacks, 0, sizeof(callbacks));
 
     callbacks.FieldModification = &FieldModification;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done.\n");
 
     NSK_DISPLAY0("enabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4( SetEventNotificationMode,
-                                         jvmti,
-                                         JVMTI_ENABLE,
-                                         JVMTI_EVENT_FIELD_MODIFICATION,
-                                         NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE,
+                                                          JVMTI_EVENT_FIELD_MODIFICATION,
+                                                          NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done.\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t003/ap04t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP04/ap04t003/ap04t003.cpp
@@ -61,30 +61,26 @@ static jrawMonitorID counterMonitor_ptr = NULL;
 
 static void increaseCounter(volatile int* counterPtr) {
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
     (*counterPtr)++;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 }
 
 static void setCounter(volatile int* counterPtr, int value) {
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
     *counterPtr = value;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -92,15 +88,13 @@ static void setCounter(volatile int* counterPtr, int value) {
 static int getCounter(volatile int* counterPtr) {
     int result;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
     result = *counterPtr;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, jvmti, counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(counterMonitor_ptr))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -113,16 +107,13 @@ void notifyThread() {
 
     /* enter and notify runLock */
     {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorEnter, jvmti, runLock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(runLock))) {
             nsk_jvmti_setFailStatus();
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorNotify, jvmti, runLock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorNotify(runLock))) {
             nsk_jvmti_setFailStatus();
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorExit, jvmti, runLock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(runLock))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -227,12 +218,8 @@ void JNICALL agent_start(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
     {
         jlong tag = (jlong)1;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB6(GetObjectsWithTags, jvmti,
-                                              1, &tag,
-                                              &taggedObjectsCount,
-                                              &taggedObjectsList,
-                                              NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetObjectsWithTags(
+                1, &tag, &taggedObjectsCount, &taggedObjectsList, NULL))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -246,23 +233,19 @@ void JNICALL agent_start(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
     }
 
     /* enter runLock */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, jvmti, runLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(runLock))) {
         nsk_jvmti_setFailStatus();
     }
 
     /* enter and notify startLock */
     {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorEnter, jvmti, startLock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(startLock))) {
             nsk_jvmti_setFailStatus();
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorNotify, jvmti, startLock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorNotify(startLock))) {
             nsk_jvmti_setFailStatus();
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorExit, jvmti, startLock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(startLock))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -271,12 +254,10 @@ void JNICALL agent_start(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
 
     /* wait on runLock */
     {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(RawMonitorWait, jvmti, runLock, timeout))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorWait(runLock, timeout))) {
             nsk_jvmti_setFailStatus();
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorExit, jvmti, runLock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(runLock))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -288,8 +269,7 @@ void JNICALL agent_start(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
         int modified = 0;
         int i;
         for (i = 0; i < taggedObjectsCount; i+=2) {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(SetTag, jvmti, taggedObjectsList[i], 0))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->SetTag(taggedObjectsList[i], 0))) {
                 nsk_jvmti_setFailStatus();
                 continue;
             }
@@ -302,24 +282,20 @@ void JNICALL agent_start(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
 
     /* destroy objects list */
     {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)taggedObjectsList))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)taggedObjectsList))) {
             nsk_jvmti_setFailStatus();
         }
     }
 
     /* enter and notify endLock */
     {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorEnter, jvmti, endLock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(endLock))) {
             nsk_jvmti_setFailStatus();
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorNotify, jvmti, endLock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorNotify(endLock))) {
             nsk_jvmti_setFailStatus();
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorExit, jvmti, endLock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(endLock))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -333,31 +309,24 @@ static int startThread(JNIEnv* jni, jthread threadObj) {
     int success = NSK_TRUE;
 
     /* enter startLock */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, jvmti, startLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(startLock))) {
         nsk_jvmti_setFailStatus();
     }
 
     /* start thread */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(RunAgentThread, jvmti,
-                                          threadObj,
-                                          agent_start,
-                                          NULL,
-                                          JVMTI_THREAD_NORM_PRIORITY))) {
+            jvmti->RunAgentThread(threadObj, agent_start, NULL, JVMTI_THREAD_NORM_PRIORITY))) {
         success = NSK_FALSE;
         nsk_jvmti_setFailStatus();
     } else {
         /* wait on startLock */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(RawMonitorWait, jvmti, startLock, timeout))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorWait(startLock, timeout))) {
             nsk_jvmti_setFailStatus();
         }
     }
 
     /* exit starLock */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, jvmti, startLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(startLock))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -370,26 +339,17 @@ static jthread newThreadObj(JNIEnv* jni) {
     jmethodID cid;
     jthread result = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (thrClass =
-            NSK_CPP_STUB2(FindClass, jni,
-                                     "java/lang/Thread")) != NULL )) {
+    if (!NSK_JNI_VERIFY(jni, (thrClass = jni->FindClass("java/lang/Thread")) != NULL )) {
         nsk_jvmti_setFailStatus();
         return result;
     }
 
-    if (!NSK_JNI_VERIFY(jni, (cid =
-            NSK_CPP_STUB4(GetMethodID, jni,
-                                       thrClass,
-                                       "<init>",
-                                       "()V")) != NULL )) {
+    if (!NSK_JNI_VERIFY(jni, (cid = jni->GetMethodID(thrClass, "<init>", "()V")) != NULL )) {
         nsk_jvmti_setFailStatus();
         return result;
     }
 
-    if (!NSK_JNI_VERIFY(jni, (result =
-            NSK_CPP_STUB3(NewObject, jni,
-                                     thrClass,
-                                     cid )) != NULL )) {
+    if (!NSK_JNI_VERIFY(jni, (result = jni->NewObject(thrClass, cid)) != NULL )) {
         nsk_jvmti_setFailStatus();
         return result;
     }
@@ -412,8 +372,7 @@ static int prepareToIteration (JNIEnv* jni) {
     }
 
     /* enter endLock */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, jvmti, endLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(endLock))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -430,14 +389,12 @@ static void afterIteration (JNIEnv* jni) {
     NSK_DISPLAY0("Wait for new agent thread to complete\n");
 
     /* wait on endLock */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RawMonitorWait, jvmti, endLock, timeout))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorWait(endLock, timeout))) {
         nsk_jvmti_setFailStatus();
     }
 
     /* exit endLock */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, jvmti, endLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(endLock))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -450,7 +407,7 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t003_setTag( JNIEnv* jni,
                                                           jobject target, /* object to be tagged */
                                                           jlong   tag ) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, target, tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(target, tag))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -465,11 +422,9 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t003_runIterateOverHeap( JNIEnv* jn
         return;
 
     NSK_DISPLAY0("Calling IterateOverHeap...\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IterateOverHeap, jvmti,
-                                           JVMTI_HEAP_OBJECT_TAGGED,
-                                           heapObjectCallback,
-                                           NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED,
+                                                 heapObjectCallback,
+                                                 NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY0("IterateOverHeap finished.\n");
@@ -497,12 +452,10 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t003_runIterateOverReachableObjects
         return;
 
     NSK_DISPLAY0("Calling IterateOverReachableObjects...\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                                                       heapRootCallback,
-                                                       stackReferenceCallback,
-                                                       objectReferenceCallback,
-                                                       NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(heapRootCallback,
+                                                             stackReferenceCallback,
+                                                             objectReferenceCallback,
+                                                             NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY0("IterateOverReachableObjects finished.\n");
@@ -530,12 +483,10 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t003_runIterateOverInstancesOfClass
         return;
 
     NSK_DISPLAY0("Calling IterateOverInstancesOfClass...\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-                                                       debugeeClass,
-                                                       JVMTI_HEAP_OBJECT_TAGGED,
-                                                       heapObjectCallback,
-                                                       NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(debugeeClass,
+                                                             JVMTI_HEAP_OBJECT_TAGGED,
+                                                             heapObjectCallback,
+                                                             NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY0("IterateOverInstancesOfClass finished.\n");
@@ -561,9 +512,7 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t003_runIterateOverObjectsReachable
     int found = 0;
 
     if (!NSK_JNI_VERIFY(jni, (root =
-            NSK_CPP_STUB3(GetStaticObjectField, jni,
-                                                debugeeClass,
-                                                rootFieldID )) != NULL )) {
+            jni->GetStaticObjectField(debugeeClass, rootFieldID)) != NULL )) {
         NSK_COMPLAIN0("GetStaticObjectField returned NULL for 'root' field value\n\n");
         nsk_jvmti_setFailStatus();
         return;
@@ -573,11 +522,9 @@ Java_nsk_jvmti_scenarios_allocation_AP04_ap04t003_runIterateOverObjectsReachable
         return;
 
     NSK_DISPLAY0("Calling IterateOverObjectsReachableFromObject...\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject, jvmti,
-                                                                 root,
-                                                                 objectReferenceCallback,
-                                                                 NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(root,
+                                                                       objectReferenceCallback,
+                                                                       NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     NSK_DISPLAY0("IterateOverObjectsReachableFromObject finished.\n");
@@ -609,16 +556,12 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
     }
 
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, debugeeClass)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = (jclass)jni->NewGlobalRef(debugeeClass)) != NULL))
         return;
 
     NSK_DISPLAY1("Find ID of 'root' field: %s\n", ROOT_SIGNATURE);
     if (!NSK_JNI_VERIFY(jni, (rootFieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni,
-                                            debugeeClass,
-                                            "root",
-                                            ROOT_SIGNATURE)) != NULL )) {
+            jni->GetStaticFieldID(debugeeClass, "root", ROOT_SIGNATURE)) != NULL )) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -631,11 +574,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!NSK_VERIFY(nsk_jvmti_waitForSync(timeout)))
         return;
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, debugeeClass));
-    NSK_TRACE(NSK_CPP_STUB2(DestroyRawMonitor, jvmti, counterMonitor_ptr));
-    NSK_TRACE(NSK_CPP_STUB2(DestroyRawMonitor, jvmti, startLock));
-    NSK_TRACE(NSK_CPP_STUB2(DestroyRawMonitor, jvmti, runLock));
-    NSK_TRACE(NSK_CPP_STUB2(DestroyRawMonitor, jvmti, endLock));
+    NSK_TRACE(jni->DeleteGlobalRef(debugeeClass));
+    NSK_TRACE(jvmti->DestroyRawMonitor(counterMonitor_ptr));
+    NSK_TRACE(jvmti->DestroyRawMonitor(startLock));
+    NSK_TRACE(jvmti->DestroyRawMonitor(runLock));
+    NSK_TRACE(jvmti->DestroyRawMonitor(endLock));
 
     NSK_DISPLAY0("Let debugee to finish\n");
     if (!NSK_VERIFY(nsk_jvmti_resumeSync()))
@@ -663,33 +606,27 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
             nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "counterMonitor", &counterMonitor_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("counterMonitor", &counterMonitor_ptr))) {
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "startLock", &startLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("startLock", &startLock))) {
         return JNI_ERR;
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "runLock", &runLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("runLock", &runLock))) {
         return JNI_ERR;
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "endLock", &endLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("endLock", &endLock))) {
         return JNI_ERR;
     }
 
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_tag_objects = 1;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_tag_objects)

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP05/ap05t001/ap05t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP05/ap05t001/ap05t001.cpp
@@ -105,15 +105,14 @@ Java_nsk_jvmti_scenarios_allocation_AP05_ap05t001_setTag( JNIEnv* jni,
                                                           jobject target,
                                                           jlong   tag ) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, target, tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(target, tag))) {
         nsk_jvmti_setFailStatus();
     }
 }
 
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_scenarios_allocation_AP05_ap05t001_setReferrer( JNIEnv* jni, jclass klass, jobject ref) {
-    if (!NSK_JNI_VERIFY(jni, (referrer =
-            NSK_CPP_STUB2(NewGlobalRef, jni, ref)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (referrer = jni->NewGlobalRef(ref)) != NULL))
         nsk_jvmti_setFailStatus();
 }
 
@@ -130,12 +129,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         staticFieldsCount = 0;
         instanceFieldsCount = 0;
         NSK_DISPLAY0("\nCalling IterateOverReachableObjects\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                                                           heapRootCallback,
-                                                           stackReferenceCallback,
-                                                           objectReferenceCallback,
-                                                           NULL /*user_data*/))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(heapRootCallback,
+                                                                 stackReferenceCallback,
+                                                                 objectReferenceCallback,
+                                                                 NULL /*user_data*/))) {
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -156,12 +153,8 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         instanceFieldsCount = 0;
         NSK_DISPLAY0("\nCalling IterateOverObjectsReachableFromObject\n");
         {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(IterateOverObjectsReachableFromObject,
-                        jvmti,
-                        referrer,
-                        objectReferenceCallback,
-                        NULL /*user_data*/))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(
+                    referrer, objectReferenceCallback, NULL /*user_data*/))) {
                 nsk_jvmti_setFailStatus();
                 break;
             }
@@ -180,7 +173,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
 
 
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, referrer));
+        NSK_TRACE(jni->DeleteGlobalRef(referrer));
 
     } while (0);
 
@@ -213,12 +206,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_tag_objects = 1;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_tag_objects)

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP05/ap05t002/ap05t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/allocation/AP05/ap05t002/ap05t002.cpp
@@ -103,7 +103,7 @@ Java_nsk_jvmti_scenarios_allocation_AP05_ap05t002_setTag( JNIEnv* jni,
                                                           jobject target,
                                                           jlong   tag ) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, target, tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(target, tag))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -111,8 +111,7 @@ Java_nsk_jvmti_scenarios_allocation_AP05_ap05t002_setTag( JNIEnv* jni,
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_scenarios_allocation_AP05_ap05t002_setReferrer( JNIEnv* jni, jclass klass, jobject ref, jint caseNum) {
     caseNumber = caseNum;
-    if (!NSK_JNI_VERIFY(jni, (referrer =
-            NSK_CPP_STUB2(NewGlobalRef, jni, ref)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (referrer = jni->NewGlobalRef(ref)) != NULL))
         nsk_jvmti_setFailStatus();
 }
 
@@ -120,12 +119,10 @@ static void runCase() {
     NSK_DISPLAY0("\nCalling IterateOverReachableObjects\n");
     forthRef = 0;
     backRef = 0;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(IterateOverReachableObjects, jvmti,
-                                                       heapRootCallback,
-                                                       stackReferenceCallback,
-                                                       objectReferenceCallback,
-                                                       NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverReachableObjects(heapRootCallback,
+                                                             stackReferenceCallback,
+                                                             objectReferenceCallback,
+                                                             NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     if (forthRef != 1) {
@@ -142,12 +139,9 @@ static void runCase() {
     NSK_DISPLAY0("\nCalling IterateOverObjectsReachableFromObject\n");
     forthRef = 0;
     backRef = 0;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(IterateOverObjectsReachableFromObject,
-                jvmti,
-                referrer,
-                objectReferenceCallback,
-                NULL /*user_data*/))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverObjectsReachableFromObject(referrer,
+                                                                       objectReferenceCallback,
+                                                                       NULL /*user_data*/))) {
         nsk_jvmti_setFailStatus();
     }
     if (forthRef != 1) {
@@ -175,7 +169,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0("CASE #1\n");
         runCase();
 
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, referrer));
+        NSK_TRACE(jni->DeleteGlobalRef(referrer));
         if (!NSK_VERIFY(nsk_jvmti_resumeSync()))
             return;
         if (!NSK_VERIFY(nsk_jvmti_waitForSync(timeout)))
@@ -184,7 +178,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0("CASE #2\n");
         runCase();
 
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, referrer));
+        NSK_TRACE(jni->DeleteGlobalRef(referrer));
     } while (0);
 
     NSK_DISPLAY0("Let debugee to finish\n");
@@ -216,12 +210,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_tag_objects = 1;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_tag_objects)


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

I omitted one hunk for test/hotspot/jtreg/vmTestbase/nsk/jvmti/MonitorWaited/monitorwaited001/monitorwaited001.cpp
and  test/hotspot/jtreg/vmTestbase/nsk/jvmti/MonitorWaited/monitorwaited001/monitorwaited001.cpp
because JDK-8220352 "[TESTBUG] Crash with assert(external_guard || result != __null) failed: Invalid JNI handle" 
removing the code was already backported.
In head, 8220352 was applied after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8211782](https://bugs.openjdk.java.net/browse/JDK-8211782): Remove the NSK_CPP_STUB macros from vmTestbase for jvmti/[I-S]*


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/667/head:pull/667` \
`$ git checkout pull/667`

Update a local copy of the PR: \
`$ git checkout pull/667` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 667`

View PR using the GUI difftool: \
`$ git pr show -t 667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/667.diff">https://git.openjdk.java.net/jdk11u-dev/pull/667.diff</a>

</details>
