### PR TITLE
8212082: Remove the NSK_CPP_STUB macros for remaining vmTestbase/jvmti/[sS]*

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEnvironmentLocalStorage/setenvstor001/setenvstor001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEnvironmentLocalStorage/setenvstor001/setenvstor001.cpp
@@ -73,8 +73,7 @@ static void fillEnvStorage(StorageStructure* storage) {
 static int setEnvStorage(jvmtiEnv* jvmti, StorageStructure* storage, const char where[]) {
 
     NSK_DISPLAY1("Set local storage for current JVMTI env: 0x%p\n", (void*)storage);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(SetEnvironmentLocalStorage, jvmti, storage))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEnvironmentLocalStorage(storage))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... ok\n");
@@ -89,8 +88,7 @@ static int checkEnvStorage(jvmtiEnv* jvmti, StorageStructure* initialStorage, co
     StorageStructure* storage = NULL;
 
     NSK_DISPLAY0("Get local storage for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetEnvironmentLocalStorage, jvmti, (void**)&storage))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetEnvironmentLocalStorage((void**)&storage))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got storage: 0x%p\n", (void*)storage);
@@ -216,9 +214,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEnvironmentLocalStorage/setenvstor002/setenvstor002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEnvironmentLocalStorage/setenvstor002/setenvstor002.cpp
@@ -73,8 +73,7 @@ static void fillEnvStorage(StorageStructure* storage) {
 static int setEnvStorage(jvmtiEnv* jvmti, StorageStructure* storage, const char where[]) {
 
     NSK_DISPLAY1("Set local storage for current JVMTI env: 0x%p\n", (void*)storage);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(SetEnvironmentLocalStorage, jvmti, storage))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEnvironmentLocalStorage(storage))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... ok\n");
@@ -89,8 +88,7 @@ static int checkEnvStorage(jvmtiEnv* jvmti, StorageStructure* initialStorage, co
     StorageStructure* storage = NULL;
 
     NSK_DISPLAY0("Get local storage for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetEnvironmentLocalStorage, jvmti, (void**)&storage))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetEnvironmentLocalStorage((void**)&storage))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got storage: 0x%p\n", (void*)storage);
@@ -221,9 +219,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEnvironmentLocalStorage/setenvstor003/setenvstor003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEnvironmentLocalStorage/setenvstor003/setenvstor003.cpp
@@ -73,8 +73,7 @@ static void fillEnvStorage(StorageStructure* storage) {
 static int setEnvStorage(jvmtiEnv* jvmti, StorageStructure* storage, const char where[]) {
 
     NSK_DISPLAY1("Set local storage for current JVMTI env: 0x%p\n", (void*)storage);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(SetEnvironmentLocalStorage, jvmti, storage))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEnvironmentLocalStorage(storage))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... ok\n");
@@ -89,8 +88,7 @@ static int checkEnvStorage(jvmtiEnv* jvmti, StorageStructure* initialStorage, co
     StorageStructure* storage = NULL;
 
     NSK_DISPLAY0("Get local storage for current JVMTI env\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetEnvironmentLocalStorage, jvmti, (void**)&storage))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetEnvironmentLocalStorage((void**)&storage))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got storage: 0x%p\n", (void*)storage);
@@ -224,9 +222,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEventCallbacks/setevntcallb001/setevntcallb001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEventCallbacks/setevntcallb001/setevntcallb001.cpp
@@ -143,9 +143,7 @@ callbackVMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ThreadStart = callbackThreadStart;
         eventCallbacks.ThreadEnd = callbackThreadEnd;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             nsk_jvmti_setFailStatus();
         } else {
             nsk_jvmti_enableEvents(JVMTI_ENABLE, EVENTS_COUNT - 1, eventsList + 1, NULL);
@@ -190,9 +188,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMInit = callbackVMInit;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             nsk_jvmti_setFailStatus();
         } else {
             nsk_jvmti_enableEvents(JVMTI_ENABLE, 1, eventsList, NULL);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEventCallbacks/setevntcallb002/setevntcallb002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEventCallbacks/setevntcallb002/setevntcallb002.cpp
@@ -145,8 +145,7 @@ callbackVMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 
     NSK_DISPLAY0(">>> Testcase #2: Set NULL for events callbacks\n");
     {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, NULL, 0))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(NULL, 0))) {
             nsk_jvmti_setFailStatus();
         }
 
@@ -193,9 +192,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.ThreadStart = callbackThreadStart;
         eventCallbacks.ThreadEnd = callbackThreadEnd;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             nsk_jvmti_setFailStatus();
         } else {
             nsk_jvmti_enableEvents(JVMTI_ENABLE, 1, eventsList, NULL);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEventCallbacks/setevntcallb003/setevntcallb003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetEventCallbacks/setevntcallb003/setevntcallb003.cpp
@@ -151,9 +151,7 @@ callbackVMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ThreadStart = callbackThreadStart;
         eventCallbacks.ThreadEnd = callbackThreadEnd;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, size))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, size))) {
             nsk_jvmti_setFailStatus();
         }
 
@@ -198,9 +196,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.VMInit = callbackVMInit;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             nsk_jvmti_setFailStatus();
         } else {
             nsk_jvmti_enableEvents(JVMTI_ENABLE, 1, eventsList, NULL);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetExtensionEventCallback/setextevent001/setextevent001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetExtensionEventCallback/setextevent001/setextevent001.cpp
@@ -48,8 +48,7 @@ static int checkExtensions(jvmtiEnv* jvmti, const char phase[]) {
     int i;
 
     NSK_DISPLAY0("Get extension events list\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetExtensionEvents, jvmti, &extCount, &extList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetExtensionEvents(&extCount, &extList))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got count: %d\n", (int)extCount);
@@ -72,18 +71,14 @@ static int checkExtensions(jvmtiEnv* jvmti, const char phase[]) {
 
             NSK_DISPLAY1("    ... setting callback: 0x%p\n", (void*)callbackExtensionEvent);
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(SetExtensionEventCallback, jvmti,
-                                        extList[i].extension_event_index,
-                                        callbackExtensionEvent))) {
+                    jvmti->SetExtensionEventCallback(extList[i].extension_event_index, callbackExtensionEvent))) {
                 success = NSK_FALSE;
             }
             NSK_DISPLAY0("    ... done\n");
 
             NSK_DISPLAY1("    ... clearing callback: 0x%p\n", (void*)NULL);
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(SetExtensionEventCallback, jvmti,
-                                        extList[i].extension_event_index,
-                                        NULL))) {
+                    jvmti->SetExtensionEventCallback(extList[i].extension_event_index, NULL))) {
                 success = NSK_FALSE;
             }
             NSK_DISPLAY0("    ... done\n");
@@ -91,8 +86,7 @@ static int checkExtensions(jvmtiEnv* jvmti, const char phase[]) {
     }
 
     NSK_DISPLAY1("Deallocate extension events list: 0x%p\n", (void*)extList);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)extList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)extList))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... deallocated\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetNativeMethodPrefix/SetNativeMethodPrefix001/SetNativeMethodPrefix001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetNativeMethodPrefix/SetNativeMethodPrefix001/SetNativeMethodPrefix001.cpp
@@ -123,27 +123,11 @@ Java_nsk_jvmti_SetNativeMethodPrefix_Binder_setMethodPrefix (
     char *str = NULL;
 
     if (prefix != NULL) {
-        if (!NSK_VERIFY(
-                (str = (char *) NSK_CPP_STUB3(
-                              GetStringUTFChars
-                              , jni
-                              , prefix
-                              , 0
-                         )
-                    ) != NULL
-                )
-           )
+        if (!NSK_VERIFY((str = (char *) jni->GetStringUTFChars(prefix, 0)) != NULL))
         { result = JNI_FALSE; goto finally; }
     }
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    SetNativeMethodPrefix
-                    , jvmti
-                    , str
-                    )
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->SetNativeMethodPrefix(str)))
     { result = JNI_FALSE; goto finally; }
 
     if (str != NULL) {
@@ -175,27 +159,10 @@ Java_nsk_jvmti_SetNativeMethodPrefix_Binder_setMultiplePrefixes (
     char *str = NULL;
 
     if (prefix != NULL) {
-        if (!NSK_VERIFY(
-                (str = (char *) NSK_CPP_STUB3(
-                              GetStringUTFChars
-                              , jni
-                              , prefix
-                              , 0
-                         )
-                    ) != NULL
-                )
-           )
+        if (!NSK_VERIFY((str = (char *) jni->GetStringUTFChars(prefix, 0)) != NULL))
         { result = JNI_FALSE; goto finally; }
 
-        if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(
-                        SetNativeMethodPrefixes
-                        , jvmti
-                        , 1
-                        , (char **) &str
-                        )
-                    )
-           )
+        if (!NSK_JVMTI_VERIFY(jvmti->SetNativeMethodPrefixes(1, (char **) &str)))
         { result = JNI_FALSE; goto finally; }
 
         NSK_DISPLAY1("MultiplePrefixes: New PREFIX is set: %s\n"
@@ -205,15 +172,7 @@ Java_nsk_jvmti_SetNativeMethodPrefix_Binder_setMultiplePrefixes (
         char* prefixes[1];
         prefixes[0] = NULL;
 
-        if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(
-                        SetNativeMethodPrefixes
-                        , jvmti
-                        , 0
-                        , (char **)&prefixes
-                        )
-                    )
-           )
+        if (!NSK_JVMTI_VERIFY(jvmti->SetNativeMethodPrefixes(0, (char **)&prefixes)))
         { result = JNI_FALSE; goto finally; }
 
         NSK_DISPLAY0("Old PREFIX is reset\n");
@@ -250,33 +209,11 @@ Java_nsk_jvmti_SetNativeMethodPrefix_Binder_registerMethod (
         return JNI_FALSE;
     }
 
-    if (!NSK_VERIFY(
-            (method.name =
-                (char *) NSK_CPP_STUB3(
-                     GetStringUTFChars
-                     , jni
-                     , method_name_obj
-                     , 0
-                    )
-            ) != NULL
-            )
-       )
-    {
+    if (!NSK_VERIFY((method.name = (char *) jni->GetStringUTFChars(method_name_obj, 0)) != NULL)) {
         goto finally;
     }
 
-    if (!NSK_VERIFY(
-            (method.signature =
-                    (char *) NSK_CPP_STUB3(
-                         GetStringUTFChars
-                         , jni
-                         , method_sig_obj
-                         , 0
-                    )
-            ) != NULL
-            )
-       )
-    {
+    if (!NSK_VERIFY((method.signature = (char *) jni->GetStringUTFChars(method_sig_obj, 0)) != NULL)) {
         goto finally;
     }
 
@@ -341,25 +278,13 @@ jint Agent_Initialize(JavaVM *vm, char *options, void *reserved)
        )
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    GetCapabilities
-                    , jvmti
-                    , &caps)
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     // Register all necessary JVM capabilities
     caps.can_set_native_method_prefix = 1;
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    AddCapabilities
-                    , jvmti
-                    , &caps)
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetNativeMethodPrefix/SetNativeMethodPrefix002/SetNativeMethodPrefix002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetNativeMethodPrefix/SetNativeMethodPrefix002/SetNativeMethodPrefix002.cpp
@@ -60,13 +60,7 @@ Java_nsk_jvmti_SetNativeMethodPrefix_SetNativeMethodPrefix002_foo (
 
 static jboolean setMethodPrefix (char *prefix)
 {
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    SetNativeMethodPrefix
-                    , jvmti
-                    , prefix)
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->SetNativeMethodPrefix(prefix)))
         return JNI_FALSE;
 
     return JNI_TRUE;
@@ -114,25 +108,13 @@ jint Agent_Initialize(JavaVM *vm, char *options, void *reserved)
        )
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    GetCapabilities
-                    , jvmti
-                    , &caps)
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     // Register all necessary JVM capabilities
     caps.can_set_native_method_prefix = 1;
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(
-                    AddCapabilities
-                    , jvmti
-                    , &caps)
-                )
-       )
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop002/setsysprop002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop002/setsysprop002.cpp
@@ -76,8 +76,7 @@ static int checkPropertyValue(jvmtiEnv* jvmti, const char phase[],
     char* value = NULL;
 
     NSK_DISPLAY1("  property: %s\n", name);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetSystemProperty, jvmti, name, &value))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetSystemProperty(name, &value))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("     value: \"%s\"\n", nsk_null_string(value));
@@ -93,8 +92,7 @@ static int checkPropertyValue(jvmtiEnv* jvmti, const char phase[],
         success = NSK_FALSE;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)value))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)value))) {
         success = NSK_FALSE;
     }
 
@@ -120,14 +118,12 @@ static int checkProperties(jvmtiEnv* jvmti, const char phase[], int step) {
         NSK_DISPLAY1("     value: \"%s\"\n", propDescList[i].values[step]);
         if (step > 1) {
             if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_WRONG_PHASE,
-                   NSK_CPP_STUB3(SetSystemProperty, jvmti,
-                     propDescList[i].name, propDescList[i].values[step]))) {
+                   jvmti->SetSystemProperty(propDescList[i].name, propDescList[i].values[step]))) {
                 success = NSK_FALSE;
             }
         } else {
             if (!NSK_JVMTI_VERIFY(
-                   NSK_CPP_STUB3(SetSystemProperty, jvmti,
-                     propDescList[i].name, propDescList[i].values[step]))) {
+                   jvmti->SetSystemProperty(propDescList[i].name, propDescList[i].values[step]))) {
                 success = NSK_FALSE;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop003/setsysprop003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetSystemProperty/setsysprop003/setsysprop003.cpp
@@ -56,8 +56,7 @@ static int setProperties(jvmtiEnv* jvmti) {
         NSK_DISPLAY1("  property: %s\n", propDescList[i].name);
         NSK_DISPLAY1("     value: \"%s\"\n", propDescList[i].value);
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetSystemProperty, jvmti,
-                                propDescList[i].name, propDescList[i].value))) {
+                jvmti->SetSystemProperty(propDescList[i].name, propDescList[i].value))) {
             success = NSK_FALSE;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetTag/settag001/settag001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetTag/settag001/settag001.cpp
@@ -61,7 +61,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
             if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-                    NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+                    jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -69,8 +69,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Find static field: %s\n", OBJECT_FIELD_NAME);
             if (!NSK_JNI_VERIFY(jni, (objectField =
-                    NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                                    OBJECT_FIELD_NAME, OBJECT_CLASS_SIG)) != NULL)) {
+                    jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, OBJECT_CLASS_SIG)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -78,16 +77,14 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
             NSK_DISPLAY1("Get object from static field: %s\n", OBJECT_FIELD_NAME);
             if (!NSK_JNI_VERIFY(jni, (testedObject =
-                    NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                            objectField)) != NULL)) {
+                    jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
             NSK_DISPLAY1("  ... got object: 0x%p\n", (void*)testedObject);
 
             NSK_DISPLAY1("Create global reference for object: 0x%p\n", (void*)testedObject);
-            if (!NSK_JNI_VERIFY(jni, (testedObject =
-                    NSK_CPP_STUB2(NewGlobalRef, jni, testedObject)) != NULL)) {
+            if (!NSK_JNI_VERIFY(jni, (testedObject = jni->NewGlobalRef(testedObject)) != NULL)) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -97,8 +94,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Testcase #1: set tag for the tested object\n");
         {
             NSK_DISPLAY1("Set tag for object: 0x%p\n", (void*)testedObject);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(SetTag, jvmti, testedObject, objectTag))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->SetTag(testedObject, objectTag))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -110,8 +106,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             jlong tag = 222;
 
             NSK_DISPLAY1("Get tag for object: 0x%p\n", (void*)testedObject);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetTag, jvmti, testedObject, &tag))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetTag(testedObject, &tag))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -140,8 +135,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
                 return;
 
             NSK_DISPLAY1("Get tag for object: 0x%p\n", (void*)testedObject);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetTag, jvmti, testedObject, &tag))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetTag(testedObject, &tag))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -162,7 +156,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0(">>> Clean used data\n");
         {
             NSK_DISPLAY1("Delete object reference: 0x%p\n", (void*)testedObject);
-            NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedObject));
+            NSK_TRACE(jni->DeleteGlobalRef(testedObject));
         }
     }
 
@@ -205,8 +199,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetThreadLocalStorage/setthrdstor001/setthrdstor001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetThreadLocalStorage/setthrdstor001/setthrdstor001.cpp
@@ -73,9 +73,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
         NSK_DISPLAY1("SetThreadLocalStorage() for tested thread with pointer: %p\n",
                                                     (void*)initialStorage);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetThreadLocalStorage, jvmti,
-                                        testedThread, (void*)initialStorage))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetThreadLocalStorage(testedThread, (void*)initialStorage))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -90,8 +88,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
         NSK_DISPLAY0("GetThreadLocalStorage() for tested thread\n");
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadLocalStorage, jvmti,
-                                        testedThread, (void**)&obtainedStorage))) {
+                jvmti->GetThreadLocalStorage(testedThread, (void**)&obtainedStorage))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -128,7 +125,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
 
         NSK_DISPLAY0("Delete thread reference\n");
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedThread));
+        NSK_TRACE(jni->DeleteGlobalRef(testedThread));
     }
 
     NSK_DISPLAY0("Let debugee to finish\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetThreadLocalStorage/setthrdstor002/setthrdstor002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetThreadLocalStorage/setthrdstor002/setthrdstor002.cpp
@@ -66,9 +66,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
         NSK_DISPLAY1("SetThreadLocalStorage() for current agent thread with pointer: %p\n",
                                                     (void*)initialStorage);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetThreadLocalStorage, jvmti,
-                                        NULL, (void*)initialStorage))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetThreadLocalStorage(NULL, (void*)initialStorage))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -82,9 +80,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY0("GetThreadLocalStorage() for current agent thread\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadLocalStorage, jvmti,
-                                        NULL, (void**)&obtainedStorage))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadLocalStorage(NULL, (void**)&obtainedStorage))) {
             nsk_jvmti_setFailStatus();
             return;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetThreadLocalStorage/setthrdstor003/setthrdstor003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetThreadLocalStorage/setthrdstor003/setthrdstor003.cpp
@@ -120,8 +120,7 @@ callbackThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     if (thread != NULL) {
         jvmtiThreadInfo info;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, thread, &info))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(thread, &info))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -133,9 +132,7 @@ callbackThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 
             NSK_DISPLAY1("SetThreadLocalStorage() for current thread with pointer: %p\n",
                                                                 (void*)initialStorage);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(SetThreadLocalStorage, jvmti,
-                                        NULL, (void*)initialStorage))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->SetThreadLocalStorage(NULL, (void*)initialStorage))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -151,8 +148,7 @@ callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     if (thread != NULL) {
         jvmtiThreadInfo info;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, thread, &info))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(thread, &info))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -168,8 +164,7 @@ callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 
                 NSK_DISPLAY0("GetThreadLocalStorage() for current thread\n");
                 if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB3(GetThreadLocalStorage, jvmti,
-                                            NULL, (void**)&obtainedStorage))) {
+                        jvmti->GetThreadLocalStorage(NULL, (void**)&obtainedStorage))) {
                     nsk_jvmti_setFailStatus();
                     return;
                 }
@@ -243,8 +238,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ThreadStart = callbackThreadStart;
         callbacks.ThreadEnd = callbackThreadEnd;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, sizeof(callbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA08/ma08t001/ma08t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA08/ma08t001/ma08t001.cpp
@@ -60,8 +60,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -73,8 +72,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -90,8 +88,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     if (threadForStop == NULL) {
@@ -106,17 +103,14 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
 
     NSK_DISPLAY0("Prepare: create new instance of ThreadDeath exception\n");
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (threadDeath =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (threadDeath = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -140,8 +134,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!NSK_VERIFY(threadForStop != NULL)) {
         nsk_jvmti_setFailStatus();
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(StopThread, jvmti, threadForStop, threadDeath)))
+        if (!NSK_JVMTI_VERIFY(jvmti->StopThread(threadForStop, threadDeath)))
             nsk_jvmti_setFailStatus();
     }
 
@@ -149,8 +142,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!NSK_VERIFY(threadForInterrupt != NULL)) {
         nsk_jvmti_setFailStatus();
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(InterruptThread, jvmti, threadForInterrupt)))
+        if (!NSK_JVMTI_VERIFY(jvmti->InterruptThread(threadForInterrupt)))
             nsk_jvmti_setFailStatus();
     }
 
@@ -199,7 +191,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_signal_thread = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t001/ma10t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t001/ma10t001.cpp
@@ -58,19 +58,17 @@ Exception(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread,
 
     ExceptionEventsCount++;
 
-    if (!NSK_JNI_VERIFY(jni_env, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, exception)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(exception)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti_env,
-            klass, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY1("Exception event: %s\n", signature);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 void JNICALL
@@ -85,19 +83,17 @@ ExceptionCatch(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread,
 
     ExceptionCatchEventsCount++;
 
-    if (!NSK_JNI_VERIFY(jni_env, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, exception)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(exception)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti_env,
-            klass, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY1("ExceptionCatch event: %s\n", signature);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 /* ========================================================================== */
@@ -109,11 +105,9 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!nsk_jvmti_waitForSync(timeout))
         return;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION, NULL)))
         nsk_jvmti_setFailStatus();
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION_CATCH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_EXCEPTION_CATCH, NULL)))
         nsk_jvmti_setFailStatus();
 
     /* resume debugee and wait for sync */
@@ -122,11 +116,9 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!nsk_jvmti_waitForSync(timeout))
         return;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_DISABLE, JVMTI_EVENT_EXCEPTION, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_EXCEPTION, NULL)))
         nsk_jvmti_setFailStatus();
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_DISABLE, JVMTI_EVENT_EXCEPTION_CATCH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_EXCEPTION_CATCH, NULL)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY1("Exception events received: %d\n",
@@ -178,7 +170,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_exception_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t001/ma10t001a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t001/ma10t001a.cpp
@@ -54,19 +54,17 @@ Exception(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread,
 
     ExceptionEventsCount++;
 
-    if (!NSK_JNI_VERIFY(jni_env, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, exception)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(exception)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti_env,
-            klass, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY1("Exception event: %s\n", signature);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 void JNICALL
@@ -77,19 +75,17 @@ ExceptionCatch(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jthread thread,
 
     ExceptionCatchEventsCount++;
 
-    if (!NSK_JNI_VERIFY(jni_env, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, exception)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(exception)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti_env,
-            klass, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY1("ExceptionCatch event: %s\n", signature);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 /* ========================================================================== */
@@ -156,7 +152,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_exception_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t002/ma10t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t002/ma10t002.cpp
@@ -54,16 +54,15 @@ MethodEntry(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     char *signature = NULL;
 
     MethodEntryEventsCount++;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("MethodEntry event: %s%s\n", name, signature);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 /* ========================================================================== */
@@ -78,8 +77,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -91,8 +89,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -103,13 +100,11 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         }
     }
 
-    if (!NSK_JNI_VERIFY(jni, (thread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL))
         return NSK_FALSE;
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -129,8 +124,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, thread)))
         nsk_jvmti_setFailStatus();
 
     /* resume debugee and wait for sync */
@@ -144,7 +138,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!NSK_VERIFY(MethodEntryEventsCount != 0))
         nsk_jvmti_setFailStatus();
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, thread));
+    NSK_TRACE(jni->DeleteGlobalRef(thread));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -185,7 +179,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_method_entry_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t002/ma10t002a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t002/ma10t002a.cpp
@@ -51,16 +51,15 @@ MethodEntry(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     char *signature = NULL;
 
     MethodEntryEventsCount++;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("MethodEntry event: %s%s\n", name, signature);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 /* ========================================================================== */
@@ -122,7 +121,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_method_entry_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t003/ma10t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t003/ma10t003.cpp
@@ -55,16 +55,15 @@ MethodExit(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     char *signature = NULL;
 
     MethodExitEventsCount++;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("MethodExit event: %s%s\n", name, signature);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 /* ========================================================================== */
@@ -79,8 +78,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -92,8 +90,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -104,13 +101,11 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         }
     }
 
-    if (!NSK_JNI_VERIFY(jni, (thread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL))
         return NSK_FALSE;
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -130,8 +125,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_METHOD_EXIT, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_EXIT, thread)))
         nsk_jvmti_setFailStatus();
 
     /* resume debugee and wait for sync */
@@ -145,7 +139,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!NSK_VERIFY(MethodExitEventsCount != 0))
         nsk_jvmti_setFailStatus();
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, thread));
+    NSK_TRACE(jni->DeleteGlobalRef(thread));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -186,7 +180,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_method_exit_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t003/ma10t003a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t003/ma10t003a.cpp
@@ -52,16 +52,15 @@ MethodExit(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     char *signature = NULL;
 
     MethodExitEventsCount++;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("MethodExit event: %s%s\n", name, signature);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 /* ========================================================================== */
@@ -123,7 +122,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_method_exit_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t004/ma10t004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t004/ma10t004.cpp
@@ -56,20 +56,18 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     SingleStepEventsCount++;
 
-    NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-        jvmti_env, JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, NULL));
+    NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, NULL));
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY3("SingleStep event: %s%s, location=%s\n", name, signature,
         jlong_to_string(location, buffer));
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 /* ========================================================================== */
@@ -84,8 +82,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -97,8 +94,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -109,13 +105,11 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         }
     }
 
-    if (!NSK_JNI_VERIFY(jni, (thread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL))
         return NSK_FALSE;
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -135,8 +129,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, thread)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, thread)))
         nsk_jvmti_setFailStatus();
 
     /* resume debugee and wait for sync */
@@ -150,7 +143,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!NSK_VERIFY(SingleStepEventsCount != 0))
         nsk_jvmti_setFailStatus();
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, thread));
+    NSK_TRACE(jni->DeleteGlobalRef(thread));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -191,7 +184,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_single_step_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t004/ma10t004a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t004/ma10t004a.cpp
@@ -53,20 +53,18 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     SingleStepEventsCount++;
 
-    NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-        jvmti_env, JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, NULL));
+    NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, NULL));
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY3("SingleStep event: %s%s, location=%s\n", name, signature,
         jlong_to_string(location, buffer));
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 /* ========================================================================== */
@@ -128,7 +126,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_single_step_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t005/ma10t005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t005/ma10t005.cpp
@@ -52,14 +52,13 @@ VMObjectAlloc(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
 
     VMObjectAllocEventsCount++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti_env,
-            object_klass, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(object_klass, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("VMObjectAlloc: \"%s\", size=%d\n", signature, size);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 /* ========================================================================== */
@@ -115,7 +114,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_vm_object_alloc_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 
@@ -124,8 +123,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_OBJECT_ALLOC, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_OBJECT_ALLOC, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t005/ma10t005a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t005/ma10t005a.cpp
@@ -52,14 +52,13 @@ VMObjectAlloc(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
 
     VMObjectAllocEventsCount++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti_env,
-            object_klass, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(object_klass, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY2("VMObjectAlloc: \"%s\", size=%d\n", signature, size);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 /* ========================================================================== */
@@ -115,7 +114,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_vm_object_alloc_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t006/ma10t006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t006/ma10t006.cpp
@@ -54,17 +54,16 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method,
 
     CompiledMethodLoadEventsCount++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY3("CompiledMethodLoad event: %s%s (0x%p)\n",
         name, signature, code_addr);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 static void JNICALL
@@ -81,8 +80,8 @@ CompiledMethodUnload(jvmtiEnv *jvmti_env, jmethodID method,
     if (err == JVMTI_ERROR_NONE) {
         NSK_DISPLAY3("for: \tmethod: name=\"%s\" signature=\"%s\"\n\tnative address=0x%p\n",
           name, sig, code_addr);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)sig);
+        jvmti_env->Deallocate((unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)sig);
     }
 }
 
@@ -148,7 +147,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_compiled_method_load_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 
@@ -158,11 +157,9 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_UNLOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_COMPILED_METHOD_UNLOAD, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t006/ma10t006a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t006/ma10t006a.cpp
@@ -54,17 +54,16 @@ CompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method,
 
     CompiledMethodLoadEventsCount++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY3("CompiledMethodLoad event: %s%s (0x%p)\n",
         name, signature, code_addr);
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 static void JNICALL
@@ -82,8 +81,8 @@ CompiledMethodUnload(jvmtiEnv *jvmti_env, jmethodID method,
     if (err == JVMTI_ERROR_NONE) {
         NSK_DISPLAY3("for: \tmethod: name=\"%s\" signature=\"%s\"\n\tnative address=0x%p\n",
           name, sig, code_addr);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)sig);
+        jvmti_env->Deallocate((unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)sig);
     }
 }
 
@@ -145,7 +144,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_compiled_method_load_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t007/ma10t007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t007/ma10t007.cpp
@@ -115,7 +115,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_garbage_collection_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 
@@ -125,11 +125,9 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_START, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_GARBAGE_COLLECTION_FINISH, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t007/ma10t007a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t007/ma10t007a.cpp
@@ -115,7 +115,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_garbage_collection_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t008/ma10t008.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t008/ma10t008.cpp
@@ -55,8 +55,7 @@ MonitorContendedEnter(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
     MonitorContendedEnterEventsCount++;
 
     /* get thread information */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti_env,
-            thread, &info))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -72,8 +71,7 @@ MonitorContendedEntered(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
     MonitorContendedEnteredEventsCount++;
 
     /* get thread information */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti_env,
-            thread, &info))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -89,8 +87,7 @@ MonitorWait(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
     MonitorWaitEventsCount++;
 
     /* get thread information */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti_env,
-            thread, &info))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -106,8 +103,7 @@ MonitorWaited(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
     MonitorWaitedEventsCount++;
 
     /* get thread information */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti_env,
-            thread, &info))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -189,7 +185,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_monitor_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 
@@ -202,17 +198,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
     /* enable events */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAIT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAIT, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAITED, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_WAITED, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t008/ma10t008a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA10/ma10t008/ma10t008a.cpp
@@ -55,8 +55,7 @@ MonitorContendedEnter(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
     MonitorContendedEnterEventsCount++;
 
     /* get thread information */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti_env,
-            thread, &info))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -72,8 +71,7 @@ MonitorContendedEntered(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
     MonitorContendedEnteredEventsCount++;
 
     /* get thread information */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti_env,
-            thread, &info))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -89,8 +87,7 @@ MonitorWait(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
     MonitorWaitEventsCount++;
 
     /* get thread information */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti_env,
-            thread, &info))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -106,8 +103,7 @@ MonitorWaited(jvmtiEnv *jvmti_env, JNIEnv* jni_env,
     MonitorWaitedEventsCount++;
 
     /* get thread information */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti_env,
-            thread, &info))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -189,7 +185,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_monitor_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP01/sp01t001/sp01t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP01/sp01t001/sp01t001.cpp
@@ -121,37 +121,35 @@ static int prepare() {
     jsize i;
 
     /* find debugee class */
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     /* find static field with threads array */
     if (!NSK_JNI_VERIFY(jni, (threadsFieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                                    THREADS_FIELD_NAME, THREADS_FIELD_SIG)) != NULL))
+            jni->GetStaticFieldID(debugeeClass, THREADS_FIELD_NAME, THREADS_FIELD_SIG)) != NULL))
         return NSK_FALSE;
 
     /* get threads array from static field */
     if (!NSK_JNI_VERIFY(jni, (threadsArray = (jobjectArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass, threadsFieldID)) != NULL))
+            jni->GetStaticObjectField(debugeeClass, threadsFieldID)) != NULL))
         return NSK_FALSE;
 
     /* check array length */
     if (!NSK_JNI_VERIFY(jni, (threadsArrayLength =
-            NSK_CPP_STUB2(GetArrayLength, jni, threadsArray)) == THREADS_COUNT))
+            jni->GetArrayLength(threadsArray)) == THREADS_COUNT))
         return NSK_FALSE;
 
     /* get each thread from array */
     for (i = 0; i < THREADS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (threadsList[i] = (jthread)
-                NSK_CPP_STUB3(GetObjectArrayElement, jni, threadsArray, i)) != NULL))
+                jni->GetObjectArrayElement(threadsArray, i)) != NULL))
             return NSK_FALSE;
     }
 
     /* make global references to threads */
     for (i = 0; i < THREADS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (threadsList[i] = (jthread)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsList[i])) != NULL))
+                jni->NewGlobalRef(threadsList[i])) != NULL))
             return NSK_FALSE;
     }
 
@@ -174,8 +172,7 @@ static int checkThreads(const char* kind) {
         NSK_DISPLAY2("    thread #%d (%s):\n", i, threadsName[i]);
 
         /* get thread state */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadState, jvmti, threadsList[i], &state))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(threadsList[i], &state))) {
             nsk_jvmti_setFailStatus();
             return NSK_TRUE;
         }
@@ -233,7 +230,7 @@ static int clean() {
 
     /* dispose global references to threads */
     for (i = 0; i < THREADS_COUNT; i++) {
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsList[i]));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsList[i]));
     }
 
     return NSK_TRUE;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP01/sp01t002/sp01t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP01/sp01t002/sp01t002.cpp
@@ -155,8 +155,7 @@ static int prepare() {
     }
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &allThreadsCount, &allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&allThreadsCount, &allThreadsList)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(allThreadsCount > 0 && allThreadsList != NULL))
@@ -170,8 +169,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread name (info) */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, allThreadsList[i], &threadInfo)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(allThreadsList[i], &threadInfo)))
             return NSK_FALSE;
 
         /* find by name */
@@ -189,8 +187,7 @@ static int prepare() {
     }
 
     /* deallocate all threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)allThreadsList)))
         return NSK_FALSE;
 
     /* check if all tested threads found */
@@ -208,8 +205,7 @@ static int prepare() {
 
     /* make global refs */
     for (i = 0; i < THREADS_COUNT; i++) {
-        if (!NSK_JNI_VERIFY(jni, (threadsList[i] =
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsList[i])) != NULL))
+        if (!NSK_JNI_VERIFY(jni, (threadsList[i] = jni->NewGlobalRef(threadsList[i])) != NULL))
             return NSK_FALSE;
     }
 
@@ -225,13 +221,11 @@ static int suspendThreadsIndividually(int suspend) {
     for (i = 0; i < THREADS_COUNT; i++) {
         if (suspend) {
             NSK_DISPLAY2("    suspend thread #%d (%s)\n", i, threadsName[i]);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(SuspendThread, jvmti, threadsList[i])))
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(threadsList[i])))
                 nsk_jvmti_setFailStatus();
         } else {
             NSK_DISPLAY2("    resume thread #%d (%s)\n", i, threadsName[i]);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(ResumeThread, jvmti, threadsList[i])))
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(threadsList[i])))
                 nsk_jvmti_setFailStatus();
         }
     }
@@ -260,8 +254,7 @@ static int checkThreads(int suspended, const char* kind, jlong timeout) {
         /* wait for WAITTIME for thread to reach expected state */
         do {
             /* get thread state */
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetThreadState, jvmti, threadsList[i], &state))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(threadsList[i], &state))) {
                 nsk_jvmti_setFailStatus();
                 return NSK_TRUE;
             }
@@ -371,7 +364,7 @@ static int clean() {
 
     /* dispose global references to threads */
     for (i = 0; i < THREADS_COUNT; i++) {
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsList[i]));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsList[i]));
     }
 
     return NSK_TRUE;
@@ -449,8 +442,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP01/sp01t003/sp01t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP01/sp01t003/sp01t003.cpp
@@ -155,8 +155,7 @@ static int prepare() {
     }
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &allThreadsCount, &allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&allThreadsCount, &allThreadsList)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(allThreadsCount > 0 && allThreadsList != NULL))
@@ -170,8 +169,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread name (info) */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, allThreadsList[i], &threadInfo)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(allThreadsList[i], &threadInfo)))
             return NSK_FALSE;
 
         /* find by name */
@@ -189,8 +187,7 @@ static int prepare() {
     }
 
     /* deallocate all threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)allThreadsList)))
         return NSK_FALSE;
 
     /* check if all tested threads found */
@@ -208,8 +205,7 @@ static int prepare() {
 
     /* make global refs */
     for (i = 0; i < THREADS_COUNT; i++) {
-        if (!NSK_JNI_VERIFY(jni, (threadsList[i] =
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsList[i])) != NULL))
+        if (!NSK_JNI_VERIFY(jni, (threadsList[i] = jni->NewGlobalRef(threadsList[i])) != NULL))
             return NSK_FALSE;
     }
 
@@ -226,14 +222,10 @@ static int suspendThreadsList(int suspend) {
 
     /* suspend or resume threads list */
     if (suspend) {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SuspendThreadList, jvmti, THREADS_COUNT,
-                                                    threadsList, results)))
+        if (!NSK_JVMTI_VERIFY(jvmti->SuspendThreadList(THREADS_COUNT, threadsList, results)))
             nsk_jvmti_setFailStatus();
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(ResumeThreadList, jvmti, THREADS_COUNT,
-                                                    threadsList, results)))
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThreadList(THREADS_COUNT, threadsList, results)))
             nsk_jvmti_setFailStatus();
     }
 
@@ -273,8 +265,7 @@ static int checkThreads(int suspended, const char* kind, jlong timeout) {
         /* wait for WAITTIME for thread to reach expected state */
         do {
             /* get thread status */
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetThreadState, jvmti, threadsList[i], &state))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(threadsList[i], &state))) {
                 nsk_jvmti_setFailStatus();
                 return NSK_TRUE;
             }
@@ -384,7 +375,7 @@ static int clean() {
 
     /* dispose global references to threads */
     for (i = 0; i < THREADS_COUNT; i++) {
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsList[i]));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsList[i]));
     }
 
     return NSK_TRUE;
@@ -462,8 +453,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP02/sp02t001/sp02t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP02/sp02t001/sp02t001.cpp
@@ -147,8 +147,7 @@ static int prepare() {
     }
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &allThreadsCount, &allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&allThreadsCount, &allThreadsList)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(allThreadsCount > 0 && allThreadsList != NULL))
@@ -162,8 +161,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread name (info) */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, allThreadsList[i], &threadInfo)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(allThreadsList[i], &threadInfo)))
             return NSK_FALSE;
 
         /* find by name */
@@ -181,8 +179,7 @@ static int prepare() {
     }
 
     /* deallocate all threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)allThreadsList)))
         return NSK_FALSE;
 
     /* check if all tested threads found */
@@ -201,7 +198,7 @@ static int prepare() {
     /* make global refs */
     for (i = 0; i < THREADS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].thread = (jthread)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsDesc[i].thread)) != NULL))
+                jni->NewGlobalRef(threadsDesc[i].thread)) != NULL))
             return NSK_FALSE;
     }
 
@@ -217,13 +214,11 @@ static int suspendThreadsIndividually(int suspend) {
     for (i = 0; i < THREADS_COUNT; i++) {
         if (suspend) {
             NSK_DISPLAY2("    suspend thread #%d (%s)\n", i, threadsDesc[i].threadName);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(SuspendThread, jvmti, threadsDesc[i].thread)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(threadsDesc[i].thread)))
                 nsk_jvmti_setFailStatus();
         } else {
             NSK_DISPLAY2("    resume thread #%d (%s)\n", i, threadsDesc[i].threadName);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(ResumeThread, jvmti, threadsDesc[i].thread)))
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(threadsDesc[i].thread)))
                 nsk_jvmti_setFailStatus();
         }
     }
@@ -253,9 +248,7 @@ static int checkThreads(int suspended, const char* kind) {
         NSK_DISPLAY2("  thread #%d (%s):\n", i, threadsDesc[i].threadName);
 
         /* get frame count */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetFrameCount, jvmti,
-                                    threadsDesc[i].thread, &frameCount))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetFrameCount(threadsDesc[i].thread, &frameCount))) {
             nsk_jvmti_setFailStatus();
             return NSK_TRUE;
         }
@@ -264,8 +257,7 @@ static int checkThreads(int suspended, const char* kind) {
 
         /* get stack trace */
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB6(GetStackTrace, jvmti, threadsDesc[i].thread,
-                                    0, MAX_STACK_SIZE, frameStack, &frameStackSize))) {
+                jvmti->GetStackTrace(threadsDesc[i].thread, 0, MAX_STACK_SIZE, frameStack, &frameStackSize))) {
             nsk_jvmti_setFailStatus();
             return NSK_TRUE;
         }
@@ -318,7 +310,7 @@ static int clean() {
 
     /* dispose global references to threads */
     for (i = 0; i < THREADS_COUNT; i++) {
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsDesc[i].thread));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsDesc[i].thread));
     }
 
     return NSK_TRUE;
@@ -396,8 +388,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP02/sp02t002/sp02t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP02/sp02t002/sp02t002.cpp
@@ -158,8 +158,7 @@ static int prepare() {
     }
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &allThreadsCount, &allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&allThreadsCount, &allThreadsList)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(allThreadsCount > 0 && allThreadsList != NULL))
@@ -173,8 +172,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread name (info) */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, allThreadsList[i], &threadInfo)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(allThreadsList[i], &threadInfo)))
             return NSK_FALSE;
 
         /* find by name */
@@ -192,8 +190,7 @@ static int prepare() {
     }
 
     /* deallocate all threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)allThreadsList)))
         return NSK_FALSE;
 
     /* check if all tested threads found */
@@ -214,12 +211,11 @@ static int prepare() {
     for (i = 0; i < THREADS_COUNT; i++) {
         /* get thread class */
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].cls =
-                NSK_CPP_STUB2(GetObjectClass, jni, threadsDesc[i].thread)) != NULL))
+                jni->GetObjectClass(threadsDesc[i].thread)) != NULL))
             return NSK_FALSE;
         /* get frame method */
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].method =
-                NSK_CPP_STUB4(GetMethodID, jni, threadsDesc[i].cls,
-                            threadsDesc[i].methodName, threadsDesc[i].methodSig)) != NULL))
+                jni->GetMethodID(threadsDesc[i].cls, threadsDesc[i].methodName, threadsDesc[i].methodSig)) != NULL))
             return NSK_FALSE;
 
         NSK_DISPLAY4("    thread #%d (%s): %p (%s)\n",
@@ -231,10 +227,10 @@ static int prepare() {
     /* make global refs */
     for (i = 0; i < THREADS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].thread = (jthread)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsDesc[i].thread)) != NULL))
+                jni->NewGlobalRef(threadsDesc[i].thread)) != NULL))
             return NSK_FALSE;
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].cls = (jclass)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsDesc[i].cls)) != NULL))
+                jni->NewGlobalRef(threadsDesc[i].cls)) != NULL))
             return NSK_FALSE;
     }
 
@@ -250,13 +246,11 @@ static int suspendThreadsIndividually(int suspend) {
     for (i = 0; i < THREADS_COUNT; i++) {
         if (suspend) {
             NSK_DISPLAY2("    suspend thread #%d (%s)\n", i, threadsDesc[i].threadName);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(SuspendThread, jvmti, threadsDesc[i].thread)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(threadsDesc[i].thread)))
                 nsk_jvmti_setFailStatus();
         } else {
             NSK_DISPLAY2("    resume thread #%d (%s)\n", i, threadsDesc[i].threadName);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(ResumeThread, jvmti, threadsDesc[i].thread)))
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(threadsDesc[i].thread)))
                 nsk_jvmti_setFailStatus();
         }
     }
@@ -285,9 +279,7 @@ static int checkThreads(int suspended, const char* kind) {
         NSK_DISPLAY2("  thread #%d (%s):\n", i, threadsDesc[i].threadName);
 
         /* get frame count */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetFrameCount, jvmti,
-                                    threadsDesc[i].thread, &frameCount))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetFrameCount(threadsDesc[i].thread, &frameCount))) {
             nsk_jvmti_setFailStatus();
             return NSK_TRUE;
         }
@@ -296,8 +288,7 @@ static int checkThreads(int suspended, const char* kind) {
 
         /* get stack trace */
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB6(GetStackTrace, jvmti, threadsDesc[i].thread,
-                                    0, MAX_STACK_SIZE, frameStack, &frameStackSize))) {
+                jvmti->GetStackTrace(threadsDesc[i].thread, 0, MAX_STACK_SIZE, frameStack, &frameStackSize))) {
             nsk_jvmti_setFailStatus();
             return NSK_TRUE;
         }
@@ -356,8 +347,8 @@ static int clean() {
 
     /* dispose global references to threads */
     for (i = 0; i < THREADS_COUNT; i++) {
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsDesc[i].thread));
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsDesc[i].cls));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsDesc[i].thread));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsDesc[i].cls));
     }
 
     return NSK_TRUE;
@@ -435,8 +426,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP02/sp02t003/sp02t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP02/sp02t003/sp02t003.cpp
@@ -159,8 +159,7 @@ static int prepare() {
     }
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &allThreadsCount, &allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&allThreadsCount, &allThreadsList)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(allThreadsCount > 0 && allThreadsList != NULL))
@@ -174,8 +173,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread name (info) */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, allThreadsList[i], &threadInfo)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(allThreadsList[i], &threadInfo)))
             return NSK_FALSE;
 
         /* find by name */
@@ -193,8 +191,7 @@ static int prepare() {
     }
 
     /* deallocate all threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)allThreadsList)))
         return NSK_FALSE;
 
     /* check if all tested threads found */
@@ -215,12 +212,11 @@ static int prepare() {
     for (i = 0; i < THREADS_COUNT; i++) {
         /* get thread class */
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].cls =
-                NSK_CPP_STUB2(GetObjectClass, jni, threadsDesc[i].thread)) != NULL))
+                jni->GetObjectClass(threadsDesc[i].thread)) != NULL))
             return NSK_FALSE;
         /* get frame method */
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].method =
-                NSK_CPP_STUB4(GetMethodID, jni, threadsDesc[i].cls,
-                            threadsDesc[i].methodName, threadsDesc[i].methodSig)) != NULL))
+                jni->GetMethodID(threadsDesc[i].cls, threadsDesc[i].methodName, threadsDesc[i].methodSig)) != NULL))
             return NSK_FALSE;
 
         NSK_DISPLAY4("    thread #%d (%s): %p (%s)\n",
@@ -232,10 +228,10 @@ static int prepare() {
     /* make global refs */
     for (i = 0; i < THREADS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].thread = (jthread)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsDesc[i].thread)) != NULL))
+                jni->NewGlobalRef(threadsDesc[i].thread)) != NULL))
             return NSK_FALSE;
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].cls = (jclass)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsDesc[i].cls)) != NULL))
+                jni->NewGlobalRef(threadsDesc[i].cls)) != NULL))
             return NSK_FALSE;
     }
 
@@ -251,13 +247,11 @@ static int suspendThreadsIndividually(int suspend) {
     for (i = 0; i < THREADS_COUNT; i++) {
         if (suspend) {
             NSK_DISPLAY2("    suspend thread #%d (%s)\n", i, threadsDesc[i].threadName);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(SuspendThread, jvmti, threadsDesc[i].thread)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(threadsDesc[i].thread)))
                 nsk_jvmti_setFailStatus();
         } else {
             NSK_DISPLAY2("    resume thread #%d (%s)\n", i, threadsDesc[i].threadName);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(ResumeThread, jvmti, threadsDesc[i].thread)))
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(threadsDesc[i].thread)))
                 nsk_jvmti_setFailStatus();
         }
     }
@@ -288,9 +282,7 @@ static int checkThreads(int suspended, const char* kind) {
         NSK_DISPLAY2("  thread #%d (%s):\n", i, threadsDesc[i].threadName);
 
         /* get frame count */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetFrameCount, jvmti,
-                                    threadsDesc[i].thread, &frameCount))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetFrameCount(threadsDesc[i].thread, &frameCount))) {
             nsk_jvmti_setFailStatus();
             return NSK_TRUE;
         }
@@ -298,8 +290,7 @@ static int checkThreads(int suspended, const char* kind) {
 
         /* get stack trace */
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB6(GetStackTrace, jvmti, threadsDesc[i].thread,
-                                    0, MAX_STACK_SIZE, frameStack, &frameStackSize))) {
+                jvmti->GetStackTrace(threadsDesc[i].thread, 0, MAX_STACK_SIZE, frameStack, &frameStackSize))) {
             nsk_jvmti_setFailStatus();
             return NSK_TRUE;
         }
@@ -319,8 +310,7 @@ static int checkThreads(int suspended, const char* kind) {
                                         (long)frameStack[j].location);
             /* query frame location */
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB5(GetFrameLocation, jvmti, threadsDesc[i].thread,
-                                                        j, &qMethod, &qLocation))
+                    jvmti->GetFrameLocation(threadsDesc[i].thread, j, &qMethod, &qLocation))
                 && (suspended == NSK_TRUE)) {
                 nsk_jvmti_setFailStatus();
                 continue;
@@ -376,8 +366,8 @@ static int clean() {
 
     /* dispose global references to threads */
     for (i = 0; i < THREADS_COUNT; i++) {
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsDesc[i].thread));
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsDesc[i].cls));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsDesc[i].thread));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsDesc[i].cls));
     }
 
     return NSK_TRUE;
@@ -454,8 +444,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t001/sp03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t001/sp03t001.cpp
@@ -158,9 +158,8 @@ static int prepare() {
         threadsCounts[i] = 0;
         threadsList[i] = NULL;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti, (threadsCount * sizeof(jthread)),
-                                                    (unsigned char**)&threadsList[i])))
+        if (!NSK_JVMTI_VERIFY(jvmti->Allocate(threadsCount * sizeof(jthread),
+                                              (unsigned char**)&threadsList[i])))
             return NSK_FALSE;
 
         for (j = 0; j < threadsCount; j++) {
@@ -169,8 +168,7 @@ static int prepare() {
     }
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &allThreadsCount, &allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&allThreadsCount, &allThreadsList)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(allThreadsCount > 0 && allThreadsList != NULL))
@@ -184,8 +182,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread name (info) */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, allThreadsList[i], &threadInfo)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(allThreadsList[i], &threadInfo)))
             return NSK_FALSE;
 
         /* find by name */
@@ -202,8 +199,7 @@ static int prepare() {
     }
 
     /* deallocate all threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)allThreadsList)))
         return NSK_FALSE;
 
     /* check if all tested threads found */
@@ -226,7 +222,7 @@ static int prepare() {
     for (i = 0; i < THREADS_KINDS; i++) {
         for (j = 0; j < threadsCount; j++) {
             if (!NSK_JNI_VERIFY(jni, (threadsList[i][j] =
-                    NSK_CPP_STUB2(NewGlobalRef, jni, threadsList[i][j])) != NULL))
+                    jni->NewGlobalRef(threadsList[i][j])) != NULL))
                 return NSK_FALSE;
         }
     }
@@ -244,8 +240,7 @@ static int suspendThreadsList(int suspend) {
     int i, j;
 
     /* allocate results array */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, resultsSize, (unsigned char**)&results))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(resultsSize, (unsigned char**)&results))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -253,14 +248,10 @@ static int suspendThreadsList(int suspend) {
     for (i = 0; i < THREADS_KINDS; i++) {
         /* suspend or resume threads list */
         if (suspend) {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(SuspendThreadList, jvmti, threadsCount,
-                                                        threadsList[i], results)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThreadList(threadsCount, threadsList[i], results)))
                 nsk_jvmti_setFailStatus();
         } else {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(ResumeThreadList, jvmti, threadsCount,
-                                                        threadsList[i], results)))
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThreadList(threadsCount, threadsList[i], results)))
                 nsk_jvmti_setFailStatus();
         }
 
@@ -277,8 +268,7 @@ static int suspendThreadsList(int suspend) {
     }
 
     /* deallocate results array */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)results))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)results))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -295,13 +285,11 @@ static int suspendThreadsIndividually(int suspend) {
         for (j = 0; j < threadsCount; j++) {
             if (suspend) {
                 NSK_DISPLAY2("    suspend thread #%d (%s)\n", j, threadsName[i]);
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(SuspendThread, jvmti, threadsList[i][j])))
+                if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(threadsList[i][j])))
                     nsk_jvmti_setFailStatus();
             } else {
                 NSK_DISPLAY2("    resume thread #%d (%s)\n", j, threadsName[i]);
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(ResumeThread, jvmti, threadsList[i][j])))
+                if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(threadsList[i][j])))
                     nsk_jvmti_setFailStatus();
             }
         }
@@ -329,8 +317,7 @@ static int checkThreads(int suspended, const char* kind, jlong timeout) {
             NSK_DISPLAY2("    thread #%d (%s):\n", j, threadsName[i]);
 
             /* get thread state */
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetThreadState, jvmti, threadsList[i][j], &state))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(threadsList[i][j], &state))) {
                 nsk_jvmti_setFailStatus();
                 return NSK_FALSE;
             }
@@ -373,14 +360,13 @@ static int clean() {
     /* dispose global references to threads */
     for (i = 0; i < THREADS_KINDS; i++) {
         for (j = 0; j < threadsCount; j++) {
-            NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsList[i][j]));
+            NSK_TRACE(jni->DeleteGlobalRef(threadsList[i][j]));
         }
     }
 
     /* deallocate memory */
     for (i = 0; i < THREADS_KINDS; i++) {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threadsList[i])))
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threadsList[i])))
             return NSK_FALSE;
         threadsList[i] = NULL;
     }
@@ -465,8 +451,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t002/sp03t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP03/sp03t002/sp03t002.cpp
@@ -161,9 +161,8 @@ static int prepare() {
         threadsCounts[i] = 0;
         threadsList[i] = NULL;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti, (threadsCount * sizeof(jthread)),
-                                                    (unsigned char**)&threadsList[i])))
+        if (!NSK_JVMTI_VERIFY(jvmti->Allocate(threadsCount * sizeof(jthread),
+                                              (unsigned char**)&threadsList[i])))
             return NSK_FALSE;
 
         for (j = 0; j < threadsCount; j++) {
@@ -172,8 +171,7 @@ static int prepare() {
     }
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &allThreadsCount, &allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&allThreadsCount, &allThreadsList)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(allThreadsCount > 0 && allThreadsList != NULL))
@@ -187,8 +185,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread name (info) */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, allThreadsList[i], &threadInfo)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(allThreadsList[i], &threadInfo)))
             return NSK_FALSE;
 
         /* find by name */
@@ -205,8 +202,7 @@ static int prepare() {
     }
 
     /* deallocate all threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)allThreadsList)))
         return NSK_FALSE;
 
     /* check if all tested threads found */
@@ -229,7 +225,7 @@ static int prepare() {
     for (i = 0; i < THREADS_KINDS; i++) {
         for (j = 0; j < threadsCount; j++) {
             if (!NSK_JNI_VERIFY(jni, (threadsList[i][j] =
-                    NSK_CPP_STUB2(NewGlobalRef, jni, threadsList[i][j])) != NULL))
+                    jni->NewGlobalRef(threadsList[i][j])) != NULL))
                 return NSK_FALSE;
         }
     }
@@ -247,8 +243,7 @@ static int suspendThreadsList(int suspend) {
     int i, j;
 
     /* allocate results array */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, resultsSize, (unsigned char**)&results))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(resultsSize, (unsigned char**)&results))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -256,14 +251,10 @@ static int suspendThreadsList(int suspend) {
     for (i = 0; i < THREADS_KINDS; i++) {
         /* suspend or resume threads list */
         if (suspend) {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(SuspendThreadList, jvmti, threadsCount,
-                                                        threadsList[i], results)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThreadList(threadsCount, threadsList[i], results)))
                 nsk_jvmti_setFailStatus();
         } else {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(ResumeThreadList, jvmti, threadsCount,
-                                                        threadsList[i], results)))
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThreadList(threadsCount, threadsList[i], results)))
                 nsk_jvmti_setFailStatus();
         }
 
@@ -280,8 +271,7 @@ static int suspendThreadsList(int suspend) {
     }
 
     /* deallocate results array */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)results))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)results))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -298,13 +288,11 @@ static int suspendThreadsIndividually(int suspend) {
         for (j = 0; j < threadsCount; j++) {
             if (suspend) {
                 NSK_DISPLAY2("    suspend thread #%d (%s)\n", j, threadsName[i]);
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(SuspendThread, jvmti, threadsList[i][j])))
+                if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(threadsList[i][j])))
                     nsk_jvmti_setFailStatus();
             } else {
                 NSK_DISPLAY2("    resume thread #%d (%s)\n", j, threadsName[i]);
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(ResumeThread, jvmti, threadsList[i][j])))
+                if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(threadsList[i][j])))
                     nsk_jvmti_setFailStatus();
             }
         }
@@ -332,8 +320,7 @@ static int checkThreads(int suspended, const char* kind, jlong timeout) {
             NSK_DISPLAY2("    thread #%d (%s):\n", j, threadsName[i]);
 
             /* get thread state */
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetThreadState, jvmti, threadsList[i][j], &state))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(threadsList[i][j], &state))) {
                 nsk_jvmti_setFailStatus();
                 return NSK_FALSE;
             }
@@ -376,14 +363,13 @@ static int clean() {
     /* dispose global references to threads */
     for (i = 0; i < THREADS_KINDS; i++) {
         for (j = 0; j < threadsCount; j++) {
-            NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsList[i][j]));
+            NSK_TRACE(jni->DeleteGlobalRef(threadsList[i][j]));
         }
     }
 
     /* deallocate memory */
     for (i = 0; i < THREADS_KINDS; i++) {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threadsList[i])))
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threadsList[i])))
             return NSK_FALSE;
         threadsList[i] = NULL;
     }
@@ -468,8 +454,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t001/sp04t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t001/sp04t001.cpp
@@ -158,9 +158,8 @@ static int prepare() {
         threadsCounts[i] = 0;
         threadsList[i] = NULL;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti, (threadsCount * sizeof(jthread)),
-                                                    (unsigned char**)&threadsList[i])))
+        if (!NSK_JVMTI_VERIFY(jvmti->Allocate(threadsCount * sizeof(jthread),
+                                              (unsigned char**)&threadsList[i])))
             return NSK_FALSE;
 
         for (j = 0; j < threadsCount; j++) {
@@ -169,8 +168,7 @@ static int prepare() {
     }
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &allThreadsCount, &allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&allThreadsCount, &allThreadsList)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(allThreadsCount > 0 && allThreadsList != NULL))
@@ -184,8 +182,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread name (info) */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, allThreadsList[i], &threadInfo)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(allThreadsList[i], &threadInfo)))
             return NSK_FALSE;
 
         /* find by name */
@@ -202,8 +199,7 @@ static int prepare() {
     }
 
     /* deallocate all threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)allThreadsList)))
         return NSK_FALSE;
 
     /* check if all tested threads found */
@@ -226,7 +222,7 @@ static int prepare() {
     for (i = 0; i < THREADS_KINDS; i++) {
         for (j = 0; j < threadsCount; j++) {
             if (!NSK_JNI_VERIFY(jni, (threadsList[i][j] =
-                    NSK_CPP_STUB2(NewGlobalRef, jni, threadsList[i][j])) != NULL))
+                    jni->NewGlobalRef(threadsList[i][j])) != NULL))
                 return NSK_FALSE;
         }
     }
@@ -244,8 +240,7 @@ static int suspendThreadsList(int suspend) {
     int i, j;
 
     /* allocate results array */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, resultsSize, (unsigned char**)&results))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(resultsSize, (unsigned char**)&results))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -253,14 +248,10 @@ static int suspendThreadsList(int suspend) {
     for (i = 0; i < THREADS_KINDS; i++) {
         /* suspend or resume threads list */
         if (suspend) {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(SuspendThreadList, jvmti, threadsCount,
-                                                        threadsList[i], results)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThreadList(threadsCount, threadsList[i], results)))
                 nsk_jvmti_setFailStatus();
         } else {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(ResumeThreadList, jvmti, threadsCount,
-                                                        threadsList[i], results)))
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThreadList(threadsCount, threadsList[i], results)))
                 nsk_jvmti_setFailStatus();
         }
 
@@ -277,8 +268,7 @@ static int suspendThreadsList(int suspend) {
     }
 
     /* deallocate results array */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)results))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)results))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -295,13 +285,11 @@ static int suspendThreadsIndividually(int suspend) {
         for (j = 0; j < threadsCount; j++) {
             if (suspend) {
                 NSK_DISPLAY2("    suspend thread #%d (%s)\n", j, threadsName[i]);
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(SuspendThread, jvmti, threadsList[i][j])))
+                if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(threadsList[i][j])))
                     nsk_jvmti_setFailStatus();
             } else {
                 NSK_DISPLAY2("    resume thread #%d (%s)\n", j, threadsName[i]);
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(ResumeThread, jvmti, threadsList[i][j])))
+                if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(threadsList[i][j])))
                     nsk_jvmti_setFailStatus();
             }
         }
@@ -329,8 +317,7 @@ static int checkThreads(int suspended, const char* kind, jlong timeout) {
             NSK_DISPLAY2("    thread #%d (%s):\n", j, threadsName[i]);
 
             /* get thread state */
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetThreadState, jvmti, threadsList[i][j], &state))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(threadsList[i][j], &state))) {
                 nsk_jvmti_setFailStatus();
                 return NSK_FALSE;
             }
@@ -373,14 +360,13 @@ static int clean() {
     /* dispose global references to threads */
     for (i = 0; i < THREADS_KINDS; i++) {
         for (j = 0; j < threadsCount; j++) {
-            NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsList[i][j]));
+            NSK_TRACE(jni->DeleteGlobalRef(threadsList[i][j]));
         }
     }
 
     /* deallocate memory */
     for (i = 0; i < THREADS_KINDS; i++) {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threadsList[i])))
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threadsList[i])))
             return NSK_FALSE;
         threadsList[i] = NULL;
     }
@@ -465,8 +451,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t002/sp04t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP04/sp04t002/sp04t002.cpp
@@ -158,9 +158,8 @@ static int prepare() {
         threadsCounts[i] = 0;
         threadsList[i] = NULL;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti, (threadsCount * sizeof(jthread)),
-                                                    (unsigned char**)&threadsList[i])))
+        if (!NSK_JVMTI_VERIFY(jvmti->Allocate(threadsCount * sizeof(jthread),
+                                              (unsigned char**)&threadsList[i])))
             return NSK_FALSE;
 
         for (j = 0; j < threadsCount; j++) {
@@ -169,8 +168,7 @@ static int prepare() {
     }
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &allThreadsCount, &allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&allThreadsCount, &allThreadsList)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(allThreadsCount > 0 && allThreadsList != NULL))
@@ -184,8 +182,7 @@ static int prepare() {
             return NSK_FALSE;
 
         /* get thread name (info) */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, allThreadsList[i], &threadInfo)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(allThreadsList[i], &threadInfo)))
             return NSK_FALSE;
 
         /* find by name */
@@ -202,8 +199,7 @@ static int prepare() {
     }
 
     /* deallocate all threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)allThreadsList)))
         return NSK_FALSE;
 
     /* check if all tested threads found */
@@ -226,7 +222,7 @@ static int prepare() {
     for (i = 0; i < THREADS_KINDS; i++) {
         for (j = 0; j < threadsCount; j++) {
             if (!NSK_JNI_VERIFY(jni, (threadsList[i][j] =
-                    NSK_CPP_STUB2(NewGlobalRef, jni, threadsList[i][j])) != NULL))
+                    jni->NewGlobalRef(threadsList[i][j])) != NULL))
                 return NSK_FALSE;
         }
     }
@@ -244,8 +240,7 @@ static int suspendThreadsList(int suspend) {
     int i, j;
 
     /* allocate results array */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, resultsSize, (unsigned char**)&results))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(resultsSize, (unsigned char**)&results))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -253,14 +248,10 @@ static int suspendThreadsList(int suspend) {
     for (i = 0; i < THREADS_KINDS; i++) {
         /* suspend or resume threads list */
         if (suspend) {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(SuspendThreadList, jvmti, threadsCount,
-                                                        threadsList[i], results)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThreadList(threadsCount, threadsList[i], results)))
                 nsk_jvmti_setFailStatus();
         } else {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(ResumeThreadList, jvmti, threadsCount,
-                                                        threadsList[i], results)))
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThreadList(threadsCount, threadsList[i], results)))
                 nsk_jvmti_setFailStatus();
         }
 
@@ -277,8 +268,7 @@ static int suspendThreadsList(int suspend) {
     }
 
     /* deallocate results array */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)results))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)results))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -295,13 +285,11 @@ static int suspendThreadsIndividually(int suspend) {
         for (j = 0; j < threadsCount; j++) {
             if (suspend)  {
                 NSK_DISPLAY2("    suspend thread #%d (%s)\n", j, threadsName[i]);
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(SuspendThread, jvmti, threadsList[i][j])))
+                if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(threadsList[i][j])))
                     nsk_jvmti_setFailStatus();
             } else {
                 NSK_DISPLAY2("    resume thread #%d (%s)\n", j, threadsName[i]);
-                if (!NSK_JVMTI_VERIFY(
-                        NSK_CPP_STUB2(ResumeThread, jvmti, threadsList[i][j])))
+                if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(threadsList[i][j])))
                     nsk_jvmti_setFailStatus();
             }
         }
@@ -329,8 +317,7 @@ static int checkThreads(int suspended, const char* kind, jlong timeout) {
             NSK_DISPLAY2("    thread #%d (%s):\n", j, threadsName[i]);
 
             /* get thread state */
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetThreadState, jvmti, threadsList[i][j], &state))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(threadsList[i][j], &state))) {
                 nsk_jvmti_setFailStatus();
                 return NSK_FALSE;
             }
@@ -373,14 +360,13 @@ static int clean() {
     /* dispose global references to threads */
     for (i = 0; i < THREADS_KINDS; i++) {
         for (j = 0; j < threadsCount; j++) {
-            NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsList[i][j]));
+            NSK_TRACE(jni->DeleteGlobalRef(threadsList[i][j]));
         }
     }
 
     /* deallocate memory */
     for (i = 0; i < THREADS_KINDS; i++) {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threadsList[i])))
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threadsList[i])))
             return NSK_FALSE;
         threadsList[i] = NULL;
     }
@@ -465,8 +451,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP05/sp05t002/sp05t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP05/sp05t002/sp05t002.cpp
@@ -143,9 +143,7 @@ static int enableEvents(jvmtiEventMode enable) {
     int i;
 
     for (i = 0; i < EVENTS_COUNT; i++) {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti, enable,
-                                                eventsList[i], NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(enable, eventsList[i], NULL))) {
             nsk_jvmti_setFailStatus();
             return NSK_FALSE;
         }
@@ -168,37 +166,35 @@ static int prepare() {
     jsize i;
 
     /* find debugee class */
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     /* find static field with threads array */
     if (!NSK_JNI_VERIFY(jni, (threadsFieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                                    THREADS_FIELD_NAME, THREADS_FIELD_SIG)) != NULL))
+            jni->GetStaticFieldID(debugeeClass, THREADS_FIELD_NAME, THREADS_FIELD_SIG)) != NULL))
         return NSK_FALSE;
 
     /* get threads array from static field */
     if (!NSK_JNI_VERIFY(jni, (threadsArray = (jobjectArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass, threadsFieldID)) != NULL))
+            jni->GetStaticObjectField(debugeeClass, threadsFieldID)) != NULL))
         return NSK_FALSE;
 
     /* check array length */
     if (!NSK_JNI_VERIFY(jni, (threadsArrayLength =
-            NSK_CPP_STUB2(GetArrayLength, jni, threadsArray)) == THREADS_COUNT))
+            jni->GetArrayLength(threadsArray)) == THREADS_COUNT))
         return NSK_FALSE;
 
     /* get each thread from array */
     for (i = 0; i < THREADS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (threadsList[i] = (jthread)
-                NSK_CPP_STUB3(GetObjectArrayElement, jni, threadsArray, i)) != NULL))
+                jni->GetObjectArrayElement(threadsArray, i)) != NULL))
             return NSK_FALSE;
     }
 
     /* make global references to threads */
     for (i = 0; i < THREADS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (threadsList[i] = (jthread)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsList[i])) != NULL))
+                jni->NewGlobalRef(threadsList[i])) != NULL))
             return NSK_FALSE;
     }
 
@@ -218,8 +214,7 @@ static int checkThread(jthread thread, int i, const char* kind) {
     NSK_DISPLAY3("  thread #%d (%s): %p\n", i, threadsName[i], (void*)thread);
 
     /* get frames count */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetFrameCount, jvmti, thread, &framesCount))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetFrameCount(thread, &framesCount))) {
         nsk_jvmti_setFailStatus();
         return NSK_TRUE;
     }
@@ -227,8 +222,7 @@ static int checkThread(jthread thread, int i, const char* kind) {
 
     /* get stack frames */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB6(GetStackTrace, jvmti, thread, 0, MAX_STACK_DEPTH,
-                                                    stackFrames, &stackDepth))) {
+            jvmti->GetStackTrace(thread, 0, MAX_STACK_DEPTH, stackFrames, &stackDepth))) {
         nsk_jvmti_setFailStatus();
         return NSK_TRUE;
     }
@@ -269,7 +263,7 @@ static int clean() {
 
     /* dispose global references to threads */
     for (i = 0; i < THREADS_COUNT; i++) {
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsList[i]));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsList[i]));
     }
 
     return NSK_TRUE;
@@ -293,7 +287,7 @@ callbackThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 
     /* check if event is for tested thread */
     for (i = 0; i < THREADS_COUNT; i++) {
-        if (NSK_CPP_STUB3(IsSameObject, jni, threadsList[i], thread)) {
+        if (jni->IsSameObject(threadsList[i], thread)) {
                 NSK_DISPLAY0("SUCCESS: expected THREAD_START event\n");
             eventsStart++;
 
@@ -320,7 +314,7 @@ callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 
     /* check if event is for tested thread */
     for (i = 0; i < THREADS_COUNT; i++) {
-        if (NSK_CPP_STUB3(IsSameObject, jni, threadsList[i], thread)) {
+        if (jni->IsSameObject(threadsList[i], thread)) {
                 NSK_DISPLAY0("SUCCESS: expected THREAD_START event\n");
             eventsEnd++;
 
@@ -403,9 +397,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ThreadStart = callbackThreadStart;
         eventCallbacks.ThreadEnd = callbackThreadEnd;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP05/sp05t003/sp05t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP05/sp05t003/sp05t003.cpp
@@ -100,8 +100,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
         {
             eventsStart = 0;
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                                            JVMTI_EVENT_THREAD_START, NULL))) {
+                    jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_THREAD_START, NULL))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -122,8 +121,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
             }
 
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                                            JVMTI_EVENT_THREAD_START, NULL))) {
+                    jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_THREAD_START, NULL))) {
                 nsk_jvmti_setFailStatus();
             }
 
@@ -152,8 +150,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
         {
             eventsEnd = 0;
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                                            JVMTI_EVENT_THREAD_END, NULL))) {
+                    jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_THREAD_END, NULL))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -174,8 +171,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
             }
 
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_DISABLE,
-                                            JVMTI_EVENT_THREAD_END, NULL))) {
+                    jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_THREAD_END, NULL))) {
                 nsk_jvmti_setFailStatus();
             }
 
@@ -221,8 +217,7 @@ static int resumeThreads(const char* kind) {
     int i;
 
     for (i = 0; i < THREADS_COUNT; i++) {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(ResumeThread, jvmti, threadsList[i]))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(threadsList[i]))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -243,37 +238,35 @@ static int prepare() {
     jsize i;
 
     /* find debugee class */
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     /* find static field with threads array */
     if (!NSK_JNI_VERIFY(jni, (threadsFieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                                    THREADS_FIELD_NAME, THREADS_FIELD_SIG)) != NULL))
+            jni->GetStaticFieldID(debugeeClass, THREADS_FIELD_NAME, THREADS_FIELD_SIG)) != NULL))
         return NSK_FALSE;
 
     /* get threads array from static field */
     if (!NSK_JNI_VERIFY(jni, (threadsArray = (jobjectArray)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass, threadsFieldID)) != NULL))
+            jni->GetStaticObjectField(debugeeClass, threadsFieldID)) != NULL))
         return NSK_FALSE;
 
     /* check array length */
     if (!NSK_JNI_VERIFY(jni, (threadsArrayLength =
-            NSK_CPP_STUB2(GetArrayLength, jni, threadsArray)) == THREADS_COUNT))
+            jni->GetArrayLength(threadsArray)) == THREADS_COUNT))
         return NSK_FALSE;
 
     /* get each thread from array */
     for (i = 0; i < THREADS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (threadsList[i] = (jthread)
-                NSK_CPP_STUB3(GetObjectArrayElement, jni, threadsArray, i)) != NULL))
+                jni->GetObjectArrayElement(threadsArray, i)) != NULL))
             return NSK_FALSE;
     }
 
     /* make global references to threads */
     for (i = 0; i < THREADS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (threadsList[i] = (jthread)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsList[i])) != NULL))
+                jni->NewGlobalRef(threadsList[i])) != NULL))
             return NSK_FALSE;
     }
 
@@ -293,8 +286,7 @@ static int checkThread(jthread thread, int i, const char* kind) {
     NSK_DISPLAY3("  thread #%d (%s): %p\n", i, threadsName[i], (void*)thread);
 
     /* get frames count */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetFrameCount, jvmti, thread, &framesCount))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetFrameCount(thread, &framesCount))) {
         nsk_jvmti_setFailStatus();
         return NSK_TRUE;
     }
@@ -302,8 +294,7 @@ static int checkThread(jthread thread, int i, const char* kind) {
 
     /* get stack frames */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB6(GetStackTrace, jvmti, thread, 0, MAX_STACK_DEPTH,
-                                                    stackFrames, &stackDepth))) {
+            jvmti->GetStackTrace(thread, 0, MAX_STACK_DEPTH, stackFrames, &stackDepth))) {
         nsk_jvmti_setFailStatus();
         return NSK_TRUE;
     }
@@ -355,7 +346,7 @@ static int clean() {
 
     /* dispose global references to threads */
     for (i = 0; i < THREADS_COUNT; i++) {
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsList[i]));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsList[i]));
     }
 
     return NSK_TRUE;
@@ -379,15 +370,14 @@ callbackThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 
     /* check if event is for tested thread */
     for (i = 0; i < THREADS_COUNT; i++) {
-        if (NSK_CPP_STUB3(IsSameObject, jni, threadsList[i], thread)) {
+        if (jni->IsSameObject(threadsList[i], thread)) {
                 NSK_DISPLAY0("SUCCESS: expected THREAD_START event\n");
 
             /* suspend thread */
             NSK_DISPLAY3("  suspend starting thread #%d (%s): %p\n",
                                 i, threadsName[i], (void*)thread);
 
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(SuspendThread, jvmti, thread))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(thread))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -414,15 +404,14 @@ callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 
     /* check if event is for tested thread */
     for (i = 0; i < THREADS_COUNT; i++) {
-        if (NSK_CPP_STUB3(IsSameObject, jni, threadsList[i], thread)) {
+        if (jni->IsSameObject(threadsList[i], thread)) {
                 NSK_DISPLAY0("SUCCESS: expected THREAD_END event\n");
 
             /* suspend thread */
             NSK_DISPLAY3("  suspend finishing thread #%d (%s): %p\n",
                                 i, threadsName[i], (void*)thread);
 
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(SuspendThread, jvmti, thread))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(thread))) {
                 nsk_jvmti_setFailStatus();
                 return;
             }
@@ -504,8 +493,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 
@@ -515,9 +503,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ThreadStart = callbackThreadStart;
         eventCallbacks.ThreadEnd = callbackThreadEnd;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP06/sp06t001/sp06t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP06/sp06t001/sp06t001.cpp
@@ -143,8 +143,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
  * Generate missed events (COMPILED_METHOD_LOAD only).
  */
 static int generateEvents() {
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GenerateEvents, jvmti, JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -176,8 +175,7 @@ static int prepare() {
     }
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &allThreadsCount, &allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&allThreadsCount, &allThreadsList)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(allThreadsCount > 0 && allThreadsList != NULL))
@@ -190,8 +188,7 @@ static int prepare() {
         if (!NSK_VERIFY(allThreadsList[i] != NULL))
             return NSK_FALSE;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, allThreadsList[i], &threadInfo)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(allThreadsList[i], &threadInfo)))
             return NSK_FALSE;
 
         if (threadInfo.name != NULL) {
@@ -208,8 +205,7 @@ static int prepare() {
     }
 
     /* deallocate all threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)allThreadsList)))
         return NSK_FALSE;
 
     /* check if all tested threads found */
@@ -230,12 +226,11 @@ static int prepare() {
     for (i = 0; i < THREADS_COUNT; i++) {
 
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].cls =
-                NSK_CPP_STUB2(GetObjectClass, jni, threadsDesc[i].thread)) != NULL))
+                jni->GetObjectClass(threadsDesc[i].thread)) != NULL))
             return NSK_FALSE;
 
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].method =
-                NSK_CPP_STUB4(GetMethodID, jni, threadsDesc[i].cls,
-                            threadsDesc[i].methodName, threadsDesc[i].methodSig)) != NULL))
+                jni->GetMethodID(threadsDesc[i].cls, threadsDesc[i].methodName, threadsDesc[i].methodSig)) != NULL))
             return NSK_FALSE;
 
         NSK_DISPLAY4("    thread #%d (%s): 0x%p (%s)\n",
@@ -247,10 +242,10 @@ static int prepare() {
     /* make global refs */
     for (i = 0; i < THREADS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].thread = (jthread)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsDesc[i].thread)) != NULL))
+                jni->NewGlobalRef(threadsDesc[i].thread)) != NULL))
             return NSK_FALSE;
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].cls = (jclass)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsDesc[i].cls)) != NULL))
+                jni->NewGlobalRef(threadsDesc[i].cls)) != NULL))
             return NSK_FALSE;
     }
 
@@ -270,13 +265,11 @@ static int suspendThreadsIndividually(int suspend) {
     for (i = 0; i < THREADS_COUNT; i++) {
         if (suspend) {
             NSK_DISPLAY2("    suspend thread #%d (%s)\n", i, threadsDesc[i].threadName);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(SuspendThread, jvmti, threadsDesc[i].thread)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(threadsDesc[i].thread)))
                 nsk_jvmti_setFailStatus();
         } else {
             NSK_DISPLAY2("    resume thread #%d (%s)\n", i, threadsDesc[i].threadName);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(ResumeThread, jvmti, threadsDesc[i].thread)))
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(threadsDesc[i].thread)))
                 nsk_jvmti_setFailStatus();
         }
     }
@@ -310,9 +303,7 @@ static int checkThreads(int suspended, const char* kind0) {
         NSK_DISPLAY2("  thread #%d (%s):\n", i, threadsDesc[i].threadName);
 
         /* get frame count */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetFrameCount, jvmti,
-                                    threadsDesc[i].thread, &frameCount))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetFrameCount(threadsDesc[i].thread, &frameCount))) {
             nsk_jvmti_setFailStatus();
             return NSK_TRUE;
         }
@@ -321,8 +312,7 @@ static int checkThreads(int suspended, const char* kind0) {
 
         /* get stack trace */
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB6(GetStackTrace, jvmti, threadsDesc[i].thread,
-                                    0, MAX_STACK_SIZE, frameStack, &frameStackSize))) {
+                jvmti->GetStackTrace(threadsDesc[i].thread, 0, MAX_STACK_SIZE, frameStack, &frameStackSize))) {
             nsk_jvmti_setFailStatus();
             return NSK_TRUE;
         }
@@ -380,8 +370,8 @@ static int clean() {
 
     NSK_DISPLAY0("Dispose global references to threads\n");
     for (i = 0; i < THREADS_COUNT; i++) {
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsDesc[i].thread));
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsDesc[i].cls));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsDesc[i].thread));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsDesc[i].cls));
     }
 
     return NSK_TRUE;
@@ -514,8 +504,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_suspend = 1;
         caps.can_generate_compiled_method_load_events = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 
@@ -524,9 +513,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.CompiledMethodLoad = callbackCompiledMethodLoad;
         eventCallbacks.CompiledMethodUnload = callbackCompiledMethodUnload;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP06/sp06t002/sp06t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP06/sp06t002/sp06t002.cpp
@@ -143,8 +143,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
  * Generate missed events (COMPILED_METHOD_LOAD only).
  */
 static int generateEvents() {
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GenerateEvents, jvmti, JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -177,8 +176,7 @@ static int prepare() {
     }
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &allThreadsCount, &allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&allThreadsCount, &allThreadsList)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(allThreadsCount > 0 && allThreadsList != NULL))
@@ -191,8 +189,7 @@ static int prepare() {
         if (!NSK_VERIFY(allThreadsList[i] != NULL))
             return NSK_FALSE;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, allThreadsList[i], &threadInfo)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(allThreadsList[i], &threadInfo)))
             return NSK_FALSE;
 
         if (threadInfo.name != NULL) {
@@ -209,8 +206,7 @@ static int prepare() {
     }
 
     /* deallocate all threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)allThreadsList)))
         return NSK_FALSE;
 
     /* check if all tested threads found */
@@ -231,12 +227,11 @@ static int prepare() {
     for (i = 0; i < THREADS_COUNT; i++) {
 
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].cls =
-                NSK_CPP_STUB2(GetObjectClass, jni, threadsDesc[i].thread)) != NULL))
+                jni->GetObjectClass(threadsDesc[i].thread)) != NULL))
             return NSK_FALSE;
 
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].method =
-                NSK_CPP_STUB4(GetMethodID, jni, threadsDesc[i].cls,
-                            threadsDesc[i].methodName, threadsDesc[i].methodSig)) != NULL))
+                jni->GetMethodID(threadsDesc[i].cls, threadsDesc[i].methodName, threadsDesc[i].methodSig)) != NULL))
             return NSK_FALSE;
 
         NSK_DISPLAY4("    thread #%d (%s): 0x%p (%s)\n",
@@ -248,10 +243,10 @@ static int prepare() {
     /* make global refs */
     for (i = 0; i < THREADS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].thread = (jthread)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsDesc[i].thread)) != NULL))
+                jni->NewGlobalRef(threadsDesc[i].thread)) != NULL))
             return NSK_FALSE;
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].cls = (jclass)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsDesc[i].cls)) != NULL))
+                jni->NewGlobalRef(threadsDesc[i].cls)) != NULL))
             return NSK_FALSE;
     }
 
@@ -271,13 +266,11 @@ static int suspendThreadsIndividually(int suspend) {
     for (i = 0; i < THREADS_COUNT; i++) {
         if (suspend) {
             NSK_DISPLAY2("    suspend thread #%d (%s)\n", i, threadsDesc[i].threadName);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(SuspendThread, jvmti, threadsDesc[i].thread)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(threadsDesc[i].thread)))
                 nsk_jvmti_setFailStatus();
         } else {
             NSK_DISPLAY2("    resume thread #%d (%s)\n", i, threadsDesc[i].threadName);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(ResumeThread, jvmti, threadsDesc[i].thread)))
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(threadsDesc[i].thread)))
                 nsk_jvmti_setFailStatus();
         }
     }
@@ -310,9 +303,7 @@ static int checkThreads(int suspended, const char* kind0) {
         NSK_DISPLAY2("  thread #%d (%s):\n", i, threadsDesc[i].threadName);
 
         /* get frame count */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetFrameCount, jvmti,
-                                    threadsDesc[i].thread, &frameCount))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetFrameCount(threadsDesc[i].thread, &frameCount))) {
             nsk_jvmti_setFailStatus();
             return NSK_TRUE;
         }
@@ -321,8 +312,7 @@ static int checkThreads(int suspended, const char* kind0) {
 
         /* get stack trace */
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB6(GetStackTrace, jvmti, threadsDesc[i].thread,
-                                    0, MAX_STACK_SIZE, frameStack, &frameStackSize))) {
+                jvmti->GetStackTrace(threadsDesc[i].thread, 0, MAX_STACK_SIZE, frameStack, &frameStackSize))) {
             nsk_jvmti_setFailStatus();
             return NSK_TRUE;
         }
@@ -386,8 +376,8 @@ static int clean() {
 
     NSK_DISPLAY0("Dispose global references to threads\n");
     for (i = 0; i < THREADS_COUNT; i++) {
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsDesc[i].thread));
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsDesc[i].cls));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsDesc[i].thread));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsDesc[i].cls));
     }
 
     return NSK_TRUE;
@@ -520,8 +510,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_suspend = 1;
         caps.can_generate_compiled_method_load_events = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 
@@ -530,9 +519,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.CompiledMethodLoad = callbackCompiledMethodLoad;
         eventCallbacks.CompiledMethodUnload = callbackCompiledMethodUnload;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP06/sp06t003/sp06t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP06/sp06t003/sp06t003.cpp
@@ -143,8 +143,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
  * Generate missed events (COMPILED_METHOD_LOAD only).
  */
 static int generateEvents() {
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GenerateEvents, jvmti, JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -177,8 +176,7 @@ static int prepare() {
     }
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &allThreadsCount, &allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&allThreadsCount, &allThreadsList)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(allThreadsCount > 0 && allThreadsList != NULL))
@@ -191,8 +189,7 @@ static int prepare() {
         if (!NSK_VERIFY(allThreadsList[i] != NULL))
             return NSK_FALSE;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, allThreadsList[i], &threadInfo)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(allThreadsList[i], &threadInfo)))
             return NSK_FALSE;
 
         if (threadInfo.name != NULL) {
@@ -209,8 +206,7 @@ static int prepare() {
     }
 
     /* deallocate all threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)allThreadsList)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)allThreadsList)))
         return NSK_FALSE;
 
     /* check if all tested threads found */
@@ -231,12 +227,11 @@ static int prepare() {
     for (i = 0; i < THREADS_COUNT; i++) {
 
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].cls =
-                NSK_CPP_STUB2(GetObjectClass, jni, threadsDesc[i].thread)) != NULL))
+                jni->GetObjectClass(threadsDesc[i].thread)) != NULL))
             return NSK_FALSE;
 
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].method =
-                NSK_CPP_STUB4(GetMethodID, jni, threadsDesc[i].cls,
-                            threadsDesc[i].methodName, threadsDesc[i].methodSig)) != NULL))
+                jni->GetMethodID(threadsDesc[i].cls, threadsDesc[i].methodName, threadsDesc[i].methodSig)) != NULL))
             return NSK_FALSE;
 
         NSK_DISPLAY4("    thread #%d (%s): 0x%p (%s)\n",
@@ -248,10 +243,10 @@ static int prepare() {
     /* make global refs */
     for (i = 0; i < THREADS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].thread = (jthread)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsDesc[i].thread)) != NULL))
+                jni->NewGlobalRef(threadsDesc[i].thread)) != NULL))
             return NSK_FALSE;
         if (!NSK_JNI_VERIFY(jni, (threadsDesc[i].cls = (jclass)
-                NSK_CPP_STUB2(NewGlobalRef, jni, threadsDesc[i].cls)) != NULL))
+                jni->NewGlobalRef(threadsDesc[i].cls)) != NULL))
             return NSK_FALSE;
     }
 
@@ -271,13 +266,11 @@ static int suspendThreadsIndividually(int suspend) {
     for (i = 0; i < THREADS_COUNT; i++) {
         if (suspend) {
             NSK_DISPLAY2("    suspend thread #%d (%s)\n", i, threadsDesc[i].threadName);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(SuspendThread, jvmti, threadsDesc[i].thread)))
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(threadsDesc[i].thread)))
                 nsk_jvmti_setFailStatus();
         } else {
             NSK_DISPLAY2("    resume thread #%d (%s)\n", i, threadsDesc[i].threadName);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(ResumeThread, jvmti, threadsDesc[i].thread)))
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(threadsDesc[i].thread)))
                 nsk_jvmti_setFailStatus();
         }
     }
@@ -312,9 +305,7 @@ static int checkThreads(int suspended, const char* kind0) {
         NSK_DISPLAY2("  thread #%d (%s):\n", i, threadsDesc[i].threadName);
 
         /* get frame count */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetFrameCount, jvmti,
-                                    threadsDesc[i].thread, &frameCount))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetFrameCount(threadsDesc[i].thread, &frameCount))) {
             nsk_jvmti_setFailStatus();
             return NSK_TRUE;
         }
@@ -322,8 +313,7 @@ static int checkThreads(int suspended, const char* kind0) {
 
         /* get stack trace */
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB6(GetStackTrace, jvmti, threadsDesc[i].thread,
-                                    0, MAX_STACK_SIZE, frameStack, &frameStackSize))) {
+                jvmti->GetStackTrace(threadsDesc[i].thread, 0, MAX_STACK_SIZE, frameStack, &frameStackSize))) {
             nsk_jvmti_setFailStatus();
             return NSK_TRUE;
         }
@@ -343,8 +333,7 @@ static int checkThreads(int suspended, const char* kind0) {
                                         (long)frameStack[j].location);
             /* query frame location */
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB5(GetFrameLocation, jvmti, threadsDesc[i].thread,
-                                        j, &qMethod, &qLocation))
+                    jvmti->GetFrameLocation(threadsDesc[i].thread, j, &qMethod, &qLocation))
                 && (suspended == NSK_TRUE)) {
                 nsk_jvmti_setFailStatus();
                 continue;
@@ -405,8 +394,8 @@ static int clean() {
 
     NSK_DISPLAY0("Dispose global references to threads\n");
     for (i = 0; i < THREADS_COUNT; i++) {
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsDesc[i].thread));
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threadsDesc[i].cls));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsDesc[i].thread));
+        NSK_TRACE(jni->DeleteGlobalRef(threadsDesc[i].cls));
     }
 
     return NSK_TRUE;
@@ -539,8 +528,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_suspend = 1;
         caps.can_generate_compiled_method_load_events = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 
@@ -549,9 +537,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.CompiledMethodLoad = callbackCompiledMethodLoad;
         eventCallbacks.CompiledMethodUnload = callbackCompiledMethodUnload;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t001/sp07t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t001/sp07t001.cpp
@@ -62,8 +62,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -75,8 +74,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -87,15 +85,13 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         }
 
         if (info.name != NULL) {
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                    Deallocate, jvmti, (unsigned char*)info.name)))
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)info.name)))
                 return NSK_FALSE;
         }
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     if (thread == NULL) {
@@ -103,8 +99,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         return NSK_FALSE;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "waitLock", &waitLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("waitLock", &waitLock)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -114,14 +109,13 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
 
 static int wait_for(jvmtiEnv* jvmti, jlong millis) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, waitLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(waitLock)))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RawMonitorWait, jvmti, waitLock, millis)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorWait(waitLock, millis)))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, waitLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(waitLock)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -132,27 +126,25 @@ static int displayFrameInfo(jvmtiEnv* jvmti, jint i) {
     char *name = NULL;
     char *signature = NULL;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName, jvmti,
-            frameBuffer[frameCount-1-i].method, &name, &signature, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetMethodName(frameBuffer[frameCount-1-i].method, &name, &signature, NULL)))
         return NSK_FALSE;
 
     NSK_DISPLAY4("    got[%d] method: %s%s, location: %s\n", i, name,
         signature, jlong_to_string(frameBuffer[frameCount-1-i].location, buffer));
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)name);
+        jvmti->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)signature);
+        jvmti->Deallocate((unsigned char*)signature);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName, jvmti,
-            sampleStack[i].method, &name, &signature, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetMethodName(sampleStack[i].method, &name, &signature, NULL)))
         return NSK_FALSE;
 
     NSK_DISPLAY4("    exp[%d] method: %s%s, location: %s\n", i, name,
         signature, jlong_to_string(sampleStack[i].location, buffer));
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)name);
+        jvmti->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)signature);
+        jvmti->Deallocate((unsigned char*)signature);
 
     return NSK_TRUE;
 }
@@ -162,27 +154,25 @@ static int complainFrameInfo(jvmtiEnv* jvmti, jint i) {
     char *name = NULL;
     char *signature = NULL;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName, jvmti,
-            frameBuffer[frameCount-1-i].method, &name, &signature, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetMethodName(frameBuffer[frameCount-1-i].method, &name, &signature, NULL)))
         return NSK_FALSE;
 
     NSK_COMPLAIN3("    got: method=%s%s, location=%s\n", name, signature,
         jlong_to_string(frameBuffer[frameCount-1-i].location, buffer));
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)name);
+        jvmti->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)signature);
+        jvmti->Deallocate((unsigned char*)signature);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName, jvmti,
-            sampleStack[i].method, &name, &signature, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetMethodName(sampleStack[i].method, &name, &signature, NULL)))
         return NSK_FALSE;
 
     NSK_COMPLAIN3("    expected: method=%s%s, location=%s\n", name, signature,
         jlong_to_string(sampleStack[i].location, buffer));
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)name);
+        jvmti->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)signature);
+        jvmti->Deallocate((unsigned char*)signature);
 
     return NSK_TRUE;
 }
@@ -193,13 +183,11 @@ static int checkStackTrace(jvmtiEnv* jvmti, JNIEnv* jni) {
     int displayFlag =
         (nsk_getVerboseMode() && (sampleCount % DISPLAYING_FREQUENCY) == 0);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, frameLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(frameLock)))
         return NSK_FALSE;
 
     /* get stack trace */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB6(GetStackTrace, jvmti, thread,
-                0, MAX_DEPTH, frameBuffer, &frameCount))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetStackTrace(thread, 0, MAX_DEPTH, frameBuffer, &frameCount))) {
         res = NSK_FALSE;
     } else {
         if (displayFlag) {
@@ -228,7 +216,7 @@ static int checkStackTrace(jvmtiEnv* jvmti, JNIEnv* jni) {
         }
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, frameLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(frameLock)))
         return NSK_FALSE;
 
     return res;
@@ -278,49 +266,45 @@ Java_nsk_jvmti_scenarios_sampling_SP07_sp07t001Thread_wrapper(JNIEnv* jni,
         return 0;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, frameLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(frameLock)))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetFrameLocation, jvmti, NULL, 1,
-            &sampleStack[depth].method, &sampleStack[depth].location))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetFrameLocation(NULL, 1, &sampleStack[depth].method, &sampleStack[depth].location))) {
         nsk_jvmti_setFailStatus();
         return 0;
     }
 
     depth++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetFrameLocation, jvmti, NULL, 0,
-            &sampleStack[depth].method, &sampleStack[depth].location))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetFrameLocation(NULL, 0, &sampleStack[depth].method, &sampleStack[depth].location))) {
         nsk_jvmti_setFailStatus();
         return 0;
     }
 
     depth++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, frameLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(frameLock)))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (klass = NSK_CPP_STUB2(GetObjectClass,
-            jni, obj)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(obj)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return 0;
     }
 
-    if (!NSK_JNI_VERIFY(jni, (method = NSK_CPP_STUB4(GetMethodID,
-            jni, klass, "fibonacci", "(I)I")) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "fibonacci", "(I)I")) != NULL)) {
         nsk_jvmti_setFailStatus();
         return 0;
     }
 
-    result = NSK_CPP_STUB4(CallIntMethod, jni, obj, method, i);
+    result = jni->CallIntMethod(obj, method, i);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, frameLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(frameLock)))
         return NSK_FALSE;
 
     depth--;
     depth--;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, frameLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(frameLock)))
         return NSK_FALSE;
 
     return result;
@@ -355,8 +339,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
             nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "frameLock", &frameLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("frameLock", &frameLock)))
         return NSK_FALSE;
 
     /* register agent proc and arg */


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

The patch does not apply to 
test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP02/sp02t003/sp02t003.cpp and
test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/sampling/SP06/sp06t003/sp06t003.cpp
because we backported "8051349: nsk/jvmti/scenarios/sampling/SP06/sp06t003 fails in nightly"

Simple resolve.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8212082](https://bugs.openjdk.java.net/browse/JDK-8212082): Remove the NSK_CPP_STUB macros for remaining vmTestbase/jvmti/[sS]*


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/668/head:pull/668` \
`$ git checkout pull/668`

Update a local copy of the PR: \
`$ git checkout pull/668` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 668`

View PR using the GUI difftool: \
`$ git pr show -t 668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/668.diff">https://git.openjdk.java.net/jdk11u-dev/pull/668.diff</a>

</details>
