### PR TITLE
8212083: Handle remaining gc/lock native code and fix two strings

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/BooleanArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/BooleanArrayCriticalLocker.cpp
@@ -23,6 +23,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <time.h>
+#include "ExceptionCheckingJniEnv.hpp"
 #include "jni_tools.h"
 
 extern "C" {
@@ -35,7 +36,9 @@ static jfieldID objFieldId = NULL;
  * Signature: ([Z)Z
  */
 JNIEXPORT jboolean JNICALL Java_nsk_share_gc_lock_jni_BooleanArrayCriticalLocker_criticalNative
-(JNIEnv *env, jobject o, jlong enterTime, jlong sleepTime) {
+(JNIEnv *jni_env, jobject o, jlong enterTime, jlong sleepTime) {
+        ExceptionCheckingJniEnvPtr env(jni_env);
+
         jsize size, i;
         jbooleanArray arr;
         jboolean *pa;
@@ -44,22 +47,11 @@ JNIEXPORT jboolean JNICALL Java_nsk_share_gc_lock_jni_BooleanArrayCriticalLocker
 
         if (objFieldId == NULL) {
                 jclass klass = env->GetObjectClass(o);
-                if (klass == NULL) {
-                        printf("Error: GetObjectClass returned NULL\n");
-                        return JNI_FALSE;
-                }
                 objFieldId = env->GetFieldID(klass, "obj", "Ljava/lang/Object;");
-                if (objFieldId == NULL) {
-                        printf("Error: GetFieldID returned NULL\n");
-                        return JNI_FALSE;
-                }
         }
         arr = (jbooleanArray) env->GetObjectField(o, objFieldId);
-        if (arr == NULL) {
-                printf("Error: GetObjectField returned NULL\n");
-                return JNI_FALSE;
-        }
         env->SetObjectField(o, objFieldId, NULL);
+
         size = env->GetArrayLength(arr);
         start_time = time(NULL);
         enterTime /= 1000;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/ByteArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/ByteArrayCriticalLocker.cpp
@@ -23,6 +23,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <time.h>
+#include "ExceptionCheckingJniEnv.hpp"
 #include "jni_tools.h"
 
 extern "C" {
@@ -34,7 +35,9 @@ static jfieldID objFieldId = NULL;
  * Method:    criticalNative
  */
 JNIEXPORT jbyte JNICALL Java_nsk_share_gc_lock_jni_ByteArrayCriticalLocker_criticalNative
-(JNIEnv *env, jobject o, jlong enterTime, jlong sleepTime) {
+(JNIEnv *jni_env, jobject o, jlong enterTime, jlong sleepTime) {
+        ExceptionCheckingJniEnvPtr env(jni_env);
+
         jsize size, i;
         jbyteArray arr;
         jbyte *pa;
@@ -43,22 +46,11 @@ JNIEXPORT jbyte JNICALL Java_nsk_share_gc_lock_jni_ByteArrayCriticalLocker_criti
 
         if (objFieldId == NULL) {
                 jclass klass = env->GetObjectClass(o);
-                if (klass == NULL) {
-                        printf("Error: GetObjectClass returned NULL\n");
-                        return 0;
-                }
                 objFieldId = env->GetFieldID(klass, "obj", "Ljava/lang/Object;");
-                if (objFieldId == NULL) {
-                        printf("Error: GetFieldID returned NULL\n");
-                        return 0;
-                }
         }
         arr = (jbyteArray) env->GetObjectField(o, objFieldId);
-        if (arr == NULL) {
-                printf("Error: GetObjectField returned NULL\n");
-                return 0;
-        }
         env->SetObjectField(o, objFieldId, NULL);
+
         size = env->GetArrayLength(arr);
         start_time = time(NULL);
         enterTime /= 1000;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/CharArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/CharArrayCriticalLocker.cpp
@@ -23,6 +23,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <time.h>
+#include "ExceptionCheckingJniEnv.hpp"
 #include "jni_tools.h"
 
 extern "C" {
@@ -35,7 +36,9 @@ static jfieldID objFieldId = NULL;
  * Signature: ([Z)Z
  */
 JNIEXPORT jchar JNICALL Java_nsk_share_gc_lock_jni_CharArrayCriticalLocker_criticalNative
-(JNIEnv *env, jobject o, jlong enterTime, jlong sleepTime) {
+(JNIEnv *jni_env, jobject o, jlong enterTime, jlong sleepTime) {
+        ExceptionCheckingJniEnvPtr env(jni_env);
+
         jsize size, i;
         jcharArray arr;
         jchar *pa;
@@ -44,22 +47,11 @@ JNIEXPORT jchar JNICALL Java_nsk_share_gc_lock_jni_CharArrayCriticalLocker_criti
 
         if (objFieldId == NULL) {
                 jclass klass = env->GetObjectClass(o);
-                if (klass == NULL) {
-                        printf("Error: GetObjectClass returned NULL\n");
-                        return 0;
-                }
                 objFieldId = env->GetFieldID(klass, "obj", "Ljava/lang/Object;");
-                if (objFieldId == NULL) {
-                        printf("Error: GetFieldID returned NULL\n");
-                        return 0;
-                }
         }
         arr = (jcharArray) env->GetObjectField(o, objFieldId);
-        if (arr == NULL) {
-                printf("Error: GetObjectField returned NULL\n");
-                return JNI_FALSE;
-        }
         env->SetObjectField(o, objFieldId, NULL);
+
         size = env->GetArrayLength(arr);
         start_time = time(NULL);
         current_time = 0;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/DoubleArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/DoubleArrayCriticalLocker.cpp
@@ -23,6 +23,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <time.h>
+#include "ExceptionCheckingJniEnv.hpp"
 #include "jni_tools.h"
 
 extern "C" {
@@ -35,7 +36,9 @@ static jfieldID objFieldId = NULL;
  * Signature: ([Z)Z
  */
 JNIEXPORT jdouble JNICALL Java_nsk_share_gc_lock_jni_DoubleArrayCriticalLocker_criticalNative
-(JNIEnv *env, jobject o, jlong enterTime, jlong sleepTime) {
+(JNIEnv *jni_env, jobject o, jlong enterTime, jlong sleepTime) {
+        ExceptionCheckingJniEnvPtr env(jni_env);
+
         jsize size, i;
         jdoubleArray arr;
         jdouble *pa;
@@ -44,22 +47,11 @@ JNIEXPORT jdouble JNICALL Java_nsk_share_gc_lock_jni_DoubleArrayCriticalLocker_c
 
         if (objFieldId == NULL) {
                 jclass klass = env->GetObjectClass(o);
-                if (klass == NULL) {
-                        printf("Error: GetObjectClass returned NULL\n");
-                        return 0;
-                }
                 objFieldId = env->GetFieldID(klass, "obj", "Ljava/lang/Object;");
-                if (objFieldId == NULL) {
-                        printf("Error: GetFieldID returned NULL\n");
-                        return 0;
-                }
         }
         arr = (jdoubleArray) env->GetObjectField(o, objFieldId);
-        if (arr == NULL) {
-                printf("Error: GetObjectField returned NULL\n");
-                return JNI_FALSE;
-        }
         env->SetObjectField(o, objFieldId, NULL);
+
         size = env->GetArrayLength(arr);
         start_time = time(NULL);
         enterTime /= 1000;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/FloatArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/FloatArrayCriticalLocker.cpp
@@ -23,6 +23,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <time.h>
+#include "ExceptionCheckingJniEnv.hpp"
 #include "jni_tools.h"
 
 extern "C" {
@@ -35,7 +36,9 @@ static jfieldID objFieldId = NULL;
  * Signature: ([Z)Z
  */
 JNIEXPORT jfloat JNICALL Java_nsk_share_gc_lock_jni_FloatArrayCriticalLocker_criticalNative
-(JNIEnv *env, jobject o, jlong enterTime, jlong sleepTime) {
+(JNIEnv *jni_env, jobject o, jlong enterTime, jlong sleepTime) {
+        ExceptionCheckingJniEnvPtr env(jni_env);
+
         jsize size, i;
         jfloatArray arr;
         jfloat *pa;
@@ -44,22 +47,11 @@ JNIEXPORT jfloat JNICALL Java_nsk_share_gc_lock_jni_FloatArrayCriticalLocker_cri
 
         if (objFieldId == NULL) {
                 jclass klass = env->GetObjectClass(o);
-                if (klass == NULL) {
-                        printf("Error: GetObjectClass returned NULL\n");
-                        return 0;
-                }
                 objFieldId = env->GetFieldID(klass, "obj", "Ljava/lang/Object;");
-                if (objFieldId == NULL) {
-                        printf("Error: GetFieldID returned NULL\n");
-                        return 0;
-                }
         }
         arr = (jfloatArray) env->GetObjectField(o, objFieldId);
-        if (arr == NULL) {
-                printf("Error: GetObjectField returned NULL\n");
-                return JNI_FALSE;
-        }
         env->SetObjectField(o, objFieldId, NULL);
+
         size = env->GetArrayLength(arr);
         start_time = time(NULL);
         enterTime /= 1000;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/IntArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/IntArrayCriticalLocker.cpp
@@ -23,6 +23,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <time.h>
+#include "ExceptionCheckingJniEnv.hpp"
 #include "jni_tools.h"
 
 extern "C" {
@@ -35,7 +36,9 @@ static jfieldID objFieldId = NULL;
  * Signature: ([Z)Z
  */
 JNIEXPORT jint JNICALL Java_nsk_share_gc_lock_jni_IntArrayCriticalLocker_criticalNative
-(JNIEnv *env, jobject o, jlong enterTime, jlong sleepTime) {
+(JNIEnv *jni_env, jobject o, jlong enterTime, jlong sleepTime) {
+        ExceptionCheckingJniEnvPtr env(jni_env);
+
         jsize size, i;
         jintArray arr;
         jint *pa;
@@ -44,22 +47,11 @@ JNIEXPORT jint JNICALL Java_nsk_share_gc_lock_jni_IntArrayCriticalLocker_critica
 
         if (objFieldId == NULL) {
                 jclass klass = env->GetObjectClass(o);
-                if (klass == NULL) {
-                        printf("Error: GetObjectClass returned NULL\n");
-                        return 0;
-                }
                 objFieldId = env->GetFieldID(klass, "obj", "Ljava/lang/Object;");
-                if (objFieldId == NULL) {
-                        printf("Error: GetFieldID returned NULL\n");
-                        return 0;
-                }
         }
         arr = (jintArray) env->GetObjectField(o, objFieldId);
-        if (arr == NULL) {
-                printf("Error: GetObjectField returned NULL\n");
-                return JNI_FALSE;
-        }
         env->SetObjectField(o, objFieldId, NULL);
+
         size = env->GetArrayLength(arr);
         start_time = time(NULL);
         enterTime /= 1000;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/LongArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/LongArrayCriticalLocker.cpp
@@ -23,6 +23,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <time.h>
+#include "ExceptionCheckingJniEnv.hpp"
 #include "jni_tools.h"
 
 extern "C" {
@@ -35,7 +36,9 @@ static jfieldID objFieldId = NULL;
  * Signature: ([Z)Z
  */
 JNIEXPORT jlong JNICALL Java_nsk_share_gc_lock_jni_LongArrayCriticalLocker_criticalNative
-(JNIEnv *env, jobject o, jlong enterTime, jlong sleepTime) {
+(JNIEnv *jni_env, jobject o, jlong enterTime, jlong sleepTime) {
+        ExceptionCheckingJniEnvPtr env(jni_env);
+
         jsize size, i;
         jlongArray arr;
         jlong *pa;
@@ -44,22 +47,11 @@ JNIEXPORT jlong JNICALL Java_nsk_share_gc_lock_jni_LongArrayCriticalLocker_criti
 
         if (objFieldId == NULL) {
                 jclass klass = env->GetObjectClass(o);
-                if (klass == NULL) {
-                        printf("Error: GetObjectClass returned NULL\n");
-                        return 0;
-                }
                 objFieldId = env->GetFieldID(klass, "obj", "Ljava/lang/Object;");
-                if (objFieldId == NULL) {
-                        printf("Error: GetFieldID returned NULL\n");
-                        return 0;
-                }
         }
         arr = (jlongArray) env->GetObjectField(o, objFieldId);
-        if (arr == NULL) {
-                printf("Error: GetObjectField returned NULL\n");
-                return JNI_FALSE;
-        }
         env->SetObjectField(o, objFieldId, NULL);
+
         size = env->GetArrayLength(arr);
         start_time = time(NULL);
         enterTime /= 1000;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/ShortArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/ShortArrayCriticalLocker.cpp
@@ -23,6 +23,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <time.h>
+#include "ExceptionCheckingJniEnv.hpp"
 #include "jni_tools.h"
 
 extern "C" {
@@ -35,7 +36,9 @@ static jfieldID objFieldId = NULL;
  * Signature: ([Z)Z
  */
 JNIEXPORT jshort JNICALL Java_nsk_share_gc_lock_jni_ShortArrayCriticalLocker_criticalNative
-(JNIEnv *env, jobject o, jlong enterTime, jlong sleepTime) {
+(JNIEnv *jni_env, jobject o, jlong enterTime, jlong sleepTime) {
+        ExceptionCheckingJniEnvPtr env(jni_env);
+
         jsize size, i;
         jshortArray arr;
         jshort *pa;
@@ -44,22 +47,11 @@ JNIEXPORT jshort JNICALL Java_nsk_share_gc_lock_jni_ShortArrayCriticalLocker_cri
 
         if (objFieldId == NULL) {
                 jclass klass = env->GetObjectClass(o);
-                if (klass == NULL) {
-                        printf("Error: GetObjectClass returned NULL\n");
-                        return 0;
-                }
                 objFieldId = env->GetFieldID(klass, "obj", "Ljava/lang/Object;");
-                if (objFieldId == NULL) {
-                        printf("Error: GetFieldID returned NULL\n");
-                        return 0;
-                }
         }
         arr = (jshortArray) env->GetObjectField(o, objFieldId);
-        if (arr == NULL) {
-                printf("Error: GetObjectField returned NULL\n");
-                return JNI_FALSE;
-        }
         env->SetObjectField(o, objFieldId, NULL);
+
         size = env->GetArrayLength(arr);
         start_time = time(NULL);
         enterTime /= 1000;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/StringCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/StringCriticalLocker.cpp
@@ -23,6 +23,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <time.h>
+#include "ExceptionCheckingJniEnv.hpp"
 #include "jni_tools.h"
 
 extern "C" {
@@ -35,7 +36,9 @@ static jfieldID objFieldId = NULL;
  * Signature: ([Z)Z
  */
 JNIEXPORT jchar JNICALL Java_nsk_share_gc_lock_jni_StringCriticalLocker_criticalNative
-(JNIEnv *env, jobject o, jlong enterTime, jlong sleepTime) {
+(JNIEnv *jni_env, jobject o, jlong enterTime, jlong sleepTime) {
+        ExceptionCheckingJniEnvPtr env(jni_env);
+
         jsize size, i;
         jstring str;
         const jchar *pa;
@@ -44,22 +47,11 @@ JNIEXPORT jchar JNICALL Java_nsk_share_gc_lock_jni_StringCriticalLocker_critical
 
         if (objFieldId == NULL) {
                 jclass klass = env->GetObjectClass(o);
-                if (klass == NULL) {
-                        printf("Error: GetObjectClass returned NULL\n");
-                        return JNI_FALSE;
-                }
                 objFieldId = env->GetFieldID(klass, "obj", "Ljava/lang/Object;");
-                if (objFieldId == NULL) {
-                        printf("Error: GetFieldID returned NULL\n");
-                        return JNI_FALSE;
-                }
         }
         str = (jstring) env->GetObjectField(o, objFieldId);
-        if (str == NULL) {
-                printf("Error: GetObjectField returned NULL\n");
-                return JNI_FALSE;
-        }
         env->SetObjectField(o, objFieldId, NULL);
+
         size = env->GetStringLength(str);
         start_time = time(NULL);
         enterTime /= 1000;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libBooleanArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libBooleanArrayCriticalLocker.cpp
@@ -22,5 +22,6 @@
  */
 
 #include "BooleanArrayCriticalLocker.cpp"
+#include "ExceptionCheckingJniEnv.cpp"
 #include "jni_tools.cpp"
 #include "nsk_tools.cpp"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libByteArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libByteArrayCriticalLocker.cpp
@@ -22,5 +22,6 @@
  */
 
 #include "ByteArrayCriticalLocker.cpp"
+#include "ExceptionCheckingJniEnv.cpp"
 #include "jni_tools.cpp"
 #include "nsk_tools.cpp"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libCharArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libCharArrayCriticalLocker.cpp
@@ -22,5 +22,6 @@
  */
 
 #include "CharArrayCriticalLocker.cpp"
+#include "ExceptionCheckingJniEnv.cpp"
 #include "jni_tools.cpp"
 #include "nsk_tools.cpp"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libDoubleArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libDoubleArrayCriticalLocker.cpp
@@ -22,5 +22,6 @@
  */
 
 #include "DoubleArrayCriticalLocker.cpp"
+#include "ExceptionCheckingJniEnv.cpp"
 #include "jni_tools.cpp"
 #include "nsk_tools.cpp"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libFloatArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libFloatArrayCriticalLocker.cpp
@@ -21,6 +21,7 @@
  * questions.
  */
 
+#include "ExceptionCheckingJniEnv.cpp"
 #include "FloatArrayCriticalLocker.cpp"
 #include "jni_tools.cpp"
 #include "nsk_tools.cpp"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libIntArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libIntArrayCriticalLocker.cpp
@@ -21,6 +21,7 @@
  * questions.
  */
 
+#include "ExceptionCheckingJniEnv.cpp"
 #include "IntArrayCriticalLocker.cpp"
 #include "jni_tools.cpp"
 #include "nsk_tools.cpp"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libLongArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libLongArrayCriticalLocker.cpp
@@ -21,6 +21,7 @@
  * questions.
  */
 
+#include "ExceptionCheckingJniEnv.cpp"
 #include "LongArrayCriticalLocker.cpp"
 #include "jni_tools.cpp"
 #include "nsk_tools.cpp"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libShortArrayCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libShortArrayCriticalLocker.cpp
@@ -21,6 +21,7 @@
  * questions.
  */
 
+#include "ExceptionCheckingJniEnv.cpp"
 #include "ShortArrayCriticalLocker.cpp"
 #include "jni_tools.cpp"
 #include "nsk_tools.cpp"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libStringCriticalLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jni/libStringCriticalLocker.cpp
@@ -21,6 +21,7 @@
  * questions.
  */
 
+#include "ExceptionCheckingJniEnv.cpp"
 #include "StringCriticalLocker.cpp"
 #include "jni_tools.cpp"
 #include "nsk_tools.cpp"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/JNIGlobalRefLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/JNIGlobalRefLocker.cpp
@@ -24,8 +24,8 @@
 #include <jni.h>
 #include <stdio.h>
 #include <time.h>
-#include "jni_tools.h"
 #include "ExceptionCheckingJniEnv.hpp"
+#include "jni_tools.h"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/JNILocalRefLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/JNILocalRefLocker.cpp
@@ -23,6 +23,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <time.h>
+#include "ExceptionCheckingJniEnv.hpp"
 #include "jni_tools.h"
 
 extern "C" {
@@ -35,28 +36,18 @@ static jfieldID objFieldId = NULL;
  * Signature: (JJ)V
  */
 JNIEXPORT void JNICALL Java_nsk_share_gc_lock_jniref_JNILocalRefLocker_criticalNative
-  (JNIEnv *env, jobject o, jlong enterTime, jlong sleepTime) {
+  (JNIEnv *jni_env, jobject o, jlong enterTime, jlong sleepTime) {
+        ExceptionCheckingJniEnvPtr env(jni_env);
+
         jobject obj;
         jobject gref;
         time_t start_time, current_time;
 
         if (objFieldId == NULL) {
                 jclass klass = env->GetObjectClass(o);
-                if (klass == NULL) {
-                        printf("Error: GetObjectClass returned NULL\n");
-                        return;
-                }
                 objFieldId = env->GetFieldID(klass, "obj", "Ljava/lang/Object;");
-                if (objFieldId == NULL) {
-                        printf("Error: GetFieldID returned NULL\n");
-                        return;
-                }
         }
         obj = env->GetObjectField(o, objFieldId);
-        if (obj == NULL) {
-                printf("Error: GetObjectField returned NULL\n");
-                return;
-        }
         env->SetObjectField(o, objFieldId, NULL);
         start_time = time(NULL);
         enterTime /= 1000;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/JNIRefLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/JNIRefLocker.cpp
@@ -23,6 +23,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <time.h>
+#include "ExceptionCheckingJniEnv.hpp"
 #include "jni_tools.h"
 
 extern "C" {
@@ -35,29 +36,21 @@ static jfieldID objFieldId = NULL;
  * Signature: (JJ)V
  */
 JNIEXPORT void JNICALL Java_nsk_share_gc_lock_jniref_JNIRefLocker_criticalNative
-  (JNIEnv *env, jobject o, jlong enterTime, jlong sleepTime) {
+  (JNIEnv *jni_env, jobject o, jlong enterTime, jlong sleepTime) {
+        ExceptionCheckingJniEnvPtr env(jni_env);
+
         jobject obj;
         jobject gref, lref, gwref;
         time_t start_time, current_time;
 
         if (objFieldId == NULL) {
                 jclass klass = env->GetObjectClass(o);
-                if (klass == NULL) {
-                        printf("Error: GetObjectClass returned NULL\n");
-                        return;
-                }
                 objFieldId = env->GetFieldID(klass, "obj", "Ljava/lang/Object;");
-                if (objFieldId == NULL) {
-                        printf("Error: GetFieldID returned NULL\n");
-                        return;
-                }
         }
+
         obj = env->GetObjectField(o, objFieldId);
-        if (obj == NULL) {
-                printf("Error: GetObjectField returned NULL\n");
-                return;
-        }
         env->SetObjectField(o, objFieldId, NULL);
+
         start_time = time(NULL);
         enterTime /= 1000;
         current_time = 0;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/JNIWeakGlobalRefLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/JNIWeakGlobalRefLocker.cpp
@@ -23,6 +23,7 @@
 #include <jni.h>
 #include <stdio.h>
 #include <time.h>
+#include "ExceptionCheckingJniEnv.hpp"
 #include "jni_tools.h"
 
 extern "C" {
@@ -35,29 +36,20 @@ static jfieldID objFieldId = NULL;
  * Signature: (JJ)V
  */
 JNIEXPORT void JNICALL Java_nsk_share_gc_lock_jniref_JNIWeakGlobalRefLocker_criticalNative
-  (JNIEnv *env, jobject o, jlong enterTime, jlong sleepTime) {
+  (JNIEnv *jni_env, jobject o, jlong enterTime, jlong sleepTime) {
+        ExceptionCheckingJniEnvPtr env(jni_env);
+
         jobject obj;
         jobject gref;
         time_t start_time, current_time;
 
         if (objFieldId == NULL) {
                 jclass klass = env->GetObjectClass(o);
-                if (klass == NULL) {
-                        printf("Error: GetObjectClass returned NULL\n");
-                        return;
-                }
                 objFieldId = env->GetFieldID(klass, "obj", "Ljava/lang/Object;");
-                if (objFieldId == NULL) {
-                        printf("Error: GetFieldID returned NULL\n");
-                        return;
-                }
         }
         obj = env->GetObjectField(o, objFieldId);
-        if (obj == NULL) {
-                printf("Error: GetObjectField returned NULL\n");
-                return;
-        }
         env->SetObjectField(o, objFieldId, NULL);
+
         start_time = time(NULL);
         enterTime /= 1000;
         current_time = 0;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/libJNIGlobalRefLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/libJNIGlobalRefLocker.cpp
@@ -21,7 +21,7 @@
  * questions.
  */
 
+#include "ExceptionCheckingJniEnv.cpp"
 #include "JNIGlobalRefLocker.cpp"
 #include "jni_tools.cpp"
 #include "nsk_tools.cpp"
-#include "ExceptionCheckingJniEnv.cpp"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/libJNILocalRefLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/libJNILocalRefLocker.cpp
@@ -21,6 +21,7 @@
  * questions.
  */
 
+#include "ExceptionCheckingJniEnv.cpp"
 #include "JNILocalRefLocker.cpp"
 #include "jni_tools.cpp"
 #include "nsk_tools.cpp"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/libJNIRefLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/libJNIRefLocker.cpp
@@ -21,6 +21,7 @@
  * questions.
  */
 
+#include "ExceptionCheckingJniEnv.cpp"
 #include "JNIRefLocker.cpp"
 #include "jni_tools.cpp"
 #include "nsk_tools.cpp"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/libJNIWeakGlobalRefLocker.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/lock/jniref/libJNIWeakGlobalRefLocker.cpp
@@ -21,6 +21,7 @@
  * questions.
  */
 
+#include "ExceptionCheckingJniEnv.cpp"
 #include "JNIWeakGlobalRefLocker.cpp"
 #include "jni_tools.cpp"
 #include "nsk_tools.cpp"

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jni/ExceptionCheckingJniEnv.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jni/ExceptionCheckingJniEnv.cpp
@@ -22,6 +22,8 @@
  * questions.
  */
 
+#include <stdlib.h>
+
 #include "ExceptionCheckingJniEnv.hpp"
 
 namespace {
@@ -86,7 +88,7 @@ jclass ExceptionCheckingJniEnv::GetObjectClass(jobject obj) {
 }
 
 jfieldID ExceptionCheckingJniEnv::GetFieldID(jclass klass, const char *name, const char* type) {
-  JNIVerifier<jfieldID> marker(this, "GetObjectClass");
+  JNIVerifier<jfieldID> marker(this, "GetFieldID");
   return marker.ResultNotNull(_jni_env->GetFieldID(klass, name, type));
 }
 
@@ -101,11 +103,61 @@ void ExceptionCheckingJniEnv::SetObjectField(jobject obj, jfieldID field, jobjec
 }
 
 jobject ExceptionCheckingJniEnv::NewGlobalRef(jobject obj) {
-  JNIVerifier<jobject> marker(this, "GetObjectField");
+  JNIVerifier<jobject> marker(this, "NewGlobalRef");
   return marker.ResultNotNull(_jni_env->NewGlobalRef(obj));
 }
 
 void ExceptionCheckingJniEnv::DeleteGlobalRef(jobject obj) {
   JNIVerifier<> marker(this, "DeleteGlobalRef");
   _jni_env->DeleteGlobalRef(obj);
+}
+
+jobject ExceptionCheckingJniEnv::NewLocalRef(jobject obj) {
+  JNIVerifier<jobject> marker(this, "NewLocalRef");
+  return marker.ResultNotNull(_jni_env->NewLocalRef(obj));
+}
+
+void ExceptionCheckingJniEnv::DeleteLocalRef(jobject obj) {
+  JNIVerifier<> marker(this, "DeleteLocalRef");
+  _jni_env->DeleteLocalRef(obj);
+}
+
+jweak ExceptionCheckingJniEnv::NewWeakGlobalRef(jobject obj) {
+  JNIVerifier<jweak> marker(this, "NewWeakGlobalRef");
+  return marker.ResultNotNull(_jni_env->NewWeakGlobalRef(obj));
+}
+
+void ExceptionCheckingJniEnv::DeleteWeakGlobalRef(jweak weak_ref) {
+  JNIVerifier<> marker(this, "DeleteWeakGlobalRef");
+  _jni_env->DeleteWeakGlobalRef(weak_ref);
+}
+
+jsize ExceptionCheckingJniEnv::GetArrayLength(jarray array) {
+  JNIVerifier<> marker(this, "GetArrayLength");
+  return _jni_env->GetArrayLength(array);
+}
+
+jsize ExceptionCheckingJniEnv::GetStringLength(jstring str) {
+  JNIVerifier<> marker(this, "GetStringLength");
+  return _jni_env->GetStringLength(str);
+}
+
+void* ExceptionCheckingJniEnv::GetPrimitiveArrayCritical(jarray array, jboolean* isCopy) {
+  JNIVerifier<> marker(this, "GetPrimitiveArrayCritical");
+  return marker.ResultNotNull(_jni_env->GetPrimitiveArrayCritical(array, isCopy));
+}
+
+void ExceptionCheckingJniEnv::ReleasePrimitiveArrayCritical(jarray array, void* carray, jint mode) {
+  JNIVerifier<> marker(this, "ReleasePrimitiveArrayCritical");
+  _jni_env->ReleasePrimitiveArrayCritical(array, carray, mode);
+}
+
+const jchar* ExceptionCheckingJniEnv::GetStringCritical(jstring str, jboolean* isCopy) {
+  JNIVerifier<const jchar*> marker(this, "GetPrimitiveArrayCritical");
+  return marker.ResultNotNull(_jni_env->GetStringCritical(str, isCopy));
+}
+
+void ExceptionCheckingJniEnv::ReleaseStringCritical(jstring str, const jchar* carray) {
+  JNIVerifier<> marker(this, "ReleaseStringCritical");
+  _jni_env->ReleaseStringCritical(str, carray);
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jni/ExceptionCheckingJniEnv.hpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jni/ExceptionCheckingJniEnv.hpp
@@ -66,8 +66,20 @@ class ExceptionCheckingJniEnv {
   jobject GetObjectField(jobject obj, jfieldID field);
   void SetObjectField(jobject obj, jfieldID field, jobject value);
 
+  jsize GetArrayLength(jarray array);
+  jsize GetStringLength(jstring str);
+
+  void* GetPrimitiveArrayCritical(jarray array, jboolean* isCopy);
+  void ReleasePrimitiveArrayCritical(jarray array, void* carray, jint mode);
+  const jchar* GetStringCritical(jstring str, jboolean* isCopy);
+  void ReleaseStringCritical(jstring str, const jchar* carray);
+
   jobject NewGlobalRef(jobject obj);
   void DeleteGlobalRef(jobject obj);
+  jobject NewLocalRef(jobject ref);
+  void DeleteLocalRef(jobject ref);
+  jweak NewWeakGlobalRef(jobject obj);
+  void DeleteWeakGlobalRef(jweak obj);
 
   // ExceptionCheckingJniEnv methods.
   JNIEnv* GetJNIEnv() {


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8212083](https://bugs.openjdk.java.net/browse/JDK-8212083): Handle remaining gc/lock native code and fix two strings


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/669/head:pull/669` \
`$ git checkout pull/669`

Update a local copy of the PR: \
`$ git checkout pull/669` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 669`

View PR using the GUI difftool: \
`$ git pr show -t 669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/669.diff">https://git.openjdk.java.net/jdk11u-dev/pull/669.diff</a>

</details>
