### PR TITLE
8211899: Remove the NSK_CPP_STUB macros from vmTestbase for jvmti/scenarios/[E-M]

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t006/em02t006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t006/em02t006.cpp
@@ -57,7 +57,7 @@ JNIEXPORT jboolean JNICALL
 Java_nsk_jvmti_scenarios_events_EM02_em02t006_setTag(JNIEnv *env,
                         jobject o, jobject object, jlong tag) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, object, tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(object, tag))) {
         NSK_COMPLAIN0("TEST FAILED: unable to set tag for a tested object\n");
         return NSK_FALSE;
     }
@@ -148,12 +148,12 @@ int checkEvents(int step) {
 static void
 changeCount(jvmtiEvent event, int *currentCounts) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     currentCounts[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -173,8 +173,7 @@ cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
     if (!checkEvents(STEP_NUMBER))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -329,16 +328,13 @@ static int enableEvent(jvmtiEvent event) {
     if (nsk_jvmti_isOptionalEvent(event)
             && (event != JVMTI_EVENT_OBJECT_FREE)) {
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
         }
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
@@ -431,10 +427,7 @@ setCallBacks(int step) {
             break;
 
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -495,8 +488,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }
@@ -507,7 +499,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         caps.can_tag_objects = 1;
         caps.can_generate_object_free_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t007/em02t007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t007/em02t007.cpp
@@ -133,12 +133,12 @@ int checkEvents(int step) {
 static void
 changeCount(jvmtiEvent event, int *currentCounts) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     currentCounts[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -158,8 +158,7 @@ cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
     if (!checkEvents(STEP_NUMBER))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -184,9 +183,7 @@ cbSingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
     char *sign;
     char *genc;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(
-                GetMethodName, jvmti_env, method, &name, &sign, &genc))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sign, &genc))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -197,17 +194,14 @@ cbSingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         changeCount(JVMTI_EVENT_SINGLE_STEP, &eventCount[0]);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)name))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)name))) {
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)sign))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)sign))) {
         nsk_jvmti_setFailStatus();
     }
     if (genc != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)genc))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)genc))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -219,9 +213,7 @@ cbNewSingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
     char *sign;
     char *genc;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(
-                GetMethodName, jvmti_env, method, &name, &sign, &genc))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sign, &genc))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -232,17 +224,14 @@ cbNewSingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         changeCount(JVMTI_EVENT_SINGLE_STEP, &newEventCount[0]);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)name))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)name))) {
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)sign))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)sign))) {
         nsk_jvmti_setFailStatus();
     }
     if (genc != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)genc))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)genc))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -368,16 +357,13 @@ static int enableEvent(jvmtiEvent event) {
     if (nsk_jvmti_isOptionalEvent(event)
             && (event != JVMTI_EVENT_SINGLE_STEP)) {
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
         }
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
@@ -477,10 +463,7 @@ setCallBacks(int step) {
             break;
 
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -541,8 +524,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }
@@ -552,7 +534,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
 
         caps.can_generate_single_step_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t008/em02t008.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t008/em02t008.cpp
@@ -132,12 +132,12 @@ int checkEvents(int step) {
 static void
 changeCount(jvmtiEvent event, int *currentCounts) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     currentCounts[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -157,8 +157,7 @@ cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
     if (!checkEvents(STEP_NUMBER))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -170,9 +169,7 @@ cbException(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     jvmtiThreadInfo info_ptr;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(
-                GetThreadInfo, jvmti_env, thread, &info_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info_ptr))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -183,8 +180,7 @@ cbException(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         changeCount(JVMTI_EVENT_EXCEPTION, &eventCount[0]);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)info_ptr.name))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)info_ptr.name))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -196,9 +192,7 @@ cbNewException(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     jvmtiThreadInfo info_ptr;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(
-                GetThreadInfo, jvmti_env, thread, &info_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info_ptr))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -209,8 +203,7 @@ cbNewException(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         changeCount(JVMTI_EVENT_EXCEPTION, &newEventCount[0]);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)info_ptr.name))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)info_ptr.name))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -221,9 +214,7 @@ cbExceptionCatch(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     jvmtiThreadInfo info_ptr;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(
-                GetThreadInfo, jvmti_env, thread, &info_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info_ptr))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -234,8 +225,7 @@ cbExceptionCatch(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         changeCount(JVMTI_EVENT_EXCEPTION_CATCH, &eventCount[0]);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)info_ptr.name))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)info_ptr.name))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -246,9 +236,7 @@ cbNewExceptionCatch(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     jvmtiThreadInfo info_ptr;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(
-                GetThreadInfo, jvmti_env, thread, &info_ptr))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info_ptr))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -259,8 +247,7 @@ cbNewExceptionCatch(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         changeCount(JVMTI_EVENT_EXCEPTION_CATCH, &newEventCount[0]);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)info_ptr.name))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)info_ptr.name))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -390,16 +377,13 @@ static int enableEvent(jvmtiEvent event) {
             && (event != JVMTI_EVENT_EXCEPTION)
             && (event != JVMTI_EVENT_EXCEPTION_CATCH)) {
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
         }
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
@@ -493,10 +477,7 @@ setCallBacks(int step) {
             break;
 
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -555,8 +536,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }
@@ -566,7 +546,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
 
         caps.can_generate_exception_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t009/em02t009.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t009/em02t009.cpp
@@ -143,12 +143,12 @@ int checkEvents(int step) {
 static void
 changeCount(jvmtiEvent event, int *currentCounts) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     currentCounts[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -168,8 +168,7 @@ cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
     if (!checkEvents(STEP_NUMBER))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -229,9 +228,7 @@ void handler1(jvmtiEnv *jvmti_env, jvmtiEvent event, jmethodID method) {
     char *sign;
     char *genc;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(
-                GetMethodName, jvmti_env, method, &name, &sign, &genc))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sign, &genc))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -240,17 +237,14 @@ void handler1(jvmtiEnv *jvmti_env, jvmtiEvent event, jmethodID method) {
         changeCount(event, &eventCount[0]);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)name))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)name))) {
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)sign))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)sign))) {
         nsk_jvmti_setFailStatus();
     }
     if (genc != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)genc))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)genc))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -276,9 +270,7 @@ void handler2(jvmtiEnv *jvmti_env, jvmtiEvent event, jmethodID method) {
     char *sign;
     char *genc;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(
-                GetMethodName, jvmti_env, method, &name, &sign, &genc))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sign, &genc))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -287,17 +279,14 @@ void handler2(jvmtiEnv *jvmti_env, jvmtiEvent event, jmethodID method) {
         changeCount(event, &newEventCount[0]);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)name))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)name))) {
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)sign))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)sign))) {
         nsk_jvmti_setFailStatus();
     }
     if (genc != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)genc))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)genc))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -395,16 +384,13 @@ static int enableEvent(jvmtiEvent event) {
             && (event != JVMTI_EVENT_METHOD_ENTRY)
             && (event != JVMTI_EVENT_METHOD_EXIT)) {
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
         }
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
@@ -498,10 +484,7 @@ setCallBacks(int step) {
             break;
 
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -560,8 +543,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }
@@ -572,7 +554,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         caps.can_generate_method_entry_events = 1;
         caps.can_generate_method_exit_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t010/em02t010.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t010/em02t010.cpp
@@ -148,12 +148,12 @@ int checkEvents(int step) {
 static void
 changeCount(jvmtiEvent event, int *currentCounts) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     currentCounts[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -173,8 +173,7 @@ cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
     if (!checkEvents(STEP_NUMBER))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -340,16 +339,13 @@ static int enableEvent(jvmtiEvent event) {
             && (event != JVMTI_EVENT_FIELD_MODIFICATION)
             && (event != JVMTI_EVENT_FIELD_ACCESS)) {
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
         }
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
@@ -443,10 +439,7 @@ setCallBacks(int step) {
             break;
 
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -466,26 +459,21 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
     if (!nsk_jvmti_waitForSync(timeout))
         return;
 
-    if (!NSK_JNI_VERIFY(agentJNI, (cls =
-            NSK_CPP_STUB2(FindClass, agentJNI, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(agentJNI, (cls = agentJNI->FindClass(CLASS_NAME)) != NULL))
         return;
 
     if (!NSK_JNI_VERIFY(agentJNI, (field_accID =
-            NSK_CPP_STUB4(GetStaticFieldID, agentJNI, cls, FIELD_ACC_NAME,
-                                "I")) != NULL))
+            agentJNI->GetStaticFieldID(cls, FIELD_ACC_NAME, "I")) != NULL))
         return;
 
     if (!NSK_JNI_VERIFY(agentJNI, (field_modID =
-            NSK_CPP_STUB4(GetStaticFieldID, agentJNI, cls, FIELD_MOD_NAME,
-                                "I")) != NULL))
+            agentJNI->GetStaticFieldID(cls, FIELD_MOD_NAME, "I")) != NULL))
         return;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetFieldModificationWatch, jvmti, cls, field_modID)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetFieldModificationWatch(cls, field_modID)))
         return;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetFieldAccessWatch, jvmti, cls, field_accID)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetFieldAccessWatch(cls, field_accID)))
         return;
 
     if (!nsk_jvmti_resumeSync())
@@ -536,8 +524,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }
@@ -548,7 +535,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         caps.can_generate_field_modification_events = 1;
         caps.can_generate_field_access_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t011/em02t011.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t011/em02t011.cpp
@@ -144,12 +144,12 @@ int checkEvents(int step) {
 static void
 changeCount(jvmtiEvent event, int *currentCounts) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     currentCounts[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -169,8 +169,7 @@ cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
     if (!checkEvents(STEP_NUMBER))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -326,16 +325,13 @@ static int enableEvent(jvmtiEvent event) {
     if (nsk_jvmti_isOptionalEvent(event)
             && (event != JVMTI_EVENT_BREAKPOINT)) {
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
         }
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
@@ -428,10 +424,7 @@ setCallBacks(int step) {
             break;
 
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -451,17 +444,14 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
     if (!nsk_jvmti_waitForSync(timeout))
         return;
 
-    if (!NSK_JNI_VERIFY(agentJNI, (cls =
-            NSK_CPP_STUB2(FindClass, agentJNI, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(agentJNI, (cls = agentJNI->FindClass(CLASS_NAME)) != NULL))
         return;
 
     if (!NSK_JNI_VERIFY(agentJNI, (methodID =
-            NSK_CPP_STUB4(GetStaticMethodID, agentJNI, cls, METHOD_NAME,
-                                "()I")) != NULL))
+            agentJNI->GetStaticMethodID(cls, METHOD_NAME, "()I")) != NULL))
         return;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetBreakpoint, jvmti, methodID, 0)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetBreakpoint(methodID, 0)))
         return;
 
     if (!nsk_jvmti_resumeSync())
@@ -512,8 +502,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }
@@ -523,7 +512,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
 
         caps.can_generate_breakpoint_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t012/em02t012.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM02/em02t012/em02t012.cpp
@@ -52,8 +52,7 @@ Java_nsk_jvmti_scenarios_events_EM02_em02t012_setThread(JNIEnv *jni_env,
                         jobject o, jthread thrd) {
 
     /* make thread accessable for a long time */
-    NSK_JNI_VERIFY(jni_env, (testedThread =
-            NSK_CPP_STUB2(NewGlobalRef, jni_env, thrd)) != NULL);
+    NSK_JNI_VERIFY(jni_env, (testedThread = jni_env->NewGlobalRef(thrd)) != NULL);
 }
 
 static void
@@ -151,12 +150,12 @@ int checkEvents(int step) {
 static void
 changeCount(jvmtiEvent event, int *currentCounts) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     currentCounts[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -176,8 +175,7 @@ cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
     if (!checkEvents(STEP_NUMBER))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -331,16 +329,13 @@ static int enableEvent(jvmtiEvent event) {
     if (nsk_jvmti_isOptionalEvent(event)
             && (event != JVMTI_EVENT_FRAME_POP)) {
         if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+                jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
         }
     } else {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                    JVMTI_ENABLE, event, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
             NSK_COMPLAIN1("Unexpected error enabling %s\n",
                 TranslateEvent(event));
             return NSK_FALSE;
@@ -433,10 +428,7 @@ setCallBacks(int step) {
             break;
 
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -455,18 +447,15 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
         if (!nsk_jvmti_waitForSync(timeout))
             return;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(SuspendThread, jvmti, testedThread)))
+        if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(testedThread)))
             return;
 
         for (j = 2; j < 1002; j++) {
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(NotifyFramePop, jvmti, testedThread, j)))
+            if (!NSK_JVMTI_VERIFY(jvmti->NotifyFramePop(testedThread, j)))
                 return;
         }
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(ResumeThread, jvmti, testedThread)))
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(testedThread)))
             return;
 
         if (!nsk_jvmti_resumeSync())
@@ -489,7 +478,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
             return;
     }
 
-    NSK_CPP_STUB2(DeleteGlobalRef, agentJNI, testedThread);
+    agentJNI->DeleteGlobalRef(testedThread);
 }
 
 /* ============================================================================= */
@@ -516,8 +505,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }
@@ -528,7 +516,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         caps.can_suspend = 1;
         caps.can_generate_frame_pop_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp
@@ -111,9 +111,7 @@ cbDynamicCodeGenerated2(jvmtiEnv *jvmti_env, const char *name,
 
 static int
 enableEvent(jvmtiEventMode enable, jvmtiEvent event) {
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, enable,
-                                            event, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(enable, event, NULL))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -129,10 +127,7 @@ int setCallBacks(int stage) {
     eventCallbacks.DynamicCodeGenerated = (stage == 1) ?
                             cbDynamicCodeGenerated1 : cbDynamicCodeGenerated2;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -153,9 +148,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GenerateEvents, jvmti,
-                                JVMTI_EVENT_DYNAMIC_CODE_GENERATED)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GenerateEvents(JVMTI_EVENT_DYNAMIC_CODE_GENERATED)))
         nsk_jvmti_setFailStatus();
 
     {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM05/em05t001/em05t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM05/em05t001/em05t001.cpp
@@ -127,9 +127,7 @@ static int enableEvents(jvmtiEventMode enable) {
     int i;
 
     for (i = 0; i < EVENTS_COUNT; i++) {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SetEventNotificationMode, jvmti, enable,
-                                                eventsList[i], NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(enable, eventsList[i], NULL))) {
             nsk_jvmti_setFailStatus();
             return NSK_FALSE;
         }
@@ -156,28 +154,24 @@ static int prepare() {
         methodsDesc[i].unloadEvents = 0;
     }
 
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (threadFieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                                    THREAD_FIELD_NAME, THREAD_FIELD_SIG)) != NULL))
+            jni->GetStaticFieldID(debugeeClass, THREAD_FIELD_NAME, THREAD_FIELD_SIG)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (thread = (jthread)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass, threadFieldID)) != NULL))
+            jni->GetStaticObjectField(debugeeClass, threadFieldID)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (threadClass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (threadClass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Find tested methods:\n");
     for (i = 0; i < METHODS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (methodsDesc[i].method =
-                NSK_CPP_STUB4(GetMethodID, jni, threadClass,
-                            methodsDesc[i].methodName, methodsDesc[i].methodSig)) != NULL))
+                jni->GetMethodID(threadClass, methodsDesc[i].methodName, methodsDesc[i].methodSig)) != NULL))
             return NSK_FALSE;
         NSK_DISPLAY3("    method #%d (%s): 0x%p\n",
                                 i, methodsDesc[i].methodName, (void*)methodsDesc[i].method);
@@ -327,8 +321,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities caps;
         memset(&caps, 0, sizeof(caps));
         caps.can_generate_compiled_method_load_events = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 
@@ -337,9 +330,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.CompiledMethodLoad = callbackCompiledMethodLoad;
         eventCallbacks.CompiledMethodUnload = callbackCompiledMethodUnload;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM05/em05t002/em05t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM05/em05t002/em05t002.cpp
@@ -152,8 +152,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
  * Generate tested events (COMPILED_METHOD_LOAD only).
  */
 static int generateEvents() {
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GenerateEvents, jvmti, JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -183,28 +182,24 @@ static int prepare() {
         }
     }
 
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (threadFieldID =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                                    THREAD_FIELD_NAME, THREAD_FIELD_SIG)) != NULL))
+            jni->GetStaticFieldID(debugeeClass, THREAD_FIELD_NAME, THREAD_FIELD_SIG)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (thread = (jthread)
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass, threadFieldID)) != NULL))
+            jni->GetStaticObjectField(debugeeClass, threadFieldID)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (threadClass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (threadClass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Find tested methods:\n");
     for (i = 0; i < METHODS_COUNT; i++) {
         if (!NSK_JNI_VERIFY(jni, (methodsDesc[i].method =
-                NSK_CPP_STUB4(GetMethodID, jni, threadClass,
-                            methodsDesc[i].methodName, methodsDesc[i].methodSig)) != NULL))
+                jni->GetMethodID(threadClass, methodsDesc[i].methodName, methodsDesc[i].methodSig)) != NULL))
             return NSK_FALSE;
         NSK_DISPLAY3("    method #%d (%s): 0x%p\n",
                                 i, methodsDesc[i].methodName, (void*)methodsDesc[i].method);
@@ -395,8 +390,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities caps;
         memset(&caps, 0, sizeof(caps));
         caps.can_generate_compiled_method_load_events = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 
@@ -405,9 +399,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.CompiledMethodLoad = callbackCompiledMethodLoad;
         eventCallbacks.CompiledMethodUnload = callbackCompiledMethodUnload;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM06/em06t001/em06t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM06/em06t001/em06t001.cpp
@@ -60,26 +60,24 @@ handler(jvmtiEvent event, jvmtiEnv* jvmti, JNIEnv* jni_env,
     jstring jclassName;
     const char *className;
 
-    if (!NSK_JNI_VERIFY(jni_env, (classObject =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, klass)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (classObject = jni_env->GetObjectClass(klass)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
 
     if (!NSK_JNI_VERIFY(jni_env, (methodID =
-            NSK_CPP_STUB4(GetMethodID, jni_env, classObject,
-                        "getName", "()Ljava/lang/String;")) != NULL)) {
+            jni_env->GetMethodID(classObject, "getName", "()Ljava/lang/String;")) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
 
-    jclassName = (jstring) NSK_CPP_STUB3(CallObjectMethod, jni_env, klass, methodID);
+    jclassName = (jstring) jni_env->CallObjectMethod(klass, methodID);
 
-    className = NSK_CPP_STUB3(GetStringUTFChars, jni_env, jclassName, 0);
+    className = jni_env->GetStringUTFChars(jclassName, 0);
 
     if ( className != NULL && (strcmp(className, EXPECTED_CLASS_NAME)==0) ) {
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
             nsk_jvmti_setFailStatus();
 
         switch (event) {
@@ -92,12 +90,12 @@ handler(jvmtiEvent event, jvmtiEnv* jvmti, JNIEnv* jni_env,
                 nsk_jvmti_setFailStatus();
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
             nsk_jvmti_setFailStatus();
 
     }
 
-    NSK_CPP_STUB3(ReleaseStringUTFChars, jni_env, jclassName, className);
+    jni_env->ReleaseStringUTFChars(jclassName, className);
 }
 
 JNIEXPORT void JNICALL
@@ -116,9 +114,7 @@ cbClassPrepare(jvmtiEnv* jvmti, JNIEnv* jni_env, jthread thread, jclass klass) {
 
 static int
 enableEvent(jvmtiEventMode enable, jvmtiEvent event) {
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, enable,
-                                            event, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(enable, event, NULL))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -171,10 +167,7 @@ setCallBacks() {
     eventCallbacks.ClassLoad    = cbClassLoad;
     eventCallbacks.ClassPrepare = cbClassPrepare;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -186,8 +179,7 @@ setCallBacks() {
 static void JNICALL
 agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -230,8 +222,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
     if (!nsk_jvmti_resumeSync())
         return;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t001/em07t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t001/em07t001.cpp
@@ -64,12 +64,12 @@ void showEventStatistics() {
 
 void changeCount(jvmtiEvent event) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
         nsk_jvmti_setFailStatus();
 
     eventCount[event - JVMTI_MIN_EVENT_TYPE_VAL]++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -87,8 +87,7 @@ JNIEXPORT void JNICALL
 cbVMDeath(jvmtiEnv* jvmti, JNIEnv* jni_env) {
     changeCount(JVMTI_EVENT_VM_DEATH);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -234,8 +233,7 @@ int enableOptionalEvents(jvmtiEnv *jvmti) {
         jvmtiEvent event = (jvmtiEvent)(i + JVMTI_MIN_EVENT_TYPE_VAL);
         if (nsk_jvmti_isOptionalEvent(event))
             if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_MUST_POSSESS_CAPABILITY,
-                    NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                        JVMTI_ENABLE, event, NULL))) {
+                    jvmti->SetEventNotificationMode(JVMTI_ENABLE, event, NULL))) {
                 NSK_COMPLAIN1("Unexpected error enabling %s\n",
                     TranslateEvent(event));
                 result = NSK_FALSE;
@@ -309,10 +307,7 @@ static int setCallBacks(jvmtiEnv *jvmti) {
     eventCallbacks.ObjectFree                = cbObjectFree;
     eventCallbacks.VMObjectAlloc             = cbVMObjectAlloc;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -363,8 +358,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/em07t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/em07t002.cpp
@@ -63,9 +63,7 @@ cbCompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method, jint code_size,
     char *sign;
     char *genc;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB5(
-                GetMethodName, jvmti_env, method, &name, &sign, &genc))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sign, &genc))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -86,28 +84,25 @@ cbCompiledMethodLoad(jvmtiEnv *jvmti_env, jmethodID method, jint code_size,
             NSK_DISPLAY0(">>>JVMTI_EVENT_COMPILED_METHOD_LOAD received for\n");
             NSK_DISPLAY1("\t\tmethod: %s\n", rec->name);
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+            if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
                 nsk_jvmti_setFailStatus();
 
             methodLoadCount++;
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+            if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
                 nsk_jvmti_setFailStatus();
 
         }
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)name))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)name))) {
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)sign))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)sign))) {
         nsk_jvmti_setFailStatus();
     }
     if (genc != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)genc))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)genc))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -127,12 +122,12 @@ cbCompiledMethodUnload(jvmtiEnv *jvmti_env, jmethodID method,
             NSK_DISPLAY0(">>>JVMTI_EVENT_COMPILED_METHOD_UNLOAD received for\n");
             NSK_DISPLAY1("\t\tmethod: %s\n", rec->name);
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, syncLock)))
+            if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(syncLock)))
                 nsk_jvmti_setFailStatus();
 
             methodUnloadCount++;
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, syncLock)))
+            if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(syncLock)))
                 nsk_jvmti_setFailStatus();
 
             free(rec);
@@ -148,9 +143,7 @@ cbCompiledMethodUnload(jvmtiEnv *jvmti_env, jmethodID method,
 
 static int
 enableEvent(jvmtiEventMode enable, jvmtiEvent event) {
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, enable,
-                                            event, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(enable, event, NULL))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -191,9 +184,7 @@ setCallBacks() {
     eventCallbacks.CompiledMethodLoad        = cbCompiledMethodLoad;
     eventCallbacks.CompiledMethodUnload      = cbCompiledMethodUnload;
 
-    return NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                            &eventCallbacks,
-                                            sizeof(eventCallbacks)));
+    return NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)));
 }
 
 /* ============================================================================= */
@@ -230,8 +221,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
 
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(DestroyRawMonitor, jvmti, syncLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->DestroyRawMonitor(syncLock)))
         nsk_jvmti_setFailStatus();
 
 }
@@ -260,8 +250,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY((jvmti = nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_syncLock", &syncLock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_syncLock", &syncLock))) {
         nsk_jvmti_setFailStatus();
         return JNI_ERR;
     }
@@ -274,7 +263,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
 
         caps.can_generate_compiled_method_load_events = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/extension/EX03/ex03t001/ex03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/extension/EX03/ex03t001/ex03t001.cpp
@@ -66,16 +66,13 @@ ClassUnload(jvmtiEnv* jvmti_env, ...) {
     }
 
     /* Notify main agent thread */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorEnter, jvmti, eventMon))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(eventMon))) {
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorNotify, jvmti, eventMon))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorNotify(eventMon))) {
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(RawMonitorExit, jvmti, eventMon))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(eventMon))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -89,8 +86,7 @@ jboolean isClassUnloadingEnabled() {
 
     NSK_DISPLAY0("Get extension functions list\n");
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetExtensionFunctions, jvmti, &extCount, &extList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetExtensionFunctions(&extCount, &extList))) {
         nsk_jvmti_setFailStatus();
         return JNI_FALSE;
     }
@@ -136,8 +132,7 @@ jboolean enableClassUnloadEvent (jboolean enable) {
     jboolean found = JNI_FALSE;
 
     NSK_DISPLAY0("Get extension events list\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetExtensionEvents, jvmti, &extCount, &extList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetExtensionEvents(&extCount, &extList))) {
         nsk_jvmti_setFailStatus();
         return JNI_FALSE;
     }
@@ -155,8 +150,8 @@ jboolean enableClassUnloadEvent (jboolean enable) {
             }
 
             if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(SetExtensionEventCallback, jvmti, extList[i].extension_event_index,
-                     enable ? (jvmtiExtensionEvent)ClassUnload : NULL ))) {
+                    jvmti->SetExtensionEventCallback(extList[i].extension_event_index,
+                                                     enable ? (jvmtiExtensionEvent)ClassUnload : NULL ))) {
                 nsk_jvmti_setFailStatus();
                 return JNI_FALSE;
             }
@@ -202,16 +197,13 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             break;
 
         /* Wait for notifying from event's thread */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorEnter, jvmti, eventMon))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(eventMon))) {
             nsk_jvmti_setFailStatus();
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(RawMonitorWait, jvmti, eventMon, timeout))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorWait(eventMon, timeout))) {
             nsk_jvmti_setFailStatus();
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorExit, jvmti, eventMon))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(eventMon))) {
             nsk_jvmti_setFailStatus();
         }
 
@@ -229,16 +221,13 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         /* Wait during 10 secs for notifying from event's thread */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorEnter, jvmti, eventMon))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(eventMon))) {
             nsk_jvmti_setFailStatus();
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(RawMonitorWait, jvmti, eventMon, 10000))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorWait(eventMon, 10000))) {
             nsk_jvmti_setFailStatus();
         }
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(RawMonitorExit, jvmti, eventMon))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(eventMon))) {
             nsk_jvmti_setFailStatus();
         }
 
@@ -257,7 +246,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
     } while (0);
 
-    NSK_TRACE(NSK_CPP_STUB2(DestroyRawMonitor, jvmti, eventMon));
+    NSK_TRACE(jvmti->DestroyRawMonitor(eventMon));
 
     NSK_DISPLAY0("Let debugee to finish\n");
     if (!NSK_VERIFY(nsk_jvmti_resumeSync()))
@@ -289,8 +278,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
             nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti, "eventMon", &eventMon))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("eventMon", &eventMon))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF01/gf01t001/gf01t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF01/gf01t001/gf01t001.cpp
@@ -77,8 +77,7 @@ static void checkProps(jvmtiEnv *jvmti_env, const char *stepMsg) {
 
     NSK_DISPLAY1("%s: Getting system property keys ...\n",
         stepMsg);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetSystemProperties,
-            jvmti_env, &count, &propKeys))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetSystemProperties(&count, &propKeys))) {
         result = STATUS_FAILED;
         return;
     }
@@ -94,8 +93,7 @@ static void checkProps(jvmtiEnv *jvmti_env, const char *stepMsg) {
     for (i=0; i< count; i++) {
         NSK_DISPLAY2("%d) getting property for the key \"%s\":\n",
             i+1, propKeys[i]);
-       if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetSystemProperty,
-               jvmti_env, (const char*) propKeys[i], &prop))) {
+       if (!NSK_JVMTI_VERIFY(jvmti_env->GetSystemProperty((const char*) propKeys[i], &prop))) {
            result = STATUS_FAILED;
            return;
         }
@@ -105,23 +103,20 @@ static void checkProps(jvmtiEnv *jvmti_env, const char *stepMsg) {
         foundProps += findProp(propKeys[i]);
 
         NSK_DISPLAY0("\tdeallocating system property\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*) prop))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) prop))) {
             result = STATUS_FAILED;
             return;
         }
 
         NSK_DISPLAY0("\tdeallocating the system property key\n\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*) propKeys[i]))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) propKeys[i]))) {
             result = STATUS_FAILED;
             return;
         }
     }
 
 /*    NSK_DISPLAY0("Deallocating the property key array ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) &propKeys))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) &propKeys))) {
         result = STATUS_FAILED;
         return;
     }*/
@@ -185,17 +180,14 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.VMInit = &VMInit;
     callbacks.VMDeath = &VMDeath;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling events ...\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
         return JNI_ERR;
 
     NSK_DISPLAY0("enabling events done\n\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF04/gf04t001/gf04t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF04/gf04t001/gf04t001.cpp
@@ -52,8 +52,7 @@ static int addSegment(jvmtiEnv* jvmti, const char segment[], const char where[])
     void* storage = NULL;
 
     NSK_DISPLAY1("Add segment: %s\n", segment);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(AddToBootstrapClassLoaderSearch, jvmti, segment))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddToBootstrapClassLoaderSearch(segment))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY0("  ... added\n");
@@ -62,17 +61,13 @@ static int addSegment(jvmtiEnv* jvmti, const char segment[], const char where[])
 }
 
 static void setupLock(jvmtiEnv *jvmti_env, JNIEnv *jni_env) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter,
-            jvmti_env, countLock)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-                "failed to enter a raw monitor\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(countLock)))
+        jni_env->FatalError("failed to enter a raw monitor\n");
 }
 
 static void setoffLock(jvmtiEnv *jvmti_env, JNIEnv *jni_env) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit,
-        jvmti_env, countLock)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-                "failed to exit a raw monitor\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(countLock)))
+        jni_env->FatalError("failed to exit a raw monitor\n");
 }
 
 JNIEXPORT jint JNICALL
@@ -93,8 +88,7 @@ ClassLoad(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread, jclass klass) {
 
     setupLock(jvmti_env, env);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-            jvmti_env, klass, &sig, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &sig, &generic))) {
         result = STATUS_FAILED;
     }
 
@@ -103,8 +97,7 @@ ClassLoad(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread, jclass klass) {
             sig);
         classLoadReceived = JNI_TRUE;
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-                jvmti_env, JVMTI_DISABLE, JVMTI_EVENT_CLASS_LOAD, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_LOAD, NULL))) {
             result = STATUS_FAILED;
         } else {
             NSK_DISPLAY0("ClassLoad event disabled\n");
@@ -121,8 +114,7 @@ ClassPrepare(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread, jclass klass) {
 
     setupLock(jvmti_env, env);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-            jvmti_env, klass, &sig, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &sig, &generic))) {
         result = STATUS_FAILED;
     }
 
@@ -131,8 +123,7 @@ ClassPrepare(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread, jclass klass) {
             sig);
         classPrepareReceived = JNI_TRUE;
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-                jvmti_env, JVMTI_DISABLE, JVMTI_EVENT_CLASS_PREPARE, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_PREPARE, NULL))) {
             result = STATUS_FAILED;
         } else {
             NSK_DISPLAY0("ClassPrepare event disabled\n");
@@ -172,8 +163,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
             nsk_jvmti_createJVMTIEnv(jvm, reserved)) != NULL))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor,
-            jvmti, "eventLock", &countLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("eventLock", &countLock)))
         return JNI_ERR;
 
     NSK_DISPLAY0("Add bootstrap class load segment in Agent_OnLoad()\n");
@@ -189,22 +179,19 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ClassLoad = &ClassLoad;
         callbacks.ClassPrepare = &ClassPrepare;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, size))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, size))) {
             return JNI_ERR;
         }
     }
     NSK_DISPLAY0("  ... set\n");
 
     NSK_DISPLAY0("Enabling events: \n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL))) {
         return JNI_ERR;
     } else {
         NSK_DISPLAY0("  ... ClassLoad enabled\n");
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_PREPARE, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_PREPARE, NULL))) {
         return JNI_ERR;
     } else {
         NSK_DISPLAY0("  ... ClassPrepare enabled\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF06/gf06t001/gf06t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF06/gf06t001/gf06t001.cpp
@@ -75,8 +75,7 @@ static int checkEnvStorage(jvmtiEnv* jvmti, const char where[]) {
     void* storage = NULL;
 
     NSK_DISPLAY0("Calling GetEnvironmentLocalStorage():");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetEnvironmentLocalStorage, jvmti, &storage))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetEnvironmentLocalStorage(&storage))) {
         return NSK_FALSE;
     }
     NSK_DISPLAY1("  ... got storage: 0x%p\n", (void*)storage);
@@ -115,9 +114,9 @@ jthread getEnvThread(JNIEnv *env) {
     jmethodID cid;
     jthread res;
 
-    thrClass = NSK_CPP_STUB2(FindClass, env, "java/lang/Thread");
-    cid = NSK_CPP_STUB4(GetMethodID, env, thrClass, "<init>", "()V");
-    res = NSK_CPP_STUB3(NewObject, env, thrClass, cid);
+    thrClass = env->FindClass("java/lang/Thread");
+    cid = env->GetMethodID(thrClass, "<init>", "()V");
+    res = env->NewObject(thrClass, cid);
     return res;
 }
 
@@ -193,8 +192,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     }
 
     NSK_DISPLAY1("Set local storage in JVM_OnLoad() for first JVMTI env: 0x%p\n", (void*)initialStorage);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(SetEnvironmentLocalStorage, jvmti_1, initialStorage))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_1->SetEnvironmentLocalStorage(initialStorage))) {
         return JNI_ERR;
     }
     NSK_DISPLAY0("  ... ok\n");
@@ -212,8 +210,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
         if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti_2,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+                jvmti_2->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t001/gf08t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t001/gf08t001.cpp
@@ -70,8 +70,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     setVerboseMode = nsk_jvmti_findOptionStringValue("setVerboseMode", NULL);
 
     if (strcmp(setVerboseMode, "y") == 0 || strcmp(setVerboseMode, "yes") == 0) {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetVerboseFlag, jvmti, JVMTI_VERBOSE_GC, JNI_TRUE))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetVerboseFlag(JVMTI_VERBOSE_GC, JNI_TRUE))) {
             return JNI_ERR;
         } else {
             NSK_DISPLAY0("JVMTI_VERBOSE_GC mode has been set.\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t002/gf08t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t002/gf08t002.cpp
@@ -70,8 +70,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     setVerboseMode = nsk_jvmti_findOptionStringValue("setVerboseMode", NULL);
 
     if (strcmp(setVerboseMode, "y") == 0 || strcmp(setVerboseMode, "yes") == 0) {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetVerboseFlag, jvmti, JVMTI_VERBOSE_CLASS, JNI_TRUE))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetVerboseFlag(JVMTI_VERBOSE_CLASS, JNI_TRUE))) {
             return JNI_ERR;
         } else {
             NSK_DISPLAY0("JVMTI_VERBOSE_CLASS mode has been set.\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t003/gf08t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/general_functions/GF08/gf08t003/gf08t003.cpp
@@ -70,8 +70,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     setVerboseMode = nsk_jvmti_findOptionStringValue("setVerboseMode", NULL);
 
     if (strcmp(setVerboseMode, "y") == 0 || strcmp(setVerboseMode, "yes") == 0) {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetVerboseFlag, jvmti, JVMTI_VERBOSE_JNI, JNI_TRUE))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetVerboseFlag(JVMTI_VERBOSE_JNI, JNI_TRUE))) {
             return JNI_ERR;
         } else {
             NSK_DISPLAY0("JVMTI_VERBOSE_JNI mode has been set.\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS103/hs103t002/hs103t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS103/hs103t002/hs103t002.cpp
@@ -57,19 +57,15 @@ JNIEXPORT void JNICALL doRedefineInNativeThread(jvmtiEnv * jvmti,
   testClass = jni->FindClass(MAIN_CLASS);
 
   if (!NSK_JNI_VERIFY(jni, (
-    setRedefinitionFailed = NSK_CPP_STUB4(GetStaticMethodID, jni,
-                        testClass, "setRedefinitionFailed", "()V")) != NULL))
+    setRedefinitionFailed = jni->GetStaticMethodID(testClass, "setRedefinitionFailed", "()V")) != NULL))
   {
-    NSK_CPP_STUB2(FatalError, jni,
-                "TEST FAILED: while getting setRedefinitionFailed()\n");
+    jni->FatalError("TEST FAILED: while getting setRedefinitionFailed()\n");
   }
 
   if (!NSK_JNI_VERIFY(jni, (
-    setRedefinitionDone = NSK_CPP_STUB4(GetStaticMethodID, jni,
-                testClass, "setRedefinitionDone", "()V")) != NULL))
+    setRedefinitionDone = jni->GetStaticMethodID(testClass, "setRedefinitionDone", "()V")) != NULL))
   {
-    NSK_CPP_STUB2(FatalError, jni,
-        "TEST FAILED: while getting setRedefinitionDone()\n");
+    jni->FatalError("TEST FAILED: while getting setRedefinitionDone()\n");
   }
 
   nsk_printf("doRedefineInNativeThread\n");
@@ -82,20 +78,16 @@ JNIEXPORT void JNICALL doRedefineInNativeThread(jvmtiEnv * jvmti,
     } else {
       nsk_printf("\nMyClass :: Failed to redefine ..\n");
 
-      if (!NSK_JNI_VERIFY_VOID(jni, NSK_CPP_STUB3(CallStaticVoidMethod, jni,
-                                   testClass, setRedefinitionFailed)))
+      if (!NSK_JNI_VERIFY_VOID(jni, jni->CallStaticVoidMethod(testClass, setRedefinitionFailed)))
       {
-         NSK_CPP_STUB2(FatalError, jni,
-                "TEST FAILED: while calling setRedefinitionFailed()\n");
+         jni->FatalError("TEST FAILED: while calling setRedefinitionFailed()\n");
       }
     }
   }
 
-  if (!NSK_JNI_VERIFY_VOID(jni, NSK_CPP_STUB3(CallStaticVoidMethod, jni,
-                           testClass, setRedefinitionDone)))
+  if (!NSK_JNI_VERIFY_VOID(jni, jni->CallStaticVoidMethod(testClass, setRedefinitionDone)))
   {
-    NSK_CPP_STUB2(FatalError, jni,
-        "TEST FAILED: while calling setRedefinitionDone()\n");
+    jni->FatalError("TEST FAILED: while calling setRedefinitionDone()\n");
   }
 
   nsk_printf(" All 30 redefinitions are done..\n");
@@ -150,10 +142,8 @@ Java_nsk_jvmti_scenarios_hotswap_HS103_hs103t002_hs103t002_startAgentThread(JNIE
   name = jni->NewStringUTF(threadName);
   clas = jni->FindClass("java/lang/Thread");
 
-  if (!NSK_JNI_VERIFY(jni, (method = NSK_CPP_STUB4(GetMethodID,
-            jni, clas, "<init>","(Ljava/lang/String;)V")) != NULL)) {
-    NSK_CPP_STUB2(FatalError, jni,
-            "failed to get ID for the java method\n");
+  if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(clas, "<init>", "(Ljava/lang/String;)V")) != NULL)) {
+    jni->FatalError("failed to get ID for the java method\n");
   }
 
   thread = (jthread) jni->NewObject(clas,method,name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS104/hs104t002/hs104t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS104/hs104t002/hs104t002.cpp
@@ -49,8 +49,7 @@ JNIEXPORT jint JNI_OnLoad_hs104t002(JavaVM *jvm, char *options, void *reserved) 
 }
 #endif
 jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved){
-    if ( ! NSK_VERIFY ( JNI_OK == NSK_CPP_STUB3(GetEnv, vm,
-                    (void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
+    if ( ! NSK_VERIFY ( JNI_OK == vm->GetEnv((void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
         nsk_printf("#error Agent :: Could not load JVMTI interface.\n");
         return JNI_ERR;
     } else {
@@ -61,8 +60,7 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved){
         }
         memset(&caps, 0, sizeof(caps));
         caps.can_redefine_classes = 1;
-        if (! NSK_JVMTI_VERIFY ( NSK_CPP_STUB2(AddCapabilities, jvmti,
-                &caps) )) {
+        if (! NSK_JVMTI_VERIFY ( jvmti->AddCapabilities(&caps) )) {
             nsk_printf("#error Agent :: occured while adding capabilities.\n");
             return JNI_ERR;
         }
@@ -76,8 +74,7 @@ Java_nsk_jvmti_scenarios_hotswap_HS104_hs104t002_hs104t002_redefineClasses(
     jclass cla;
     char fileName[512];
 
-    if ( ! NSK_JNI_VERIFY(jni, ( cla = NSK_CPP_STUB2(FindClass,
-                                jni, SEARCH_NAME) ) != NULL ) ) {
+    if ( ! NSK_JNI_VERIFY(jni, ( cla = jni->FindClass(SEARCH_NAME) ) != NULL ) ) {
         nsk_printf(" Agent :: Failed to get class.\n");
         nsk_jvmti_agentFailed();
         return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t001/hs201t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t001/hs201t001.cpp
@@ -64,15 +64,12 @@ void setCurrentStep(JNIEnv* jni_env, int value) {
     jfieldID fld;
 
     if (!NSK_JNI_VERIFY(jni_env, (fld =
-            NSK_CPP_STUB4(GetStaticFieldID, jni_env, testClass, "currentStep", "I")) != NULL)) {
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "TEST FAILED: while getting currentStep fieldID\n");
+            jni_env->GetStaticFieldID(testClass, "currentStep", "I")) != NULL)) {
+        jni_env->FatalError("TEST FAILED: while getting currentStep fieldID\n");
     }
 
-    if (!NSK_JNI_VERIFY_VOID(jni_env,
-            NSK_CPP_STUB4(SetStaticIntField, jni_env, testClass, fld, value))) {
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "TEST FAILED: while setting  value of currentStep fieldID\n");
+    if (!NSK_JNI_VERIFY_VOID(jni_env, jni_env->SetStaticIntField(testClass, fld, value))) {
+        jni_env->FatalError("TEST FAILED: while setting  value of currentStep fieldID\n");
     }
 
 }
@@ -81,9 +78,7 @@ void setCurrentStep(JNIEnv* jni_env, int value) {
 
 void enableEvent(jvmtiEnv *jvmti_env, jvmtiEvent event, jthread thread) {
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti_env, JVMTI_ENABLE,
-                                            event, thread))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_ENABLE, event, thread))) {
         NSK_COMPLAIN1("TEST FAILED: enabling %s\n", TranslateEvent(event));
         nsk_jvmti_setFailStatus();
     }
@@ -93,9 +88,7 @@ void enableEvent(jvmtiEnv *jvmti_env, jvmtiEvent event, jthread thread) {
 
 void disableEvent(jvmtiEnv *jvmti_env, jvmtiEvent event, jthread thread) {
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti_env, JVMTI_DISABLE,
-                                            event, thread))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_DISABLE, event, thread))) {
         NSK_COMPLAIN1("TEST FAILED: disabling %s\n", TranslateEvent(event));
         nsk_jvmti_setFailStatus();
     }
@@ -109,9 +102,7 @@ void redefineClass(jvmtiEnv *jvmti_env, jclass klass) {
 
     char *className;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetClassSignature, jvmti_env, klass,
-                                &className, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &className, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -127,15 +118,13 @@ void redefineClass(jvmtiEnv *jvmti_env, jclass klass) {
     classDef.class_bytes = newClassBytes;
 
     NSK_DISPLAY1("\tredefining class %s\n", className);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RedefineClasses, jvmti_env, 1, &classDef))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RedefineClasses(1, &classDef))) {
         NSK_COMPLAIN1("TEST FAILED: while redefining class %s\n", className);
         nsk_jvmti_setFailStatus();
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)className))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)className))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -163,8 +152,8 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
     if (!nsk_jvmti_waitForSync(timeout))
         return;
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testClass));
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedThread));
+    NSK_TRACE(jni->DeleteGlobalRef(testClass));
+    NSK_TRACE(jni->DeleteGlobalRef(testedThread));
 
     NSK_DISPLAY0("Let debuggee to finish\n");
     if (!nsk_jvmti_resumeSync())
@@ -176,15 +165,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
 void setBreakPoint(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jclass klass) {
     jmethodID mid;
 
-    if (!NSK_JNI_VERIFY(jni_env, (mid = NSK_CPP_STUB4(GetMethodID,
-            jni_env, klass, METHOD_NAME, METHOD_SIG)) != NULL))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "[agent] failed to get ID for the java method\n");
+    if (!NSK_JNI_VERIFY(jni_env, (mid = jni_env->GetMethodID(klass, METHOD_NAME, METHOD_SIG)) != NULL))
+        jni_env->FatalError("[agent] failed to get ID for the java method\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetBreakpoint,
-            jvmti_env, mid, 1)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "[agent] failed to set breakpoint\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->SetBreakpoint(mid, 1)))
+        jni_env->FatalError("[agent] failed to set breakpoint\n");
 }
 
 /* ============================================================================= */
@@ -200,9 +185,7 @@ callbackClassLoad(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
     char *className;
     char *generic;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetClassSignature, jvmti_env, klass,
-                                &className, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &className, &generic))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -215,14 +198,12 @@ callbackClassLoad(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         setBreakPoint(jvmti_env, jni_env, klass);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)className))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)className))) {
         nsk_jvmti_setFailStatus();
     }
 
     if (generic != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)generic))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)generic))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -253,8 +234,7 @@ callbackSingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     char *methodName;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &methodName, NULL, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &methodName, NULL, NULL))) {
         NSK_COMPLAIN0("TEST FAILED: unable to get method name during Breakpoint callback\n\n");
     }
 
@@ -262,13 +242,11 @@ callbackSingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         char *declaringClassName;
         jclass declaringClass;
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-                jvmti_env, method, &declaringClass))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(method, &declaringClass))) {
             NSK_COMPLAIN0("TEST FAILED: unable to get method name during Breakpoint callback\n\n");
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-                jvmti_env, declaringClass, &declaringClassName, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(declaringClass, &declaringClassName, NULL))) {
             NSK_COMPLAIN0("TEST FAILED: unable to get method name during Breakpoint callback\n\n");
         }
 
@@ -292,8 +270,7 @@ callbackSingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
                 NSK_DISPLAY1("\n\n>>>> Checking if redefined method is obsolete\n", testStep);
 
-                if (!NSK_JVMTI_VERIFY(
-                            NSK_CPP_STUB3(IsMethodObsolete, jvmti, method, &is_obsolete))) {
+                if (!NSK_JVMTI_VERIFY(jvmti->IsMethodObsolete(method, &is_obsolete))) {
                     NSK_COMPLAIN0("TEST FAILED: unable to check method to be obsolete\n");
                     nsk_jvmti_setFailStatus();
                     return;
@@ -326,15 +303,13 @@ callbackSingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*) declaringClassName))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) declaringClassName))) {
             NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method name\n\n");
         }
 
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) methodName))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methodName))) {
         NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method name\n\n");
     }
 
@@ -362,8 +337,7 @@ callbackException(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
                         className, getThreadName(jni_env, thread));
 
         testStep++;
-        if (!NSK_JNI_VERIFY(jni_env, (klass =
-                NSK_CPP_STUB2(GetObjectClass, jni_env, exception)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(exception)) != NULL)) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -394,8 +368,7 @@ callbackExceptionCatch(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
                         className, getThreadName(jni_env, thread));
 
         testStep++;
-        if (!NSK_JNI_VERIFY(jni_env, (klass =
-                NSK_CPP_STUB2(GetObjectClass, jni_env, exception)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(exception)) != NULL)) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -435,8 +408,7 @@ int readNewBytecode(jvmtiEnv* jvmti, int testcase) {
     newClassSize = ftell(bytecode);
     rewind(bytecode);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate, jvmti,
-                                newClassSize, &newClassBytes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(newClassSize, &newClassBytes))) {
         NSK_COMPLAIN0("buffer couldn't be allocated\n");
         return NSK_FALSE;
     }
@@ -460,27 +432,24 @@ const char* getThreadName(JNIEnv* jni_env, jthread thread) {
 
     strcpy(chbuffer, "");
 
-    if (!NSK_JNI_VERIFY(jni_env, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, thread)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(thread)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return chbuffer;
     }
 
     if (!NSK_JNI_VERIFY(jni_env, (methodID =
-            NSK_CPP_STUB4(GetMethodID, jni_env, klass,
-                        "getName", "()Ljava/lang/String;")) != NULL)) {
+            jni_env->GetMethodID(klass, "getName", "()Ljava/lang/String;")) != NULL)) {
         nsk_jvmti_setFailStatus();
         return chbuffer;
     }
 
-    jthreadName = (jstring) NSK_CPP_STUB3(CallObjectMethod, jni_env, thread,
-                        methodID);
+    jthreadName = (jstring) jni_env->CallObjectMethod(thread, methodID);
 
-    threadName = NSK_CPP_STUB3(GetStringUTFChars, jni_env, jthreadName, 0);
+    threadName = jni_env->GetStringUTFChars(jthreadName, 0);
 
     strcpy(chbuffer, threadName);
 
-    NSK_CPP_STUB3(ReleaseStringUTFChars, jni_env, jthreadName, threadName);
+    jni_env->ReleaseStringUTFChars(jthreadName, threadName);
 
     return chbuffer;
 }
@@ -495,29 +464,24 @@ const char* getClassName(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jobject object) {
 
     strcpy(chbuffer, "");
 
-    if (!NSK_JNI_VERIFY(jni_env, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, object)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(object)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return chbuffer;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetClassSignature, jvmti_env, klass,
-                                &className, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &className, &generic))) {
         nsk_jvmti_setFailStatus();
         return chbuffer;
     }
 
     strcpy(chbuffer, className);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)className))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)className))) {
         nsk_jvmti_setFailStatus();
     }
 
     if (generic != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)generic))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)generic))) {
             nsk_jvmti_setFailStatus();
         }
 
@@ -535,8 +499,7 @@ int getLocalVariableValue(jvmtiEnv *jvmti_env, jthread thread,
     jint value = -1;
 
     /* getting local variable table*/
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetLocalVariableTable,
-            jvmti_env, method, &entryCount, &table))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetLocalVariableTable(method, &entryCount, &table))) {
         NSK_COMPLAIN0("TEST FAILED: unable to get local variable table\n\n");
     }
 
@@ -545,8 +508,7 @@ int getLocalVariableValue(jvmtiEnv *jvmti_env, jthread thread,
 
         for (i = 0; i < entryCount; i++) {
             if (strcmp(table[i].name, LOCAL_VARIABLE_NAME) == 0) {
-                error = NSK_CPP_STUB5(GetLocalInt, jvmti_env, thread, 0,
-                                        table[i].slot, &value);
+                error = jvmti_env->GetLocalInt(thread, 0, table[i].slot, &value);
                 if (!NSK_VERIFY(error == JVMTI_ERROR_NONE
                                 || error == JVMTI_ERROR_INVALID_SLOT))
                     NSK_COMPLAIN0("TEST FAILED: unable to get local variable table\n\n");
@@ -555,20 +517,17 @@ int getLocalVariableValue(jvmtiEnv *jvmti_env, jthread thread,
 
         for (i = 0; i < entryCount; i++) {
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                    jvmti_env, (unsigned char*)table[i].name))) {
+            if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)table[i].name))) {
                 NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method name\n\n");
             }
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                    jvmti_env, (unsigned char*)table[i].signature))) {
+            if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)table[i].signature))) {
                 NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method signature\n\n");
             }
 
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)table))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)table))) {
             NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to local variable table\n\n");
         }
 
@@ -583,12 +542,10 @@ JNIEXPORT void JNICALL
 Java_nsk_jvmti_scenarios_hotswap_HS201_hs201t001_setThread(JNIEnv *env,
                         jclass cls, jthread thread) {
 
-    if (!NSK_JNI_VERIFY(env, (testClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, env, cls)) != NULL))
+    if (!NSK_JNI_VERIFY(env, (testClass = (jclass) env->NewGlobalRef(cls)) != NULL))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JNI_VERIFY(env, (testedThread =
-            NSK_CPP_STUB2(NewGlobalRef, env, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(env, (testedThread = env->NewGlobalRef(thread)) != NULL))
         nsk_jvmti_setFailStatus();
 
 }
@@ -602,8 +559,7 @@ Java_nsk_jvmti_scenarios_hotswap_HS201_hs201t001_resumeThread(JNIEnv *env,
     NSK_DISPLAY0("\tresuming thread...\n");
     disableEvent(jvmti, JVMTI_EVENT_SINGLE_STEP, thread);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(thread))) {
         NSK_COMPLAIN0("TEST FAILED: unable to resume the thread\n");
         nsk_jvmti_setFailStatus();
         return JNI_FALSE;
@@ -621,8 +577,7 @@ Java_nsk_jvmti_scenarios_hotswap_HS201_hs201t001_suspendThread(JNIEnv *env,
     NSK_DISPLAY0("\tsuspending thread...\n");
     disableEvent(jvmti, JVMTI_EVENT_SINGLE_STEP, thread);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(thread))) {
         NSK_COMPLAIN0("TEST FAILED: unable to suspend the thread\n");
         nsk_jvmti_setFailStatus();
         return JNI_FALSE;
@@ -638,16 +593,14 @@ Java_nsk_jvmti_scenarios_hotswap_HS201_hs201t001_popFrame(JNIEnv *env,
                         jclass cls, jthread thread) {
 
     NSK_DISPLAY0("\tpopping frame...\n");
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(PopFrame, jvmti, thread))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->PopFrame(thread))) {
         NSK_COMPLAIN0("TEST FAILED: unable to pop the currently executed frame\n");
         nsk_jvmti_setFailStatus();
         return JNI_FALSE;
     }
 
     NSK_DISPLAY0("\tresuming thread...\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(thread))) {
         NSK_COMPLAIN0("TEST FAILED: unable to resume the thread\n");
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
@@ -696,8 +649,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         caps.can_pop_frame = 1;
         caps.can_suspend = 1;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 
@@ -709,9 +661,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.ExceptionCatch = callbackExceptionCatch;
         eventCallbacks.Breakpoint = callbackBreakpoint;
         eventCallbacks.SingleStep = callbackSingleStep;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/hs201t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t002/hs201t002.cpp
@@ -64,15 +64,12 @@ void setCurrentStep(JNIEnv* jni_env, int value) {
     jfieldID fld;
 
     if (!NSK_JNI_VERIFY(jni_env, (fld =
-            NSK_CPP_STUB4(GetStaticFieldID, jni_env, testClass, "currentStep", "I")) != NULL)) {
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "TEST FAILED: while getting currentStep fieldID\n");
+            jni_env->GetStaticFieldID(testClass, "currentStep", "I")) != NULL)) {
+        jni_env->FatalError("TEST FAILED: while getting currentStep fieldID\n");
     }
 
-    if (!NSK_JNI_VERIFY_VOID(jni_env,
-            NSK_CPP_STUB4(SetStaticIntField, jni_env, testClass, fld, value))) {
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "TEST FAILED: while setting  value of currentStep fieldID\n");
+    if (!NSK_JNI_VERIFY_VOID(jni_env, jni_env->SetStaticIntField(testClass, fld, value))) {
+        jni_env->FatalError("TEST FAILED: while setting  value of currentStep fieldID\n");
     }
 
 }
@@ -81,9 +78,7 @@ void setCurrentStep(JNIEnv* jni_env, int value) {
 
 void enableEvent(jvmtiEnv *jvmti_env, jvmtiEvent event, jthread thread) {
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti_env, JVMTI_ENABLE,
-                                            event, thread))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_ENABLE, event, thread))) {
         NSK_COMPLAIN1("TEST FAILED: enabling %s\n", TranslateEvent(event));
         nsk_jvmti_setFailStatus();
     }
@@ -93,9 +88,7 @@ void enableEvent(jvmtiEnv *jvmti_env, jvmtiEvent event, jthread thread) {
 
 void disableEvent(jvmtiEnv *jvmti_env, jvmtiEvent event, jthread thread) {
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti_env, JVMTI_DISABLE,
-                                            event, thread))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_DISABLE, event, thread))) {
         NSK_COMPLAIN1("TEST FAILED: disabling %s\n", TranslateEvent(event));
         nsk_jvmti_setFailStatus();
     }
@@ -109,9 +102,7 @@ void redefineClass(jvmtiEnv *jvmti_env, jclass klass) {
 
     char *className;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetClassSignature, jvmti_env, klass,
-                                &className, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &className, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -127,15 +118,13 @@ void redefineClass(jvmtiEnv *jvmti_env, jclass klass) {
     classDef.class_bytes = newClassBytes;
 
     NSK_DISPLAY1("\tredefining class %s\n", className);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(RedefineClasses, jvmti_env, 1, &classDef))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RedefineClasses(1, &classDef))) {
         NSK_COMPLAIN1("TEST FAILED: while redefining class %s\n", className);
         nsk_jvmti_setFailStatus();
         return;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)className))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)className))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -163,8 +152,8 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
     if (!nsk_jvmti_waitForSync(timeout))
         return;
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testClass));
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedThread));
+    NSK_TRACE(jni->DeleteGlobalRef(testClass));
+    NSK_TRACE(jni->DeleteGlobalRef(testedThread));
 
     NSK_DISPLAY0("Let debuggee to finish\n");
     if (!nsk_jvmti_resumeSync())
@@ -176,15 +165,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* agentJNI, void* arg) {
 void setBreakPoint(jvmtiEnv *jvmti_env, JNIEnv *jni_env, jclass klass) {
     jmethodID mid;
 
-    if (!NSK_JNI_VERIFY(jni_env, (mid = NSK_CPP_STUB4(GetMethodID,
-            jni_env, klass, METHOD_NAME, METHOD_SIG)) != NULL))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "[agent] failed to get ID for the java method\n");
+    if (!NSK_JNI_VERIFY(jni_env, (mid = jni_env->GetMethodID(klass, METHOD_NAME, METHOD_SIG)) != NULL))
+        jni_env->FatalError("[agent] failed to get ID for the java method\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetBreakpoint,
-            jvmti_env, mid, 1)))
-        NSK_CPP_STUB2(FatalError, jni_env,
-            "[agent] failed to set breakpoint\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->SetBreakpoint(mid, 1)))
+        jni_env->FatalError("[agent] failed to set breakpoint\n");
 }
 
 /* ============================================================================= */
@@ -200,9 +185,7 @@ callbackClassLoad(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
     char *className;
     char *generic;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetClassSignature, jvmti_env, klass,
-                                &className, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &className, &generic))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -215,14 +198,12 @@ callbackClassLoad(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         setBreakPoint(jvmti_env, jni_env, klass);
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)className))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)className))) {
         nsk_jvmti_setFailStatus();
     }
 
     if (generic != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)generic))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)generic))) {
             nsk_jvmti_setFailStatus();
         }
 }
@@ -253,8 +234,7 @@ callbackSingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     char *methodName;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &methodName, NULL, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &methodName, NULL, NULL))) {
         NSK_COMPLAIN0("TEST FAILED: unable to get method name during Breakpoint callback\n\n");
     }
 
@@ -262,13 +242,11 @@ callbackSingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         char *declaringClassName;
         jclass declaringClass;
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-                jvmti_env, method, &declaringClass))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(method, &declaringClass))) {
             NSK_COMPLAIN0("TEST FAILED: unable to get method name during Breakpoint callback\n\n");
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-                jvmti_env, declaringClass, &declaringClassName, NULL))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(declaringClass, &declaringClassName, NULL))) {
             NSK_COMPLAIN0("TEST FAILED: unable to get method name during Breakpoint callback\n\n");
         }
 
@@ -292,8 +270,7 @@ callbackSingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
                 NSK_DISPLAY1("\n\n>>>> Checking if redefined method is not obsolete\n", testStep);
 
-                if (!NSK_JVMTI_VERIFY(
-                            NSK_CPP_STUB3(IsMethodObsolete, jvmti, method, &is_obsolete))) {
+                if (!NSK_JVMTI_VERIFY(jvmti->IsMethodObsolete(method, &is_obsolete))) {
                     NSK_COMPLAIN0("TEST FAILED: unable to check method to be obsolete\n");
                     nsk_jvmti_setFailStatus();
                     return;
@@ -326,15 +303,13 @@ callbackSingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*) declaringClassName))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) declaringClassName))) {
             NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method name\n\n");
         }
 
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) methodName))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methodName))) {
         NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method name\n\n");
     }
 
@@ -362,8 +337,7 @@ callbackException(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
                         className, getThreadName(jni_env, thread));
 
         testStep++;
-        if (!NSK_JNI_VERIFY(jni_env, (klass =
-                NSK_CPP_STUB2(GetObjectClass, jni_env, exception)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(exception)) != NULL)) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -394,8 +368,7 @@ callbackExceptionCatch(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
                         className, getThreadName(jni_env, thread));
 
         testStep++;
-        if (!NSK_JNI_VERIFY(jni_env, (klass =
-                NSK_CPP_STUB2(GetObjectClass, jni_env, exception)) != NULL)) {
+        if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(exception)) != NULL)) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -435,8 +408,7 @@ int readNewBytecode(jvmtiEnv* jvmti) {
     newClassSize = ftell(bytecode);
     rewind(bytecode);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate, jvmti,
-                                newClassSize, &newClassBytes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate(newClassSize, &newClassBytes))) {
         NSK_COMPLAIN0("buffer couldn't be allocated\n");
         return NSK_FALSE;
     }
@@ -460,27 +432,24 @@ const char* getThreadName(JNIEnv* jni_env, jthread thread) {
 
     strcpy(chbuffer, "");
 
-    if (!NSK_JNI_VERIFY(jni_env, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, thread)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(thread)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return chbuffer;
     }
 
     if (!NSK_JNI_VERIFY(jni_env, (methodID =
-            NSK_CPP_STUB4(GetMethodID, jni_env, klass,
-                        "getName", "()Ljava/lang/String;")) != NULL)) {
+            jni_env->GetMethodID(klass, "getName", "()Ljava/lang/String;")) != NULL)) {
         nsk_jvmti_setFailStatus();
         return chbuffer;
     }
 
-    jthreadName = (jstring) NSK_CPP_STUB3(CallObjectMethod, jni_env, thread,
-                        methodID);
+    jthreadName = (jstring) jni_env->CallObjectMethod(thread, methodID);
 
-    threadName = NSK_CPP_STUB3(GetStringUTFChars, jni_env, jthreadName, 0);
+    threadName = jni_env->GetStringUTFChars(jthreadName, 0);
 
     strcpy(chbuffer, threadName);
 
-    NSK_CPP_STUB3(ReleaseStringUTFChars, jni_env, jthreadName, threadName);
+    jni_env->ReleaseStringUTFChars(jthreadName, threadName);
 
     return chbuffer;
 }
@@ -495,29 +464,24 @@ const char* getClassName(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jobject object) {
 
     strcpy(chbuffer, "");
 
-    if (!NSK_JNI_VERIFY(jni_env, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni_env, object)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni_env, (klass = jni_env->GetObjectClass(object)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return chbuffer;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(GetClassSignature, jvmti_env, klass,
-                                &className, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &className, &generic))) {
         nsk_jvmti_setFailStatus();
         return chbuffer;
     }
 
     strcpy(chbuffer, className);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*)className))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)className))) {
         nsk_jvmti_setFailStatus();
     }
 
     if (generic != NULL)
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)generic))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)generic))) {
             nsk_jvmti_setFailStatus();
         }
 
@@ -535,8 +499,7 @@ int getLocalVariableValue(jvmtiEnv *jvmti_env, jthread thread,
     jint value = -1;
 
     /* getting local variable table*/
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetLocalVariableTable,
-            jvmti_env, method, &entryCount, &table))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetLocalVariableTable(method, &entryCount, &table))) {
         NSK_COMPLAIN0("TEST FAILED: unable to get local variable table\n\n");
     }
 
@@ -545,8 +508,7 @@ int getLocalVariableValue(jvmtiEnv *jvmti_env, jthread thread,
 
         for (i = 0; i < entryCount; i++) {
             if (strcmp(table[i].name, LOCAL_VARIABLE_NAME) == 0) {
-                error = NSK_CPP_STUB5(GetLocalInt, jvmti_env, thread, 0,
-                                        table[i].slot, &value);
+                error = jvmti_env->GetLocalInt(thread, 0, table[i].slot, &value);
                 if (!NSK_VERIFY(error == JVMTI_ERROR_NONE
                                 || error == JVMTI_ERROR_INVALID_SLOT))
                     NSK_COMPLAIN0("TEST FAILED: unable to get local variable table\n\n");
@@ -555,20 +517,17 @@ int getLocalVariableValue(jvmtiEnv *jvmti_env, jthread thread,
 
         for (i = 0; i < entryCount; i++) {
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                    jvmti_env, (unsigned char*)table[i].name))) {
+            if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)table[i].name))) {
                 NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method name\n\n");
             }
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                    jvmti_env, (unsigned char*)table[i].signature))) {
+            if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)table[i].signature))) {
                 NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method signature\n\n");
             }
 
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-                jvmti_env, (unsigned char*)table))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*)table))) {
             NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to local variable table\n\n");
         }
 
@@ -583,12 +542,10 @@ JNIEXPORT void JNICALL
 Java_nsk_jvmti_scenarios_hotswap_HS201_hs201t002_setThread(JNIEnv *env,
                         jclass cls, jthread thread) {
 
-    if (!NSK_JNI_VERIFY(env, (testClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, env, cls)) != NULL))
+    if (!NSK_JNI_VERIFY(env, (testClass = (jclass) env->NewGlobalRef(cls)) != NULL))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JNI_VERIFY(env, (testedThread =
-            NSK_CPP_STUB2(NewGlobalRef, env, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(env, (testedThread = env->NewGlobalRef(thread)) != NULL))
         nsk_jvmti_setFailStatus();
 
 }
@@ -602,8 +559,7 @@ Java_nsk_jvmti_scenarios_hotswap_HS201_hs201t002_resumeThread(JNIEnv *env,
     NSK_DISPLAY0("\tresuming thread...\n");
     disableEvent(jvmti, JVMTI_EVENT_SINGLE_STEP, thread);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(thread))) {
         NSK_COMPLAIN0("TEST FAILED: unable to resume the thread\n");
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
@@ -621,8 +577,7 @@ Java_nsk_jvmti_scenarios_hotswap_HS201_hs201t002_suspendThread(JNIEnv *env,
     NSK_DISPLAY0("\tsuspending thread...\n");
     disableEvent(jvmti, JVMTI_EVENT_SINGLE_STEP, thread);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(SuspendThread, jvmti, thread))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(thread))) {
         NSK_COMPLAIN0("TEST FAILED: unable to suspend the thread\n");
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
@@ -638,16 +593,14 @@ Java_nsk_jvmti_scenarios_hotswap_HS201_hs201t002_popFrame(JNIEnv *env,
                         jclass cls, jthread thread) {
 
     NSK_DISPLAY0("\tpopping frame...\n");
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(PopFrame, jvmti, thread))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->PopFrame(thread))) {
         NSK_COMPLAIN0("TEST FAILED: unable to pop the currently executed frame\n");
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
     NSK_DISPLAY0("\tresuming thread...\n");
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(ResumeThread, jvmti, thread))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(thread))) {
         NSK_COMPLAIN0("TEST FAILED: unable to resume the thread\n");
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
@@ -696,8 +649,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         caps.can_pop_frame = 1;
         caps.can_suspend = 1;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
             return JNI_ERR;
     }
 
@@ -709,9 +661,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.ExceptionCatch = callbackExceptionCatch;
         eventCallbacks.Breakpoint = callbackBreakpoint;
         eventCallbacks.SingleStep = callbackSingleStep;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t003/hs201t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t003/hs201t003.cpp
@@ -63,9 +63,9 @@ JNIEXPORT void JNICALL Java_nsk_jvmti_scenarios_hotswap_HS201_hs201t003_storeCla
         (JNIEnv *jni_env, jclass cls, jbyteArray classBytes) {
     jboolean isCopy;
 
-    bytesCount = NSK_CPP_STUB2(GetArrayLength, jni_env, classBytes);
+    bytesCount = jni_env->GetArrayLength(classBytes);
     clsBytes =
-        NSK_CPP_STUB3(GetByteArrayElements, jni_env, classBytes, &isCopy);
+        jni_env->GetByteArrayElements(classBytes, &isCopy);
 }
 
 static int expectedMeth(jvmtiEnv *jvmti_env, const char *event,
@@ -74,8 +74,7 @@ static int expectedMeth(jvmtiEnv *jvmti_env, const char *event,
     char *sig;
     int methFound = 0;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &sig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &sig, NULL))) {
         nsk_jvmti_setFailStatus();
         return 0;
     }
@@ -90,11 +89,9 @@ static int expectedMeth(jvmtiEnv *jvmti_env, const char *event,
     else
         methFound = 0;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) name)))
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) name)))
         nsk_jvmti_setFailStatus();
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) sig)))
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) sig)))
         nsk_jvmti_setFailStatus();
 
     return methFound;
@@ -106,13 +103,11 @@ static void doHotSwap(jvmtiEnv *jvmti_env,
     char *cls_sig;
     jvmtiClassDefinition classDef;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-            jvmti_env, tMethodID, &decl_cls))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(tMethodID, &decl_cls))) {
         nsk_jvmti_setFailStatus();
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-            jvmti_env, decl_cls, &cls_sig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(decl_cls, &cls_sig, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -120,8 +115,7 @@ static void doHotSwap(jvmtiEnv *jvmti_env,
         NSK_DISPLAY2("[%s] tested method class signature: \"%s\"\n\n",
             event, cls_sig);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) cls_sig)))
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) cls_sig)))
         nsk_jvmti_setFailStatus();
 
     /* fill the structure jvmtiClassDefinition */
@@ -133,8 +127,7 @@ static void doHotSwap(jvmtiEnv *jvmti_env,
         "[%s] >>>>> Invoke RedefineClasses():\n"
         "\tnew class byte count=%d\n",
         event, classDef.class_byte_count);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RedefineClasses,
-            jvmti, 1, &classDef))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &classDef))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -150,16 +143,14 @@ static void doChecks(jvmtiEnv *jvmti_env,
     jint methBytesCount; /* number of bytes of a method */
     unsigned char *methBytes; /* bytes defining a method */
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, tMethodID, &name, &sig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(tMethodID, &name, &sig, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
     NSK_DISPLAY4("[%s] method ID=0x%p name=\"%s\" signature=\"%s\"\n",
         event, (void*) tMethodID, name, sig);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetBytecodes,
-           jvmti_env, tMethodID, &methBytesCount, &methBytes))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetBytecodes(tMethodID, &methBytesCount, &methBytes))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -167,12 +158,10 @@ static void doChecks(jvmtiEnv *jvmti_env,
         "[%s] method bytes count=%d\n"
         "\tbytes count of the redefined method=%d\n",
         event, methBytesCount, redefMethBytesCount);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-           jvmti_env, (unsigned char*) methBytes)))
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methBytes)))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(IsMethodObsolete,
-            jvmti_env, tMethodID, &isObsolete))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->IsMethodObsolete(tMethodID, &isObsolete))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -197,20 +186,17 @@ void JNICALL MethodEntry(jvmtiEnv *jvmti_env, JNIEnv *env,
 
     if (expectedMeth(jvmti_env, "MethodEntry",
             method, expHSMethod, expHSSignature)==1) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetBytecodes,
-               jvmti_env, method, &redefMethBytesCount, &redefMethBytes)))
+        if (!NSK_JVMTI_VERIFY(jvmti_env->GetBytecodes(method, &redefMethBytesCount, &redefMethBytes)))
             nsk_jvmti_setFailStatus();
         else {
             NSK_DISPLAY2("[MethodEntry] thread=0x%p method bytes count=%d\n",
                 thr, redefMethBytesCount);
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(NotifyFramePop,
-                    jvmti_env, thr, 0)))
+            if (!NSK_JVMTI_VERIFY(jvmti_env->NotifyFramePop(thr, 0)))
                 nsk_jvmti_setFailStatus();
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-                jvmti_env, JVMTI_DISABLE, JVMTI_EVENT_METHOD_ENTRY, NULL)))
+        if (!NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_METHOD_ENTRY, NULL)))
             nsk_jvmti_setFailStatus();
     }
 }
@@ -277,8 +263,7 @@ agentProc(jvmtiEnv* jvmti_env, JNIEnv* jni_env, void* arg) {
         return;
 
     /* deallocating used memory */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-           jvmti_env, (unsigned char*) redefMethBytes)))
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) redefMethBytes)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY0("agentProc: final resuming of the debuggee ...\n\n");
@@ -324,8 +309,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     caps.can_generate_method_exit_events = 1;
     caps.can_generate_frame_pop_events = 1;
     caps.can_redefine_classes = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     /* set event callback */
@@ -335,8 +319,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.MethodEntry = &MethodEntry;
     callbacks.MethodExit = &MethodExit;
     callbacks.FramePop = &FramePop;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling events ...\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t003/hs203t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t003/hs203t003.cpp
@@ -60,20 +60,17 @@ JNIEXPORT void JNICALL callbackClassPrepare(jvmtiEnv *jvmti_env,
     redefineNumber=0;
     className=NULL;
     generic=NULL;
-    if ( ! NSK_JVMTI_VERIFY ( NSK_CPP_STUB4(GetClassSignature,
-                    jvmti_env, klass, &className, &generic) ) ) {
+    if ( ! NSK_JVMTI_VERIFY ( jvmti_env->GetClassSignature(klass, &className, &generic) ) ) {
         nsk_printf("#error Agent :: while getting classname Signature.\n");
         nsk_jvmti_agentFailed();
     } else {
         if (strcmp(className,CLASS_NAME) == 0) {
             jfieldID field;
             /* get the field id and set watch on that .*/
-            if (! NSK_JNI_VERIFY(jni, (field = NSK_CPP_STUB4(GetFieldID,
-                                jni, klass, FIELDNAME, TYPE)) != NULL) ) {
+            if (! NSK_JNI_VERIFY(jni, (field = jni->GetFieldID(klass, FIELDNAME, TYPE)) != NULL) ) {
                 nsk_printf(" Agent :: (*JNI)->GetFieldID(jni, ... ) returns `null`.\n");
                 nsk_jvmti_agentFailed();
-            } else  if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetFieldAccessWatch,
-                            jvmti_env, klass, field) ) ) {
+            } else  if ( ! NSK_JVMTI_VERIFY(jvmti_env->SetFieldAccessWatch(klass, field) ) ) {
                 nsk_printf("#error Agent :: occured while jvmti->SetFieldAccessWatch(... ) .\n");
                 nsk_jvmti_agentFailed();
             }
@@ -96,7 +93,7 @@ JNIEXPORT void JNICALL callbackFieldAccess(jvmtiEnv *jvmti_env,
         return;
     }
     redefineNumber=0;
-    if (! NSK_JNI_VERIFY(jni, (clas = NSK_CPP_STUB2(FindClass, jni, SEARCH_NAME)) != NULL) ) {
+    if (! NSK_JNI_VERIFY(jni, (clas = jni->FindClass(SEARCH_NAME)) != NULL) ) {
         nsk_printf(" Agent :: (*JNI)->FindClass(jni, %s) returns `null`.\n",SEARCH_NAME);
         nsk_jvmti_agentFailed();
     } else  {
@@ -109,7 +106,7 @@ JNIEXPORT void JNICALL callbackFieldAccess(jvmtiEnv *jvmti_env,
             nsk_printf(" Agent :: Redefined.\n");
             nsk_printf(" Agent :: Suspendeding thread.\n");
             /* pop the current working frame. */
-            if ( ! NSK_JVMTI_VERIFY( NSK_CPP_STUB2(SuspendThread, jvmti_env, thread) ) ) {
+            if ( ! NSK_JVMTI_VERIFY(jvmti_env->SuspendThread(thread) ) ) {
                 nsk_printf("#error Agent :: occured suspending Thread.\n");
                 nsk_jvmti_agentFailed();
             } else {
@@ -131,8 +128,7 @@ JNIEXPORT jint JNI_OnLoad_hs203t003(JavaVM *jvm, char *options, void *reserved) 
 }
 #endif
 jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
-    if ( ! NSK_VERIFY ( JNI_OK == NSK_CPP_STUB3(GetEnv, vm,
-                    (void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
+    if ( ! NSK_VERIFY ( JNI_OK == vm->GetEnv((void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
         nsk_printf(" Agent :: Could not load JVMTI interface.\n");
         return JNI_ERR;
     } else {
@@ -148,16 +144,14 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
         caps.can_pop_frame=1;
         caps.can_generate_all_class_hook_events=1;
         caps.can_generate_field_access_events=1;
-        if (! NSK_JVMTI_VERIFY ( NSK_CPP_STUB2(AddCapabilities, jvmti, &caps) )) {
+        if (! NSK_JVMTI_VERIFY ( jvmti->AddCapabilities(&caps) ) ) {
             nsk_printf("#error Agent :: while adding capabilities.\n");
             return JNI_ERR;
         }
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ClassPrepare =callbackClassPrepare;
         eventCallbacks.FieldAccess= callbackFieldAccess;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             nsk_printf("#error Agent :: while setting event callbacks.\n");
             return JNI_ERR;
         }
@@ -181,7 +175,7 @@ Java_nsk_jvmti_scenarios_hotswap_HS203_hs203t003_hs203t003_isSuspended(JNIEnv * 
     jboolean retvalue;
     jint state;
     retvalue = JNI_FALSE;
-    if ( ! NSK_JVMTI_VERIFY( NSK_CPP_STUB3(GetThreadState, jvmti, thread, &state) )  ) {
+    if ( ! NSK_JVMTI_VERIFY( jvmti->GetThreadState(thread, &state) ) ) {
         nsk_printf(" Agent :: Error while getting thread state.\n");
         nsk_jvmti_agentFailed();
     } else {
@@ -199,18 +193,18 @@ Java_nsk_jvmti_scenarios_hotswap_HS203_hs203t003_hs203t003_popThreadFrame(JNIEnv
     jboolean retvalue;
     jint state;
     retvalue = JNI_FALSE;
-    if ( ! NSK_JVMTI_VERIFY( NSK_CPP_STUB3(GetThreadState, jvmti, thread, &state) )  ) {
+    if ( ! NSK_JVMTI_VERIFY( jvmti->GetThreadState(thread, &state) ) ) {
         nsk_printf(" Agent :: Error while getting thread state.\n");
         nsk_jvmti_agentFailed();
     } else {
         if ( state & JVMTI_THREAD_STATE_SUSPENDED) {
-            if ( ! NSK_JVMTI_VERIFY ( NSK_CPP_STUB2( PopFrame, jvmti, thread) ) ) {
+            if ( ! NSK_JVMTI_VERIFY ( jvmti->PopFrame(thread) ) ) {
                 nsk_printf("#error Agent :: while poping thread's frame.\n");
                 nsk_jvmti_agentFailed();
             } else {
                 nsk_printf(" Agent :: poped thread frame.\n");
-                if ( ! NSK_JVMTI_VERIFY ( NSK_CPP_STUB4 (SetEventNotificationMode, jvmti,
-                                JVMTI_DISABLE, JVMTI_EVENT_FIELD_ACCESS, NULL) ) ) {
+                if ( ! NSK_JVMTI_VERIFY (
+                        jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_FIELD_ACCESS, NULL) ) ) {
                     nsk_printf("#error Agent :: failed to disable notification JVMTI_EVENT_FIELD ACCESS.\n");
                     nsk_jvmti_agentFailed();
                 } else {
@@ -232,7 +226,7 @@ Java_nsk_jvmti_scenarios_hotswap_HS203_hs203t003_hs203t003_resumeThread(JNIEnv *
         jthread thread) {
     jboolean retvalue;
     retvalue = JNI_FALSE;
-    if ( !NSK_JVMTI_VERIFY( NSK_CPP_STUB2 ( ResumeThread, jvmti, thread)) ) {
+    if ( !NSK_JVMTI_VERIFY( jvmti->ResumeThread(thread) ) ) {
         nsk_printf("#error Agent :: while resuming thread.\n");
         nsk_jvmti_agentFailed();
     } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t004/hs203t004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS203/hs203t004/hs203t004.cpp
@@ -45,23 +45,21 @@ JNIEXPORT void JNICALL callbackClassPrepare(jvmtiEnv *jvmti_env,
     char * className;
     className=NULL;
 
-    if (!NSK_JVMTI_VERIFY (NSK_CPP_STUB4(GetClassSignature,
-                    jvmti_env, klass, &className, NULL) ) ) {
+    if (!NSK_JVMTI_VERIFY (jvmti_env->GetClassSignature(klass, &className, NULL) ) ) {
         NSK_COMPLAIN0("#error Agent :: while getting classname.\n");
         nsk_jvmti_agentFailed();
     } else {
         if (strcmp(className, CLASS_NAME) == 0) {
-            if (nsk_jvmti_enableNotification(jvmti_env, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL) == NSK_TRUE ) {
+            if (nsk_jvmti_enableNotification(jvmti_env, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL) == NSK_TRUE) {
                 NSK_DISPLAY0(" Agent :: notification enabled for COMPILED_METHOD_LOAD.\n");
-                if ( ! NSK_JVMTI_VERIFY ( NSK_CPP_STUB2(GenerateEvents, jvmti_env,
-                                JVMTI_EVENT_COMPILED_METHOD_LOAD ) )) {
+                if ( ! NSK_JVMTI_VERIFY ( jvmti_env->GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD) ) ) {
                     NSK_COMPLAIN0("#error Agent :: occured while enabling compiled method events.\n");
                     nsk_jvmti_agentFailed();
                 }
             }
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char *)className))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char *)className))) {
             NSK_COMPLAIN1("#error Agent :: failed to Deallocate className = %s.", className);
             nsk_jvmti_agentFailed();
         }
@@ -78,8 +76,7 @@ JNIEXPORT void JNICALL callbackCompiledMethodLoad(jvmtiEnv *jvmti_env,
         const void* compile_info) {
     jclass threadClass;
     if (redefineNumber == 0) {
-        if ( ! NSK_JVMTI_VERIFY ( NSK_CPP_STUB3(GetMethodDeclaringClass,
-                        jvmti_env, method, &threadClass) ) ) {
+        if ( ! NSK_JVMTI_VERIFY ( jvmti_env->GetMethodDeclaringClass(method, &threadClass) ) ) {
             NSK_COMPLAIN0("#error Agent :: while geting the declaring class.\n");
             nsk_jvmti_agentFailed();
         } else {
@@ -89,15 +86,13 @@ JNIEXPORT void JNICALL callbackCompiledMethodLoad(jvmtiEnv *jvmti_env,
             className = NULL;
             methodName = NULL;
 
-            if ( ! NSK_JVMTI_VERIFY (NSK_CPP_STUB4(GetClassSignature,
-                            jvmti_env, threadClass, &className, NULL) ) ) {
+            if ( ! NSK_JVMTI_VERIFY (jvmti_env->GetClassSignature(threadClass, &className, NULL) ) ) {
                 NSK_COMPLAIN0("#error Agent :: while getting classname.\n");
                 nsk_jvmti_agentFailed();
                 return;
             }
 
-            if ( ! NSK_JVMTI_VERIFY (NSK_CPP_STUB5(GetMethodName,
-                            jvmti_env, method, &methodName, NULL, NULL) ) ) {
+            if ( ! NSK_JVMTI_VERIFY (jvmti_env->GetMethodName(method, &methodName, NULL, NULL) ) ) {
                 NSK_COMPLAIN0("#error Agent :: while getting methodname.\n");
                 nsk_jvmti_agentFailed();
                 return;
@@ -121,13 +116,13 @@ JNIEXPORT void JNICALL callbackCompiledMethodLoad(jvmtiEnv *jvmti_env,
             }
 
             if ( className != NULL ) {
-                if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char *)className))) {
+                if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char *)className))) {
                     NSK_COMPLAIN1("#error Agent :: failed to Deallocate className = %s.", className);
                     nsk_jvmti_agentFailed();
                 }
             }
             if ( methodName != NULL ) {
-                if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char *)methodName))) {
+                if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char *)methodName))) {
                     NSK_COMPLAIN1("#error Agent :: failed to Deallocate methodName = %s.", methodName);
                     nsk_jvmti_agentFailed();
                 }
@@ -149,8 +144,7 @@ JNIEXPORT jint JNI_OnLoad_hs203t004(JavaVM *jvm, char *options, void *reserved) 
 #endif
 jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     redefineNumber=0;
-    if ( ! NSK_VERIFY ( JNI_OK == NSK_CPP_STUB3(GetEnv, vm,
-                    (void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
+    if ( ! NSK_VERIFY ( JNI_OK == vm->GetEnv((void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
         NSK_DISPLAY0("#error Agent :: Could not load JVMTI interface.\n");
         return JNI_ERR;
         } else {
@@ -166,16 +160,14 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
         caps.can_pop_frame = 1;
         caps.can_generate_all_class_hook_events = 1;
         caps.can_generate_compiled_method_load_events = 1;
-        if (! NSK_JVMTI_VERIFY ( NSK_CPP_STUB2(AddCapabilities, jvmti, &caps) )) {
+        if (! NSK_JVMTI_VERIFY ( jvmti->AddCapabilities(&caps) ) ) {
             NSK_DISPLAY0("#error Agent :: occured while adding capabilities.\n");
             return JNI_ERR;
         }
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ClassPrepare =callbackClassPrepare;
         eventCallbacks.CompiledMethodLoad=callbackCompiledMethodLoad;
-        if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                        &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             NSK_COMPLAIN0("#error Agent :: occured while setting event callback.\n");
             return JNI_ERR;
         }
@@ -194,7 +186,7 @@ Java_nsk_jvmti_scenarios_hotswap_HS203_hs203t004_hs203t004_suspendThread(JNIEnv 
         jobject clas,
         jthread thread) {
     NSK_DISPLAY0(" Agent :: Suspending Thread.\n");
-    if (  NSK_JVMTI_VERIFY( NSK_CPP_STUB2(SuspendThread, jvmti, thread) ) ) {
+    if (  NSK_JVMTI_VERIFY( jvmti->SuspendThread(thread) ) ) {
         NSK_DISPLAY0(" Agent :: Succeded in suspending.\n");
     } else {
         NSK_COMPLAIN0("#error Agent :: occured while suspending thread.\n");
@@ -211,18 +203,18 @@ Java_nsk_jvmti_scenarios_hotswap_HS203_hs203t004_hs203t004_popThreadFrame(JNIEnv
 
     NSK_DISPLAY0(" Agent :: nsk.jvmti.scenarios.hotswap.HS203.hs203t004.popThreadFrame(... ).\n");
     retvalue = JNI_FALSE;
-    if ( ! NSK_JVMTI_VERIFY ( NSK_CPP_STUB3(GetThreadState, jvmti,
-                    thread, &state) ) ) {
+    if ( ! NSK_JVMTI_VERIFY (jvmti->GetThreadState(thread, &state) ) ) {
         NSK_COMPLAIN0("#error Agent :: while getting thread's state.\n");
         nsk_jvmti_agentFailed();
     } else {
         if ( state & JVMTI_THREAD_STATE_SUSPENDED) {
-            if ( ! NSK_JVMTI_VERIFY( NSK_CPP_STUB2(PopFrame, jvmti, thread) ) ){
+            if ( ! NSK_JVMTI_VERIFY( jvmti->PopFrame(thread) ) ) {
                 NSK_DISPLAY0("#error Agent :: occured while poping thread's frame.\n");
                 nsk_jvmti_agentFailed();
             } else {
-                if ( NSK_JVMTI_VERIFY( NSK_CPP_STUB4(SetEventNotificationMode, jvmti,
-                                JVMTI_DISABLE, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL) ) ) {
+                if ( NSK_JVMTI_VERIFY(
+                        jvmti->SetEventNotificationMode(JVMTI_DISABLE,
+                                                        JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL) ) ) {
                     NSK_DISPLAY0(" Agent :: Disabled JVMTI_EVENT_COMPILED_METHOD_LOAD.\n");
                     retvalue = JNI_TRUE;
                 } else {
@@ -245,7 +237,7 @@ Java_nsk_jvmti_scenarios_hotswap_HS203_hs203t004_hs203t004_resumeThread(JNIEnv *
     jboolean retvalue;
 
     retvalue = JNI_FALSE;
-    if ( NSK_JVMTI_VERIFY ( NSK_CPP_STUB2(ResumeThread, jvmti, thread))) {
+    if ( NSK_JVMTI_VERIFY (jvmti->ResumeThread(thread))) {
         NSK_DISPLAY0(" Agent :: Thread resumed.\n");
         retvalue= JNI_TRUE;
     } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t001/hs204t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t001/hs204t001.cpp
@@ -51,7 +51,7 @@ static jint newClassSize;
 char *getClassName(jvmtiEnv *jvmti, jclass  klass) {
     char * className;
     char * generic;
-    if( !NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti, klass, &className, &generic))) {
+    if( !NSK_JVMTI_VERIFY(jvmti->GetClassSignature(klass, &className, &generic))) {
         nsk_jvmti_setFailStatus();
     }
     return className;
@@ -75,7 +75,7 @@ callbackClassLoad(jvmtiEnv *jvmti_env,
         } else {
             NSK_COMPLAIN0("\nMyClass :: Failed to redefine ..\n");
         }
-        /* if( (myTestClass =NSK_CPP_STUB2(NewGlobalRef,jni_env, klass)) == NULL) {
+        /* if ( (myTestClass = jni_env->NewGlobalRef(klass) ) == NULL) {
            NSK_COMPLAIN0("Failed to create global ref...");
            }
          */
@@ -100,7 +100,7 @@ callbackClassPrepare(jvmtiEnv *jvmti_env,
         } else {
             NSK_COMPLAIN0("\nMyClass :: Failed to redefine ..\n");
         }
-        if( (myTestClass = (jclass) NSK_CPP_STUB2(NewGlobalRef,jni_env, klass)) == NULL) {
+        if( (myTestClass = (jclass) jni_env->NewGlobalRef(klass)) == NULL) {
             NSK_COMPLAIN0("Failed to create global ref...");
         }
     }
@@ -240,9 +240,9 @@ Java_nsk_jvmti_scenarios_hotswap_HS204_hs204t001_hs204t001_setThread(JNIEnv * en
                          jclass klass,
              jobject thread) {
     NSK_DISPLAY0(" Inside the setThread Method");
-    if (!NSK_JNI_VERIFY(env, (testClass =(jclass) NSK_CPP_STUB2(NewGlobalRef, env, klass)) != NULL))
+    if (!NSK_JNI_VERIFY(env, (testClass = (jclass) env->NewGlobalRef(klass)) != NULL))
         nsk_jvmti_setFailStatus();
-    if (!NSK_JNI_VERIFY(env, (testedThread =NSK_CPP_STUB2(NewGlobalRef, env, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(env, (testedThread = env->NewGlobalRef(thread)) != NULL))
         nsk_jvmti_setFailStatus();
 }
 
@@ -252,12 +252,12 @@ Java_nsk_jvmti_scenarios_hotswap_HS204_hs204t001_hs204t001_suspendThread(JNIEnv 
         jobject thread) {
     jint state;
     NSK_DISPLAY0("---suspend thread .. \n");
-    if (NSK_CPP_STUB3(GetThreadState,jvmti,thread, &state) == JVMTI_ERROR_NONE) {
+    if (jvmti->GetThreadState(thread, &state) == JVMTI_ERROR_NONE) {
         NSK_DISPLAY0(" No Errors in finding state of the thread.\n");
         if (state & JVMTI_THREAD_STATE_ALIVE) {
             NSK_DISPLAY0(" Thread state is alive .. So can be suspend should be possible ..\n");
             nsk_jvmti_disableNotification(jvmti, JVMTI_EVENT_SINGLE_STEP, thread);
-            if (!NSK_JVMTI_VERIFY(  NSK_CPP_STUB2(SuspendThread, jvmti, thread))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(thread))) {
                 NSK_COMPLAIN0("TEST FAILED: unable to suspend the thread \n");
                 nsk_jvmti_setFailStatus();
                 return NSK_FALSE;
@@ -278,11 +278,11 @@ Java_nsk_jvmti_scenarios_hotswap_HS204_hs204t001_hs204t001_popFrame(JNIEnv * env
         jthread thread) {
     jint state;
     NSK_DISPLAY0("Inside pop_Frame method.....\n");
-    if (NSK_CPP_STUB3(GetThreadState,jvmti,thread, &state) == JVMTI_ERROR_NONE) {
+    if (jvmti->GetThreadState(thread, &state) == JVMTI_ERROR_NONE) {
         NSK_DISPLAY0(" Got the state of thread \n");
         if ( state & JVMTI_THREAD_STATE_SUSPENDED) {
             NSK_DISPLAY0(" Thread is already in suspended mode..\n");
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(PopFrame, jvmti, thread))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->PopFrame(thread))) {
                 NSK_COMPLAIN0(" TEST FAILED: UNABLE TO POP FRAME \n");
                 nsk_jvmti_setFailStatus();
                 return NSK_FALSE;
@@ -290,7 +290,7 @@ Java_nsk_jvmti_scenarios_hotswap_HS204_hs204t001_hs204t001_popFrame(JNIEnv * env
                 NSK_DISPLAY0(" Poped frame safely..");
             }
             /* We should resume that thread for next execution.. */
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(ResumeThread, jvmti, thread))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(thread))) {
                 NSK_COMPLAIN0(" TEST FAILED: UNABLE TO Resume thread \n");
                 nsk_jvmti_setFailStatus();
                 return NSK_FALSE;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t003/hs204t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t003/hs204t003.cpp
@@ -51,27 +51,24 @@ JNIEXPORT void JNICALL callbackClassPrepare(jvmtiEnv *jvmti_env,
     className = NULL;
     generic   = NULL;
     redefineNumber=0;
-    if ( !NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti_env,
-                    klass, &className, &generic)) ) {
+    if ( !NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &className, &generic)) ) {
         NSK_DISPLAY0(" Agent :: Failed get class signature.\n");
         nsk_jvmti_agentFailed();
     } else {
         if( (strcmp(className, CLASS_NAME) == 0 ) ) {
             jfieldID fieldId;
-            if ( ! NSK_JNI_VERIFY(jni, (fieldId = NSK_CPP_STUB4(GetStaticFieldID,
-                                jni, klass, FIELDNAME, TYPE) ) != NULL ) ) {
+            if ( ! NSK_JNI_VERIFY(jni, (fieldId = jni->GetStaticFieldID(klass, FIELDNAME, TYPE) ) != NULL ) ) {
                     NSK_DISPLAY0(" Agent :: Failed to get FieldId.\n");
                     nsk_jvmti_agentFailed();
             } else {
-                if ( ! NSK_JVMTI_VERIFY( NSK_CPP_STUB3(SetFieldAccessWatch,
-                                jvmti_env, klass, fieldId) )  ) {
+                if ( ! NSK_JVMTI_VERIFY(jvmti_env->SetFieldAccessWatch(klass, fieldId) )  ) {
                     NSK_DISPLAY0(" Agent :: Failed to set watch point on a field.\n");
                     nsk_jvmti_agentFailed();
                 } else {
                     nsk_jvmti_enableNotification(jvmti_env, JVMTI_EVENT_FIELD_ACCESS, NULL);
                     if (! NSK_JNI_VERIFY(jni,
                                 ( watchFieldClass = (jclass)
-                                  NSK_CPP_STUB2(NewGlobalRef, jni, klass) )
+                                  jni->NewGlobalRef(klass) )
                                 != NULL ) ) {
                         NSK_DISPLAY0(" Agent :: Failed to get global reference for class.\n");
                         nsk_jvmti_agentFailed();
@@ -84,14 +81,14 @@ JNIEXPORT void JNICALL callbackClassPrepare(jvmtiEnv *jvmti_env,
     }
 
     if ( className != NULL ) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char *)className))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char *)className))) {
             NSK_DISPLAY1(" Agent :: #error failed to Deallocate className = %s.", className);
             nsk_jvmti_agentFailed();
         }
     }
 
     if ( generic != NULL ) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char *)generic))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char *)generic))) {
             NSK_DISPLAY1(" Agent :: #error failed to Deallocate class signature = %s.", generic);
             nsk_jvmti_agentFailed();
         }
@@ -116,8 +113,7 @@ JNIEXPORT void JNICALL callbackFieldAccess(jvmtiEnv *jvmti_env,
     if (redefineNumber != 0 ) {
         return;
     }
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti_env,
-                    field_klass, &className, &generic)) ) {
+    if ( ! NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(field_klass, &className, &generic)) ) {
         NSK_DISPLAY0(" Agent :: Failed get class signature.\n");
         nsk_jvmti_agentFailed();
     } else {
@@ -133,13 +129,13 @@ JNIEXPORT void JNICALL callbackFieldAccess(jvmtiEnv *jvmti_env,
                 nsk_jvmti_agentFailed();
             }
             NSK_DISPLAY0(" Agent :: Before attempting thread suspend.\n");
-            if ( ! NSK_JVMTI_VERIFY( NSK_CPP_STUB3(GetThreadInfo, jvmti_env, thread , &info)) ) {
+            if ( ! NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &info))) {
                 NSK_DISPLAY0(" Agent :: error getting thread info ");
                 nsk_jvmti_agentFailed();
             } else {
                 NSK_DISPLAY1(" Agent :: Thread Name = %s .\n", info.name);
             }
-            if ( ! NSK_JVMTI_VERIFY( NSK_CPP_STUB2(SuspendThread, jvmti_env, thread)) ) {
+            if ( ! NSK_JVMTI_VERIFY(jvmti_env->SuspendThread(thread))) {
                 NSK_DISPLAY0(" Agent :: Failed to suspend thread.\n");
                 nsk_jvmti_agentFailed();
             }
@@ -147,14 +143,14 @@ JNIEXPORT void JNICALL callbackFieldAccess(jvmtiEnv *jvmti_env,
     }
 
     if ( className != NULL ) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char *)className))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char *)className))) {
             NSK_DISPLAY1(" Agent :: #error failed to Deallocate className = %s.", className);
             nsk_jvmti_agentFailed();
         }
     }
 
     if ( generic != NULL ) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char *)generic))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char *)generic))) {
             NSK_DISPLAY1(" Agent :: #error failed to Deallocate class signature = %s.", generic);
             nsk_jvmti_agentFailed();
         }
@@ -173,8 +169,7 @@ JNIEXPORT jint JNI_OnLoad_hs204t003(JavaVM *jvm, char *options, void *reserved) 
 }
 #endif
 jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
-    if ( ! NSK_VERIFY ( JNI_OK == NSK_CPP_STUB3(GetEnv, vm,
-                    (void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
+    if ( ! NSK_VERIFY ( JNI_OK == vm->GetEnv((void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
         NSK_DISPLAY0("Agent :: Could not load JVMTI interface \n");
         return JNI_ERR;
     } else {
@@ -189,15 +184,14 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
         caps.can_generate_field_access_events = 1;
         caps.can_pop_frame                    = 1;
         caps.can_suspend                      = 1;
-        if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB2( AddCapabilities, jvmti, &caps)) ) {
+        if ( ! NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)) ) {
             NSK_DISPLAY0(" Agent :: Failed add required capabilities\n.");
             return JNI_ERR;
         }
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ClassPrepare = callbackClassPrepare;
         eventCallbacks.FieldAccess  = callbackFieldAccess;
-        if (!NSK_JVMTI_VERIFY( NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                        &eventCallbacks, sizeof(eventCallbacks) ) ) ) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks) ) ) ) {
             NSK_DISPLAY0(" Agent :: Error occured while setting event call back \n");
             return JNI_ERR;
         }
@@ -213,28 +207,26 @@ Java_nsk_jvmti_scenarios_hotswap_HS204_hs204t003_hs204t003_popFrame(JNIEnv * jni
     jboolean retvalue;
     jint state;
     retvalue = JNI_FALSE;
-    if (! NSK_JVMTI_VERIFY( NSK_CPP_STUB3(GetThreadState, jvmti, thread, &state)) ){
+    if (! NSK_JVMTI_VERIFY(jvmti->GetThreadState(thread, &state))) {
         NSK_DISPLAY0(" Agent :: Error getting thread state.\n");
         nsk_jvmti_agentFailed();
     } else {
         if ( state & JVMTI_THREAD_STATE_SUSPENDED) {
             NSK_DISPLAY0(" Agent :: Thread state = JVMTI_THREAD_STATE_SUSPENDED.\n");
-            if ( ! NSK_JVMTI_VERIFY ( NSK_CPP_STUB2(PopFrame, jvmti, thread) ) ) {
+            if ( ! NSK_JVMTI_VERIFY ( jvmti->PopFrame(thread) ) ) {
                 NSK_DISPLAY0("#error Agent :: Jvmti failed to do popFrame.\n");
                 nsk_jvmti_agentFailed();
             } else {
-                if ( ! NSK_JVMTI_VERIFY ( NSK_CPP_STUB2(ResumeThread, jvmti, thread)) ) {
+                if ( ! NSK_JVMTI_VERIFY ( jvmti->ResumeThread(thread) ) ) {
                     NSK_DISPLAY0(" Agent :: Error occured in resuming a thread.\n");
                     nsk_jvmti_agentFailed();
                 } else {
-                    jfieldID fieldId;
-                    if ( ! NSK_JNI_VERIFY(jni, (fieldId = NSK_CPP_STUB4(GetStaticFieldID,
-                                jni, watchFieldClass, FIELDNAME, TYPE) ) != NULL ) ) {
+                    jfieldID fieldId = jni->GetStaticFieldID(watchFieldClass, FIELDNAME, TYPE);
+                    if ( ! NSK_JNI_VERIFY(jni, fieldId != NULL ) ) {
                         NSK_DISPLAY0(" Agent :: Failed to get FieldId before droping watchers.\n");
                         nsk_jvmti_agentFailed();
                     } else {
-                        if ( ! NSK_JVMTI_VERIFY ( NSK_CPP_STUB3(ClearFieldAccessWatch,
-                                        jvmti, watchFieldClass, fieldId)) ) {
+                        if ( ! NSK_JVMTI_VERIFY ( jvmti->ClearFieldAccessWatch(watchFieldClass, fieldId) ) ) {
                             NSK_DISPLAY0(" Agent :: failed to drop field watces.\n");
                             nsk_jvmti_agentFailed();
                         } else {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t001/hs301t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t001/hs301t001.cpp
@@ -49,8 +49,7 @@ JNIEXPORT jint JNI_OnLoad_hs301t001(JavaVM *jvm, char *options, void *reserved) 
 #endif
 jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     nsk_printf("Agent:: Agent_OnLoad .\n");
-    if ( ! NSK_VERIFY ( JNI_OK == NSK_CPP_STUB3(GetEnv, vm,
-                    (void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
+    if ( ! NSK_VERIFY ( JNI_OK == vm->GetEnv((void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
         nsk_printf("Agent:: Could not load JVMTI interface.\n");
         return JNI_ERR;
     } else {
@@ -62,14 +61,12 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
         }
         memset(&caps, 0, sizeof(caps));
         caps.can_redefine_classes = 1;
-        if (! NSK_JVMTI_VERIFY ( NSK_CPP_STUB2(AddCapabilities, jvmti, &caps) )) {
+        if (! NSK_JVMTI_VERIFY ( jvmti->AddCapabilities(&caps) )) {
             nsk_printf(" Agent:: Error occured while adding capabilities.\n");
             return JNI_ERR;
         }
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             nsk_printf(" Agent:: Error occured while setting event call back.\n");
             return JNI_ERR;
         }
@@ -86,8 +83,8 @@ Java_nsk_jvmti_scenarios_hotswap_HS301_hs301t001_hs301t001_redefine(JNIEnv * jni
 
 
     redefineNumber=0;
-    //cls= NSK_CPP_STUB2(FindClass, jni, SEARCH_NAME);
-    if (! NSK_JNI_VERIFY(jni, (cls = NSK_CPP_STUB2(FindClass, jni, SEARCH_NAME)) != NULL) ) {
+    cls = jni->FindClass(SEARCH_NAME);
+    if (! NSK_JNI_VERIFY(jni, cls != NULL) ) {
         nsk_printf("Agent:: (*JNI)->FindClass(jni, %s) returns `null`.\n",SEARCH_NAME);
         return NSK_FALSE;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t002/hs301t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t002/hs301t002.cpp
@@ -52,8 +52,7 @@ JNIEXPORT jint JNI_OnLoad_hs301t002(JavaVM *jvm, char *options, void *reserved) 
 #endif
 jint Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     nsk_printf(" Agent:: VM Started.\n");
-    if ( ! NSK_VERIFY ( JNI_OK == NSK_CPP_STUB3(GetEnv, vm,
-                    (void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
+    if ( ! NSK_VERIFY ( JNI_OK == vm->GetEnv((void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
         nsk_printf(" Agent ::Agent failed to get jvmti env.\n");
         return JNI_ERR;
     } else {
@@ -64,7 +63,7 @@ jint Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
         }
         memset(&caps, 0, sizeof(caps));
         caps.can_redefine_classes = 1;
-        if ( ! NSK_JVMTI_VERIFY ( NSK_CPP_STUB2(AddCapabilities, jvmti, &caps) ) ) {
+        if ( ! NSK_JVMTI_VERIFY ( jvmti->AddCapabilities(&caps) ) ) {
             nsk_printf(" Agent:: Error occured while adding capabilities.\n");
             return JNI_ERR;
         }
@@ -85,7 +84,7 @@ Java_nsk_jvmti_scenarios_hotswap_HS301_hs301t002_hs301t002_redefine(JNIEnv * jni
 
     redefineNumber=0;
     ret = JNI_FALSE;
-    if (!NSK_JNI_VERIFY(jni, (cls = NSK_CPP_STUB2(FindClass, jni, SEARCH_NAME)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(SEARCH_NAME)) != NULL)) {
         nsk_printf("Agent:: (*JNI)->FindClass(jni, %s) returns `null`.\n", SEARCH_NAME);
         return NSK_FALSE;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t003/hs301t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t003/hs301t003.cpp
@@ -36,8 +36,7 @@ void JNICALL callbackClassPrepare(jvmtiEnv *jvmti_env,
                                jclass klass) {
   char * className;
   char * generic;
-  if ( ! NSK_JVMTI_VERIFY ( NSK_CPP_STUB4(GetClassSignature,
-                  jvmti_env, klass, &className, &generic) ) ) {
+  if ( ! NSK_JVMTI_VERIFY ( jvmti_env->GetClassSignature(klass, &className, &generic) ) ) {
     nsk_printf(" Agent:: Error while getting ClassFileName Signature ");
   } else {
       if (strcmp(className, CLASS_NAME ) == 0) {
@@ -70,8 +69,7 @@ JNIEXPORT jint JNI_OnLoad_hs301t003(JavaVM *jvm, char *options, void *reserved) 
 jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     jvmtiEnv * jvmti;
     nsk_printf("Agent:: Agent_OnLoad.\n");
-    if ( ! NSK_VERIFY ( JNI_OK == NSK_CPP_STUB3(GetEnv, vm,
-                    (void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
+    if ( ! NSK_VERIFY ( JNI_OK == vm->GetEnv((void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
         nsk_printf("Agent:: Could not load JVMTI interface.\n");
         return JNI_ERR;
     } else {
@@ -84,15 +82,13 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_redefine_classes = 1;
         caps.can_generate_all_class_hook_events=1;
-        if (! NSK_JVMTI_VERIFY ( NSK_CPP_STUB2(AddCapabilities, jvmti, &caps) ))  {
+        if (! NSK_JVMTI_VERIFY ( jvmti->AddCapabilities(&caps) ) )  {
             nsk_printf(" Agent:: Error occured while adding capabilities.\n");
             return JNI_ERR;
         }
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ClassPrepare = &callbackClassPrepare;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                    &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             nsk_printf(" Agent:: Error occured while setting event call back.\n");
             return JNI_ERR;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t004/hs301t004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS301/hs301t004/hs301t004.cpp
@@ -37,8 +37,7 @@ void JNICALL callbackClassPrepare(jvmtiEnv *jvmti_env,
     char * className;
     char * generic;
     int redefineNumber=0;
-    if (! NSK_JVMTI_VERIFY( NSK_CPP_STUB4(GetClassSignature,
-                    jvmti_env, klass, &className, &generic)) ) {
+    if (! NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &className, &generic)) ) {
         nsk_printf(" Agent :: Error occured in getting class signature.\n");
         return;
     } else {
@@ -71,8 +70,7 @@ JNIEXPORT jint JNI_OnLoad_hs301t004(JavaVM *jvm, char *options, void *reserved) 
 jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
     jvmtiEnv * jvmti;
     nsk_printf("Agent:: VM Started.\n");
-    if (! NSK_VERIFY ( JNI_OK == NSK_CPP_STUB3(GetEnv,
-                    vm, (void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
+    if (! NSK_VERIFY ( JNI_OK == vm->GetEnv((void **)&jvmti, JVMTI_VERSION_1_1) ) ) {
         nsk_printf("Agent:: Could not load JVMTI interface \n");
         return JNI_ERR;
     } else {
@@ -85,15 +83,13 @@ jint  Agent_Initialize(JavaVM *vm, char *options, void *reserved) {
         memset(&caps, 0, sizeof(caps));
         caps.can_redefine_classes = 1;
         caps.can_generate_all_class_hook_events=1;
-        if ( ! NSK_JVMTI_VERIFY ( NSK_CPP_STUB2(AddCapabilities,
-                        jvmti, &caps) ))  {
+        if ( ! NSK_JVMTI_VERIFY (jvmti->AddCapabilities(&caps) ))  {
             nsk_printf(" Agent:: Error occured while adding capabilities.\n");
             return JNI_ERR;
         }
         memset(&eventCallbacks, 0, sizeof(eventCallbacks));
         eventCallbacks.ClassPrepare = &callbackClassPrepare;
-        if ( ! NSK_JVMTI_VERIFY( NSK_CPP_STUB3(SetEventCallbacks,
-                        jvmti, &eventCallbacks, sizeof(eventCallbacks)) ) ) {
+        if ( ! NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)) ) ) {
             nsk_printf(" Agent:: Error occured while setting event call back \n");
             return JNI_ERR;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/ji06t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/ji06t001.cpp
@@ -81,14 +81,12 @@ static jniNativeInterface *redir_jni_functions = NULL;
 static volatile int monent_calls = 0;
 
 static void lock() {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter,
-            jvmti, countLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(countLock)))
         exit(STATUS_FAILED);
 }
 
 static void unlock() {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit,
-            jvmti, countLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(countLock)))
         exit(STATUS_FAILED);
 }
 
@@ -482,8 +480,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     vm = jvm;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor,
-            jvmti, "_counter_lock", &countLock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_counter_lock", &countLock)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA02/ma02t001/ma02t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA02/ma02t001/ma02t001.cpp
@@ -114,12 +114,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA02/ma02t001/ma02t001a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA02/ma02t001/ma02t001a.cpp
@@ -114,12 +114,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA03/ma03t001/ma03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA03/ma03t001/ma03t001.cpp
@@ -126,16 +126,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_THREAD_START, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_THREAD_START, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t001/ma04t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t001/ma04t001.cpp
@@ -53,22 +53,18 @@ static int prepare(JNIEnv* jni) {
     NSK_DISPLAY0("Obtain tested object from a static field of debugee class\n");
 
     NSK_DISPLAY1("Find class: %s\n", CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY2("Find field: %s:%s\n", FIELD_NAME, FIELD_SIGNATURE);
     if (!NSK_JNI_VERIFY(jni, (fid =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls,
-                FIELD_NAME, FIELD_SIGNATURE)) != NULL))
+            jni->GetStaticFieldID(cls, FIELD_NAME, FIELD_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fid)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedObject = jni->GetStaticObjectField(cls, fid)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedObject =
-            NSK_CPP_STUB2(NewGlobalRef, jni, testedObject)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedObject = jni->NewGlobalRef(testedObject)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -91,7 +87,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     NSK_DISPLAY0("Testcase #1: check that testedObject is not tagged \n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetTag, jvmti, testedObject, &tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetTag(testedObject, &tag))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -101,8 +97,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             jlong_to_string(tag, buffer));
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, testedObject,
-            SAMPLE_TAG))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(testedObject, SAMPLE_TAG))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -112,7 +107,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
 
     NSK_DISPLAY0("Testcase #2: check that testedObject is tagged correctly\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetTag, jvmti, testedObject, &tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetTag(testedObject, &tag))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -133,7 +128,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
 
     NSK_DISPLAY0("Testcase #3: check that testedObject is tagged correctly\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetTag, jvmti, testedObject, &tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetTag(testedObject, &tag))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -148,7 +143,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, testedObject, (jlong)0))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(testedObject, (jlong)0))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -158,7 +153,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
 
     NSK_DISPLAY0("Testcase #4: check that testedObject is not tagged \n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetTag, jvmti, testedObject, &tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetTag(testedObject, &tag))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -174,7 +169,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
 
     NSK_DISPLAY0("Testcase #5: check that testedObject is not tagged\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetTag, jvmti, testedObject, &tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetTag(testedObject, &tag))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -184,7 +179,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             jlong_to_string(tag, buffer));
         nsk_jvmti_setFailStatus();
     }
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedObject));
+    NSK_TRACE(jni->DeleteGlobalRef(testedObject));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -222,7 +217,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_tag_objects = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t001/ma04t001a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t001/ma04t001a.cpp
@@ -53,22 +53,18 @@ static int prepare(JNIEnv* jni) {
     NSK_DISPLAY0("Obtain tested object from a static field of debugee class\n");
 
     NSK_DISPLAY1("Find class: %s\n", CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY2("Find field: %s:%s\n", FIELD_NAME, FIELD_SIGNATURE);
     if (!NSK_JNI_VERIFY(jni, (fid =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls,
-                FIELD_NAME, FIELD_SIGNATURE)) != NULL))
+            jni->GetStaticFieldID(cls, FIELD_NAME, FIELD_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fid)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedObject = jni->GetStaticObjectField(cls, fid)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedObject =
-            NSK_CPP_STUB2(NewGlobalRef, jni, testedObject)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedObject = jni->NewGlobalRef(testedObject)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -91,7 +87,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     NSK_DISPLAY0("Testcase #1: check that testedObject is not tagged\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetTag, jvmti, testedObject, &tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetTag(testedObject, &tag))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -107,7 +103,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
 
     NSK_DISPLAY0("Testcase #2: check that testedObject is not tagged\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetTag, jvmti, testedObject, &tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetTag(testedObject, &tag))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -117,8 +113,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             jlong_to_string(tag, buffer));
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, testedObject,
-            SAMPLE_TAG))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(testedObject, SAMPLE_TAG))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -128,7 +123,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
 
     NSK_DISPLAY0("Testcase #3: check that testedObject is tagged correctly\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetTag, jvmti, testedObject, &tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetTag(testedObject, &tag))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -149,7 +144,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
 
     NSK_DISPLAY0("Testcase #4: check that testedObject is tagged correctly\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetTag, jvmti, testedObject, &tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetTag(testedObject, &tag))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -164,7 +159,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
         nsk_jvmti_setFailStatus();
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, testedObject, (jlong)0))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(testedObject, (jlong)0))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -174,7 +169,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         return;
 
     NSK_DISPLAY0("Testcase #5: check that testedObject is not tagged\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetTag, jvmti, testedObject, &tag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetTag(testedObject, &tag))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -184,7 +179,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             jlong_to_string(tag, buffer));
         nsk_jvmti_setFailStatus();
     }
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedObject));
+    NSK_TRACE(jni->DeleteGlobalRef(testedObject));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -222,7 +217,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_tag_objects = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002.cpp
@@ -81,33 +81,28 @@ static int prepare(JNIEnv* jni) {
     NSK_DISPLAY0("Obtain tested object from a static field of debugee class\n");
 
     NSK_DISPLAY1("Find class: %s\n", CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (testedClass =
-            NSK_CPP_STUB2(FindClass, jni, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = jni->FindClass(CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, testedClass)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass) jni->NewGlobalRef(testedClass)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY2("Find field: %s:%s\n", FIELD_NAME, FIELD_SIGNATURE);
     if (!NSK_JNI_VERIFY(jni, (fid =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, testedClass,
-                FIELD_NAME, FIELD_SIGNATURE)) != NULL))
+            jni->GetStaticFieldID(testedClass, FIELD_NAME, FIELD_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, testedClass, fid)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedObject = jni->GetStaticObjectField(testedClass, fid)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY2("Find class instance: %s:%s\n",
         INSTANCE_NAME, INSTANCE_SIGNATURE);
     if (!NSK_JNI_VERIFY(jni, (fid =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, testedClass,
-                INSTANCE_NAME, INSTANCE_SIGNATURE)) != NULL))
+            jni->GetStaticFieldID(testedClass, INSTANCE_NAME, INSTANCE_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (testedInstance =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, testedClass, fid)) != NULL))
+            jni->GetStaticObjectField(testedClass, fid)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -131,8 +126,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     NSK_DISPLAY0("Testcase #1: check that there are no tagged objects\n");
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(IterateOverHeap, jvmti,
-            JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -144,8 +138,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(IterateOverHeap, jvmti,
-            JVMTI_HEAP_OBJECT_TAGGED, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, heap_object_callback, &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -157,8 +150,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-            testedClass, JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(testedClass,
+                                                             JVMTI_HEAP_OBJECT_EITHER,
+                                                             heap_object_callback,
+                                                             &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -170,8 +165,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-            testedClass, JVMTI_HEAP_OBJECT_TAGGED, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(testedClass,
+                                                             JVMTI_HEAP_OBJECT_TAGGED,
+                                                             heap_object_callback,
+                                                             &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -182,8 +179,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, testedObject,
-            SAMPLE_TAG))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(testedObject, SAMPLE_TAG))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -197,8 +193,8 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     NSK_DISPLAY0("Testcase #2: check that there is only one object tagged\n");
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(IterateOverHeap, jvmti,
-            JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -209,8 +205,8 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(IterateOverHeap, jvmti,
-            JVMTI_HEAP_OBJECT_TAGGED, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(
+            jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, heap_object_callback, &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -221,8 +217,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(IterateOverHeap, jvmti,
-            JVMTI_HEAP_OBJECT_UNTAGGED, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_UNTAGGED, heap_object_callback, &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -233,8 +228,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, testedInstance,
-            SAMPLE_TAG))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(testedInstance, SAMPLE_TAG))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -248,8 +242,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     NSK_DISPLAY0("Testcase #3: check that there is only one class object tagged\n");
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-            testedClass, JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(testedClass,
+                                                             JVMTI_HEAP_OBJECT_EITHER,
+                                                             heap_object_callback,
+                                                             &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -261,8 +257,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-            testedClass, JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(testedClass,
+                                                             JVMTI_HEAP_OBJECT_EITHER,
+                                                             heap_object_callback,
+                                                             &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -274,8 +272,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(IterateOverHeap, jvmti,
-            JVMTI_HEAP_OBJECT_UNTAGGED, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_UNTAGGED, heap_object_callback, &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -287,7 +284,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass));
+    NSK_TRACE(jni->DeleteGlobalRef(testedClass));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -326,7 +323,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(caps));
     caps.can_tag_objects = 1;
     caps.can_generate_object_free_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 
@@ -337,8 +334,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t002/ma04t002a.cpp
@@ -81,33 +81,28 @@ static int prepare(JNIEnv* jni) {
     NSK_DISPLAY0("Obtain tested object from a static field of debugee class\n");
 
     NSK_DISPLAY1("Find class: %s\n", CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (testedClass =
-            NSK_CPP_STUB2(FindClass, jni, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = jni->FindClass(CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, testedClass)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass) jni->NewGlobalRef(testedClass)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY2("Find field: %s:%s\n", FIELD_NAME, FIELD_SIGNATURE);
     if (!NSK_JNI_VERIFY(jni, (fid =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, testedClass,
-                FIELD_NAME, FIELD_SIGNATURE)) != NULL))
+            jni->GetStaticFieldID(testedClass, FIELD_NAME, FIELD_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, testedClass, fid)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedObject = jni->GetStaticObjectField(testedClass, fid)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY2("Find class instance: %s:%s\n",
         INSTANCE_NAME, INSTANCE_SIGNATURE);
     if (!NSK_JNI_VERIFY(jni, (fid =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, testedClass,
-                INSTANCE_NAME, INSTANCE_SIGNATURE)) != NULL))
+            jni->GetStaticFieldID(testedClass, INSTANCE_NAME, INSTANCE_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (testedInstance =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, testedClass, fid)) != NULL))
+            jni->GetStaticObjectField(testedClass, fid)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -131,8 +126,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     NSK_DISPLAY0("Testcase #1: check that there are no tagged objects\n");
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(IterateOverHeap, jvmti,
-            JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -144,8 +138,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(IterateOverHeap, jvmti,
-            JVMTI_HEAP_OBJECT_TAGGED, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, heap_object_callback, &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -157,8 +150,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-            testedClass, JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(testedClass,
+                                                             JVMTI_HEAP_OBJECT_EITHER,
+                                                             heap_object_callback,
+                                                             &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -170,8 +165,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-            testedClass, JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(testedClass,
+                                                             JVMTI_HEAP_OBJECT_EITHER,
+                                                             heap_object_callback,
+                                                             &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -182,8 +179,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, testedObject,
-            SAMPLE_TAG))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(testedObject, SAMPLE_TAG))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -197,8 +193,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     NSK_DISPLAY0("Testcase #2: check that there is only one object tagged\n");
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(IterateOverHeap, jvmti,
-            JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -209,8 +204,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(IterateOverHeap, jvmti,
-            JVMTI_HEAP_OBJECT_TAGGED, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_TAGGED, heap_object_callback, &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -221,8 +215,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(IterateOverHeap, jvmti,
-            JVMTI_HEAP_OBJECT_UNTAGGED, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_UNTAGGED, heap_object_callback, &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -233,8 +226,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, testedInstance,
-            SAMPLE_TAG))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(testedInstance, SAMPLE_TAG))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -248,8 +240,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     NSK_DISPLAY0("Testcase #3: check that there is only one class object tagged\n");
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-            testedClass, JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(testedClass,
+                                                             JVMTI_HEAP_OBJECT_EITHER,
+                                                             heap_object_callback,
+                                                             &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -261,8 +255,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(IterateOverInstancesOfClass, jvmti,
-            testedClass, JVMTI_HEAP_OBJECT_EITHER, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverInstancesOfClass(testedClass,
+                                                             JVMTI_HEAP_OBJECT_EITHER,
+                                                             heap_object_callback,
+                                                             &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -274,8 +270,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     ObjectsCount = 0;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(IterateOverHeap, jvmti,
-            JVMTI_HEAP_OBJECT_UNTAGGED, heap_object_callback, &dummy))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->IterateOverHeap(JVMTI_HEAP_OBJECT_UNTAGGED, heap_object_callback, &dummy))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -287,7 +282,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass));
+    NSK_TRACE(jni->DeleteGlobalRef(testedClass));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -326,7 +321,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(caps));
     caps.can_tag_objects = 1;
     caps.can_generate_object_free_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 
@@ -337,8 +332,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t003/ma04t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t003/ma04t003.cpp
@@ -88,22 +88,18 @@ static int prepare(JNIEnv* jni) {
     NSK_DISPLAY0("Obtain tested object from a static field of debugee class\n");
 
     NSK_DISPLAY1("Find class: %s\n", CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY2("Find field: %s:%s\n", FIELD_NAME, FIELD_SIGNATURE);
     if (!NSK_JNI_VERIFY(jni, (fid =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls,
-                FIELD_NAME, FIELD_SIGNATURE)) != NULL))
+            jni->GetStaticFieldID(cls, FIELD_NAME, FIELD_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fid)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedObject = jni->GetStaticObjectField(cls, fid)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedObject =
-            NSK_CPP_STUB2(NewGlobalRef, jni, testedObject)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedObject = jni->NewGlobalRef(testedObject)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -124,13 +120,12 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     NSK_DISPLAY0("Set tag on testedObject\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, testedObject,
-            SAMPLE_TAG))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(testedObject, SAMPLE_TAG))) {
         nsk_jvmti_setFailStatus();
         return;
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedObject));
+    NSK_TRACE(jni->DeleteGlobalRef(testedObject));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -169,7 +164,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(caps));
     caps.can_tag_objects = 1;
     caps.can_generate_object_free_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 
@@ -182,12 +177,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t003/ma04t003a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA04/ma04t003/ma04t003a.cpp
@@ -88,22 +88,18 @@ static int prepare(JNIEnv* jni) {
     NSK_DISPLAY0("Obtain tested object from a static field of debugee class\n");
 
     NSK_DISPLAY1("Find class: %s\n", CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     NSK_DISPLAY2("Find field: %s:%s\n", FIELD_NAME, FIELD_SIGNATURE);
     if (!NSK_JNI_VERIFY(jni, (fid =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, cls,
-                FIELD_NAME, FIELD_SIGNATURE)) != NULL))
+            jni->GetStaticFieldID(cls, FIELD_NAME, FIELD_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, cls, fid)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedObject = jni->GetStaticObjectField(cls, fid)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedObject =
-            NSK_CPP_STUB2(NewGlobalRef, jni, testedObject)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedObject = jni->NewGlobalRef(testedObject)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -124,13 +120,12 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     NSK_DISPLAY0("Set tag on testedObject\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, testedObject,
-            SAMPLE_TAG))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(testedObject, SAMPLE_TAG))) {
         nsk_jvmti_setFailStatus();
         return;
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedObject));
+    NSK_TRACE(jni->DeleteGlobalRef(testedObject));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -169,7 +164,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(caps));
     caps.can_tag_objects = 1;
     caps.can_generate_object_free_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 
@@ -182,12 +177,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_OBJECT_FREE, NULL)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA05/ma05t001/ma05t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA05/ma05t001/ma05t001.cpp
@@ -54,17 +54,16 @@ Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     char *signature = NULL;
 
     BreakpointEventsCount++;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
     }
 
     NSK_DISPLAY2("Breakpoint event: %s%s\n", name, signature);
 
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 
     switch(BreakpointEventsCount) {
     case 1:
@@ -85,8 +84,7 @@ Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
         break;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-        NSK_CPP_STUB3(NotifyFramePop, jvmti_env, thread, 0))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->NotifyFramePop(thread, 0))) {
         nsk_jvmti_setFailStatus();
     }
 }
@@ -99,8 +97,7 @@ FramePop(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     char *signature = NULL;
 
     FramePopEventsCount++;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -108,9 +105,9 @@ FramePop(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     NSK_DISPLAY2("FramePop event: %s%s\n", name, signature);
 
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 }
 
 /* ========================================================================== */
@@ -126,8 +123,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -139,8 +135,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -151,15 +146,13 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         }
 
         if (info.name != NULL) {
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                    Deallocate, jvmti, (unsigned char*)info.name)))
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)info.name)))
                 return NSK_FALSE;
         }
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     if (thread == NULL) {
@@ -167,29 +160,24 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         return NSK_FALSE;
     }
 
-    if (!NSK_JNI_VERIFY(jni, (thread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'checkPoint' */
-    if (!NSK_JNI_VERIFY(jni, (method = NSK_CPP_STUB4(
-            GetMethodID, jni, klass, "checkPoint", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "checkPoint", "()V")) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetBreakpoint, jvmti, method, 0)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetBreakpoint(method, 0)))
         return NSK_FALSE;
 
     /* enable events */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL)))
         return NSK_FALSE;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_FRAME_POP, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_FRAME_POP, NULL)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -224,12 +212,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_DISABLE, JVMTI_EVENT_FRAME_POP, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_FRAME_POP, NULL)))
         nsk_jvmti_setFailStatus();
 
-    NSK_TRACE(NSK_CPP_STUB3(ClearBreakpoint, jvmti, method, 0));
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, thread));
+    NSK_TRACE(jvmti->ClearBreakpoint(method, 0));
+    NSK_TRACE(jni->DeleteGlobalRef(thread));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -268,7 +255,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_breakpoint_events = 1;
     caps.can_generate_frame_pop_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     if (!NSK_VERIFY(nsk_jvmti_setAgentProc(agentProc, NULL)))

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA05/ma05t001/ma05t001a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA05/ma05t001/ma05t001a.cpp
@@ -57,8 +57,7 @@ MethodEntry(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
         return;
 
     MethodEntryEventsCount++;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -66,15 +65,14 @@ MethodEntry(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     NSK_DISPLAY2("MethodEntry event: %s%s\n", name, signature);
 
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 
     switch(MethodEntryEventsCount) {
     case 1:
         NSK_DISPLAY0("Testcase #1: FramePop in both agents\n");
-        if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(NotifyFramePop, jvmti_env, thread, 0)))
+        if (!NSK_JVMTI_VERIFY(jvmti_env->NotifyFramePop(thread, 0)))
             nsk_jvmti_setFailStatus();
         break;
 
@@ -84,11 +82,9 @@ MethodEntry(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
 
     case 3:
         NSK_DISPLAY0("Testcase #3: FramePop disabled in 2nd agent\n");
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-                jvmti_env, JVMTI_DISABLE, JVMTI_EVENT_FRAME_POP, NULL)))
+        if (!NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_FRAME_POP, NULL)))
             nsk_jvmti_setFailStatus();
-        if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(NotifyFramePop, jvmti_env, thread, 0)))
+        if (!NSK_JVMTI_VERIFY(jvmti_env->NotifyFramePop(thread, 0)))
             nsk_jvmti_setFailStatus();
         break;
 
@@ -107,8 +103,7 @@ FramePop(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     char *signature = NULL;
 
     FramePopEventsCount++;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &name, &signature, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &name, &signature, NULL))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -116,9 +111,9 @@ FramePop(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
     NSK_DISPLAY2("FramePop event: %s%s\n", name, signature);
 
     if (name != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)name);
+        jvmti_env->Deallocate((unsigned char*)name);
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti_env, (unsigned char*)signature);
+        jvmti_env->Deallocate((unsigned char*)signature);
 
     switch(MethodEntryEventsCount) {
     case 1:
@@ -155,8 +150,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare: find tested thread\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -168,8 +162,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -180,15 +173,13 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         }
 
         if (info.name != NULL) {
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(
-                    Deallocate, jvmti, (unsigned char*)info.name)))
+            if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)info.name)))
                 return NSK_FALSE;
         }
     }
 
     /* deallocate threads list */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     if (thread == NULL) {
@@ -196,26 +187,21 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         return NSK_FALSE;
     }
 
-    if (!NSK_JNI_VERIFY(jni, (thread =
-            NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread class */
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(GetObjectClass, jni, thread)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
     /* get tested thread method 'checkPoint' */
-    if (!NSK_JNI_VERIFY(jni, (midCheckPoint = NSK_CPP_STUB4(
-            GetMethodID, jni, klass, "checkPoint", "()V")) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (midCheckPoint = jni->GetMethodID(klass, "checkPoint", "()V")) != NULL))
         return NSK_FALSE;
 
     /* enable events */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, NULL)))
         return NSK_FALSE;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_FRAME_POP, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_FRAME_POP, NULL)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -246,9 +232,8 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         nsk_jvmti_setFailStatus();
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, thread));
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_DISABLE, JVMTI_EVENT_METHOD_ENTRY, NULL)))
+    NSK_TRACE(jni->DeleteGlobalRef(thread));
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_METHOD_ENTRY, NULL)))
         nsk_jvmti_setFailStatus();
 
     if (!nsk_jvmti_resumeSync())
@@ -288,7 +273,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_method_entry_events = 1;
     caps.can_generate_frame_pop_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     if (!NSK_VERIFY(nsk_jvmti_setAgentProc(agentProc, NULL)))

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA06/ma06t001/ma06t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA06/ma06t001/ma06t001.cpp
@@ -65,8 +65,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
 
         if (class_being_redefined == NULL) {
             /* sent by class load */
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate,
-                    jvmti_env, class_data_len, &klass_bytes)))
+            if (!NSK_JVMTI_VERIFY(jvmti_env->Allocate(class_data_len, &klass_bytes)))
                 nsk_jvmti_setFailStatus();
             else {
                 memcpy(klass_bytes, class_data, class_data_len);
@@ -94,12 +93,10 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
 static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
 
     NSK_DISPLAY1("Find class: %s\n", CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (testedClass =
-            NSK_CPP_STUB2(FindClass, jni, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = jni->FindClass(CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, testedClass)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass) jni->NewGlobalRef(testedClass)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -126,7 +123,7 @@ static int redefine(jvmtiEnv* jvmti, jint value) {
     class_def.klass = testedClass;
     class_def.class_byte_count = klass_byte_count;
     class_def.class_bytes = klass_bytes;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -181,11 +178,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         nsk_jvmti_setFailStatus();
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass));
+    NSK_TRACE(jni->DeleteGlobalRef(testedClass));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -223,7 +219,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_redefine_classes = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     if (!NSK_VERIFY(nsk_jvmti_setAgentProc(agentProc, NULL)))
@@ -234,8 +230,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA06/ma06t001/ma06t001a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA06/ma06t001/ma06t001a.cpp
@@ -65,8 +65,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
 
         if (class_being_redefined == NULL) {
             /* sent by class load */
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate,
-                    jvmti_env, class_data_len, &klass_bytes)))
+            if (!NSK_JVMTI_VERIFY(jvmti_env->Allocate(class_data_len, &klass_bytes)))
                 nsk_jvmti_setFailStatus();
             else {
                 memcpy(klass_bytes, class_data, class_data_len);
@@ -94,12 +93,10 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
 static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
 
     NSK_DISPLAY1("Find class: %s\n", CLASS_NAME);
-    if (!NSK_JNI_VERIFY(jni, (testedClass =
-            NSK_CPP_STUB2(FindClass, jni, CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = jni->FindClass(CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass)
-            NSK_CPP_STUB2(NewGlobalRef, jni, testedClass)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (testedClass = (jclass) jni->NewGlobalRef(testedClass)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -126,7 +123,7 @@ static int redefine(jvmtiEnv* jvmti, jint value) {
     class_def.klass = testedClass;
     class_def.class_byte_count = klass_byte_count;
     class_def.class_bytes = klass_bytes;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RedefineClasses, jvmti, 1, &class_def)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &class_def)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -181,11 +178,10 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         nsk_jvmti_setFailStatus();
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedClass));
+    NSK_TRACE(jni->DeleteGlobalRef(testedClass));
 
     if (!nsk_jvmti_resumeSync())
         return;
@@ -223,7 +219,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_redefine_classes = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
     if (!NSK_VERIFY(nsk_jvmti_setAgentProc(agentProc, NULL)))
@@ -234,8 +230,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA07/ma07t001/ma07t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA07/ma07t001/ma07t001.cpp
@@ -71,8 +71,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
             return;
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate,
-                jvmti_env, class_data_len, &klass_bytes)))
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Allocate(class_data_len, &klass_bytes)))
             nsk_jvmti_setFailStatus();
 
         else {
@@ -174,8 +173,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA07/ma07t001/ma07t001a.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/multienv/MA07/ma07t001/ma07t001a.cpp
@@ -71,8 +71,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti_env, JNIEnv *jni_env,
             return;
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(Allocate,
-                jvmti_env, class_data_len, &klass_bytes)))
+        if (!NSK_JVMTI_VERIFY(jvmti_env->Allocate(class_data_len, &klass_bytes)))
             nsk_jvmti_setFailStatus();
 
         else {
@@ -175,8 +174,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     if (!NSK_VERIFY(nsk_jvmti_init_MA(&callbacks)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
 
     return JNI_OK;


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211899](https://bugs.openjdk.java.net/browse/JDK-8211899): Remove the NSK_CPP_STUB macros from vmTestbase for jvmti/scenarios/[E-M]


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/670/head:pull/670` \
`$ git checkout pull/670`

Update a local copy of the PR: \
`$ git checkout pull/670` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/670/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 670`

View PR using the GUI difftool: \
`$ git pr show -t 670`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/670.diff">https://git.openjdk.java.net/jdk11u-dev/pull/670.diff</a>

</details>
