### PR TITLE
8212148: Remove remaining NSK_CPP_STUBs

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetVerboseFlag/setvrbflag001/setvrbflag001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetVerboseFlag/setvrbflag001/setvrbflag001.cpp
@@ -43,36 +43,28 @@ static jvmtiPhase phase;
 /* Check SetVerboseFlag function
  */
 static int checkSetVerboseFlag(jvmtiEnv *jvmti) {
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetVerboseFlag, jvmti, JVMTI_VERBOSE_OTHER, JNI_TRUE)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetVerboseFlag(JVMTI_VERBOSE_OTHER, JNI_TRUE)))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetVerboseFlag, jvmti, JVMTI_VERBOSE_OTHER, JNI_FALSE)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetVerboseFlag(JVMTI_VERBOSE_OTHER, JNI_FALSE)))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetVerboseFlag, jvmti, JVMTI_VERBOSE_GC, JNI_TRUE)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetVerboseFlag(JVMTI_VERBOSE_GC, JNI_TRUE)))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetVerboseFlag, jvmti, JVMTI_VERBOSE_GC, JNI_FALSE)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetVerboseFlag(JVMTI_VERBOSE_GC, JNI_FALSE)))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetVerboseFlag, jvmti, JVMTI_VERBOSE_CLASS, JNI_TRUE)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetVerboseFlag(JVMTI_VERBOSE_CLASS, JNI_TRUE)))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetVerboseFlag, jvmti, JVMTI_VERBOSE_CLASS, JNI_FALSE)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetVerboseFlag(JVMTI_VERBOSE_CLASS, JNI_FALSE)))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetVerboseFlag, jvmti, JVMTI_VERBOSE_JNI, JNI_TRUE)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetVerboseFlag(JVMTI_VERBOSE_JNI, JNI_TRUE)))
         return NSK_FALSE;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetVerboseFlag, jvmti, JVMTI_VERBOSE_JNI, JNI_FALSE)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetVerboseFlag(JVMTI_VERBOSE_JNI, JNI_FALSE)))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -83,7 +75,7 @@ static int checkSetVerboseFlag(jvmtiEnv *jvmti) {
 void JNICALL
 VMInit(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread) {
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY1("Phase: %s\n", TranslatePhase(phase));
@@ -105,10 +97,10 @@ ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
                   unsigned char** new_class_data) {
     jvmtiPhase curr_phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(access_lock)))
         nsk_jvmti_setFailStatus();
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &curr_phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&curr_phase)))
         nsk_jvmti_setFailStatus();
 
     if (phase != curr_phase) {
@@ -121,7 +113,7 @@ ClassFileLoadHook(jvmtiEnv *jvmti, JNIEnv *jni,
             nsk_jvmti_setFailStatus();
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(access_lock)))
         nsk_jvmti_setFailStatus();
 }
 
@@ -135,7 +127,7 @@ agentProc(jvmtiEnv *jvmti, JNIEnv* jni, void* arg) {
     if (!nsk_jvmti_waitForSync(timeout))
         return;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         nsk_jvmti_setFailStatus();
 
     NSK_DISPLAY1("Phase: %s\n", TranslatePhase(phase));
@@ -181,12 +173,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
 
     /* Create data access lock */
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(CreateRawMonitor, jvmti,
-                "_access_lock", &access_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_access_lock", &access_lock)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         return JNI_ERR;
 
     NSK_DISPLAY1("Phase: %s\n", TranslatePhase(phase));
@@ -199,21 +189,17 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.VMInit = &VMInit;
     callbacks.ClassFileLoadHook = &ClassFileLoadHook;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* enable VMInit event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_VM_INIT, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL)))
         return JNI_ERR;
 
     /* enable ClassFileLoadHook event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetVerboseFlag/setvrbflag002/setvrbflag002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetVerboseFlag/setvrbflag002/setvrbflag002.cpp
@@ -47,8 +47,7 @@ agentProc(jvmtiEnv *jvmti, JNIEnv* jni, void* arg) {
 
     NSK_DISPLAY0("Check on JVMTI_ERROR_ILLEGAL_ARGUMENT\n");
     if (!NSK_JVMTI_VERIFY_CODE(JVMTI_ERROR_ILLEGAL_ARGUMENT,
-            NSK_CPP_STUB3(SetVerboseFlag, jvmti,
-                (jvmtiVerboseFlag)(-1), JNI_TRUE)))
+            jvmti->SetVerboseFlag((jvmtiVerboseFlag)(-1), JNI_TRUE)))
         nsk_jvmti_setFailStatus();
 
     /* resume debugee after last sync */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SingleStep/singlestep001/singlestep001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SingleStep/singlestep001/singlestep001.cpp
@@ -63,15 +63,11 @@ static jrawMonitorID agent_lock;
 static void setBP(jvmtiEnv *jvmti_env, JNIEnv *env, jclass klass) {
     jmethodID mid;
 
-    if (!NSK_JNI_VERIFY(env, (mid = NSK_CPP_STUB4(GetMethodID,
-            env, klass, METHODS[0], METHOD_SIGS[0])) != NULL))
-        NSK_CPP_STUB2(FatalError, env,
-            "failed to get ID for the java method\n");
+    if (!NSK_JNI_VERIFY(env, (mid = env->GetMethodID(klass, METHODS[0], METHOD_SIGS[0])) != NULL))
+        env->FatalError("failed to get ID for the java method\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetBreakpoint,
-            jvmti_env, mid, 0)))
-        NSK_CPP_STUB2(FatalError, env,
-            "failed to set breakpoint\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->SetBreakpoint(mid, 0)))
+        env->FatalError("failed to set breakpoint\n");
 }
 
 /** callback functions **/
@@ -82,10 +78,8 @@ ClassLoad(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread, jclass klass) {
     jvmti->RawMonitorEnter(agent_lock);
 
     if (vm_started) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-                                            jvmti_env, klass, &sig, &generic)))
-            NSK_CPP_STUB2(FatalError, env,
-                          "failed to obtain a class signature\n");
+        if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &sig, &generic)))
+            env->FatalError("failed to obtain a class signature\n");
 
         if (sig != NULL && (strcmp(sig, CLASS_SIG) == 0)) {
             NSK_DISPLAY1(
@@ -106,20 +100,16 @@ Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr, jmethodID method,
     char *sig, *generic;
 
     NSK_DISPLAY0("Breakpoint event received\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-            jvmti_env, method, &klass)))
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(method, &klass)))
         NSK_COMPLAIN0("TEST FAILURE: unable to get method declaring class\n\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-            jvmti_env, klass, &sig, &generic)))
-        NSK_CPP_STUB2(FatalError, env,
-            "Breakpoint: failed to obtain a class signature\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &sig, &generic)))
+        env->FatalError("Breakpoint: failed to obtain a class signature\n");
 
     if (sig != NULL && (strcmp(sig, CLASS_SIG) == 0)) {
         NSK_DISPLAY1("method declaring class \"%s\"\n\tenabling SingleStep events ...\n",
             sig);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-                jvmti_env, JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, thr))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, thr))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN0("TEST FAILURE: cannot enable SingleStep events\n\n");
         }
@@ -142,20 +132,17 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     NSK_DISPLAY0(">>>> SingleStep event received\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &methNam, &methSig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &methNam, &methSig, NULL))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to get method name during SingleStep callback\n\n");
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-            jvmti_env, method, &klass))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(method, &klass))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to get method declaring class during SingleStep callback\n\n");
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-            jvmti_env, klass, &sig, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &sig, &generic))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to obtain a class signature during SingleStep callback\n\n");
         return;
@@ -187,21 +174,18 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
                 "CHECK PASSED: SingleStep event received for the method \"%s\" as expected\n"
                 "\tdisabling the event generation\n",
                 methNam);
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-                    jvmti_env, JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, thread))) {
+            if (!NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, thread))) {
                 result = STATUS_FAILED;
                 NSK_COMPLAIN0("TEST FAILED: cannot disable SingleStep events\n\n");
             }
         }
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) methNam))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methNam))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method name\n\n");
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) methSig))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methSig))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method signature\n\n");
     }
@@ -261,12 +245,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_breakpoint_events = 1;
     caps.can_generate_single_step_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_single_step_events)
@@ -279,24 +261,19 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.Breakpoint = &Breakpoint;
     callbacks.SingleStep = &SingleStep;
     callbacks.VMStart = &VMStart;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_START, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_START, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor,
-            jvmti, "agent lock", &agent_lock)))
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("agent lock", &agent_lock)))
         return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SingleStep/singlestep002/singlestep002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SingleStep/singlestep002/singlestep002.cpp
@@ -50,8 +50,7 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         jmethodID method, jlocation location) {
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase,
-            jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to obtain phase of the VM execution during SingleStep callback\n\n");
     }
@@ -105,12 +104,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     /* add capability to generate compiled method events */
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_single_step_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
 
     if (!caps.can_generate_single_step_events)
@@ -121,16 +118,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.SingleStep = &SingleStep;
     callbacks.VMDeath = &VMDeath;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SingleStep/singlestep003/singlestep003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SingleStep/singlestep003/singlestep003.cpp
@@ -64,15 +64,11 @@ static jvmtiEventCallbacks callbacks;
 static void setBP(jvmtiEnv *jvmti_env, JNIEnv *env, jclass klass) {
     jmethodID mid;
 
-    if (!NSK_JNI_VERIFY(env, (mid = NSK_CPP_STUB4(GetMethodID,
-            env, klass, METHODS[0][0], METHODS[0][1])) != NULL))
-        NSK_CPP_STUB2(FatalError, env,
-            "failed to get ID for the java method\n");
+    if (!NSK_JNI_VERIFY(env, (mid = env->GetMethodID(klass, METHODS[0][0], METHODS[0][1])) != NULL))
+        env->FatalError("failed to get ID for the java method\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetBreakpoint,
-            jvmti_env, mid, 0)))
-        NSK_CPP_STUB2(FatalError, env,
-            "failed to set breakpoint\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->SetBreakpoint(mid, 0)))
+        env->FatalError("failed to set breakpoint\n");
 }
 
 /** callback functions **/
@@ -80,10 +76,8 @@ void JNICALL
 ClassLoad(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread, jclass klass) {
     char *sig, *generic;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-            jvmti_env, klass, &sig, &generic)))
-        NSK_CPP_STUB2(FatalError, env,
-            "failed to obtain a class signature\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &sig, &generic)))
+        env->FatalError("failed to obtain a class signature\n");
 
     if (sig != NULL && (strcmp(sig, CLASS_SIG) == 0)) {
         NSK_DISPLAY1(
@@ -101,20 +95,16 @@ Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr, jmethodID method,
     char *sig, *generic;
 
     NSK_DISPLAY0("Breakpoint event received\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-            jvmti_env, method, &klass)))
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(method, &klass)))
         NSK_COMPLAIN0("TEST FAILURE: unable to get method declaring class\n\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-            jvmti_env, klass, &sig, &generic)))
-        NSK_CPP_STUB2(FatalError, env,
-            "Breakpoint: failed to obtain a class signature\n");
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &sig, &generic)))
+        env->FatalError("Breakpoint: failed to obtain a class signature\n");
 
     if (sig != NULL && (strcmp(sig, CLASS_SIG) == 0)) {
         NSK_DISPLAY1("method declaring class \"%s\"\n\tenabling SingleStep events ...\n",
             sig);
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-                jvmti_env, JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, thr))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, thr))) {
             result = STATUS_FAILED;
             NSK_COMPLAIN0("TEST FAILURE: cannot enable SingleStep events\n\n");
         }
@@ -138,20 +128,17 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
     NSK_DISPLAY0(">>>> SingleStep event received\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(GetMethodName,
-            jvmti_env, method, &methNam, &methSig, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodName(method, &methNam, &methSig, NULL))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to get method name during SingleStep callback\n\n");
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass,
-            jvmti_env, method, &klass))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(method, &klass))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to get method declaring class during SingleStep callback\n\n");
         return;
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature,
-            jvmti_env, klass, &sig, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetClassSignature(klass, &sig, &generic))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to obtain a class signature during SingleStep callback\n\n");
         return;
@@ -186,8 +173,7 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
 
                 if (i == (METH_NUM-1)) {
                     NSK_DISPLAY0("Disabling the single step event generation\n");
-                    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-                            jvmti_env, JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, thread))) {
+                    if (!NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, thread))) {
                         result = STATUS_FAILED;
                         NSK_COMPLAIN0("TEST FAILED: cannot disable SingleStep events\n\n");
                     }
@@ -196,13 +182,11 @@ SingleStep(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread thread,
         }
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) methNam))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methNam))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method name\n\n");
     }
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate,
-            jvmti_env, (unsigned char*) methSig))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->Deallocate((unsigned char*) methSig))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: unable to deallocate memory pointed to method signature\n\n");
     }
@@ -278,12 +262,10 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     memset(&caps, 0, sizeof(jvmtiCapabilities));
     caps.can_generate_breakpoint_events = 1;
     caps.can_generate_single_step_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps)))
         return JNI_ERR;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities,
-            jvmti, &caps)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps)))
         return JNI_ERR;
     if (!caps.can_generate_single_step_events)
         NSK_DISPLAY0("Warning: generation of single step events is not implemented\n");
@@ -294,16 +276,13 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.ClassLoad = &ClassLoad;
     callbacks.Breakpoint = &Breakpoint;
     callbacks.SingleStep = &SingleStep;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling JVMTI events ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_LOAD, NULL)))
         return JNI_ERR;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling the events done\n\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/StopThread/stopthrd007/stopthrd007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/StopThread/stopthrd007/stopthrd007.cpp
@@ -62,8 +62,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     NSK_DISPLAY0("Prepare: find tested threads\n");
 
     /* get all live threads */
-    if (!NSK_JVMTI_VERIFY(
-           NSK_CPP_STUB3(GetAllThreads, jvmti, &threads_count, &threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&threads_count, &threads)))
         return NSK_FALSE;
 
     if (!NSK_VERIFY(threads_count > 0 && threads != NULL))
@@ -75,8 +74,7 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
             return NSK_FALSE;
 
         /* get thread information */
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info)))
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info)))
             return NSK_FALSE;
 
         NSK_DISPLAY3("    thread #%d (%s): %p\n", i, info.name, threads[i]);
@@ -93,23 +91,19 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
         }
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads)))
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads)))
         return NSK_FALSE;
 
     NSK_DISPLAY0("Prepare: create new instance of ThreadDeath exception\n");
 
-    if (!NSK_JNI_VERIFY(jni, (cls =
-            NSK_CPP_STUB2(FindClass, jni, THREAD_DEATH_CLASS_NAME)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (cls = jni->FindClass(THREAD_DEATH_CLASS_NAME)) != NULL))
         return NSK_FALSE;
 
     if (!NSK_JNI_VERIFY(jni, (ctor =
-            NSK_CPP_STUB4(GetMethodID, jni, cls,
-                THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
+            jni->GetMethodID(cls, THREAD_DEATH_CTOR_NAME, THREAD_DEATH_CTOR_SIGNATURE)) != NULL))
         return NSK_FALSE;
 
-    if (!NSK_JNI_VERIFY(jni, (threadDeath =
-            NSK_CPP_STUB3(NewObject, jni, cls, ctor)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (threadDeath = jni->NewObject(cls, ctor)) != NULL))
         return NSK_FALSE;
 
     return NSK_TRUE;
@@ -133,8 +127,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!NSK_VERIFY(runningThread != NULL)) {
         nsk_jvmti_setFailStatus();
     } else {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(StopThread,
-                jvmti, runningThread, threadDeath)))
+        if (!NSK_JVMTI_VERIFY(jvmti->StopThread(runningThread, threadDeath)))
             nsk_jvmti_setFailStatus();
     }
 
@@ -142,8 +135,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!NSK_VERIFY(waitingThread != NULL)) {
         nsk_jvmti_setFailStatus();
     } else {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(StopThread,
-                jvmti, waitingThread, threadDeath)))
+        if (!NSK_JVMTI_VERIFY(jvmti->StopThread(waitingThread, threadDeath)))
             nsk_jvmti_setFailStatus();
     }
 
@@ -151,8 +143,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     if (!NSK_VERIFY(sleepingThread != NULL)) {
         nsk_jvmti_setFailStatus();
     } else {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(StopThread,
-                jvmti, sleepingThread, threadDeath)))
+        if (!NSK_JVMTI_VERIFY(jvmti->StopThread(sleepingThread, threadDeath)))
             nsk_jvmti_setFailStatus();
     }
 
@@ -194,7 +185,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_signal_thread = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThread/suspendthrd001/suspendthrd001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThread/suspendthrd001/suspendthrd001.cpp
@@ -58,8 +58,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY1("  ... found thread: %p\n", (void*)testedThread);
 
         NSK_DISPLAY1("Suspend thread: %p\n", (void*)testedThread);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(SuspendThread, jvmti, testedThread))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(testedThread))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -72,8 +71,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         {
             jint state = 0;
 
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetThreadState, jvmti, testedThread, &state))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(testedThread, &state))) {
                 nsk_jvmti_setFailStatus();
             }
             NSK_DISPLAY2("  ... got state vector: %s (%d)\n",
@@ -88,8 +86,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
 
         NSK_DISPLAY1("Resume thread: %p\n", (void*)testedThread);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(ResumeThread, jvmti, testedThread))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(testedThread))) {
             nsk_jvmti_setFailStatus();
         }
 
@@ -98,7 +95,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY0("Delete thread reference\n");
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedThread));
+        NSK_TRACE(jni->DeleteGlobalRef(testedThread));
     }
 
     NSK_DISPLAY0("Let debugee to finish\n");
@@ -139,8 +136,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThread/suspendthrd002/suspendthrd002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThread/suspendthrd002/suspendthrd002.cpp
@@ -75,8 +75,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY1("Suspend thread: %p\n", (void*)testedThread);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(SuspendThread, jvmti, testedThread))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(testedThread))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -104,8 +103,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY1("Resume thread: %p\n", (void*)testedThread);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(ResumeThread, jvmti, testedThread))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(testedThread))) {
             nsk_jvmti_setFailStatus();
         }
 
@@ -114,7 +112,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY0("Delete thread reference\n");
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedThread));
+        NSK_TRACE(jni->DeleteGlobalRef(testedThread));
     }
 
     NSK_DISPLAY0("Let debugee to finish\n");
@@ -129,7 +127,7 @@ JNIEXPORT void JNICALL
 callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     /* check if event is for tested thread */
     if (thread != NULL &&
-                NSK_CPP_STUB3(IsSameObject, jni, testedThread, thread)) {
+                jni->IsSameObject(testedThread, thread)) {
         NSK_DISPLAY1("  ... received THREAD_END event for tested thread: %p\n", (void*)thread);
         eventsReceived++;
     } else {
@@ -170,8 +168,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 
@@ -180,8 +177,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiEventCallbacks callbacks;
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ThreadEnd = callbackThreadEnd;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, sizeof(callbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThread/suspendthrd003/suspendthrd003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThread/suspendthrd003/suspendthrd003.cpp
@@ -63,8 +63,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY1("  ... found thread: %p\n", (void*)testedThread);
 
         NSK_DISPLAY1("Suspend thread: %p\n", (void*)testedThread);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(SuspendThread, jvmti, testedThread))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(testedThread))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -78,8 +77,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         {
             jint state = 0;
 
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetThreadState, jvmti, testedThread, &state))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(testedThread, &state))) {
                 nsk_jvmti_setFailStatus();
             }
             NSK_DISPLAY2("  ... got state vector: %s (%d)\n",
@@ -94,8 +92,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
 
         NSK_DISPLAY1("Resume thread: %p\n", (void*)testedThread);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(ResumeThread, jvmti, testedThread))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(testedThread))) {
             nsk_jvmti_setFailStatus();
         }
         /* Original agentProc test block ends here. */
@@ -107,7 +104,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         for (late_count = 0; late_count < N_LATE_CALLS; late_count++) {
             jvmtiError l_err;
             printf("INFO: Late suspend thread: %p\n", (void*)testedThread);
-            l_err = NSK_CPP_STUB2(SuspendThread, jvmti, testedThread);
+            l_err = jvmti->SuspendThread(testedThread);
             if (l_err != JVMTI_ERROR_NONE) {
                 printf("INFO: Late suspend thread err: %d\n", l_err);
                 // testedThread has exited so we're done with late calls
@@ -117,8 +114,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             // Only resume a thread if suspend worked. Using NSK_DISPLAY1()
             // here because we want ResumeThread() to be faster.
             NSK_DISPLAY1("INFO: Late resume thread: %p\n", (void*)testedThread);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB2(ResumeThread, jvmti, testedThread))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(testedThread))) {
                 nsk_jvmti_setFailStatus();
             }
         }
@@ -137,7 +133,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY0("Delete thread reference\n");
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, testedThread));
+        NSK_TRACE(jni->DeleteGlobalRef(testedThread));
     }
 
     NSK_DISPLAY0("Let debugee to finish\n");
@@ -180,8 +176,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst001/suspendthrdlst001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst001/suspendthrdlst001.cpp
@@ -62,18 +62,16 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         int i;
 
         NSK_DISPLAY1("Allocate threads array: %d threads\n", threadsCount);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti, (threadsCount * sizeof(jthread)),
-                                                (unsigned char**)&threads))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Allocate((threadsCount * sizeof(jthread)),
+                                              (unsigned char**)&threads))) {
             nsk_jvmti_setFailStatus();
             return;
         }
         NSK_DISPLAY1("  ... allocated array: %p\n", (void*)threads);
 
         NSK_DISPLAY1("Allocate results array: %d threads\n", threadsCount);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti, (threadsCount * sizeof(jvmtiError)),
-                                                (unsigned char**)&results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Allocate((threadsCount * sizeof(jvmtiError)),
+                                              (unsigned char**)&results))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -84,8 +82,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY0("Suspend threads list\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SuspendThreadList, jvmti, threadsCount, threads, results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SuspendThreadList(threadsCount, threads, results))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -107,8 +104,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             jint state = 0;
 
             NSK_DISPLAY2("  thread #%d (%p):\n", i, (void*)threads[i]);
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetThreadState, jvmti, threads[i], &state))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(threads[i], &state))) {
                 nsk_jvmti_setFailStatus();
             }
             NSK_DISPLAY2("  ... got state vector: %s (%d)\n",
@@ -123,8 +119,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         }
 
         NSK_DISPLAY0("Resume threads list\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(ResumeThreadList, jvmti, threadsCount, threads, results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThreadList(threadsCount, threads, results))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -136,18 +131,16 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0("Delete threads references\n");
         for (i = 0; i < threadsCount; i++) {
             if (threads[i] != NULL)
-                NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threads[i]));
+                NSK_TRACE(jni->DeleteGlobalRef(threads[i]));
         }
 
         NSK_DISPLAY1("Deallocate threads array: %p\n", (void*)threads);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads))) {
             nsk_jvmti_setFailStatus();
         }
 
         NSK_DISPLAY1("Deallocate results array: %p\n", (void*)results);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)results))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -173,8 +166,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
         foundThreads[i] = NULL;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &count, &threads))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&count, &threads))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -183,8 +175,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
     for (i = 0; i < count; i++) {
         jvmtiThreadInfo info;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info))) {
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -199,8 +190,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
 
     }
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -218,7 +208,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
     NSK_DISPLAY1("Make global references for threads: %d threads\n", foundCount);
     for (i = 0; i < foundCount; i++) {
         if (!NSK_JNI_VERIFY(jni, (foundThreads[i] = (jthread)
-                    NSK_CPP_STUB2(NewGlobalRef, jni, foundThreads[i])) != NULL)) {
+                    jni->NewGlobalRef(foundThreads[i])) != NULL)) {
             nsk_jvmti_setFailStatus();
             return NSK_FALSE;
         }
@@ -266,8 +256,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst002/suspendthrdlst002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThreadList/suspendthrdlst002/suspendthrdlst002.cpp
@@ -73,18 +73,16 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         int i;
 
         NSK_DISPLAY1("Allocate threads array: %d threads\n", threadsCount);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti, (threadsCount * sizeof(jthread)),
-                                                (unsigned char**)&threads))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Allocate((threadsCount * sizeof(jthread)),
+                                              (unsigned char**)&threads))) {
             nsk_jvmti_setFailStatus();
             return;
         }
         NSK_DISPLAY1("  ... allocated array: %p\n", (void*)threads);
 
         NSK_DISPLAY1("Allocate results array: %d threads\n", threadsCount);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(Allocate, jvmti, (threadsCount * sizeof(jvmtiError)),
-                                                (unsigned char**)&results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Allocate((threadsCount * sizeof(jvmtiError)),
+                                              (unsigned char**)&results))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -95,8 +93,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY0("Suspend threads list\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(SuspendThreadList, jvmti, threadsCount, threads, results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SuspendThreadList(threadsCount, threads, results))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -138,8 +135,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
             return;
 
         NSK_DISPLAY0("Resume threads list\n");
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB4(ResumeThreadList, jvmti, threadsCount, threads, results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->ResumeThreadList(threadsCount, threads, results))) {
             nsk_jvmti_setFailStatus();
             return;
         }
@@ -151,18 +147,16 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         NSK_DISPLAY0("Delete threads references\n");
         for (i = 0; i < threadsCount; i++) {
             if (threads[i] != NULL)
-                NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, threads[i]));
+                NSK_TRACE(jni->DeleteGlobalRef(threads[i]));
         }
 
         NSK_DISPLAY1("Deallocate threads array: %p\n", (void*)threads);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads))) {
             nsk_jvmti_setFailStatus();
         }
 
         NSK_DISPLAY1("Deallocate results array: %p\n", (void*)results);
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)results))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)results))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -188,8 +182,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
         foundThreads[i] = NULL;
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(GetAllThreads, jvmti, &count, &threads))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetAllThreads(&count, &threads))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -198,8 +191,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
     for (i = 0; i < count; i++) {
         jvmtiThreadInfo info;
 
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(GetThreadInfo, jvmti, threads[i], &info))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(threads[i], &info))) {
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -214,8 +206,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
 
     }
 
-    if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)threads))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)threads))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -233,7 +224,7 @@ static int fillThreadsByName(jvmtiEnv* jvmti, JNIEnv* jni,
     NSK_DISPLAY1("Make global references for threads: %d threads\n", foundCount);
     for (i = 0; i < foundCount; i++) {
         if (!NSK_JNI_VERIFY(jni, (foundThreads[i] = (jthread)
-                    NSK_CPP_STUB2(NewGlobalRef, jni, foundThreads[i])) != NULL)) {
+                    jni->NewGlobalRef(foundThreads[i])) != NULL)) {
             nsk_jvmti_setFailStatus();
             return NSK_FALSE;
         }
@@ -253,7 +244,7 @@ callbackThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     /* check if event is for tested thread */
     for (i = 0; i < threadsCount; i++) {
         if (thread != NULL &&
-                NSK_CPP_STUB3(IsSameObject, jni, threads[i], thread)) {
+                jni->IsSameObject(threads[i], thread)) {
             NSK_DISPLAY2("  ... received THREAD_END event for thread #%d: %p\n",
                                                                     i, (void*)thread);
             eventsReceived++;
@@ -301,8 +292,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiCapabilities suspendCaps;
         memset(&suspendCaps, 0, sizeof(suspendCaps));
         suspendCaps.can_suspend = 1;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB2(AddCapabilities, jvmti, &suspendCaps)))
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&suspendCaps)))
             return JNI_ERR;
     }
 
@@ -311,8 +301,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         jvmtiEventCallbacks callbacks;
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.ThreadEnd = callbackThreadEnd;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, sizeof(callbacks))))
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadEnd/threadend002/threadend002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadEnd/threadend002/threadend002.cpp
@@ -57,9 +57,7 @@ enableEvent(jvmtiEventMode enable, jvmtiEvent event) {
         NSK_DISPLAY1("disabling %s\n", TranslateEvent(event));
     }
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, enable,
-                                            event, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(enable, event, NULL))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -92,10 +90,7 @@ setCallBacks() {
 
     eventCallbacks.ThreadEnd = cbThreadEnd;
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                &eventCallbacks,
-                                sizeof(eventCallbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks))))
         return NSK_FALSE;
 
     return NSK_TRUE;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadStart/threadstart002/threadstart002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ThreadStart/threadstart002/threadstart002.cpp
@@ -119,17 +119,17 @@ debug_agent(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
     /* Notify VMInit callback as well as ThreadStart callback (if any)
      * that agent thread has been started
      */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, agent_start_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(agent_start_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("[agent] failed to acquire agent_start_lock\n");
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorNotifyAll, jvmti, agent_start_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorNotifyAll(agent_start_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("[agent] failed to notify about agent_start_lock\n");
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, agent_start_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(agent_start_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("[agent] failed to release agent_start_lock\n");
     }
@@ -138,7 +138,7 @@ debug_agent(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
 
     debug_agent_started = JNI_TRUE;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, thr_start_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(thr_start_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("[agent] failed to enter thr_start_lock\n");
     }
@@ -147,7 +147,7 @@ debug_agent(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
 
         if (next_thread == NULL ) {
             /* wait till new thread will be created and started */
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RawMonitorWait, jvmti, thr_start_lock, (jlong)0))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorWait(thr_start_lock, (jlong)0))) {
                 result = STATUS_FAILED;
                 NSK_COMPLAIN0("[agent] Failed while waiting thr_start_lock\n");
             }
@@ -155,9 +155,9 @@ debug_agent(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
 
         if (next_thread != NULL) {
             /* hmm, why NewGlobalRef is called one more time???
-             * next_thread = NSK_CPP_STUB2(NewGlobalRef, env, next_thread);
+             * next_thread = env->NewGlobalRef(next_thread);
              */
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(SuspendThread, jvmti, next_thread))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->SuspendThread(next_thread))) {
                 result = STATUS_FAILED;
                 NSK_COMPLAIN1("[agent] Failed to suspend thread#%d\n", eventsCount);
             }
@@ -165,17 +165,17 @@ debug_agent(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
             NSK_DISPLAY2(">>> [agent] thread#%d %s suspended ...\n", eventsCount, inf.name);
 
             /* these dummy calls provoke VM to hang */
-            temp = NSK_CPP_STUB2(NewGlobalRef, env, next_thread);
-            NSK_CPP_STUB2(DeleteGlobalRef, env, temp);
+            temp = env->NewGlobalRef(next_thread);
+            env->DeleteGlobalRef(temp);
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(ResumeThread, jvmti, next_thread))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->ResumeThread(next_thread))) {
                 result = STATUS_FAILED;
                 NSK_COMPLAIN1("[agent] Failed to resume thread#%d\n", eventsCount);
             }
 
             NSK_DISPLAY2(">>> [agent] thread#%d %s resumed ...\n", eventsCount, inf.name);
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadState, jvmti, next_thread, &thrStat))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->GetThreadState(next_thread, &thrStat))) {
                 result = STATUS_FAILED;
                 NSK_COMPLAIN1("[agent] Failed to get thread state for thread#%d\n", eventsCount);
             }
@@ -185,26 +185,26 @@ debug_agent(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
 
             if (thrStat & JVMTI_THREAD_STATE_SUSPENDED) {
                 NSK_COMPLAIN1("[agent] \"%s\" was not resumed\n", inf.name);
-                NSK_CPP_STUB2(FatalError, env, "[agent] could not recover");
+                env->FatalError("[agent] could not recover");
             }
 
-            NSK_CPP_STUB2(DeleteGlobalRef, env, next_thread);
+            env->DeleteGlobalRef(next_thread);
             next_thread = NULL;
 
             /* Notify ThreadStart callback that thread has been resumed */
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti, thr_resume_lock))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorEnter(thr_resume_lock))) {
                 NSK_COMPLAIN0("[agent] Failed to acquire thr_resume_lock\n");
                 result = STATUS_FAILED;
             }
 
             debug_agent_timed_out = JNI_FALSE;
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorNotify, jvmti, thr_resume_lock))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorNotify(thr_resume_lock))) {
                 NSK_COMPLAIN0("[agent] Failed to notifing about thr_resume_lock\n");
                 result = STATUS_FAILED;
             }
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, thr_resume_lock))) {
+            if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(thr_resume_lock))) {
                 NSK_COMPLAIN0("[agent] Failed to release thr_resume_lock\n");
                 result = STATUS_FAILED;
             }
@@ -215,7 +215,7 @@ debug_agent(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
      * We don't call RawMonitorExit(thr_start_lock) in the loop so we don't
      * lose any notify calls.
      */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti, thr_start_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->RawMonitorExit(thr_start_lock))) {
         NSK_COMPLAIN0("[agent] Failed to release thr_start_lock\n");
         result = STATUS_FAILED;
     }
@@ -230,7 +230,7 @@ void JNICALL ThreadStart(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread) {
     NSK_DISPLAY0(">>> [ThreadStart hook] start\n");
 
     /* skip if thread is 'agent thread' */
-    if (NSK_CPP_STUB3(IsSameObject, env, agent_thread, thread) == JNI_TRUE) {
+    if (env->IsSameObject(agent_thread, thread) == JNI_TRUE) {
         NSK_DISPLAY0(">>> [ThreadStart hook] skip agent thread\n");
         NSK_DISPLAY0(">>> [ThreadStart hook] end\n");
         return;
@@ -240,7 +240,7 @@ void JNICALL ThreadStart(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread) {
      * (otherwise can fail while waiting on thr_resume_thread due to timeout)
      */
     if (debug_agent_started != JNI_TRUE) {
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti_env, agent_start_lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(agent_start_lock))) {
             NSK_COMPLAIN0("[ThreadStart hook] Failed to acquire agent_start_lock\n");
             result = STATUS_FAILED;
         }
@@ -248,14 +248,13 @@ void JNICALL ThreadStart(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread) {
         while (debug_agent_started != JNI_TRUE) {
             NSK_DISPLAY1(">>> [ThreadStart hook] waiting %dms for agent thread to start\n", WAIT_TIME);
 
-            if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RawMonitorWait,
-                    jvmti_env, agent_start_lock, (jlong)WAIT_TIME))) {
+            if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorWait(agent_start_lock, (jlong)WAIT_TIME))) {
                 NSK_COMPLAIN0("[ThreadStart hook] Failed to wait for agent_start_lock\n");
                 result = STATUS_FAILED;
             }
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti_env, agent_start_lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(agent_start_lock))) {
             NSK_COMPLAIN0("[ThreadStart hook] Failed to release agent_start_lock\n");
             result = STATUS_FAILED;
         }
@@ -263,7 +262,7 @@ void JNICALL ThreadStart(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread) {
 
 
     /* get JVMTI phase */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti_env, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->GetPhase(&phase))) {
         NSK_COMPLAIN0("[ThreadStart hook] Failed to get JVMTI phase\n");
         result = STATUS_FAILED;
     }
@@ -271,7 +270,7 @@ void JNICALL ThreadStart(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread) {
     /* Acquire event lock,
      * so only one StartThread callback could be proceeded at the time
      */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti_env, thr_event_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(thr_event_lock))) {
         NSK_COMPLAIN0("[ThreadStart hook] Failed to acquire thr_event_lock\n");
         result = STATUS_FAILED;
     }
@@ -281,8 +280,7 @@ void JNICALL ThreadStart(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread) {
         inf.name = (char*) "UNKNOWN";
         if (phase == JVMTI_PHASE_LIVE) {
             /* GetThreadInfo may only be called during the live phase */
-            if (!NSK_JVMTI_VERIFY(
-                    NSK_CPP_STUB3(GetThreadInfo, jvmti_env, thread, &inf))) {
+            if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadInfo(thread, &inf))) {
                 NSK_COMPLAIN1("[ThreadStart hook] Failed to get thread infor for thread#%d\n", eventsCount);
                 result = STATUS_FAILED;
             }
@@ -291,7 +289,7 @@ void JNICALL ThreadStart(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread) {
         NSK_DISPLAY2(">>> [ThreadStart hook] thread#%d: %s\n", eventsCount, inf.name);
 
         /* Acquire thr_start_lock */
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti_env, thr_start_lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(thr_start_lock))) {
             NSK_COMPLAIN1("[ThreadStart hook] thread#%d failed to acquire thr_start_lock\n", eventsCount);
             result = STATUS_FAILED;
         }
@@ -299,46 +297,45 @@ void JNICALL ThreadStart(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread) {
             /* Acquire thr_resume_lock before we release thr_start_lock to prevent
              * debug agent from notifying us before we are ready.
          */
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti_env, thr_resume_lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(thr_resume_lock))) {
             NSK_COMPLAIN1("[ThreadStart hook] thread#%d failed to acquire thr_resume_lock\n", eventsCount);
             result = STATUS_FAILED;
         }
 
         /* Store thread */
-        next_thread = NSK_CPP_STUB2(NewGlobalRef, env, thread);
+        next_thread = env->NewGlobalRef(thread);
         debug_agent_timed_out = JNI_TRUE;
 
         /* Notify agent thread about new started thread and let agent thread to work with it */
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorNotify, jvmti_env, thr_start_lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorNotify(thr_start_lock))) {
             NSK_COMPLAIN1("[ThreadStart hook] thread#%d failed to notify about thr_start_lock\n", eventsCount);
             result = STATUS_FAILED;
         }
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti_env, thr_start_lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(thr_start_lock))) {
             NSK_COMPLAIN1("[ThreadStart hook] thread#%d failed to release thr_start_lock\n", eventsCount);
             result = STATUS_FAILED;
         }
 
         /* Wait till this started thread will be resumed by agent thread */
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RawMonitorWait,
-                jvmti_env, thr_resume_lock, (jlong)WAIT_TIME ))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorWait(thr_resume_lock, (jlong)WAIT_TIME ))) {
             NSK_COMPLAIN1("[ThreadStart hook] thread#%d failed while waiting for thr_resume_lock\n", eventsCount);
             result = STATUS_FAILED;
         }
 
         if (debug_agent_timed_out == JNI_TRUE) {
             NSK_COMPLAIN1("[ThreadStart hook] \"%s\": debug agent timed out\n", inf.name);
-            NSK_CPP_STUB2(FatalError, env, "[ThreadStart hook] could not recover");
+            env->FatalError("[ThreadStart hook] could not recover");
         }
 
         /* Release thr_resume_lock lock */
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti_env, thr_resume_lock))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(thr_resume_lock))) {
             NSK_COMPLAIN1("[ThreadStart hook] thread#%d failed to release thr_resume_lock\n", eventsCount);
             result = STATUS_FAILED;
         }
 
         /* check that thread is not in SUSPENDED state */
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadState, jvmti_env, thread, &thrStat))) {
+        if (!NSK_JVMTI_VERIFY(jvmti_env->GetThreadState(thread, &thrStat))) {
             NSK_COMPLAIN1("[ThreadStart hook] Failed to get thread state for thread#%d\n", eventsCount);
             result = STATUS_FAILED;
         }
@@ -348,13 +345,13 @@ void JNICALL ThreadStart(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread) {
 
         if (thrStat & JVMTI_THREAD_STATE_SUSPENDED) {
             NSK_COMPLAIN1("[ThreadStart hook] \"%s\" was self-suspended\n", inf.name);
-            NSK_CPP_STUB2(FatalError, env, "[ThreadStart hook] could not recover");
+            env->FatalError("[ThreadStart hook] could not recover");
         }
 
         eventsCount++;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti_env, thr_event_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(thr_event_lock))) {
         NSK_COMPLAIN0("[ThreadStart hook] Failed to release thr_event_lock\n");
         result = STATUS_FAILED;
     }
@@ -368,37 +365,33 @@ void JNICALL VMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr) {
 
     NSK_DISPLAY0(">>> VMInit event: start\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti_env, JVMTI_ENABLE, JVMTI_EVENT_THREAD_START, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_THREAD_START, NULL))) {
         NSK_COMPLAIN0("TEST FAILED: failed to enable JVMTI_EVENT_THREAD_START\n");
         return;
     }
 
     /* Start agent thread */
-    if (!NSK_VERIFY((cls =
-            NSK_CPP_STUB2(FindClass, env, "java/lang/Thread")) != NULL)) {
+    if (!NSK_VERIFY((cls = env->FindClass("java/lang/Thread")) != NULL)) {
         result = STATUS_FAILED;
             NSK_COMPLAIN0("TEST FAILED: Cannot start agent thread: FindClass() failed\n");
         return;
     }
 
 
-    if (!NSK_VERIFY((mid =
-            NSK_CPP_STUB4(GetMethodID, env, cls, "<init>", "()V")) != NULL)) {
+    if (!NSK_VERIFY((mid = env->GetMethodID(cls, "<init>", "()V")) != NULL)) {
         result = STATUS_FAILED;
             NSK_COMPLAIN0("TEST FAILED: Cannot start agent thread: GetMethodID() failed\n");
         return;
     }
 
 
-    if (!NSK_VERIFY((agent_thread =
-            NSK_CPP_STUB3(NewObject, env, cls, mid)) != NULL)) {
+    if (!NSK_VERIFY((agent_thread = env->NewObject(cls, mid)) != NULL)) {
         result = STATUS_FAILED;
             NSK_COMPLAIN0("Cannot start agent thread: NewObject() failed\n");
         return;
     }
 
-    agent_thread = (jthread) NSK_CPP_STUB2(NewGlobalRef, env, agent_thread);
+    agent_thread = (jthread) env->NewGlobalRef(agent_thread);
     if (agent_thread == NULL) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("Cannot create global reference for agent_thread\n");
@@ -410,23 +403,22 @@ void JNICALL VMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr) {
      * debug_agent from notifying us before we are ready.
      */
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorEnter, jvmti_env, agent_start_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorEnter(agent_start_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: failed to enter agent_start_lock\n");
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB5(RunAgentThread,
-            jvmti_env, agent_thread, debug_agent, NULL, JVMTI_THREAD_NORM_PRIORITY))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RunAgentThread(agent_thread, debug_agent, NULL, JVMTI_THREAD_NORM_PRIORITY))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: failed to create agent thread\n");
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(RawMonitorWait, jvmti_env, agent_start_lock, (jlong)0))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorWait(agent_start_lock, (jlong)0))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: failed to wait agent_start_lock\n");
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(RawMonitorExit, jvmti_env, agent_start_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti_env->RawMonitorExit(agent_start_lock))) {
         result = STATUS_FAILED;
         NSK_COMPLAIN0("TEST FAILED: failed to exit agent_start_lock\n");
     }
@@ -464,17 +456,17 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPotentialCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPotentialCapabilities(&caps))) {
         NSK_COMPLAIN0("TEST FAILED: failed to get potential capabilities\n");
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         NSK_COMPLAIN0("TEST FAILED: failed to add capabilities during agent load\n");
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetCapabilities(&caps))) {
         NSK_COMPLAIN0("TEST FAILED: failed to get capabilities\n");
         return JNI_ERR;
     }
@@ -484,22 +476,22 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     }
 
     /* create raw monitors */
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_agent_start_lock", &agent_start_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_agent_start_lock", &agent_start_lock))) {
         NSK_COMPLAIN0("TEST FAILED: failed to create agent_start_lock\n");
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_thr_event_lock", &thr_event_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_thr_event_lock", &thr_event_lock))) {
         NSK_COMPLAIN0("TEST FAILED: failed to create thr_event_lock\n");
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_thr_start_lock", &thr_start_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_thr_start_lock", &thr_start_lock))) {
         NSK_COMPLAIN0("TEST FAILED: failed to create thr_start_lock\n");
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(CreateRawMonitor, jvmti, "_thr_resume_lock", &thr_resume_lock))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->CreateRawMonitor("_thr_resume_lock", &thr_resume_lock))) {
         NSK_COMPLAIN0("TEST FAILED: failed to create thr_resume_lock\n");
         return JNI_ERR;
     }
@@ -508,19 +500,17 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     callbacks.VMDeath = &VMDeath;
     callbacks.ThreadStart = &ThreadStart;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti, &callbacks, sizeof(callbacks)))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks)))) {
         NSK_COMPLAIN0("TEST FAILED: failed to set event callbacks\n");
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, NULL))) {
         NSK_COMPLAIN0("TEST FAILED: failed to enable JVMTI_EVENT_VM_INIT\n");
         return JNI_ERR;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL))) {
         NSK_COMPLAIN0("TEST FAILED: failed to enable JVMTI_EVENT_VM_DEATH\n");
         return JNI_ERR;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/VMDeath/vmdeath001/vmdeath001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/VMDeath/vmdeath001/vmdeath001.cpp
@@ -48,8 +48,7 @@ VMDeath(jvmtiEnv *jvmti_env, JNIEnv *env) {
 
     NSK_DISPLAY0("CHECK PASSED: VMDeath event received\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase,
-            jvmti, &phase)))
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase)))
         exit(95 + STATUS_FAILED);
 
     if (phase != JVMTI_PHASE_LIVE) {
@@ -88,13 +87,11 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     NSK_DISPLAY0("setting event callbacks ...\n");
     (void) memset(&callbacks, 0, sizeof(callbacks));
     callbacks.VMDeath = &VMDeath;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks,
-            jvmti, &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     NSK_DISPLAY0("setting event callbacks done\nenabling VMDeath event ...\n");
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode,
-            jvmti, JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, NULL)))
         return JNI_ERR;
     NSK_DISPLAY0("enabling VMDeath event done\n");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/VMObjectAlloc/vmobjalloc001/vmobjalloc001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/VMObjectAlloc/vmobjalloc001/vmobjalloc001.cpp
@@ -61,8 +61,7 @@ VMObjectAlloc(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread, jobject object,
 
     eventsCount++;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti,
-            object_klass, &signature, &generic))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetClassSignature(object_klass, &signature, &generic))) {
         nsk_jvmti_setFailStatus();
         return;
     }
@@ -70,10 +69,10 @@ VMObjectAlloc(jvmtiEnv *jvmti, JNIEnv* jni, jthread thread, jobject object,
     NSK_DISPLAY2("VMObjectAlloc: \"%s\", size=%d\n", signature, size);
 
     if (signature != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)signature);
+        jvmti->Deallocate((unsigned char*)signature);
 
     if (generic != NULL)
-        NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)generic);
+        jvmti->Deallocate((unsigned char*)generic);
 
 }
 
@@ -130,21 +129,18 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
     memset(&caps, 0, sizeof(caps));
     caps.can_generate_vm_object_alloc_events = 1;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
         return JNI_ERR;
     }
 
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.VMObjectAlloc= &VMObjectAlloc;
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                &callbacks, sizeof(callbacks))))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&callbacks, sizeof(callbacks))))
         return JNI_ERR;
 
     /* enable VMObjectAlloc event */
     if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB4(SetEventNotificationMode, jvmti, JVMTI_ENABLE,
-                JVMTI_EVENT_VM_OBJECT_ALLOC, NULL)))
+            jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_OBJECT_ALLOC, NULL)))
         return JNI_ERR;
 
     /* register agent proc and arg */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref001/followref001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref001/followref001.cpp
@@ -142,10 +142,8 @@ static int initObjectDescList(jvmtiEnv*    jvmti,
 
     printf("Allocate memory for objects list: %d objects\n", *objectsCount);
     fflush(0);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti,
-                                    (*objectsCount * sizeof(ObjectDesc)),
-                                    (unsigned char**) objectDescList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)),
+                                          (unsigned char**) objectDescList))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -180,8 +178,7 @@ static int getAndTagClasses(jvmtiEnv*    jvmti,
                             jclass*      chainObjectClass)
 {
 
-    if (!NSK_JNI_VERIFY(jni, (*debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (*debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -190,14 +187,12 @@ static int getAndTagClasses(jvmtiEnv*    jvmti,
     fflush(0);
 
     if (!NSK_JNI_VERIFY(jni, (*rootObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, ROOT_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti,
-                                                *rootObjectClass,
-                                                ROOT_CLASS_TAG))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(*rootObjectClass, ROOT_CLASS_TAG))) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -208,14 +203,12 @@ static int getAndTagClasses(jvmtiEnv*    jvmti,
 
 
     if (!NSK_JNI_VERIFY(jni, (*chainObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti,
-                                                *chainObjectClass,
-                                                CHAIN_CLASS_TAG))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(*chainObjectClass, CHAIN_CLASS_TAG))) {
         nsk_jvmti_setFailStatus();
     }
     printf("\nFound chain object class: 0x%p, tag=%ld\n  %s\n",
@@ -241,10 +234,7 @@ static int getFieldsAndObjects(jvmtiEnv*  jvmti,
     jfieldID rootObjectField = NULL;
 
     if (!NSK_JNI_VERIFY(jni, (rootObjectField =
-            NSK_CPP_STUB4(GetStaticFieldID, jni,
-                                            debugeeClass,
-                                            OBJECT_FIELD_NAME,
-                                            ROOT_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -253,9 +243,7 @@ static int getFieldsAndObjects(jvmtiEnv*  jvmti,
     fflush(0);
 
     if (!NSK_JNI_VERIFY(jni, (*reachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                          REACHABLE_CHAIN_FIELD_NAME,
-                          CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -264,9 +252,7 @@ static int getFieldsAndObjects(jvmtiEnv*  jvmti,
     fflush(0);
 
     if (!NSK_JNI_VERIFY(jni, (*unreachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                          UNREACHABLE_CHAIN_FIELD_NAME,
-                          CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -276,8 +262,7 @@ static int getFieldsAndObjects(jvmtiEnv*  jvmti,
     fflush(0);
 
     if (!NSK_JNI_VERIFY(jni, (*nextField =
-            NSK_CPP_STUB4(GetFieldID, jni, chainObjectClass,
-                          NEXT_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(chainObjectClass, NEXT_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -286,16 +271,14 @@ static int getFieldsAndObjects(jvmtiEnv*  jvmti,
     fflush(0);
 
     if (!NSK_JNI_VERIFY(jni, (*rootObjectPtr =
-            NSK_CPP_STUB3(GetStaticObjectField, jni,
-                          debugeeClass, rootObjectField)) != NULL)) {
+            jni->GetStaticObjectField(debugeeClass, rootObjectField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     printf("\nFound root object: 0x%p\n", (void*) *rootObjectPtr);
     fflush(0);
 
-    if (!NSK_JNI_VERIFY(jni, (*rootObjectPtr =
-            NSK_CPP_STUB2(NewGlobalRef, jni, *rootObjectPtr)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (*rootObjectPtr = jni->NewGlobalRef(*rootObjectPtr)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -328,8 +311,7 @@ static int getAndTagChainObjects(
     count--;
     tag++;
 
-    if (!NSK_JNI_VERIFY(jni, (nextObj =
-         NSK_CPP_STUB3(GetObjectField, jni, currObj, refField)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (nextObj = jni->GetObjectField(currObj, refField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -339,7 +321,7 @@ static int getAndTagChainObjects(
         objectDescList[count].exp_found++;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, nextObj, objTag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(nextObj, objTag))) {
         nsk_jvmti_setFailStatus();
     }
     printf("        tag=%-5ld object=0x%p\n", (long)objTag, (void*)nextObj);
@@ -359,7 +341,7 @@ static int getAndTagChainObjects(
         return NSK_FALSE;
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteLocalRef, jni, nextObj));
+    NSK_TRACE(jni->DeleteLocalRef(nextObj));
 
     return NSK_TRUE;
 } /* getAndTagChainObjects */
@@ -411,9 +393,7 @@ static int getAndTagTestedObjects(
     printf("\nObtain and tag chain objects:\n");
     printf("    root tested object:\n");
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti,
-                                                *rootObjectPtr,
-                                                ROOT_OBJECT_TAG))
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(*rootObjectPtr, ROOT_OBJECT_TAG))
     ) {
         nsk_jvmti_setFailStatus();
     }
@@ -531,13 +511,12 @@ static int releaseTestedObjects(jvmtiEnv*   jvmti,
 {
     if (rootObject != NULL) {
         printf("Release object reference to root tested object: 0x%p\n", rootObject);
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, rootObject));
+        NSK_TRACE(jni->DeleteGlobalRef(rootObject));
     }
 
     if (objectDescList != NULL) {
         printf("Deallocate objects list: 0x%p\n", (void*)objectDescList);
-        if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescList))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)objectDescList))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -786,14 +765,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     printf(">>> Start iteration from root tested object: 0x%p\n\n", rootObject);
     fflush(0);
 
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB6(FollowReferences, jvmti,
-                                            (jint)   0,    /* heap_filter    */
-                                            (jclass) NULL, /* class          */
-                                            rootObject,    /* initial_object */
-                                            &heapCallbacks,
-                                            (const void *) &fakeUserData))
-    ) {
+    if (!NSK_JVMTI_VERIFY(jvmti->FollowReferences((jint)   0,    /* heap_filter    */
+                                                  (jclass) NULL, /* class          */
+                                                  rootObject,    /* initial_object */
+                                                  &heapCallbacks,
+                                                  (const void *) &fakeUserData))) {
          nsk_jvmti_setFailStatus();
          return;
     }
@@ -856,7 +832,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref002/followref002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref002/followref002.cpp
@@ -119,8 +119,7 @@ static int getAndTagChainObjects(
     count--;
     tag++;
 
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetObjectField, jni, firstObject, firstField)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->GetObjectField(firstObject, firstField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -130,7 +129,7 @@ static int getAndTagChainObjects(
         objectDescList[count].exp_found++;
     }
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, obj, objTag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(obj, objTag))) {
         nsk_jvmti_setFailStatus();
     }
     printf("        tag=%-5ld object=0x%p\n", (long)objTag, (void*)obj);
@@ -147,7 +146,7 @@ static int getAndTagChainObjects(
         return NSK_FALSE;
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteLocalRef, jni, obj));
+    NSK_TRACE(jni->DeleteLocalRef(obj));
     return NSK_TRUE;
 } /* getAndTagChainObjects */
 
@@ -174,9 +173,8 @@ static int getAndTagTestedObjects(
 
     printf("Allocate memory for objects list: %d objects\n", *objectsCount);
     fflush(0);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (*objectsCount * sizeof(ObjectDesc)),
-                                             (unsigned char**)objectDescList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)),
+                                          (unsigned char**)objectDescList))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -196,8 +194,7 @@ static int getAndTagTestedObjects(
 
     printf("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
     fflush(0);
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -205,14 +202,13 @@ static int getAndTagTestedObjects(
 
     printf("Find root object class: %s\n", ROOT_OBJECT_CLASS_NAME);
     fflush(0);
-    if (!NSK_JNI_VERIFY(jni, (rootObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, ROOT_OBJECT_CLASS_NAME)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (rootObjectClass = jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     printf("  ... found class: 0x%p\n", (void*)rootObjectClass);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, rootObjectClass, rootClassTag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(rootObjectClass, rootClassTag))) {
         nsk_jvmti_setFailStatus();
     }
     printf("        tag=%-5ld rootClass=0x%p\n", (long)rootClassTag, (void*)rootObjectClass);
@@ -220,13 +216,13 @@ static int getAndTagTestedObjects(
     printf("Find chain object class: %s\n", CHAIN_OBJECT_CLASS_NAME);
     fflush(0);
     if (!NSK_JNI_VERIFY(jni, (chainObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     printf("  ... found class: 0x%p\n", (void*)chainObjectClass);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, chainObjectClass, chainClassTag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(chainObjectClass, chainClassTag))) {
         nsk_jvmti_setFailStatus();
     }
     printf("        tag=%-5ld chainClass=0x%p\n", (long)chainClassTag, (void*)chainObjectClass);
@@ -234,8 +230,7 @@ static int getAndTagTestedObjects(
     printf("Find static field in debugee class: %s\n", OBJECT_FIELD_NAME);
     fflush(0);
     if (!NSK_JNI_VERIFY(jni, (objectField =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                            OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -244,8 +239,7 @@ static int getAndTagTestedObjects(
     printf("Find instance field in root object class: %s\n", REACHABLE_CHAIN_FIELD_NAME);
     fflush(0);
     if (!NSK_JNI_VERIFY(jni, (reachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -254,8 +248,7 @@ static int getAndTagTestedObjects(
     printf("Find instance field in root object class: %s\n", UNREACHABLE_CHAIN_FIELD_NAME);
     fflush(0);
     if (!NSK_JNI_VERIFY(jni, (unreachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                          UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -264,8 +257,7 @@ static int getAndTagTestedObjects(
     printf("Find instance field in chain object class: %s\n", TAIL_FIELD_NAME);
     fflush(0);
     if (!NSK_JNI_VERIFY(jni, (tailField =
-            NSK_CPP_STUB4(GetFieldID, jni, chainObjectClass,
-                          TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(chainObjectClass, TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -274,16 +266,14 @@ static int getAndTagTestedObjects(
     printf("Get root object from static field: %s\n", OBJECT_FIELD_NAME);
     fflush(0);
     if (!NSK_JNI_VERIFY(jni, (*rootObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                    objectField)) != NULL)) {
+            jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     printf("  ... got object: 0x%p\n", (void*)*rootObject);
     fflush(0);
 
-    if (!NSK_JNI_VERIFY(jni, (*rootObject =
-            NSK_CPP_STUB2(NewGlobalRef, jni, *rootObject)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (*rootObject = jni->NewGlobalRef(*rootObject)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -293,7 +283,7 @@ static int getAndTagTestedObjects(
 
     printf("    root tested object:\n");
     fflush(0);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, *rootObject, rootObjectTag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(*rootObject, rootObjectTag))) {
         nsk_jvmti_setFailStatus();
     }
     printf("        tag=%-5ld object=0x%p\n", (long)rootObjectTag, (void*)*rootObject);
@@ -406,13 +396,12 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
                                 ObjectDesc* objectDescList, jobject rootObject) {
     if (rootObject != NULL) {
         printf("Release object reference to root tested object: 0x%p\n", rootObject);
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, rootObject));
+        NSK_TRACE(jni->DeleteGlobalRef(rootObject));
     }
 
     if (objectDescList != NULL) {
         printf("Deallocate objects list: 0x%p\n", (void*)objectDescList);
-        if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescList))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)objectDescList))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -645,14 +634,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     fflush(0);
     {
         jint heap_filter = JVMTI_HEAP_FILTER_UNTAGGED | JVMTI_HEAP_FILTER_CLASS_UNTAGGED;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB6(FollowReferences, jvmti,
-                    heap_filter,
-                    (jclass) NULL, /* class          */
-                    rootObject,    /* initial_object */
-                    &heapCallbacks,
-                    (const void *) &fakeUserData)))
-        {
+        if (!NSK_JVMTI_VERIFY(jvmti->FollowReferences(heap_filter,
+                                                      (jclass) NULL, /* class          */
+                                                      rootObject,    /* initial_object */
+                                                      &heapCallbacks,
+                                                      (const void *) &fakeUserData))) {
              nsk_jvmti_setFailStatus();
              return;
         }
@@ -681,14 +667,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         /* This time everythig is filtered out */
         jint heap_filter = JVMTI_HEAP_FILTER_UNTAGGED | JVMTI_HEAP_FILTER_CLASS_UNTAGGED |
                            JVMTI_HEAP_FILTER_TAGGED   | JVMTI_HEAP_FILTER_CLASS_TAGGED;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB6(FollowReferences, jvmti,
-                    heap_filter,
-                    (jclass) NULL, /* class          */
-                    rootObject,    /* initial_object */
-                    &heapCallbacks,
-                    (const void *) &fakeUserData)))
-        {
+        if (!NSK_JVMTI_VERIFY(jvmti->FollowReferences(heap_filter,
+                                                      (jclass) NULL, /* class          */
+                                                      rootObject,    /* initial_object */
+                                                      &heapCallbacks,
+                                                      (const void *) &fakeUserData))) {
              nsk_jvmti_setFailStatus();
              return;
         }
@@ -751,7 +734,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/followref003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/followref003.cpp
@@ -138,15 +138,14 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
     count--;
     tag++;
 
-    if (!NSK_JNI_VERIFY(jni, (obj =
-            NSK_CPP_STUB3(GetObjectField, jni, firstObject, firstField)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (obj = jni->GetObjectField(firstObject, firstField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
 
     objectDescList[count].tag = objTag;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, obj, objTag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(obj, objTag))) {
         nsk_jvmti_setFailStatus();
     }
     printf("        tag=%-5ld object=0x%p\n", (long)objTag, (void*)obj);
@@ -157,7 +156,7 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
         return NSK_FALSE;
     }
 
-    NSK_TRACE(NSK_CPP_STUB2(DeleteLocalRef, jni, obj));
+    NSK_TRACE(jni->DeleteLocalRef(obj));
     return NSK_TRUE;
 }
 
@@ -178,9 +177,8 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     printf("Allocate memory for objects list: %d objects\n", *objectsCount);
     fflush(0);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB3(Allocate, jvmti, (*objectsCount * sizeof(ObjectDesc)),
-                                             (unsigned char**)objectDescList))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)),
+                                          (unsigned char**)objectDescList))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -200,8 +198,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     printf("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
     fflush(0);
-    if (!NSK_JNI_VERIFY(jni, (debugeeClass =
-            NSK_CPP_STUB2(FindClass, jni, DEBUGEE_CLASS_NAME)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -209,14 +206,13 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     printf("Find root object class: %s\n", ROOT_OBJECT_CLASS_NAME);
     fflush(0);
-    if (!NSK_JNI_VERIFY(jni, (rootObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, ROOT_OBJECT_CLASS_NAME)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (rootObjectClass = jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     printf("  ... found class: 0x%p\n", (void*)rootObjectClass);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, rootObjectClass, rootClassTag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(rootObjectClass, rootClassTag))) {
         nsk_jvmti_setFailStatus();
     }
     printf("        tag=%-5ld rootClass=0x%p\n",
@@ -225,14 +221,14 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     printf("Find chain object class: %s\n", CHAIN_OBJECT_CLASS_NAME);
     fflush(0);
     if (!NSK_JNI_VERIFY(jni, (chainObjectClass =
-            NSK_CPP_STUB2(FindClass, jni, CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
+            jni->FindClass(CHAIN_OBJECT_CLASS_NAME)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     printf("  ... found class: 0x%p\n",
            (void*)chainObjectClass);
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, chainObjectClass, chainClassTag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(chainObjectClass, chainClassTag))) {
         nsk_jvmti_setFailStatus();
     }
     printf("        tag=%-5ld chainClass=0x%p\n",
@@ -241,8 +237,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     printf("Find static field in debugee class: %s\n", OBJECT_FIELD_NAME);
     fflush(0);
     if (!NSK_JNI_VERIFY(jni, (objectField =
-            NSK_CPP_STUB4(GetStaticFieldID, jni, debugeeClass,
-                            OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -251,8 +246,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     printf("Find instance field in root object class: %s\n", REACHABLE_CHAIN_FIELD_NAME);
     fflush(0);
     if (!NSK_JNI_VERIFY(jni, (reachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                        REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -261,8 +255,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     printf("Find instance field in root object class: %s\n", UNREACHABLE_CHAIN_FIELD_NAME);
     fflush(0);
     if (!NSK_JNI_VERIFY(jni, (unreachableChainField =
-            NSK_CPP_STUB4(GetFieldID, jni, rootObjectClass,
-                          UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -271,8 +264,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     printf("Find instance field in chain object class: %s\n", TAIL_FIELD_NAME);
     fflush(0);
     if (!NSK_JNI_VERIFY(jni, (tailField =
-            NSK_CPP_STUB4(GetFieldID, jni, chainObjectClass,
-                          TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
+            jni->GetFieldID(chainObjectClass, TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -281,16 +273,14 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     printf("Get root object from static field: %s\n", OBJECT_FIELD_NAME);
     fflush(0);
     if (!NSK_JNI_VERIFY(jni, (*rootObject =
-            NSK_CPP_STUB3(GetStaticObjectField, jni, debugeeClass,
-                                                    objectField)) != NULL)) {
+            jni->GetStaticObjectField(debugeeClass, objectField)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     printf("  ... got object: 0x%p\n", (void*)*rootObject);
     fflush(0);
 
-    if (!NSK_JNI_VERIFY(jni, (*rootObject =
-            NSK_CPP_STUB2(NewGlobalRef, jni, *rootObject)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (*rootObject = jni->NewGlobalRef(*rootObject)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
@@ -300,7 +290,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
 
     printf("    root tested object\n");
     fflush(0);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, *rootObject, rootObjectTag))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->SetTag(*rootObject, rootObjectTag))) {
         nsk_jvmti_setFailStatus();
     }
     printf("        tag=%-5ld object=0x%p\n",
@@ -406,13 +396,12 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
                                 ObjectDesc* objectDescList, jobject rootObject) {
     if (rootObject != NULL) {
         printf("Release object reference to root tested object: 0x%p\n", rootObject);
-        NSK_TRACE(NSK_CPP_STUB2(DeleteGlobalRef, jni, rootObject));
+        NSK_TRACE(jni->DeleteGlobalRef(rootObject));
     }
 
     if (objectDescList != NULL) {
         printf("Deallocate objects list: 0x%p\n", (void*)objectDescList);
-        if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(Deallocate, jvmti, (unsigned char*)objectDescList))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->Deallocate((unsigned char*)objectDescList))) {
             nsk_jvmti_setFailStatus();
         }
     }
@@ -949,14 +938,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     printf("\n\n>>> Start 1-st iteration starting from the heap root\n");
     fflush(0);
     {
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB6(FollowReferences, jvmti,
-                    (jint)   0,     /* heap_filter    */
-                    (jclass)  NULL, /* class          */
-                    (jobject) NULL, /* initial_object */
-                    &heapCallbacks,
-                    (const void *) &fakeUserData)))
-        {
+        if (!NSK_JVMTI_VERIFY(jvmti->FollowReferences((jint)   0,     /* heap_filter    */
+                                                      (jclass)  NULL, /* class          */
+                                                      (jobject) NULL, /* initial_object */
+                                                      &heapCallbacks,
+                                                      (const void *) &fakeUserData))) {
              nsk_jvmti_setFailStatus();
              return;
         }
@@ -990,14 +976,11 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     {
         jint heap_filter = JVMTI_HEAP_FILTER_UNTAGGED
                          | JVMTI_HEAP_FILTER_CLASS_UNTAGGED;
-        if (!NSK_JVMTI_VERIFY(
-                NSK_CPP_STUB6(FollowReferences, jvmti,
-                    heap_filter,
-                    (jclass)  NULL, /* class          */
-                    (jobject) NULL, /* initial_object */
-                    &heapCallbacks,
-                    (const void *) &fakeUserData)))
-        {
+        if (!NSK_JVMTI_VERIFY(jvmti->FollowReferences(heap_filter,
+                                                      (jclass)  NULL, /* class          */
+                                                      (jobject) NULL, /* initial_object */
+                                                      &heapCallbacks,
+                                                      (const void *) &fakeUserData))) {
              nsk_jvmti_setFailStatus();
              return;
         }
@@ -1086,7 +1069,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref004/followref004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref004/followref004.cpp
@@ -146,16 +146,16 @@ static void createGlobalRefs(JNIEnv * jni)
 {
     jclass klass;
 
-    if  ( ! NSK_JNI_VERIFY(jni, (klass = NSK_CPP_STUB2(FindClass, jni, JAVA_LANG_STRING_CLASS_NAME)) != NULL) ) {
+    if  ( ! NSK_JNI_VERIFY(jni, (klass = jni->FindClass(JAVA_LANG_STRING_CLASS_NAME)) != NULL) ) {
         nsk_jvmti_setFailStatus();
         return;
     }
 
-    if ( ! NSK_JNI_VERIFY(jni, (g_jniGlobalRef = NSK_CPP_STUB2(NewGlobalRef, jni, klass)) != NULL) ) {
+    if ( ! NSK_JNI_VERIFY(jni, (g_jniGlobalRef = jni->NewGlobalRef(klass)) != NULL) ) {
         nsk_jvmti_setFailStatus();
     }
 
-    if ( ! NSK_JNI_VERIFY(jni, (g_jniWeakGlobalRef = NSK_CPP_STUB2(NewWeakGlobalRef, jni, klass)) != NULL) ) {
+    if ( ! NSK_JNI_VERIFY(jni, (g_jniWeakGlobalRef = jni->NewWeakGlobalRef(klass)) != NULL) ) {
         nsk_jvmti_setFailStatus();
     }
 
@@ -179,13 +179,11 @@ static void JNICALL agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg)
 
     createGlobalRefs(jni);
 
-    retCode = NSK_CPP_STUB6(FollowReferences,
-                              jvmti,
-                              (jint) 0,                 /* heap filter */
-                              NULL,                     /* class */
-                              NULL,                     /* inital object */
-                              &g_heapCallbacks,
-                              (const void *) &g_fakeUserData);
+    retCode = jvmti->FollowReferences((jint) 0,                 /* heap filter */
+                                      NULL,                     /* class */
+                                      NULL,                     /* inital object */
+                                      &g_heapCallbacks,
+                                      (const void *) &g_fakeUserData);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_NONE) ) {
         nsk_jvmti_setFailStatus();
@@ -247,7 +245,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved)
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref005/followref005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref005/followref005.cpp
@@ -45,58 +45,42 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     printf(">>> Check that FollowReferences(), IterateThroughHeap(), GetTag(), SetTag() and GetObjectsWithTags() \n"
            "    return an error if env. doesn't possess can_tag_objects capability\n");
 
-    retCode = NSK_CPP_STUB6(FollowReferences,
-                              jvmti,
-                              (jint) 0,                 /* heap filter */
-                              NULL,                     /* class */
-                              NULL,                     /* inital object */
-                              &g_wrongHeapCallbacks,
-                              (const void *) &g_fakeUserData);
+    retCode = jvmti->FollowReferences((jint) 0,                 /* heap filter */
+                                      NULL,                     /* class */
+                                      NULL,                     /* inital object */
+                                      &g_wrongHeapCallbacks,
+                                      (const void *) &g_fakeUserData);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_MUST_POSSESS_CAPABILITY ) ) {
         NSK_COMPLAIN1("FollowReferences() returned %i", retCode);
         nsk_jvmti_setFailStatus();
     }
 
-    retCode = NSK_CPP_STUB5(IterateThroughHeap,
-                              jvmti,
-                              (jint) 0,                 /* heap filter */
-                              NULL,                     /* class */
-                              &g_wrongHeapCallbacks,
-                              (const void *) &g_fakeUserData);
+    retCode = jvmti->IterateThroughHeap((jint) 0,                 /* heap filter */
+                                        NULL,                     /* class */
+                                        &g_wrongHeapCallbacks,
+                                        (const void *) &g_fakeUserData);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_MUST_POSSESS_CAPABILITY ) ) {
         NSK_COMPLAIN1("IterateThroughHeap() returned %i", retCode);
         nsk_jvmti_setFailStatus();
     }
 
-    retCode = NSK_CPP_STUB3(GetTag,
-                              jvmti,
-                              (jobject) &g_wrongHeapCallbacks,
-                              &tag);
+    retCode = jvmti->GetTag((jobject) &g_wrongHeapCallbacks, &tag);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_MUST_POSSESS_CAPABILITY ) ) {
         NSK_COMPLAIN1("GetTag() returned %i", retCode);
         nsk_jvmti_setFailStatus();
     }
 
-    retCode = NSK_CPP_STUB3(SetTag,
-                              jvmti,
-                              (jobject) &g_wrongHeapCallbacks,
-                              tag);
+    retCode = jvmti->SetTag((jobject) &g_wrongHeapCallbacks, tag);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_MUST_POSSESS_CAPABILITY ) ) {
         NSK_COMPLAIN1("SetTag() returned %i", retCode);
         nsk_jvmti_setFailStatus();
     }
 
-    retCode = NSK_CPP_STUB6(GetObjectsWithTags,
-                              jvmti,
-                              1,
-                              &tag,
-                              &cnt,
-                              &pObjs,
-                              &pObjTags);
+    retCode = jvmti->GetObjectsWithTags(1, &tag, &cnt, &pObjs, &pObjTags);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_MUST_POSSESS_CAPABILITY ) ) {
         NSK_COMPLAIN1("GetObjectsWithTags() returned %i", retCode);
@@ -148,7 +132,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 
         memset(&caps, 0, sizeof(caps));
         /* Don't add can_tag_objects capability */
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref006/followref006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref006/followref006.cpp
@@ -49,13 +49,11 @@ static void verifyReturnCodes(JNIEnv* jni, jvmtiEnv* jvmti)
 
     NSK_DISPLAY0("FollowReferences: Invalid class:");
 
-    retCode = NSK_CPP_STUB6(FollowReferences,
-                              jvmti,
-                              (jint) 0,                 /* heap filter */
-                              (jclass) &g_wrongHeapCallbacks ,   /* invalid class, but valid memory address */
-                              NULL,                     /* inital object */
-                              &g_wrongHeapCallbacks,
-                              (const void *) &g_fakeUserData);
+    retCode = jvmti->FollowReferences((jint) 0,                 /* heap filter */
+                                      (jclass) &g_wrongHeapCallbacks ,   /* invalid class, but valid memory address */
+                                      NULL,                     /* inital object */
+                                      &g_wrongHeapCallbacks,
+                                      (const void *) &g_fakeUserData);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_INVALID_CLASS ) ) {
         nsk_jvmti_setFailStatus();
@@ -75,13 +73,11 @@ static void verifyReturnCodes(JNIEnv* jni, jvmtiEnv* jvmti)
     emptyHeapCallbacks.primitive_field_callback = NULL;
     emptyHeapCallbacks.array_primitive_value_callback = NULL;
     emptyHeapCallbacks.string_primitive_value_callback = NULL;
-    retCode = NSK_CPP_STUB6(FollowReferences,
-                            jvmti,
-                            (jint) 0,               // heap filter
-                            NULL,                   // class
-                            (jobject) &g_wrongHeapCallbacks,  // invalid inital object
-                            &emptyHeapCallbacks,    // No callbacks
-                            (const void *) &g_fakeUserData);
+    retCode = jvmti->FollowReferences((jint) 0,               // heap filter
+                                      NULL,                   // class
+                                      (jobject) &g_wrongHeapCallbacks,  // invalid inital object
+                                      &emptyHeapCallbacks,    // No callbacks
+                                      (const void *) &g_fakeUserData);
 
     // Accept both JVMTI_ERROR_INVALID_OBJECT and JVMTI_ERROR_NONE
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_INVALID_OBJECT || retCode == JVMTI_ERROR_NONE ) ) {
@@ -90,13 +86,11 @@ static void verifyReturnCodes(JNIEnv* jni, jvmtiEnv* jvmti)
 
     NSK_DISPLAY0("FollowReferences: Invalid callbacks:");
 
-    retCode = NSK_CPP_STUB6(FollowReferences,
-                              jvmti,
-                              (jint) 0,     /* heap filter */
-                              NULL,         /* class */
-                              NULL,         /* inital object */
-                              NULL,
-                              (const void *) &g_fakeUserData);
+    retCode = jvmti->FollowReferences((jint) 0,     /* heap filter */
+                                      NULL,         /* class */
+                                      NULL,         /* inital object */
+                                      NULL,
+                                      (const void *) &g_fakeUserData);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_NULL_POINTER ) ) {
         nsk_jvmti_setFailStatus();
@@ -104,10 +98,8 @@ static void verifyReturnCodes(JNIEnv* jni, jvmtiEnv* jvmti)
 
     NSK_DISPLAY0("GetTag: Invalid object:");
 
-    retCode = NSK_CPP_STUB3(GetTag,
-                              jvmti,
-                              (jobject) &g_wrongHeapCallbacks,  /* invalid inital object */
-                              &tag);
+    retCode = jvmti->GetTag((jobject) &g_wrongHeapCallbacks,  /* invalid inital object */
+                            &tag);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_INVALID_OBJECT ) ) {
         nsk_jvmti_setFailStatus();
@@ -115,10 +107,7 @@ static void verifyReturnCodes(JNIEnv* jni, jvmtiEnv* jvmti)
 
     NSK_DISPLAY0("GetTag: NULL object pointer:");
 
-    retCode = NSK_CPP_STUB3(GetTag,
-                              jvmti,
-                              NULL,
-                              &tag);
+    retCode = jvmti->GetTag(NULL, &tag);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_INVALID_OBJECT ) ) {
         nsk_jvmti_setFailStatus();
@@ -126,10 +115,7 @@ static void verifyReturnCodes(JNIEnv* jni, jvmtiEnv* jvmti)
 
     NSK_DISPLAY0("GetTag: NULL tag pointer:");
 
-    retCode = NSK_CPP_STUB3(GetTag,
-                              jvmti,
-                              (jobject) &g_wrongHeapCallbacks,
-                              NULL);
+    retCode = jvmti->GetTag((jobject) &g_wrongHeapCallbacks, NULL);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_NULL_POINTER ) ) {
         nsk_jvmti_setFailStatus();
@@ -138,10 +124,8 @@ static void verifyReturnCodes(JNIEnv* jni, jvmtiEnv* jvmti)
     NSK_DISPLAY0("SetTag: Invalid object:");
 
     tag = 1;
-    retCode = NSK_CPP_STUB3(SetTag,
-                              jvmti,
-                              (jobject) &g_wrongHeapCallbacks,  /* invalid inital object */
-                              tag);
+    retCode = jvmti->SetTag((jobject) &g_wrongHeapCallbacks,  /* invalid inital object */
+                            tag);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_INVALID_OBJECT ) ) {
         nsk_jvmti_setFailStatus();
@@ -149,10 +133,7 @@ static void verifyReturnCodes(JNIEnv* jni, jvmtiEnv* jvmti)
 
     NSK_DISPLAY0("SetTag: NULL object pointer:");
 
-    retCode = NSK_CPP_STUB3(GetTag,
-                              jvmti,
-                              NULL,
-                              &tag);
+    retCode = jvmti->GetTag(NULL, &tag);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_INVALID_OBJECT ) ) {
         nsk_jvmti_setFailStatus();
@@ -170,19 +151,16 @@ static void checkNoObjIterated(JNIEnv* jni, jvmtiEnv* jvmti, const char * szClas
     jclass klass;
 
     NSK_DISPLAY1("Verify, that no objects are returned if initial object is %s", szClassName);
-    if (!NSK_JNI_VERIFY(jni, (klass =
-            NSK_CPP_STUB2(FindClass, jni, szClassName)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->FindClass(szClassName)) != NULL)) {
         nsk_jvmti_setFailStatus();
         return;
     }
 
-    retCode = NSK_CPP_STUB6(FollowReferences,
-                              jvmti,
-                              (jint) 0,     /* heap filter */
-                              klass, /* class */
-                              NULL,         /* inital object */
-                              &g_wrongHeapCallbacks,
-                              (const void *) &g_fakeUserData);
+    retCode = jvmti->FollowReferences((jint) 0,     /* heap filter */
+                                      klass, /* class */
+                                      NULL,         /* inital object */
+                                      &g_wrongHeapCallbacks,
+                                      (const void *) &g_fakeUserData);
 
     if ( ! NSK_VERIFY(retCode == JVMTI_ERROR_NONE ) ) {
         nsk_jvmti_setFailStatus();
@@ -252,7 +230,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved)
 
         memset(&caps, 0, sizeof(caps));
         caps.can_tag_objects = 1;
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, jvmti, &caps))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->AddCapabilities(&caps))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/JVMTIagent.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/JVMTIagent.cpp
@@ -715,7 +715,7 @@ static int doHotSwap(JNIEnv *jni_env, jclass redefCls, jint bCount,
             "#### JVMTIagent: >>>>>>>> Invoke RedefineClasses():\n"
             "<JVMTIagent>\tnew class byte count=%d\n",
             classDef.class_byte_count);
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(jvmti->RedefineClasses(1, &classDef)))
+    if (!NSK_JVMTI_VERIFY(jvmti->RedefineClasses(1, &classDef)))
         return 1;
 
     display(0, "#### JVMTIagent: <<<<<<<< RedefineClasses() is successfully done ####\n");

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jni/README
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jni/README
@@ -42,7 +42,7 @@ and checking JNI errors and pending exceptions:
     NSK_JNI_VERIFY(jni, action)
     NSK_JNI_VERIFY_NEGATIVE(jni, action)
 
-Typical example of usage of NSK_JNI_VERIFY and NSK_CPP_STUB macroses
+Typical example of usage of the NSK_JNI_VERIFY macro
 for invokation of JNI functions:
 
     // jni->FindClass(jni, class_name)

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch_agent.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/AddToBootstrapClassLoaderSearch/bootclssearch_agent.cpp
@@ -51,8 +51,7 @@ jvmtiPhase jvmti_phase_to_check = JVMTI_PHASE_ONLOAD;
  */
 static int addSegment(jvmtiEnv* jvmti, const char segment[], const char where[]) {
     NSK_DISPLAY1("Add segment: \"%s\"\n", segment);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(AddToBootstrapClassLoaderSearch, jvmti, segment))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddToBootstrapClassLoaderSearch(segment))) {
         NSK_COMPLAIN1("TEST FAILURE: failed to add segment %s\n", segment);
         return NSK_FALSE;
     }
@@ -68,8 +67,7 @@ static int addSegment(jvmtiEnv* jvmti, const char segment[], const char where[])
  */
 static int addIllegalSegment(jvmtiEnv* jvmti, const char segment[], const char where[], jvmtiError expectedError) {
     NSK_DISPLAY1("Add illegal segment: \"%s\"\n", segment);
-    if (!NSK_JVMTI_VERIFY_CODE(expectedError,
-            NSK_CPP_STUB2(AddToBootstrapClassLoaderSearch, jvmti, segment))) {
+    if (!NSK_JVMTI_VERIFY_CODE(expectedError, jvmti->AddToBootstrapClassLoaderSearch(segment))) {
 
         NSK_COMPLAIN2("TEST FAILURE: got wrong error when tried to add segment %s (expected error=%s)\n",
                       segment, TranslateError(expectedError));
@@ -123,7 +121,7 @@ void JNICALL
 callbackVMDeath(jvmtiEnv *jvmti, JNIEnv* jni) {
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase))) {
         NSK_COMPLAIN0("TEST FAILURE: unable to get phase\n");
         nsk_jvmti_setFailStatus();
         NSK_BEFORE_TRACE(exit(nsk_jvmti_getStatus()));
@@ -218,8 +216,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                            &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/AddToSystemClassLoaderSearch/systemclssearch_agent.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/AddToSystemClassLoaderSearch/systemclssearch_agent.cpp
@@ -51,8 +51,7 @@ jvmtiPhase jvmti_phase_to_check = JVMTI_PHASE_ONLOAD;
  */
 static int addSegment(jvmtiEnv* jvmti, const char segment[], const char where[]) {
     NSK_DISPLAY1("Add segment: \"%s\"\n", segment);
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(AddToSystemClassLoaderSearch, jvmti, segment))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->AddToSystemClassLoaderSearch(segment))) {
         NSK_COMPLAIN1("TEST FAILURE: failed to add segment %s\n", segment);
         return NSK_FALSE;
     }
@@ -68,8 +67,7 @@ static int addSegment(jvmtiEnv* jvmti, const char segment[], const char where[])
  */
 static int addIllegalSegment(jvmtiEnv* jvmti, const char segment[], const char where[], jvmtiError expectedError) {
     NSK_DISPLAY1("Add illegal segment: \"%s\"\n", segment);
-    if (!NSK_JVMTI_VERIFY_CODE(expectedError,
-            NSK_CPP_STUB2(AddToSystemClassLoaderSearch, jvmti, segment))) {
+    if (!NSK_JVMTI_VERIFY_CODE(expectedError, jvmti->AddToSystemClassLoaderSearch(segment))) {
 
         NSK_COMPLAIN2("TEST FAILURE: got wrong error when tried to add segment %s (expected error=%s)\n",
                       segment, TranslateError(expectedError));
@@ -123,7 +121,7 @@ void JNICALL
 callbackVMDeath(jvmtiEnv *jvmti, JNIEnv* jni) {
     jvmtiPhase phase;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(GetPhase, jvmti, &phase))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetPhase(&phase))) {
         NSK_COMPLAIN0("TEST FAILURE: unable to get phase\n");
         nsk_jvmti_setFailStatus();
         NSK_BEFORE_TRACE(exit(nsk_jvmti_getStatus()));
@@ -218,8 +216,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         eventCallbacks.VMInit = callbackVMInit;
         eventCallbacks.VMDeath = callbackVMDeath;
 
-        if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, jvmti,
-                                            &eventCallbacks, sizeof(eventCallbacks)))) {
+        if (!NSK_JVMTI_VERIFY(jvmti->SetEventCallbacks(&eventCallbacks, sizeof(eventCallbacks)))) {
             return JNI_ERR;
         }
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/README
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/README
@@ -117,20 +117,18 @@ Also provides functions for running JVMTI agent:
 
 ---------------------------------------------------------------------------------
 
-Typical example of usage of NSK_JVMTI_VERIFY and NSK_CPP_STUB macroses
+Typical example of usage of the NSK_JVMTI_VERIFY macro
 for invocation of JVMTI functions:
 
     // jvmti->GetVersion(jvmti, &version)
-    if (!NSK_JVMTI_VERIFY(
-            NSK_CPP_STUB2(GetVersion, jvmti, &version) != NULL)) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetVersion(&version) != NULL)) {
         return JNI_ERR;
     }
 
 or with saving error code:
 
     // err = jvmti->GetVersion(jvmti, &version)
-    if (!NSK_JVMTI_VERIFY(err =
-            NSK_CPP_STUB2(GetVersion, jvmti, &version))) {
+    if (!NSK_JVMTI_VERIFY(err = jvmti->GetVersion(&version))) {
         return err;
     }
         functions: nsk_jvmti_*

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/aod/jvmti_aod.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/aod/jvmti_aod.cpp
@@ -87,7 +87,7 @@ Options* nsk_jvmti_aod_getMultiagentsOptions(jvmtiEnv *jvmti) {
  */
 
 void nsk_jvmti_aod_deallocate(jvmtiEnv *jvmti, unsigned char* mem) {
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB2(Deallocate, jvmti, mem))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->Deallocate(mem))) {
         NSK_COMPLAIN0("Deallocate failed\n");
 
         /*
@@ -101,7 +101,7 @@ void nsk_jvmti_aod_deallocate(jvmtiEnv *jvmti, unsigned char* mem) {
 int nsk_jvmti_aod_getClassName(jvmtiEnv *jvmti, jclass klass, char classNameBuffer[]) {
     char* className;
 
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB4(GetClassSignature, jvmti, klass, &className, NULL))) {
+    if (!NSK_JVMTI_VERIFY(jvmti->GetClassSignature(klass, &className, NULL))) {
         NSK_COMPLAIN0("Failed to get class name\n");
         classNameBuffer[0] = '\0';
         return NSK_FALSE;
@@ -116,7 +116,7 @@ int nsk_jvmti_aod_getClassName(jvmtiEnv *jvmti, jclass klass, char classNameBuff
 
 int nsk_jvmti_aod_getThreadName(jvmtiEnv * jvmti, jthread thread, char threadNameBuffer[]) {
     jvmtiThreadInfo info;
-    if (!NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetThreadInfo, jvmti, thread, &info))){
+    if (!NSK_JVMTI_VERIFY(jvmti->GetThreadInfo(thread, &info))){
         NSK_COMPLAIN0("Failed to get thread info\n");
         threadNameBuffer[0] = '\0';
         return NSK_FALSE;
@@ -161,25 +161,23 @@ jthread nsk_jvmti_aod_createThread(JNIEnv *jni) {
     jmethodID threadConstructor;
     jthread thread;
 
-    if (!NSK_JNI_VERIFY(jni,
-            (klass = NSK_CPP_STUB2(FindClass, jni, "java/lang/Thread")) != NULL )) {
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->FindClass("java/lang/Thread")) != NULL )) {
         NSK_COMPLAIN0("Failed to get the java.lang.Thread class\n");
         return NULL;
     }
     if (!NSK_JNI_VERIFY(jni,
-            (threadConstructor = NSK_CPP_STUB4(GetMethodID, jni, klass, "<init>", "()V") )  != NULL )) {
+            (threadConstructor = jni->GetMethodID(klass, "<init>", "()V") )  != NULL )) {
         NSK_COMPLAIN0("Failed to get java.lang.Thread constructor\n");
         return NULL;
     }
 
     if (!NSK_JNI_VERIFY (jni,
-            (thread = NSK_CPP_STUB4(NewObject, jni, klass, threadConstructor, NULL)) != NULL ) ) {
+            (thread = jni->NewObject(klass, threadConstructor, NULL)) != NULL ) ) {
         NSK_COMPLAIN0("Failed to create Thread object\n");
         return NULL;
     }
 
-    if (!NSK_JNI_VERIFY(jni, (thread =
-        NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL)) {
         NSK_COMPLAIN0("Failed to create global reference\n");
         return NULL;
     }
@@ -193,29 +191,26 @@ jthread nsk_jvmti_aod_createThreadWithName(JNIEnv *jni, const char* threadName) 
     jthread thread;
     jstring threadNameString;
 
-    if (!NSK_JNI_VERIFY(jni, (threadNameString =
-        NSK_CPP_STUB2(NewStringUTF, jni, threadName)) != NULL))
+    if (!NSK_JNI_VERIFY(jni, (threadNameString = jni->NewStringUTF(threadName)) != NULL))
         return NULL;
 
-    if (!NSK_JNI_VERIFY(jni,
-            (klass = NSK_CPP_STUB2(FindClass, jni, "java/lang/Thread")) != NULL )) {
+    if (!NSK_JNI_VERIFY(jni, (klass = jni->FindClass("java/lang/Thread")) != NULL )) {
         NSK_COMPLAIN0("Failed to get the java.lang.Thread class\n");
         return NULL;
     }
     if (!NSK_JNI_VERIFY(jni,
-            (threadConstructor = NSK_CPP_STUB4(GetMethodID, jni, klass, "<init>", "(Ljava/lang/String;)V") )  != NULL )) {
+            (threadConstructor = jni->GetMethodID(klass, "<init>", "(Ljava/lang/String;)V") )  != NULL )) {
         NSK_COMPLAIN0("Failed to get java.lang.Thread constructor\n");
         return NULL;
     }
 
     if (!NSK_JNI_VERIFY(jni,
-            (thread = NSK_CPP_STUB4(NewObject, jni, klass, threadConstructor, threadNameString)) != NULL ) ) {
+            (thread = jni->NewObject(klass, threadConstructor, threadNameString)) != NULL ) ) {
         NSK_COMPLAIN0("Failed to create Thread object\n");
         return NULL;
     }
 
-    if (!NSK_JNI_VERIFY(jni, (thread =
-        NSK_CPP_STUB2(NewGlobalRef, jni, thread)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (thread = jni->NewGlobalRef(thread)) != NULL)) {
         NSK_COMPLAIN0("Failed to create global reference\n");
         return NULL;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/aod/jvmti_aod.h
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/aod/jvmti_aod.h
@@ -68,8 +68,8 @@ int nsk_jvmti_aod_getThreadName(jvmtiEnv * jvmti, jthread thread, char threadNam
 
 // events enabling/disabling
 
-#define nsk_jvmti_aod_enableEvent(X,Y)  NSK_JVMTI_VERIFY( NSK_CPP_STUB4(SetEventNotificationMode, X, JVMTI_ENABLE, Y, NULL))
-#define nsk_jvmti_aod_disableEvent(X,Y) NSK_JVMTI_VERIFY( NSK_CPP_STUB4(SetEventNotificationMode, X, JVMTI_DISABLE, Y, NULL))
+#define nsk_jvmti_aod_enableEvent(X,Y)  NSK_JVMTI_VERIFY(X->SetEventNotificationMode(JVMTI_ENABLE, Y, NULL))
+#define nsk_jvmti_aod_disableEvent(X,Y) NSK_JVMTI_VERIFY(X->SetEventNotificationMode(JVMTI_DISABLE, Y, NULL))
 
 int nsk_jvmti_aod_enableEvents(jvmtiEnv* jvmti, jvmtiEvent events[], int eventsNumber);
 int nsk_jvmti_aod_disableEvents(jvmtiEnv* jvmti, jvmtiEvent events[], int eventsNumber);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_FollowRefObjects.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_FollowRefObjects.cpp
@@ -115,12 +115,12 @@ JNIEXPORT jboolean JNICALL Java_nsk_jvmti_unit_FollowReferences_FollowRefObjects
     jvmtiEnv * jvmti = nsk_jvmti_getAgentJVMTIEnv();
     jint hashCode;
 
-    if ( ! NSK_VERIFY(NSK_CPP_STUB3(SetTag, jvmti, o, tag) == JVMTI_ERROR_NONE) ) {
+    if ( ! NSK_VERIFY(jvmti->SetTag(o, tag) == JVMTI_ERROR_NONE) ) {
         NSK_COMPLAIN2("Can't set tag %li for object %lx\n", tag, o);
         return JNI_FALSE;
     }
 
-    if ( ! NSK_VERIFY(NSK_CPP_STUB3(GetObjectHashCode, jvmti, o, &hashCode) == JVMTI_ERROR_NONE) ) {
+    if ( ! NSK_VERIFY(jvmti->GetObjectHashCode(o, &hashCode) == JVMTI_ERROR_NONE) ) {
         NSK_COMPLAIN1("Can't get hash object %lx\n", o);
         return JNI_FALSE;
     }
@@ -131,7 +131,7 @@ JNIEXPORT jboolean JNICALL Java_nsk_jvmti_unit_FollowReferences_FollowRefObjects
         jboolean fCopy;
         const char * s;
 
-        if ( ! NSK_VERIFY((s = NSK_CPP_STUB3(GetStringUTFChars, jni, sInfo, &fCopy)) != NULL) ) {
+        if ( ! NSK_VERIFY((s = jni->GetStringUTFChars(sInfo, &fCopy)) != NULL) ) {
             NSK_COMPLAIN1("Can't get string at %#p\n", sInfo);
             return JNI_FALSE;
         }
@@ -143,7 +143,7 @@ JNIEXPORT jboolean JNICALL Java_nsk_jvmti_unit_FollowReferences_FollowRefObjects
 
         g_szTagInfo[tag] = strdup(s);
 
-        NSK_CPP_STUB3(ReleaseStringUTFChars, jni, sInfo, s);
+        jni->ReleaseStringUTFChars(sInfo, s);
 
         NSK_DISPLAY1(" // %s", g_szTagInfo[tag]);
 
@@ -160,7 +160,7 @@ JNIEXPORT jlong JNICALL Java_nsk_jvmti_unit_FollowReferences_FollowRefObjects_ge
 
     jlong tag;
     jvmtiError r;
-    if ( ! NSK_VERIFY((r = NSK_CPP_STUB3(GetTag, jvmti, o, &tag)) == JVMTI_ERROR_NONE) ) {
+    if ( ! NSK_VERIFY((r = jvmti->GetTag(o, &tag)) == JVMTI_ERROR_NONE) ) {
         NSK_COMPLAIN2("Can't GetTag for object %lx. Return code: %i\n", o, r);
         return -1;
     }
@@ -224,14 +224,14 @@ JNIEXPORT jboolean JNICALL Java_nsk_jvmti_unit_FollowReferences_FollowRefObjects
     jlong tagFrom, tagTo;
     RefToVerify * pRefRec;
 
-    if ( ! NSK_VERIFY((r = NSK_CPP_STUB3(GetTag, jvmti, from, &tagFrom)) == JVMTI_ERROR_NONE) ) {
+    if ( ! NSK_VERIFY((r = jvmti->GetTag(from, &tagFrom)) == JVMTI_ERROR_NONE) ) {
         NSK_COMPLAIN2("TEST_BUG: Can't GetTag for object %lx. Return code: %i\n", from, r);
         nsk_jvmti_setFailStatus();
         return JNI_FALSE;
     }
 
 
-    if ( ! NSK_VERIFY((r = NSK_CPP_STUB3(GetTag, jvmti, to, &tagTo)) == JVMTI_ERROR_NONE) ) {
+    if ( ! NSK_VERIFY((r = jvmti->GetTag(to, &tagTo)) == JVMTI_ERROR_NONE) ) {
         NSK_COMPLAIN2("TEST_BUG: Can't GetTag for object %lx. Return code: %i\n", to, r);
         nsk_jvmti_setFailStatus();
         return JNI_FALSE;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp
@@ -460,8 +460,7 @@ JNIEXPORT jstring JNICALL
 Java_nsk_share_jvmti_ArgumentHandler_getAgentOptionsString(JNIEnv *jni, jobject obj) {
     jstring str_obj = NULL;
 
-    if (!NSK_JNI_VERIFY(jni, (str_obj =
-            NSK_CPP_STUB2(NewStringUTF, jni, context.options.string)) != NULL)) {
+    if (!NSK_JNI_VERIFY(jni, (str_obj = jni->NewStringUTF(context.options.string)) != NULL)) {
         return NULL;
     }
     return str_obj;
@@ -645,7 +644,7 @@ int isThreadExpected(jvmtiEnv *jvmti, jthread thread) {
 }
 
 jint createRawMonitor(jvmtiEnv *env, const char *name, jrawMonitorID *monitor) {
-    jvmtiError error = NSK_CPP_STUB3(CreateRawMonitor, env, name, monitor);
+    jvmtiError error = env->CreateRawMonitor(name, monitor);
     if (!NSK_JVMTI_VERIFY(error)) {
         return JNI_ERR;
     }
@@ -659,27 +658,27 @@ void exitOnError(jvmtiError error) {
 }
 
 void rawMonitorEnter(jvmtiEnv *env, jrawMonitorID monitor) {
-    jvmtiError error = NSK_CPP_STUB2(RawMonitorEnter, env, monitor);
+    jvmtiError error = env->RawMonitorEnter(monitor);
     exitOnError(error);
 }
 
 void rawMonitorExit(jvmtiEnv *env, jrawMonitorID monitor) {
-    jvmtiError error = NSK_CPP_STUB2(RawMonitorExit, env, monitor);
+    jvmtiError error = env->RawMonitorExit(monitor);
     exitOnError(error);
 }
 
 void rawMonitorNotify(jvmtiEnv *env, jrawMonitorID monitor) {
-    jvmtiError error = NSK_CPP_STUB2(RawMonitorNotify, env, monitor);
+    jvmtiError error = env->RawMonitorNotify(monitor);
     exitOnError(error);
 }
 
 void rawMonitorWait(jvmtiEnv *env, jrawMonitorID monitor, jlong millis) {
-    jvmtiError error = NSK_CPP_STUB3(RawMonitorWait, env, monitor, millis);
+    jvmtiError error = env->RawMonitorWait(monitor, millis);
     exitOnError(error);
 }
 
 void getPhase(jvmtiEnv *env, jvmtiPhase *phase) {
-    jvmtiError error = NSK_CPP_STUB2(GetPhase, env, phase);
+    jvmtiError error = env->GetPhase(phase);
     exitOnError(error);
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/README
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/README
@@ -58,10 +58,6 @@ nsk_tools.h
 
 Provides functions and macroses for the most usefull actions:
 
-    - access native JVM environment in a compiler independent manner
-
-        NSK_CPP_STUBn(function, env, arg1, ..., argn)
-
     - print error message with arguments
 
         NSK_COMPLAINn(format, arg1, ..., argn)
@@ -90,7 +86,7 @@ Provides functions and macroses for the most usefull actions:
     - miscelaneous functions for printing messages
       (hidden by above mentioned macroses)
 
-Typical example of using macroses NSK_CPP_STUB and NSK_VERIFY
+Typical example of using the NSK_VERIFY macro
 for accesing JVM native environment:
 
     // jvm->GetEnv(jvm, &env, version)

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_tools.h
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_tools.h
@@ -38,25 +38,6 @@
 #endif // _LP64 && __APPLE__
 
 
-/**
- * Use examples:
- *
- *     jfieldID id = NSK_CPP_STUB3(jni,GetFieldID,clazz,name,sig);
- *
- *     jvmtiError code = NSK_CPP_STUB0(jvmti,DisposeEnvironment);
- *
- */
-
-#define NSK_CPP_STUB1(Func,env)  env->Func()
-#define NSK_CPP_STUB2(Func,env,a)  env->Func(a)
-#define NSK_CPP_STUB3(Func,env,a,b)  env->Func(a,b)
-#define NSK_CPP_STUB4(Func,env,a,b,c)  env->Func(a,b,c)
-#define NSK_CPP_STUB5(Func,env,a,b,c,d)  env->Func(a,b,c,d)
-#define NSK_CPP_STUB6(Func,env,a,b,c,d,e)  env->Func(a,b,c,d,e)
-#define NSK_CPP_STUB7(Func,env,a,b,c,d,e,f)  env->Func(a,b,c,d,e,f)
-#define NSK_CPP_STUB8(Func,env,a,b,c,d,e,f,g)  env->Func(a,b,c,d,e,f,g)
-#define NSK_CPP_STUB9(Func,env,a,b,c,d,e,f,g,h)  env->Func(a,b,c,d,e,f,g,h)
-
 /*************************************************************/
 
 /**

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/func/jvmti/share/IndyRedefineClass.cpp
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/func/jvmti/share/IndyRedefineClass.cpp
@@ -88,22 +88,22 @@ static void popFrameLogic(jvmtiEnv * jvmti_env, jthread thread) {
     if ( tls->countOfFramesToPop <= 0 ) {
 
         NSK_DISPLAY0("Disabling single step\n");
-        if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode, jvmti_env, JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, NULL)) )
+        if ( ! NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, NULL)) )
             gIsErrorOccured = JNI_TRUE;
 
     } else {
 
         NSK_DISPLAY0("Enabling single step\n");
-        if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode, jvmti_env, JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, NULL)) )
+        if ( ! NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, NULL)) )
             gIsErrorOccured = JNI_TRUE;
 
         if ( tls->countOfFramesToPop == 1 ) {
             NSK_DISPLAY0("Popping a frame\n");
-            if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB2(PopFrame, jvmti_env, thread)) )
+            if ( ! NSK_JVMTI_VERIFY(jvmti_env->PopFrame(thread)) )
                 gIsErrorOccured = JNI_TRUE;
         } else {
             NSK_DISPLAY0("Forcing early return\n");
-            if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB2(ForceEarlyReturnVoid, jvmti_env, thread)) )
+            if ( ! NSK_JVMTI_VERIFY(jvmti_env->ForceEarlyReturnVoid(thread)) )
                 gIsErrorOccured = JNI_TRUE;
         }
 
@@ -141,7 +141,7 @@ MethodEntry(jvmtiEnv *jvmti_env,
 
     NSK_DISPLAY1("Redefining class %s\n", gszRedefinedClassFileName);
 
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB3(GetMethodDeclaringClass, jvmti_env, method, &clazz)) )
+    if ( ! NSK_JVMTI_VERIFY(jvmti_env->GetMethodDeclaringClass(method, &clazz)) )
         return;
 
     if ( ! NSK_VERIFY(nsk_jvmti_redefineClass(jvmti_env, clazz, gszRedefinedClassFileName)) ) {
@@ -200,20 +200,20 @@ jint Agent_Initialize(JavaVM * vm, char * options, void * reserved) {
     caps.can_force_early_return = 1;
     caps.can_redefine_classes = 1;
 
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, gJvmtiEnv, &caps)) )
+    if ( ! NSK_JVMTI_VERIFY(gJvmtiEnv->AddCapabilities(&caps)) )
         return JNI_ERR;
 
     memset(&callbacks, 0, sizeof(callbacks));
     callbacks.MethodEntry = &MethodEntry;
     callbacks.SingleStep = &SingleStep;
 
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, gJvmtiEnv, &callbacks, sizeof(callbacks))) )
+    if ( ! NSK_JVMTI_VERIFY(gJvmtiEnv->SetEventCallbacks(&callbacks, sizeof(callbacks))) )
             return JNI_ERR;
 
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode, gJvmtiEnv, JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, NULL) ) )
+    if ( ! NSK_JVMTI_VERIFY(gJvmtiEnv->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, NULL) ) )
             return JNI_ERR;
 
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode, gJvmtiEnv, JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, NULL) ) )
+    if ( ! NSK_JVMTI_VERIFY(gJvmtiEnv->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, NULL) ) )
             return JNI_ERR;
 
     return JNI_OK;

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/func/jvmti/stepBreakPopReturn/stepBreakPopReturn.cpp
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/indy/func/jvmti/stepBreakPopReturn/stepBreakPopReturn.cpp
@@ -89,7 +89,7 @@ MethodEntry(jvmtiEnv *jvmti_env,
             gIsMethodEntryWorking = JNI_TRUE;
 
             if ( ! gIsBreakpointSet )
-                NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode, jvmti_env, JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, NULL));
+                NSK_JVMTI_VERIFY(jvmti_env->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_SINGLE_STEP, NULL));
         }
     }
 
@@ -116,21 +116,21 @@ SingleStep(jvmtiEnv *jvmti_env,
         free(locStr);
     }
 
-    NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode, gJvmtiEnv, JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, NULL));
+    NSK_JVMTI_VERIFY(gJvmtiEnv->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_SINGLE_STEP, NULL));
 
     if ( ! gIsDebuggerCompatible ) {
-        if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetBreakpoint, jvmti_env, method, location)) )
+        if ( ! NSK_JVMTI_VERIFY(jvmti_env->SetBreakpoint(method, location)) )
             return;
 
-        NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode, gJvmtiEnv, JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL));
+        NSK_JVMTI_VERIFY(gJvmtiEnv->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_BREAKPOINT, NULL));
         gIsBreakpointSet = JNI_TRUE;
 
         NSK_DISPLAY0("Pop a frame\n");
-        NSK_JVMTI_VERIFY(NSK_CPP_STUB2(PopFrame, gJvmtiEnv, thread));
+        NSK_JVMTI_VERIFY(gJvmtiEnv->PopFrame(thread));
     } else {
         if ( gIsFirstCall ) {
             NSK_DISPLAY0("Pop a frame\n");
-            NSK_JVMTI_VERIFY(NSK_CPP_STUB2(PopFrame, gJvmtiEnv, thread));
+            NSK_JVMTI_VERIFY(gJvmtiEnv->PopFrame(thread));
             gIsFirstCall = JNI_FALSE;
         } else {
             gIsFirstCall = JNI_TRUE;
@@ -158,12 +158,12 @@ Breakpoint(jvmtiEnv *jvmti_env,
         free(locStr);
     }
 
-    NSK_JVMTI_VERIFY(NSK_CPP_STUB3(ClearBreakpoint, jvmti_env, method, location));
-    NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode, gJvmtiEnv, JVMTI_DISABLE, JVMTI_EVENT_BREAKPOINT, NULL));
+    NSK_JVMTI_VERIFY(jvmti_env->ClearBreakpoint(method, location));
+    NSK_JVMTI_VERIFY(gJvmtiEnv->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_BREAKPOINT, NULL));
     gIsBreakpointSet = JNI_FALSE;
 
     NSK_DISPLAY0("Forcing early return.\n");
-    NSK_JVMTI_VERIFY(NSK_CPP_STUB3(ForceEarlyReturnInt, jvmti_env, thread, 0));
+    NSK_JVMTI_VERIFY(jvmti_env->ForceEarlyReturnInt(thread, 0));
 }
 
 jint Agent_Initialize(JavaVM * vm, char * options, void * reserved) {
@@ -187,7 +187,7 @@ jint Agent_Initialize(JavaVM * vm, char * options, void * reserved) {
     caps.can_pop_frame = 1;
     caps.can_force_early_return = 1;
 
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB2(AddCapabilities, gJvmtiEnv, &caps)) )
+    if ( ! NSK_JVMTI_VERIFY(gJvmtiEnv->AddCapabilities(&caps)) )
         return JNI_ERR;
 
     memset(&callbacks, 0, sizeof(callbacks));
@@ -195,10 +195,10 @@ jint Agent_Initialize(JavaVM * vm, char * options, void * reserved) {
     callbacks.SingleStep = &SingleStep;
     callbacks.Breakpoint = &Breakpoint;
 
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB3(SetEventCallbacks, gJvmtiEnv, &callbacks, sizeof(callbacks))) )
+    if ( ! NSK_JVMTI_VERIFY(gJvmtiEnv->SetEventCallbacks(&callbacks, sizeof(callbacks))) )
         return JNI_ERR;
 
-    if ( ! NSK_JVMTI_VERIFY(NSK_CPP_STUB4(SetEventNotificationMode, gJvmtiEnv, JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, NULL) ) )
+    if ( ! NSK_JVMTI_VERIFY(gJvmtiEnv->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_METHOD_ENTRY, NULL) ) )
         return JNI_ERR;
 
     return JNI_OK;


### PR DESCRIPTION
I backport this for parity with 11.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8212148](https://bugs.openjdk.java.net/browse/JDK-8212148): Remove remaining NSK_CPP_STUBs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/671/head:pull/671` \
`$ git checkout pull/671`

Update a local copy of the PR: \
`$ git checkout pull/671` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 671`

View PR using the GUI difftool: \
`$ git pr show -t 671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/671.diff">https://git.openjdk.java.net/jdk11u-dev/pull/671.diff</a>

</details>
