### PR TITLE
8261661: gc/stress/TestReclaimStringsLeaksMemory.java fails because Reserved memory size is too big

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
+++ b/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
+++ b/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
@@ -48,9 +48,9 @@ import jdk.test.lib.process.ProcessTools;
 
 public class TestReclaimStringsLeaksMemory {
 
-    // The amount of memory in kB reserved in the "Symbol" category that indicates a memory leak for
+    // The amount of memory in B reserved in the "Symbol" category that indicates a memory leak for
     // this test.
-    public static final int ReservedThreshold = 70000;
+    public static final int ReservedThreshold = 70000000;
 
     public static void main(String[] args) throws Exception {
         ArrayList<String> baseargs = new ArrayList(Arrays.asList( "-Xms256M",
@@ -78,7 +78,7 @@ public class TestReclaimStringsLeaksMemory {
         }
 
         int reserved = Integer.parseInt(m.group(1));
-        Asserts.assertLT(reserved, ReservedThreshold, "Reserved memory size is " + reserved + "KB which is greater than or equal to " + ReservedThreshold + "KB indicating a memory leak");
+        Asserts.assertLT(reserved, ReservedThreshold, "Reserved memory size is " + reserved + "B which is greater than or equal to " + ReservedThreshold + "B indicating a memory leak");
 
         output.shouldHaveExitValue(0);
     }


### PR DESCRIPTION
Hi,

trivial backport of 8261661: "gc/stress/TestReclaimStringsLeaksMemory.java fails because Reserved memory size is too big"

Did not apply cleanly due to copyright header changes.

Cheers, Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261661](https://bugs.openjdk.java.net/browse/JDK-8261661): gc/stress/TestReclaimStringsLeaksMemory.java fails because Reserved memory size is too big


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/672/head:pull/672` \
`$ git checkout pull/672`

Update a local copy of the PR: \
`$ git checkout pull/672` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 672`

View PR using the GUI difftool: \
`$ git pr show -t 672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/672.diff">https://git.openjdk.java.net/jdk11u-dev/pull/672.diff</a>

</details>
