### PR TITLE
8272345: macos doesn't check `os::set_boot_path()` result

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -468,7 +468,9 @@ void os::init_system_properties_values() {
       }
     }
     Arguments::set_java_home(buf);
-    set_boot_path('/', ':');
+    if (!set_boot_path('/', ':')) {
+        vm_exit_during_initialization("Failed setting boot class path.", NULL);
+    }
   }
 
   // Where to look for native libraries.

--- a/test/hotspot/jtreg/runtime/appcds/MoveJDKTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/MoveJDKTest.java
@@ -25,8 +25,10 @@
 /*
  * @test
  * @summary Test that CDS still works when the JDK is moved to a new directory
+ * @bug 8272345
  * @requires vm.cds
- * @requires os.family == "linux"
+ * @comment This test doesn't work on Windows because it depends on symlinks
+ * @requires os.family != "windows"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -34,11 +36,6 @@
  * @compile test-classes/Hello.java
  * @run main MoveJDKTest
  */
-
-// This test works only on Linux because it depends on symlinks and the name of the hotspot DLL (libjvm.so).
-// It probably doesn't work on Windows.
-// TODO: change libjvm.so to libjvm.dylib on MacOS, before adding "@requires os.family == mac"
-// TODO: test on solaris, before adding "@requires os.family == solaris"
 
 import java.io.File;
 import java.nio.file.Files;
@@ -122,6 +119,7 @@ public class MoveJDKTest {
                 throw new RuntimeException("Cannot create directory: " + dst);
             }
         }
+        final String jvmLib = System.mapLibraryName("jvm");
         for (String child : src.list()) {
             if (child.equals(".") || child.equals("..")) {
                 continue;
@@ -133,7 +131,7 @@ public class MoveJDKTest {
                 throw new RuntimeException("Already exists: " + child_dst);
             }
             if (child_src.isFile()) {
-                if (child.equals("libjvm.so") || child.equals("java")) {
+                if (child.equals(jvmLib) || child.equals("java")) {
                     Files.copy(child_src.toPath(), /* copy data to -> */ child_dst.toPath());
                 } else {
                     Files.createSymbolicLink(child_dst.toPath(),  /* link to -> */ child_src.toPath());


### PR DESCRIPTION
Backport of the Mac-specific fix.

Test change does not apply cleanly, it was resolved manually because this test was moved into different directory with [JDK-8202339](https://bugs.openjdk.java.net/browse/JDK-8202339).

Additional testing:

 - [x] checked that test passes on Mac and Linux, was unable to reproduce the crash problem on Mac without the patch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272345](https://bugs.openjdk.java.net/browse/JDK-8272345): macos doesn't check `os::set_boot_path()` result


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/674/head:pull/674` \
`$ git checkout pull/674`

Update a local copy of the PR: \
`$ git checkout pull/674` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 674`

View PR using the GUI difftool: \
`$ git pr show -t 674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/674.diff">https://git.openjdk.java.net/jdk11u-dev/pull/674.diff</a>

</details>
