### PR TITLE
8266176: -Wmaybe-uninitialized happens in libArrayIndexOutOfBoundsExceptionTest.c

### DIFF
--- a/test/hotspot/jtreg/runtime/exceptionMsgs/ArrayIndexOutOfBoundsException/libArrayIndexOutOfBoundsExceptionTest.c
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/ArrayIndexOutOfBoundsException/libArrayIndexOutOfBoundsExceptionTest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -47,7 +47,7 @@ JNIEXPORT void JNICALL \
 JNIEXPORT void JNICALL \
   Java_ArrayIndexOutOfBoundsExceptionTest_doNative##NameType##ArrayRegionStore(JNIEnv *env, jclass klass, \
                                                                       ElementType##Array array, jint start, jint len) { \
-  ElementType content[100]; \
+  ElementType content[100] = {0}; \
   (*env)->Set##NameType##ArrayRegion(env, array, start, len, content); \
 }
 


### PR DESCRIPTION
Applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266176](https://bugs.openjdk.java.net/browse/JDK-8266176): -Wmaybe-uninitialized happens in libArrayIndexOutOfBoundsExceptionTest.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/678/head:pull/678` \
`$ git checkout pull/678`

Update a local copy of the PR: \
`$ git checkout pull/678` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 678`

View PR using the GUI difftool: \
`$ git pr show -t 678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/678.diff">https://git.openjdk.java.net/jdk11u-dev/pull/678.diff</a>

</details>
