### PR TITLE
8254940: AArch64: Cleanup non-product thread members

### DIFF
--- a/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/thread_linux_aarch64.hpp
@@ -27,15 +27,6 @@
 #define OS_CPU_LINUX_AARCH64_VM_THREAD_LINUX_AARCH64_HPP
 
  private:
-#ifdef ASSERT
-  // spill stack holds N callee-save registers at each Java call and
-  // grows downwards towards limit
-  // we need limit to check we have space for a spill and base so we
-  // can identify all live spill frames at GC (eventually)
-  address          _spill_stack;
-  address          _spill_stack_base;
-  address          _spill_stack_limit;
-#endif // ASSERT
 
   void pd_initialize() {
     _anchor.clear();

--- a/src/hotspot/os_cpu/windows_aarch64/thread_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/thread_windows_aarch64.hpp
@@ -27,16 +27,6 @@
 
  private:
 
-#ifdef ASSERT
-  // spill stack holds N callee-save registers at each Java call and
-  // grows downwards towards limit
-  // we need limit to check we have space for a spill and base so we
-  // can identify all live spill frames at GC (eventually)
-  address          _spill_stack;
-  address          _spill_stack_base;
-  address          _spill_stack_limit;
-#endif // ASSERT
-
   void pd_initialize() {
     _anchor.clear();
   }


### PR DESCRIPTION
Backport of JDK-8254940 to jdk11u-dev
Needed to let jep-391 backport apply more cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8254940](https://bugs.openjdk.java.net/browse/JDK-8254940): AArch64: Cleanup non-product thread members


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/680/head:pull/680` \
`$ git checkout pull/680`

Update a local copy of the PR: \
`$ git checkout pull/680` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 680`

View PR using the GUI difftool: \
`$ git pr show -t 680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/680.diff">https://git.openjdk.java.net/jdk11u-dev/pull/680.diff</a>

</details>
