### PR TITLE
8266168: -Wmaybe-uninitialized happens in check_code.c

### DIFF
--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3830,7 +3830,7 @@ signature_to_fieldtype(context_type *context,
                 }
                 length = finish - p;
                 if (length + 1 > (int)sizeof(buffer_space)) {
-                    buffer = malloc(length + 1);
+                    buffer = calloc(length + 1, sizeof(char));
                     check_and_push(context, buffer, VM_MALLOC_BLK);
                 }
                 memcpy(buffer, p, length);


### PR DESCRIPTION
Applies cleanly net of copyright date update conflict.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266168](https://bugs.openjdk.java.net/browse/JDK-8266168): -Wmaybe-uninitialized happens in check_code.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/682/head:pull/682` \
`$ git checkout pull/682`

Update a local copy of the PR: \
`$ git checkout pull/682` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 682`

View PR using the GUI difftool: \
`$ git pr show -t 682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/682.diff">https://git.openjdk.java.net/jdk11u-dev/pull/682.diff</a>

</details>
