### PR TITLE
8256373: [Windows/HiDPI] The Frame#setBounds does not work in a minimized state

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Frame.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Frame.cpp
@@ -651,31 +651,38 @@ MsgRouting AwtFrame::WmNcMouseDown(WPARAM hitTest, int x, int y, int button) {
 
 // Override AwtWindow::Reshape() to handle minimized/maximized
 // frames (see 6525850, 4065534)
-void AwtFrame::Reshape(int x, int y, int width, int height)
+void AwtFrame::Reshape(int x, int y, int w, int h)
 {
     if (isIconic()) {
     // normal AwtComponent::Reshape will not work for iconified windows so...
+        POINT pt = {x + w / 2, y + h / 2};
+        Devices::InstanceAccess devices;
+        HMONITOR monitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+        int screen = AwtWin32GraphicsDevice::GetScreenFromHMONITOR(monitor);
+        AwtWin32GraphicsDevice *device = devices->GetDevice(screen);
+        // Try to set the correct size and jump to the correct location, even if
+        // it is on the different monitor. Note that for the "size" we use the
+        // current monitor, so the WM_DPICHANGED will adjust it for the "target"
+        // monitor.
+        MONITORINFO *miInfo = AwtWin32GraphicsDevice::GetMonitorInfo(screen);
+        x = device == NULL ? x : device->ScaleUpAbsX(x);
+        y = device == NULL ? y : device->ScaleUpAbsY(y);
+        w = ScaleUpX(w);
+        h = ScaleUpY(h);
+        // SetWindowPlacement takes workspace coordinates, but if taskbar is at
+        // top/left of screen, workspace coords != screen coords, so offset by
+        // workspace origin
+        x = x - (miInfo->rcWork.left - miInfo->rcMonitor.left);
+        y = y - (miInfo->rcWork.top - miInfo->rcMonitor.top);
         WINDOWPLACEMENT wp;
-        POINT       ptMinPosition = {x,y};
-        POINT       ptMaxPosition = {0,0};
-        RECT        rcNormalPosition = {x,y,x+width,y+height};
-        RECT        rcWorkspace;
-        HWND        hWndDesktop = GetDesktopWindow();
-        HWND        hWndSelf = GetHWnd();
-
-        // SetWindowPlacement takes workspace coordinates, but
-        // if taskbar is at top of screen, workspace coords !=
-        // screen coords, so offset by workspace origin
-        VERIFY(::SystemParametersInfo(SPI_GETWORKAREA, 0, (PVOID)&rcWorkspace, 0));
-        ::OffsetRect(&rcNormalPosition, -rcWorkspace.left, -rcWorkspace.top);
-
+        ::ZeroMemory(&wp, sizeof(WINDOWPLACEMENT));
         // set the window size for when it is not-iconified
         wp.length = sizeof(wp);
         wp.flags = WPF_SETMINPOSITION;
         wp.showCmd = IsVisible() ? SW_SHOWMINIMIZED : SW_HIDE;
-        wp.ptMinPosition = ptMinPosition;
-        wp.ptMaxPosition = ptMaxPosition;
-        wp.rcNormalPosition = rcNormalPosition;
+        wp.ptMinPosition = {x, y};
+        wp.ptMaxPosition = {0, 0};
+        wp.rcNormalPosition = {x, y, x + w, y + h};
 
         // If the call is not guarded with ignoreWmSize,
         // a regression for bug 4851435 appears.
@@ -683,7 +690,7 @@ void AwtFrame::Reshape(int x, int y, int width, int height)
         // changing the iconified state of the frame
         // while calling the Frame.setBounds() method.
         m_ignoreWmSize = TRUE;
-        ::SetWindowPlacement(hWndSelf, &wp);
+        ::SetWindowPlacement(GetHWnd(), &wp);
         m_ignoreWmSize = FALSE;
 
         return;
@@ -700,7 +707,7 @@ void AwtFrame::Reshape(int x, int y, int width, int height)
         SetStyle(style);
     }
 
-    AwtWindow::Reshape(x, y, width, height);
+    AwtWindow::Reshape(x, y, w, h);
 }
 
 

--- a/test/jdk/java/awt/Frame/RestoreToOppositeScreen/RestoreToOppositeScreen.java
+++ b/test/jdk/java/awt/Frame/RestoreToOppositeScreen/RestoreToOppositeScreen.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
+
+/**
+ * @test
+ * @bug 8256373
+ * @key headful
+ * @summary setBounds() should work if the frame is minimized
+ */
+public final class RestoreToOppositeScreen {
+
+    public static void main(String[] args) throws Exception {
+        Toolkit toolkit = Toolkit.getDefaultToolkit();
+        if (!toolkit.isFrameStateSupported(Frame.ICONIFIED)) {
+            return;
+        }
+
+        var ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+        GraphicsDevice[] gds = ge.getScreenDevices();
+        for (GraphicsDevice gd1 : gds) {
+            Rectangle screen1 = gd1.getDefaultConfiguration().getBounds();
+            int x1 = (int) screen1.getCenterX();
+            int y1 = (int) screen1.getCenterY();
+            for (GraphicsDevice gd2 : gds) {
+                Rectangle screen2 = gd2.getDefaultConfiguration().getBounds();
+                // tweak the (x2, y2) point so even if the screen1 and screen2
+                // are the same, we will use different bounds, otherwise
+                // setBounds() will be ignored
+                int x2 = (int) screen2.getCenterX() - 50;
+                int y2 = (int) screen2.getCenterY() - 50;
+                Frame frame = new Frame();
+                try {
+                    // show the frame on one monitor, and then move it to
+                    // another while the frame minimized
+                    frame.setBounds(x1, y1, 400, 400);
+                    frame.setVisible(true);
+                    Thread.sleep(2000);
+                    frame.setExtendedState(Frame.ICONIFIED);
+                    Thread.sleep(2000);
+                    Rectangle before = new Rectangle(x2, y2, 380, 380);
+                    frame.setBounds(before);
+                    Thread.sleep(2000);
+                    frame.setExtendedState(Frame.NORMAL);
+                    Thread.sleep(2000);
+                    Rectangle after = frame.getBounds();
+                    checkSize(after.x, before.x, "x");
+                    checkSize(after.y, before.y, "y");
+                    checkSize(after.width, before.width, "width");
+                    checkSize(after.height, before.height, "height");
+                } finally {
+                    frame.dispose();
+                }
+            }
+        }
+    }
+
+    private static void checkSize(int actual, int expected, String prop) {
+        if (Math.abs(actual - expected) > 10) { // let's allow size variation,
+                                                // the bug is reproduced anyway
+            System.err.println("Expected: " + expected);
+            System.err.println("Actual: " + actual);
+            throw new RuntimeException(prop + " is wrong");
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b5ce8af3](https://github.com/openjdk/jdk/commit/b5ce8af3d7f991c0cea7b2380469fd30f3030670) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 1 Dec 2020 and was reviewed by Alexander Zuev and Alexey Ivanov.

The new test passed, no new issue in the jdk_desktop test group on the system where the bug was reproduced.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8256373](https://bugs.openjdk.java.net/browse/JDK-8256373): [Windows/HiDPI] The Frame#setBounds does not work in a minimized state


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/683/head:pull/683` \
`$ git checkout pull/683`

Update a local copy of the PR: \
`$ git checkout pull/683` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 683`

View PR using the GUI difftool: \
`$ git pr show -t 683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/683.diff">https://git.openjdk.java.net/jdk11u-dev/pull/683.diff</a>

</details>
