### PR TITLE
8208074: [TESTBUG] vmTestbase/nsk/jvmti/RedefineClasses/StressRedefineWithoutBytecodeCorruption/TestDescription.java failed with NullPointerException

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -193,7 +193,6 @@ vmTestbase/metaspace/gc/firstGC_default/TestDescription.java 8208250 generic-all
 
 vmTestbase/nsk/jvmti/ClearBreakpoint/clrbrk001/TestDescription.java 8016181 generic-all
 vmTestbase/nsk/jvmti/FieldModification/fieldmod001/TestDescription.java 8016181 generic-all
-vmTestbase/nsk/jvmti/RedefineClasses/StressRedefineWithoutBytecodeCorruption/TestDescription.java 8202896,8206076,8208074 generic-all
 vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java 7013634 generic-all
 vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java 6606767 generic-all
 vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004/TestDescription.java 7013634,6606767 generic-all

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/StressRedefine.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/StressRedefine.java
@@ -114,8 +114,8 @@ public class StressRedefine extends GCTestBase {
             try {
                 // Just for fun we transfer parameters to method
                 Object res = myClass.getMethod(name, double.class, int.class, Object.class)
-                                         .invoke(null, random.nextDouble(), random.nextInt(), new Object());
-             } catch (IllegalArgumentException | InvocationTargetException
+                                         .invoke(myClass.newInstance(), random.nextDouble(), random.nextInt(), new Object());
+             } catch (IllegalArgumentException | InvocationTargetException | InstantiationException
                      | IllegalAccessException | NoSuchMethodException e) {
                  // It's okay to get exception here since we are corrupting bytecode and can't expect
                  // class to work properly.


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8208074](https://bugs.openjdk.java.net/browse/JDK-8208074): [TESTBUG] vmTestbase/nsk/jvmti/RedefineClasses/StressRedefineWithoutBytecodeCorruption/TestDescription.java failed with NullPointerException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/684/head:pull/684` \
`$ git checkout pull/684`

Update a local copy of the PR: \
`$ git checkout pull/684` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 684`

View PR using the GUI difftool: \
`$ git pr show -t 684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/684.diff">https://git.openjdk.java.net/jdk11u-dev/pull/684.diff</a>

</details>
