### PR TITLE
8233827: Enable screenshots in the enhanced failure handler on Linux/macOS

### DIFF
--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -68,7 +68,8 @@ environment=\
         memory.vmstat.slabinfo memory.vmstat.disk \
   files \
   locks \
-  net.sockets net.statistics
+  net.sockets net.statistics \
+  screenshot
 ################################################################################
 users.current.app=id
 users.current.args=-a
@@ -106,5 +107,8 @@ locks.args=-u
 net.app=netstat
 net.sockets.args=-aeeopv
 net.statistics.args=-sv
+
+screenshot.app=gnome-screenshot
+screenshot.args= -f screen.png
 ################################################################################
 

--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -77,7 +77,8 @@ environment=\
   files \
   netstat.av netstat.aL netstat.m netstat.s \
   ifconfig \
-  scutil.nwi scutil.proxy
+  scutil.nwi scutil.proxy \
+  screenshot
 ################################################################################
 users.current.app=id
 users.current.args=-a
@@ -117,4 +118,7 @@ ifconfig.args=-a
 scutil.app=scutil
 scutil.nwi.args=--nwi
 scutil.proxy.args=--proxy
+
+screenshot.app=screencapture
+screenshot.args= -x screen1.png screen2.png screen3.png screen4.png screen5.png
 ################################################################################


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

I had to resolve because of context differences.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8233827](https://bugs.openjdk.java.net/browse/JDK-8233827): Enable screenshots in the enhanced failure handler on Linux/macOS


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to e986d254280a148ba35d3d312f32f12ac6356a4a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/685/head:pull/685` \
`$ git checkout pull/685`

Update a local copy of the PR: \
`$ git checkout pull/685` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 685`

View PR using the GUI difftool: \
`$ git pr show -t 685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/685.diff">https://git.openjdk.java.net/jdk11u-dev/pull/685.diff</a>

</details>
