### PR TITLE
8210236: Prepare ciReceiverTypeData::translate_receiver_data_from for concurrent class unloading

### DIFF
--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -266,8 +266,13 @@ void ciReceiverTypeData::translate_receiver_data_from(const ProfileData* data) {
   for (uint row = 0; row < row_limit(); row++) {
     Klass* k = data->as_ReceiverTypeData()->receiver(row);
     if (k != NULL) {
-      ciKlass* klass = CURRENT_ENV->get_klass(k);
-      set_receiver(row, klass);
+      if (k->is_loader_alive()) {
+        ciKlass* klass = CURRENT_ENV->get_klass(k);
+        set_receiver(row, klass);
+      } else {
+        // With concurrent class unloading, the MDO could have stale metadata; override it
+        clear_row(row);
+      }
     } else {
       set_receiver(row, NULL);
     }


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

I had to resolve this because "8230019: [REDO] compiler/types/correctness/* tests fail with ...", 
which came after this change in head, was already backported.

Code of translate_receiver_data_from() now is identical to that in repo jdk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210236](https://bugs.openjdk.java.net/browse/JDK-8210236): Prepare ciReceiverTypeData::translate_receiver_data_from for concurrent class unloading


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/689/head:pull/689` \
`$ git checkout pull/689`

Update a local copy of the PR: \
`$ git checkout pull/689` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 689`

View PR using the GUI difftool: \
`$ git pr show -t 689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/689.diff">https://git.openjdk.java.net/jdk11u-dev/pull/689.diff</a>

</details>
