### PR TITLE
8199079: Test javax/swing/UIDefaults/6302464/bug6302464.java is unstable

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -773,7 +773,6 @@ javax/swing/text/html/parser/Parser/HtmlCommentTagParseTest/HtmlCommentTagParseT
 javax/swing/text/StyledEditorKit/8016833/bug8016833.java 8199055 generic-all
 javax/swing/text/Utilities/8134721/bug8134721.java 8199062 generic-all
 javax/swing/tree/DefaultTreeCellRenderer/7142955/bug7142955.java 8199076 generic-all
-javax/swing/UIDefaults/6302464/bug6302464.java 8199079 generic-all
 javax/swing/UIDefaults/8133926/InternalFrameIcon.java 8199075 generic-all
 javax/swing/UIDefaults/8149879/InternalResourceBundle.java 8199054 windows-all
 javax/swing/text/html/parser/Parser/8078268/bug8078268.java 8199092 generic-all

--- a/test/jdk/javax/swing/UIDefaults/6302464/bug6302464.java
+++ b/test/jdk/javax/swing/UIDefaults/6302464/bug6302464.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,28 +118,49 @@ public class bug6302464 {
     private static void testAntialiasingHints() {
         setMetalLookAndFeel();
 
-        HashSet colorsAAOff = getAntialiasedColors(VALUE_TEXT_ANTIALIAS_OFF, 100);
+        boolean isMacOSX14 = false;
+        boolean isMacOSXBigSur = false;
+        if (System.getProperty("os.name").contains("OS X")) {
+            String version = System.getProperty("os.version", "");
+            if (version.startsWith("10.")) {
+                version = version.substring(3);
+                int periodIndex = version.indexOf('.');
+                if (periodIndex != -1) {
+                    version = version.substring(0, periodIndex);
+                }
+                try {
+                    int v = Integer.parseInt(version);
+                    isMacOSX14 = (v >= 14);
+                } catch (NumberFormatException e) {
+                }
+            } else if (version.startsWith("11.")) {
+                isMacOSXBigSur = true;
+            }
+        }
+        if (!isMacOSX14 && !isMacOSXBigSur) {
+            HashSet colorsAAOff = getAntialiasedColors(VALUE_TEXT_ANTIALIAS_OFF, 100);
 
-        if (colorsAAOff.size() > 2) {
-            throw new RuntimeException("Wrong number of antialiased colors.");
+            if (colorsAAOff.size() > 2) {
+                throw new RuntimeException("Wrong number of antialiased colors.");
+            }
         }
 
         HashSet colorsAAOnLCD100 = getAntialiasedColors(
                 VALUE_TEXT_ANTIALIAS_LCD_HRGB, 100);
 
         if (colorsAAOnLCD100.size() <= 2) {
-            throw new RuntimeException("Wrong number of antialiased colors.");
+            throw new RuntimeException("Wrong number of antialiased ANTIALIAS_LCD_HRGB_100 colors.");
         }
 
         HashSet colorsAAOnLCD250 = getAntialiasedColors(
                 VALUE_TEXT_ANTIALIAS_LCD_HRGB, 250);
 
         if (colorsAAOnLCD250.size() <= 2) {
-            throw new RuntimeException("Wrong number of antialiased colors.");
+            throw new RuntimeException("Wrong number of antialiased ANTIALIAS_LCD_HRGB_250 colors.");
         }
 
         if (colorsAAOnLCD100.equals(colorsAAOnLCD250)) {
-            throw new RuntimeException("LCD contarst is not used.");
+            throw new RuntimeException("LCD contrast is not used.");
         }
     }
 


### PR DESCRIPTION
Basically clean backport of JDK-8199079. I only had to remove the test from the problem list manually due to different context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8199079](https://bugs.openjdk.java.net/browse/JDK-8199079): Test javax/swing/UIDefaults/6302464/bug6302464.java is unstable


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/697/head:pull/697` \
`$ git checkout pull/697`

Update a local copy of the PR: \
`$ git checkout pull/697` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 697`

View PR using the GUI difftool: \
`$ git pr show -t 697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/697.diff">https://git.openjdk.java.net/jdk11u-dev/pull/697.diff</a>

</details>
