### PR TITLE
8273366: [testbug] javax/swing/UIDefaults/6302464/bug6302464.java fails on macOS12

### DIFF
--- a/test/jdk/javax/swing/UIDefaults/6302464/bug6302464.java
+++ b/test/jdk/javax/swing/UIDefaults/6302464/bug6302464.java
@@ -119,7 +119,7 @@ public class bug6302464 {
         setMetalLookAndFeel();
 
         boolean isMacOSX14 = false;
-        boolean isMacOSXBigSur = false;
+        boolean isMacOSXBigSurOrAbove = false;
         if (System.getProperty("os.name").contains("OS X")) {
             String version = System.getProperty("os.version", "");
             if (version.startsWith("10.")) {
@@ -133,11 +133,17 @@ public class bug6302464 {
                     isMacOSX14 = (v >= 14);
                 } catch (NumberFormatException e) {
                 }
-            } else if (version.startsWith("11.")) {
-                isMacOSXBigSur = true;
+            } else {
+                String majorVersion = version.substring(0, version.indexOf("."));
+                System.out.println(majorVersion);
+                try {
+                    int ver = Integer.parseInt(majorVersion);
+                    isMacOSXBigSurOrAbove = (ver >= 11);
+                } catch (NumberFormatException e){
+                }
             }
         }
-        if (!isMacOSX14 && !isMacOSXBigSur) {
+        if (!isMacOSX14 && !isMacOSXBigSurOrAbove) {
             HashSet colorsAAOff = getAntialiasedColors(VALUE_TEXT_ANTIALIAS_OFF, 100);
 
             if (colorsAAOff.size() > 2) {


### PR DESCRIPTION
Clean Backport of JDK-8273366 on top of JDK-8199079.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273366](https://bugs.openjdk.java.net/browse/JDK-8273366): [testbug] javax/swing/UIDefaults/6302464/bug6302464.java fails on macOS12


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to 649c1f98013d9dbdf3d3bfa97a019a6cd0afcd50


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/698/head:pull/698` \
`$ git checkout pull/698`

Update a local copy of the PR: \
`$ git checkout pull/698` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 698`

View PR using the GUI difftool: \
`$ git pr show -t 698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/698.diff">https://git.openjdk.java.net/jdk11u-dev/pull/698.diff</a>

</details>
