### PR TITLE
Backport a1c942c02b65a7fc2a837d2bb43fa134dadcad11

### DIFF
--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -613,9 +613,9 @@ void Dictionary::verify() {
   ClassLoaderData* cld = loader_data();
   // class loader must be present;  a null class loader is the
   // boostrap loader
-  guarantee(cld != NULL || DumpSharedSpaces ||
-            cld->class_loader() == NULL ||
-            cld->class_loader()->is_instance(),
+  guarantee(DumpSharedSpaces ||
+            (cld != NULL &&
+             (cld->the_null_class_loader_data() || cld->class_loader()->is_instance())),
             "checking type of class_loader");
 
   ResourceMark rm;


### PR DESCRIPTION
Part of GCC 11 compatibility. Did not apply cleanly due to presence of DumpSharedSpaces in the modified guarantee(). Backport is otherwise identical to original patch.
