### PR TITLE
8266172: -Wstringop-overflow happens in vmError.cpp

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1754,8 +1754,8 @@ static void crash_with_sigfpe() {
 // crash with sigsegv at non-null address.
 static void crash_with_segfault() {
 
-  char* const crash_addr = (char*) VMError::get_segfault_address();
-  *crash_addr = 'X';
+  int* crash_addr = reinterpret_cast<int*>(VMError::get_segfault_address());
+  *crash_addr = 1;
 
 } // end: crash_with_segfault
 


### PR DESCRIPTION
Part of GCC 11 compatibility. Does not apply cleanly due to previous 11u replacement of VMError::segfault_address with VMError::get_segfault_address().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266172](https://bugs.openjdk.java.net/browse/JDK-8266172): -Wstringop-overflow happens in vmError.cpp


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/704/head:pull/704` \
`$ git checkout pull/704`

Update a local copy of the PR: \
`$ git checkout pull/704` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 704`

View PR using the GUI difftool: \
`$ git pr show -t 704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/704.diff">https://git.openjdk.java.net/jdk11u-dev/pull/704.diff</a>

</details>
