### PR TITLE
8240904: Screen flashes on test failures when running tests from make

### DIFF
--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,16 @@ net.app=netstat
 net.sockets.args=-aeeopv
 net.statistics.args=-sv
 
-screenshot.app=gnome-screenshot
-screenshot.args= -f screen.png
+screenshot.app=bash
+screenshot.args=-c\0\
+    echo '\
+        var robot = new java.awt.Robot();\
+        var ge = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment();\
+        var bounds = ge.getDefaultScreenDevice().getDefaultConfiguration().getBounds();\
+        var capture = robot.createScreenCapture(bounds);\
+        var file = new java.io.File("screen.png");\
+        javax.imageio.ImageIO.write(capture, "png", file);\
+    ' | jshell -
+screenshot.args.delimiter=\0
 ################################################################################
 

--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -120,5 +120,5 @@ scutil.nwi.args=--nwi
 scutil.proxy.args=--proxy
 
 screenshot.app=screencapture
-screenshot.args= -x screen1.png screen2.png screen3.png screen4.png screen5.png
+screenshot.args=-x screen1.png screen2.png screen3.png screen4.png screen5.png
 ################################################################################

--- a/test/failure_handler/src/share/conf/solaris.properties
+++ b/test/failure_handler/src/share/conf/solaris.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,8 @@ environment=\
   system.dmesg system.prtconf system.sysdef \
   process.ps process.top \
   memory.swap memory.vmstat.default memory.vmstat.statistics memory.pagesize \
-  netstat.av netstat.m netstat.s netstat.i
+  netstat.av netstat.m netstat.s netstat.i \
+  screenshot
 ################################################################################
 # common unix
 ################################################################################
@@ -108,4 +109,16 @@ netstat.av.args=-av
 netstat.m.args=-m
 netstat.s.args=-s
 netstat.i.args=-i 1 5
+
+screenshot.app=bash
+screenshot.args=-c\0\
+    echo '\
+        var robot = new java.awt.Robot();\
+        var ge = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment();\
+        var bounds = ge.getDefaultScreenDevice().getDefaultConfiguration().getBounds();\
+        var capture = robot.createScreenCapture(bounds);\
+        var file = new java.io.File("screen.png");\
+        javax.imageio.ImageIO.write(capture, "png", file);\
+    ' | jshell -
+screenshot.args.delimiter=\0
 ################################################################################

--- a/test/failure_handler/src/share/conf/windows.properties
+++ b/test/failure_handler/src/share/conf/windows.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,8 @@ environment=\
   memory.free memory.vmstat.default memory.vmstat.statistics \
         memory.vmstat.slabinfo memory.vmstat.disk \
   files \
-  net.sockets net.statistics
+  net.sockets net.statistics \
+  screenshot
 ################################################################################
 users.current.app=id
 users.current.args=-a
@@ -112,4 +113,16 @@ net.sockets.args=-c\0netstat -b -a -t -o || netstat -a -t -o
 net.sockets.args.delimiter=\0
 net.statistics.app=netstat
 net.statistics.args=-s -e
+
+screenshot.app=bash
+screenshot.args=-c\0\
+    echo '\
+        var robot = new java.awt.Robot();\
+        var ge = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment();\
+        var bounds = ge.getDefaultScreenDevice().getDefaultConfiguration().getBounds();\
+        var capture = robot.createScreenCapture(bounds);\
+        var file = new java.io.File(""screen.png"");\
+        javax.imageio.ImageIO.write(capture, ""png"", file);\
+    ' | jshell -
+screenshot.args.delimiter=\0
 ################################################################################


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

Besides Copyright, I had to resolve the solaris and windows files.
The patches did not apply because of context differences.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240904](https://bugs.openjdk.java.net/browse/JDK-8240904): Screen flashes on test failures when running tests from make


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/712/head:pull/712` \
`$ git checkout pull/712`

Update a local copy of the PR: \
`$ git checkout pull/712` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 712`

View PR using the GUI difftool: \
`$ git pr show -t 712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/712.diff">https://git.openjdk.java.net/jdk11u-dev/pull/712.diff</a>

</details>
