### PR TITLE
8266187: Memory leak in appendBootClassPath()

### DIFF
--- a/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
+++ b/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -956,6 +956,7 @@ appendBootClassPath( JPLISAgent* agent,
 
             resolved = resolve(parent, path);
             jvmtierr = (*jvmtienv)->AddToBootstrapClassLoaderSearch(jvmtienv, resolved);
+            free(resolved);
         }
 
         /* print warning if boot class path not updated */


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266187](https://bugs.openjdk.java.net/browse/JDK-8266187): Memory leak in appendBootClassPath()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/713/head:pull/713` \
`$ git checkout pull/713`

Update a local copy of the PR: \
`$ git checkout pull/713` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 713`

View PR using the GUI difftool: \
`$ git pr show -t 713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/713.diff">https://git.openjdk.java.net/jdk11u-dev/pull/713.diff</a>

</details>
