### PR TITLE
8273575: memory leak in appendBootClassPath(), paths must be deallocated

### DIFF
--- a/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
+++ b/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
@@ -981,4 +981,5 @@ appendBootClassPath( JPLISAgent* agent,
     if (haveBasePath && parent != canonicalPath) {
         free(parent);
     }
+    free(paths);
 }


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273575](https://bugs.openjdk.java.net/browse/JDK-8273575): memory leak in appendBootClassPath(), paths must be deallocated


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/714/head:pull/714` \
`$ git checkout pull/714`

Update a local copy of the PR: \
`$ git checkout pull/714` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 714`

View PR using the GUI difftool: \
`$ git pr show -t 714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/714.diff">https://git.openjdk.java.net/jdk11u-dev/pull/714.diff</a>

</details>
