### PR TITLE
8211170: AArch64: Warnings in C1 and template interpreter

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1732,6 +1732,7 @@ void LIR_Assembler::arith_op(LIR_Code code, LIR_Opr left, LIR_Opr right, LIR_Opr
         default: ShouldNotReachHere();
         }
         break;
+      default:
         ShouldNotReachHere();
       }
     } else {

--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -584,8 +584,8 @@ void LIRGenerator::do_ArithmeticOp(ArithmeticOp* x) {
     case doubleTag:  do_ArithmeticOp_FPU(x);  return;
     case longTag:    do_ArithmeticOp_Long(x); return;
     case intTag:     do_ArithmeticOp_Int(x);  return;
+    default:         ShouldNotReachHere();    return;
   }
-  ShouldNotReachHere();
 }
 
 // _ishl, _lshl, _ishr, _lshr, _iushr, _lushr
@@ -792,9 +792,13 @@ void LIRGenerator::do_MathIntrinsic(Intrinsic* x) {
           __ abs(value.result(), dst, LIR_OprFact::illegalOpr);
           break;
         }
+        default:
+          ShouldNotReachHere();
       }
       break;
     }
+    default:
+      ShouldNotReachHere();
   }
 }
 

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -2323,6 +2323,7 @@ void TemplateTable::resolve_cache_and_index(int byte_no,
   switch (code) {
   case Bytecodes::_nofast_getfield: code = Bytecodes::_getfield; break;
   case Bytecodes::_nofast_putfield: code = Bytecodes::_putfield; break;
+  default: break;
   }
 
   assert(byte_no == f1_byte || byte_no == f2_byte, "byte_no out of range");
@@ -2947,6 +2948,7 @@ void TemplateTable::jvmti_post_fast_field_mod()
     case Bytecodes::_fast_dputfield: __ pop_d(); break;
     case Bytecodes::_fast_fputfield: __ pop_f(); break;
     case Bytecodes::_fast_lputfield: __ pop_l(r0); break;
+    default: break;
     }
     __ bind(L2);
   }


### PR DESCRIPTION
Clean backport to jdkj11u-dev. needed to allow backport of JEP-391 to build without warnings

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211170](https://bugs.openjdk.java.net/browse/JDK-8211170): AArch64: Warnings in C1 and template interpreter


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/716/head:pull/716` \
`$ git checkout pull/716`

Update a local copy of the PR: \
`$ git checkout pull/716` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 716`

View PR using the GUI difftool: \
`$ git pr show -t 716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/716.diff">https://git.openjdk.java.net/jdk11u-dev/pull/716.diff</a>

</details>
