### PR TITLE
8207793: [TESTBUG] runtime/Metaspace/FragmentMetaspace.java fails: heap needs to be increased

### DIFF
--- a/test/hotspot/jtreg/runtime/Metaspace/FragmentMetaspace.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/FragmentMetaspace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @library /runtime/testlibrary
  * @modules java.base/jdk.internal.misc
  * @modules java.compiler
- * @run main/othervm/timeout=200 -Xmx300m FragmentMetaspace
+ * @run main/othervm/timeout=200 -Xmx1g FragmentMetaspace
  */
 
 import java.io.IOException;
@@ -42,8 +42,8 @@ public class FragmentMetaspace {
     public static Class<?> c;
 
     public static void main(String... args) {
-        runGrowing(Long.valueOf(System.getProperty("time", "80000")),
-            Integer.valueOf(System.getProperty("iterations", "200")));
+        runGrowing(Long.valueOf(System.getProperty("time", "40000")),
+            Integer.valueOf(System.getProperty("iterations", "100")));
         // try to clean up and unload classes to decrease
         // class verification time in debug vm
         System.gc();
@@ -68,6 +68,9 @@ public class FragmentMetaspace {
                 gcl = null;
             } catch (IOException | InstantiationException | IllegalAccessException ex) {
                 throw new RuntimeException(ex);
+            } catch (OutOfMemoryError oome) {
+                System.out.println("javac failed with OOM; ignored.");
+                return;
             }
         }
     }

--- a/test/hotspot/jtreg/runtime/testlibrary/GeneratedClassLoader.java
+++ b/test/hotspot/jtreg/runtime/testlibrary/GeneratedClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 
 import java.io.DataInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
@@ -145,10 +146,17 @@ public class GeneratedClassLoader extends ClassLoader {
             pw.append(src);
             pw.flush();
         }
-        int exitcode = javac.run(null, null, null, file.getCanonicalPath());
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int exitcode = javac.run(null, null, err, file.getCanonicalPath());
         if (exitcode != 0) {
-            throw new RuntimeException("javac failure when compiling: " +
-                    file.getCanonicalPath());
+            // Print Error
+            System.err.print(err);
+            if (err.toString().contains("java.lang.OutOfMemoryError: Java heap space")) {
+              throw new OutOfMemoryError("javac failed with resources exhausted");
+            } else {
+              throw new RuntimeException("javac failure when compiling: " +
+                      file.getCanonicalPath());
+            }
         } else {
             if (deleteFiles) {
                 file.delete();


### PR DESCRIPTION
Applies clean, needed for the test to pass on macos-aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8207793](https://bugs.openjdk.java.net/browse/JDK-8207793): [TESTBUG] runtime/Metaspace/FragmentMetaspace.java fails: heap needs to be increased


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/718/head:pull/718` \
`$ git checkout pull/718`

Update a local copy of the PR: \
`$ git checkout pull/718` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 718`

View PR using the GUI difftool: \
`$ git pr show -t 718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/718.diff">https://git.openjdk.java.net/jdk11u-dev/pull/718.diff</a>

</details>
