### PR TITLE
8258554: javax/swing/JTable/4235420/bug4235420.java fails in GTK L&F

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -697,7 +697,6 @@ javax/swing/JComboBox/8033069/bug8033069ScrollBar.java 8163367 generic-all
 javax/swing/JColorChooser/Test6827032.java 8197825 windows-all
 javax/swing/JColorChooser/Test7194184.java 8194126 linux-all,macosx-all
 javax/swing/JTable/7124218/SelectEditTableCell.java 8148958 linux-all,macosx-all
-javax/swing/JTable/4235420/bug4235420.java     8079127 generic-all
 javax/swing/JSplitPane/4201995/bug4201995.java 8079127 generic-all
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all

--- a/test/jdk/javax/swing/JTable/4235420/bug4235420.java
+++ b/test/jdk/javax/swing/JTable/4235420/bug4235420.java
@@ -37,20 +37,34 @@ import java.util.Map;
 public class bug4235420 {
 
     public static void main(String[] argv) throws Exception {
-        if ("Nimbus".equals(UIManager.getLookAndFeel().getName())) {
-            System.out.println("The test is skipped for Nimbus");
-
-            return;
-        }
-
-        SwingUtilities.invokeAndWait(new Runnable() {
-            @Override
-            public void run() {
-                Table table = new Table();
-
-                table.test();
+        for (UIManager.LookAndFeelInfo LF :
+                UIManager.getInstalledLookAndFeels()) {
+            try {
+                UIManager.setLookAndFeel(LF.getClassName());
+            } catch (UnsupportedLookAndFeelException ignored) {
+                System.out.println("Unsupported L&F: " + LF.getClassName());
+            } catch (ClassNotFoundException | InstantiationException
+                     | IllegalAccessException e) {
+                throw new RuntimeException(e);
             }
-        });
+            System.out.println("Testing L&F: " + LF.getClassName());
+
+            if ("Nimbus".equals(UIManager.getLookAndFeel().getName()) ||
+                "GTK".equals(UIManager.getLookAndFeel().getName())) {
+                System.out.println("The test is skipped for Nimbus and GTK");
+
+                continue;
+            }
+
+            SwingUtilities.invokeAndWait(new Runnable() {
+                @Override
+                public void run() {
+                    Table table = new Table();
+
+                    table.test();
+                }
+            });
+        }
     }
 
     private static class Table extends JTable {


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

I had to resolve the ProblemList.

The fix is incomplete, the test still fails. Follow-up JDK-8273638 is needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8258554](https://bugs.openjdk.java.net/browse/JDK-8258554): javax/swing/JTable/4235420/bug4235420.java fails in GTK L&F


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/721/head:pull/721` \
`$ git checkout pull/721`

Update a local copy of the PR: \
`$ git checkout pull/721` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 721`

View PR using the GUI difftool: \
`$ git pr show -t 721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/721.diff">https://git.openjdk.java.net/jdk11u-dev/pull/721.diff</a>

</details>
