### PR TITLE
8273638: javax/swing/JTable/4235420/bug4235420.java fails in GTK L&F

### DIFF
--- a/test/jdk/javax/swing/JTable/4235420/bug4235420.java
+++ b/test/jdk/javax/swing/JTable/4235420/bug4235420.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class bug4235420 {
             System.out.println("Testing L&F: " + LF.getClassName());
 
             if ("Nimbus".equals(UIManager.getLookAndFeel().getName()) ||
-                "GTK".equals(UIManager.getLookAndFeel().getName())) {
+                "GTK".equals(UIManager.getLookAndFeel().getID())) {
                 System.out.println("The test is skipped for Nimbus and GTK");
 
                 continue;


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

Required follow-up of JDK-8258554.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273638](https://bugs.openjdk.java.net/browse/JDK-8273638): javax/swing/JTable/4235420/bug4235420.java fails in GTK L&F


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/722/head:pull/722` \
`$ git checkout pull/722`

Update a local copy of the PR: \
`$ git checkout pull/722` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 722`

View PR using the GUI difftool: \
`$ git pr show -t 722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/722.diff">https://git.openjdk.java.net/jdk11u-dev/pull/722.diff</a>

</details>
