### PR TITLE
8265150: AsyncGetCallTrace crashes on ResourceMark

### DIFF
--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -251,14 +251,11 @@ int Method::bci_from(address bcp) const {
   if (is_native() && bcp == 0) {
     return 0;
   }
-#ifdef ASSERT
-  {
-    ResourceMark rm;
-    assert(is_native() && bcp == code_base() || contains(bcp) || VMError::is_error_reported(),
-           "bcp doesn't belong to this method: bcp: " INTPTR_FORMAT ", method: %s",
-           p2i(bcp), name_and_sig_as_C_string());
-  }
-#endif
+  // Do not have a ResourceMark here because AsyncGetCallTrace stack walking code
+  // may call this after interrupting a nested ResourceMark.
+  assert(is_native() && bcp == code_base() || contains(bcp) || VMError::is_error_reported(),
+         "bcp doesn't belong to this method. bcp: " INTPTR_FORMAT, p2i(bcp));
+
   return bcp - code_base();
 }
 

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -814,8 +814,8 @@ JvmtiEnvBase::get_stack_trace(JavaThread *java_thread,
          "at safepoint or target thread is suspended");
   int count = 0;
   if (java_thread->has_last_Java_frame()) {
-    RegisterMap reg_map(java_thread);
     Thread* current_thread = Thread::current();
+    RegisterMap reg_map(java_thread, false /* update_map */);
     ResourceMark rm(current_thread);
     javaVFrame *jvf = java_thread->last_java_vframe(&reg_map);
     HandleMark hm(current_thread);

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -814,8 +814,8 @@ JvmtiEnvBase::get_stack_trace(JavaThread *java_thread,
          "at safepoint or target thread is suspended");
   int count = 0;
   if (java_thread->has_last_Java_frame()) {
-    Thread* current_thread = Thread::current();
     RegisterMap reg_map(java_thread, false /* update_map */);
+    Thread* current_thread = Thread::current();
     ResourceMark rm(current_thread);
     javaVFrame *jvf = java_thread->last_java_vframe(&reg_map);
     HandleMark hm(current_thread);


### PR DESCRIPTION
Backport to openjdk 11u for parity with Oracle 11.0.15.

The original patch does not apply cleanly. The conflicts is in jvmtiEnvBase.cpp due to surrounding context difference. Also, RegisterMap constructor in 11u does not take the third parameter (process_frames), which was introduced for concurrent stack processing in later version.

Test:
- [x] tier1 on Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265150](https://bugs.openjdk.java.net/browse/JDK-8265150): AsyncGetCallTrace crashes on ResourceMark


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/724/head:pull/724` \
`$ git checkout pull/724`

Update a local copy of the PR: \
`$ git checkout pull/724` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 724`

View PR using the GUI difftool: \
`$ git pr show -t 724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/724.diff">https://git.openjdk.java.net/jdk11u-dev/pull/724.diff</a>

</details>
