### PR TITLE
8225559: assertion error at TransTypes.visitApply

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/DeferredAttr.java
@@ -150,7 +150,7 @@ public class DeferredAttr extends JCTree.Visitor {
                         JCExpression clazz = copy(t.clazz, p);
                         List<JCExpression> args = copy(t.args, p);
                         JCClassDecl def = null;
-                        return make.at(t.pos).SpeculativeNewClass(encl, typeargs, clazz, args, def, t.def != null);
+                        return make.at(t.pos).SpeculativeNewClass(encl, typeargs, clazz, args, def, t.def != null || t.classDeclRemoved());
                     } else {
                         return super.visitNewClass(node, p);
                     }

--- a/test/langtools/tools/javac/generics/diamond/protectedConstructor/ProtectedConstructorTest.java
+++ b/test/langtools/tools/javac/generics/diamond/protectedConstructor/ProtectedConstructorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8225559
+ * @summary assertion error at TransTypes.visitApply
+ * @compile ProtectedConstructorTest.java
+ */
+
+import pkg.Bar;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+class ProtectedConstructorTest {
+    public void foo() {
+        supply(getSupplier(new Bar<>(){}));
+        CompletableFuture<List<String>> completableFuture = getCompletableFuture(getSupplier(new Bar<>(){}));
+        completableFuture = getCompletableFuture(() -> getList(null, new Bar<>() {}));
+    }
+
+    static <U> Supplier<U> getSupplier(Bar<U> t) {
+        return null;
+    }
+
+    static <U> void supply(Supplier<U> supplier) {}
+    static <U> CompletableFuture<U> getCompletableFuture(Supplier<U> supplier) { return null; }
+    <T> List<T> getList(final Supplier<List<T>> supplier, Bar<T> t) { return null; }
+}

--- a/test/langtools/tools/javac/generics/diamond/protectedConstructor/pkg/Bar.java
+++ b/test/langtools/tools/javac/generics/diamond/protectedConstructor/pkg/Bar.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg;
+
+public abstract class Bar<T> {
+    protected Bar() {}
+    protected Bar(Class<?> c) {}
+}


### PR DESCRIPTION
This is a backport of [JDK-8225559](https://bugs.openjdk.java.net/browse/JDK-8225559): assertion error at TransTypes.visitApply

The patch applied cleanly.
 
Testing: tier1 tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8225559](https://bugs.openjdk.java.net/browse/JDK-8225559): assertion error at TransTypes.visitApply


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/725/head:pull/725` \
`$ git checkout pull/725`

Update a local copy of the PR: \
`$ git checkout pull/725` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 725`

View PR using the GUI difftool: \
`$ git pr show -t 725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/725.diff">https://git.openjdk.java.net/jdk11u-dev/pull/725.diff</a>

</details>
