### PR TITLE
8277385: Zero: Enable CompactStrings support

### DIFF
--- a/src/hotspot/cpu/zero/globals_zero.hpp
+++ b/src/hotspot/cpu/zero/globals_zero.hpp
@@ -77,8 +77,7 @@ define_pd_global(uintx, TypeProfileLevel, 0);
 
 define_pd_global(bool, PreserveFramePointer, false);
 
-// No performance work done here yet.
-define_pd_global(bool, CompactStrings, false);
+define_pd_global(bool, CompactStrings, true);
 
 define_pd_global(bool, ThreadLocalHandshakes, false);
 


### PR DESCRIPTION
Clean backport to improve Zero performance.

Additional testing:
 - [x] Linux x86_64 Zero fastdebug `make bootcycle-images`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277385](https://bugs.openjdk.java.net/browse/JDK-8277385): Zero: Enable CompactStrings support


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/726/head:pull/726` \
`$ git checkout pull/726`

Update a local copy of the PR: \
`$ git checkout pull/726` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 726`

View PR using the GUI difftool: \
`$ git pr show -t 726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/726.diff">https://git.openjdk.java.net/jdk11u-dev/pull/726.diff</a>

</details>
