### PR TITLE
8278115: gc/stress/gclocker/TestGCLockerWithSerial.java has duplicate -Xmx

### DIFF
--- a/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithSerial.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithSerial.java
@@ -28,7 +28,7 @@
  * @requires vm.gc.Serial
  * @requires vm.flavor != "minimal"
  * @summary Stress Serial's GC locker by calling GetPrimitiveArrayCritical while concurrently filling up old gen.
- * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xmx1500m -Xmx1500m -XX:+UseSerialGC TestGCLockerWithSerial
+ * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UseSerialGC TestGCLockerWithSerial
  */
 public class TestGCLockerWithSerial {
     public static void main(String[] args) {


### PR DESCRIPTION
Test backport to improve testing. Does not apply cleanly, because the test have not been moved in the separate package (done in bulk later).

Additional testing:
 - [x] Linux x86_64 fastdebug, affected test still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278115](https://bugs.openjdk.java.net/browse/JDK-8278115): gc/stress/gclocker/TestGCLockerWithSerial.java has duplicate -Xmx


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/727/head:pull/727` \
`$ git checkout pull/727`

Update a local copy of the PR: \
`$ git checkout pull/727` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 727`

View PR using the GUI difftool: \
`$ git pr show -t 727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/727.diff">https://git.openjdk.java.net/jdk11u-dev/pull/727.diff</a>

</details>
