### PR TITLE
8278116: runtime/modules/LoadUnloadModuleStress.java has duplicate -Xmx

### DIFF
--- a/test/hotspot/jtreg/runtime/modules/LoadUnloadModuleStress.java
+++ b/test/hotspot/jtreg/runtime/modules/LoadUnloadModuleStress.java
@@ -31,7 +31,7 @@
  * @compile/module=java.base java/lang/ModuleHelper.java
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xmx64m -Xmx64m LoadUnloadModuleStress 15000
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xms64m -Xmx64m LoadUnloadModuleStress 15000
  */
 
 import java.lang.ref.WeakReference;


### PR DESCRIPTION
Unclean backport to improve testing. The original patch does not apply cleanly because the context is a bit different.

Additional testing:
 - [x] Linux x86_64 fastdebug, affected test passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278116](https://bugs.openjdk.java.net/browse/JDK-8278116): runtime/modules/LoadUnloadModuleStress.java has duplicate -Xmx


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/728/head:pull/728` \
`$ git checkout pull/728`

Update a local copy of the PR: \
`$ git checkout pull/728` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 728`

View PR using the GUI difftool: \
`$ git pr show -t 728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/728.diff">https://git.openjdk.java.net/jdk11u-dev/pull/728.diff</a>

</details>
