### PR TITLE
8279077: JFR crashes on Linux ppc due to missing crash protector in signal handler

### DIFF
--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -229,6 +229,10 @@ JVM_handle_linux_signal(int sig,
 
   Thread* t = Thread::current_or_null_safe();
 
+  // Must do this before SignalHandlerMark, if crash protection installed we will longjmp away
+  // (no destructors can be run)
+  os::ThreadCrashProtection::check_crash_protection(sig, t);
+
   SignalHandlerMark shm(t);
 
   // Note: it's not uncommon that JNI code uses signal/sigset to install


### PR DESCRIPTION
This is a linux_ppc specific bug, probably a day-one bug till relevant code was refactored by JDK-8255711 in 16.

Linux ppc signal handler does not install crash protector as other Linux based platforms do, e.g. linux_x86, that can result a crash while jfr tries to fill stack trace for other thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8279077](https://bugs.openjdk.java.net/browse/JDK-8279077): JFR crashes on Linux ppc due to missing crash protector in signal handler


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/729/head:pull/729` \
`$ git checkout pull/729`

Update a local copy of the PR: \
`$ git checkout pull/729` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 729`

View PR using the GUI difftool: \
`$ git pr show -t 729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/729.diff">https://git.openjdk.java.net/jdk11u-dev/pull/729.diff</a>

</details>
