### PR TITLE
8278384: Bytecodes::result_type() for arraylength returns T_VOID instead of T_INT

### DIFF
--- a/src/hotspot/share/interpreter/bytecodes.cpp
+++ b/src/hotspot/share/interpreter/bytecodes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -471,7 +471,7 @@ void Bytecodes::initialize() {
   def(_new                 , "new"                 , "bkk"  , NULL    , T_OBJECT ,  1, true );
   def(_newarray            , "newarray"            , "bc"   , NULL    , T_OBJECT ,  0, true );
   def(_anewarray           , "anewarray"           , "bkk"  , NULL    , T_OBJECT ,  0, true );
-  def(_arraylength         , "arraylength"         , "b"    , NULL    , T_VOID   ,  0, true );
+  def(_arraylength         , "arraylength"         , "b"    , NULL    , T_INT    ,  0, true );
   def(_athrow              , "athrow"              , "b"    , NULL    , T_VOID   , -1, true );
   def(_checkcast           , "checkcast"           , "bkk"  , NULL    , T_OBJECT ,  0, true );
   def(_instanceof          , "instanceof"          , "bkk"  , NULL    , T_INT    ,  0, true );


### PR DESCRIPTION
I would like to backport this patch for parity with Oracle 11.0.15.

The original patch does not apply cleanly. JDK 11u does not have bytecodeUtils.cpp file, which was introduced by JDK-8218628 in JDK 14.

Test:
- [x] Passed compiler/c1/CanonicalizeArrayLength.java  with -XX:+DeoptimizeALot -XX:+VerifyStack

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278384](https://bugs.openjdk.java.net/browse/JDK-8278384): Bytecodes::result_type() for arraylength returns T_VOID instead of T_INT


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/730/head:pull/730` \
`$ git checkout pull/730`

Update a local copy of the PR: \
`$ git checkout pull/730` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 730`

View PR using the GUI difftool: \
`$ git pr show -t 730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/730.diff">https://git.openjdk.java.net/jdk11u-dev/pull/730.diff</a>

</details>
