### PR TITLE
8270874: JFrame paint artifacts when dragged from standard monitor to HiDPI monitor

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@
 #include "awt_Win32GraphicsDevice.h"
 #include "Hashtable.h"
 #include "ComCtl32Util.h"
+#include "math.h"
 
 #include <Region.h>
 
@@ -2234,8 +2235,8 @@ void AwtComponent::PaintUpdateRgn(const RECT *insets)
          */
         RECT* r = (RECT*)(buffer + rgndata->rdh.dwSize);
         RECT* un[2] = {0, 0};
-    DWORD i;
-    for (i = 0; i < rgndata->rdh.nCount; i++, r++) {
+        DWORD i;
+        for (i = 0; i < rgndata->rdh.nCount; i++, r++) {
             int width = r->right-r->left;
             int height = r->bottom-r->top;
             if (width > 0 && height > 0) {
@@ -2247,13 +2248,22 @@ void AwtComponent::PaintUpdateRgn(const RECT *insets)
                 }
             }
         }
+        // The Windows may request to update the small region of pixels that
+        // cannot be represented in the user's space, in this case, we will
+        // request to repaint the smallest non-empty bounding box in the user's
+        // space
+        int screen = GetScreenImOn();
+        Devices::InstanceAccess devices;
+        AwtWin32GraphicsDevice* device = devices->GetDevice(screen);
+        float scaleX = (device == NULL) ? 1 : device->GetScaleX();
+        float scaleY = (device == NULL) ? 1 : device->GetScaleY();
         for(i = 0; i < 2; i++) {
             if (un[i] != 0) {
-                DoCallback("handleExpose", "(IIII)V",
-                           ScaleDownX(un[i]->left),
-                           ScaleDownY(un[i]->top),
-                           ScaleDownX(un[i]->right - un[i]->left),
-                           ScaleDownY(un[i]->bottom - un[i]->top));
+                int x1 = floor(un[i]->left / scaleX);
+                int y1 = floor(un[i]->top / scaleY);
+                int x2 = ceil(un[i]->right / scaleX);
+                int y2 = ceil(un[i]->bottom  / scaleY);
+                DoCallback("handleExpose", "(IIII)V", x1, y1, x2 - x1, y2 - y1);
             }
         }
         delete [] buffer;

--- a/test/jdk/java/awt/Window/WindowResizingOnDPIChanging/WindowResizingOnMovingToAnotherDisplay.java
+++ b/test/jdk/java/awt/Window/WindowResizingOnDPIChanging/WindowResizingOnMovingToAnotherDisplay.java
@@ -53,7 +53,7 @@ import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 
 /* @test
- * @bug 8147440 8147016
+ * @bug 8147440 8147016 8270874
  * @summary HiDPI (Windows): Swing components have incorrect sizes after
  *          changing display resolution
  * @run main/manual/othervm WindowResizingOnMovingToAnotherDisplay


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [03473b4c](https://github.com/openjdk/jdk/commit/03473b4c271b2ec7f0ebdb0edabadf7f36816b9d) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 18 Nov 2021 and was reviewed by Jayathirth D V.

The patch is not clean due to copyright date conflict. The jdk_desktop tests are green on the system where the bug was reproduced.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270874](https://bugs.openjdk.java.net/browse/JDK-8270874): JFrame paint artifacts when dragged from standard monitor to HiDPI monitor


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/732/head:pull/732` \
`$ git checkout pull/732`

Update a local copy of the PR: \
`$ git checkout pull/732` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 732`

View PR using the GUI difftool: \
`$ git pr show -t 732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/732.diff">https://git.openjdk.java.net/jdk11u-dev/pull/732.diff</a>

</details>
