### PR TITLE
8268014: Build failure on SUSE Linux Enterprise Server 11.4 (s390x) due to 'SYS_get_mempolicy' was not declared

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3232,10 +3232,12 @@ static bool numa_syscall_check() {
   // Especially in dockers, get_mempolicy is not allowed with the default configuration. So it's necessary
   // to check whether the syscalls are available. Currently, only get_mempolicy is checked since checking
   // others like mbind would cause unexpected side effects.
+#ifdef SYS_get_mempolicy
   int dummy = 0;
   if (syscall(SYS_get_mempolicy, &dummy, NULL, 0, (void*)&dummy, 3) == -1) {
     return false;
   }
+#endif
 
   return true;
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268014](https://bugs.openjdk.java.net/browse/JDK-8268014): Build failure on SUSE Linux Enterprise Server 11.4 (s390x) due to 'SYS_get_mempolicy' was not declared


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/734/head:pull/734` \
`$ git checkout pull/734`

Update a local copy of the PR: \
`$ git checkout pull/734` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 734`

View PR using the GUI difftool: \
`$ git pr show -t 734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/734.diff">https://git.openjdk.java.net/jdk11u-dev/pull/734.diff</a>

</details>
