### PR TITLE
8275536: Add test to check that File::lastModified returns same time stamp as Files.getLastModifiedTime

### DIFF
--- a/test/jdk/java/io/File/LastModifiedTest.java
+++ b/test/jdk/java/io/File/LastModifiedTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Amazon and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Instant;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+/**
+ * @test
+ * @library ..
+ * @run testng LastModifiedTest
+ * @summary Test to validate that java.nio.Files returns the same value
+ * as java.io.File
+ */
+public class LastModifiedTest {
+
+    private static final Instant MILLISECOND_PRECISION = Instant.ofEpochMilli(1999L);
+
+    @Test
+    public void verifyLastModifiedTime() throws IOException {
+        File tempFile = Files.createTempFile("MillisecondPrecisionTest", "txt").toFile();
+        try {
+            tempFile.setLastModified(MILLISECOND_PRECISION.toEpochMilli());
+
+            long ioTimestamp = tempFile.lastModified();
+            long nioTimestamp = Files.getLastModifiedTime(tempFile.toPath()).toMillis();
+
+            assertEquals(ioTimestamp, nioTimestamp);
+        } finally {
+            tempFile.delete();
+        }
+
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275536](https://bugs.openjdk.java.net/browse/JDK-8275536): Add test to check that File::lastModified returns same time stamp as Files.getLastModifiedTime


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/737/head:pull/737` \
`$ git checkout pull/737`

Update a local copy of the PR: \
`$ git checkout pull/737` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 737`

View PR using the GUI difftool: \
`$ git pr show -t 737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/737.diff">https://git.openjdk.java.net/jdk11u-dev/pull/737.diff</a>

</details>
