### PR TITLE
8279077: JFR crashes on Linux ppc due to missing crash protector in signal handler

### DIFF
--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -229,6 +229,10 @@ JVM_handle_linux_signal(int sig,
 
   Thread* t = Thread::current_or_null_safe();
 
+  // Must do this before SignalHandlerMark, if crash protection installed we will longjmp away
+  // (no destructors can be run)
+  os::ThreadCrashProtection::check_crash_protection(sig, t);
+
   SignalHandlerMark shm(t);
 
   // Note: it's not uncommon that JNI code uses signal/sigset to install


### PR DESCRIPTION
I would like to backport this Linux ppc specific bug to 11u.

The patch fixes potential crashes when jfr try to snapshot stacks of other threads.

The JDK15u patch applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279077](https://bugs.openjdk.java.net/browse/JDK-8279077): JFR crashes on Linux ppc due to missing crash protector in signal handler


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/739/head:pull/739` \
`$ git checkout pull/739`

Update a local copy of the PR: \
`$ git checkout pull/739` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 739`

View PR using the GUI difftool: \
`$ git pr show -t 739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/739.diff">https://git.openjdk.java.net/jdk11u-dev/pull/739.diff</a>

</details>
