### PR TITLE
8279379: GHA: Print tests that are in error

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -341,6 +341,7 @@ jobs:
         run: >
           if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
             cat build/*/test-results/*/text/newfailures.txt ;
+            cat build/*/test-results/*/text/other_errors.txt ;
             exit 1 ;
           fi
 
@@ -809,6 +810,7 @@ jobs:
         run: >
           if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
             cat build/*/test-results/*/text/newfailures.txt ;
+            cat build/*/test-results/*/text/other_errors.txt ;
             exit 1 ;
           fi
 
@@ -1124,6 +1126,7 @@ jobs:
         run: >
           if ((Get-ChildItem -Path build\*\test-results\test-summary.txt -Recurse | Select-String -Pattern "TEST SUCCESS" ).Count -eq 0) {
             Get-Content -Path build\*\test-results\*\*\newfailures.txt ;
+            Get-Content -Path build\*\test-results\*\*\other_errors.txt ;
             exit 1
           }
 
@@ -1409,6 +1412,7 @@ jobs:
         run: >
           if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
             cat build/*/test-results/*/text/newfailures.txt ;
+            cat build/*/test-results/*/text/other_errors.txt ;
             exit 1 ;
           fi
 


### PR DESCRIPTION
Clean backport to improve GHA.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279379](https://bugs.openjdk.java.net/browse/JDK-8279379): GHA: Print tests that are in error


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/741/head:pull/741` \
`$ git checkout pull/741`

Update a local copy of the PR: \
`$ git checkout pull/741` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 741`

View PR using the GUI difftool: \
`$ git pr show -t 741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/741.diff">https://git.openjdk.java.net/jdk11u-dev/pull/741.diff</a>

</details>
