### PR TITLE
8278172: java/nio/channels/FileChannel/BlockDeviceSize.java should only run on Linux

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 8054029
+ * @requires (os.family == "linux")
  * @summary Block devices should not report size=0 on Linux
  */
 


### PR DESCRIPTION
A clean backport for parity with Oracle 11.0.15.

This is a test only patch, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278172](https://bugs.openjdk.java.net/browse/JDK-8278172): java/nio/channels/FileChannel/BlockDeviceSize.java should only run on Linux


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/742/head:pull/742` \
`$ git checkout pull/742`

Update a local copy of the PR: \
`$ git checkout pull/742` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/742/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 742`

View PR using the GUI difftool: \
`$ git pr show -t 742`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/742.diff">https://git.openjdk.java.net/jdk11u-dev/pull/742.diff</a>

</details>
