### PR TITLE
8279225: [arm32] C1 longs comparison operation destroys argument registers

### DIFF
--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -2396,8 +2396,8 @@ void LIR_Assembler::comp_op(LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2,
         __ teq(xhi, yhi);
         __ teq(xlo, ylo, eq);
       } else {
-        __ subs(xlo, xlo, ylo);
-        __ sbcs(xhi, xhi, yhi);
+        __ subs(Rtemp, xlo, ylo);
+        __ sbcs(Rtemp, xhi, yhi);
       }
     } else {
       ShouldNotReachHere();


### PR DESCRIPTION
Clean backport to fix ARM32 and get parity with 11.0.5-oracle.

Additional testing:
 - [x] `java/math/BigDecimal/DivideMcTests.java` with `-XX:+TieredCompilation` on ARM32 fails before the patch, passes with it

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279225](https://bugs.openjdk.java.net/browse/JDK-8279225): [arm32] C1 longs comparison operation destroys argument registers


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/743/head:pull/743` \
`$ git checkout pull/743`

Update a local copy of the PR: \
`$ git checkout pull/743` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 743`

View PR using the GUI difftool: \
`$ git pr show -t 743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/743.diff">https://git.openjdk.java.net/jdk11u-dev/pull/743.diff</a>

</details>
