### PR TITLE
8274795: AArch64: avoid spilling and restoring r18 in macro assembler

### DIFF
--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1458,11 +1458,12 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     __ cmp(rscratch1, JavaThread::stack_guard_yellow_reserved_disabled);
     __ br(Assembler::NE, no_reguard);
 
-    __ pusha(); // XXX only save smashed registers
+    __ push_call_clobbered_registers();
     __ mov(c_rarg0, rthread);
     __ mov(rscratch2, CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages));
     __ blr(rscratch2);
-    __ popa(); // XXX only restore smashed registers
+    __ pop_call_clobbered_registers();
+
     __ bind(no_reguard);
   }
 


### PR DESCRIPTION
`r18` should not be used as it is reserved as platform register. Linux is fine with userspace using it, but Windows and also recently macOS (https://github.com/openjdk/jdk11u-dev/pull/301#issuecomment-911998917 ) are actually using it on the kernel side.

The macro assembler uses the bit pattern `0x7fff_ffff` (== `r0-r30`) to specify which registers to spill. While spilling `r18` is fine (e.g. for a register dump), we should never restore it.

Tested tier1 on Linux/AArch64 and macOS/AArch64 (the latter on top of the current patches from https://github.com/openjdk/aarch64-port/pull/14 ).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274795](https://bugs.openjdk.java.net/browse/JDK-8274795): AArch64: avoid spilling and restoring r18 in macro assembler


### Reviewers
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/744/head:pull/744` \
`$ git checkout pull/744`

Update a local copy of the PR: \
`$ git checkout pull/744` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 744`

View PR using the GUI difftool: \
`$ git pr show -t 744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/744.diff">https://git.openjdk.java.net/jdk11u-dev/pull/744.diff</a>

</details>
