### PR TITLE
8256154: Some TestNG tests require default constructors

### DIFF
--- a/test/jdk/java/lang/Package/GetPackages.java
+++ b/test/jdk/java/lang/Package/GetPackages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,12 @@ public class GetPackages {
     GetPackages(TestClassLoader loader) throws ClassNotFoundException {
         this.loader = loader;
         this.fooClass = loader.loadClass("foo.Foo");
+    }
+
+    /** For TestNG */
+    public GetPackages() {
+        loader = null;
+        fooClass = null;
     }
 
     /*

--- a/test/jdk/java/lang/StackWalker/Basic.java
+++ b/test/jdk/java/lang/StackWalker/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,6 +109,11 @@ public class Basic {
     private final int depth;
     Basic(int depth) {
         this.depth = depth;
+    }
+
+    /** For TestNG */
+    public Basic() {
+        depth = 0;
     }
 
     /*


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8256154](https://bugs.openjdk.java.net/browse/JDK-8256154): Some TestNG tests require default constructors


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/747/head:pull/747` \
`$ git checkout pull/747`

Update a local copy of the PR: \
`$ git checkout pull/747` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 747`

View PR using the GUI difftool: \
`$ git pr show -t 747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/747.diff">https://git.openjdk.java.net/jdk11u-dev/pull/747.diff</a>

</details>
