### PR TITLE
8279300: [arm32] SIGILL when running GetObjectSizeIntrinsicsTest

### DIFF
--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -2201,6 +2201,9 @@ void LIR_Assembler::logic_op(LIR_Code code, LIR_Opr left, LIR_Opr right, LIR_Opr
     } else {
       assert(right->is_constant(), "must be");
       const uint c = (uint)right->as_constant_ptr()->as_jint();
+      if (!Assembler::is_arith_imm_in_range(c)) {
+        BAILOUT("illegal arithmetic operand");
+      }
       switch (code) {
         case lir_logic_and: __ and_32(res, lreg, c); break;
         case lir_logic_or:  __ orr_32(res, lreg, c); break;


### PR DESCRIPTION
I'd like to backport SIGILL fix for arm32 platform. The patch applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279300](https://bugs.openjdk.java.net/browse/JDK-8279300): [arm32] SIGILL when running GetObjectSizeIntrinsicsTest


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/748/head:pull/748` \
`$ git checkout pull/748`

Update a local copy of the PR: \
`$ git checkout pull/748` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 748`

View PR using the GUI difftool: \
`$ git pr show -t 748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/748.diff">https://git.openjdk.java.net/jdk11u-dev/pull/748.diff</a>

</details>
