### PR TITLE
8249019: clean up FileInstaller $test.src $cwd in vmTestbase_vm_compiler tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/jit/Arrays/ArrayBounds/ArrayBounds.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/Arrays/ArrayBounds/ArrayBounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.Arrays.ArrayBounds.ArrayBounds
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/Arrays/ArrayStoreCheck/ArrayStoreCheck.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/Arrays/ArrayStoreCheck/ArrayStoreCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.Arrays.ArrayStoreCheck.ArrayStoreCheck
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/Arrays/ArrayTests/ArrayTests.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/Arrays/ArrayTests/ArrayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.Arrays.ArrayTests.ArrayTests
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/CEETest/CEETest.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/CEETest/CEETest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.CEETest.CEETest
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/CondExpr/CondExpr.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/CondExpr/CondExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.CondExpr.CondExpr
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/DivTest/DivTest.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/DivTest/DivTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.DivTest.DivTest
  * @run driver ExecDriver --java jit.DivTest.DivTest
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/ExcOpt/ExcOpt.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/ExcOpt/ExcOpt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.ExcOpt.ExcOpt
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Filtering/Filtering.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Filtering/Filtering.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.FloatingPoint.gen_math.Filtering.Filtering
  * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Filtering.Filtering
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops01/Loops01.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops01/Loops01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.FloatingPoint.gen_math.Loops01.Loops01
  * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops01.Loops01
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops02/Loops02.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops02/Loops02.java
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.FloatingPoint.gen_math.Loops02.Loops02
  * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops02.Loops02
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops03/Loops03.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops03/Loops03.java
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.FloatingPoint.gen_math.Loops03.Loops03
  * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops03.Loops03
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops04/Loops04.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops04/Loops04.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.FloatingPoint.gen_math.Loops04.Loops04
  * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops04.Loops04
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops05/Loops05.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops05/Loops05.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.FloatingPoint.gen_math.Loops05.Loops05
  * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops05.Loops05
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops06/Loops06.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops06/Loops06.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.FloatingPoint.gen_math.Loops06.Loops06
  * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops06.Loops06
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops07/Loops07.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops07/Loops07.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.FloatingPoint.gen_math.Loops07.Loops07
  * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops07.Loops07
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Matrix_3d/Matrix_3d.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Matrix_3d/Matrix_3d.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.FloatingPoint.gen_math.Matrix_3d.Matrix_3d
  * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Matrix_3d.Matrix_3d
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/ShortCircuitTest/ShortCircuitTest.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/ShortCircuitTest/ShortCircuitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.FloatingPoint.gen_math.ShortCircuitTest.ShortCircuitTest
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Summ/Summ.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Summ/Summ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.FloatingPoint.gen_math.Summ.Summ
  * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Summ.Summ
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/PrintProperties/PrintProperties.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/PrintProperties/PrintProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.PrintProperties.PrintProperties
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/PrintThis/PrintThis.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/PrintThis/PrintThis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.PrintThis.PrintThis
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/Robert/Robert.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/Robert/Robert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.Robert.Robert
  * @run driver ExecDriver --java jit.Robert.Robert
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/Sleeper/Sleeper.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/Sleeper/Sleeper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.Sleeper.Sleeper
  * @run driver ExecDriver --java jit.Sleeper.Sleeper
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/bounds/bounds.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/bounds/bounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.bounds.bounds
  * @run driver ExecDriver --java jit.bounds.bounds
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test01/test01.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test01/test01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.deoptimization.test01.test01
  * @run driver ExecDriver --java jit.deoptimization.test01.test01
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test02/test02.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test02/test02.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.deoptimization.test02.test02
  * @run driver ExecDriver --java jit.deoptimization.test02.test02
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test03/test03.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test03/test03.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.deoptimization.test03.test03
  * @run driver ExecDriver --java jit.deoptimization.test03.test03
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test04/test04.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test04/test04.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.deoptimization.test04.test04
  * @run driver ExecDriver --java jit.deoptimization.test04.test04
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test05/test05.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test05/test05.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.deoptimization.test05.test05
  * @run driver ExecDriver --java jit.deoptimization.test05.test05
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test06/test06.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test06/test06.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.deoptimization.test06.test06
  * @run driver ExecDriver --java jit.deoptimization.test06.test06
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test07/test07.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test07/test07.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.deoptimization.test07.test07
  * @run driver ExecDriver --java jit.deoptimization.test07.test07
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test08/test08.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test08/test08.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.deoptimization.test08.test08
  * @run driver ExecDriver --java jit.deoptimization.test08.test08
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.escape.AdaptiveBlocking.AdaptiveBlocking001.AdaptiveBlocking001
  * @run driver/timeout=300 ExecDriver --java -server -Xcomp -XX:+DoEscapeAnalysis
  *             jit.escape.AdaptiveBlocking.AdaptiveBlocking001.AdaptiveBlocking001 -numRounds 10

--- a/test/hotspot/jtreg/vmTestbase/jit/escape/LockElision/MatMul/MatMul.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/escape/LockElision/MatMul/MatMul.java
@@ -40,7 +40,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.escape.LockElision.MatMul.MatMul
  * @run driver ExecDriver --java jit.escape.LockElision.MatMul.MatMul -dim 30 -threadCount 10
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/exception/exception.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/exception/exception.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.exception.exception
  * @run driver ExecDriver --java jit.exception.exception
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/init/init01/init01.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/init/init01/init01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.init.init01.init01
  * @run driver ExecDriver --java jit.init.init01.init01
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/init/init02/init02.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/init/init02/init02.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.init.init02.init02
  * @run driver ExecDriver --java jit.init.init02.init02
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/inline/inline005/inline005.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/inline/inline005/inline005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.inline.inline005.inline005
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/misctests/JitBug1/JitBug1.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/misctests/JitBug1/JitBug1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.misctests.JitBug1.JitBug1
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/misctests/Pi/Pi.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/misctests/Pi/Pi.java
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.misctests.Pi.Pi
  * @run driver ExecDriver --java jit.misctests.Pi.Pi
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/misctests/clss14702/clss14702.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/misctests/clss14702/clss14702.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.misctests.clss14702.clss14702
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/misctests/fpustack/GraphApplet.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/misctests/fpustack/GraphApplet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.misctests.fpustack.GraphApplet
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/misctests/putfield00802/putfield00802.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/misctests/putfield00802/putfield00802.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.misctests.putfield00802.putfield00802
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/misctests/t5/t5.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/misctests/t5/t5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.misctests.t5.t5
  * @run driver ExecDriver --java jit.misctests.t5.t5
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/overflow/overflow.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/overflow/overflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.overflow.overflow
  * @run driver ExecDriver --java jit.overflow.overflow
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/regression/CrashC1/CrashC1.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/regression/CrashC1/CrashC1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.regression.CrashC1.CrashC1
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/regression/b4427606/b4427606.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/regression/b4427606/b4427606.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.regression.b4427606.b4427606
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/regression/b4446672/b4446672.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/regression/b4446672/b4446672.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm jit.regression.b4446672.b4446672
  */
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t007/t007.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t007/t007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.t.t007.t007
  * @run driver ExecDriver --java jit.t.t007.t007
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t008/t008.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t008/t008.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.t.t008.t008
  * @run driver ExecDriver --java jit.t.t008.t008
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t009/t009.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t009/t009.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.t.t009.t009
  * @run driver ExecDriver --java jit.t.t009.t009
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t012/t012.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t012/t012.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.t.t012.t012
  * @run driver ExecDriver --java jit.t.t012.t012
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t014/t014.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t014/t014.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.t.t014.t014
  * @run driver ExecDriver --java jit.t.t014.t014
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t026/t026.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t026/t026.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.t.t026.t026
  * @run driver ExecDriver --java jit.t.t026.t026
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t041/t041.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t041/t041.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.t.t041.t041
  * @run driver ExecDriver --java jit.t.t041.t041
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t044/t044.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t044/t044.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.t.t044.t044
  * @run driver ExecDriver --java jit.t.t044.t044
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t045/t045.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t045/t045.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.t.t045.t045
  * @run driver ExecDriver --java jit.t.t045.t045
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t050/t050.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t050/t050.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.t.t050.t050
  * @run driver ExecDriver --java jit.t.t050.t050
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t066/t066.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t066/t066.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.t.t066.t066
  * @run driver ExecDriver --java jit.t.t066.t066
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/verifier/VerifyInitLocal/VerifyInitLocal.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/verifier/VerifyInitLocal/VerifyInitLocal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @compile VerifyInitLocal1P.jasm
  * @compile VerifyInitLocal2N.jasm
  * @compile VerifyInitLocal3N.jasm

--- a/test/hotspot/jtreg/vmTestbase/jit/verifier/VerifyMergeStack/VerifyMergeStack.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/verifier/VerifyMergeStack/VerifyMergeStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @compile MergeStack.jasm
  * @run main/othervm jit.verifier.VerifyMergeStack.VerifyMergeStack
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/wide/wide01/wide01.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/wide/wide01/wide01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.wide.wide01.wide01
  * @run driver ExecDriver --java jit.wide.wide01.wide01
  */

--- a/test/hotspot/jtreg/vmTestbase/jit/wide/wide02/wide02.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/wide/wide02/wide02.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build jit.wide.wide02.wide02
  * @run driver ExecDriver --java jit.wide.wide02.wide02
  */

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit001/uninit001.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit001/uninit001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build vm.compiler.complog.share.LogCompilationTest
  *        vm.compiler.complog.uninit.uninit001.uninit001
  *        vm.compiler.complog.uninit.UninitializedTrapCounter

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit002/uninit002.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit002/uninit002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build vm.compiler.complog.share.LogCompilationTest
  *        vm.compiler.complog.uninit.uninit002.uninit002
  *        vm.compiler.complog.uninit.UninitializedTrapCounter

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit003/uninit003.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit003/uninit003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build vm.compiler.complog.share.LogCompilationTest
  *        vm.compiler.complog.uninit.uninit003.uninit003
  *        vm.compiler.complog.uninit.UninitializedTrapCounter

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit004/uninit004.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit004/uninit004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build vm.compiler.complog.share.LogCompilationTest
  *        vm.compiler.complog.uninit.uninit004.uninit004
  *        vm.compiler.complog.uninit.UninitializedTrapCounter

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit005/uninit005.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit005/uninit005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build vm.compiler.complog.share.LogCompilationTest
  *        vm.compiler.complog.uninit.uninit005.uninit005
  *        vm.compiler.complog.uninit.UninitializedTrapCounter

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit006/uninit006.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit006/uninit006.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build vm.compiler.complog.share.LogCompilationTest
  *        vm.compiler.complog.uninit.uninit006.uninit006
  *        vm.compiler.complog.uninit.UninitializedTrapCounter

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit007/uninit007.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit007/uninit007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build vm.compiler.complog.share.LogCompilationTest
  *        vm.compiler.complog.uninit.uninit007.uninit007
  *        vm.compiler.complog.uninit.UninitializedTrapCounter

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit008/uninit008.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit008/uninit008.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build vm.compiler.complog.share.LogCompilationTest
  *        vm.compiler.complog.uninit.uninit008.uninit008
  *        vm.compiler.complog.uninit.UninitializedTrapCounter

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit009/uninit009.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit009/uninit009.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build vm.compiler.complog.share.LogCompilationTest
  *        vm.compiler.complog.uninit.uninit009.uninit009
  *        vm.compiler.complog.uninit.UninitializedTrapCounter

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit010/uninit010.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit010/uninit010.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build vm.compiler.complog.share.LogCompilationTest
  *        vm.compiler.complog.uninit.uninit010.uninit010
  *        vm.compiler.complog.uninit.UninitializedTrapCounter

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit011/uninit011.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit011/uninit011.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build vm.compiler.complog.share.LogCompilationTest
  *        vm.compiler.complog.uninit.uninit011.uninit011
  *        vm.compiler.complog.uninit.UninitializedTrapCounter

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit012/uninit012.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit012/uninit012.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build vm.compiler.complog.share.LogCompilationTest
  *        vm.compiler.complog.uninit.uninit012.uninit012
  *        vm.compiler.complog.uninit.UninitializedTrapCounter

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit013/uninit013.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/uninit013/uninit013.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @build vm.compiler.complog.share.LogCompilationTest
  *        vm.compiler.complog.uninit.uninit013.uninit013
  *        vm.compiler.complog.uninit.UninitializedTrapCounter

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/coverage/parentheses/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/coverage/parentheses/TestDescription.java
@@ -45,7 +45,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.coverage.parentheses.Parentheses
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/constprop/constprop01/constprop01.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/constprop/constprop01/constprop01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.constprop.constprop01.constprop01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/constprop/constprop02/constprop02.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/constprop/constprop02/constprop02.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.constprop.constprop02.constprop02
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead01/dead01.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead01/dead01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead01.dead01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead02/dead02.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead02/dead02.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead02.dead02
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead03/dead03.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead03/dead03.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead03.dead03
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead04/dead04.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead04/dead04.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead04.dead04
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead05/dead05.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead05/dead05.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead05.dead05
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead06/dead06.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead06/dead06.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead06.dead06
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead07/dead07.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead07/dead07.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead07.dead07
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead08/dead08.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead08/dead08.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead08.dead08
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead09/dead09.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead09/dead09.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead09.dead09
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead10/dead10.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead10/dead10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead10.dead10
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead11/dead11.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead11/dead11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead11.dead11
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead12/dead12.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead12/dead12.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead12.dead12
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead13/dead13.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead13/dead13.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead13.dead13
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead14/dead14.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead14/dead14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead14.dead14
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead15/dead15.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead15/dead15.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead15.dead15
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead16/dead16.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/dead/dead16/dead16.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.dead.dead16.dead16
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/hoist/hoist01/hoist01.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/hoist/hoist01/hoist01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.hoist.hoist01.hoist01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/hoist/hoist02/hoist02.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/hoist/hoist02/hoist02.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.hoist.hoist02.hoist02
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/hoist/hoist03/hoist03.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/hoist/hoist03/hoist03.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.hoist.hoist03.hoist03
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/hoist/hoist04/hoist04.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/hoist/hoist04/hoist04.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.hoist.hoist04.hoist04
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/subcommon/subcommon01/subcommon01.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/subcommon/subcommon01/subcommon01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.subcommon.subcommon01.subcommon01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/subcommon/subcommon02/subcommon02.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/subcommon/subcommon02/subcommon02.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.subcommon.subcommon02.subcommon02
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/subcommon/subcommon03/subcommon03.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/subcommon/subcommon03/subcommon03.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.subcommon.subcommon03.subcommon03
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/subcommon/subcommon04/subcommon04.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/subcommon/subcommon04/subcommon04.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.subcommon.subcommon04.subcommon04
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/subcommon/subcommon05/subcommon05.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/jbe/subcommon/subcommon05/subcommon05.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm vm.compiler.jbe.subcommon.subcommon05.subcommon05
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/explicit/Explicit01/cs_disabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/explicit/Explicit01/cs_disabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm -XX:-CompactStrings vm.compiler.optimizations.stringconcat.explicit.Explicit01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/explicit/Explicit01/cs_enabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/explicit/Explicit01/cs_enabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm -XX:+CompactStrings vm.compiler.optimizations.stringconcat.explicit.Explicit01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/explicit/Merge01/cs_disabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/explicit/Merge01/cs_disabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm -XX:-CompactStrings vm.compiler.optimizations.stringconcat.explicit.Merge01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/explicit/Merge01/cs_enabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/explicit/Merge01/cs_enabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm -XX:+CompactStrings vm.compiler.optimizations.stringconcat.explicit.Merge01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Implicit01/cs_disabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Implicit01/cs_disabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm -XX:-CompactStrings vm.compiler.optimizations.stringconcat.implicit.Implicit01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Implicit01/cs_enabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Implicit01/cs_enabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm -XX:+CompactStrings vm.compiler.optimizations.stringconcat.implicit.Implicit01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Merge01/cs_disabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Merge01/cs_disabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm -XX:-CompactStrings vm.compiler.optimizations.stringconcat.implicit.Merge01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Merge01/cs_enabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Merge01/cs_enabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm -XX:+CompactStrings vm.compiler.optimizations.stringconcat.implicit.Merge01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc1/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc1/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc1
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc10/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc10/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc10
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc11/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc11/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc11
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc12/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc12/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc12
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc13/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc13/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc13
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc14/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc14/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc14
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc15/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc15/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc15
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc16/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc16/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc16
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc17/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc17/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc17
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc18/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc18/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc18
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc19/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc19/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc19
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc2/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc2/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc2
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc20/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc20/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc20
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc21/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc21/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc21
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc22/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc22/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc22
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc23/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc23/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc23
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc24/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc24/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc24
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc25/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc25/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc25
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc26/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc26/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc26
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc27/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc27/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc27
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc28/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc28/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc28
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc29/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc29/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc29
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc3/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc3/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc3
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc30/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc30/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc30
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc31/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc31/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc31
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc32/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc32/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc32
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc33/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc33/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc33
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc34/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc34/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc34
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc35/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc35/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc35
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc36/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc36/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc36
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc37/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc37/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc37
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc38/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc38/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc38
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc39/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc39/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc39
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc4/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc4/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc4
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc40/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc40/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc40
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc41/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc41/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc41
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc42/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc42/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc42
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc43/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc43/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc43
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc44/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc44/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc44
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc45/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc45/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc45
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc46/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc46/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc46
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc47/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc47/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc47
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc48/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc48/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc48
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc49/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc49/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc49
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc5/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc5/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc5
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc50/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc50/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc50
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc51/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc51/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc51
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc52/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc52/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc52
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc6/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc6/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc6
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc7/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc7/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc7
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc8/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc8/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc8
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc9/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/jit/LongTransitions/nativeFnc9/TestDescription.java
@@ -30,7 +30,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
  * @run main/native/othervm vm.jit.LongTransitions.LTTest nativeFnc9
  */
 


### PR DESCRIPTION
This test cleanup is a clean backport and simplifies follow-up backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8249019](https://bugs.openjdk.java.net/browse/JDK-8249019): clean up FileInstaller $test.src $cwd in vmTestbase_vm_compiler tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/752/head:pull/752` \
`$ git checkout pull/752`

Update a local copy of the PR: \
`$ git checkout pull/752` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 752`

View PR using the GUI difftool: \
`$ git pr show -t 752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/752.diff">https://git.openjdk.java.net/jdk11u-dev/pull/752.diff</a>

</details>
