### PR TITLE
8251132: make main classes public in vmTestbase/jit tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/jit/DivTest/DivTest.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/DivTest/DivTest.java
@@ -32,15 +32,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.DivTest.DivTest
- * @run driver ExecDriver --java jit.DivTest.DivTest
+ * @run main/othervm jit.DivTest.DivTest
  */
 
 package jit.DivTest;
 
 import nsk.share.TestFailure;
 
-class DivTest{
+public class DivTest{
   static int n;
   static boolean test1 (int n1, int n2) {
     try {

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Filtering/Filtering.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Filtering/Filtering.java
@@ -29,15 +29,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.FloatingPoint.gen_math.Filtering.Filtering
- * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Filtering.Filtering
+ * @run main/othervm jit.FloatingPoint.gen_math.Filtering.Filtering
  */
 
 package jit.FloatingPoint.gen_math.Filtering;
 
 import nsk.share.TestFailure;
 
-class Filtering
+public class Filtering
 {
    static int N = 1000;
    static double xx[];

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops01/Loops01.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops01/Loops01.java
@@ -29,15 +29,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.FloatingPoint.gen_math.Loops01.Loops01
- * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops01.Loops01
+ * @run main/othervm jit.FloatingPoint.gen_math.Loops01.Loops01
  */
 
 package jit.FloatingPoint.gen_math.Loops01;
 
 import nsk.share.TestFailure;
 
-class Loops01
+public class Loops01
 {
 
    static final int N = 500;

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops02/Loops02.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops02/Loops02.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.FloatingPoint.gen_math.Loops02.Loops02
- * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops02.Loops02
+ * @run main/othervm jit.FloatingPoint.gen_math.Loops02.Loops02
  */
 
 package jit.FloatingPoint.gen_math.Loops02;
@@ -38,7 +37,7 @@ package jit.FloatingPoint.gen_math.Loops02;
 // Test working with  loops and random functions.
 import nsk.share.TestFailure;
 
-class Loops02
+public class Loops02
 {
 
    static final int N = 300;

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops03/Loops03.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops03/Loops03.java
@@ -29,15 +29,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.FloatingPoint.gen_math.Loops03.Loops03
- * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops03.Loops03
+ * @run main/othervm jit.FloatingPoint.gen_math.Loops03.Loops03
  */
 
 package jit.FloatingPoint.gen_math.Loops03;
 
 import nsk.share.TestFailure;
 
-class Loops03
+public class Loops03
 {
 
    static final int N = 100000;

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops04/Loops04.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops04/Loops04.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.FloatingPoint.gen_math.Loops04.Loops04
- * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops04.Loops04
+ * @run main/othervm jit.FloatingPoint.gen_math.Loops04.Loops04
  */
 
 package jit.FloatingPoint.gen_math.Loops04;
@@ -38,7 +37,7 @@ package jit.FloatingPoint.gen_math.Loops04;
 // Test working with nested loops.
 import nsk.share.TestFailure;
 
-class Loops04
+public class Loops04
 {
 
    public static void main (String args[])

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops05/Loops05.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops05/Loops05.java
@@ -29,15 +29,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.FloatingPoint.gen_math.Loops05.Loops05
- * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops05.Loops05
+ * @run main/othervm jit.FloatingPoint.gen_math.Loops05.Loops05
  */
 
 package jit.FloatingPoint.gen_math.Loops05;
 
 import nsk.share.TestFailure;
 
-class Loops05
+public class Loops05
 {
 
    static final int N = 100;

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops06/Loops06.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops06/Loops06.java
@@ -29,15 +29,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.FloatingPoint.gen_math.Loops06.Loops06
- * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops06.Loops06
+ * @run main/othervm jit.FloatingPoint.gen_math.Loops06.Loops06
  */
 
 package jit.FloatingPoint.gen_math.Loops06;
 
 import nsk.share.TestFailure;
 
-class Loops06
+public class Loops06
 {
 
    static final int N = 20;

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops07/Loops07.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Loops07/Loops07.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.FloatingPoint.gen_math.Loops07.Loops07
- * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Loops07.Loops07
+ * @run main/othervm jit.FloatingPoint.gen_math.Loops07.Loops07
  */
 
 package jit.FloatingPoint.gen_math.Loops07;
@@ -41,7 +40,7 @@ package jit.FloatingPoint.gen_math.Loops07;
 
 import nsk.share.TestFailure;
 
-class Loops07
+public class Loops07
 {
 
    public static void main (String args[])

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Matrix_3d/Matrix_3d.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Matrix_3d/Matrix_3d.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.FloatingPoint.gen_math.Matrix_3d.Matrix_3d
- * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Matrix_3d.Matrix_3d
+ * @run main/othervm jit.FloatingPoint.gen_math.Matrix_3d.Matrix_3d
  */
 
 package jit.FloatingPoint.gen_math.Matrix_3d;
@@ -40,7 +39,7 @@ package jit.FloatingPoint.gen_math.Matrix_3d;
 
 import nsk.share.TestFailure;
 
-class Matrix_3d
+public class Matrix_3d
 {
 
    public static void main (String args[])

--- a/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Summ/Summ.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/FloatingPoint/gen_math/Summ/Summ.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.FloatingPoint.gen_math.Summ.Summ
- * @run driver ExecDriver --java jit.FloatingPoint.gen_math.Summ.Summ
+ * @run main/othervm jit.FloatingPoint.gen_math.Summ.Summ
  */
 
 package jit.FloatingPoint.gen_math.Summ;
@@ -39,7 +38,7 @@ package jit.FloatingPoint.gen_math.Summ;
 
 import nsk.share.TestFailure;
 
-class Summ
+public class Summ
 {
    public static void main (String args[])
    {

--- a/test/hotspot/jtreg/vmTestbase/jit/Robert/Robert.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/Robert/Robert.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.Robert.Robert
- * @run driver ExecDriver --java jit.Robert.Robert
+ * @run main/othervm jit.Robert.Robert
  */
 
 package jit.Robert;
@@ -38,7 +37,7 @@ package jit.Robert;
 import java.io.*;
 import nsk.share.TestFailure;
 
-class Robert
+public class Robert
    {
    Robert()
       throws Exception

--- a/test/hotspot/jtreg/vmTestbase/jit/Sleeper/Sleeper.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/Sleeper/Sleeper.java
@@ -29,15 +29,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.Sleeper.Sleeper
- * @run driver ExecDriver --java jit.Sleeper.Sleeper
+ * @run main/othervm jit.Sleeper.Sleeper
  */
 
 package jit.Sleeper;
 
 import nsk.share.TestFailure;
 
-class Sleeper {
+public class Sleeper {
     public static void main(String args[] ) {
       System.out.println ("1");
       try { Thread.sleep(1000); } catch (InterruptedException e) {}

--- a/test/hotspot/jtreg/vmTestbase/jit/bounds/bounds.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/bounds/bounds.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.bounds.bounds
- * @run driver ExecDriver --java jit.bounds.bounds
+ * @run main/othervm jit.bounds.bounds
  */
 
 package jit.bounds;
@@ -40,7 +39,7 @@ package jit.bounds;
 
 import nsk.share.TestFailure;
 
-class bounds {
+public class bounds {
     public static void main(String[] argv) {
         int i;
         int a[] = new int[2];

--- a/test/hotspot/jtreg/vmTestbase/jit/collapse/collapse.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/collapse/collapse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.collapse.collapse
- * @run driver ExecDriver --java jit.collapse.collapse
+ * @run main/othervm jit.collapse.collapse
  */
 
 package jit.collapse;
@@ -39,7 +38,7 @@ package jit.collapse;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class collapse {
+public class collapse {
         public static final GoldChecker goldChecker = new GoldChecker( "collapse" );
 
         public static void main( String[] argv )

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test01/test01.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test01/test01.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.deoptimization.test01.test01
- * @run driver ExecDriver --java jit.deoptimization.test01.test01
+ * @run main/othervm jit.deoptimization.test01.test01
  */
 
 package jit.deoptimization.test01;
@@ -44,7 +43,7 @@ import nsk.share.TestFailure;
  *      run with the -XX:TraceDeoptimization to observ the result.
  */
 
-class test01 {
+public class test01 {
   public static void main (String[] args) {
     A obj = new A();
     for (int index = 0; index < 100; index++) {

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test02/test02.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test02/test02.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.deoptimization.test02.test02
- * @run driver ExecDriver --java jit.deoptimization.test02.test02
+ * @run main/othervm jit.deoptimization.test02.test02
  */
 
 package jit.deoptimization.test02;
@@ -44,7 +43,7 @@ import nsk.share.TestFailure;
  *      run with the -XX:TraceDeoptimization to observ the result.
  */
 
-class test02 {
+public class test02 {
   public static void main (String[] args) {
     A obj = new A();
     for (int index = 0; index < 100; index++) {

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test03/test03.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test03/test03.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.deoptimization.test03.test03
- * @run driver ExecDriver --java jit.deoptimization.test03.test03
+ * @run main/othervm jit.deoptimization.test03.test03
  */
 
 package jit.deoptimization.test03;
@@ -44,7 +43,7 @@ import nsk.share.TestFailure;
  *      run with the -XX:TraceDeoptimization to observ the result.
  */
 
-class test03 {
+public class test03 {
   public static void main (String[] args) {
     A obj = new A();
     for (int index = 0; index < 100; index++) {

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test04/test04.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test04/test04.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.deoptimization.test04.test04
- * @run driver ExecDriver --java jit.deoptimization.test04.test04
+ * @run main/othervm jit.deoptimization.test04.test04
  */
 
 package jit.deoptimization.test04;
@@ -41,7 +40,7 @@ import nsk.share.TestFailure;
  *
  */
 
-class test04 {
+public class test04 {
         public static void main (String[] args) {
                 A obj = new A();
 

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test05/test05.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test05/test05.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.deoptimization.test05.test05
- * @run driver ExecDriver --java jit.deoptimization.test05.test05
+ * @run main/othervm jit.deoptimization.test05.test05
  */
 
 package jit.deoptimization.test05;
@@ -41,7 +40,7 @@ import nsk.share.TestFailure;
  *
  */
 
-class test05 {
+public class test05 {
         public static void main (String[] args) {
                 A obj = new A();
 

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test06/test06.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test06/test06.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.deoptimization.test06.test06
- * @run driver ExecDriver --java jit.deoptimization.test06.test06
+ * @run main/othervm jit.deoptimization.test06.test06
  */
 
 package jit.deoptimization.test06;
@@ -45,7 +44,7 @@ import nsk.share.TestFailure;
  *      run with the -XX:TraceDeoptimization to observ the result.
  */
 
-class test06 {
+public class test06 {
   public static void main (String[] args) {
     A obj = new A();
     for (int index = 0; index < 1; index++) {

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test07/test07.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test07/test07.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.deoptimization.test07.test07
- * @run driver ExecDriver --java jit.deoptimization.test07.test07
+ * @run main/othervm jit.deoptimization.test07.test07
  */
 
 package jit.deoptimization.test07;
@@ -45,7 +44,7 @@ import nsk.share.TestFailure;
  *      run with the -XX:TraceDeoptimization to observ the result.
  */
 
-class test07 {
+public class test07 {
   public static void main (String[] args) {
     A obj = new A();
     for (int index = 0; index < 1; index++) {

--- a/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test08/test08.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/deoptimization/test08/test08.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.deoptimization.test08.test08
- * @run driver ExecDriver --java jit.deoptimization.test08.test08
+ * @run main/othervm jit.deoptimization.test08.test08
  */
 
 package jit.deoptimization.test08;
@@ -45,7 +44,7 @@ import nsk.share.TestFailure;
  *      run with the -XX:TraceDeoptimization to observ the result.
  */
 
-class test08 {
+public class test08 {
   public static void main (String[] args) {
     A obj = new A();
     for (int index = 0; index < 1; index++) {

--- a/test/hotspot/jtreg/vmTestbase/jit/escape/LockElision/MatMul/MatMul.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/escape/LockElision/MatMul/MatMul.java
@@ -40,8 +40,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.escape.LockElision.MatMul.MatMul
- * @run driver ExecDriver --java jit.escape.LockElision.MatMul.MatMul -dim 30 -threadCount 10
+ * @run main/othervm jit.escape.LockElision.MatMul.MatMul -dim 30 -threadCount 10
  */
 
 package jit.escape.LockElision.MatMul;
@@ -61,7 +60,7 @@ import vm.share.options.OptionSupport;
 import vm.share.options.Options;
 
 
-class MatMul {
+public class MatMul {
 
     @Option(name = "dim", description = "dimension of matrices")
     int dim;

--- a/test/hotspot/jtreg/vmTestbase/jit/exception/exception.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/exception/exception.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.exception.exception
- * @run driver ExecDriver --java jit.exception.exception
+ * @run main/othervm jit.exception.exception
  */
 
 package jit.exception;
@@ -49,7 +48,7 @@ package jit.exception;
 
 import nsk.share.TestFailure;
 
-class exception {
+public class exception {
     public static void main(String[] args) {
         int i, j;
 

--- a/test/hotspot/jtreg/vmTestbase/jit/init/init01/init01.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/init/init01/init01.java
@@ -31,8 +31,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.init.init01.init01
- * @run driver ExecDriver --java jit.init.init01.init01
+ * @run main/othervm jit.init.init01.init01
  */
 
 package jit.init.init01;
@@ -52,7 +51,7 @@ class InitTest2 {
   static InitTest1 oop = new InitTest1();
 }
 
-class init01 {
+public class init01 {
 
 
   public static void main (String s[]) {

--- a/test/hotspot/jtreg/vmTestbase/jit/init/init02/init02.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/init/init02/init02.java
@@ -35,15 +35,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.init.init02.init02
- * @run driver ExecDriver --java jit.init.init02.init02
+ * @run main/othervm jit.init.init02.init02
  */
 
 package jit.init.init02;
 
 import nsk.share.TestFailure;
 
-class init02 {
+public class init02 {
     public static boolean failed = false;
     public static void main(String args[]) {
         int i, x;

--- a/test/hotspot/jtreg/vmTestbase/jit/inline/inline003/inline003.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/inline/inline003/inline003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.inline.inline003.inline003
- * @run driver ExecDriver --java jit.inline.inline003.inline003
+ * @run main/othervm jit.inline.inline003.inline003
  */
 
 package jit.inline.inline003;
@@ -48,7 +47,7 @@ class inline003_1 {
         final protected static int[] trash = { 10, 11};
 }
 
-class inline003 extends inline003_1 {
+public class inline003 extends inline003_1 {
         public static final GoldChecker goldChecker = new GoldChecker( "inline003" );
 
         final private static int ITERS=4;

--- a/test/hotspot/jtreg/vmTestbase/jit/inline/inline004/inline004.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/inline/inline004/inline004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.inline.inline004.inline004
- * @run driver ExecDriver --java jit.inline.inline004.inline004
+ * @run main/othervm jit.inline.inline004.inline004
  */
 
 package jit.inline.inline004;
@@ -51,7 +50,7 @@ class inline004_1 {
         }
 }
 
-class inline004 extends inline004_1 {
+public class inline004 extends inline004_1 {
         public static final GoldChecker goldChecker = new GoldChecker( "inline004" );
 
         static int pFlag = 0;

--- a/test/hotspot/jtreg/vmTestbase/jit/inline/inline007/inline007.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/inline/inline007/inline007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.inline.inline007.inline007
- * @run driver ExecDriver --java jit.inline.inline007.inline007
+ * @run main/othervm jit.inline.inline007.inline007
  */
 
 package jit.inline.inline007;
@@ -158,7 +157,7 @@ class inline007Sub extends inline007Sup {
         }
 }
 
-class inline007 extends inline007_1 {
+public class inline007 extends inline007_1 {
         public static final GoldChecker goldChecker = new GoldChecker( "inline007" );
 
         static int[] myIters = new int[14];

--- a/test/hotspot/jtreg/vmTestbase/jit/misctests/Pi/Pi.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/misctests/Pi/Pi.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.misctests.Pi.Pi
- * @run driver ExecDriver --java jit.misctests.Pi.Pi
+ * @run main/othervm jit.misctests.Pi.Pi
  */
 
 package jit.misctests.Pi;
@@ -38,7 +37,7 @@ package jit.misctests.Pi;
 import java.util.Random;
 import nsk.share.TestFailure;
 
-class Pi{
+public class Pi{
     static double pi;
     static int imKreis=0, imQuadrat=0, i=0;
 

--- a/test/hotspot/jtreg/vmTestbase/jit/misctests/t5/t5.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/misctests/t5/t5.java
@@ -29,15 +29,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.misctests.t5.t5
- * @run driver ExecDriver --java jit.misctests.t5.t5
+ * @run main/othervm jit.misctests.t5.t5
  */
 
 package jit.misctests.t5;
 
 import nsk.share.TestFailure;
 
-class t5
+public class t5
 {
     public static void main (String [] args)
     {

--- a/test/hotspot/jtreg/vmTestbase/jit/overflow/overflow.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/overflow/overflow.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.overflow.overflow
- * @run driver ExecDriver --java jit.overflow.overflow
+ * @run main/othervm jit.overflow.overflow
  */
 
 package jit.overflow;
@@ -46,7 +45,7 @@ import java.lang.*;
 
 import nsk.share.TestFailure;
 
-class overflow {
+public class overflow {
     public static void main(String[] args) {
         try {
            recurse(1);

--- a/test/hotspot/jtreg/vmTestbase/jit/series/series.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/series/series.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.series.series
- * @run driver ExecDriver --java jit.series.series
+ * @run main/othervm jit.series.series
  */
 
 package jit.series;
@@ -39,7 +38,7 @@ package jit.series;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class series {
+public class series {
 
   public static final GoldChecker goldChecker = new GoldChecker( "series" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t001/t001.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t001/t001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t001.t001
- * @run driver ExecDriver --java jit.t.t001.t001
+ * @run main/othervm jit.t.t001.t001
  */
 
 package jit.t.t001;
@@ -39,7 +38,7 @@ package jit.t.t001;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t001
+public class t001
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t001" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t002/t002.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t002/t002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t002.t002
- * @run driver ExecDriver --java jit.t.t002.t002
+ * @run main/othervm jit.t.t002.t002
  */
 
 package jit.t.t002;
@@ -39,7 +38,7 @@ package jit.t.t002;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t002
+public class t002
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t002" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t003/t003.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t003/t003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t003.t003
- * @run driver ExecDriver --java jit.t.t003.t003
+ * @run main/othervm jit.t.t003.t003
  */
 
 package jit.t.t003;
@@ -39,7 +38,7 @@ package jit.t.t003;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t003
+public class t003
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t003" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t004/t004.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t004/t004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t004.t004
- * @run driver ExecDriver --java jit.t.t004.t004
+ * @run main/othervm jit.t.t004.t004
  */
 
 package jit.t.t004;
@@ -39,7 +38,7 @@ package jit.t.t004;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t004
+public class t004
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t004" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t005/t005.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t005/t005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t005.t005
- * @run driver ExecDriver --java jit.t.t005.t005
+ * @run main/othervm jit.t.t005.t005
  */
 
 package jit.t.t005;
@@ -39,7 +38,7 @@ package jit.t.t005;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t005
+public class t005
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t005" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t006/t006.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t006/t006.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t006.t006
- * @run driver ExecDriver --java jit.t.t006.t006
+ * @run main/othervm jit.t.t006.t006
  */
 
 package jit.t.t006;
@@ -39,7 +38,7 @@ package jit.t.t006;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t006
+public class t006
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t006" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t007/t007.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t007/t007.java
@@ -29,15 +29,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.t.t007.t007
- * @run driver ExecDriver --java jit.t.t007.t007
+ * @run main/othervm jit.t.t007.t007
  */
 
 package jit.t.t007;
 
 import nsk.share.TestFailure;
 
-class t007
+public class t007
 {
     public static void main(String argv[])
     {

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t008/t008.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t008/t008.java
@@ -29,15 +29,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.t.t008.t008
- * @run driver ExecDriver --java jit.t.t008.t008
+ * @run main/othervm jit.t.t008.t008
  */
 
 package jit.t.t008;
 
 import nsk.share.TestFailure;
 
-class t008
+public class t008
 {
     public static void main(String argv[])
     {

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t009/t009.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t009/t009.java
@@ -29,15 +29,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.t.t009.t009
- * @run driver ExecDriver --java jit.t.t009.t009
+ * @run main/othervm jit.t.t009.t009
  */
 
 package jit.t.t009;
 
 import nsk.share.TestFailure;
 
-class t009
+public class t009
 {
     public static void main(String argv[])
     {

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t011/t011.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t011/t011.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t011.t011
- * @run driver ExecDriver --java jit.t.t011.t011
+ * @run main/othervm jit.t.t011.t011
  */
 
 package jit.t.t011;
@@ -39,7 +38,7 @@ package jit.t.t011;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t011
+public class t011
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t011" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t012/t012.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t012/t012.java
@@ -29,15 +29,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.t.t012.t012
- * @run driver ExecDriver --java jit.t.t012.t012
+ * @run main/othervm jit.t.t012.t012
  */
 
 package jit.t.t012;
 
 import nsk.share.TestFailure;
 
-class t012
+public class t012
 {
     public static void main(String argv[])
     {

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t013/t013.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t013/t013.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t013.t013
- * @run driver ExecDriver --java jit.t.t013.t013
+ * @run main/othervm jit.t.t013.t013
  */
 
 package jit.t.t013;
@@ -44,7 +43,7 @@ class Globals {
         static public int MaxDisks = 64; // this will do!
 }
 
-class t013 {
+public class t013 {
 
     public static final GoldChecker goldChecker = new GoldChecker( "t013" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t014/t014.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t014/t014.java
@@ -29,15 +29,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.t.t014.t014
- * @run driver ExecDriver --java jit.t.t014.t014
+ * @run main/othervm jit.t.t014.t014
  */
 
 package jit.t.t014;
 
 import nsk.share.TestFailure;
 
-class t014
+public class t014
 {
     void foo()
     {

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t015/t015.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t015/t015.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t015.t015
- * @run driver ExecDriver --java jit.t.t015.t015
+ * @run main/othervm jit.t.t015.t015
  */
 
 package jit.t.t015;
@@ -39,7 +38,7 @@ package jit.t.t015;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t015
+public class t015
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t015" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t016/t016.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t016/t016.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t016.t016
- * @run driver ExecDriver --java jit.t.t016.t016
+ * @run main/othervm jit.t.t016.t016
  */
 
 package jit.t.t016;
@@ -39,7 +38,7 @@ package jit.t.t016;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t016
+public class t016
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t016" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t017/t017.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t017/t017.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t017.t017
- * @run driver ExecDriver --java jit.t.t017.t017
+ * @run main/othervm jit.t.t017.t017
  */
 
 package jit.t.t017;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // opc_arraylength
 
-class t017
+public class t017
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t017" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t018/t018.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t018/t018.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t018.t018
- * @run driver ExecDriver --java jit.t.t018.t018
+ * @run main/othervm jit.t.t018.t018
  */
 
 package jit.t.t018;
@@ -51,7 +50,7 @@ class jj extends Throwable
     }
 }
 
-class t018
+public class t018
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t018" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t019/t019.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t019/t019.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t019.t019
- * @run driver ExecDriver --java jit.t.t019.t019
+ * @run main/othervm jit.t.t019.t019
  */
 
 package jit.t.t019;
@@ -43,7 +42,7 @@ import nsk.share.GoldChecker;
 // opc_caload, opc_castore,
 // opc_saload, opc_sastore
 
-class t019
+public class t019
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t019" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t020/t020.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t020/t020.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t020.t020
- * @run driver ExecDriver --java jit.t.t020.t020
+ * @run main/othervm jit.t.t020.t020
  */
 
 package jit.t.t020;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // opc_checkcast, opc_instanceof, opc_ifnull, opc_ifnonnull
 
-class t020
+public class t020
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t020" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t021/t021.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t021/t021.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t021.t021
- * @run driver ExecDriver --java jit.t.t021.t021
+ * @run main/othervm jit.t.t021.t021
  */
 
 package jit.t.t021;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // opc_fconst_0, opc_fconst_1, opc_fconst_2, opc_fload_<n>, opc_fload,
 // opc_fadd, opc_fsub, opc_fmul, opc_fdiv
-class t021
+public class t021
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t021" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t022/t022.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t022/t022.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t022.t022
- * @run driver ExecDriver --java jit.t.t022.t022
+ * @run main/othervm jit.t.t022.t022
  */
 
 package jit.t.t022;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // The double-precision version of t021.java.
 
-class t022
+public class t022
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t022" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t023/t023.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t023/t023.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t023.t023
- * @run driver ExecDriver --java jit.t.t023.t023
+ * @run main/othervm jit.t.t023.t023
  */
 
 package jit.t.t023;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // opc_d2f, opc_d2i, opc_d2l
 
-class t023
+public class t023
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t023" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t024/t024.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t024/t024.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t024.t024
- * @run driver ExecDriver --java jit.t.t024.t024
+ * @run main/othervm jit.t.t024.t024
  */
 
 package jit.t.t024;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // opc_f2d, opc_f2i, opc_f2l
 
-class t024
+public class t024
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t024" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t025/t025.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t025/t025.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t025.t025
- * @run driver ExecDriver --java jit.t.t025.t025
+ * @run main/othervm jit.t.t025.t025
  */
 
 package jit.t.t025;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // opc_daload, opc_dastore, opc_faload, opc_fastore
 
-class t025
+public class t025
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t025" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t026/t026.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t026/t026.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.t.t026.t026
- * @run driver ExecDriver --java jit.t.t026.t026
+ * @run main/othervm jit.t.t026.t026
  */
 
 package jit.t.t026;
@@ -39,7 +38,7 @@ import nsk.share.TestFailure;
 
 // opc_areturn
 
-class t026
+public class t026
 {
     t026 foo()
     {

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t027/t027.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t027/t027.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t027.t027
- * @run driver ExecDriver --java jit.t.t027.t027
+ * @run main/othervm jit.t.t027.t027
  */
 
 package jit.t.t027;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // opc_dcmpg, opc_dcmpl
 
-class t027
+public class t027
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t027" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t028/t028.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t028/t028.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t028.t028
- * @run driver ExecDriver --java jit.t.t028.t028
+ * @run main/othervm jit.t.t028.t028
  */
 
 package jit.t.t028;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // opc_dneg, opc_fneg
 
-class t028
+public class t028
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t028" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t029/t029.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t029/t029.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t029.t029
- * @run driver ExecDriver --java jit.t.t029.t029
+ * @run main/othervm jit.t.t029.t029
  */
 
 package jit.t.t029;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // opc_drem, opc_frem, opc_dreturn opc_freturn
 
-class t029
+public class t029
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t029" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t030/t030.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t030/t030.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t030.t030
- * @run driver ExecDriver --java jit.t.t030.t030
+ * @run main/othervm jit.t.t030.t030
  */
 
 package jit.t.t030;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // opc_dup2, opc_dup2_x1, opc_dup2_x2
 
-class t030
+public class t030
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t030" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t031/t031.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t031/t031.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t031.t031
- * @run driver ExecDriver --java jit.t.t031.t031
+ * @run main/othervm jit.t.t031.t031
  */
 
 package jit.t.t031;
@@ -42,7 +41,7 @@ import nsk.share.GoldChecker;
 
 // opc_fcmpg, opc_fcmpl
 
-class t031
+public class t031
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t031" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t032/t032.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t032/t032.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t032.t032
- * @run driver ExecDriver --java jit.t.t032.t032
+ * @run main/othervm jit.t.t032.t032
  */
 
 package jit.t.t032;
@@ -42,7 +41,7 @@ import nsk.share.GoldChecker;
 // opc_i2d, opc_i2f, opc_i2l
 // opc_l2d, opc_l2f, opc_l2i
 
-class t032
+public class t032
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t032" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t033/t033.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t033/t033.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t033.t033
- * @run driver ExecDriver --java jit.t.t033.t033
+ * @run main/othervm jit.t.t033.t033
  */
 
 package jit.t.t033;
@@ -42,7 +41,7 @@ import nsk.share.GoldChecker;
 // opc_iand, opc_ior, opc_ixor
 // opc_land, opc_lor, opc_lxor
 
-class t033
+public class t033
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t033" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t034/t034.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t034/t034.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t034.t034
- * @run driver ExecDriver --java jit.t.t034.t034
+ * @run main/othervm jit.t.t034.t034
  */
 
 package jit.t.t034;
@@ -50,7 +49,7 @@ import nsk.share.GoldChecker;
 // opc_lrem
 // opc_lsub
 
-class t034
+public class t034
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t034" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t035/t035.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t035/t035.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t035.t035
- * @run driver ExecDriver --java jit.t.t035.t035
+ * @run main/othervm jit.t.t035.t035
  */
 
 package jit.t.t035;
@@ -50,7 +49,7 @@ import nsk.share.GoldChecker;
 // opc_lrem
 // opc_lsub
 
-class t035
+public class t035
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t035" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t036/t036.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t036/t036.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t036.t036
- * @run driver ExecDriver --java jit.t.t036.t036
+ * @run main/othervm jit.t.t036.t036
  */
 
 package jit.t.t036;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // opc_int2byte, opc_int2char, opc_int2short
 
-class t036
+public class t036
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t036" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t037/t037.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t037/t037.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t037.t037
- * @run driver ExecDriver --java jit.t.t037.t037
+ * @run main/othervm jit.t.t037.t037
  */
 
 package jit.t.t037;
@@ -46,7 +45,7 @@ interface foo
     void doit();
 }
 
-class t037 implements foo
+public class t037 implements foo
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t037" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t038/t038.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t038/t038.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t038.t038
- * @run driver ExecDriver --java jit.t.t038.t038
+ * @run main/othervm jit.t.t038.t038
  */
 
 package jit.t.t038;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // opc_laload, opc_lastore, opc_lconst_0
 
-class t038
+public class t038
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t038" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t039/t039.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t039/t039.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t039.t039
- * @run driver ExecDriver --java jit.t.t039.t039
+ * @run main/othervm jit.t.t039.t039
  */
 
 package jit.t.t039;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // opc_lreturn, opc_monitorenter, opc_monitorexit
 
-class t039
+public class t039
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t039" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t040/t040.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t040/t040.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t040.t040
- * @run driver ExecDriver --java jit.t.t040.t040
+ * @run main/othervm jit.t.t040.t040
  */
 
 package jit.t.t040;
@@ -42,7 +41,7 @@ import nsk.share.GoldChecker;
 
 // opc_multianewarray
 
-class t040
+public class t040
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t040" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t041/t041.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t041/t041.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.t.t041.t041
- * @run driver ExecDriver --java jit.t.t041.t041
+ * @run main/othervm jit.t.t041.t041
  */
 
 package jit.t.t041;
@@ -39,7 +38,7 @@ import nsk.share.TestFailure;
 
 // opc_swap
 
-class t041
+public class t041
 {
     public static void main(String argv[])
     {

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t042/t042.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t042/t042.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t042.t042
- * @run driver ExecDriver --java jit.t.t042.t042
+ * @run main/othervm jit.t.t042.t042
  */
 
 package jit.t.t042;
@@ -42,7 +41,7 @@ import nsk.share.GoldChecker;
 // The special little twiddle that occurs when you invoke a method
 // of an array.
 
-class t042
+public class t042
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t042" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t043/t043.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t043/t043.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t043.t043
- * @run driver ExecDriver --java jit.t.t043.t043
+ * @run main/othervm jit.t.t043.t043
  */
 
 package jit.t.t043;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Register jams and spills
 
-class t043
+public class t043
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t043" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t044/t044.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t044/t044.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.t.t044.t044
- * @run driver ExecDriver --java jit.t.t044.t044
+ * @run main/othervm jit.t.t044.t044
  */
 
 package jit.t.t044;
@@ -39,7 +38,7 @@ import nsk.share.TestFailure;
 
 // Call interferes with one lazy load but not the other.
 
-class t044
+public class t044
 {
     static double x = 409.0;
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t045/t045.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t045/t045.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.t.t045.t045
- * @run driver ExecDriver --java jit.t.t045.t045
+ * @run main/othervm jit.t.t045.t045
  */
 
 package jit.t.t045;
@@ -39,7 +38,7 @@ import nsk.share.TestFailure;
 
 // Putfield interferes with one lazy load but not the other.
 
-class t045
+public class t045
 {
     static double x = 409.0;
     static double y;

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t046/t046.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t046/t046.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t046.t046
- * @run driver ExecDriver --java jit.t.t046.t046
+ * @run main/othervm jit.t.t046.t046
  */
 
 package jit.t.t046;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Register jams and spills
 
-class t046
+public class t046
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t046" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t047/t047.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t047/t047.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t047.t047
- * @run driver ExecDriver --java jit.t.t047.t047
+ * @run main/othervm jit.t.t047.t047
  */
 
 package jit.t.t047;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Register jams and spills
 
-class t047
+public class t047
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t047" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t048/t048.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t048/t048.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t048.t048
- * @run driver ExecDriver --java jit.t.t048.t048
+ * @run main/othervm jit.t.t048.t048
  */
 
 package jit.t.t048;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Register jams and spills
 
-class t048
+public class t048
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t048" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t049/t049.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t049/t049.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t049.t049
- * @run driver ExecDriver --java jit.t.t049.t049
+ * @run main/othervm jit.t.t049.t049
  */
 
 package jit.t.t049;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Register jams and spills
 
-class t049
+public class t049
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t049" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t050/t050.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t050/t050.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.t.t050.t050
- * @run driver ExecDriver --java jit.t.t050.t050
+ * @run main/othervm jit.t.t050.t050
  */
 
 package jit.t.t050;
@@ -39,7 +38,7 @@ import nsk.share.TestFailure;
 
 // Pending local load clobbered by local store.
 
-class t050
+public class t050
 {
     public static void main(String argv[])
     {

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t051/t051.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t051/t051.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t051.t051
- * @run driver ExecDriver --java jit.t.t051.t051
+ * @run main/othervm jit.t.t051.t051
  */
 
 package jit.t.t051;
@@ -39,7 +38,7 @@ package jit.t.t051;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t051
+public class t051
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t051" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t052/t052.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t052/t052.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t052.t052
- * @run driver ExecDriver --java jit.t.t052.t052
+ * @run main/othervm jit.t.t052.t052
  */
 
 package jit.t.t052;
@@ -43,7 +42,7 @@ import nsk.share.GoldChecker;
 // its way in among the tests, it failed because of a failure correctly
 // to reverse the sense of an integer branch when swapping the operands.
 
-class t052 {
+public class t052 {
     public static final GoldChecker goldChecker = new GoldChecker( "t052" );
 
     static double aa[][],dd[][],x[][],y[][],

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t053/t053.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t053/t053.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t053.t053
- * @run driver ExecDriver --java jit.t.t053.t053
+ * @run main/othervm jit.t.t053.t053
  */
 
 package jit.t.t053;
@@ -43,7 +42,7 @@ import nsk.share.GoldChecker;
 // Tomcatv in java, with prints active
 //
 
-class t053 {
+public class t053 {
     public static final GoldChecker goldChecker = new GoldChecker( "t053" );
 
     static double aa[][],dd[][],x[][],y[][],

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t054/t054.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t054/t054.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t054.t054
- * @run driver ExecDriver --java jit.t.t054.t054
+ * @run main/othervm jit.t.t054.t054
  */
 
 package jit.t.t054;
@@ -43,7 +42,7 @@ import nsk.share.GoldChecker;
 // A more comprehensive test for the tomcatv bug, that being failure
 // correctly to reverse the sense of a jump.
 
-class t054
+public class t054
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t054" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t055/t055.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t055/t055.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t055.t055
- * @run driver ExecDriver --java jit.t.t055.t055
+ * @run main/othervm jit.t.t055.t055
  */
 
 package jit.t.t055;
@@ -39,7 +38,7 @@ package jit.t.t055;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t055
+public class t055
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t055" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t056/t056.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t056/t056.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t056.t056
- * @run driver ExecDriver --java jit.t.t056.t056
+ * @run main/othervm jit.t.t056.t056
  */
 
 package jit.t.t056;
@@ -39,7 +38,7 @@ package jit.t.t056;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t056
+public class t056
 {
     // Routine nest in which exception is thrown and caught in
     // the fourth routine.

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t057/t057.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t057/t057.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t057.t057
- * @run driver ExecDriver --java jit.t.t057.t057
+ * @run main/othervm jit.t.t057.t057
  */
 
 package jit.t.t057;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Just like t056 except here the exception is not explicitly thrown.
 
-class t057
+public class t057
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t057" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t058/t058.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t058/t058.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t058.t058
- * @run driver ExecDriver --java jit.t.t058.t058
+ * @run main/othervm jit.t.t058.t058
  */
 
 package jit.t.t058;
@@ -83,7 +82,7 @@ class k implements l
     }
 }
 
-class t058
+public class t058
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t058" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t059/t059.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t059/t059.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t059.t059
- * @run driver ExecDriver --java jit.t.t059.t059
+ * @run main/othervm jit.t.t059.t059
  */
 
 package jit.t.t059;
@@ -39,7 +38,7 @@ package jit.t.t059;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t059
+public class t059
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t059" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t060/t060.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t060/t060.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t060.t060
- * @run driver ExecDriver --java jit.t.t060.t060
+ * @run main/othervm jit.t.t060.t060
  */
 
 package jit.t.t060;
@@ -39,7 +38,7 @@ package jit.t.t060;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t060
+public class t060
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t060" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t061/t061.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t061/t061.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t061.t061
- * @run driver ExecDriver --java jit.t.t061.t061
+ * @run main/othervm jit.t.t061.t061
  */
 
 package jit.t.t061;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Long and double array loads with variable and constant subscripts.
 
-class t061
+public class t061
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t061" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t062/t062.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t062/t062.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t062.t062
- * @run driver ExecDriver --java jit.t.t062.t062
+ * @run main/othervm jit.t.t062.t062
  */
 
 package jit.t.t062;
@@ -47,7 +46,7 @@ interface l
     void voodoo();
 }
 
-class t062 implements l
+public class t062 implements l
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t062" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t063/t063.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t063/t063.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t063.t063
- * @run driver ExecDriver --java jit.t.t063.t063
+ * @run main/othervm jit.t.t063.t063
  */
 
 package jit.t.t063;
@@ -39,7 +38,7 @@ package jit.t.t063;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t063
+public class t063
 {
   public static final GoldChecker goldChecker = new GoldChecker( "t063" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t064/t064.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t064/t064.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t064.t064
- * @run driver ExecDriver --java jit.t.t064.t064
+ * @run main/othervm jit.t.t064.t064
  */
 
 package jit.t.t064;
@@ -64,7 +63,7 @@ class l
     }
 }
 
-class t064
+public class t064
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t064" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t065/t065.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t065/t065.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t065.t065
- * @run driver ExecDriver --java jit.t.t065.t065
+ * @run main/othervm jit.t.t065.t065
  */
 
 package jit.t.t065;
@@ -64,7 +63,7 @@ class l
     }
 }
 
-class t065
+public class t065
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t065" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t066/t066.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t066/t066.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.t.t066.t066
- * @run driver ExecDriver --java jit.t.t066.t066
+ * @run main/othervm jit.t.t066.t066
  */
 
 package jit.t.t066;
@@ -41,7 +40,7 @@ import nsk.share.TestFailure;
 // offsets on the stores of the two halves of the double
 // constant.
 
-class t066
+public class t066
 {
     public static void main(String argv[])
     {

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t067/t067.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t067/t067.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t067.t067
- * @run driver ExecDriver --java jit.t.t067.t067
+ * @run main/othervm jit.t.t067.t067
  */
 
 package jit.t.t067;
@@ -39,7 +38,7 @@ package jit.t.t067;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t067
+public class t067
 {
   public static final GoldChecker goldChecker = new GoldChecker( "t067" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t068/t068.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t068/t068.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t068.t068
- * @run driver ExecDriver --java jit.t.t068.t068
+ * @run main/othervm jit.t.t068.t068
  */
 
 package jit.t.t068;
@@ -39,7 +38,7 @@ package jit.t.t068;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t068
+public class t068
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t068" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t069/t069.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t069/t069.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t069.t069
- * @run driver ExecDriver --java jit.t.t069.t069
+ * @run main/othervm jit.t.t069.t069
  */
 
 package jit.t.t069;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Dup, dup_x2, and dup2_x2.
 
-class t069
+public class t069
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t069" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t070/t070.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t070/t070.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t070.t070
- * @run driver ExecDriver --java jit.t.t070.t070
+ * @run main/othervm jit.t.t070.t070
  */
 
 package jit.t.t070;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Dup, dup_x2, and dup2_x2.
 
-class t070
+public class t070
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t070" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t071/t071.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t071/t071.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t071.t071
- * @run driver ExecDriver --java jit.t.t071.t071
+ * @run main/othervm jit.t.t071.t071
  */
 
 package jit.t.t071;
@@ -39,7 +38,7 @@ package jit.t.t071;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t071
+public class t071
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t071" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t072/t072.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t072/t072.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t072.t072
- * @run driver ExecDriver --java jit.t.t072.t072
+ * @run main/othervm jit.t.t072.t072
  */
 
 package jit.t.t072;
@@ -39,7 +38,7 @@ package jit.t.t072;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t072
+public class t072
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t072" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t073/t073.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t073/t073.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t073.t073
- * @run driver ExecDriver --java jit.t.t073.t073
+ * @run main/othervm jit.t.t073.t073
  */
 
 package jit.t.t073;
@@ -39,7 +38,7 @@ package jit.t.t073;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t073{
+public class t073{
     public static final GoldChecker goldChecker = new GoldChecker( "t073" );
 
     static int i0 = 0;

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t074/t074.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t074/t074.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t074.t074
- * @run driver ExecDriver --java jit.t.t074.t074
+ * @run main/othervm jit.t.t074.t074
  */
 
 package jit.t.t074;
@@ -39,7 +38,7 @@ package jit.t.t074;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t074{
+public class t074{
     public static final GoldChecker goldChecker = new GoldChecker( "t074" );
 
     static int i0 = 0;

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t075/t075.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t075/t075.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t075.t075
- * @run driver ExecDriver --java jit.t.t075.t075
+ * @run main/othervm jit.t.t075.t075
  */
 
 package jit.t.t075;
@@ -39,7 +38,7 @@ package jit.t.t075;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t075{
+public class t075{
     public static final GoldChecker goldChecker = new GoldChecker( "t075" );
 
     static int i0 = 0;

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t076/t076.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t076/t076.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t076.t076
- * @run driver ExecDriver --java jit.t.t076.t076
+ * @run main/othervm jit.t.t076.t076
  */
 
 package jit.t.t076;
@@ -39,7 +38,7 @@ package jit.t.t076;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t076{
+public class t076{
     public static final GoldChecker goldChecker = new GoldChecker( "t076" );
 
     static long i0 = 0;

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t077/t077.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t077/t077.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t077.t077
- * @run driver ExecDriver --java jit.t.t077.t077
+ * @run main/othervm jit.t.t077.t077
  */
 
 package jit.t.t077;
@@ -39,7 +38,7 @@ package jit.t.t077;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t077{
+public class t077{
     public static final GoldChecker goldChecker = new GoldChecker( "t077" );
 
     static float i0 = 0.0f;

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t078/t078.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t078/t078.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t078.t078
- * @run driver ExecDriver --java jit.t.t078.t078
+ * @run main/othervm jit.t.t078.t078
  */
 
 package jit.t.t078;
@@ -39,7 +38,7 @@ package jit.t.t078;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t078{
+public class t078{
     public static final GoldChecker goldChecker = new GoldChecker( "t078" );
 
     static double i0 = 0.0;

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t079/t079.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t079/t079.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t079.t079
- * @run driver ExecDriver --java jit.t.t079.t079
+ * @run main/othervm jit.t.t079.t079
  */
 
 package jit.t.t079;
@@ -39,7 +38,7 @@ package jit.t.t079;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t079
+public class t079
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t079" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t080/t080.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t080/t080.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t080.t080
- * @run driver ExecDriver --java jit.t.t080.t080
+ * @run main/othervm jit.t.t080.t080
  */
 
 package jit.t.t080;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Like t079.java except this one has lots of local variables.
 
-class t080
+public class t080
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t080" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t081/t081.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t081/t081.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t081.t081
- * @run driver ExecDriver --java jit.t.t081.t081
+ * @run main/othervm jit.t.t081.t081
  */
 
 package jit.t.t081;
@@ -39,7 +38,7 @@ package jit.t.t081;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t081
+public class t081
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t081" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t086/t086.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t086/t086.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t086.t086
- * @run driver ExecDriver --java jit.t.t086.t086
+ * @run main/othervm jit.t.t086.t086
  */
 
 package jit.t.t086;
@@ -58,7 +57,7 @@ class foo
     }
 }
 
-class t086
+public class t086
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t086" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t091/t091.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t091/t091.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t091.t091
- * @run driver ExecDriver --java jit.t.t091.t091
+ * @run main/othervm jit.t.t091.t091
  */
 
 package jit.t.t091;
@@ -49,7 +48,7 @@ import nsk.share.GoldChecker;
 // screwing up the flags in the state[] vector around the wide
 // instructions.
 
-class t091
+public class t091
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t091" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t093/t093.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t093/t093.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t093.t093
- * @run driver ExecDriver --java jit.t.t093.t093
+ * @run main/othervm jit.t.t093.t093
  */
 
 package jit.t.t093;
@@ -39,7 +38,7 @@ package jit.t.t093;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t093
+public class t093
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t093" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t094/t094.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t094/t094.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t094.t094
- * @run driver ExecDriver --java jit.t.t094.t094
+ * @run main/othervm jit.t.t094.t094
  */
 
 package jit.t.t094;
@@ -39,7 +38,7 @@ package jit.t.t094;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t094
+public class t094
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t094" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t095/t095.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t095/t095.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t095.t095
- * @run driver ExecDriver --java jit.t.t095.t095
+ * @run main/othervm jit.t.t095.t095
  */
 
 package jit.t.t095;
@@ -39,7 +38,7 @@ package jit.t.t095;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t095
+public class t095
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t095" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t096/t096.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t096/t096.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t096.t096
- * @run driver ExecDriver --java jit.t.t096.t096
+ * @run main/othervm jit.t.t096.t096
  */
 
 package jit.t.t096;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Empty synchronized methods.
 
-class t096
+public class t096
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t096" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t098/t098.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t098/t098.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t098.t098
- * @run driver ExecDriver --java jit.t.t098.t098
+ * @run main/othervm jit.t.t098.t098
  */
 
 package jit.t.t098;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Check for too-wide intermediate results.
 
-class t098
+public class t098
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t098" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t099/t099.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t099/t099.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t099.t099
- * @run driver ExecDriver --java jit.t.t099.t099
+ * @run main/othervm jit.t.t099.t099
  */
 
 package jit.t.t099;
@@ -39,7 +38,7 @@ package jit.t.t099;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t099
+public class t099
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t099" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t100/t100.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t100/t100.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t100.t100
- * @run driver ExecDriver --java jit.t.t100.t100
+ * @run main/othervm jit.t.t100.t100
  */
 
 package jit.t.t100;
@@ -47,7 +46,7 @@ import java.lang.*;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t100 {
+public class t100 {
     public static final GoldChecker goldChecker = new GoldChecker( "t100" );
 
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t101/t101.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t101/t101.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t101.t101
- * @run driver ExecDriver --java jit.t.t101.t101
+ * @run main/othervm jit.t.t101.t101
  */
 
 package jit.t.t101;
@@ -45,7 +44,7 @@ import nsk.share.GoldChecker;
 //
 // , which ain't anything Ma Intel understands.
 
-class t101
+public class t101
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t101" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t102/t102.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t102/t102.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t102.t102
- * @run driver ExecDriver --java jit.t.t102.t102
+ * @run main/othervm jit.t.t102.t102
  */
 
 package jit.t.t102;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Like t101.java except the short intege type is short instead of char.
 
-class t102
+public class t102
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t102" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t103/t103.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t103/t103.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t103.t103
- * @run driver ExecDriver --java jit.t.t103.t103
+ * @run main/othervm jit.t.t103.t103
  */
 
 package jit.t.t103;
@@ -41,7 +40,7 @@ import nsk.share.GoldChecker;
 
 // Like t101.java except the short intege type is byte instead of char.
 
-class t103
+public class t103
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t103" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t104/t104.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t104/t104.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t104.t104
- * @run driver ExecDriver --java jit.t.t104.t104
+ * @run main/othervm jit.t.t104.t104
  */
 
 package jit.t.t104;
@@ -39,7 +38,7 @@ package jit.t.t104;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t104
+public class t104
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t104" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t105/t105.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t105.t105
- * @run driver ExecDriver --java jit.t.t105.t105
+ * @run main/othervm jit.t.t105.t105
  */
 
 package jit.t.t105;
@@ -39,7 +38,7 @@ package jit.t.t105;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t105
+public class t105
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t105" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t106/t106.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t106/t106.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t106.t106
- * @run driver ExecDriver --java jit.t.t106.t106
+ * @run main/othervm jit.t.t106.t106
  */
 
 package jit.t.t106;
@@ -39,7 +38,7 @@ package jit.t.t106;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t106 {
+public class t106 {
    public static final GoldChecker goldChecker = new GoldChecker( "t106" );
 
    static public void main(String argv[]) {

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t107/t107.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t107/t107.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @build jit.t.t107.t107
- * @run driver ExecDriver --java jit.t.t107.t107
+ * @run main/othervm jit.t.t107.t107
  */
 
 package jit.t.t107;
@@ -39,7 +38,7 @@ package jit.t.t107;
 import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class t107 {
+public class t107 {
 
         public static final GoldChecker goldChecker = new GoldChecker( "t107" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t108/t108.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t108/t108.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import nsk.share.GoldChecker;
 
 // Uncaught exception, one jit'd frame on the stack.
 
-class t108
+public class t108
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t108" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t109/t109.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t109/t109.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import nsk.share.GoldChecker;
 
 // Uncaught exception, one jit'd frame on the stack, implicit exception.
 
-class t109
+public class t109
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t109" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t110/t110.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t110/t110.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import nsk.share.GoldChecker;
 
 // Uncaught exception, one jit'd frame on the stack, implicit exception.
 
-class t110
+public class t110
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t110" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t111/t111.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t111/t111.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import nsk.share.GoldChecker;
 
 // Uncaught exception, one jit'd frame on the stack.
 
-class t111
+public class t111
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t111" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t112/t112.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t112/t112.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import nsk.share.GoldChecker;
 
 // Uncaught exception, one jit'd frame on the stack.
 
-class t112
+public class t112
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t112" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t113/t113.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t113/t113.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ class kid2 extends parent
     int j;
 }
 
-class t113
+public class t113
 {
     public static final GoldChecker goldChecker = new GoldChecker( "t113" );
 

--- a/test/hotspot/jtreg/vmTestbase/jit/wide/wide01/wide01.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/wide/wide01/wide01.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.wide.wide01.wide01
- * @run driver ExecDriver --java jit.wide.wide01.wide01
+ * @run main/othervm jit.wide.wide01.wide01
  */
 
 package jit.wide.wide01;
@@ -45,7 +44,7 @@ import nsk.share.TestFailure;
      greater-than-double precision.
 */
 
-strictfp class wide01
+strictfp public class wide01
 {
    public static void main(String[] arg) {
        float  f1 = Float.MAX_VALUE;

--- a/test/hotspot/jtreg/vmTestbase/jit/wide/wide02/wide02.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/wide/wide02/wide02.java
@@ -29,8 +29,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @build jit.wide.wide02.wide02
- * @run driver ExecDriver --java jit.wide.wide02.wide02
+ * @run main/othervm jit.wide.wide02.wide02
  */
 
 package jit.wide.wide02;
@@ -44,7 +43,7 @@ import nsk.share.TestFailure;
      or if the result of the expression (d0+d53) is maintained in
      greater-than-double precision.
 */
-class wide02
+public class wide02
 {
    static double twoto(int n) {
        double res = 1.0;


### PR DESCRIPTION
This test cleanup is a clean backport and simplifies follow-up backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8251132](https://bugs.openjdk.java.net/browse/JDK-8251132): make main classes public in vmTestbase/jit tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/755/head:pull/755` \
`$ git checkout pull/755`

Update a local copy of the PR: \
`$ git checkout pull/755` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 755`

View PR using the GUI difftool: \
`$ git pr show -t 755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/755.diff">https://git.openjdk.java.net/jdk11u-dev/pull/755.diff</a>

</details>
