### PR TITLE
8277441: CompileQueue::add fails with assert(_last->next() == __null) failed: not last

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -411,6 +411,7 @@ void CompileQueue::free_all() {
     CompileTask::free(current);
   }
   _first = NULL;
+  _last = NULL;
 
   // Wake up all threads that block on the queue.
   MethodCompileQueue_lock->notify_all();


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277441](https://bugs.openjdk.java.net/browse/JDK-8277441): CompileQueue::add fails with assert(_last->next() == __null) failed: not last


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/756/head:pull/756` \
`$ git checkout pull/756`

Update a local copy of the PR: \
`$ git checkout pull/756` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 756`

View PR using the GUI difftool: \
`$ git pr show -t 756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/756.diff">https://git.openjdk.java.net/jdk11u-dev/pull/756.diff</a>

</details>
