### PR TITLE
8214026: Canonicalized archive paths appearing in diagnostics

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -313,7 +313,7 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
                 fs = new DirectoryContainer(realPath);
             } else {
                 try {
-                    fs = new ArchiveContainer(realPath);
+                    fs = new ArchiveContainer(path);
                 } catch (ProviderNotFoundException | SecurityException ex) {
                     throw new IOException(ex);
                 }

--- a/test/langtools/tools/javac/file/SymLinkArchiveTest.java
+++ b/test/langtools/tools/javac/file/SymLinkArchiveTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2018, Google LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8181897
+ * @summary
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.jdeps/com.sun.tools.classfile
+ * @build toolbox.JavacTask toolbox.TestRunner toolbox.ToolBox
+ * @run main SymLinkArchiveTest
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import toolbox.JavacTask;
+import toolbox.Task.Expect;
+import toolbox.Task.OutputKind;
+import toolbox.Task.Result;
+import toolbox.TestRunner;
+import toolbox.TestRunner.Test;
+import toolbox.ToolBox;
+
+public class SymLinkArchiveTest extends TestRunner {
+    public static void main(String... args) throws Exception {
+        new SymLinkArchiveTest().runTests(m -> new Object[] {Paths.get(m.getName())});
+    }
+
+    private final ToolBox tb = new ToolBox();
+
+    public SymLinkArchiveTest() {
+        super(System.err);
+    }
+
+    @Test
+    public void testJarSymlink(Path base) throws Exception {
+        Files.createDirectories(base);
+        Path classpath = base.resolve("CLASSPATH");
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(classpath))) {
+            jos.putNextEntry(new JarEntry("p/B.class"));
+            jos.write(new byte[10]);
+        }
+        Path javaFile = base.resolve("T.java");
+        tb.writeFile(javaFile, "class T extends p.B {}");
+
+        Path jar = base.resolve("lib.jar");
+        Files.createSymbolicLink(jar, classpath.getFileName());
+
+        Result result = new JavacTask(tb).files(javaFile).classpath(jar).run(Expect.FAIL);
+        String output = result.getOutput(OutputKind.DIRECT);
+
+        String expected = jar + "(/p/B.class)";
+        if (!output.contains(expected)) {
+            throw new AssertionError(
+                    "expected output to contain: " + expected + "\nwas:\n" + output);
+        }
+    }
+}


### PR DESCRIPTION
This is a backport of [JDK-8214026: Canonicalized archive paths appearing in diagnostics](https://bugs.openjdk.java.net/browse/JDK-8214026)

The original patch applied cleanly.

Testing: tier1 tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8214026](https://bugs.openjdk.java.net/browse/JDK-8214026): Canonicalized archive paths appearing in diagnostics


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/760/head:pull/760` \
`$ git checkout pull/760`

Update a local copy of the PR: \
`$ git checkout pull/760` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/760/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 760`

View PR using the GUI difftool: \
`$ git pr show -t 760`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/760.diff">https://git.openjdk.java.net/jdk11u-dev/pull/760.diff</a>

</details>
