### PR TITLE
8210194: [TESTBUG] jvmti_FollowRefObjects.cpp missing initializer for member _jvmtiHeapCallbacks::heap_reference_callback

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref001/followref001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref001/followref001.cpp
@@ -69,7 +69,7 @@ static const jlong CHAIN_CLASS_TAG  = 99;
 static const jlong ROOT_OBJECT_TAG  = 10;
 static const jlong CHAIN_OBJECT_TAG = 100;
 
-static jvmtiHeapCallbacks heapCallbacks = {};
+static jvmtiHeapCallbacks heapCallbacks;
 
 /* This array has to be up-to-date with the jvmtiHeapReferenceKind enum */
 static const char* ref_kind_str[28] = {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref002/followref002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref002/followref002.cpp
@@ -67,7 +67,7 @@ static jlong chainClassTag  = 99;
 static jlong rootObjectTag  = 10;
 static jlong chainObjectTag = 100;
 
-static jvmtiHeapCallbacks heapCallbacks = {};
+static jvmtiHeapCallbacks heapCallbacks;
 
 static const char* ref_kind_str[28] = {
    "unknown_0",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/followref003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/followref003.cpp
@@ -92,7 +92,7 @@ static jlong chainObjectTag = 100;
 #define DUMMY_STRING_ARR_SLOT  11
 
 
-static jvmtiHeapCallbacks heapCallbacks = {};
+static jvmtiHeapCallbacks heapCallbacks;
 
 static const char* ref_kind_str[28] = {
    "unknown_0",

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_FollowRefObjects.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_FollowRefObjects.cpp
@@ -33,7 +33,7 @@ extern "C" {
 
 int g_fakeUserData = 0;
 int g_userDataError = 0;
-jvmtiHeapCallbacks g_wrongHeapCallbacks = {};
+jvmtiHeapCallbacks g_wrongHeapCallbacks;
 
 /* This array has to be up-to-date with the jvmtiHeapReferenceKind enum */
 const char * const g_refKindStr[28] = {


### PR DESCRIPTION
Clean backport to soothe compilation warnings in 11.0.14 after [JDK-8209611](https://bugs.openjdk.java.net/browse/JDK-8209611) backport. This affects one of our CIs.

Additional testing:
 - [x] Linux x86_64 fastdebug `vmTestbase_nsk_jvmti` still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210194](https://bugs.openjdk.java.net/browse/JDK-8210194): [TESTBUG] jvmti_FollowRefObjects.cpp missing initializer for member _jvmtiHeapCallbacks::heap_reference_callback


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/761/head:pull/761` \
`$ git checkout pull/761`

Update a local copy of the PR: \
`$ git checkout pull/761` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 761`

View PR using the GUI difftool: \
`$ git pr show -t 761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/761.diff">https://git.openjdk.java.net/jdk11u-dev/pull/761.diff</a>

</details>
