### PR TITLE
8220634: SymLinkArchiveTest should handle not being able to create symlinks

### DIFF
--- a/test/langtools/tools/javac/file/SymLinkArchiveTest.java
+++ b/test/langtools/tools/javac/file/SymLinkArchiveTest.java
@@ -33,6 +33,7 @@
  * @run main SymLinkArchiveTest
  */
 
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -69,7 +70,13 @@ public class SymLinkArchiveTest extends TestRunner {
         tb.writeFile(javaFile, "class T extends p.B {}");
 
         Path jar = base.resolve("lib.jar");
-        Files.createSymbolicLink(jar, classpath.getFileName());
+        try {
+            Files.createSymbolicLink(jar, classpath.getFileName());
+        } catch (FileSystemException fse) {
+            System.err.println("warning: test passes vacuously, sym-link could not be created");
+            System.err.println(fse.getMessage());
+            return;
+        }
 
         Result result = new JavacTask(tb).files(javaFile).classpath(jar).run(Expect.FAIL);
         String output = result.getOutput(OutputKind.DIRECT);


### PR DESCRIPTION
This is a backport of [JDK-8220634: SymLinkArchiveTest should handle not being able to create symlinks](https://bugs.openjdk.java.net/browse/JDK-8220634)

The original patch applied cleanly on top of the backport of [JDK-8214026](https://bugs.openjdk.java.net/browse/JDK-8214026), this is a follow-up to https://github.com/openjdk/jdk11u-dev/pull/760

Testing: tier1 tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8220634](https://bugs.openjdk.java.net/browse/JDK-8220634): SymLinkArchiveTest should handle not being able to create symlinks


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/765/head:pull/765` \
`$ git checkout pull/765`

Update a local copy of the PR: \
`$ git checkout pull/765` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/765/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 765`

View PR using the GUI difftool: \
`$ git pr show -t 765`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/765.diff">https://git.openjdk.java.net/jdk11u-dev/pull/765.diff</a>

</details>
