### PR TITLE
8280002: jmap -histo may leak stream

### DIFF
--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,6 +264,7 @@ static jint heap_inspection(AttachOperation* op, outputStream* out) {
     uintx num;
     if (!Arguments::parse_uintx(num_str, &num, 0)) {
       out->print_cr("Invalid parallel thread number: [%s]", num_str);
+      delete fs;
       return JNI_ERR;
     }
     parallel_thread_num = num == 0 ? parallel_thread_num : (uint)num;


### PR DESCRIPTION
Clean backport of a small patch that fixes a leak (file handle + memory) introduced with JDK-8215624.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280002](https://bugs.openjdk.java.net/browse/JDK-8280002): jmap -histo may leak stream


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/768/head:pull/768` \
`$ git checkout pull/768`

Update a local copy of the PR: \
`$ git checkout pull/768` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 768`

View PR using the GUI difftool: \
`$ git pr show -t 768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/768.diff">https://git.openjdk.java.net/jdk11u-dev/pull/768.diff</a>

</details>
