### PR TITLE
8277447: Hotspot C1 compiler crashes on Kotlin suspend fun with loop

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -838,6 +838,11 @@ bool BlockBegin::try_merge(ValueStack* new_state) {
           existing_state->invalidate_local(index);
           TRACE_PHI(tty->print_cr("invalidating local %d because of type mismatch", index));
         }
+
+        if (existing_value != new_state->local_at(index) && existing_value->as_Phi() == NULL) {
+          TRACE_PHI(tty->print_cr("required phi for local %d is missing, irreducible loop?", index));
+          return false; // BAILOUT in caller
+        }
       }
 
 #ifdef ASSERT

--- a/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathology.jasm
+++ b/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathology.jasm
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+super public class TestC1PhiPlacementPathology
+   version 55:0
+{
+  public static volatile Field sideEffect:I;
+
+  public Method "<init>":"()V"
+   stack 1 locals 1
+  {
+      aload_0;
+      invokespecial   Method java/lang/Object."<init>":"()V";
+      return;
+  }
+  private static Method effect:"(I)V"
+   stack 2 locals 1
+  {
+      getstatic   Field sideEffect:"I";
+      iload_0;
+      iadd;
+      putstatic   Field sideEffect:"I";
+      return;
+  }
+  public static Method test:"(I)V"
+   stack 2 locals 2
+  {
+      iconst_0;
+      istore_1;
+      iload_0;
+      iconst_2;
+      irem;
+      ifne   MODIFY_LOCAL;
+      iinc   1, 1;
+      goto   LH2;
+   MODIFY_LOCAL:   stack_frame_type append;
+      locals_map int;
+      iinc   1, 2;
+      iinc   0, 1;
+    goto LH1;
+   LH1:   stack_frame_type same;
+      iinc   1, 1;
+      iload_1;
+      sipush   10000;
+      if_icmpge   EXIT;
+   LH2:   stack_frame_type same;
+      iinc   1, 1;
+      goto   LH1;
+   EXIT:   stack_frame_type same;
+      iload_1;
+      iload_0;
+      iadd;
+      invokestatic   Method effect:"(I)V";
+      return;
+  }
+} // end Class TestC1PhiPlacementPathology

--- a/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathologyMain.java
+++ b/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathologyMain.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8277447
+ * @summary Test a pathological case for phi placement with an irreducible loop of a particular shape.
+ *
+ * @compile TestC1PhiPlacementPathology.jasm
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,TestC1PhiPlacementPathology::test
+ *                   -XX:TieredStopAtLevel=3 -XX:-UseOnStackReplacement TestC1PhiPlacementPathologyMain
+ */
+
+public class TestC1PhiPlacementPathologyMain {
+    public static void main(String[] args) {
+        for (int i = 0; i < 11000; i++) {
+            TestC1PhiPlacementPathology.test(0);
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

I had to do adaptions in the test:
 * I changed the class file version from 62 to 55 in the .jasm file.
 * I replaced  -XX:CompilationMode=quick-only by -XX:TieredStopAtLevel=3
   because the flag CompilationMode is not in 11. I tried to reproduce the bug
   with the new settings, but I can not see the bug. But I also can not reproduce
   it with the original test and the original 17 release.  The test is passing with and 
   without the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277447](https://bugs.openjdk.java.net/browse/JDK-8277447): Hotspot C1 compiler crashes on Kotlin suspend fun with loop


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/770/head:pull/770` \
`$ git checkout pull/770`

Update a local copy of the PR: \
`$ git checkout pull/770` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 770`

View PR using the GUI difftool: \
`$ git pr show -t 770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/770.diff">https://git.openjdk.java.net/jdk11u-dev/pull/770.diff</a>

</details>
