### PR TITLE
8236210: javac generates wrong annotation for fields generated from record components

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -3084,8 +3084,19 @@ public class Check {
 
     /** Is the annotation applicable to the symbol? */
     boolean annotationApplicable(JCAnnotation a, Symbol s) {
+        Optional<Set<Name>> targets = getApplicableTargets(a, s);
+        /* the optional could be emtpy if the annotation is unknown in that case
+         * we return that it is applicable and if it is erroneous that should imply
+         * an error at the declaration site
+         */
+        return targets.isEmpty() || targets.isPresent() && !targets.get().isEmpty();
+    }
+
+    @SuppressWarnings("preview")
+    Optional<Set<Name>> getApplicableTargets(JCAnnotation a, Symbol s) {
         Attribute.Array arr = getAttributeTargetAttribute(a.annotationType.type.tsym);
         Name[] targets;
+        Set<Name> applicableTargets = new HashSet<>();
 
         if (arr == null) {
             targets = defaultTargetMetaInfo(a, s);
@@ -3095,7 +3106,8 @@ public class Check {
             for (int i=0; i<arr.values.length; ++i) {
                 Attribute app = arr.values[i];
                 if (!(app instanceof Attribute.Enum)) {
-                    return true; // recovery
+                    // recovery
+                    return Optional.empty();
                 }
                 Attribute.Enum e = (Attribute.Enum) app;
                 targets[i] = e.value.name;
@@ -3104,51 +3116,51 @@ public class Check {
         for (Name target : targets) {
             if (target == names.TYPE) {
                 if (s.kind == TYP)
-                    return true;
+                    applicableTargets.add(names.TYPE);
             } else if (target == names.FIELD) {
                 if (s.kind == VAR && s.owner.kind != MTH)
-                    return true;
+                    applicableTargets.add(names.FIELD);
             } else if (target == names.METHOD) {
                 if (s.kind == MTH && !s.isConstructor())
-                    return true;
+                    applicableTargets.add(names.METHOD);
             } else if (target == names.PARAMETER) {
                 if (s.kind == VAR && s.owner.kind == MTH &&
                       (s.flags() & PARAMETER) != 0) {
-                    return true;
+                    applicableTargets.add(names.PARAMETER);
                 }
             } else if (target == names.CONSTRUCTOR) {
                 if (s.kind == MTH && s.isConstructor())
-                    return true;
+                    applicableTargets.add(names.CONSTRUCTOR);
             } else if (target == names.LOCAL_VARIABLE) {
                 if (s.kind == VAR && s.owner.kind == MTH &&
                       (s.flags() & PARAMETER) == 0) {
-                    return true;
+                    applicableTargets.add(names.LOCAL_VARIABLE);
                 }
             } else if (target == names.ANNOTATION_TYPE) {
                 if (s.kind == TYP && (s.flags() & ANNOTATION) != 0) {
-                    return true;
+                    applicableTargets.add(names.ANNOTATION_TYPE);
                 }
             } else if (target == names.PACKAGE) {
                 if (s.kind == PCK)
-                    return true;
+                    applicableTargets.add(names.PACKAGE);
             } else if (target == names.TYPE_USE) {
                 if (s.kind == VAR && s.owner.kind == MTH && s.type.hasTag(NONE)) {
-                    //cannot type annotate implictly typed locals
-                    return false;
+                    //cannot type annotate implicitly typed locals
+                    continue;
                 } else if (s.kind == TYP || s.kind == VAR ||
                         (s.kind == MTH && !s.isConstructor() &&
                                 !s.type.getReturnType().hasTag(VOID)) ||
                         (s.kind == MTH && s.isConstructor())) {
-                    return true;
+                    applicableTargets.add(names.TYPE_USE);
                 }
             } else if (target == names.TYPE_PARAMETER) {
                 if (s.kind == TYP && s.type.hasTag(TYPEVAR))
-                    return true;
+                    applicableTargets.add(names.TYPE_PARAMETER);
             } else
-                return true; // Unknown ElementType. This should be an error at declaration site,
-                             // assume applicable.
+                return Optional.empty(); // Unknown ElementType. This should be an error at declaration site,
+                                         // assume applicable.
         }
-        return false;
+        return Optional.of(applicableTargets);
     }
 
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -3089,7 +3089,7 @@ public class Check {
          * we return that it is applicable and if it is erroneous that should imply
          * an error at the declaration site
          */
-        return targets.isEmpty() || targets.isPresent() && !targets.get().isEmpty();
+        return !targets.isPresent() || targets.isPresent() && !targets.get().isEmpty();
     }
 
     @SuppressWarnings("preview")

--- a/test/langtools/tools/javac/lvti/T8236210.java
+++ b/test/langtools/tools/javac/lvti/T8236210.java
@@ -1,0 +1,28 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8236210
+ * @summary Annotations on var
+ * @compile/fail/ref=T8236210.out -XDrawDiagnostics T8236210.java
+ */
+
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+import static java.lang.annotation.ElementType.TYPE_USE;
+
+import java.lang.annotation.Target;
+
+@Target({TYPE_USE, LOCAL_VARIABLE})
+@interface Both {}
+
+@Target(LOCAL_VARIABLE)
+@interface Decl {}
+
+@Target(TYPE_USE)
+@interface Type {}
+
+class T8236210 {
+    {
+        @Both var a = 1;
+        @Decl var b = 2;
+        @Type var c = 3;
+    }
+}

--- a/test/langtools/tools/javac/lvti/T8236210.out
+++ b/test/langtools/tools/javac/lvti/T8236210.out
@@ -1,0 +1,2 @@
+T8236210.java:26:9: compiler.err.annotation.type.not.applicable
+1 error


### PR DESCRIPTION
This is a backport of [JDK-8236210: javac generates wrong annotation for fields generated from record components](https://bugs.openjdk.java.net/browse/JDK-8236210)

This is a partial backport.

* The focus of JDK-8236210 was a bug with records and most of the diff was to logic that was added to deal with records. However the patch also included a fix to the logic for checking annotation applicability in `Check.annotationApplicable` that fixes a bug with annotations on `var`, so I backported the part that is relevant to Java 11.
* I added a test for the issue specific to `var`, since the original test is for records and cannot be backported.

Testing: x86 build, affected tests, tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236210](https://bugs.openjdk.java.net/browse/JDK-8236210): javac generates wrong annotation for fields generated from record components


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/771/head:pull/771` \
`$ git checkout pull/771`

Update a local copy of the PR: \
`$ git checkout pull/771` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 771`

View PR using the GUI difftool: \
`$ git pr show -t 771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/771.diff">https://git.openjdk.java.net/jdk11u-dev/pull/771.diff</a>

</details>
