### PR TITLE
8252005: narrow disabling of allowSmartActionArgs in vmTestbase

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8219140 is fixed
-allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/jit/t/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/TEST.properties
@@ -1,0 +1,2 @@
+# disabled till JDK-8251998 is fixed
+allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/nsk/aod/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/aod/TEST.properties
@@ -1,0 +1,2 @@
+# disabled till JDK-8251999 is fixed
+allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/TEST.properties
@@ -1,0 +1,2 @@
+# disabled till JDK-8252000 is fixed
+allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TEST.properties
@@ -1,0 +1,2 @@
+# disabled till JDK-8252001 is fixed
+allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/TEST.properties
@@ -1,0 +1,2 @@
+# disabled till JDK-8252002 is fixed
+allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/TEST.properties
@@ -1,0 +1,2 @@
+# disabled till JDK-8252003 is fixed
+allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/TEST.properties
@@ -1,0 +1,2 @@
+# disabled till JDK-8252004 is fixed
+allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/complog/uninit/TEST.properties
@@ -1,0 +1,2 @@
+# disabled till JDK-8251996 is fixed
+allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/TEST.properties
@@ -1,0 +1,2 @@
+# disabled till JDK-8251997 is fixed
+allowSmartActionArgs=false


### PR DESCRIPTION
This test cleanup is a clean backport and simplifies follow-up backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8252005](https://bugs.openjdk.java.net/browse/JDK-8252005): narrow disabling of allowSmartActionArgs in vmTestbase


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/775/head:pull/775` \
`$ git checkout pull/775`

Update a local copy of the PR: \
`$ git checkout pull/775` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 775`

View PR using the GUI difftool: \
`$ git pr show -t 775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/775.diff">https://git.openjdk.java.net/jdk11u-dev/pull/775.diff</a>

</details>
