### PR TITLE
8277992: Add fast jdk_svc subtests to jdk:tier3

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -77,7 +77,10 @@ tier3 = \
     :jdk_beans \
     :jdk_imageio \
     :jdk_sound \
-    :jdk_client_sanity
+    :jdk_client_sanity \
+    :jdk_svc \
+   -:jdk_svc_sanity \
+   -:svc_tools
 
 # Everything not in other tiers
 tier4 = \


### PR DESCRIPTION
Unclean backport to improve 11u testing. It does not apply cleanly for two reasons:

-  https://bugs.openjdk.java.net/browse/JDK-8265793 is not in 11u yet, and I think it would be cleaner to backport that one *after* this issue;
- https://github.com/openjdk/jdk/commit/1b45bf2d581bf75fabefa13e56ecec6e6ae9036c is not in 11u, and it would be not that relevant after this backport;

The avaiability of catch-all `jdk:tier4` protects us from skipping the tests. If there are test group mistakes that drop some tests from `jdk:tier3`, they would be captured by `jdk:tier4`.

Additional testing:
 - [x] Linux x86_64 fastdebug `jdk:tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277992](https://bugs.openjdk.java.net/browse/JDK-8277992): Add fast jdk_svc subtests to jdk:tier3


### Reviewers
 * [Sergey Bylokhov](https://openjdk.java.net/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/780/head:pull/780` \
`$ git checkout pull/780`

Update a local copy of the PR: \
`$ git checkout pull/780` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 780`

View PR using the GUI difftool: \
`$ git pr show -t 780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/780.diff">https://git.openjdk.java.net/jdk11u-dev/pull/780.diff</a>

</details>
