### PR TITLE
8268542: serviceability/logging/TestFullNames.java tests only 1st test case

### DIFF
--- a/test/hotspot/jtreg/serviceability/logging/TestFullNames.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestFullNames.java
@@ -59,6 +59,7 @@ public class TestFullNames {
             fileName
         };
         for (String logOutput : validOutputs) {
+            Asserts.assertFalse(file.exists());
             // Run with logging=trace on stdout so that we can verify the log configuration afterwards.
             ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xlog:logging=trace",
                                                                       "-Xlog:all=trace:" + logOutput,
@@ -66,7 +67,7 @@ public class TestFullNames {
             OutputAnalyzer output = new OutputAnalyzer(pb.start());
             output.shouldHaveExitValue(0);
             Asserts.assertTrue(file.exists());
-            file.deleteOnExit(); // Clean up after test
+            file.delete();
             output.shouldMatch("\\[logging *\\].*" + baseName); // Expect to see the log output listed
         }
     }


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268542](https://bugs.openjdk.java.net/browse/JDK-8268542): serviceability/logging/TestFullNames.java tests only 1st test case


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/782/head:pull/782` \
`$ git checkout pull/782`

Update a local copy of the PR: \
`$ git checkout pull/782` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 782`

View PR using the GUI difftool: \
`$ git pr show -t 782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/782.diff">https://git.openjdk.java.net/jdk11u-dev/pull/782.diff</a>

</details>
