### PR TITLE
8274471: Add support for RSASSA-PSS in OCSP Response

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,12 @@
  */
 package sun.security.provider.certpath;
 
-import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
 import java.net.HttpURLConnection;
+import java.net.URLEncoder;
 import java.security.cert.CertificateException;
 import java.security.cert.CertPathValidatorException;
 import java.security.cert.CertPathValidatorException.BasicReason;
@@ -37,7 +37,7 @@ import java.security.cert.CRLReason;
 import java.security.cert.Extension;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -45,6 +45,7 @@ import java.util.Map;
 
 import sun.security.action.GetIntegerAction;
 import sun.security.util.Debug;
+import sun.security.util.IOUtils;
 import sun.security.validator.Validator;
 import sun.security.x509.AccessDescription;
 import sun.security.x509.AuthorityInfoAccessExtension;
@@ -53,6 +54,8 @@ import sun.security.x509.GeneralNameInterface;
 import sun.security.x509.PKIXExtensions;
 import sun.security.x509.URIName;
 import sun.security.x509.X509CertImpl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * This is a class that checks the revocation status of a certificate(s) using
@@ -223,70 +226,64 @@ public final class OCSP {
             List<Extension> extensions) throws IOException {
         OCSPRequest request = new OCSPRequest(certIds, extensions);
         byte[] bytes = request.encodeBytes();
+        String responder = responderURI.toString();
 
-        InputStream in = null;
-        OutputStream out = null;
-        byte[] response = null;
+        if (debug != null) {
+            debug.println("connecting to OCSP service at: " + responder);
+        }
 
+        URL url;
+        HttpURLConnection con = null;
         try {
-            URL url = responderURI.toURL();
-            if (debug != null) {
-                debug.println("connecting to OCSP service at: " + url);
+            StringBuilder encodedGetReq = new StringBuilder(responder);
+            if (!responder.endsWith("/")) {
+                encodedGetReq.append("/");
             }
-            HttpURLConnection con = (HttpURLConnection)url.openConnection();
-            con.setConnectTimeout(CONNECT_TIMEOUT);
-            con.setReadTimeout(CONNECT_TIMEOUT);
-            con.setDoOutput(true);
-            con.setDoInput(true);
-            con.setRequestMethod("POST");
-            con.setRequestProperty
-                ("Content-type", "application/ocsp-request");
-            con.setRequestProperty
-                ("Content-length", String.valueOf(bytes.length));
-            out = con.getOutputStream();
-            out.write(bytes);
-            out.flush();
+            encodedGetReq.append(URLEncoder.encode(
+                    Base64.getEncoder().encodeToString(bytes), UTF_8));
+
+            if (encodedGetReq.length() <= 255) {
+                url = new URL(encodedGetReq.toString());
+                con = (HttpURLConnection)url.openConnection();
+                con.setDoOutput(true);
+                con.setDoInput(true);
+                con.setRequestMethod("GET");
+            } else {
+                url = responderURI.toURL();
+                con = (HttpURLConnection)url.openConnection();
+                con.setConnectTimeout(CONNECT_TIMEOUT);
+                con.setReadTimeout(CONNECT_TIMEOUT);
+                con.setDoOutput(true);
+                con.setDoInput(true);
+                con.setRequestMethod("POST");
+                con.setRequestProperty
+                    ("Content-type", "application/ocsp-request");
+                con.setRequestProperty
+                    ("Content-length", String.valueOf(bytes.length));
+                OutputStream out = con.getOutputStream();
+                out.write(bytes);
+                out.flush();
+            }
+
             // Check the response
             if (debug != null &&
                 con.getResponseCode() != HttpURLConnection.HTTP_OK) {
                 debug.println("Received HTTP error: " + con.getResponseCode()
                     + " - " + con.getResponseMessage());
             }
-            in = con.getInputStream();
+
             int contentLength = con.getContentLength();
             if (contentLength == -1) {
                 contentLength = Integer.MAX_VALUE;
             }
-            response = new byte[contentLength > 2048 ? 2048 : contentLength];
-            int total = 0;
-            while (total < contentLength) {
-                int count = in.read(response, total, response.length - total);
-                if (count < 0)
-                    break;
 
-                total += count;
-                if (total >= response.length && total < contentLength) {
-                    response = Arrays.copyOf(response, total * 2);
-                }
-            }
-            response = Arrays.copyOf(response, total);
+            return IOUtils.readExactlyNBytes(con.getInputStream(),
+                    contentLength);
         } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException ioe) {
-                    throw ioe;
-                }
-            }
-            if (out != null) {
-                try {
-                    out.close();
-                } catch (IOException ioe) {
-                    throw ioe;
-                }
+            if (con != null) {
+                con.disconnect();
             }
         }
-        return response;
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
@@ -640,7 +640,10 @@ public final class OCSPResponse {
 
         try {
             Signature respSignature = Signature.getInstance(sigAlgId.getName());
-            respSignature.initVerify(cert.getPublicKey());
+            SignatureUtil.initVerifyWithParam(respSignature,
+                    cert.getPublicKey(),
+                    SignatureUtil.getParamSpec(sigAlgId.getName(),
+                            sigAlgId.getEncodedParams()));
             respSignature.update(tbsResponseData);
 
             if (respSignature.verify(signature)) {
@@ -656,8 +659,8 @@ public final class OCSPResponse {
                 }
                 return false;
             }
-        } catch (InvalidKeyException | NoSuchAlgorithmException |
-                 SignatureException e)
+        } catch (InvalidAlgorithmParameterException | InvalidKeyException 
+                | NoSuchAlgorithmException | SignatureException e)
         {
             throw new CertPathValidatorException(e);
         }

--- a/src/java.base/share/classes/sun/security/util/SignatureUtil.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.security.spec.*;
 import java.util.Locale;
 import sun.security.rsa.RSAUtil;
 import jdk.internal.misc.SharedSecrets;
+import sun.security.x509.AlgorithmId;
 
 /**
  * Utility class for Signature related operations. Currently used by various
@@ -145,8 +146,7 @@ public class SignatureUtil {
     // for verification with the specified key and params (may be null)
     public static void initVerifyWithParam(Signature s, PublicKey key,
             AlgorithmParameterSpec params)
-            throws ProviderException, InvalidAlgorithmParameterException,
-            InvalidKeyException {
+            throws InvalidAlgorithmParameterException, InvalidKeyException {
         SharedSecrets.getJavaSecuritySignatureAccess().initVerify(s, key, params);
     }
 
@@ -155,8 +155,7 @@ public class SignatureUtil {
     public static void initVerifyWithParam(Signature s,
             java.security.cert.Certificate cert,
             AlgorithmParameterSpec params)
-            throws ProviderException, InvalidAlgorithmParameterException,
-            InvalidKeyException {
+            throws InvalidAlgorithmParameterException, InvalidKeyException {
         SharedSecrets.getJavaSecuritySignatureAccess().initVerify(s, cert, params);
     }
 
@@ -164,8 +163,83 @@ public class SignatureUtil {
     // for signing with the specified key and params (may be null)
     public static void initSignWithParam(Signature s, PrivateKey key,
             AlgorithmParameterSpec params, SecureRandom sr)
-            throws ProviderException, InvalidAlgorithmParameterException,
-            InvalidKeyException {
+            throws InvalidAlgorithmParameterException, InvalidKeyException {
         SharedSecrets.getJavaSecuritySignatureAccess().initSign(s, key, params, sr);
+    }
+
+    /**
+     * Create a Signature that has been initialized with proper key and params.
+     *
+     * @param sigAlg signature algorithms
+     * @param key private key
+     * @param provider (optional) provider
+     */
+    public static Signature fromKey(String sigAlg, PrivateKey key, String provider)
+        throws NoSuchAlgorithmException, NoSuchProviderException,
+        InvalidKeyException{
+        Signature sigEngine = (provider == null || provider.isEmpty())
+            ? Signature.getInstance(sigAlg)
+            : Signature.getInstance(sigAlg, provider);
+        return autoInitInternal(sigAlg, key, sigEngine);
+    }
+
+    /**
+     * Create a Signature that has been initialized with proper key and params.
+     *
+     * @param sigAlg signature algorithms
+     * @param key private key
+     * @param provider (optional) provider
+     */
+    public static Signature fromKey(String sigAlg, PrivateKey key, Provider provider)
+            throws NoSuchAlgorithmException, InvalidKeyException{
+        Signature sigEngine = (provider == null)
+                ? Signature.getInstance(sigAlg)
+                : Signature.getInstance(sigAlg, provider);
+        return autoInitInternal(sigAlg, key, sigEngine);
+    }
+
+    private static Signature autoInitInternal(String alg, PrivateKey key, Signature s)
+        throws InvalidKeyException {
+        AlgorithmParameterSpec params = AlgorithmId
+                .getDefaultAlgorithmParameterSpec(alg, key);
+        try {
+            SignatureUtil.initSignWithParam(s, key, params, null);
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new AssertionError("Should not happen", e);
+        }
+        return s;
+    }
+
+    /**
+     * Derives AlgorithmId from a signature object and a key.
+     * @param sigEngine the signature object
+     * @param key the private key
+     * @return the AlgorithmId, not null
+     * @throws SignatureException if cannot find one
+     */
+    public static AlgorithmId fromSignature(Signature sigEngine, PrivateKey key)
+        throws SignatureException {
+        try {
+            AlgorithmParameters params = null;
+            try {
+                params = sigEngine.getParameters();
+            } catch (UnsupportedOperationException e) {
+                // some provider does not support it
+            }
+            if (params != null) {
+                return AlgorithmId.get(sigEngine.getParameters());
+            } else {
+                String sigAlg = sigEngine.getAlgorithm();
+                if (sigAlg.equalsIgnoreCase("EdDSA")) {
+                    // Hopefully key knows if it's Ed25519 or Ed448
+                    sigAlg = key.getAlgorithm();
+                }
+                return AlgorithmId.get(sigAlg);
+            }
+        } catch (NoSuchAlgorithmException e) {
+            // This could happen if both sig alg and key alg is EdDSA,
+            // we don't know which provider does this.
+            throw new SignatureException("Cannot derive AlgorithmIdentifier", e);
+        }
     }
 }

--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -291,7 +291,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      *
      * @return DER encoded parameters, or null not present.
      */
-    public byte[] getEncodedParams() throws IOException {
+    public byte[] getEncodedParams() {
         return (encodedParams == null || algid.equals(specifiedWithECDSA_oid))
                 ? null
                 : encodedParams.clone();

--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -839,13 +839,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      *         null if no parameters are present.
      */
     public byte[] getSigAlgParams() {
-        if (sigAlgId == null)
-            return null;
-        try {
-            return sigAlgId.getEncodedParams();
-        } catch (IOException e) {
-            return null;
-        }
+        return sigAlgId == null ? null : sigAlgId.getEncodedParams();
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1084,13 +1084,7 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
      *         null if no parameters are present.
      */
     public byte[] getSigAlgParams() {
-        if (algId == null)
-            return null;
-        try {
-            return algId.getEncodedParams();
-        } catch (IOException e) {
-            return null;
-        }
+        return algId == null ? null : algId.getEncodedParams();
     }
 
     /**

--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8179503
+ * @summary Java should support GET OCSP calls
+ * @library /javax/net/ssl/templates /java/security/testlibrary
+ * @build SimpleOCSPServer
+ * @modules java.base/sun.security.util
+ *          java.base/sun.security.provider.certpath
+ *          java.base/sun.security.x509
+ * @run main/othervm GetAndPostTests
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.CertPath;
+import java.security.cert.CertPathValidator;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.Extension;
+import java.security.cert.PKIXCertPathChecker;
+import java.security.cert.PKIXParameters;
+import java.security.cert.PKIXRevocationChecker;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import sun.security.testlibrary.SimpleOCSPServer;
+import sun.security.testlibrary.SimpleOCSPServer;
+import sun.security.testlibrary.SimpleOCSPServer;
+import sun.security.util.DerOutputStream;
+import sun.security.util.DerValue;
+import sun.security.util.ObjectIdentifier;
+import sun.security.testlibrary.SimpleOCSPServer;
+
+public class GetAndPostTests {
+    private static final String PASS = "passphrase";
+    private static CertificateFactory certFac;
+
+    public static void main(String args[]) throws Exception {
+        SimpleOCSPServer ocspResponder = null;
+
+        try {
+            certFac = CertificateFactory.getInstance("X.509");
+
+            // Read in the certificates and keys needed for this test and
+            // create the keystore for the SimpleOCSPServer.  For the purposes
+            // of this test, the CA certificate will also be the OCSP responder
+            // signing certificate.
+            SSLSocketTemplate.Cert certAuth =
+                    SSLSocketTemplate.Cert.CA_ECDSA_SECP256R1;
+            X509Certificate caCert = pem2Cert(certAuth.certStr);
+            PrivateKey caKey = pem2Key(certAuth.privKeyStr, certAuth.keyAlgo);
+            X509Certificate endEntCert =
+                    pem2Cert(SSLSocketTemplate.Cert.EE_ECDSA_SECP256R1.certStr);
+
+            KeyStore.Builder keyStoreBuilder =
+                    KeyStore.Builder.newInstance("PKCS12", null,
+                        new KeyStore.PasswordProtection(PASS.toCharArray()));
+            KeyStore ocspStore = keyStoreBuilder.getKeyStore();
+            Certificate[] ocspChain = {caCert};
+            ocspStore.setKeyEntry("ocspsigner", caKey, PASS.toCharArray(),
+                    ocspChain);
+
+            // Create the certificate path we'll use for cert path validation.
+            CertPath path = certFac.generateCertPath(List.of(endEntCert));
+
+            // Next, create and start the OCSP responder.  Obtain the socket
+            // address so we can set that in the PKIXRevocationChecker since
+            // these certificates do not have AIA extensions on them.
+            ocspResponder = new SimpleOCSPServer(ocspStore, PASS,
+                    "ocspsigner", null);
+            ocspResponder.setSignatureAlgorithm("SHA256WithECDSA");
+            ocspResponder.enableLog(true);
+            ocspResponder.setNextUpdateInterval(3600);
+            ocspResponder.updateStatusDb(Map.of(
+                    endEntCert.getSerialNumber(),
+                    new SimpleOCSPServer.CertStatusInfo(
+                            SimpleOCSPServer.CertStatus.CERT_STATUS_GOOD)));
+            ocspResponder.start();
+            // Wait 5 seconds for server ready
+            for (int i = 0; (i < 100 && !ocspResponder.isServerReady()); i++) {
+                Thread.sleep(50);
+            }
+            if (!ocspResponder.isServerReady()) {
+                throw new RuntimeException("Server not ready yet");
+            }
+
+            int ocspPort = ocspResponder.getPort();
+            URI ocspURI = new URI("http://localhost:" + ocspPort);
+            System.out.println("Configured CPV to connect to " + ocspURI);
+
+            // Create the PKIXParameters needed for path validation and
+            // configure any necessary OCSP parameters to control the OCSP
+            // request size.
+            Set<TrustAnchor> anchors = Set.of(new TrustAnchor(caCert, null));
+
+            CertPathValidator validator = CertPathValidator.getInstance("PKIX");
+            PKIXRevocationChecker revChkr =
+                    (PKIXRevocationChecker)validator.getRevocationChecker();
+            revChkr.setOcspResponder(ocspURI);
+            revChkr.setOptions(Set.of(
+                    PKIXRevocationChecker.Option.ONLY_END_ENTITY,
+                    PKIXRevocationChecker.Option.NO_FALLBACK));
+
+            PKIXParameters params = new PKIXParameters(anchors);
+            params.setRevocationEnabled(true);
+            params.setDate(new Date(1590926400000L)); // 05/31/2020 @ 12:00:00Z
+            params.addCertPathChecker(revChkr);
+
+            System.out.println("Test 1: Request < 255 bytes, HTTP GET");
+            validator.validate(path, params);
+
+            System.out.println("Test 2: Request > 255 bytes, HTTP POST");
+            // Modify the PKIXRevocationChecker to include a bogus non-critical
+            // request extension that makes the request large enough to be
+            // issued as an HTTP POST.
+            List<PKIXCertPathChecker> chkrList = params.getCertPathCheckers();
+            for (PKIXCertPathChecker chkr : chkrList) {
+                if (chkr instanceof PKIXRevocationChecker) {
+                    ((PKIXRevocationChecker)chkr).setOcspExtensions(
+                            List.of(new BogusExtension("1.2.3.4.5.6.7.8.9",
+                                    false, 256)));
+                }
+            }
+            params.setCertPathCheckers(chkrList);
+            validator.validate(path, params);
+
+        } finally {
+            if (ocspResponder != null) {
+                ocspResponder.stop();
+            }
+        }
+    }
+
+    /**
+     * Create an X509Certificate object from its PEM encoding
+     *
+     * @param pemCert the base64 encoded certificate
+     *
+     * @return the corresponding X509Certificate object from the PEM encoding.
+     *
+     * @throws IOException if any InputStream or Base64 decoding failures occur.
+     * @throws CertificateException if any certificate parsing errors occur.
+     */
+    private static X509Certificate pem2Cert(String pemCert)
+            throws IOException, CertificateException {
+        return (X509Certificate)certFac.generateCertificate(
+                new ByteArrayInputStream(pemCert.getBytes()));
+    }
+
+    /**
+     * Create a private key from its PEM-encoded PKCS#8 representation.
+     *
+     * @param pemKey the private key in PEM-encoded PKCS#8 unencrypted format
+     * @param algorithm the private key algorithm
+     *
+     * @return the PrivateKey extracted from the PKCS#8 encoding.
+     *
+     * @throws GeneralSecurityException if any errors take place during
+     * decoding or parsing.
+     */
+    private static PrivateKey pem2Key(String pemKey, String algorithm)
+            throws GeneralSecurityException {
+        byte[] p8Der = Base64.getMimeDecoder().decode(pemKey);
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(p8Der, algorithm);
+        KeyFactory kf = KeyFactory.getInstance(algorithm);
+        return kf.generatePrivate(spec);
+    }
+
+    /**
+     * The BogusOcspExtension is an extension with random data in the
+     * extension value field.  It is used in this test to expand the size
+     * of the OCSP request so it crosses the boundary that forces an HTTP
+     * POST operation instead of a GET.
+     */
+    private static class BogusExtension implements Extension {
+        private final ObjectIdentifier oid;
+        private final boolean critical;
+        private final byte[] data;
+
+        public BogusExtension(String oidStr, boolean isCrit, int size)
+                throws IOException {
+            // For this test we don't need anything larger than 10K
+            if (size > 0 && size <= 10240) {
+                data = new byte[size];
+            } else {
+                throw new IllegalArgumentException(
+                        "Size must be 0 < X <= 10240");
+            }
+            oid = new ObjectIdentifier(oidStr);
+            SecureRandom sr = new SecureRandom();
+            sr.nextBytes(data);
+            critical = isCrit;
+        }
+
+        @Override
+        public String getId() {
+            return oid.toString();
+        }
+
+        @Override
+        public boolean isCritical() {
+            return critical;
+        }
+
+        @Override
+        public byte[] getValue() {
+            return data.clone();
+        }
+
+        @Override
+        public void encode(OutputStream out) throws IOException {
+            Objects.requireNonNull(out, "Non-null OutputStream required");
+
+            DerOutputStream dos1 = new DerOutputStream();
+            DerOutputStream dos2 = new DerOutputStream();
+
+            dos1.putOID(oid);
+            if (critical) {
+                dos1.putBoolean(critical);
+            }
+            dos1.putOctetString(data);
+
+            dos2.write(DerValue.tag_Sequence, dos1);
+            out.write(dos2.toByteArray());
+        }
+    }
+}

--- a/test/jdk/java/security/testlibrary/CertificateBuilder.java
+++ b/test/jdk/java/security/testlibrary/CertificateBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import java.math.BigInteger;
 import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 import sun.security.util.ObjectIdentifier;
+import sun.security.util.SignatureUtil;
 import sun.security.x509.AccessDescription;
 import sun.security.x509.AlgorithmId;
 import sun.security.x509.AuthorityInfoAccessExtension;
@@ -364,8 +365,7 @@ public class CertificateBuilder {
             throws IOException, CertificateException, NoSuchAlgorithmException {
         // TODO: add some basic checks (key usage, basic constraints maybe)
 
-        AlgorithmId signAlg = AlgorithmId.get(algName);
-        byte[] encodedCert = encodeTopLevel(issuerCert, issuerKey, signAlg);
+        byte[] encodedCert = encodeTopLevel(issuerCert, issuerKey, algName);
         ByteArrayInputStream bais = new ByteArrayInputStream(encodedCert);
         return (X509Certificate)factory.generateCertificate(bais);
     }
@@ -392,18 +392,23 @@ public class CertificateBuilder {
      * @throws IOException if an encoding error occurs.
      */
     private byte[] encodeTopLevel(X509Certificate issuerCert,
-            PrivateKey issuerKey, AlgorithmId signAlg)
-            throws CertificateException, IOException {
+            PrivateKey issuerKey, String algName)
+            throws CertificateException, IOException, NoSuchAlgorithmException {
+        AlgorithmId signAlg = AlgorithmId.get(algName);
         DerOutputStream outerSeq = new DerOutputStream();
         DerOutputStream topLevelItems = new DerOutputStream();
 
-        tbsCertBytes = encodeTbsCert(issuerCert, signAlg);
-        topLevelItems.write(tbsCertBytes);
         try {
-            signatureBytes = signCert(issuerKey, signAlg);
+            Signature sig = SignatureUtil.fromKey(signAlg.getName(), issuerKey, (Provider)null);
+            // Rewrite signAlg, RSASSA-PSS needs some parameters.
+            signAlg = SignatureUtil.fromSignature(sig, issuerKey);
+            tbsCertBytes = encodeTbsCert(issuerCert, signAlg);
+            sig.update(tbsCertBytes);
+            signatureBytes = sig.sign();
         } catch (GeneralSecurityException ge) {
             throw new CertificateException(ge);
         }
+        topLevelItems.write(tbsCertBytes);
         signAlg.derEncode(topLevelItems);
         topLevelItems.putBitString(signatureBytes);
         outerSeq.write(DerValue.tag_Sequence, topLevelItems);
@@ -517,23 +522,4 @@ public class CertificateBuilder {
         tbsStream.write(DerValue.createTag(DerValue.TAG_CONTEXT, true,
                 (byte)3), extSequence);
     }
-
-    /**
-     * Digitally sign the X.509 certificate.
-     *
-     * @param issuerKey The private key of the issuing authority
-     * @param signAlg The signature algorithm object
-     *
-     * @return The digital signature bytes.
-     *
-     * @throws GeneralSecurityException If any errors occur during the
-     * digital signature process.
-     */
-    private byte[] signCert(PrivateKey issuerKey, AlgorithmId signAlg)
-            throws GeneralSecurityException {
-        Signature sig = Signature.getInstance(signAlg.getName());
-        sig.initSign(issuerKey);
-        sig.update(tbsCertBytes);
-        return sig.sign();
-    }
- }
+}

--- a/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
+++ b/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ import sun.security.util.DerInputStream;
 import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 import sun.security.util.ObjectIdentifier;
-
+import sun.security.util.SignatureUtil;
 
 /**
  * This is a simple OCSP server designed to listen and respond to incoming
@@ -178,8 +178,7 @@ public class SimpleOCSPServer {
                     issuerAlias + " not found");
             }
         }
-
-        sigAlgId = AlgorithmId.get("Sha256withRSA");
+        sigAlgId = AlgorithmId.get(AlgorithmId.getDefaultSigAlgForKey(signerKey));
         respId = new ResponderId(signerCert.getSubjectX500Principal());
         listenAddress = addr;
         listenPort = port;
@@ -707,21 +706,21 @@ public class SimpleOCSPServer {
                     OutputStream out = ocspSocket.getOutputStream()) {
                 peerSockAddr =
                         (InetSocketAddress)ocspSocket.getRemoteSocketAddress();
-                log("Received incoming connection from " + peerSockAddr);
                 String[] headerTokens = readLine(in).split(" ");
                 LocalOcspRequest ocspReq = null;
                 LocalOcspResponse ocspResp = null;
                 ResponseStatus respStat = ResponseStatus.INTERNAL_ERROR;
                 try {
                     if (headerTokens[0] != null) {
+                        log("Received incoming HTTP " + headerTokens[0] +
+                                " from " + peerSockAddr);
                         switch (headerTokens[0]) {
                             case "POST":
-                                    ocspReq = parseHttpOcspPost(in);
+                                ocspReq = parseHttpOcspPost(in);
                                 break;
                             case "GET":
-                                // req = parseHttpOcspGet(in);
-                                // TODO implement the GET parsing
-                                throw new IOException("GET method unsupported");
+                                ocspReq = parseHttpOcspGet(headerTokens);
+                                break;
                             default:
                                 respStat = ResponseStatus.MALFORMED_REQUEST;
                                 throw new IOException("Not a GET or POST");
@@ -841,6 +840,30 @@ public class SimpleOCSPServer {
             } else {
                 return null;
             }
+        }
+
+        /**
+         * Parse the incoming HTTP GET of an OCSP Request.
+         *
+         * @param headerTokens the individual String tokens from the first
+         * line of the HTTP GET.
+         *
+         * @return the OCSP Request as a {@code LocalOcspRequest}
+         *
+         * @throws IOException if there are network related issues or problems
+         * occur during parsing of the OCSP request.
+         * @throws CertificateException if one or more of the certificates in
+         * the OCSP request cannot be read/parsed.
+         */
+        private LocalOcspRequest parseHttpOcspGet(String[] headerTokens)
+                throws IOException, CertificateException {
+            // We have already established headerTokens[0] to be "GET".
+            // We should have the URL-encoded base64 representation of the
+            // OCSP request in headerTokens[1].  We need to strip any leading
+            // "/" off before decoding.
+            return new LocalOcspRequest(Base64.getMimeDecoder().decode(
+                    URLDecoder.decode(headerTokens[1].replaceAll("/", ""),
+                            "UTF-8")));
         }
 
         /**
@@ -1328,13 +1351,14 @@ public class SimpleOCSPServer {
             basicORItemStream.write(tbsResponseBytes);
 
             try {
-                sigAlgId.derEncode(basicORItemStream);
-
                 // Create the signature
-                Signature sig = Signature.getInstance(sigAlgId.getName());
-                sig.initSign(signerKey);
+                Signature sig = SignatureUtil.fromKey(
+                        sigAlgId.getName(), signerKey, (Provider)null);
                 sig.update(tbsResponseBytes);
                 signature = sig.sign();
+                // Rewrite signAlg, RSASSA-PSS needs some parameters.
+                sigAlgId = SignatureUtil.fromSignature(sig, signerKey);
+                sigAlgId.derEncode(basicORItemStream);
                 basicORItemStream.putBitString(signature);
             } catch (GeneralSecurityException exc) {
                 err(exc);

--- a/test/jdk/javax/net/ssl/Stapling/HttpsUrlConnClient.java
+++ b/test/jdk/javax/net/ssl/Stapling/HttpsUrlConnClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,8 @@
  * @summary OCSP Stapling for TLS
  * @library ../../../../java/security/testlibrary
  * @build CertificateBuilder SimpleOCSPServer
- * @run main/othervm HttpsUrlConnClient
+ * @run main/othervm HttpsUrlConnClient RSA SHA256withRSA
+ * @run main/othervm HttpsUrlConnClient RSASSA-PSS RSASSA-PSS
  */
 
 import java.io.*;
@@ -60,7 +61,6 @@ import java.util.concurrent.TimeUnit;
 
 import sun.security.testlibrary.SimpleOCSPServer;
 import sun.security.testlibrary.CertificateBuilder;
-import sun.security.validator.ValidatorException;
 
 public class HttpsUrlConnClient {
 
@@ -72,6 +72,9 @@ public class HttpsUrlConnClient {
 
     static final byte[] LINESEP = { 10 };
     static final Base64.Encoder B64E = Base64.getMimeEncoder(64, LINESEP);
+
+    static String SIGALG;
+    static String KEYALG;
 
     // Turn on TLS debugging
     static boolean debug = true;
@@ -136,6 +139,9 @@ public class HttpsUrlConnClient {
         System.setProperty("javax.net.ssl.keyStorePassword", "");
         System.setProperty("javax.net.ssl.trustStore", "");
         System.setProperty("javax.net.ssl.trustStorePassword", "");
+
+        KEYALG = args[0];
+        SIGALG = args[1];
 
         // Create the PKI we will use for the test and start the OCSP servers
         createPKI();
@@ -514,7 +520,7 @@ public class HttpsUrlConnClient {
      */
     private static void createPKI() throws Exception {
         CertificateBuilder cbld = new CertificateBuilder();
-        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance(KEYALG);
         keyGen.initialize(2048);
         KeyStore.Builder keyStoreBuilder =
                 KeyStore.Builder.newInstance("PKCS12", null,
@@ -540,7 +546,7 @@ public class HttpsUrlConnClient {
         addCommonCAExts(cbld);
         // Make our Root CA Cert!
         X509Certificate rootCert = cbld.build(null, rootCaKP.getPrivate(),
-                "SHA256withRSA");
+                SIGALG);
         log("Root CA Created:\n" + certInfo(rootCert));
 
         // Now build a keystore and add the keys and cert
@@ -582,7 +588,7 @@ public class HttpsUrlConnClient {
         cbld.addAIAExt(Collections.singletonList(rootRespURI));
         // Make our Intermediate CA Cert!
         X509Certificate intCaCert = cbld.build(rootCert, rootCaKP.getPrivate(),
-                "SHA256withRSA");
+                SIGALG);
         log("Intermediate CA Created:\n" + certInfo(intCaCert));
 
         // Provide intermediate CA cert revocation info to the Root CA
@@ -644,7 +650,7 @@ public class HttpsUrlConnClient {
         cbld.addAIAExt(Collections.singletonList(intCaRespURI));
         // Make our SSL Server Cert!
         X509Certificate sslCert = cbld.build(intCaCert, intCaKP.getPrivate(),
-                "SHA256withRSA");
+                SIGALG);
         log("SSL Certificate Created:\n" + certInfo(sslCert));
 
         // Provide SSL server cert revocation info to the Intermeidate CA


### PR DESCRIPTION
I'd like to backport

8274471: Add support for RSASSA-PSS in OCSP Response

that depends on

8179503: Java should support GET OCSP calls

to jdk11u-dev. 

The patches fix internal error upon verification of OCSP Response signed with RSASSA-PSS. 

The following changes were done to original patches:

8179503: 

src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
- resolved baseline conflict that took place due to absent revocation checking code

test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
- unsupported `ObjectIdentifier.of()` substituted with `new ObjectIdentifier`

8274471:

src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
- changes to absent revokation checking code ignored

src/java.base/share/classes/sun/security/util/SignatureUtil.java
- the following non-existing methods transferred from jdk17:
    `public static Signature fromKey(String sigAlg, PrivateKey key, String provider);`
    `public static Signature fromKey(String sigAlg, PrivateKey key, Provider provider);`
    `private static Signature autoInitInternal(String alg, PrivateKey key, Signature s);`
    `public static AlgorithmId fromSignature(Signature sigEngine, PrivateKey key);`
- `EdEcKey` (unsupported in jdk11) hook removed from fromSignature() method
- copied `SignatureUtil.autoInitInternal()` method updated to use `AlgorithmId.getDefaultAlgorithmParameterSpec()` instead of `SignatureUtil.getDefaultParamSpec()`
- imported AlgorithmId class

test/jdk/java/security/testlibrary/SimpleOCSPServer.java
- imported SignatureUtil class

Verified (20.04 LTS/amd64) with

- test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
- test/jdk/javax/net/ssl/Stapling/HttpsUrlConnClient.java

Regression: jdk_security

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8274471](https://bugs.openjdk.java.net/browse/JDK-8274471): Add support for RSASSA-PSS in OCSP Response


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/785/head:pull/785` \
`$ git checkout pull/785`

Update a local copy of the PR: \
`$ git checkout pull/785` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 785`

View PR using the GUI difftool: \
`$ git pr show -t 785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/785.diff">https://git.openjdk.java.net/jdk11u-dev/pull/785.diff</a>

</details>
