### PR TITLE
8251998: remove usage of PropertyResolvingWrapper in vmTestbase/jit/t

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/jit/t/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/TEST.properties
@@ -1,2 +1,0 @@
-# disabled till JDK-8251998 is fixed
-allowSmartActionArgs=false

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t087/t087.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t087/t087.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,14 +36,14 @@
  *
  * @comment make sure foo.class is only in the current directory
  * @clean jit.t.t087.foo
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/javac
  *      -d .
  *      -cp ${test.class.path}
  *      ${test.src}/t087.java
  *
  * @comment run the test
- * @run driver PropertyResolvingWrapper ExecDriver --java
+ * @run driver ExecDriver --java
  *      -cp .${path.separator}${test.class.path}
  *      -Dtest.src=${test.src}
  *      jit.t.t087.t087
@@ -52,49 +52,41 @@
 
 package jit.t.t087;
 
-import java.io.File;
-import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class foo
-{
-    static void bar()
-    {
+import java.io.File;
+
+class foo {
+    static void bar() {
         t087.goldChecker.println("You shouldn't see this.");
     }
 }
 
-class t087
-{
-    public static final GoldChecker goldChecker = new GoldChecker( "t087" );
+class t087 {
+    public static final GoldChecker goldChecker = new GoldChecker("t087");
 
-    public static void main(String[] argv)
-    {
+    public static void main(String[] argv) {
         File f;
-        if (argv.length < 2 || !argv[0].equals("-WorkDir"))
-                f = new File(".", "foo.class");
-        else
-                f = new File(argv[1], "foo.class");
-        if(f.isFile())
-        {
-
+        if (argv.length < 2 || !argv[0].equals("-WorkDir")) {
+            f = new File(".", "foo.class");
+        } else {
+            f = new File(argv[1], "foo.class");
+        }
+        if (f.isFile()) {
             f.delete();
 
-            for(int i = 1; i <= 2; i += 1)
-            {
-                try
-                {
+            for (int i = 1; i <= 2; i += 1) {
+                try {
                     foo.bar();
-                }
-                catch(Throwable t)
-                {
+                } catch (Throwable t) {
                     t087.goldChecker.println("Exception on try" + i);
                 }
             }
 
-        }
-        else
+        } else {
             t087.goldChecker.println("No foo.class in cwd");
+        }
         t087.goldChecker.check();
     }
 }
+

--- a/test/hotspot/jtreg/vmTestbase/jit/t/t088/t088.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/t/t088/t088.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,14 +36,14 @@
  *
  * @comment make sure foo.class is only in the current directory
  * @clean jit.t.t088.foo
- * @run driver PropertyResolvingWrapper ExecDriver --cmd
+ * @run driver ExecDriver --cmd
  *      ${compile.jdk}/bin/javac
  *      -d .
  *      -cp ${test.class.path}
  *      ${test.src}/t088.java
  *
  * @comment run the test
- * @run driver PropertyResolvingWrapper ExecDriver --java
+ * @run driver ExecDriver --java
  *      -cp .${path.separator}${test.class.path}
  *      -Dtest.src=${test.src}
  *      jit.t.t088.t088
@@ -55,55 +55,45 @@ package jit.t.t088;
 // Just like the one before except that the two patched calls
 // are attempted from distinct call sites.
 
-import java.io.File;
-import nsk.share.TestFailure;
 import nsk.share.GoldChecker;
 
-class foo
-{
-    static void bar()
-    {
+import java.io.File;
+
+class foo {
+    static void bar() {
         t088.goldChecker.println("You shouldn't see this.");
     }
 }
 
-class t088
-{
-    public static final GoldChecker goldChecker = new GoldChecker( "t088" );
+class t088 {
+    public static final GoldChecker goldChecker = new GoldChecker("t088");
 
-    public static void main(String[] argv)
-    {
+    public static void main(String[] argv) {
         File f;
-    if (argv.length < 2 || !argv[0].equals("-WorkDir"))
-        f = new File(".", "foo.class");
-    else
-        f = new File(argv[1], "foo.class");
-        if(f.isFile())
-        {
-
+        if (argv.length < 2 || !argv[0].equals("-WorkDir")) {
+            f = new File(".", "foo.class");
+        } else {
+            f = new File(argv[1], "foo.class");
+        }
+        if (f.isFile()) {
             f.delete();
 
-            try
-            {
+            try {
                 foo.bar();
-            }
-            catch(Throwable t)
-            {
+            } catch (Throwable t) {
                 t088.goldChecker.println("Exception on first try");
             }
 
-            try
-            {
+            try {
                 foo.bar();
-            }
-            catch(Throwable t)
-            {
+            } catch (Throwable t) {
                 t088.goldChecker.println("Exception on second try");
             }
 
-        }
-        else
+        } else {
             t088.goldChecker.println("No foo.class in cwd");
+        }
         t088.goldChecker.check();
     }
 }
+


### PR DESCRIPTION
This test cleanup is a clean backport and simplifies follow-up backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8251998](https://bugs.openjdk.java.net/browse/JDK-8251998): remove usage of PropertyResolvingWrapper in vmTestbase/jit/t


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/786/head:pull/786` \
`$ git checkout pull/786`

Update a local copy of the PR: \
`$ git checkout pull/786` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 786`

View PR using the GUI difftool: \
`$ git pr show -t 786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/786.diff">https://git.openjdk.java.net/jdk11u-dev/pull/786.diff</a>

</details>
