### PR TITLE
8236505: Mark jdk/editpad/EditPadTest.java as @headful

### DIFF
--- a/test/jdk/jdk/editpad/EditPadTest.java
+++ b/test/jdk/jdk/editpad/EditPadTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key headful
  * @bug 8167636 8167639 8168972
  * @summary Testing built-in editor.
  * @modules java.desktop/java.awt


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8236505](https://bugs.openjdk.java.net/browse/JDK-8236505): Mark jdk/editpad/EditPadTest.java as @headful


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/789/head:pull/789` \
`$ git checkout pull/789`

Update a local copy of the PR: \
`$ git checkout pull/789` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 789`

View PR using the GUI difftool: \
`$ git pr show -t 789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/789.diff">https://git.openjdk.java.net/jdk11u-dev/pull/789.diff</a>

</details>
