### PR TITLE
8253197: vmTestbase/nsk/jvmti/StopThread/stopthrd007/TestDescription.java fails with "ERROR: DebuggeeSleepingThread: ThreadDeath lost"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/StopThread/stopthrd007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/StopThread/stopthrd007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,8 +170,8 @@ class stopthrd007ThreadRunning extends Thread {
     }
 
     public void run() {
-        stopthrd007.startingBarrier.unlock();
         try {
+            stopthrd007.startingBarrier.unlock();
             int i = 0;
             int n = 1000;
             while (flag) {
@@ -216,8 +216,8 @@ class stopthrd007ThreadWaiting extends Thread {
     }
 
     public synchronized void run() {
-        stopthrd007.startingBarrier.unlock();
         try {
+            stopthrd007.startingBarrier.unlock();
             wait(timeout);
             status = 1;
         } catch (ThreadDeath t) {
@@ -249,8 +249,8 @@ class stopthrd007ThreadSleeping extends Thread {
     }
 
     public void run() {
-        stopthrd007.startingBarrier.unlock();
         try {
+            stopthrd007.startingBarrier.unlock();
             sleep(timeout);
             status = 1;
         } catch (ThreadDeath t) {


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253197](https://bugs.openjdk.java.net/browse/JDK-8253197): vmTestbase/nsk/jvmti/StopThread/stopthrd007/TestDescription.java fails with "ERROR: DebuggeeSleepingThread: ThreadDeath lost"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/790/head:pull/790` \
`$ git checkout pull/790`

Update a local copy of the PR: \
`$ git checkout pull/790` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 790`

View PR using the GUI difftool: \
`$ git pr show -t 790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/790.diff">https://git.openjdk.java.net/jdk11u-dev/pull/790.diff</a>

</details>
