### PR TITLE
8279833: Loop optimization issue in String.encodeUTF8_UTF16

### DIFF
--- a/src/java.base/share/classes/java/lang/StringCoding.java
+++ b/src/java.base/share/classes/java/lang/StringCoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -921,14 +921,17 @@ class StringCoding {
         int sp = 0;
         int sl = val.length >> 1;
         byte[] dst = new byte[sl * 3];
-        char c;
-        while (sp < sl && (c = StringUTF16.getChar(val, sp)) < '\u0080') {
+        while (sp < sl) {
             // ascii fast loop;
+            char c = StringUTF16.getChar(val, sp);
+            if (c >= '\u0080') {
+                break;
+            }
             dst[dp++] = (byte)c;
             sp++;
         }
         while (sp < sl) {
-            c = StringUTF16.getChar(val, sp++);
+            char c = StringUTF16.getChar(val, sp++);
             if (c < 0x80) {
                 dst[dp++] = (byte)c;
             } else if (c < 0x800) {

--- a/test/micro/org/openjdk/bench/java/lang/StringEncode.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringEncode.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 3)
+@State(Scope.Thread)
+public class StringEncode {
+
+    @Param({"US-ASCII", "ISO-8859-1", "UTF-8", "MS932", "ISO-8859-6"})
+    private String charsetName;
+    private Charset charset;
+    private String asciiString;
+    private String utf16String;
+    private String longUtf16String;
+    private String longUtf16StartString;
+
+    @Setup
+    public void setup() {
+        charset = Charset.forName(charsetName);
+        asciiString = "ascii string";
+        utf16String = "UTF-\uFF11\uFF16 string";
+        longUtf16String =
+                 " Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ac sem eu\n" +
+                 " urna egestas placerat. Etiam finibus ipsum nulla, non mattis dolor cursus a.\n" +
+                 " Nulla nec nisl consectetur, lacinia neque id, accumsan ante. Curabitur et\n" +
+                 " sapien in magna porta ultricies. Sed vel pellentesque nibh. Pellentesque dictum\n" +
+                 " dignissim diam eu ultricies. Class aptent taciti sociosqu ad litora torquent\n" +
+                 " per conubia nostra, per inceptos himenaeos. Suspendisse erat diam, fringilla\n" +
+                 " sed massa sed, posuere viverra orci. Suspendisse tempor libero non gravida\n" +
+                 " efficitur. Vivamus lacinia risus non orci viverra, at consectetur odio laoreet.\n" +
+                 " Suspendisse potenti.\n" +
+                 "\n" +
+                 " Phasellus vel nisi iaculis, accumsan quam sed, bibendum eros. Sed venenatis\n" +
+                 " nulla tortor, et eleifend urna sodales id. Nullam tempus ac metus sit amet\n" +
+                 " sollicitudin. Nam sed ex diam. Praesent vitae eros et neque condimentum\n" +
+                 " consectetur eget non tortor. Praesent bibendum vel felis nec dignissim.\n" +
+                 " Maecenas a enim diam. Suspendisse quis ligula at nisi accumsan lacinia id\n" +
+                 " hendrerit sapien. Donec aliquam mattis lectus eu ultrices. Duis eu nisl\n" +
+                 " euismod, blandit mauris vel, placerat urna. Etiam malesuada enim purus,\n" +
+                 " tristique mollis odio blandit quis. Vivamus posuere.\n" +
+                 " \uFF11";
+        longUtf16StartString =
+                 " \uFF11" +
+                 " Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ac sem eu\n" +
+                 " urna egestas placerat. Etiam finibus ipsum nulla, non mattis dolor cursus a.\n" +
+                 " Nulla nec nisl consectetur, lacinia neque id, accumsan ante. Curabitur et\n" +
+                 " sapien in magna porta ultricies. Sed vel pellentesque nibh. Pellentesque dictum\n" +
+                 " dignissim diam eu ultricies. Class aptent taciti sociosqu ad litora torquent\n" +
+                 " per conubia nostra, per inceptos himenaeos. Suspendisse erat diam, fringilla\n" +
+                 " sed massa sed, posuere viverra orci. Suspendisse tempor libero non gravida\n" +
+                 " efficitur. Vivamus lacinia risus non orci viverra, at consectetur odio laoreet.\n" +
+                 " Suspendisse potenti.\n" +
+                 "\n" +
+                 " Phasellus vel nisi iaculis, accumsan quam sed, bibendum eros. Sed venenatis\n" +
+                 " nulla tortor, et eleifend urna sodales id. Nullam tempus ac metus sit amet\n" +
+                 " sollicitudin. Nam sed ex diam. Praesent vitae eros et neque condimentum\n" +
+                 " consectetur eget non tortor. Praesent bibendum vel felis nec dignissim.\n" +
+                 " Maecenas a enim diam. Suspendisse quis ligula at nisi accumsan lacinia id\n" +
+                 " hendrerit sapien. Donec aliquam mattis lectus eu ultrices. Duis eu nisl\n" +
+                 " euismod, blandit mauris vel, placerat urna. Etiam malesuada enim purus,\n" +
+                 " tristique mollis odio blandit quis. Vivamus posuere.\n";
+    }
+
+    @Benchmark
+    public byte[] encodeAsciiCharsetName() throws Exception {
+        return asciiString.getBytes(charset);
+    }
+
+    @Benchmark
+    public byte[] encodeAscii() throws Exception {
+        return asciiString.getBytes(charset);
+    }
+
+    @Benchmark
+    public void encodeMix(Blackhole bh) throws Exception {
+        bh.consume(asciiString.getBytes(charset));
+        bh.consume(utf16String.getBytes(charset));
+    }
+
+    @Benchmark
+    public byte[] encodeUTF16LongEnd() throws Exception {
+        return longUtf16String.getBytes(charset);
+    }
+
+    @Benchmark
+    public byte[] encodeUTF16LongStart() throws Exception {
+        return longUtf16StartString.getBytes(charset);
+    }
+
+    @Benchmark
+    public byte[] encodeUTF16() throws Exception {
+        return utf16String.getBytes(charset);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

The patch does not apply well.

8259842: Remove Result cache from StringCoding  is missing in 11.
Therefore the actual change must be applied to StringCoding.java
and not to String.java.  The method encodeUTF8_UTF16() was moved
from the one to the other file in 8259842.

8259842 change also brought the benchmark edited by this change.
I include the whole benchmark in this change. I had to adapt the strings
to compile with 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279833](https://bugs.openjdk.java.net/browse/JDK-8279833): Loop optimization issue in String.encodeUTF8_UTF16


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/791/head:pull/791` \
`$ git checkout pull/791`

Update a local copy of the PR: \
`$ git checkout pull/791` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 791`

View PR using the GUI difftool: \
`$ git pr show -t 791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/791.diff">https://git.openjdk.java.net/jdk11u-dev/pull/791.diff</a>

</details>
