### PR TITLE
8256321: Some "inactive" color profiles use the wrong profile class

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -864,7 +864,7 @@ public class ICC_Profile implements Serializable {
                     ProfileDeferralInfo pInfo =
                         new ProfileDeferralInfo("CIEXYZ.pf",
                                                 ColorSpace.TYPE_XYZ, 3,
-                                                CLASS_DISPLAY);
+                                                CLASS_ABSTRACT);
                     XYZprofile = getDeferredInstance(pInfo);
                 }
                 thisProfile = XYZprofile;
@@ -880,7 +880,7 @@ public class ICC_Profile implements Serializable {
                         ProfileDeferralInfo pInfo =
                             new ProfileDeferralInfo("PYCC.pf",
                                                     ColorSpace.TYPE_3CLR, 3,
-                                                    CLASS_DISPLAY);
+                                                    CLASS_COLORSPACECONVERSION);
                         PYCCprofile = getDeferredInstance(pInfo);
                     } else {
                         throw new IllegalArgumentException(

--- a/test/jdk/java/awt/color/CheckDefaultProperties.java
+++ b/test/jdk/java/awt/color/CheckDefaultProperties.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_Profile;
+
+import static java.awt.color.ColorSpace.TYPE_3CLR;
+import static java.awt.color.ColorSpace.TYPE_GRAY;
+import static java.awt.color.ColorSpace.TYPE_RGB;
+import static java.awt.color.ColorSpace.TYPE_XYZ;
+import static java.awt.color.ICC_Profile.CLASS_ABSTRACT;
+import static java.awt.color.ICC_Profile.CLASS_COLORSPACECONVERSION;
+import static java.awt.color.ICC_Profile.CLASS_DISPLAY;
+
+/**
+ * @test
+ * @bug 8256321
+ * @summary Verifies profile properties are the same before/after activation
+ */
+public final class CheckDefaultProperties {
+
+    public static void main(String[] args) {
+        ICC_Profile srgb = ICC_Profile.getInstance(ColorSpace.CS_sRGB);
+        ICC_Profile gray = ICC_Profile.getInstance(ColorSpace.CS_GRAY);
+        ICC_Profile xyz = ICC_Profile.getInstance(ColorSpace.CS_CIEXYZ);
+        ICC_Profile lrgb = ICC_Profile.getInstance(ColorSpace.CS_LINEAR_RGB);
+        ICC_Profile pycc = ICC_Profile.getInstance(ColorSpace.CS_PYCC);
+
+        // check default values, before profile activation
+        test(srgb, TYPE_RGB, 3, CLASS_DISPLAY);
+        test(gray, TYPE_GRAY, 1, CLASS_DISPLAY);
+        test(xyz, TYPE_XYZ, 3, CLASS_ABSTRACT);
+        test(lrgb, TYPE_RGB, 3, CLASS_DISPLAY);
+        test(pycc, TYPE_3CLR, 3, CLASS_COLORSPACECONVERSION);
+
+        // activate profiles
+        srgb.getData();
+        gray.getData();
+        xyz.getData();
+        lrgb.getData();
+        pycc.getData();
+
+        // check default values, after profile activation
+        test(srgb, TYPE_RGB, 3, CLASS_DISPLAY);
+        test(gray, TYPE_GRAY, 1, CLASS_DISPLAY);
+        test(xyz, TYPE_XYZ, 3, CLASS_ABSTRACT);
+        test(lrgb, TYPE_RGB, 3, CLASS_DISPLAY);
+        test(pycc, TYPE_3CLR, 3, CLASS_COLORSPACECONVERSION);
+    }
+
+    private static void test(ICC_Profile profile, int type, int num, int pcls) {
+        int profileClass = profile.getProfileClass();
+        int colorSpaceType = profile.getColorSpaceType();
+        int numComponents = profile.getNumComponents();
+        if (profileClass != pcls) {
+            throw new RuntimeException("Wrong profile class: " + profileClass);
+        }
+        if (colorSpaceType != type) {
+            throw new RuntimeException("Wrong profile type: " + colorSpaceType);
+        }
+        if (numComponents != num) {
+            throw new RuntimeException("Wrong profile comps: " + numComponents);
+        }
+    }
+}


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [a6c08813](https://github.com/openjdk/jdk/commit/a6c08813) from the [openjdk/jdk](https://github.com/openjdk/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 5 Jan 2021 and was reviewed by Phil Race.
See more details [here](https://github.com/openjdk/jdk/pull/1211).

This change is one of the steps to update the CMM deferral machinery, see (https://bugs.openjdk.java.net/browse/JDK-6986863)

The added test is red before the fix and green after. The jdk_desktop tests are green.
/clean The patch is not clean due to context conflict.


Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8256321](https://bugs.openjdk.java.net/browse/JDK-8256321): Some "inactive" color profiles use the wrong profile class


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/793/head:pull/793` \
`$ git checkout pull/793`

Update a local copy of the PR: \
`$ git checkout pull/793` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 793`

View PR using the GUI difftool: \
`$ git pr show -t 793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/793.diff">https://git.openjdk.java.net/jdk11u-dev/pull/793.diff</a>

</details>
