### PR TITLE
8261205: AssertionError: Cannot add metadata to an intersection type

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotations.java
@@ -1209,7 +1209,9 @@ public class TypeAnnotations {
                                 .methodParameter(tree, i, param.vartype.pos);
                         push(param);
                         try {
-                            separateAnnotationsKinds(param.vartype, param.sym.type, param.sym, pos);
+                            if (!param.declaredUsingVar()) {
+                                separateAnnotationsKinds(param.vartype, param.sym.type, param.sym, pos);
+                            }
                         } finally {
                             pop();
                         }
@@ -1247,7 +1249,7 @@ public class TypeAnnotations {
                 final TypeAnnotationPosition pos =
                     TypeAnnotationPosition.localVariable(currentLambda,
                                                          tree.pos);
-                if (!tree.isImplicitlyTyped()) {
+                if (!tree.declaredUsingVar()) {
                     separateAnnotationsKinds(tree.vartype, tree.sym.type, tree.sym, pos);
                 }
             } else if (tree.sym.getKind() == ElementKind.EXCEPTION_PARAMETER) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3054,6 +3054,7 @@ public class JavacParser implements Parser {
      */
     JCVariableDecl variableDeclaratorRest(int pos, JCModifiers mods, JCExpression type, Name name,
                                   boolean reqInit, Comment dc, boolean localDecl, boolean compound) {
+        boolean declaredUsingVar = false;
         type = bracketsOpt(type);
         JCExpression init = null;
         if (token.kind == EQ) {
@@ -3073,6 +3074,7 @@ public class JavacParser implements Parser {
                     //error - 'var' and arrays
                     reportSyntaxError(pos, Errors.VarNotAllowedArray);
                 } else {
+                    declaredUsingVar = true;
                     startPos = TreeInfo.getStartPos(mods);
                     if (startPos == Position.NOPOS)
                         startPos = TreeInfo.getStartPos(type);
@@ -3082,7 +3084,7 @@ public class JavacParser implements Parser {
             }
         }
         JCVariableDecl result =
-            toP(F.at(pos).VarDef(mods, name, type, init));
+            toP(F.at(pos).VarDef(mods, name, type, init, declaredUsingVar));
         attach(result, dc);
         result.startPos = startPos;
         return result;
@@ -3162,7 +3164,8 @@ public class JavacParser implements Parser {
             log.error(token.pos, Errors.VarargsAndOldArraySyntax);
         }
         type = bracketsOpt(type);
-        return toP(F.at(pos).VarDef(mods, name, type, null));
+        return toP(F.at(pos).VarDef(mods, name, type, null,
+                type != null && type.hasTag(IDENT) && ((JCIdent)type).name == names.var));
     }
 
     /** Resources = Resource { ";" Resources }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/JCTree.java
@@ -922,23 +922,35 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
         public VarSymbol sym;
         /** explicit start pos */
         public int startPos = Position.NOPOS;
+        /** declared using `var` */
+        private boolean declaredUsingVar;
 
         protected JCVariableDecl(JCModifiers mods,
                          Name name,
                          JCExpression vartype,
                          JCExpression init,
                          VarSymbol sym) {
+            this(mods, name, vartype, init, sym, false);
+        }
+
+        protected JCVariableDecl(JCModifiers mods,
+                                 Name name,
+                                 JCExpression vartype,
+                                 JCExpression init,
+                                 VarSymbol sym,
+                                 boolean declaredUsingVar) {
             this.mods = mods;
             this.name = name;
             this.vartype = vartype;
             this.init = init;
             this.sym = sym;
+            this.declaredUsingVar = declaredUsingVar;
         }
 
         protected JCVariableDecl(JCModifiers mods,
                          JCExpression nameexpr,
                          JCExpression vartype) {
-            this(mods, null, vartype, null, null);
+            this(mods, null, vartype, null, null, false);
             this.nameexpr = nameexpr;
             if (nameexpr.hasTag(Tag.IDENT)) {
                 this.name = ((JCIdent)nameexpr).name;
@@ -950,6 +962,10 @@ public abstract class JCTree implements Tree, Cloneable, DiagnosticPosition {
 
         public boolean isImplicitlyTyped() {
             return vartype == null;
+        }
+
+        public boolean declaredUsingVar() {
+            return declaredUsingVar;
         }
 
         @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -215,6 +215,12 @@ public class TreeMaker implements JCTree.Factory {
         return tree;
     }
 
+    public JCVariableDecl VarDef(JCModifiers mods, Name name, JCExpression vartype, JCExpression init, boolean declaredUsingVar) {
+        JCVariableDecl tree = new JCVariableDecl(mods, name, vartype, init, null, declaredUsingVar);
+        tree.pos = pos;
+        return tree;
+    }
+
     public JCVariableDecl ReceiverVarDef(JCModifiers mods, JCExpression name, JCExpression vartype) {
         JCVariableDecl tree = new JCVariableDecl(mods, name, vartype);
         tree.pos = pos;

--- a/test/langtools/tools/javac/annotations/typeAnnotations/VariablesDeclaredWithVarTest.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/VariablesDeclaredWithVarTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8261205
+ * @summary check that potentially applicable type annotations are skip if the variable or parameter was declared with var
+ * @library /tools/lib
+ * @modules
+ *      jdk.jdeps/com.sun.tools.classfile
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.main
+ *      jdk.compiler/com.sun.tools.javac.code
+ *      jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main VariablesDeclaredWithVarTest
+ */
+
+import java.util.List;
+import java.util.ArrayList;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import java.lang.annotation.*;
+import java.util.Arrays;
+
+import com.sun.tools.classfile.*;
+import com.sun.tools.javac.util.Assert;
+
+import toolbox.JavacTask;
+import toolbox.ToolBox;
+
+public class VariablesDeclaredWithVarTest {
+    ToolBox tb = new ToolBox();
+
+    final String src =
+            "import java.util.function.*;\n" +
+            "import java.lang.annotation.ElementType;\n" +
+            "import java.lang.annotation.Target;\n" +
+            "\n" +
+            "@Target({ElementType.TYPE_USE, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})\n" +
+            "@interface A {}\n" +
+            "\n" +
+            "class Test {\n" +
+            "    void kaa() {\n" +
+            "        @A var c = g(1, 1L);\n" +
+            "    }\n" +
+            "\n" +
+            "    <X> X g(X a, X b) {\n" +
+            "        return a;\n" +
+            "    }\n" +
+            "\n" +
+            "    void foo() {\n" +
+            "        bar((@A var s) -> s);\n" +
+            "    }\n" +
+            "\n" +
+            "    void bar(Function<String, String> f) {}\n" +
+            "}\n";
+
+    public static void main(String... args) throws Exception {
+        new VariablesDeclaredWithVarTest().run();
+    }
+
+    void run() throws Exception {
+        compileTestClass();
+        checkClassFile(new File(Paths.get(System.getProperty("user.dir"),
+                "Test.class").toUri()), 0);
+    }
+
+    void compileTestClass() throws Exception {
+        new JavacTask(tb)
+                .sources(src)
+                .run();
+    }
+
+    void checkClassFile(final File cfile, int... taPositions) throws Exception {
+        ClassFile classFile = ClassFile.read(cfile);
+        List<TypeAnnotation> annos = new ArrayList<>();
+        for (Method method : classFile.methods) {
+            findAnnotations(classFile, method, annos);
+            String methodName = method.getName(classFile.constant_pool);
+            Assert.check(annos.size() == 0, "there shouldn't be any type annotations in any method, found " + annos.size() +
+                    " type annotations at method " + methodName);
+        }
+    }
+
+    void findAnnotations(ClassFile cf, Method m, List<TypeAnnotation> annos) {
+        findAnnotations(cf, m, Attribute.RuntimeVisibleTypeAnnotations, annos);
+        findAnnotations(cf, m, Attribute.RuntimeInvisibleTypeAnnotations, annos);
+    }
+
+    void findAnnotations(ClassFile cf, Method m, String name, List<TypeAnnotation> annos) {
+        int index = m.attributes.getIndex(cf.constant_pool, name);
+        if (index != -1) {
+            Attribute attr = m.attributes.get(index);
+            assert attr instanceof RuntimeTypeAnnotations_attribute;
+            RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
+            annos.addAll(Arrays.asList(tAttr.annotations));
+        }
+
+        int cindex = m.attributes.getIndex(cf.constant_pool, Attribute.Code);
+        if (cindex != -1) {
+            Attribute cattr = m.attributes.get(cindex);
+            assert cattr instanceof Code_attribute;
+            Code_attribute cAttr = (Code_attribute)cattr;
+            index = cAttr.attributes.getIndex(cf.constant_pool, name);
+            if (index != -1) {
+                Attribute attr = cAttr.attributes.get(index);
+                assert attr instanceof RuntimeTypeAnnotations_attribute;
+                RuntimeTypeAnnotations_attribute tAttr = (RuntimeTypeAnnotations_attribute)attr;
+                annos.addAll(Arrays.asList(tAttr.annotations));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a backport of [JDK-8888888: AssertionError: Cannot add metadata to an intersection type](https://bugs.openjdk.java.net/browse/JDK-8261205)

Original patch does not apply cleanly to 11u

* I resolved a conflict where the loop in `JavacParser` that sets `declaredUsingVar = true;` was modified by JDK-8210742
* I adjusted the changes to imports, the original patch removed an import of `com.sun.tools.javac.code.Attribute.Array` from `TypeAnnotations.java` that was still being used in 11
* I removed the use of multi-line string literals in the test
 
Testing: x86_64 build, affected tests, tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261205](https://bugs.openjdk.java.net/browse/JDK-8261205): AssertionError: Cannot add metadata to an intersection type


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/794/head:pull/794` \
`$ git checkout pull/794`

Update a local copy of the PR: \
`$ git checkout pull/794` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 794`

View PR using the GUI difftool: \
`$ git pr show -t 794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/794.diff">https://git.openjdk.java.net/jdk11u-dev/pull/794.diff</a>

</details>
