### PR TITLE
8278758: runtime/BootstrapMethod/BSMCalledTwice.java fails with release VMs after JDK-8262134

### DIFF
--- a/test/hotspot/jtreg/runtime/BootstrapMethod/BSMCalledTwice.java
+++ b/test/hotspot/jtreg/runtime/BootstrapMethod/BSMCalledTwice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,19 @@
 /*
  * @test
  * @bug 8174954
- * @bug 8262134
  * @library /test/lib
  * @modules java.base/jdk.internal.org.objectweb.asm
  * @compile -XDignore.symbol.file BSMCalledTwice.java
  * @run main BSMCalledTwice
+ */
+
+/*
+ * @test
+ * @bug 8262134
+ * @library /test/lib
+ * @requires vm.debug
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ * @compile -XDignore.symbol.file BSMCalledTwice.java
  * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,TestC::* -XX:+DeoptimizeALot -XX:+VerifyStack BSMCalledTwice
  */
 


### PR DESCRIPTION
Clean backport to fix the test in release VMs.

Additional testing:
 - [x] Affected test now passes in Linux x86_64 release
 - [x] Affected test still passes in Linux x86_64 fastdebug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278758](https://bugs.openjdk.java.net/browse/JDK-8278758): runtime/BootstrapMethod/BSMCalledTwice.java fails with release VMs after JDK-8262134


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/795/head:pull/795` \
`$ git checkout pull/795`

Update a local copy of the PR: \
`$ git checkout pull/795` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 795`

View PR using the GUI difftool: \
`$ git pr show -t 795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/795.diff">https://git.openjdk.java.net/jdk11u-dev/pull/795.diff</a>

</details>
