### PR TITLE
8177814: jdk/editpad is not in jdk TEST.groups

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -376,6 +376,9 @@ jdk_imageio = \
 jfc_demo = \
      demo/jfc
 
+jdk_editpad = \
+     jdk/editpad
+
 jdk_desktop = \
     :jdk_awt \
     :jdk_2d \
@@ -383,7 +386,8 @@ jdk_desktop = \
     :jdk_swing \
     :jdk_sound \
     :jdk_imageio \
-    :jfc_demo
+    :jfc_demo \
+    :jdk_editpad
 
 # SwingSet3 tests.
 jdk_client_sanity = \


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

I had to resolve because of different context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8177814](https://bugs.openjdk.java.net/browse/JDK-8177814): jdk/editpad is not in jdk TEST.groups


### Reviewers
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/801/head:pull/801` \
`$ git checkout pull/801`

Update a local copy of the PR: \
`$ git checkout pull/801` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 801`

View PR using the GUI difftool: \
`$ git pr show -t 801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/801.diff">https://git.openjdk.java.net/jdk11u-dev/pull/801.diff</a>

</details>
