### PR TITLE
8279702: [macosx] ignore xcodebuild warnings on M1

### DIFF
--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -229,7 +229,7 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
   if test "x$OPENJDK_TARGET_OS" = xmacosx; then
     if test -n "$XCODEBUILD"; then
       # On Mac OS X, default toolchain to clang after Xcode 5
-      XCODE_VERSION_OUTPUT=`"$XCODEBUILD" -version 2>&1 | $HEAD -n 1`
+      XCODE_VERSION_OUTPUT=`"$XCODEBUILD" -version | $HEAD -n 1`
       $ECHO "$XCODE_VERSION_OUTPUT" | $GREP "Xcode " > /dev/null
       if test $? -ne 0; then
         AC_MSG_ERROR([Failed to determine Xcode version.])


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4b520f00](https://github.com/openjdk/jdk/commit/4b520f0001be5f33996d5ab7d9ad75773a847e54) from the [openjdk/jdk](https://github.com/openjdk/jdk) repository.

The commit being backported was authored by Johannes Bechberger on 14 Jan 2022 and was reviewed by Goetz Lindenmaier and Erik Joelsson.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279702](https://bugs.openjdk.java.net/browse/JDK-8279702): [macosx] ignore xcodebuild warnings on M1


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/802/head:pull/802` \
`$ git checkout pull/802`

Update a local copy of the PR: \
`$ git checkout pull/802` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/802/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 802`

View PR using the GUI difftool: \
`$ git pr show -t 802`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/802.diff">https://git.openjdk.java.net/jdk11u-dev/pull/802.diff</a>

</details>
