### PR TITLE
8250902: Implement MD5 Intrinsics on x86

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -251,6 +251,11 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseFMA, true);
   }
 
+  if (UseMD5Intrinsics) {
+    warning("MD5 intrinsics are not available on this CPU");
+    FLAG_SET_DEFAULT(UseMD5Intrinsics, false);
+  }
+
   if (_features & (CPU_SHA1 | CPU_SHA2)) {
     if (FLAG_IS_DEFAULT(UseSHA)) {
       FLAG_SET_DEFAULT(UseSHA, true);

--- a/src/hotspot/cpu/arm/vm_version_arm_32.cpp
+++ b/src/hotspot/cpu/arm/vm_version_arm_32.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,6 +207,11 @@ void VM_Version::initialize() {
   if (UseFMA) {
     warning("FMA instructions are not available on this CPU");
     FLAG_SET_DEFAULT(UseFMA, false);
+  }
+
+  if (UseMD5Intrinsics) {
+    warning("MD5 intrinsics are not available on this CPU");
+    FLAG_SET_DEFAULT(UseMD5Intrinsics, false);
   }
 
   if (UseSHA) {

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -294,6 +294,11 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseFMA, true);
   }
 
+  if (UseMD5Intrinsics) {
+    warning("MD5 intrinsics are not available on this CPU");
+    FLAG_SET_DEFAULT(UseMD5Intrinsics, false);
+  }
+
   if (has_vshasig()) {
     if (FLAG_IS_DEFAULT(UseSHA)) {
       UseSHA = true;

--- a/src/hotspot/cpu/s390/vm_version_s390.cpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.cpp
@@ -214,6 +214,11 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseFMA, true);
   }
 
+  if (UseMD5Intrinsics) {
+    warning("MD5 intrinsics are not available on this CPU");
+    FLAG_SET_DEFAULT(UseMD5Intrinsics, false);
+  }
+
   // On z/Architecture, we take UseSHA as the general switch to enable/disable the SHA intrinsics.
   // The specific switches UseSHAxxxIntrinsics will then be set depending on the actual
   // machine capabilities.

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4513,6 +4513,19 @@ void Assembler::ret(int imm16) {
   } else {
     emit_int8((unsigned char)0xC2);
     emit_int16(imm16);
+  }
+}
+
+void Assembler::roll(Register dst, int imm8) {
+  assert(isShiftCount(imm8 >> 1), "illegal shift count");
+  int encode = prefix_and_encode(dst->encoding());
+  if (imm8 == 1) {
+    emit_int8((unsigned char)0xD1);
+    emit_int8((unsigned char)(0xC0 | encode));
+  } else {
+    emit_int8((unsigned char)0xC1);
+    emit_int8((unsigned char)(0xc0 | encode));
+    emit_int8(imm8);
   }
 }
 

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1766,6 +1766,8 @@ private:
 
   void ret(int imm16);
 
+  void roll(Register dst, int imm8);
+
 #ifdef _LP64
   void rorq(Register dst, int imm8);
   void rorxq(Register dst, Register src, int imm8);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -986,6 +986,9 @@ public:
 
 #endif
 
+  void fast_md5(Register buf, Address state, Address ofs, Address limit,
+                bool multi_block);
+
   void fast_sha1(XMMRegister abcd, XMMRegister e0, XMMRegister e1, XMMRegister msg0,
                  XMMRegister msg1, XMMRegister msg2, XMMRegister msg3, XMMRegister shuf_mask,
                  Register buf, Register state, Register ofs, Register limit, Register rsp,

--- a/src/hotspot/cpu/x86/macroAssembler_x86_md5.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_md5.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2020 Microsoft Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * Copyright (c) 2017 Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/fast-md5-hash-implementation-in-x86-assembly
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+#include "precompiled.hpp"
+#include "asm/assembler.hpp"
+#include "asm/assembler.inline.hpp"
+#include "runtime/stubRoutines.hpp"
+#include "macroAssembler_x86.hpp"
+
+// int com.sun.security.provider.MD5.implCompress0(byte[] b, int ofs)
+void MacroAssembler::fast_md5(Register buf, Address state, Address ofs, Address limit, bool multi_block) {
+
+  Label start, done_hash, loop0;
+
+  bind(start);
+
+  bind(loop0);
+
+  // Save hash values for addition after rounds
+  movptr(rdi, state);
+  movl(rax, Address(rdi,  0));
+  movl(rbx, Address(rdi,  4));
+  movl(rcx, Address(rdi,  8));
+  movl(rdx, Address(rdi, 12));
+
+#define FF(r1, r2, r3, r4, k, s, t)              \
+  movl(rsi, r3);                                 \
+  addl(r1, Address(buf, k*4));                   \
+  xorl(rsi, r4);                                 \
+  andl(rsi, r2);                                 \
+  xorl(rsi, r4);                                 \
+  leal(r1, Address(r1, rsi, Address::times_1, t)); \
+  roll(r1, s);                                   \
+  addl(r1, r2);
+
+#define GG(r1, r2, r3, r4, k, s, t)              \
+  movl(rsi, r4);                                 \
+  movl(rdi, r4);                                 \
+  addl(r1, Address(buf, k*4));                   \
+  notl(rsi);                                     \
+  andl(rdi, r2);                                 \
+  andl(rsi, r3);                                 \
+  orl(rsi, rdi);                                 \
+  leal(r1, Address(r1, rsi, Address::times_1, t)); \
+  roll(r1, s);                                   \
+  addl(r1, r2);
+
+#define HH(r1, r2, r3, r4, k, s, t)              \
+  movl(rsi, r3);                                 \
+  addl(r1, Address(buf, k*4));                   \
+  xorl(rsi, r4);                                 \
+  xorl(rsi, r2);                                 \
+  leal(r1, Address(r1, rsi, Address::times_1, t)); \
+  roll(r1, s);                                   \
+  addl(r1, r2);
+
+#define II(r1, r2, r3, r4, k, s, t)              \
+  movl(rsi, r4);                                 \
+  notl(rsi);                                     \
+  addl(r1, Address(buf, k*4));                   \
+  orl(rsi, r2);                                  \
+  xorl(rsi, r3);                                 \
+  leal(r1, Address(r1, rsi, Address::times_1, t)); \
+  roll(r1, s);                                   \
+  addl(r1, r2);
+
+  // Round 1
+  FF(rax, rbx, rcx, rdx,  0,  7, 0xd76aa478)
+  FF(rdx, rax, rbx, rcx,  1, 12, 0xe8c7b756)
+  FF(rcx, rdx, rax, rbx,  2, 17, 0x242070db)
+  FF(rbx, rcx, rdx, rax,  3, 22, 0xc1bdceee)
+  FF(rax, rbx, rcx, rdx,  4,  7, 0xf57c0faf)
+  FF(rdx, rax, rbx, rcx,  5, 12, 0x4787c62a)
+  FF(rcx, rdx, rax, rbx,  6, 17, 0xa8304613)
+  FF(rbx, rcx, rdx, rax,  7, 22, 0xfd469501)
+  FF(rax, rbx, rcx, rdx,  8,  7, 0x698098d8)
+  FF(rdx, rax, rbx, rcx,  9, 12, 0x8b44f7af)
+  FF(rcx, rdx, rax, rbx, 10, 17, 0xffff5bb1)
+  FF(rbx, rcx, rdx, rax, 11, 22, 0x895cd7be)
+  FF(rax, rbx, rcx, rdx, 12,  7, 0x6b901122)
+  FF(rdx, rax, rbx, rcx, 13, 12, 0xfd987193)
+  FF(rcx, rdx, rax, rbx, 14, 17, 0xa679438e)
+  FF(rbx, rcx, rdx, rax, 15, 22, 0x49b40821)
+
+  // Round 2
+  GG(rax, rbx, rcx, rdx,  1,  5, 0xf61e2562)
+  GG(rdx, rax, rbx, rcx,  6,  9, 0xc040b340)
+  GG(rcx, rdx, rax, rbx, 11, 14, 0x265e5a51)
+  GG(rbx, rcx, rdx, rax,  0, 20, 0xe9b6c7aa)
+  GG(rax, rbx, rcx, rdx,  5,  5, 0xd62f105d)
+  GG(rdx, rax, rbx, rcx, 10,  9, 0x02441453)
+  GG(rcx, rdx, rax, rbx, 15, 14, 0xd8a1e681)
+  GG(rbx, rcx, rdx, rax,  4, 20, 0xe7d3fbc8)
+  GG(rax, rbx, rcx, rdx,  9,  5, 0x21e1cde6)
+  GG(rdx, rax, rbx, rcx, 14,  9, 0xc33707d6)
+  GG(rcx, rdx, rax, rbx,  3, 14, 0xf4d50d87)
+  GG(rbx, rcx, rdx, rax,  8, 20, 0x455a14ed)
+  GG(rax, rbx, rcx, rdx, 13,  5, 0xa9e3e905)
+  GG(rdx, rax, rbx, rcx,  2,  9, 0xfcefa3f8)
+  GG(rcx, rdx, rax, rbx,  7, 14, 0x676f02d9)
+  GG(rbx, rcx, rdx, rax, 12, 20, 0x8d2a4c8a)
+
+  // Round 3
+  HH(rax, rbx, rcx, rdx,  5,  4, 0xfffa3942)
+  HH(rdx, rax, rbx, rcx,  8, 11, 0x8771f681)
+  HH(rcx, rdx, rax, rbx, 11, 16, 0x6d9d6122)
+  HH(rbx, rcx, rdx, rax, 14, 23, 0xfde5380c)
+  HH(rax, rbx, rcx, rdx,  1,  4, 0xa4beea44)
+  HH(rdx, rax, rbx, rcx,  4, 11, 0x4bdecfa9)
+  HH(rcx, rdx, rax, rbx,  7, 16, 0xf6bb4b60)
+  HH(rbx, rcx, rdx, rax, 10, 23, 0xbebfbc70)
+  HH(rax, rbx, rcx, rdx, 13,  4, 0x289b7ec6)
+  HH(rdx, rax, rbx, rcx,  0, 11, 0xeaa127fa)
+  HH(rcx, rdx, rax, rbx,  3, 16, 0xd4ef3085)
+  HH(rbx, rcx, rdx, rax,  6, 23, 0x04881d05)
+  HH(rax, rbx, rcx, rdx,  9,  4, 0xd9d4d039)
+  HH(rdx, rax, rbx, rcx, 12, 11, 0xe6db99e5)
+  HH(rcx, rdx, rax, rbx, 15, 16, 0x1fa27cf8)
+  HH(rbx, rcx, rdx, rax,  2, 23, 0xc4ac5665)
+
+  // Round 4
+  II(rax, rbx, rcx, rdx,  0,  6, 0xf4292244)
+  II(rdx, rax, rbx, rcx,  7, 10, 0x432aff97)
+  II(rcx, rdx, rax, rbx, 14, 15, 0xab9423a7)
+  II(rbx, rcx, rdx, rax,  5, 21, 0xfc93a039)
+  II(rax, rbx, rcx, rdx, 12,  6, 0x655b59c3)
+  II(rdx, rax, rbx, rcx,  3, 10, 0x8f0ccc92)
+  II(rcx, rdx, rax, rbx, 10, 15, 0xffeff47d)
+  II(rbx, rcx, rdx, rax,  1, 21, 0x85845dd1)
+  II(rax, rbx, rcx, rdx,  8,  6, 0x6fa87e4f)
+  II(rdx, rax, rbx, rcx, 15, 10, 0xfe2ce6e0)
+  II(rcx, rdx, rax, rbx,  6, 15, 0xa3014314)
+  II(rbx, rcx, rdx, rax, 13, 21, 0x4e0811a1)
+  II(rax, rbx, rcx, rdx,  4,  6, 0xf7537e82)
+  II(rdx, rax, rbx, rcx, 11, 10, 0xbd3af235)
+  II(rcx, rdx, rax, rbx,  2, 15, 0x2ad7d2bb)
+  II(rbx, rcx, rdx, rax,  9, 21, 0xeb86d391)
+
+#undef FF
+#undef GG
+#undef HH
+#undef II
+
+  // write hash values back in the correct order
+  movptr(rdi, state);
+  addl(Address(rdi,  0), rax);
+  addl(Address(rdi,  4), rbx);
+  addl(Address(rdi,  8), rcx);
+  addl(Address(rdi, 12), rdx);
+
+  if (multi_block) {
+    // increment data pointer and loop if more to process
+    addptr(buf, 64);
+    addl(ofs, 64);
+    movl(rsi, ofs);
+    cmpl(rsi, limit);
+    jcc(Assembler::belowEqual, loop0);
+    movptr(rax, rsi); //return ofs
+  }
+
+  bind(done_hash);
+}

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -2969,6 +2969,46 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
+  // ofs and limit are use for multi-block byte array.
+  // int com.sun.security.provider.MD5.implCompress(byte[] b, int ofs)
+  address generate_md5_implCompress(bool multi_block, const char *name) {
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
+    address start = __ pc();
+
+    const Register buf_param = rbp;
+    const Address state_param(rsp, 0 * wordSize);
+    const Address ofs_param  (rsp, 1 * wordSize);
+    const Address limit_param(rsp, 2 * wordSize);
+
+    __ enter();
+    __ push(rbx);
+    __ push(rdi);
+    __ push(rsi);
+    __ push(rbp);
+    __ subptr(rsp, 3 * wordSize);
+
+    __ movptr(rsi, Address(rbp, 8 + 4));
+    __ movptr(state_param, rsi);
+    if (multi_block) {
+      __ movptr(rsi, Address(rbp, 8 + 8));
+      __ movptr(ofs_param, rsi);
+      __ movptr(rsi, Address(rbp, 8 + 12));
+      __ movptr(limit_param, rsi);
+    }
+    __ movptr(buf_param, Address(rbp, 8 + 0)); // do it last because it override rbp
+    __ fast_md5(buf_param, state_param, ofs_param, limit_param, multi_block);
+
+    __ addptr(rsp, 3 * wordSize);
+    __ pop(rbp);
+    __ pop(rsi);
+    __ pop(rdi);
+    __ pop(rbx);
+    __ leave();
+    __ ret(0);
+    return start;
+  }
+
   address generate_upper_word_mask() {
     __ align(64);
     StubCodeMark mark(this, "StubRoutines", "upper_word_mask");
@@ -3906,6 +3946,10 @@ class StubGenerator: public StubCodeGenerator {
       StubRoutines::_counterMode_AESCrypt = generate_counterMode_AESCrypt_Parallel();
     }
 
+    if (UseMD5Intrinsics) {
+      StubRoutines::_md5_implCompress = generate_md5_implCompress(false, "md5_implCompress");
+      StubRoutines::_md5_implCompressMB = generate_md5_implCompress(true, "md5_implCompressMB");
+    }
     if (UseSHA1Intrinsics) {
       StubRoutines::x86::_upper_word_mask_addr = generate_upper_word_mask();
       StubRoutines::x86::_shuffle_byte_flip_mask_addr = generate_shuffle_byte_flip_mask();

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -3670,6 +3670,43 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
+  // ofs and limit are use for multi-block byte array.
+  // int com.sun.security.provider.MD5.implCompress(byte[] b, int ofs)
+  address generate_md5_implCompress(bool multi_block, const char *name) {
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", name);
+    address start = __ pc();
+
+    const Register buf_param = r15;
+    const Address state_param(rsp, 0 * wordSize);
+    const Address ofs_param  (rsp, 1 * wordSize    );
+    const Address limit_param(rsp, 1 * wordSize + 4);
+
+    __ enter();
+    __ push(rbx);
+    __ push(rdi);
+    __ push(rsi);
+    __ push(r15);
+    __ subptr(rsp, 2 * wordSize);
+
+    __ movptr(buf_param, c_rarg0);
+    __ movptr(state_param, c_rarg1);
+    if (multi_block) {
+      __ movl(ofs_param, c_rarg2);
+      __ movl(limit_param, c_rarg3);
+    }
+    __ fast_md5(buf_param, state_param, ofs_param, limit_param, multi_block);
+
+    __ addptr(rsp, 2 * wordSize);
+    __ pop(r15);
+    __ pop(rsi);
+    __ pop(rdi);
+    __ pop(rbx);
+    __ leave();
+    __ ret(0);
+    return start;
+  }
+
   address generate_upper_word_mask() {
     __ align(64);
     StubCodeMark mark(this, "StubRoutines", "upper_word_mask");
@@ -6029,6 +6066,10 @@ address generate_avx_ghash_processBlocks() {
       }
     }
 
+    if (UseMD5Intrinsics) {
+      StubRoutines::_md5_implCompress = generate_md5_implCompress(false, "md5_implCompress");
+      StubRoutines::_md5_implCompressMB = generate_md5_implCompress(true, "md5_implCompressMB");
+    }
     if (UseSHA1Intrinsics) {
       StubRoutines::x86::_upper_word_mask_addr = generate_upper_word_mask();
       StubRoutines::x86::_shuffle_byte_flip_mask_addr = generate_shuffle_byte_flip_mask();

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -935,6 +935,10 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseFMA, false);
   }
 
+  if (FLAG_IS_DEFAULT(UseMD5Intrinsics)) {
+    UseMD5Intrinsics = true;
+  }
+
   if (supports_sha() LP64_ONLY(|| supports_avx2() && supports_bmi2())) {
     if (FLAG_IS_DEFAULT(UseSHA)) {
       UseSHA = true;

--- a/src/hotspot/share/classfile/vmSymbols.cpp
+++ b/src/hotspot/share/classfile/vmSymbols.cpp
@@ -467,7 +467,7 @@ int vmIntrinsics::predicates_needed(vmIntrinsics::ID id) {
   case vmIntrinsics::_counterMode_AESCrypt:
     return 1;
   case vmIntrinsics::_digestBase_implCompressMB:
-    return 3;
+    return 4;
   default:
     return 0;
   }
@@ -747,6 +747,9 @@ bool vmIntrinsics::is_disabled_by_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_counterMode_AESCrypt:
     if (!UseAESCTRIntrinsics) return true;
     break;
+  case vmIntrinsics::_md5_implCompress:
+    if (!UseMD5Intrinsics) return true;
+    break;
   case vmIntrinsics::_sha_implCompress:
     if (!UseSHA1Intrinsics) return true;
     break;
@@ -757,7 +760,7 @@ bool vmIntrinsics::is_disabled_by_flags(vmIntrinsics::ID id) {
     if (!UseSHA512Intrinsics) return true;
     break;
   case vmIntrinsics::_digestBase_implCompressMB:
-    if (!(UseSHA1Intrinsics || UseSHA256Intrinsics || UseSHA512Intrinsics)) return true;
+    if (!(UseMD5Intrinsics || UseSHA1Intrinsics || UseSHA256Intrinsics || UseSHA512Intrinsics)) return true;
     break;
   case vmIntrinsics::_ghash_processBlocks:
     if (!UseGHASHIntrinsics) return true;

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -1036,11 +1036,15 @@
    do_intrinsic(_counterMode_AESCrypt, com_sun_crypto_provider_counterMode, crypt_name, byteArray_int_int_byteArray_int_signature, F_R)   \
    do_name(     crypt_name,                                 "implCrypt")                                                    \
                                                                                                                         \
+  /* support for sun.security.provider.MD5 */                                                                           \
+  do_class(sun_security_provider_md5,                              "sun/security/provider/MD5")                         \
+  do_intrinsic(_md5_implCompress, sun_security_provider_md5, implCompress_name, implCompress_signature, F_R)            \
+   do_name(     implCompress_name,                                 "implCompress0")                                     \
+   do_signature(implCompress_signature,                            "([BI)V")                                            \
+                                                                                                                        \
   /* support for sun.security.provider.SHA */                                                                           \
   do_class(sun_security_provider_sha,                              "sun/security/provider/SHA")                         \
   do_intrinsic(_sha_implCompress, sun_security_provider_sha, implCompress_name, implCompress_signature, F_R)            \
-   do_name(     implCompress_name,                                 "implCompress0")                                     \
-   do_signature(implCompress_signature,                            "([BI)V")                                            \
                                                                                                                         \
   /* support for sun.security.provider.SHA2 */                                                                          \
   do_class(sun_security_provider_sha2,                             "sun/security/provider/SHA2")                        \

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -636,6 +636,7 @@ bool C2Compiler::is_intrinsic_supported(const methodHandle& method, bool is_virt
   case vmIntrinsics::_electronicCodeBook_encryptAESCrypt:
   case vmIntrinsics::_electronicCodeBook_decryptAESCrypt:
   case vmIntrinsics::_counterMode_AESCrypt:
+  case vmIntrinsics::_md5_implCompress:
   case vmIntrinsics::_sha_implCompress:
   case vmIntrinsics::_sha2_implCompress:
   case vmIntrinsics::_sha5_implCompress:

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -1071,6 +1071,8 @@ void ConnectionGraph::process_call_arguments(CallNode *call) {
                   strcmp(call->as_CallLeaf()->_name, "counterMode_AESCrypt") == 0 ||
                   strcmp(call->as_CallLeaf()->_name, "ghash_processBlocks") == 0 ||
                   strcmp(call->as_CallLeaf()->_name, "encodeBlock") == 0 ||
+                  strcmp(call->as_CallLeaf()->_name, "md5_implCompress") == 0 ||
+                  strcmp(call->as_CallLeaf()->_name, "md5_implCompressMB") == 0 ||
                   strcmp(call->as_CallLeaf()->_name, "sha1_implCompress") == 0 ||
                   strcmp(call->as_CallLeaf()->_name, "sha1_implCompressMB") == 0 ||
                   strcmp(call->as_CallLeaf()->_name, "sha256_implCompress") == 0 ||

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -302,13 +302,13 @@ class LibraryCallKit : public GraphKit {
   Node* get_original_key_start_from_aescrypt_object(Node* aescrypt_object);
   bool inline_ghash_processBlocks();
   bool inline_base64_encodeBlock();
-  bool inline_sha_implCompress(vmIntrinsics::ID id);
+  bool inline_digestBase_implCompress(vmIntrinsics::ID id);
   bool inline_digestBase_implCompressMB(int predicate);
-  bool inline_sha_implCompressMB(Node* digestBaseObj, ciInstanceKlass* instklass_SHA,
-                                 bool long_state, address stubAddr, const char *stubName,
-                                 Node* src_start, Node* ofs, Node* limit);
-  Node* get_state_from_sha_object(Node *sha_object);
-  Node* get_state_from_sha5_object(Node *sha_object);
+  bool inline_digestBase_implCompressMB(Node* digestBaseObj, ciInstanceKlass* instklass,
+                                        bool long_state, address stubAddr, const char *stubName,
+                                        Node* src_start, Node* ofs, Node* limit);
+  Node* get_state_from_digest_object(Node *digestBase_object);
+  Node* get_long_state_from_digest_object(Node *digestBase_object);
   Node* inline_digestBase_implCompressMB_predicate(int predicate);
   bool inline_encodeISOArray();
   bool inline_updateCRC32();
@@ -826,10 +826,11 @@ bool LibraryCallKit::try_to_inline(int predicate) {
   case vmIntrinsics::_counterMode_AESCrypt:
     return inline_counterMode_AESCrypt(intrinsic_id());
 
+  case vmIntrinsics::_md5_implCompress:
   case vmIntrinsics::_sha_implCompress:
   case vmIntrinsics::_sha2_implCompress:
   case vmIntrinsics::_sha5_implCompress:
-    return inline_sha_implCompress(intrinsic_id());
+    return inline_digestBase_implCompress(intrinsic_id());
 
   case vmIntrinsics::_digestBase_implCompressMB:
     return inline_digestBase_implCompressMB(predicate);
@@ -6438,7 +6439,10 @@ bool LibraryCallKit::inline_base64_encodeBlock() {
   return true;
 }
 
-//------------------------------inline_sha_implCompress-----------------------
+//------------------------------inline_digestBase_implCompress-----------------------
+//
+// Calculate MD5 for single-block byte[] array.
+// void com.sun.security.provider.MD5.implCompress(byte[] buf, int ofs)
 //
 // Calculate SHA (i.e., SHA-1) for single-block byte[] array.
 // void com.sun.security.provider.SHA.implCompress(byte[] buf, int ofs)
@@ -6449,12 +6453,12 @@ bool LibraryCallKit::inline_base64_encodeBlock() {
 // Calculate SHA5 (i.e., SHA-384 or SHA-512) for single-block byte[] array.
 // void com.sun.security.provider.SHA5.implCompress(byte[] buf, int ofs)
 //
-bool LibraryCallKit::inline_sha_implCompress(vmIntrinsics::ID id) {
+bool LibraryCallKit::inline_digestBase_implCompress(vmIntrinsics::ID id) {
   assert(callee()->signature()->size() == 2, "sha_implCompress has 2 parameters");
 
-  Node* sha_obj = argument(0);
-  Node* src     = argument(1); // type oop
-  Node* ofs     = argument(2); // type int
+  Node* digestBase_obj = argument(0);
+  Node* src            = argument(1); // type oop
+  Node* ofs            = argument(2); // type int
 
   const Type* src_type = src->Value(&_gvn);
   const TypeAryPtr* top_src = src_type->isa_aryptr();
@@ -6475,21 +6479,27 @@ bool LibraryCallKit::inline_sha_implCompress(vmIntrinsics::ID id) {
   const char *stubName;
 
   switch(id) {
+  case vmIntrinsics::_md5_implCompress:
+    assert(UseMD5Intrinsics, "need MD5 instruction support");
+    state = get_state_from_digest_object(digestBase_obj);
+    stubAddr = StubRoutines::md5_implCompress();
+    stubName = "md5_implCompress";
+    break;
   case vmIntrinsics::_sha_implCompress:
     assert(UseSHA1Intrinsics, "need SHA1 instruction support");
-    state = get_state_from_sha_object(sha_obj);
+    state = get_state_from_digest_object(digestBase_obj);
     stubAddr = StubRoutines::sha1_implCompress();
     stubName = "sha1_implCompress";
     break;
   case vmIntrinsics::_sha2_implCompress:
     assert(UseSHA256Intrinsics, "need SHA256 instruction support");
-    state = get_state_from_sha_object(sha_obj);
+    state = get_state_from_digest_object(digestBase_obj);
     stubAddr = StubRoutines::sha256_implCompress();
     stubName = "sha256_implCompress";
     break;
   case vmIntrinsics::_sha5_implCompress:
     assert(UseSHA512Intrinsics, "need SHA512 instruction support");
-    state = get_state_from_sha5_object(sha_obj);
+    state = get_long_state_from_digest_object(digestBase_obj);
     stubAddr = StubRoutines::sha512_implCompress();
     stubName = "sha512_implCompress";
     break;
@@ -6503,7 +6513,7 @@ bool LibraryCallKit::inline_sha_implCompress(vmIntrinsics::ID id) {
   if (stubAddr == NULL) return false;
 
   // Call the stub.
-  Node* call = make_runtime_call(RC_LEAF|RC_NO_FP, OptoRuntime::sha_implCompress_Type(),
+  Node* call = make_runtime_call(RC_LEAF|RC_NO_FP, OptoRuntime::digestBase_implCompress_Type(),
                                  stubAddr, stubName, TypePtr::BOTTOM,
                                  src_start, state);
 
@@ -6512,13 +6522,13 @@ bool LibraryCallKit::inline_sha_implCompress(vmIntrinsics::ID id) {
 
 //------------------------------inline_digestBase_implCompressMB-----------------------
 //
-// Calculate SHA/SHA2/SHA5 for multi-block byte[] array.
+// Calculate MD5/SHA/SHA2/SHA5 for multi-block byte[] array.
 // int com.sun.security.provider.DigestBase.implCompressMultiBlock(byte[] b, int ofs, int limit)
 //
 bool LibraryCallKit::inline_digestBase_implCompressMB(int predicate) {
-  assert(UseSHA1Intrinsics || UseSHA256Intrinsics || UseSHA512Intrinsics,
-         "need SHA1/SHA256/SHA512 instruction support");
-  assert((uint)predicate < 3, "sanity");
+  assert(UseMD5Intrinsics || UseSHA1Intrinsics || UseSHA256Intrinsics || UseSHA512Intrinsics,
+         "need MD5/SHA1/SHA256/SHA512 instruction support");
+  assert((uint)predicate < 4, "sanity");
   assert(callee()->signature()->size() == 3, "digestBase_implCompressMB has 3 parameters");
 
   Node* digestBase_obj = argument(0); // The receiver was checked for NULL already.
@@ -6541,38 +6551,45 @@ bool LibraryCallKit::inline_digestBase_implCompressMB(int predicate) {
   src = must_be_not_null(src, false);
   Node* src_start = array_element_address(src, ofs, src_elem);
 
-  const char* klass_SHA_name = NULL;
+  const char* klass_digestBase_name = NULL;
   const char* stub_name = NULL;
   address     stub_addr = NULL;
   bool        long_state = false;
 
   switch (predicate) {
   case 0:
+    if (UseMD5Intrinsics) {
+      klass_digestBase_name = "sun/security/provider/MD5";
+      stub_name = "md5_implCompressMB";
+      stub_addr = StubRoutines::md5_implCompressMB();
+    }
+    break;
+  case 1:
     if (UseSHA1Intrinsics) {
-      klass_SHA_name = "sun/security/provider/SHA";
+      klass_digestBase_name = "sun/security/provider/SHA";
       stub_name = "sha1_implCompressMB";
       stub_addr = StubRoutines::sha1_implCompressMB();
     }
     break;
-  case 1:
+  case 2:
     if (UseSHA256Intrinsics) {
-      klass_SHA_name = "sun/security/provider/SHA2";
+      klass_digestBase_name = "sun/security/provider/SHA2";
       stub_name = "sha256_implCompressMB";
       stub_addr = StubRoutines::sha256_implCompressMB();
     }
     break;
-  case 2:
+  case 3:
     if (UseSHA512Intrinsics) {
-      klass_SHA_name = "sun/security/provider/SHA5";
+      klass_digestBase_name = "sun/security/provider/SHA5";
       stub_name = "sha512_implCompressMB";
       stub_addr = StubRoutines::sha512_implCompressMB();
       long_state = true;
     }
     break;
   default:
-    fatal("unknown SHA intrinsic predicate: %d", predicate);
+    fatal("unknown DigestBase intrinsic predicate: %d", predicate);
   }
-  if (klass_SHA_name != NULL) {
+  if (klass_digestBase_name != NULL) {
     assert(stub_addr != NULL, "Stub is generated");
     if (stub_addr == NULL) return false;
 
@@ -6581,27 +6598,28 @@ bool LibraryCallKit::inline_digestBase_implCompressMB(int predicate) {
     assert(tinst != NULL, "digestBase_obj is not instance???");
     assert(tinst->klass()->is_loaded(), "DigestBase is not loaded");
 
-    ciKlass* klass_SHA = tinst->klass()->as_instance_klass()->find_klass(ciSymbol::make(klass_SHA_name));
-    assert(klass_SHA->is_loaded(), "predicate checks that this class is loaded");
-    ciInstanceKlass* instklass_SHA = klass_SHA->as_instance_klass();
-    return inline_sha_implCompressMB(digestBase_obj, instklass_SHA, long_state, stub_addr, stub_name, src_start, ofs, limit);
+    ciKlass* klass_digestBase = tinst->klass()->as_instance_klass()->find_klass(ciSymbol::make(klass_digestBase_name));
+    assert(klass_digestBase->is_loaded(), "predicate checks that this class is loaded");
+    ciInstanceKlass* instklass_digestBase = klass_digestBase->as_instance_klass();
+    return inline_digestBase_implCompressMB(digestBase_obj, instklass_digestBase, long_state, stub_addr, stub_name, src_start, ofs, limit);
   }
   return false;
 }
-//------------------------------inline_sha_implCompressMB-----------------------
-bool LibraryCallKit::inline_sha_implCompressMB(Node* digestBase_obj, ciInstanceKlass* instklass_SHA,
-                                               bool long_state, address stubAddr, const char *stubName,
-                                               Node* src_start, Node* ofs, Node* limit) {
-  const TypeKlassPtr* aklass = TypeKlassPtr::make(instklass_SHA);
+
+//------------------------------inline_digestBase_implCompressMB-----------------------
+bool LibraryCallKit::inline_digestBase_implCompressMB(Node* digestBase_obj, ciInstanceKlass* instklass_digestBase,
+                                                      bool long_state, address stubAddr, const char *stubName,
+                                                      Node* src_start, Node* ofs, Node* limit) {
+  const TypeKlassPtr* aklass = TypeKlassPtr::make(instklass_digestBase);
   const TypeOopPtr* xtype = aklass->as_instance_type();
-  Node* sha_obj = new CheckCastPPNode(control(), digestBase_obj, xtype);
-  sha_obj = _gvn.transform(sha_obj);
+  Node* digest_obj = new CheckCastPPNode(control(), digestBase_obj, xtype);
+  digest_obj = _gvn.transform(digest_obj);
 
   Node* state;
   if (long_state) {
-    state = get_state_from_sha5_object(sha_obj);
+    state = get_long_state_from_digest_object(digest_obj);
   } else {
-    state = get_state_from_sha_object(sha_obj);
+    state = get_state_from_digest_object(digest_obj);
   }
   if (state == NULL) return false;
 
@@ -6617,37 +6635,37 @@ bool LibraryCallKit::inline_sha_implCompressMB(Node* digestBase_obj, ciInstanceK
   return true;
 }
 
-//------------------------------get_state_from_sha_object-----------------------
-Node * LibraryCallKit::get_state_from_sha_object(Node *sha_object) {
-  Node* sha_state = load_field_from_object(sha_object, "state", "[I", /*is_exact*/ false);
-  assert (sha_state != NULL, "wrong version of sun.security.provider.SHA/SHA2");
-  if (sha_state == NULL) return (Node *) NULL;
+//------------------------------get_state_from_digest_object-----------------------
+Node * LibraryCallKit::get_state_from_digest_object(Node *digest_object) {
+  Node* digest_state = load_field_from_object(digest_object, "state", "[I", /*is_exact*/ false);
+  assert (digest_state != NULL, "wrong version of sun.security.provider.MD5/SHA/SHA2");
+  if (digest_state == NULL) return (Node *) NULL;
 
   // now have the array, need to get the start address of the state array
-  Node* state = array_element_address(sha_state, intcon(0), T_INT);
+  Node* state = array_element_address(digest_state, intcon(0), T_INT);
   return state;
 }
 
-//------------------------------get_state_from_sha5_object-----------------------
-Node * LibraryCallKit::get_state_from_sha5_object(Node *sha_object) {
-  Node* sha_state = load_field_from_object(sha_object, "state", "[J", /*is_exact*/ false);
-  assert (sha_state != NULL, "wrong version of sun.security.provider.SHA5");
-  if (sha_state == NULL) return (Node *) NULL;
+//------------------------------get_long_state_from_digest_object-----------------------
+Node * LibraryCallKit::get_long_state_from_digest_object(Node *digest_object) {
+  Node* digest_state = load_field_from_object(digest_object, "state", "[J", /*is_exact*/ false);
+  assert (digest_state != NULL, "wrong version of sun.security.provider.SHA5");
+  if (digest_state == NULL) return (Node *) NULL;
 
   // now have the array, need to get the start address of the state array
-  Node* state = array_element_address(sha_state, intcon(0), T_LONG);
+  Node* state = array_element_address(digest_state, intcon(0), T_LONG);
   return state;
 }
 
 //----------------------------inline_digestBase_implCompressMB_predicate----------------------------
 // Return node representing slow path of predicate check.
 // the pseudo code we want to emulate with this predicate is:
-//    if (digestBaseObj instanceof SHA/SHA2/SHA5) do_intrinsic, else do_javapath
+//    if (digestBaseObj instanceof MD5/SHA/SHA2/SHA5) do_intrinsic, else do_javapath
 //
 Node* LibraryCallKit::inline_digestBase_implCompressMB_predicate(int predicate) {
-  assert(UseSHA1Intrinsics || UseSHA256Intrinsics || UseSHA512Intrinsics,
-         "need SHA1/SHA256/SHA512 instruction support");
-  assert((uint)predicate < 3, "sanity");
+  assert(UseMD5Intrinsics || UseSHA1Intrinsics || UseSHA256Intrinsics || UseSHA512Intrinsics,
+         "need MD5/SHA1/SHA256/SHA512 instruction support");
+  assert((uint)predicate < 4, "sanity");
 
   // The receiver was checked for NULL already.
   Node* digestBaseObj = argument(0);
@@ -6657,44 +6675,50 @@ Node* LibraryCallKit::inline_digestBase_implCompressMB_predicate(int predicate) 
   assert(tinst != NULL, "digestBaseObj is null");
   assert(tinst->klass()->is_loaded(), "DigestBase is not loaded");
 
-  const char* klass_SHA_name = NULL;
+  const char* klass_name = NULL;
   switch (predicate) {
   case 0:
-    if (UseSHA1Intrinsics) {
-      // we want to do an instanceof comparison against the SHA class
-      klass_SHA_name = "sun/security/provider/SHA";
+    if (UseMD5Intrinsics) {
+      // we want to do an instanceof comparison against the MD5 class
+      klass_name = "sun/security/provider/MD5";
     }
     break;
   case 1:
-    if (UseSHA256Intrinsics) {
-      // we want to do an instanceof comparison against the SHA2 class
-      klass_SHA_name = "sun/security/provider/SHA2";
+    if (UseSHA1Intrinsics) {
+      // we want to do an instanceof comparison against the SHA class
+      klass_name = "sun/security/provider/SHA";
     }
     break;
   case 2:
+    if (UseSHA256Intrinsics) {
+      // we want to do an instanceof comparison against the SHA2 class
+      klass_name = "sun/security/provider/SHA2";
+    }
+    break;
+  case 3:
     if (UseSHA512Intrinsics) {
       // we want to do an instanceof comparison against the SHA5 class
-      klass_SHA_name = "sun/security/provider/SHA5";
+      klass_name = "sun/security/provider/SHA5";
     }
     break;
   default:
     fatal("unknown SHA intrinsic predicate: %d", predicate);
   }
 
-  ciKlass* klass_SHA = NULL;
-  if (klass_SHA_name != NULL) {
-    klass_SHA = tinst->klass()->as_instance_klass()->find_klass(ciSymbol::make(klass_SHA_name));
+  ciKlass* klass = NULL;
+  if (klass_name != NULL) {
+    klass = tinst->klass()->as_instance_klass()->find_klass(ciSymbol::make(klass_name));
   }
-  if ((klass_SHA == NULL) || !klass_SHA->is_loaded()) {
-    // if none of SHA/SHA2/SHA5 is loaded, we never take the intrinsic fast path
+  if ((klass == NULL) || !klass->is_loaded()) {
+    // if none of MD5/SHA/SHA2/SHA5 is loaded, we never take the intrinsic fast path
     Node* ctrl = control();
     set_control(top()); // no intrinsic path
     return ctrl;
   }
-  ciInstanceKlass* instklass_SHA = klass_SHA->as_instance_klass();
+  ciInstanceKlass* instklass = klass->as_instance_klass();
 
-  Node* instofSHA = gen_instanceof(digestBaseObj, makecon(TypeKlassPtr::make(instklass_SHA)));
-  Node* cmp_instof = _gvn.transform(new CmpINode(instofSHA, intcon(1)));
+  Node* instof = gen_instanceof(digestBaseObj, makecon(TypeKlassPtr::make(instklass)));
+  Node* cmp_instof = _gvn.transform(new CmpINode(instof, intcon(1)));
   Node* bool_instof = _gvn.transform(new BoolNode(cmp_instof, BoolTest::ne));
   Node* instof_false = generate_guard(bool_instof, NULL, PROB_MIN);
 

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -959,7 +959,7 @@ const TypeFunc* OptoRuntime::counterMode_aescrypt_Type() {
 /*
  * void implCompress(byte[] buf, int ofs)
  */
-const TypeFunc* OptoRuntime::sha_implCompress_Type() {
+const TypeFunc* OptoRuntime::digestBase_implCompress_Type() {
   // create input type (domain)
   int num_args = 2;
   int argcnt = num_args;

--- a/src/hotspot/share/opto/runtime.hpp
+++ b/src/hotspot/share/opto/runtime.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -278,7 +278,7 @@ private:
   static const TypeFunc* electronicCodeBook_aescrypt_Type();
   static const TypeFunc* counterMode_aescrypt_Type();
 
-  static const TypeFunc* sha_implCompress_Type();
+  static const TypeFunc* digestBase_implCompress_Type();
   static const TypeFunc* digestBase_implCompressMB_Type();
 
   static const TypeFunc* multiplyToLen_Type();

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -447,6 +447,9 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
   diagnostic(bool, UseAESCTRIntrinsics, false,                              \
           "Use intrinsics for the paralleled version of AES/CTR crypto")    \
                                                                             \
+  diagnostic(bool, UseMD5Intrinsics, false,                                 \
+          "Use intrinsics for MD5 crypto hash function")                    \
+                                                                            \
   diagnostic(bool, UseSHA1Intrinsics, false,                                \
           "Use intrinsics for SHA-1 crypto hash function. "                 \
           "Requires that UseSHA is enabled.")                               \

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -132,6 +132,8 @@ address StubRoutines::_counterMode_AESCrypt                = NULL;
 address StubRoutines::_ghash_processBlocks                 = NULL;
 address StubRoutines::_base64_encodeBlock                  = NULL;
 
+address StubRoutines::_md5_implCompress      = NULL;
+address StubRoutines::_md5_implCompressMB    = NULL;
 address StubRoutines::_sha1_implCompress     = NULL;
 address StubRoutines::_sha1_implCompressMB   = NULL;
 address StubRoutines::_sha256_implCompress   = NULL;

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -176,6 +176,8 @@ class StubRoutines: AllStatic {
   static address _ghash_processBlocks;
   static address _base64_encodeBlock;
 
+  static address _md5_implCompress;
+  static address _md5_implCompressMB;
   static address _sha1_implCompress;
   static address _sha1_implCompressMB;
   static address _sha256_implCompress;
@@ -353,6 +355,8 @@ class StubRoutines: AllStatic {
   static address counterMode_AESCrypt()  { return _counterMode_AESCrypt; }
   static address ghash_processBlocks()   { return _ghash_processBlocks; }
   static address base64_encodeBlock()    { return _base64_encodeBlock; }
+  static address md5_implCompress()      { return _md5_implCompress; }
+  static address md5_implCompressMB()    { return _md5_implCompressMB; }
   static address sha1_implCompress()     { return _sha1_implCompress; }
   static address sha1_implCompressMB()   { return _sha1_implCompressMB; }
   static address sha256_implCompress()   { return _sha256_implCompress; }

--- a/src/java.base/share/classes/sun/security/provider/MD5.java
+++ b/src/java.base/share/classes/sun/security/provider/MD5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,10 @@
 package sun.security.provider;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import static sun.security.provider.ByteArrayAccess.*;
+import jdk.internal.HotSpotIntrinsicCandidate;
 
 /**
  * The MD5 class is used to compute an MD5 message digest over a given
@@ -147,8 +149,27 @@ public final class MD5 extends DigestBase {
      * bytes from the buffer, beginning at the specified offset.
      */
     void implCompress(byte[] buf, int ofs) {
-        b2iLittle64(buf, ofs, x);
+        implCompressCheck(buf, ofs);
+        implCompress0(buf, ofs);
+    }
 
+    private void implCompressCheck(byte[] buf, int ofs) {
+        Objects.requireNonNull(buf);
+
+        // The checks performed by the method 'b2iBig64'
+        // are sufficient for the case when the method
+        // 'implCompressImpl' is replaced with a compiler
+        // intrinsic.
+        b2iLittle64(buf, ofs, x);
+    }
+
+    // The method 'implCompress0 seems not to use its parameters.
+    // The method can, however, be replaced with a compiler intrinsic
+    // that operates directly on the array 'buf' (starting from
+    // offset 'ofs') and not on array 'x', therefore 'buf' and 'ofs'
+    // must be passed as parameter to the method.
+    @HotSpotIntrinsicCandidate
+    void implCompress0(byte[] buf, int ofs) {
         int a = state[0];
         int b = state[1];
         int c = state[2];

--- a/src/java.base/share/classes/sun/security/provider/SHA.java
+++ b/src/java.base/share/classes/sun/security/provider/SHA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,12 +134,12 @@ public final class SHA extends DigestBase {
 
         // The checks performed by the method 'b2iBig64'
         // are sufficient for the case when the method
-        // 'implCompressImpl' is replaced with a compiler
+        // 'implCompress0' is replaced with a compiler
         // intrinsic.
         b2iBig64(buf, ofs, W);
     }
 
-    // The method 'implCompressImpl seems not to use its parameters.
+    // The method 'implCompress0 seems not to use its parameters.
     // The method can, however, be replaced with a compiler intrinsic
     // that operates directly on the array 'buf' (starting from
     // offset 'ofs') and not on array 'W', therefore 'buf' and 'ofs'

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
@@ -390,11 +390,6 @@ public class CheckGraalIntrinsics extends GraalTest {
                             "jdk/jfr/internal/JVM.getEventWriter()Ljava/lang/Object;");
         }
 
-        if (isJDK16OrHigher()) {
-            add(toBeInvestigated,
-                            "sun/security/provider/MD5.implCompress0([BI)V");
-        }
-
         if (!config.inlineNotify()) {
             add(ignore, "java/lang/Object.notify()V");
         }
@@ -544,14 +539,6 @@ public class CheckGraalIntrinsics extends GraalTest {
 
     private static boolean isJDK11OrHigher() {
         return GraalServices.JAVA_SPECIFICATION_VERSION >= 11;
-    }
-
-    private static boolean isJDK15OrHigher() {
-        return JavaVersionUtil.JAVA_SPEC >= 15;
-    }
-
-    private static boolean isJDK16OrHigher() {
-        return JavaVersionUtil.JAVA_SPEC >= 16;
     }
 
     public interface Refiner {

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
@@ -387,7 +387,8 @@ public class CheckGraalIntrinsics extends GraalTest {
                             "java/lang/Math.signum(D)D",
                             "java/lang/Math.signum(F)F",
                             "java/util/Base64$Encoder.encodeBlock([BII[BIZ)V",
-                            "jdk/jfr/internal/JVM.getEventWriter()Ljava/lang/Object;");
+                            "jdk/jfr/internal/JVM.getEventWriter()Ljava/lang/Object;",
+                            "sun/security/provider/MD5.implCompress0([BI)V");
         }
 
         if (!config.inlineNotify()) {

--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
@@ -390,6 +390,11 @@ public class CheckGraalIntrinsics extends GraalTest {
                             "jdk/jfr/internal/JVM.getEventWriter()Ljava/lang/Object;");
         }
 
+        if (isJDK16OrHigher()) {
+            add(toBeInvestigated,
+                            "sun/security/provider/MD5.implCompress0([BI)V");
+        }
+
         if (!config.inlineNotify()) {
             add(ignore, "java/lang/Object.notify()V");
         }
@@ -539,6 +544,14 @@ public class CheckGraalIntrinsics extends GraalTest {
 
     private static boolean isJDK11OrHigher() {
         return GraalServices.JAVA_SPECIFICATION_VERSION >= 11;
+    }
+
+    private static boolean isJDK15OrHigher() {
+        return JavaVersionUtil.JAVA_SPEC >= 15;
+    }
+
+    private static boolean isJDK16OrHigher() {
+        return JavaVersionUtil.JAVA_SPEC >= 16;
     }
 
     public interface Refiner {

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/TestDigest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/TestDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,56 +24,62 @@
 /**
  * @test
  * @bug 8035968
- * @summary C2 support for SHA on SPARC
+ * @summary C2 support for MD5/SHA-1/SHA-224/SHA-256/SHA-384/SHA-512
  *
+ * @run main/othervm/timeout=600 -Xbatch
+ *      -Dalgorithm=MD5
+ *      compiler.intrinsics.sha.TestDigest
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-1
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-224
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-256
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-384
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-512
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  *
  * @run main/othervm/timeout=600 -Xbatch
+ *      -Dalgorithm=MD5   -Doffset=1
+ *      compiler.intrinsics.sha.TestDigest
+ * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-1   -Doffset=1
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-224 -Doffset=1
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-256 -Doffset=1
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-384 -Doffset=1
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-512 -Doffset=1
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  *
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-1   -Dalgorithm2=SHA-256
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-1   -Dalgorithm2=SHA-512
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-256 -Dalgorithm2=SHA-512
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  *
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=SHA-1   -Dalgorithm2=MD5
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  * @run main/othervm/timeout=600 -Xbatch
  *      -Dalgorithm=MD5     -Dalgorithm2=SHA-1
- *      compiler.intrinsics.sha.TestSHA
+ *      compiler.intrinsics.sha.TestDigest
  */
 
 package compiler.intrinsics.sha;
@@ -81,7 +87,7 @@ package compiler.intrinsics.sha;
 import java.security.MessageDigest;
 import java.util.Arrays;
 
-public class TestSHA {
+public class TestDigest {
     private static final int HASH_LEN = 64; /* up to 512-bit */
     private static final int ALIGN = 8;     /* for different data alignments */
 
@@ -94,14 +100,14 @@ public class TestSHA {
         int iters = (args.length > 0 ? Integer.valueOf(args[0]) : 100000);
         int warmupIters = (args.length > 1 ? Integer.valueOf(args[1]) : 20000);
 
-        testSHA(provider, algorithm, msgSize, offset, iters, warmupIters);
+        testDigest(provider, algorithm, msgSize, offset, iters, warmupIters);
 
         if (algorithm2.equals("") == false) {
-            testSHA(provider, algorithm2, msgSize, offset, iters, warmupIters);
+            testDigest(provider, algorithm2, msgSize, offset, iters, warmupIters);
         }
     }
 
-    public static void testSHA(String provider, String algorithm, int msgSize,
+    public static void testDigest(String provider, String algorithm, int msgSize,
                         int offset, int iters, int warmupIters) throws Exception {
         System.out.println("provider = " + provider);
         System.out.println("algorithm = " + algorithm);
@@ -117,27 +123,27 @@ public class TestSHA {
         }
 
         try {
-            MessageDigest sha = MessageDigest.getInstance(algorithm, provider);
+            MessageDigest digest = MessageDigest.getInstance(algorithm, provider);
 
             /* do once, which doesn't use intrinsics */
-            sha.reset();
-            sha.update(data, offset, msgSize);
-            expectedHash = sha.digest();
+            digest.reset();
+            digest.update(data, offset, msgSize);
+            expectedHash = digest.digest();
 
             /* warm up */
             for (int i = 0; i < warmupIters; i++) {
-                sha.reset();
-                sha.update(data, offset, msgSize);
-                hash = sha.digest();
+                digest.reset();
+                digest.update(data, offset, msgSize);
+                hash = digest.digest();
             }
 
             /* check result */
             if (Arrays.equals(hash, expectedHash) == false) {
-                System.out.println("TestSHA Error: ");
+                System.out.println("TestDigest Error: ");
                 showArray(expectedHash, "expectedHash");
                 showArray(hash,         "computedHash");
                 //System.exit(1);
-                throw new Exception("TestSHA Error");
+                throw new Exception("TestDigest Error");
             } else {
                 showArray(hash, "hash");
             }
@@ -145,15 +151,15 @@ public class TestSHA {
             /* measure performance */
             long start = System.nanoTime();
             for (int i = 0; i < iters; i++) {
-                sha.reset();
-                sha.update(data, offset, msgSize);
-                hash = sha.digest();
+                digest.reset();
+                digest.update(data, offset, msgSize);
+                hash = digest.digest();
             }
             long end = System.nanoTime();
             double total = (double)(end - start)/1e9;         /* in seconds */
             double thruput = (double)msgSize*iters/1e6/total; /* in MB/s */
-            System.out.println("TestSHA runtime = " + total + " seconds");
-            System.out.println("TestSHA throughput = " + thruput + " MB/s");
+            System.out.println("TestDigest runtime = " + total + " seconds");
+            System.out.println("TestDigest throughput = " + thruput + " MB/s");
             System.out.println();
         } catch (Exception e) {
             System.out.println("Exception: " + e);

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/DigestOptionsBase.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/DigestOptionsBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,9 @@ import java.util.function.BooleanSupplier;
  * Instead of using huge complex tests for each option, each test is constructed
  * from several test cases shared among different tests.
  */
-public class SHAOptionsBase extends CommandLineOptionTest {
+public class DigestOptionsBase extends CommandLineOptionTest {
+    public static final String USE_MD5_INTRINSICS_OPTION
+            = "UseMD5Intrinsics";
     public static final String USE_SHA_OPTION = "UseSHA";
     public static final String USE_SHA1_INTRINSICS_OPTION
             = "UseSHA1Intrinsics";
@@ -52,6 +54,8 @@ public class SHAOptionsBase extends CommandLineOptionTest {
     // Note that strings below will be passed to
     // CommandLineOptionTest.verifySameJVMStartup and thus are regular
     // expressions, not just a plain strings.
+    protected static final String MD5_INTRINSICS_ARE_NOT_AVAILABLE
+            = "Intrinsics for MD5 crypto hash functions not available on this CPU.";
     protected static final String SHA_INSTRUCTIONS_ARE_NOT_AVAILABLE
             = "SHA instructions are not available on this CPU";
     protected static final String SHA1_INTRINSICS_ARE_NOT_AVAILABLE
@@ -75,14 +79,16 @@ public class SHAOptionsBase extends CommandLineOptionTest {
      */
     public static String getWarningForUnsupportedCPU(String optionName) {
         switch (optionName) {
-        case SHAOptionsBase.USE_SHA_OPTION:
-            return SHAOptionsBase.SHA_INSTRUCTIONS_ARE_NOT_AVAILABLE;
-        case SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION:
-            return SHAOptionsBase.SHA1_INTRINSICS_ARE_NOT_AVAILABLE;
-        case SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION:
-            return SHAOptionsBase.SHA256_INTRINSICS_ARE_NOT_AVAILABLE;
-        case SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION:
-            return SHAOptionsBase.SHA512_INTRINSICS_ARE_NOT_AVAILABLE;
+        case DigestOptionsBase.USE_MD5_INTRINSICS_OPTION:
+            return DigestOptionsBase.MD5_INTRINSICS_ARE_NOT_AVAILABLE;
+        case DigestOptionsBase.USE_SHA_OPTION:
+            return DigestOptionsBase.SHA_INSTRUCTIONS_ARE_NOT_AVAILABLE;
+        case DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION:
+            return DigestOptionsBase.SHA1_INTRINSICS_ARE_NOT_AVAILABLE;
+        case DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION:
+            return DigestOptionsBase.SHA256_INTRINSICS_ARE_NOT_AVAILABLE;
+        case DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION:
+            return DigestOptionsBase.SHA512_INTRINSICS_ARE_NOT_AVAILABLE;
         default:
             throw new Error("Unexpected option " + optionName);
         }
@@ -99,20 +105,22 @@ public class SHAOptionsBase extends CommandLineOptionTest {
      */
     public static BooleanSupplier getPredicateForOption(String optionName) {
         switch (optionName) {
-            case SHAOptionsBase.USE_SHA_OPTION:
+            case DigestOptionsBase.USE_MD5_INTRINSICS_OPTION:
+                return IntrinsicPredicates.MD5_INSTRUCTION_AVAILABLE;
+            case DigestOptionsBase.USE_SHA_OPTION:
                 return IntrinsicPredicates.ANY_SHA_INSTRUCTION_AVAILABLE;
-            case SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION:
+            case DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION:
                 return IntrinsicPredicates.SHA1_INSTRUCTION_AVAILABLE;
-            case SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION:
+            case DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION:
                 return IntrinsicPredicates.SHA256_INSTRUCTION_AVAILABLE;
-            case SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION:
+            case DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION:
                 return IntrinsicPredicates.SHA512_INSTRUCTION_AVAILABLE;
             default:
                 throw new Error("Unexpected option " + optionName);
         }
     }
 
-    public SHAOptionsBase(TestCase... testCases) {
+    public DigestOptionsBase(TestCase... testCases) {
         super(Boolean.TRUE::booleanValue);
         this.testCases = testCases;
     }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnSupportedCPU.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,30 +24,25 @@
 /**
  * @test
  * @bug 8035968
- * @summary Verify UseSHA option processing on supported CPU.
+ * @summary Verify UseMD5Intrinsics option processing on supported CPU.
  * @library /test/lib testcases /
  * @modules java.base/jdk.internal.misc
  *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
- *                   compiler.intrinsics.sha.cli.TestUseSHAOptionOnSupportedCPU
+ *                   compiler.intrinsics.sha.cli.TestUseMD5IntrinsicsOptionOnSupportedCPU
  */
 
 package compiler.intrinsics.sha.cli;
 
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForSupportedCPU;
-import compiler.intrinsics.sha.cli.testcases.UseSHASpecificTestCaseForSupportedCPU;
 
-public class TestUseSHAOptionOnSupportedCPU {
+public class TestUseMD5IntrinsicsOptionOnSupportedCPU {
     public static void main(String args[]) throws Throwable {
-        new DigestOptionsBase(
-                new GenericTestCaseForSupportedCPU(
-                        DigestOptionsBase.USE_SHA_OPTION),
-                new UseSHASpecificTestCaseForSupportedCPU(
-                        DigestOptionsBase.USE_SHA_OPTION)).test();
+        new DigestOptionsBase(new GenericTestCaseForSupportedCPU(
+                DigestOptionsBase.USE_MD5_INTRINSICS_OPTION, /* checkUseSHA = */ false)).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnUnsupportedCPU.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,30 +24,33 @@
 /**
  * @test
  * @bug 8035968
- * @summary Verify UseSHA option processing on supported CPU.
+ * @summary Verify UseMD5Intrinsics option processing on unsupported CPU.
  * @library /test/lib testcases /
  * @modules java.base/jdk.internal.misc
  *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
- *                   compiler.intrinsics.sha.cli.TestUseSHAOptionOnSupportedCPU
+ *                   compiler.intrinsics.sha.cli.TestUseMD5IntrinsicsOptionOnUnsupportedCPU
  */
 
 package compiler.intrinsics.sha.cli;
 
-import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForSupportedCPU;
-import compiler.intrinsics.sha.cli.testcases.UseSHASpecificTestCaseForSupportedCPU;
+import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForOtherCPU;
+import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedAArch64CPU;
+import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedX86CPU;
+import compiler.intrinsics.sha.cli.testcases.UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU;
 
-public class TestUseSHAOptionOnSupportedCPU {
+public class TestUseMD5IntrinsicsOptionOnUnsupportedCPU {
     public static void main(String args[]) throws Throwable {
         new DigestOptionsBase(
-                new GenericTestCaseForSupportedCPU(
-                        DigestOptionsBase.USE_SHA_OPTION),
-                new UseSHASpecificTestCaseForSupportedCPU(
-                        DigestOptionsBase.USE_SHA_OPTION)).test();
+                new GenericTestCaseForUnsupportedX86CPU(
+                        DigestOptionsBase.USE_MD5_INTRINSICS_OPTION, /* checkUseSHA = */ false),
+                new GenericTestCaseForUnsupportedAArch64CPU(
+                        DigestOptionsBase.USE_MD5_INTRINSICS_OPTION, /* checkUseSHA = */ false),
+                new GenericTestCaseForOtherCPU(
+                        DigestOptionsBase.USE_MD5_INTRINSICS_OPTION, /* checkUseSHA = */ false)).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnSupportedCPU.java
@@ -43,7 +43,7 @@ import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForSupportedCPU;
 
 public class TestUseSHA1IntrinsicsOptionOnSupportedCPU {
     public static void main(String args[]) throws Throwable {
-        new SHAOptionsBase(new GenericTestCaseForSupportedCPU(
-                SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION)).test();
+        new DigestOptionsBase(new GenericTestCaseForSupportedCPU(
+                DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION)).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnUnsupportedCPU.java
@@ -47,16 +47,16 @@ import compiler.intrinsics.sha.cli.testcases.UseSHAIntrinsicsSpecificTestCaseFor
 
 public class TestUseSHA1IntrinsicsOptionOnUnsupportedCPU {
     public static void main(String args[]) throws Throwable {
-        new SHAOptionsBase(
+        new DigestOptionsBase(
                 new GenericTestCaseForUnsupportedSparcCPU(
-                        SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION),
+                        DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION),
                 new GenericTestCaseForUnsupportedX86CPU(
-                        SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION),
+                        DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION),
                 new GenericTestCaseForUnsupportedAArch64CPU(
-                        SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION),
+                        DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION),
                 new UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU(
-                        SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION),
+                        DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION),
                 new GenericTestCaseForOtherCPU(
-                        SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION)).test();
+                        DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION)).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnSupportedCPU.java
@@ -43,7 +43,7 @@ import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForSupportedCPU;
 
 public class TestUseSHA256IntrinsicsOptionOnSupportedCPU {
     public static void main(String args[]) throws Throwable {
-        new SHAOptionsBase(new GenericTestCaseForSupportedCPU(
-                SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION)).test();
+        new DigestOptionsBase(new GenericTestCaseForSupportedCPU(
+                DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION)).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java
@@ -47,16 +47,16 @@ import compiler.intrinsics.sha.cli.testcases.UseSHAIntrinsicsSpecificTestCaseFor
 
 public class TestUseSHA256IntrinsicsOptionOnUnsupportedCPU {
     public static void main(String args[]) throws Throwable {
-        new SHAOptionsBase(
+        new DigestOptionsBase(
                 new GenericTestCaseForUnsupportedSparcCPU(
-                        SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION),
+                        DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION),
                 new GenericTestCaseForUnsupportedX86CPU(
-                        SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION),
+                        DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION),
                 new GenericTestCaseForUnsupportedAArch64CPU(
-                        SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION),
+                        DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION),
                 new UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU(
-                        SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION),
+                        DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION),
                 new GenericTestCaseForOtherCPU(
-                        SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION)).test();
+                        DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION)).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java
@@ -44,7 +44,7 @@ import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForSupportedCPU;
 
 public class TestUseSHA512IntrinsicsOptionOnSupportedCPU {
     public static void main(String args[]) throws Throwable {
-        new SHAOptionsBase(new GenericTestCaseForSupportedCPU(
-                SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION)).test();
+        new DigestOptionsBase(new GenericTestCaseForSupportedCPU(
+                DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION)).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
@@ -47,16 +47,16 @@ import compiler.intrinsics.sha.cli.testcases.UseSHAIntrinsicsSpecificTestCaseFor
 
 public class TestUseSHA512IntrinsicsOptionOnUnsupportedCPU {
     public static void main(String args[]) throws Throwable {
-        new SHAOptionsBase(
+        new DigestOptionsBase(
                 new GenericTestCaseForUnsupportedSparcCPU(
-                        SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION),
+                        DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION),
                 new GenericTestCaseForUnsupportedX86CPU(
-                        SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION),
+                        DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION),
                 new GenericTestCaseForUnsupportedAArch64CPU(
-                        SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION),
+                        DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION),
                 new UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU(
-                        SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION),
+                        DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION),
                 new GenericTestCaseForOtherCPU(
-                        SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION)).test();
+                        DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION)).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnUnsupportedCPU.java
@@ -46,16 +46,16 @@ import compiler.intrinsics.sha.cli.testcases.UseSHASpecificTestCaseForUnsupporte
 
 public class TestUseSHAOptionOnUnsupportedCPU {
     public static void main(String args[]) throws Throwable {
-        new SHAOptionsBase(
+        new DigestOptionsBase(
                 new GenericTestCaseForUnsupportedSparcCPU(
-                        SHAOptionsBase.USE_SHA_OPTION),
+                        DigestOptionsBase.USE_SHA_OPTION),
                 new GenericTestCaseForUnsupportedX86CPU(
-                        SHAOptionsBase.USE_SHA_OPTION),
+                        DigestOptionsBase.USE_SHA_OPTION),
                 new GenericTestCaseForUnsupportedAArch64CPU(
-                        SHAOptionsBase.USE_SHA_OPTION),
+                        DigestOptionsBase.USE_SHA_OPTION),
                 new UseSHASpecificTestCaseForUnsupportedCPU(
-                        SHAOptionsBase.USE_SHA_OPTION),
+                        DigestOptionsBase.USE_SHA_OPTION),
                 new GenericTestCaseForOtherCPU(
-                        SHAOptionsBase.USE_SHA_OPTION)).test();
+                        DigestOptionsBase.USE_SHA_OPTION)).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/GenericTestCaseForOtherCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/GenericTestCaseForOtherCPU.java
@@ -23,7 +23,7 @@
 
 package compiler.intrinsics.sha.cli.testcases;
 
-import compiler.intrinsics.sha.cli.SHAOptionsBase;
+import compiler.intrinsics.sha.cli.DigestOptionsBase;
 import jdk.test.lib.process.ExitCode;
 import jdk.test.lib.Platform;
 import jdk.test.lib.cli.CommandLineOptionTest;
@@ -35,9 +35,16 @@ import jdk.test.lib.cli.predicate.OrPredicate;
  * AArch64, PPC, S390x, SPARC and X86.
  */
 public class GenericTestCaseForOtherCPU extends
-        SHAOptionsBase.TestCase {
+        DigestOptionsBase.TestCase {
+
+    final private boolean checkUseSHA;
+
     public GenericTestCaseForOtherCPU(String optionName) {
-        // Execute the test case on any CPU except AArch64, PPC, S390x, SPARC and X86.
+        this(optionName, true);
+    }
+
+    public GenericTestCaseForOtherCPU(String optionName, boolean checkUseSHA) {
+        // Execute the test case on any CPU except AArch64, PPC, S390x, and X86.
         super(optionName, new NotPredicate(
                               new OrPredicate(Platform::isAArch64,
                               new OrPredicate(Platform::isS390x,
@@ -45,6 +52,8 @@ public class GenericTestCaseForOtherCPU extends
                               new OrPredicate(Platform::isPPC,
                               new OrPredicate(Platform::isX64,
                                               Platform::isX86)))))));
+
+        this.checkUseSHA = checkUseSHA;
     }
 
     @Override
@@ -56,13 +65,13 @@ public class GenericTestCaseForOtherCPU extends
         CommandLineOptionTest.verifySameJVMStartup(null,
                 new String[] { ".*" + optionName + ".*" }, shouldPassMessage,
                 shouldPassMessage, ExitCode.OK,
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(optionName, true));
 
         CommandLineOptionTest.verifySameJVMStartup(null,
                 new String[] { ".*" + optionName + ".*" }, shouldPassMessage,
                 shouldPassMessage, ExitCode.OK,
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(optionName, false));
     }
 
@@ -72,24 +81,26 @@ public class GenericTestCaseForOtherCPU extends
         CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
                 String.format("Option '%s' should be disabled by default",
                         optionName),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS);
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS);
 
         // Verify that option is disabled even if it was explicitly enabled
         // using CLI options.
         CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
                 String.format("Option '%s' should be off on unsupported "
                         + "CPU even if set to true directly", optionName),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(optionName, true));
 
-        // Verify that option is disabled when it explicitly disabled
-        // using CLI options.
-        CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
-                String.format("Option '%s' should be off on unsupported CPU"
-                        + " even if '%s' flag set to JVM", optionName,
-                        CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA_OPTION, true)),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
-                CommandLineOptionTest.prepareBooleanFlag(optionName, false));
+        if (checkUseSHA) {
+            // Verify that option is disabled when it explicitly disabled
+            // using CLI options.
+            CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
+                    String.format("Option '%s' should be off on unsupported CPU"
+                            + " even if '%s' flag set to JVM", optionName,
+                            CommandLineOptionTest.prepareBooleanFlag(
+                            DigestOptionsBase.USE_SHA_OPTION, true)),
+                    DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                    CommandLineOptionTest.prepareBooleanFlag(optionName, false));
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/GenericTestCaseForSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/GenericTestCaseForSupportedCPU.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 package compiler.intrinsics.sha.cli.testcases;
 
-import compiler.intrinsics.sha.cli.SHAOptionsBase;
+import compiler.intrinsics.sha.cli.DigestOptionsBase;
 import jdk.test.lib.process.ExitCode;
 import jdk.test.lib.Platform;
 import jdk.test.lib.cli.CommandLineOptionTest;
@@ -35,9 +35,18 @@ import jdk.test.lib.cli.predicate.OrPredicate;
  * support instructions required by the tested option.
  */
 public class GenericTestCaseForSupportedCPU extends
-        SHAOptionsBase.TestCase {
+        DigestOptionsBase.TestCase {
+
+    final private boolean checkUseSHA;
+
     public GenericTestCaseForSupportedCPU(String optionName) {
-        super(optionName, SHAOptionsBase.getPredicateForOption(optionName));
+        this(optionName, true);
+    }
+
+    public GenericTestCaseForSupportedCPU(String optionName, boolean checkUseSHA) {
+        super(optionName, DigestOptionsBase.getPredicateForOption(optionName));
+
+        this.checkUseSHA = checkUseSHA;
     }
 
     @Override
@@ -47,39 +56,41 @@ public class GenericTestCaseForSupportedCPU extends
                 + " '%s' without any warnings", optionName);
         // Verify that there are no warning when option is explicitly enabled.
         CommandLineOptionTest.verifySameJVMStartup(null, new String[] {
-                        SHAOptionsBase.getWarningForUnsupportedCPU(optionName)
+                        DigestOptionsBase.getWarningForUnsupportedCPU(optionName)
                 }, shouldPassMessage, shouldPassMessage, ExitCode.OK,
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(optionName, true));
 
-        // Verify that option could be disabled even if +UseSHA was passed to
-        // JVM.
-        CommandLineOptionTest.verifySameJVMStartup(null, new String[] {
-                        SHAOptionsBase.getWarningForUnsupportedCPU(optionName)
-                }, shouldPassMessage, String.format("It should be able to "
-                        + "disable option '%s' even if %s was passed to JVM",
-                        optionName, CommandLineOptionTest.prepareBooleanFlag(
-                            SHAOptionsBase.USE_SHA_OPTION, true)),
-                ExitCode.OK,
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
-                CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA_OPTION, true),
-                CommandLineOptionTest.prepareBooleanFlag(optionName, false));
-
-        if (!optionName.equals(SHAOptionsBase.USE_SHA_OPTION)) {
-            // Verify that if -XX:-UseSHA is passed to the JVM, it is not possible
-            // to enable the tested option and a warning is printed.
-            CommandLineOptionTest.verifySameJVMStartup(
-                    new String[] { SHAOptionsBase.getWarningForUnsupportedCPU(optionName) },
-                    null,
-                    shouldPassMessage,
-                    String.format("Enabling option '%s' should not be possible and should result in a warning if %s was passed to JVM",
-                                  optionName,
-                                  CommandLineOptionTest.prepareBooleanFlag(SHAOptionsBase.USE_SHA_OPTION, false)),
+        if (checkUseSHA) {
+            // Verify that option could be disabled even if +UseSHA was passed to
+            // JVM.
+            CommandLineOptionTest.verifySameJVMStartup(null, new String[] {
+                            DigestOptionsBase.getWarningForUnsupportedCPU(optionName)
+                    }, shouldPassMessage, String.format("It should be able to "
+                            + "disable option '%s' even if %s was passed to JVM",
+                            optionName, CommandLineOptionTest.prepareBooleanFlag(
+                                DigestOptionsBase.USE_SHA_OPTION, true)),
                     ExitCode.OK,
-                    SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
-                    CommandLineOptionTest.prepareBooleanFlag(SHAOptionsBase.USE_SHA_OPTION, false),
-                    CommandLineOptionTest.prepareBooleanFlag(optionName, true));
+                    DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                    CommandLineOptionTest.prepareBooleanFlag(
+                            DigestOptionsBase.USE_SHA_OPTION, true),
+                    CommandLineOptionTest.prepareBooleanFlag(optionName, false));
+
+            if (!optionName.equals(DigestOptionsBase.USE_SHA_OPTION)) {
+                // Verify that if -XX:-UseSHA is passed to the JVM, it is not possible
+                // to enable the tested option and a warning is printed.
+                CommandLineOptionTest.verifySameJVMStartup(
+                        new String[] { DigestOptionsBase.getWarningForUnsupportedCPU(optionName) },
+                        null,
+                        shouldPassMessage,
+                        String.format("Enabling option '%s' should not be possible and should result in a warning if %s was passed to JVM",
+                                    optionName,
+                                    CommandLineOptionTest.prepareBooleanFlag(DigestOptionsBase.USE_SHA_OPTION, false)),
+                        ExitCode.OK,
+                        DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                        CommandLineOptionTest.prepareBooleanFlag(DigestOptionsBase.USE_SHA_OPTION, false),
+                        CommandLineOptionTest.prepareBooleanFlag(optionName, true));
+            }
         }
     }
 
@@ -90,43 +101,45 @@ public class GenericTestCaseForSupportedCPU extends
         CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "true",
                 String.format("Option '%s' should be enabled by default",
                         optionName),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS);
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS);
 
         // Verify that it is possible to explicitly enable the option.
         CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "true",
                 String.format("Option '%s' was set to have value 'true'",
                         optionName),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(optionName, true));
 
         // Verify that it is possible to explicitly disable the option.
         CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
                 String.format("Option '%s' was set to have value 'false'",
                         optionName),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(optionName, false));
 
-        // verify that option is disabled when -UseSHA was passed to JVM.
-        CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
-                String.format("Option '%s' should have value 'false' when %s"
-                        + " flag set to JVM", optionName,
-                        CommandLineOptionTest.prepareBooleanFlag(
-                            SHAOptionsBase.USE_SHA_OPTION, false)),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
-                CommandLineOptionTest.prepareBooleanFlag(optionName, true),
-                CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA_OPTION, false));
+        if (checkUseSHA) {
+            // verify that option is disabled when -UseSHA was passed to JVM.
+            CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
+                    String.format("Option '%s' should have value 'false' when %s"
+                            + " flag set to JVM", optionName,
+                            CommandLineOptionTest.prepareBooleanFlag(
+                            DigestOptionsBase.USE_SHA_OPTION, false)),
+                    DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                    CommandLineOptionTest.prepareBooleanFlag(optionName, true),
+                    CommandLineOptionTest.prepareBooleanFlag(
+                            DigestOptionsBase.USE_SHA_OPTION, false));
 
-        // Verify that it is possible to explicitly disable the tested option
-        // even if +UseSHA was passed to JVM.
-        CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
-                String.format("Option '%s' should have value 'false' if set so"
-                        + " even if %s flag set to JVM", optionName,
-                        CommandLineOptionTest.prepareBooleanFlag(
-                            SHAOptionsBase.USE_SHA_OPTION, true)),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
-                CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA_OPTION, true),
-                CommandLineOptionTest.prepareBooleanFlag(optionName, false));
+            // Verify that it is possible to explicitly disable the tested option
+            // even if +UseSHA was passed to JVM.
+            CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
+                    String.format("Option '%s' should have value 'false' if set so"
+                            + " even if %s flag set to JVM", optionName,
+                            CommandLineOptionTest.prepareBooleanFlag(
+                            DigestOptionsBase.USE_SHA_OPTION, true)),
+                    DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                    CommandLineOptionTest.prepareBooleanFlag(
+                            DigestOptionsBase.USE_SHA_OPTION, true),
+                    CommandLineOptionTest.prepareBooleanFlag(optionName, false));
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/GenericTestCaseForUnsupportedSparcCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/GenericTestCaseForUnsupportedSparcCPU.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 package compiler.intrinsics.sha.cli.testcases;
 
-import compiler.intrinsics.sha.cli.SHAOptionsBase;
+import compiler.intrinsics.sha.cli.DigestOptionsBase;
 import jdk.test.lib.process.ExitCode;
 import jdk.test.lib.Platform;
 import jdk.test.lib.cli.CommandLineOptionTest;
@@ -35,11 +35,20 @@ import jdk.test.lib.cli.predicate.NotPredicate;
  * support instruction required by the tested option.
  */
 public class GenericTestCaseForUnsupportedSparcCPU extends
-        SHAOptionsBase.TestCase {
+        DigestOptionsBase.TestCase {
+
+    final private boolean checkUseSHA;
+
     public GenericTestCaseForUnsupportedSparcCPU(String optionName) {
+        this(optionName, true);
+    }
+
+    public GenericTestCaseForUnsupportedSparcCPU(String optionName, boolean checkUseSHA) {
         super(optionName, new AndPredicate(Platform::isSparc,
-                new NotPredicate(SHAOptionsBase.getPredicateForOption(
+                new NotPredicate(DigestOptionsBase.getPredicateForOption(
                         optionName))));
+
+        this.checkUseSHA = checkUseSHA;
     }
 
     @Override
@@ -48,22 +57,22 @@ public class GenericTestCaseForUnsupportedSparcCPU extends
                 + "option '-XX:-%s' without any warnings", optionName);
         //Verify that option could be disabled without any warnings.
         CommandLineOptionTest.verifySameJVMStartup(null, new String[] {
-                        SHAOptionsBase.getWarningForUnsupportedCPU(optionName)
+                        DigestOptionsBase.getWarningForUnsupportedCPU(optionName)
                 }, shouldPassMessage, shouldPassMessage, ExitCode.OK,
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(optionName, false));
 
         // Verify that when the tested option is enabled, then
         // a warning will occur in VM output if UseSHA is disabled.
-        if (!optionName.equals(SHAOptionsBase.USE_SHA_OPTION)) {
+        if (checkUseSHA && !optionName.equals(DigestOptionsBase.USE_SHA_OPTION)) {
             CommandLineOptionTest.verifySameJVMStartup(
-                    new String[] { SHAOptionsBase.getWarningForUnsupportedCPU(optionName) },
+                    new String[] { DigestOptionsBase.getWarningForUnsupportedCPU(optionName) },
                     null,
                     shouldPassMessage,
                     shouldPassMessage,
                     ExitCode.OK,
-                    SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
-                    CommandLineOptionTest.prepareBooleanFlag(SHAOptionsBase.USE_SHA_OPTION, false),
+                    DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                    CommandLineOptionTest.prepareBooleanFlag(DigestOptionsBase.USE_SHA_OPTION, false),
                     CommandLineOptionTest.prepareBooleanFlag(optionName, true));
         }
     }
@@ -74,24 +83,26 @@ public class GenericTestCaseForUnsupportedSparcCPU extends
         CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
                 String.format("Option '%s' should be disabled by default",
                         optionName),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS);
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS);
 
         // Verify that option is disabled even if it was explicitly enabled
         // using CLI options.
         CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
                 String.format("Option '%s' should be off on unsupported "
                         + "SparcCPU even if set to true directly", optionName),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(optionName, true));
 
-        // Verify that option is disabled when +UseSHA was passed to JVM.
-        CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
-                String.format("Option '%s' should be off on unsupported "
-                        + "SparcCPU even if %s flag set to JVM",
-                        optionName, CommandLineOptionTest.prepareBooleanFlag(
-                            SHAOptionsBase.USE_SHA_OPTION, true)),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
-                CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA_OPTION, true));
+        if (checkUseSHA) {
+             // Verify that option is disabled when +UseSHA was passed to JVM.
+             CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
+                    String.format("Option '%s' should be off on unsupported "
+                            + "SparcCPU even if %s flag set to JVM",
+                            optionName, CommandLineOptionTest.prepareBooleanFlag(
+                                DigestOptionsBase.USE_SHA_OPTION, true)),
+                    DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                    CommandLineOptionTest.prepareBooleanFlag(
+                            DigestOptionsBase.USE_SHA_OPTION, true));
+        }
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 package compiler.intrinsics.sha.cli.testcases;
 
-import compiler.intrinsics.sha.cli.SHAOptionsBase;
+import compiler.intrinsics.sha.cli.DigestOptionsBase;
 import compiler.testlibrary.sha.predicate.IntrinsicPredicates;
 import jdk.test.lib.process.ExitCode;
 import jdk.test.lib.Platform;
@@ -41,14 +41,14 @@ import jdk.test.lib.cli.predicate.OrPredicate;
  * sha512.
  */
 public class UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU
-        extends SHAOptionsBase.TestCase {
+        extends DigestOptionsBase.TestCase {
     public UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU(
             String optionName) {
         // execute test case on CPU that supports any sha* instructions,
         // but does not support sha* instruction required by the tested option.
         super(optionName, new AndPredicate(
                 IntrinsicPredicates.ANY_SHA_INSTRUCTION_AVAILABLE,
-                new NotPredicate(SHAOptionsBase.getPredicateForOption(optionName))));
+                new NotPredicate(DigestOptionsBase.getPredicateForOption(optionName))));
     }
     @Override
     protected void verifyWarnings() throws Throwable {
@@ -57,9 +57,9 @@ public class UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU
                 optionName);
         // Verify that attempt to enable the tested option will cause a warning
         CommandLineOptionTest.verifySameJVMStartup(new String[] {
-                        SHAOptionsBase.getWarningForUnsupportedCPU(optionName)
+                        DigestOptionsBase.getWarningForUnsupportedCPU(optionName)
                 }, null, shouldPassMessage, shouldPassMessage, ExitCode.OK,
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(optionName, true));
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/UseSHASpecificTestCaseForSupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/UseSHASpecificTestCaseForSupportedCPU.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 package compiler.intrinsics.sha.cli.testcases;
 
-import compiler.intrinsics.sha.cli.SHAOptionsBase;
+import compiler.intrinsics.sha.cli.DigestOptionsBase;
 import compiler.testlibrary.sha.predicate.IntrinsicPredicates;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.ExitCode;
@@ -36,14 +36,14 @@ import jdk.test.lib.cli.predicate.OrPredicate;
  * UseSHA specific test case targeted to CPUs which support any sha* instruction.
  */
 public class UseSHASpecificTestCaseForSupportedCPU
-        extends SHAOptionsBase.TestCase {
+        extends DigestOptionsBase.TestCase {
     public UseSHASpecificTestCaseForSupportedCPU(String optionName) {
-        super(SHAOptionsBase.USE_SHA_OPTION,
+        super(DigestOptionsBase.USE_SHA_OPTION,
               IntrinsicPredicates.ANY_SHA_INSTRUCTION_AVAILABLE);
 
-        Asserts.assertEQ(optionName, SHAOptionsBase.USE_SHA_OPTION,
+        Asserts.assertEQ(optionName, DigestOptionsBase.USE_SHA_OPTION,
                 String.format("Test case should be used for '%s' option only.",
-                        SHAOptionsBase.USE_SHA_OPTION));
+                        DigestOptionsBase.USE_SHA_OPTION));
     }
 
     @Override
@@ -52,21 +52,21 @@ public class UseSHASpecificTestCaseForSupportedCPU
                         + " %s was passed and all UseSHA*Intrinsics options "
                         + "were disabled",
                         CommandLineOptionTest.prepareBooleanFlag(
-                            SHAOptionsBase.USE_SHA_OPTION, true));
+                            DigestOptionsBase.USE_SHA_OPTION, true));
         // Verify that there will be no warnings when +UseSHA was passed and
         // all UseSHA*Intrinsics options were disabled.
         CommandLineOptionTest.verifySameJVMStartup(
                 null, new String[] { ".*UseSHA.*" }, shouldPassMessage,
                 shouldPassMessage, ExitCode.OK,
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA_OPTION, true),
+                        DigestOptionsBase.USE_SHA_OPTION, true),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION, false),
+                        DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION, false),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION, false),
+                        DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION, false),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION, false));
+                        DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION, false));
     }
 
     @Override
@@ -74,53 +74,53 @@ public class UseSHASpecificTestCaseForSupportedCPU
         // Verify that UseSHA is disabled when all UseSHA*Intrinsics are
         // disabled.
         CommandLineOptionTest.verifyOptionValueForSameVM(
-                SHAOptionsBase.USE_SHA_OPTION, "false", String.format(
+                DigestOptionsBase.USE_SHA_OPTION, "false", String.format(
                 "'%s' option should be disabled when all UseSHA*Intrinsics are"
-                        + " disabled", SHAOptionsBase.USE_SHA_OPTION),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                        + " disabled", DigestOptionsBase.USE_SHA_OPTION),
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION, false),
+                        DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION, false),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION, false),
+                        DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION, false),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION, false));
+                        DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION, false));
 
         CommandLineOptionTest.verifyOptionValueForSameVM(
                 // Verify that UseSHA is disabled when all UseSHA*Intrinsics are
                 // disabled even if it was explicitly enabled.
-                SHAOptionsBase.USE_SHA_OPTION, "false",
+                DigestOptionsBase.USE_SHA_OPTION, "false",
                 String.format("'%s' option should be disabled when all "
                         + "UseSHA*Intrinsics are disabled even if %s flag set "
-                        + "to JVM", SHAOptionsBase.USE_SHA_OPTION,
+                        + "to JVM", DigestOptionsBase.USE_SHA_OPTION,
                         CommandLineOptionTest.prepareBooleanFlag(
-                             SHAOptionsBase.USE_SHA_OPTION, true)),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                             DigestOptionsBase.USE_SHA_OPTION, true)),
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA_OPTION, true),
+                        DigestOptionsBase.USE_SHA_OPTION, true),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION, false),
+                        DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION, false),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION, false),
+                        DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION, false),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION, false));
+                        DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION, false));
 
         // Verify that explicitly disabled UseSHA option remains disabled even
         // if all UseSHA*Intrinsics options were enabled.
         CommandLineOptionTest.verifyOptionValueForSameVM(
-                SHAOptionsBase.USE_SHA_OPTION, "false",
+                DigestOptionsBase.USE_SHA_OPTION, "false",
                 String.format("'%s' option should be disabled if %s flag "
                         + "set even if all UseSHA*Intrinsics were enabled",
-                        SHAOptionsBase.USE_SHA_OPTION,
+                        DigestOptionsBase.USE_SHA_OPTION,
                         CommandLineOptionTest.prepareBooleanFlag(
-                            SHAOptionsBase.USE_SHA_OPTION, false)),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                            DigestOptionsBase.USE_SHA_OPTION, false)),
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA_OPTION, false),
+                        DigestOptionsBase.USE_SHA_OPTION, false),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION, true),
+                        DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION, true),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION, true),
+                        DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION, true),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION, true));
+                        DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION, true));
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/UseSHASpecificTestCaseForUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/UseSHASpecificTestCaseForUnsupportedCPU.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 package compiler.intrinsics.sha.cli.testcases;
 
-import compiler.intrinsics.sha.cli.SHAOptionsBase;
+import compiler.intrinsics.sha.cli.DigestOptionsBase;
 import compiler.testlibrary.sha.predicate.IntrinsicPredicates;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.ExitCode;
@@ -38,13 +38,13 @@ import jdk.test.lib.cli.predicate.OrPredicate;
  * sha* instructions.
  */
 public class UseSHASpecificTestCaseForUnsupportedCPU
-        extends SHAOptionsBase.TestCase {
+        extends DigestOptionsBase.TestCase {
     public UseSHASpecificTestCaseForUnsupportedCPU(String optionName) {
-        super(SHAOptionsBase.USE_SHA_OPTION, new NotPredicate(
+        super(DigestOptionsBase.USE_SHA_OPTION, new NotPredicate(
                 IntrinsicPredicates.ANY_SHA_INSTRUCTION_AVAILABLE));
 
-        Asserts.assertEQ(optionName, SHAOptionsBase.USE_SHA_OPTION,
-                "Test case should be used for " + SHAOptionsBase.USE_SHA_OPTION
+        Asserts.assertEQ(optionName, DigestOptionsBase.USE_SHA_OPTION,
+                "Test case should be used for " + DigestOptionsBase.USE_SHA_OPTION
                         + " option only.");
     }
 
@@ -55,7 +55,7 @@ public class UseSHASpecificTestCaseForUnsupportedCPU
                 + " '%s' option on unsupported CPU, but there should be"
                 + "the message shown.", optionName);
         CommandLineOptionTest.verifySameJVMStartup(new String[] {
-                        SHAOptionsBase.getWarningForUnsupportedCPU(optionName)
+                        DigestOptionsBase.getWarningForUnsupportedCPU(optionName)
                 }, null, shouldPassMessage, shouldPassMessage, ExitCode.OK,
                 CommandLineOptionTest.prepareBooleanFlag(optionName, true));
     }
@@ -65,35 +65,35 @@ public class UseSHASpecificTestCaseForUnsupportedCPU
         // Verify that UseSHA option remains disabled even if all
         // UseSHA*Intrinsics were enabled.
         CommandLineOptionTest.verifyOptionValueForSameVM(
-                SHAOptionsBase.USE_SHA_OPTION, "false", String.format(
+                DigestOptionsBase.USE_SHA_OPTION, "false", String.format(
                     "%s option should be disabled on unsupported CPU"
                         + " even if all UseSHA*Intrinsics options were enabled.",
-                    SHAOptionsBase.USE_SHA_OPTION),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                    DigestOptionsBase.USE_SHA_OPTION),
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION, true),
+                        DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION, true),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION, true),
+                        DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION, true),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION, true));
+                        DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION, true));
 
         // Verify that UseSHA option remains disabled even if all
         // UseSHA*Intrinsics options were enabled and UseSHA was enabled as well.
         CommandLineOptionTest.verifyOptionValueForSameVM(
-                SHAOptionsBase.USE_SHA_OPTION, "false", String.format(
+                DigestOptionsBase.USE_SHA_OPTION, "false", String.format(
                     "%s option should be disabled on unsupported CPU"
                         + " even if all UseSHA*Intrinsics options were enabled"
                         + " and %s was enabled as well",
-                    SHAOptionsBase.USE_SHA_OPTION,
-                    SHAOptionsBase.USE_SHA_OPTION),
-                SHAOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
+                    DigestOptionsBase.USE_SHA_OPTION,
+                    DigestOptionsBase.USE_SHA_OPTION),
+                DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA_OPTION, true),
+                        DigestOptionsBase.USE_SHA_OPTION, true),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA1_INTRINSICS_OPTION, true),
+                        DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION, true),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA256_INTRINSICS_OPTION, true),
+                        DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION, true),
                 CommandLineOptionTest.prepareBooleanFlag(
-                        SHAOptionsBase.USE_SHA512_INTRINSICS_OPTION, true));
+                        DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION, true));
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/DigestSanityTestBase.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/DigestSanityTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 package compiler.intrinsics.sha.sanity;
 
-import compiler.intrinsics.sha.TestSHA;
+import compiler.intrinsics.sha.TestDigest;
 import compiler.testlibrary.intrinsics.Verifier;
 import sun.hotspot.WhiteBox;
 
@@ -36,7 +36,9 @@ import java.util.function.BooleanSupplier;
 /**
  * Base class for sanity tests on SHA intrinsics support.
  */
-public class SHASanityTestBase {
+public class DigestSanityTestBase {
+    protected static final String MD5_INTRINSIC_ID
+            = "_md5_implCompress";
     protected static final String SHA1_INTRINSIC_ID
             = "_sha_implCompress";
     protected static final String SHA256_INTRINSIC_ID
@@ -65,7 +67,7 @@ public class SHASanityTestBase {
      *                  be used.
      * @param intrinsicID The ID of the intrinsic to be tested.
      */
-    protected SHASanityTestBase(BooleanSupplier predicate, String intrinsicID) {
+    protected DigestSanityTestBase(BooleanSupplier predicate, String intrinsicID) {
         this.predicate = predicate;
         this.intrinsicID = intrinsicID;
     }
@@ -82,10 +84,10 @@ public class SHASanityTestBase {
 
         dumpProperties();
 
-        TestSHA.testSHA(SHASanityTestBase.PROVIDER, algorithm,
-                SHASanityTestBase.MSG_SIZE, SHASanityTestBase.OFFSET,
-                SHASanityTestBase.ITERATIONS,
-                SHASanityTestBase.WARMUP_ITERATIONS);
+        TestDigest.testDigest(DigestSanityTestBase.PROVIDER, algorithm,
+                DigestSanityTestBase.MSG_SIZE, DigestSanityTestBase.OFFSET,
+                DigestSanityTestBase.ITERATIONS,
+                DigestSanityTestBase.WARMUP_ITERATIONS);
     }
 
     /**
@@ -102,7 +104,7 @@ public class SHASanityTestBase {
                 String.valueOf(predicate.getAsBoolean()));
 
         String logFileName
-                = SHASanityTestBase.WHITE_BOX.getStringVMFlag("LogFile");
+                = DigestSanityTestBase.WHITE_BOX.getStringVMFlag("LogFile");
         FileOutputStream fileOutputStream = new FileOutputStream(logFileName
                 + Verifier.PROPERTY_FILE_SUFFIX);
 

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestMD5Intrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestMD5Intrinsics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,51 +24,42 @@
 /**
  * @test
  * @bug 8035968
- * @summary Verify that SHA-1 multi block intrinsic is actually used.
+ * @summary Verify that MD5 intrinsic is actually used.
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
  *                   -XX:Tier4InvocationThreshold=500
  *                   -XX:+LogCompilation -XX:LogFile=positive.log
  *                   -XX:CompileOnly=sun/security/provider/DigestBase
- *                   -XX:CompileOnly=sun/security/provider/SHA
- *                   -XX:+UseSHA1Intrinsics -XX:-UseMD5Intrinsics
- *                   -XX:-UseSHA256Intrinsics -XX:-UseSHA512Intrinsics
- *                   -Dalgorithm=SHA-1
- *                   compiler.intrinsics.sha.sanity.TestSHA1MultiBlockIntrinsics
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
- *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
- *                   -XX:Tier4InvocationThreshold=500
- *                   -XX:+LogCompilation -XX:LogFile=positive_def.log
- *                   -XX:CompileOnly=sun/security/provider/DigestBase
- *                   -XX:CompileOnly=sun/security/provider/SHA
- *                   -XX:+UseSHA1Intrinsics -Dalgorithm=SHA-1
- *                   compiler.intrinsics.sha.sanity.TestSHA1MultiBlockIntrinsics
+ *                   -XX:CompileOnly=sun/security/provider/MD5
+ *                   -XX:+UseMD5Intrinsics
+ *                   -Dalgorithm=MD5
+ *                   compiler.intrinsics.sha.sanity.TestMD5Intrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
  *                   -XX:Tier4InvocationThreshold=500
  *                   -XX:+LogCompilation -XX:LogFile=negative.log
  *                   -XX:CompileOnly=sun/security/provider/DigestBase
- *                   -XX:CompileOnly=sun/security/provider/SHA -XX:-UseSHA
- *                   -Dalgorithm=SHA-1
- *                   compiler.intrinsics.sha.sanity.TestSHA1MultiBlockIntrinsics
+ *                   -XX:CompileOnly=sun/security/provider/MD5
+ *                   -XX:-UseMD5Intrinsics
+ *                   -Dalgorithm=MD5
+ *                   compiler.intrinsics.sha.sanity.TestMD5Intrinsics
  * @run main/othervm -DverificationStrategy=VERIFY_INTRINSIC_USAGE
- *                   compiler.testlibrary.intrinsics.Verifier positive.log positive_def.log
- *                   negative.log
+ *                   compiler.testlibrary.intrinsics.Verifier positive.log negative.log
  */
 
 package compiler.intrinsics.sha.sanity;
+
 import compiler.testlibrary.sha.predicate.IntrinsicPredicates;
 
-public class TestSHA1MultiBlockIntrinsics {
+public class TestMD5Intrinsics {
     public static void main(String args[]) throws Exception {
-        new DigestSanityTestBase(IntrinsicPredicates.isSHA1IntrinsicAvailable(),
-                DigestSanityTestBase.MB_INTRINSIC_ID).test();
+        new DigestSanityTestBase(IntrinsicPredicates.isMD5IntrinsicAvailable(),
+                DigestSanityTestBase.MD5_INTRINSIC_ID).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestMD5MultiBlockIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestMD5MultiBlockIntrinsics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,40 +24,39 @@
 /**
  * @test
  * @bug 8035968
- * @summary Verify that SHA-1 multi block intrinsic is actually used.
+ * @summary Verify that MD5 multi block intrinsic is actually used.
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management
  *
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
  *                   -XX:Tier4InvocationThreshold=500
  *                   -XX:+LogCompilation -XX:LogFile=positive.log
  *                   -XX:CompileOnly=sun/security/provider/DigestBase
- *                   -XX:CompileOnly=sun/security/provider/SHA
- *                   -XX:+UseSHA1Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:CompileOnly=sun/security/provider/MD5
+ *                   -XX:+UseMD5Intrinsics -XX:-UseSHA1Intrinsics
  *                   -XX:-UseSHA256Intrinsics -XX:-UseSHA512Intrinsics
- *                   -Dalgorithm=SHA-1
- *                   compiler.intrinsics.sha.sanity.TestSHA1MultiBlockIntrinsics
+ *                   -Dalgorithm=MD5
+ *                   compiler.intrinsics.sha.sanity.TestMD5MultiBlockIntrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
  *                   -XX:Tier4InvocationThreshold=500
  *                   -XX:+LogCompilation -XX:LogFile=positive_def.log
  *                   -XX:CompileOnly=sun/security/provider/DigestBase
- *                   -XX:CompileOnly=sun/security/provider/SHA
- *                   -XX:+UseSHA1Intrinsics -Dalgorithm=SHA-1
- *                   compiler.intrinsics.sha.sanity.TestSHA1MultiBlockIntrinsics
+ *                   -XX:CompileOnly=sun/security/provider/MD5
+ *                   -XX:+UseMD5Intrinsics -Dalgorithm=MD5
+ *                   compiler.intrinsics.sha.sanity.TestMD5MultiBlockIntrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
  *                   -XX:Tier4InvocationThreshold=500
  *                   -XX:+LogCompilation -XX:LogFile=negative.log
  *                   -XX:CompileOnly=sun/security/provider/DigestBase
- *                   -XX:CompileOnly=sun/security/provider/SHA -XX:-UseSHA
- *                   -Dalgorithm=SHA-1
- *                   compiler.intrinsics.sha.sanity.TestSHA1MultiBlockIntrinsics
+ *                   -XX:CompileOnly=sun/security/provider/MD5
+ *                   -Dalgorithm=MD5
+ *                   compiler.intrinsics.sha.sanity.TestMD5MultiBlockIntrinsics
  * @run main/othervm -DverificationStrategy=VERIFY_INTRINSIC_USAGE
  *                   compiler.testlibrary.intrinsics.Verifier positive.log positive_def.log
  *                   negative.log
@@ -66,9 +65,9 @@
 package compiler.intrinsics.sha.sanity;
 import compiler.testlibrary.sha.predicate.IntrinsicPredicates;
 
-public class TestSHA1MultiBlockIntrinsics {
+public class TestMD5MultiBlockIntrinsics {
     public static void main(String args[]) throws Exception {
-        new DigestSanityTestBase(IntrinsicPredicates.isSHA1IntrinsicAvailable(),
+        new DigestSanityTestBase(IntrinsicPredicates.isMD5IntrinsicAvailable(),
                 DigestSanityTestBase.MB_INTRINSIC_ID).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA1Intrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA1Intrinsics.java
@@ -60,7 +60,7 @@ import compiler.testlibrary.sha.predicate.IntrinsicPredicates;
 
 public class TestSHA1Intrinsics {
     public static void main(String args[]) throws Exception {
-        new SHASanityTestBase(IntrinsicPredicates.isSHA1IntrinsicAvailable(),
-                SHASanityTestBase.SHA1_INTRINSIC_ID).test();
+        new DigestSanityTestBase(IntrinsicPredicates.isSHA1IntrinsicAvailable(),
+                DigestSanityTestBase.SHA1_INTRINSIC_ID).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA256Intrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA256Intrinsics.java
@@ -79,7 +79,7 @@ import compiler.testlibrary.sha.predicate.IntrinsicPredicates;
 
 public class TestSHA256Intrinsics {
     public static void main(String args[]) throws Exception {
-        new SHASanityTestBase(IntrinsicPredicates.isSHA256IntrinsicAvailable(),
-                SHASanityTestBase.SHA256_INTRINSIC_ID).test();
+        new DigestSanityTestBase(IntrinsicPredicates.isSHA256IntrinsicAvailable(),
+                DigestSanityTestBase.SHA256_INTRINSIC_ID).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA256MultiBlockIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA256MultiBlockIntrinsics.java
@@ -38,8 +38,8 @@
  *                   -XX:+LogCompilation -XX:LogFile=positive_224.log
  *                   -XX:CompileOnly=sun/security/provider/DigestBase
  *                   -XX:CompileOnly=sun/security/provider/SHA2
- *                   -XX:+UseSHA256Intrinsics -XX:-UseSHA1Intrinsics
- *                   -XX:-UseSHA512Intrinsics
+ *                   -XX:+UseSHA256Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA512Intrinsics
  *                   -Dalgorithm=SHA-224
  *                   compiler.intrinsics.sha.sanity.TestSHA256MultiBlockIntrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
@@ -64,8 +64,8 @@
  *                   -XX:+LogCompilation -XX:LogFile=positive_256.log
  *                   -XX:CompileOnly=sun/security/provider/DigestBase
  *                   -XX:CompileOnly=sun/security/provider/SHA2
- *                   -XX:+UseSHA256Intrinsics -XX:-UseSHA1Intrinsics
- *                   -XX:-UseSHA512Intrinsics
+ *                   -XX:+UseSHA256Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA512Intrinsics
  *                   -Dalgorithm=SHA-256
  *                   compiler.intrinsics.sha.sanity.TestSHA256MultiBlockIntrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
@@ -95,7 +95,7 @@ import compiler.testlibrary.sha.predicate.IntrinsicPredicates;
 
 public class TestSHA256MultiBlockIntrinsics {
     public static void main(String args[]) throws Exception {
-        new SHASanityTestBase(IntrinsicPredicates.isSHA256IntrinsicAvailable(),
-                SHASanityTestBase.MB_INTRINSIC_ID).test();
+        new DigestSanityTestBase(IntrinsicPredicates.isSHA256IntrinsicAvailable(),
+                DigestSanityTestBase.MB_INTRINSIC_ID).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA512Intrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA512Intrinsics.java
@@ -79,7 +79,7 @@ import compiler.testlibrary.sha.predicate.IntrinsicPredicates;
 
 public class TestSHA512Intrinsics {
     public static void main(String args[]) throws Exception {
-        new SHASanityTestBase(IntrinsicPredicates.isSHA512IntrinsicAvailable(),
-                SHASanityTestBase.SHA512_INTRINSIC_ID).test();
+        new DigestSanityTestBase(IntrinsicPredicates.isSHA512IntrinsicAvailable(),
+                DigestSanityTestBase.SHA512_INTRINSIC_ID).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA512MultiBlockIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA512MultiBlockIntrinsics.java
@@ -38,8 +38,8 @@
  *                   -XX:+LogCompilation -XX:LogFile=positive_384.log
  *                   -XX:CompileOnly=sun/security/provider/DigestBase
  *                   -XX:CompileOnly=sun/security/provider/SHA5
- *                   -XX:+UseSHA512Intrinsics -XX:-UseSHA1Intrinsics
- *                   -XX:-UseSHA256Intrinsics
+ *                   -XX:+UseSHA512Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
  *                   -Dalgorithm=SHA-384
  *                   compiler.intrinsics.sha.sanity.TestSHA512MultiBlockIntrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
@@ -64,8 +64,8 @@
  *                   -XX:+LogCompilation -XX:LogFile=positive_512.log
  *                   -XX:CompileOnly=sun/security/provider/DigestBase
  *                   -XX:CompileOnly=sun/security/provider/SHA5
- *                   -XX:+UseSHA512Intrinsics -XX:-UseSHA1Intrinsics
- *                   -XX:-UseSHA256Intrinsics
+ *                   -XX:+UseSHA512Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
  *                   -Dalgorithm=SHA-512
  *                   compiler.intrinsics.sha.sanity.TestSHA512MultiBlockIntrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
@@ -96,7 +96,7 @@ import compiler.testlibrary.sha.predicate.IntrinsicPredicates;
 
 public class TestSHA512MultiBlockIntrinsics {
     public static void main(String args[]) throws Exception {
-        new SHASanityTestBase(IntrinsicPredicates.isSHA512IntrinsicAvailable(),
-                SHASanityTestBase.MB_INTRINSIC_ID).test();
+        new DigestSanityTestBase(IntrinsicPredicates.isSHA512IntrinsicAvailable(),
+                DigestSanityTestBase.MB_INTRINSIC_ID).test();
     }
 }

--- a/test/hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java
+++ b/test/hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java
@@ -59,6 +59,12 @@ public class IntrinsicPredicates {
         return Platform.isServer() && !Platform.isEmulatedClient() && (!isTiered || maxLevelIsReachable);
     };
 
+    public static final BooleanSupplier MD5_INSTRUCTION_AVAILABLE
+            = // x86 variants
+              new OrPredicate(new CPUSpecificPredicate("amd64.*",   null, null),
+              new OrPredicate(new CPUSpecificPredicate("i386.*",    null, null),
+                              new CPUSpecificPredicate("x86.*",     null, null)));
+
     public static final BooleanSupplier SHA1_INSTRUCTION_AVAILABLE
             = new OrPredicate(new CPUSpecificPredicate("aarch64.*", new String[] { "sha1" }, null),
               new OrPredicate(new CPUSpecificPredicate("s390.*",    new String[] { "sha1" }, null),
@@ -99,6 +105,11 @@ public class IntrinsicPredicates {
                     new OrPredicate(
                             IntrinsicPredicates.SHA256_INSTRUCTION_AVAILABLE,
                             IntrinsicPredicates.SHA512_INSTRUCTION_AVAILABLE));
+
+    public static BooleanSupplier isMD5IntrinsicAvailable() {
+        return new AndPredicate(IntrinsicPredicates.COMPILABLE_BY_C2,
+                                IntrinsicPredicates.isIntrinsicAvailable("sun.security.provider.MD5", "implCompress0"));
+    }
 
     public static BooleanSupplier isSHA1IntrinsicAvailable() {
         return new AndPredicate(IntrinsicPredicates.COMPILABLE_BY_C2,


### PR DESCRIPTION
I'd like to backport MD5 intrinsification because it improves security related performance. I understand that it may be a bridge too far for 11u. In that case we (Amazon) intend to backport it to our internal 11u distro followed by Corretto.

Testing: tier1, including the new and existing sha tests.

Ludovic Henry did an 11u backport in 2020 (see [JDK-8251319](https://bugs.openjdk.java.net/browse/JDK-8251319)), but I can't find a review request on the jdk-updates-dev list. My backport is essentially identical to his, and is based on the [backport from jdk15u](https://github.com/openjdk/jdk15u-dev/pull/163). It was not clean.

1. Copyright date conflicts.
2. Context differences.
3. Changing SHAOptionsBase to DigestOptionsBase.
4. Rewriting Assembler::roll() to use emit_int8() because emit_int16() and emit_24() don't exist in 11.

This backport would be immediately followed by a backport of [JDK-8251260](https://bugs.openjdk.java.net/browse/JDK-8251260) to fix two tests. After that, I'd like to backport the aarch64 version in [JDK-8251216](https://bugs.openjdk.java.net/browse/JDK-8251216).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250902](https://bugs.openjdk.java.net/browse/JDK-8250902): Implement MD5 Intrinsics on x86


### Reviewers
 * [Bernhard Urban-Forster](https://openjdk.java.net/census#burban) (@lewurm - no project role) ⚠️ Review applies to 9fd44b55633b20c7586c10326d105c418a915b38
 * [Ludovic Henry](https://openjdk.java.net/census#luhenry) (@luhenry - no project role) ⚠️ Review applies to 9fd44b55633b20c7586c10326d105c418a915b38
 * [Volker Simonis](https://openjdk.java.net/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/806/head:pull/806` \
`$ git checkout pull/806`

Update a local copy of the PR: \
`$ git checkout pull/806` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 806`

View PR using the GUI difftool: \
`$ git pr show -t 806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/806.diff">https://git.openjdk.java.net/jdk11u-dev/pull/806.diff</a>

</details>
