### PR TITLE
8264650: Cross-compilation to macos/aarch64

### DIFF
--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -258,6 +258,14 @@ AC_DEFUN_ONCE([FLAGS_PRE_TOOLCHAIN],
     fi
   fi
 
+  if test "x$OPENJDK_TARGET_OS" = xmacosx; then
+    if test "x$OPENJDK_TARGET_CPU" = xaarch64; then
+      MACHINE_FLAG="$MACHINE_FLAG -arch arm64"
+    elif test "x$OPENJDK_TARGET_CPU" = xx86_64; then
+      MACHINE_FLAG="$MACHINE_FLAG -arch x86_64"
+    fi
+  fi
+
   # FIXME: global flags are not used yet...
   # The "global" flags will *always* be set. Without them, it is not possible to
   # get a working compilation.


### PR DESCRIPTION
Clean backport, to be done in advance of jep-391 backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8264650](https://bugs.openjdk.java.net/browse/JDK-8264650): Cross-compilation to macos/aarch64


### Reviewers
 * [Bernhard Urban-Forster](https://openjdk.java.net/census#burban) (@lewurm - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/807/head:pull/807` \
`$ git checkout pull/807`

Update a local copy of the PR: \
`$ git checkout pull/807` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 807`

View PR using the GUI difftool: \
`$ git pr show -t 807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/807.diff">https://git.openjdk.java.net/jdk11u-dev/pull/807.diff</a>

</details>
