### PR TITLE
8216969: ParseException thrown for certain months with russian locale

### DIFF
--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1189,7 +1189,7 @@ public class SimpleDateFormat extends DateFormat {
             }
             break;
 
-        case PATTERN_MONTH:            // 'M' (context seinsive)
+        case PATTERN_MONTH:            // 'M' (context sensitive)
             if (useDateFormatSymbols) {
                 String[] months;
                 if (count >= 4) {
@@ -2033,7 +2033,7 @@ public class SimpleDateFormat extends DateFormat {
                         return index;
                     }
                 } else {
-                    Map<String, Integer> map = getDisplayNamesMap(field, locale);
+                    Map<String, Integer> map = getDisplayContextNamesMap(field, locale);
                     if ((index = matchString(text, start, field, map, calb)) > 0) {
                         return index;
                     }
@@ -2445,6 +2445,22 @@ public class SimpleDateFormat extends DateFormat {
             if (m != null) {
                 map.putAll(m);
             }
+        }
+        return map;
+    }
+
+    /**
+     * Obtains display names map, taking the context into account. Currently only
+     * the month name pattern 'M' is context dependent.
+     */
+    private Map<String, Integer> getDisplayContextNamesMap(int field, Locale locale) {
+        Map<String, Integer> map = calendar.getDisplayNames(field,
+            forceStandaloneForm ? Calendar.SHORT_STANDALONE : Calendar.SHORT_FORMAT, locale);
+        // Get the LONG style
+        Map<String, Integer> m = calendar.getDisplayNames(field,
+            forceStandaloneForm ? Calendar.LONG_STANDALONE : Calendar.LONG_FORMAT, locale);
+        if (m != null) {
+            map.putAll(m);
         }
         return map;
     }

--- a/test/jdk/java/text/Format/DateFormat/DateFormatTest.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 4052223 4089987 4469904 4326988 4486735 8008577 8045998 8140571
+ *      8216969
  * @summary test DateFormat and SimpleDateFormat.
  * @library /java/text/testlib
  * @modules jdk.localedata
@@ -1204,5 +1205,19 @@ test commented out pending API-change approval
             // Restore the initial time zone
             TimeZone.setDefault(initialTimeZone);
         }
+    }
+
+    public void Test8216969() throws Exception {
+        Locale locale = new Locale("ru");
+        String format = "\u0434\u0435\u043a";
+        String standalone = "\u0434\u0435\u043a.";
+
+        // Check that format form is used so that the dot is parsed correctly.
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd MMM.yyyy", locale);
+        System.out.println(simpleDateFormat.parse("28 " + format + ".2018"));
+
+        // Check that standalone form is used.
+        simpleDateFormat = new SimpleDateFormat("MMM", locale);
+        System.out.println(simpleDateFormat.parse(standalone));
     }
 }


### PR DESCRIPTION
I think this is a useful, safe fix for 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8216969](https://bugs.openjdk.java.net/browse/JDK-8216969): ParseException thrown for certain months with russian locale


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/809/head:pull/809` \
`$ git checkout pull/809`

Update a local copy of the PR: \
`$ git checkout pull/809` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 809`

View PR using the GUI difftool: \
`$ git pr show -t 809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/809.diff">https://git.openjdk.java.net/jdk11u-dev/pull/809.diff</a>

</details>
