### PR TITLE
8241004: NMT tests fail on unaligned thread size with debug build

### DIFF
--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -535,15 +535,21 @@ public:
       address committed_start;
       size_t  committed_size;
       size_t stack_size = rgn->base() + rgn->size() - stack_bottom;
+      // Align the size to work with full pages (Alpine and AIX stack top is not page aligned)
+      size_t aligned_stack_size = align_up(stack_size, os::vm_page_size());
 
       ReservedMemoryRegion* region = const_cast<ReservedMemoryRegion*>(rgn);
       NativeCallStack ncs; // empty stack
 
-      RegionIterator itr(stack_bottom, stack_size);
+      RegionIterator itr(stack_bottom, aligned_stack_size);
       DEBUG_ONLY(bool found_stack = false;)
       while (itr.next_committed(committed_start, committed_size)) {
         assert(committed_start != NULL, "Should not be null");
         assert(committed_size > 0, "Should not be 0");
+        // unaligned stack_size case: correct the region to fit the actual stack_size
+        if (stack_bottom + stack_size < committed_start + committed_size) {
+          committed_size = stack_bottom + stack_size - committed_start;
+        }
         region->add_committed_region(committed_start, committed_size, ncs);
         DEBUG_ONLY(found_stack = true;)
       }


### PR DESCRIPTION
Backport of [JDK-8241004](https://bugs.openjdk.java.net/browse/JDK-8241004). Applies cleanly.

This is will prevent hotspot runtime/NMT test failures on mac-aarch64. See issue 2 in this comment for more context: https://github.com/openjdk/jdk11u-dev/pull/715#issuecomment-1020401252

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8241004](https://bugs.openjdk.java.net/browse/JDK-8241004): NMT tests fail on unaligned thread size with debug build


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/812/head:pull/812` \
`$ git checkout pull/812`

Update a local copy of the PR: \
`$ git checkout pull/812` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 812`

View PR using the GUI difftool: \
`$ git pr show -t 812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/812.diff">https://git.openjdk.java.net/jdk11u-dev/pull/812.diff</a>

</details>
