### PR TITLE
8281520: JFR: A wrong parameter is passed to the constructor of LeakKlassWriter

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -385,7 +385,7 @@ static bool write_klasses() {
     _subsystem_callback = &callback;
     do_klasses();
   } else {
-    LeakKlassWriter lkw(_leakp_writer, _artifacts, _class_unload);
+    LeakKlassWriter lkw(_leakp_writer, _class_unload);
     CompositeKlassWriter ckw(&lkw, &kw);
     CompositeKlassWriterRegistration ckwr(&ckw, &reg);
     CompositeKlassCallback callback(&ckwr);


### PR DESCRIPTION
Hi team,

Could I have a review of this fix?

The following code(jfrTypeSet.cpp:L388) passes a wrong parameter `_artifacts` to the constructor of LeakKlassWriter:
```
 387 } else {
 388 LeakKlassWriter lkw(_leakp_writer, _artifacts, _class_unload);
 389 CompositeKlassWriter ckw(&lkw, &kw);
 390 CompositeKlassWriterRegistration ckwr(&ckw, &reg);
 391 CompositeKlassCallback callback(&ckwr);
 392 _subsystem_callback = &callback;
 393 do_klasses();
 394 }
```

This problem is introduced by JDK-8225797 and fixed by JDK-8233111.

I filed a new issue to fix it since I think backporting JDK-8233111 is not necessary for the moment.

testing: test/jdk/jdk/jfr

Thanks,
Denghui

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281520](https://bugs.openjdk.java.net/browse/JDK-8281520): JFR: A wrong parameter is passed to the constructor of LeakKlassWriter


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/813/head:pull/813` \
`$ git checkout pull/813`

Update a local copy of the PR: \
`$ git checkout pull/813` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 813`

View PR using the GUI difftool: \
`$ git pr show -t 813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/813.diff">https://git.openjdk.java.net/jdk11u-dev/pull/813.diff</a>

</details>
