### PR TITLE
8279076: C2: Bad AD file when matching SqrtF with UseSSE=0

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1491,6 +1491,16 @@ const bool Matcher::match_rule_supported(int opcode) {
       if (UseSSE < 4)
         ret_value = false;
       break;
+    case Op_SqrtF:
+      if (UseSSE < 1) {
+        return false;
+      }
+      break;
+    case Op_SqrtD:
+      if (UseSSE < 2) {
+        return false;
+      }
+      break;
   }
 
   return ret_value;  // Per default match rules are supported.

--- a/test/hotspot/jtreg/compiler/c2/TestSqrt.java
+++ b/test/hotspot/jtreg/compiler/c2/TestSqrt.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2;
+
+/*
+ * @test
+ * @bug 8279076
+ * @summary SqrtD/SqrtF should be matched only on supported platforms
+ * @requires vm.debug
+ *
+ * @run main/othervm -XX:-TieredCompilation -Xcomp
+ *                   -XX:CompileOnly=compiler/c2/TestSqrt
+ *                   -XX:CompileOnly=java/lang/Math
+ *                   compiler.c2.TestSqrt
+ */
+public class TestSqrt {
+    static float srcF = 42.0f;
+    static double srcD = 42.0d;
+    static float dstF;
+    static double dstD;
+
+    public static void test() {
+        dstF = (float)Math.sqrt((double)srcF);
+        dstD = Math.sqrt(srcD);
+    }
+
+    public static void main(String args[]) {
+        for (int i = 0; i < 20_000; i++) {
+            test();
+        }
+    }
+}
+


### PR DESCRIPTION
Unclean backport to fix the x86_32 problem. It is not clean, because Panama is not in 11u, so context in `.ad` is different.

Additional testing:
 - [x] Linux x86_32 fails new test without the fix, passes with it

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279076](https://bugs.openjdk.java.net/browse/JDK-8279076): C2: Bad AD file when matching SqrtF with UseSSE=0


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/819/head:pull/819` \
`$ git checkout pull/819`

Update a local copy of the PR: \
`$ git checkout pull/819` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 819`

View PR using the GUI difftool: \
`$ git pr show -t 819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/819.diff">https://git.openjdk.java.net/jdk11u-dev/pull/819.diff</a>

</details>
