### PR TITLE
8276141: XPathFactory set/getProperty method

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathFactoryImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathFactoryImpl.java
@@ -305,4 +305,38 @@ public  class XPathFactoryImpl extends XPathFactory {
 
                 xPathVariableResolver = resolver;
         }
+
+    @Override
+    public void setProperty(String name, String value) {
+        // property name cannot be null
+        if (name == null) {
+            String fmsg = XSLMessages.createXPATHMessage(
+                    XPATHErrorResources.ER_PROPERTY_NAME_NULL,
+                    new Object[] {CLASS_NAME,  value} );
+            throw new NullPointerException(fmsg);
+         }
+
+        // property name not recognized
+        String fmsg = XSLMessages.createXPATHMessage(
+                XPATHErrorResources.ER_PROPERTY_UNKNOWN,
+                new Object[] {name, CLASS_NAME, value} );
+        throw new IllegalArgumentException(fmsg);
+    }
+
+    @Override
+    public String getProperty(String name) {
+        // property name cannot be null
+        if (name == null) {
+            String fmsg = XSLMessages.createXPATHMessage(
+                    XPATHErrorResources.ER_GETTING_NULL_PROPERTY,
+                    new Object[] {CLASS_NAME} );
+            throw new NullPointerException(fmsg);
+        }
+
+        // unknown property
+        String fmsg = XSLMessages.createXPATHMessage(
+                XPATHErrorResources.ER_GETTING_UNKNOWN_PROPERTY,
+                new Object[] {name, CLASS_NAME} );
+        throw new IllegalArgumentException(fmsg);
+    }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/res/XPATHErrorResources.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/res/XPATHErrorResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -31,7 +31,7 @@ import java.util.ListResourceBundle;
   * Also you need to  update the count of messages(MAX_CODE)or
  * the count of warnings(MAX_WARNING) [ Information purpose only]
  * @xsl.usage advanced
- * @LastModified: May 2019
+ * @LastModified: Nov 2021
  */
 public class XPATHErrorResources extends ListResourceBundle
 {
@@ -322,6 +322,10 @@ public static final String ER_IGNORABLE_WHITESPACE_NOT_HANDLED =
   public static final String ER_SECUREPROCESSING_FEATURE = "ER_SECUREPROCESSING_FEATURE";
   public static final String ER_NULL_XPATH_FUNCTION_RESOLVER = "ER_NULL_XPATH_FUNCTION_RESOLVER";
   public static final String ER_NULL_XPATH_VARIABLE_RESOLVER = "ER_NULL_XPATH_VARIABLE_RESOLVER";
+  public static final String ER_PROPERTY_NAME_NULL = "ER_PROPERTY_NAME_NULL";
+  public static final String ER_PROPERTY_UNKNOWN = "ER_PROPERTY_UNKNOWN";
+  public static final String ER_GETTING_NULL_PROPERTY = "ER_GETTING_NULL_PROPERTY";
+  public static final String ER_GETTING_UNKNOWN_PROPERTY = "ER_GETTING_UNKNOWN_PROPERTY";
   //END: Keys needed for exception messages of  JAXP 1.3 XPath API implementation
 
   public static final String WG_LOCALE_NAME_NOT_HANDLED =
@@ -835,6 +839,26 @@ public static final String ER_IGNORABLE_WHITESPACE_NOT_HANDLED =
 
   { ER_NULL_XPATH_VARIABLE_RESOLVER,
        "Attempting to set a null XPathVariableResolver:{0}#setXPathVariableResolver(null)"},
+
+  /** Field ER_PROPERTY_NAME_NULL                       */
+
+  { ER_PROPERTY_NAME_NULL,
+       "Trying to set a property with a null name: {0}#setProperty( null, {1})"},
+
+  /** Field ER_PROPERTY_UNKNOWN                       */
+
+  { ER_PROPERTY_UNKNOWN,
+       "Trying to set the unknown property \"{0}\":{1}#setProperty({0},{2})"},
+
+  /** Field ER_GETTING_NULL_PROPERTY                       */
+
+  { ER_GETTING_NULL_PROPERTY,
+       "Trying to get a property with a null name: {0}#getProperty(null)"},
+
+  /** Field ER_GETTING_NULL_PROPERTY                       */
+
+  { ER_GETTING_UNKNOWN_PROPERTY,
+       "Trying to get the unknown property \"{0}\":{1}#getProperty({0})"},
 
   //END:  Definitions of error keys used  in exception messages of  JAXP 1.3 XPath API implementation
 

--- a/src/java.xml/share/classes/javax/xml/xpath/XPathFactory.java
+++ b/src/java.xml/share/classes/javax/xml/xpath/XPathFactory.java
@@ -326,8 +326,9 @@ public abstract class XPathFactory {
     public abstract boolean isObjectModelSupported(String objectModel);
 
     /**
-     * <p>Set a feature for this {@code XPathFactory} and
-     * <code>XPath</code>s created by this factory.</p>
+     * Sets a feature for this {@code XPathFactory}. The feature applies to
+     * {@code XPath} objects that the {@code XPathFactory} creates. It has no
+     * impact on {@code XPath} objects that are already created.
      *
      * <p>
      * Feature names are fully qualified {@link java.net.URI}s.
@@ -420,4 +421,60 @@ public abstract class XPathFactory {
     * @return New instance of an <code>XPath</code>.
     */
     public abstract XPath newXPath();
+
+    /**
+     * Sets a property for this {@code XPathFactory}. The property applies to
+     * {@code XPath} objects that the {@code XPathFactory} creates. It has no
+     * impact on {@code XPath} objects that are already created.
+     * <p>
+     * A property can either be defined in this {@code XPathFactory}, or by the
+     * underlying implementation.
+     *
+     * @implSpec
+     * The default implementation throws
+     * {@link java.lang.UnsupportedOperationException}.
+     *
+     * @param name the property name
+     * @param value the value for the property
+     *
+     * @throws IllegalArgumentException if the property name is not recognized,
+     * or the value can not be assigned
+     * @throws UnsupportedOperationException if the implementation does not
+     * support the method
+     * @throws NullPointerException if the {@code name} is {@code null}
+     *
+     * @since 18
+     */
+    public void setProperty(String name, String value) {
+
+        if (name == null) {
+            throw new NullPointerException("the name parameter is null");
+        }
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    /**
+     * Returns the value of the specified property.
+     *
+     * @implSpec
+     * The default implementation throws
+     * {@link java.lang.UnsupportedOperationException}.
+     *
+     * @param name the property name
+     * @return the value of the property.
+     *
+     * @throws IllegalArgumentException if the property name is not recognized
+     * @throws UnsupportedOperationException if the implementation does not
+     * support the method
+     * @throws NullPointerException if the {@code name} is {@code null}
+     *
+     * @since 18
+     */
+    public String getProperty(String name) {
+
+        if (name == null) {
+            throw new NullPointerException("the name parameter is null");
+        }
+        throw new UnsupportedOperationException("not implemented");
+    }
 }

--- a/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathFactoryDummyImpl.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathFactoryDummyImpl.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package xpath;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathFactoryConfigurationException;
+import javax.xml.xpath.XPathFunctionResolver;
+import javax.xml.xpath.XPathVariableResolver;
+
+/**
+ * A dummy implementation of the XPathFactory without implementing
+ * the setProperty/getProperty methods
+ */
+public class XPathFactoryDummyImpl extends XPathFactory {
+
+    @Override
+        public boolean isObjectModelSupported(String objectModel) {
+            // support the default object model, W3C DOM
+            if (objectModel.equals(XPathFactory.DEFAULT_OBJECT_MODEL_URI)) {
+                return true;
+            }
+
+            // no support
+            return false;
+        }
+
+
+    @Override
+    public void setFeature(String name, boolean value) throws XPathFactoryConfigurationException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public boolean getFeature(String name) throws XPathFactoryConfigurationException {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void setXPathVariableResolver(XPathVariableResolver resolver) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void setXPathFunctionResolver(XPathFunctionResolver resolver) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public XPath newXPath() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+}

--- a/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathTest.java
@@ -101,7 +101,7 @@ public class XPathTest {
             throws Exception {
         xpf.getProperty(name);
     }
- 
+
     /*
       @bug 6211561
      * Verifies the specification for XPath and XPathExpression:

--- a/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,23 +30,78 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
 /*
  * @test
- * @bug 6376058
- * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
- * @run testng/othervm -DrunSecMngr=true xpath.XPathTest
+ * @bug 6376058 8276141
+ * @build xpath.XPathTest xpath.XPathFactoryDummyImpl
  * @run testng/othervm xpath.XPathTest
  * @summary Test XPath functions. See details for each test.
  */
-@Listeners({jaxp.library.BasePolicy.class})
 public class XPathTest {
+    /*
+     * DataProvider for testXPathFactory
+     */
+    @DataProvider(name = "xpath")
+    public Object[][] getXPathFactory() throws Exception {
+        return new Object[][]{
+            {null},
+            {"xpath.XPathFactoryDummyImpl"},
+        };
+    }
 
+    /*
+     * @bug 8276141
+     * Tests the setProperty/getProperty method for the XPathFactory.
+    */
+    @Test(dataProvider = "xpath")
+    public void testXPathFactory(String factoryName)
+            throws Exception {
+
+        XPathFactory xpf;
+        if (factoryName == null) {
+            xpf = XPathFactory.newInstance();
+        } else {
+            xpf = XPathFactory.newInstance(
+                XPathFactory.DEFAULT_OBJECT_MODEL_URI, factoryName, null);
+        }
+
+        // NPE
+        Assert.assertThrows(NullPointerException.class,
+                () -> setProperty(xpf, null, "value"));
+        Assert.assertThrows(NullPointerException.class,
+                () -> getProperty(xpf, null));
+
+        if (factoryName == null) {
+            // default factory impl
+            Assert.assertThrows(IllegalArgumentException.class,
+                    () -> setProperty(xpf, "unknown", "value"));
+            Assert.assertThrows(IllegalArgumentException.class,
+                    () -> getProperty(xpf, "unknown"));
+        } else {
+            // the DummyImpl does not implement the method
+            Assert.assertThrows(UnsupportedOperationException.class,
+                    () -> setProperty(xpf, "unknown", "value"));
+            Assert.assertThrows(UnsupportedOperationException.class,
+                    () -> getProperty(xpf, "unknown"));
+        }
+    }
+
+    private void setProperty(XPathFactory xpf, String name, String value)
+            throws Exception {
+        xpf.setProperty(name, value);
+    }
+
+    private void getProperty(XPathFactory xpf, String name)
+            throws Exception {
+        xpf.getProperty(name);
+    }
+ 
     /*
       @bug 6211561
      * Verifies the specification for XPath and XPathExpression:


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

I had to do two straight forward fixes:
XPathFactoryImpl Tag @LastModified is adapted in head but does not exist in 11.
XPathTest.java A larger hunk did not apply. Simple to patch by hand.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8276141](https://bugs.openjdk.java.net/browse/JDK-8276141): XPathFactory set/getProperty method
 * [JDK-8276143](https://bugs.openjdk.java.net/browse/JDK-8276143): Add XPathFactory setProperty and getProperty methods (**CSR**)


### Reviewers
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/828/head:pull/828` \
`$ git checkout pull/828`

Update a local copy of the PR: \
`$ git checkout pull/828` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 828`

View PR using the GUI difftool: \
`$ git pr show -t 828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/828.diff">https://git.openjdk.java.net/jdk11u-dev/pull/828.diff</a>

</details>
