### PR TITLE
8254085: javax/swing/text/Caret/TestCaretPositionJTextPane.java failed with "RuntimeException:  Wrong caret position"

### DIFF
--- a/test/jdk/javax/swing/text/Caret/TestCaretPositionJTextPane.java
+++ b/test/jdk/javax/swing/text/Caret/TestCaretPositionJTextPane.java
@@ -98,7 +98,7 @@ public class TestCaretPositionJTextPane {
 
             robot.waitForIdle();
             Point p = textPane.getLocationOnScreen();
-            robot.mouseMove(p.x+ 480, p.y+6);
+            robot.mouseMove(p.x+ 380, p.y+6);
             robot.waitForIdle();
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();


### PR DESCRIPTION
This is a backport of JDK-8254085:javax/swing/text/Caret/TestCaretPositionJTextPane.java failed with "RuntimeException: Wrong caret position"
TestCaretPositionJTextPane.java fails also in jdk11, so needs to be fixed. 
 
This is a clean backport to 11u. I confirmed this test passed after this backport.　
Testing: 
  build on Windows x86_64 and Linux x86_64
  tier1 on Windows x86_64 and Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8254085](https://bugs.openjdk.java.net/browse/JDK-8254085): javax/swing/text/Caret/TestCaretPositionJTextPane.java failed with "RuntimeException:  Wrong caret position"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/829/head:pull/829` \
`$ git checkout pull/829`

Update a local copy of the PR: \
`$ git checkout pull/829` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 829`

View PR using the GUI difftool: \
`$ git pr show -t 829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/829.diff">https://git.openjdk.java.net/jdk11u-dev/pull/829.diff</a>

</details>
