### PR TITLE
8233986: ProblemList javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java for windows-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -682,7 +682,7 @@ javax/sound/midi/Sequencer/MetaCallback.java 8178698 linux-all,solaris-all
 
 # jdk_swing
 
-javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 8233177 linux-all
+javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 8233177 linux-all,windows-all
 
 javax/swing/JComponent/7154030/bug7154030.java 7190978 generic-all
 javax/swing/JComboBox/ConsumedKeyTest/ConsumedKeyTest.java 8067986 generic-all
@@ -721,7 +721,6 @@ javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all
 javax/swing/JTabbedPane/4624207/bug4624207.java 8064922 macosx-all
 javax/swing/JTabbedPane/7024235/Test7024235.java 8028281 macosx-all
 javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java 8160720 generic-all
-javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 8196098 windows-all
 javax/swing/plaf/basic/Test6984643.java 8198340 windows-all
 javax/swing/text/CSSBorder/6796710/bug6796710.java 8196099 windows-all
 javax/swing/text/DefaultCaret/HidingSelection/HidingSelectionTest.java 8194048 windows-all


### PR DESCRIPTION
I would like to backport
JDK-8233986: ProblemList javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java
JDK-8213181: Updation of ProblemList.txt for removal of passing swing test (dependency)

Original patches do not apply cleanly to 11u.

I resolved a conflict and applied only the relevant parts of JDK-8213181 related to bug8001470.java.
The purpose of these backports is to exclude javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java on both Linux and Windows OS. The current ProblemList.txt has two lines containing the test and the first line is ignored. 
As a result, the test runs on the Linux OS unexpectedly.

Testing:
tier1 on Windows x86_64 and Linux x86_64
Verify that javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java does not run on Linux OS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8233986](https://bugs.openjdk.java.net/browse/JDK-8233986): ProblemList javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java for windows-x64 ⚠️ Issue is not open.


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/830/head:pull/830` \
`$ git checkout pull/830`

Update a local copy of the PR: \
`$ git checkout pull/830` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 830`

View PR using the GUI difftool: \
`$ git pr show -t 830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/830.diff">https://git.openjdk.java.net/jdk11u-dev/pull/830.diff</a>

</details>
