### PR TITLE
8247272: SA ELF file support has never worked for 64-bit causing address to symbol name mapping to fail

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/posix/elf/ELFSectionHeader.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/posix/elf/ELFSectionHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,5 +117,5 @@ public interface ELFSectionHeader {
     /** Returns the name of the section or null if the section has no name. */
     public String getName();
     /** Returns the offset in bytes to the beginning of the section. */
-    public int getOffset();
+    public long getOffset();
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/posix/elf/ELFSymbol.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/posix/elf/ELFSymbol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,5 +73,5 @@ public interface ELFSymbol {
 
     /** Size of the symbol.  0 if the symbol has no size or the size
      * is unknown. */
-    public int getSize();
+    public long getSize();
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8247272](https://bugs.openjdk.java.net/browse/JDK-8247272): SA ELF file support has never worked for 64-bit causing address to symbol name mapping to fail


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/833/head:pull/833` \
`$ git checkout pull/833`

Update a local copy of the PR: \
`$ git checkout pull/833` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 833`

View PR using the GUI difftool: \
`$ git pr show -t 833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/833.diff">https://git.openjdk.java.net/jdk11u-dev/pull/833.diff</a>

</details>
