### PR TITLE
8279669: test/jdk/com/sun/jdi/TestScaffold.java uses wrong condition

### DIFF
--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -535,9 +535,10 @@ abstract public class TestScaffold extends TargetAdapter {
                         Location loc = ((Locatable)event).location();
                         ReferenceType rt = loc.declaringType();
                         String name = rt.name();
-                        if (name.startsWith("java.") &&
-                                       !name.startsWith("sun.") &&
-                                       !name.startsWith("com.")) {
+                        if (name.startsWith("java.")
+                            || name.startsWith("sun.")
+                            || name.startsWith("com.")
+                            || name.startsWith("jdk.")) {
                             if (mainStartClass != null) {
                                 redefine(mainStartClass);
                             }


### PR DESCRIPTION
Tested locally passed tests in test/jdk/com/sun/jdi for me.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279669](https://bugs.openjdk.java.net/browse/JDK-8279669): test/jdk/com/sun/jdi/TestScaffold.java uses wrong condition


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/837/head:pull/837` \
`$ git checkout pull/837`

Update a local copy of the PR: \
`$ git checkout pull/837` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 837`

View PR using the GUI difftool: \
`$ git pr show -t 837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/837.diff">https://git.openjdk.java.net/jdk11u-dev/pull/837.diff</a>

</details>
