### PR TITLE
8250750: JDK-8247515 fix for OSX pc_to_symbol() lookup fails with some symbols

### DIFF
--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/libproc_impl.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/libproc_impl.c
@@ -208,12 +208,12 @@ void Prelease(struct ps_prochandle* ph) {
   free(ph);
 }
 
-lib_info* add_lib_info(struct ps_prochandle* ph, const char* libname, uintptr_t base, size_t memsz) {
-  return add_lib_info_fd(ph, libname, -1, base, memsz);
+lib_info* add_lib_info(struct ps_prochandle* ph, const char* libname, uintptr_t base) {
+  return add_lib_info_fd(ph, libname, -1, base);
 }
 
-lib_info* add_lib_info_fd(struct ps_prochandle* ph, const char* libname, int fd, uintptr_t base, size_t memsz) {
-   lib_info* newlib;
+lib_info* add_lib_info_fd(struct ps_prochandle* ph, const char* libname, int fd, uintptr_t base) {
+  lib_info* newlib;
   print_debug("add_lib_info_fd %s\n", libname);
 
   if ( (newlib = (lib_info*) calloc(1, sizeof(struct lib_info))) == NULL) {
@@ -229,7 +229,6 @@ lib_info* add_lib_info_fd(struct ps_prochandle* ph, const char* libname, int fd,
   strcpy(newlib->name, libname);
 
   newlib->base = base;
-  newlib->memsz = memsz;
 
   if (fd == -1) {
     if ( (newlib->fd = pathmap_open(newlib->name)) < 0) {
@@ -259,11 +258,11 @@ lib_info* add_lib_info_fd(struct ps_prochandle* ph, const char* libname, int fd,
   }
 #endif // __APPLE__
 
-  newlib->symtab = build_symtab(newlib->fd);
+  newlib->symtab = build_symtab(newlib->fd, &newlib->memsz);
   if (newlib->symtab == NULL) {
     print_debug("symbol table build failed for %s\n", newlib->name);
   } else {
-    print_debug("built symbol table for 0x%lx %s\n", newlib, newlib->name);
+    print_debug("built symbol table for 0x%lx memsz=0x%lx %s\n", newlib, newlib->memsz, newlib->name);
   }
 
   // even if symbol table building fails, we add the lib_info.

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/libproc_impl.h
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/libproc_impl.h
@@ -47,6 +47,7 @@
 #include <mach-o/loader.h>
 #include <mach-o/nlist.h>
 #include <mach-o/fat.h>
+#include <mach-o/stab.h>
 
 #ifndef register_t
 #define register_t uint64_t
@@ -225,11 +226,10 @@ typedef bool (*thread_info_callback)(struct ps_prochandle* ph, pthread_t pid, lw
 bool read_thread_info(struct ps_prochandle* ph, thread_info_callback cb);
 
 // adds a new shared object to lib list, returns NULL on failure
-lib_info* add_lib_info(struct ps_prochandle* ph, const char* libname, uintptr_t base, size_t memsz);
+lib_info* add_lib_info(struct ps_prochandle* ph, const char* libname, uintptr_t base);
 
 // adds a new shared object to lib list, supply open lib file descriptor as well
-lib_info* add_lib_info_fd(struct ps_prochandle* ph, const char* libname, int fd,
-                          uintptr_t base, size_t memsz);
+lib_info* add_lib_info_fd(struct ps_prochandle* ph, const char* libname, int fd, uintptr_t base);
 
 sa_thread_info* add_thread_info(struct ps_prochandle* ph, pthread_t pthread_id, lwpid_t lwp_id);
 // a test for ELF signature without using libelf

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -965,7 +965,7 @@ static bool read_shared_lib_info(struct ps_prochandle* ph) {
           } else {
             break; // Ignore non-relative paths, which are system libs. See JDK-8249779.
           }
-          add_lib_info(ph, name, iter->vaddr, iter->memsz);
+          add_lib_info(ph, name, iter->vaddr);
           break;
         }
       }

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/symtab.h
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/symtab.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
 struct symtab;
 
 // build symbol table for a given ELF or MachO file escriptor
-struct symtab* build_symtab(int fd);
+struct symtab* build_symtab(int fd, size_t *p_max_offset);
 
 // destroy the symbol table
 void destroy_symtab(struct symtab* symtab);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8250750](https://bugs.openjdk.java.net/browse/JDK-8250750): JDK-8247515 fix for OSX pc_to_symbol() lookup fails with some symbols


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/838/head:pull/838` \
`$ git checkout pull/838`

Update a local copy of the PR: \
`$ git checkout pull/838` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 838`

View PR using the GUI difftool: \
`$ git pr show -t 838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/838.diff">https://git.openjdk.java.net/jdk11u-dev/pull/838.diff</a>

</details>
