### PR TITLE
8257794: Zero: assert(istate->_stack_limit == istate->_thread->last_Java_sp() + 1) failed: wrong on Linux/x86_32

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/bytecodeInterpreter.cpp
@@ -481,7 +481,6 @@ BytecodeInterpreter::run(interpreterState istate) {
 #ifdef ASSERT
   if (istate->_msg != initialize) {
     assert(labs(istate->_stack_base - istate->_stack_limit) == (istate->_method->max_stack() + 1), "bad stack limit");
-    IA32_ONLY(assert(istate->_stack_limit == istate->_thread->last_Java_sp() + 1, "wrong"));
   }
   // Verify linkages.
   interpreterState l = istate;


### PR DESCRIPTION
The `slowdebug` build in 11u is broken in the same way as trunk was before this fix. We recently had to build 11u on x86_32 using Zero, due to issues with the new GCC 12 release, and the slowdebug build failed with this broken assert. Removing it allowed the build to complete.

Backport is clean, but couldn't be automated as later JDK versions have the file in a `zero` subdirectory.

Additional checks:
- [x] slowdebug build on x86_32

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257794](https://bugs.openjdk.java.net/browse/JDK-8257794): Zero: assert(istate->_stack_limit == istate->_thread->last_Java_sp() + 1) failed: wrong on Linux/x86_32


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/839/head:pull/839` \
`$ git checkout pull/839`

Update a local copy of the PR: \
`$ git checkout pull/839` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/839/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 839`

View PR using the GUI difftool: \
`$ git pr show -t 839`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/839.diff">https://git.openjdk.java.net/jdk11u-dev/pull/839.diff</a>

</details>
