### PR TITLE
8282372: [11] build issue on MacOS/aarch64 12.2.1 using Xcode 13.1: call to 'log2_intptr' is ambiguous

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -89,7 +89,7 @@ class MacroAssembler: public Assembler {
       = (operand_valid_for_logical_immediate(false /*is32*/,
                                              (uint64_t)Universe::narrow_klass_base())
          && ((uint64_t)Universe::narrow_klass_base()
-             > (1ULL << log2_intptr(Universe::narrow_klass_range()))));
+             > (1ULL << log2_intptr(checked_cast<uintptr_t>(Universe::narrow_klass_range())))));
   }
 
  // These routines should emit JVMTI PopFrame and ForceEarlyReturn handling code.


### PR DESCRIPTION
…all to 'log2_intptr' is ambiguous

Fix build error.

In case someone else addresses this I can well cancel this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282372](https://bugs.openjdk.java.net/browse/JDK-8282372): [11] build issue on MacOS/aarch64 12.2.1 using Xcode 13.1: call to 'log2_intptr' is ambiguous


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/841/head:pull/841` \
`$ git checkout pull/841`

Update a local copy of the PR: \
`$ git checkout pull/841` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 841`

View PR using the GUI difftool: \
`$ git pr show -t 841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/841.diff">https://git.openjdk.java.net/jdk11u-dev/pull/841.diff</a>

</details>
