### PR TITLE
JDK-8282589: runtime/ErrorHandling/ErrorHandler.java fails on MacOS aarch64 in jdk 11

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1799,8 +1799,9 @@ void VMError::controlled_crash(int how) {
 #endif
 
 #ifdef __APPLE__
-  // 12 is unreliable, use 15 instead
-  if (how == 12) { how = 15; }
+  // 12 is unreliable on this platform, may just yield us a "Trap" message on stdout
+  // Use 14 instead, which seems to work always
+  if (how == 12) { how = 14; }
 #endif
 
   // Keep this in sync with test/hotspot/jtreg/runtime/ErrorHandling/ErrorHandler.java

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1798,6 +1798,11 @@ void VMError::controlled_crash(int how) {
   funcPtr = (const void(*)()) 0xF;
 #endif
 
+#ifdef __APPLE__
+  // 12 is unreliable, use 15 instead
+  if (how == 12) { how = 15; }
+#endif
+
   // Keep this in sync with test/hotspot/jtreg/runtime/ErrorHandling/ErrorHandler.java
   // which tests cases 1 thru 13.
   // Case 14 is tested by test/hotspot/jtreg/runtime/ErrorHandling/SafeFetchInErrorHandlingTest.java.

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestOnError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestOnError.java
@@ -25,12 +25,9 @@
  * @test TestOnError
  * @bug 8078470
  * @summary Test using -XX:OnError=<cmd>
- * COMMENTS
- *     Macos_aarch64 (unlike macos_intel) doesn't let the java to create
- *     core file with ErrorHandlerTest=12. so need to ignore this test there.
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
- * @requires vm.debug & !(os.arch == "aarch64" & os.family == "mac")
+ * @requires vm.debug
  * @run main TestOnError
  */
 


### PR DESCRIPTION
In JDK 11 only, we see errors in runtime/ErrorHandling/ErrorHandler.java. The test induces an artificial (but real) segfault and checks the VMs reaction to it (that the hs-err file is written correctly and contains expected output).

The test does this by reading from `char* p = NULL;`. This is not guaranteed to work, and does not in this case: the process gets a "BPT/Trap" message instead and dies.

This code (`VMError::controlled_crash()`) has been streamlined and rewritten for later releases, and there we consistently use a known non-null address to invalid memory instead, which seems to work reliably for MacOs aarch64 too.

---

The patch, instead of downporting the whole reworkings of `VMError::controlled_crash`, just reuses the code which checks a segfault against a non-null invalid address. That way we do the same as newer releases, but with minimal changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282589](https://bugs.openjdk.java.net/browse/JDK-8282589): runtime/ErrorHandling/ErrorHandler.java fails on MacOS aarch64 in jdk 11


### Reviewers
 * [Vladimir Kempik](https://openjdk.java.net/census#vkempik) (@VladimirKempik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/842/head:pull/842` \
`$ git checkout pull/842`

Update a local copy of the PR: \
`$ git checkout pull/842` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 842`

View PR using the GUI difftool: \
`$ git pr show -t 842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/842.diff">https://git.openjdk.java.net/jdk11u-dev/pull/842.diff</a>

</details>
