### PR TITLE
8281615: Deadlock caused by jdwp agent

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/classTrack.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,14 +81,22 @@ cbTrackingObjectFree(jvmtiEnv* jvmti_env, jlong tag)
 struct bag *
 classTrack_processUnloads(JNIEnv *env)
 {
-    debugMonitorEnter(classTrackLock);
     if (deletedSignatures == NULL) {
-        // Class tracking not initialized, nobody's interested.
-        debugMonitorExit(classTrackLock);
-        return NULL;
+      return NULL;
     }
+
+    /* Allocate new bag outside classTrackLock lock to avoid deadlock.
+     *
+     * Note: jvmtiAllocate/jvmtiDeallocate() may be blocked by ongoing safepoints.
+     * It is dangerous to call them (via bagCreateBag/bagDestroyBag()) while holding monitor(s),
+     * because jvmti may post events, e.g. JVMTI_EVENT_OBJECT_FREE at safepoints and event processing
+     * code may acquire the same monitor(s), e.g. classTrackLock in cbTrackingObjectFree(),
+     * which can lead to deadlock.
+     */
+    struct bag* new_bag = bagCreateBag(sizeof(char*), 10);
+    debugMonitorEnter(classTrackLock);
     struct bag* deleted = deletedSignatures;
-    deletedSignatures = bagCreateBag(sizeof(char*), 10);
+    deletedSignatures = new_bag;
     debugMonitorExit(classTrackLock);
     return deleted;
 }
@@ -194,8 +202,11 @@ classTrack_initialize(JNIEnv *env)
 void
 classTrack_activate(JNIEnv *env)
 {
+    // Allocate bag outside classTrackLock lock to avoid deadlock.
+    // See comments in classTrack_processUnloads() for details.
+    struct bag* new_bag = bagCreateBag(sizeof(char*), 1000);
     debugMonitorEnter(classTrackLock);
-    deletedSignatures = bagCreateBag(sizeof(char*), 1000);
+    deletedSignatures = new_bag;
     debugMonitorExit(classTrackLock);
 }
 
@@ -214,12 +225,14 @@ void
 classTrack_reset(void)
 {
     debugMonitorEnter(classTrackLock);
-
-    if (deletedSignatures != NULL) {
-        bagEnumerateOver(deletedSignatures, cleanDeleted, NULL);
-        bagDestroyBag(deletedSignatures);
-        deletedSignatures = NULL;
-    }
-
+    struct bag* to_delete = deletedSignatures;
+    deletedSignatures = NULL;
     debugMonitorExit(classTrackLock);
+
+    // Deallocate bag outside classTrackLock to avoid deadlock.
+    // See comments in classTrack_processUnloads() for details.
+    if (to_delete != NULL) {
+      bagEnumerateOver(to_delete, cleanDeleted, NULL);
+      bagDestroyBag(to_delete);
+    }
 }


### PR DESCRIPTION
I would like to backport this patch to jdk11u, because without the fix, jdwp can potential deadlock whole JVM.

Test:
- [x] Testbase_nsk_jdi
- [x] Testbase_nsk_jvmti
- [x] Testbase_nsk_jdwp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281615](https://bugs.openjdk.java.net/browse/JDK-8281615): Deadlock caused by jdwp agent


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/843/head:pull/843` \
`$ git checkout pull/843`

Update a local copy of the PR: \
`$ git checkout pull/843` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 843`

View PR using the GUI difftool: \
`$ git pr show -t 843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/843.diff">https://git.openjdk.java.net/jdk11u-dev/pull/843.diff</a>

</details>
