### PR TITLE
8206330: Revisit com/sun/jdi/RedefineCrossEvent.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -878,14 +878,6 @@ javax/rmi/ssl/SSLSocketParametersTest.sh                        8162906 generic-
 
 ############################################################################
 
-###########################################################################
-#
-# Java EE Module Removal
-#
-com/sun/jdi/RedefineCrossEvent.java                             8194308    generic-all  Java EE Module Removal
-
-############################################################################
-
 # jdk_jfr
 
 jdk/jfr/event/sampling/TestNative.java                          8202142    generic-all

--- a/test/jdk/com/sun/jdi/RedefineCrossEvent.java
+++ b/test/jdk/com/sun/jdi/RedefineCrossEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,6 @@
  * @bug 4628726
  * @summary Test class redefinition at each event cross tested with other tests
  * @author Robert Field
- *
- * @modules java.corba
- *          jdk.jdi
  *
  * @run build TestScaffold VMConnection TargetAdapter TargetListener
  * @run compile -g AccessSpecifierTest.java


### PR DESCRIPTION
This test can now be enabled. Tested locally, com/sun/jdi/RedefineCrossEvent.java as well as all other tests in test/jdk/com/sun/jdi  pass for me with this backport. Unlike original changeset this backport does not touch test/jdk/com/sun/jdi/TestScaffold.java since  condition there was wrong and was properly reworked in JDK-8279669 [1] (backported to jdk11u-dev).

[1] https://bugs.openjdk.java.net/browse/JDK-8279669

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8206330](https://bugs.openjdk.java.net/browse/JDK-8206330): Revisit com/sun/jdi/RedefineCrossEvent.java


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/845/head:pull/845` \
`$ git checkout pull/845`

Update a local copy of the PR: \
`$ git checkout pull/845` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 845`

View PR using the GUI difftool: \
`$ git pr show -t 845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/845.diff">https://git.openjdk.java.net/jdk11u-dev/pull/845.diff</a>

</details>
