### PR TITLE
8217340: Compilation failed: tools/launcher/Test7029048.java

### DIFF
--- a/test/jdk/tools/launcher/Test7029048.java
+++ b/test/jdk/tools/launcher/Test7029048.java
@@ -23,9 +23,10 @@
 
 /*
  * @test
- * @bug 7029048
+ * @bug 7029048 8217340
  * @summary Ensure that the launcher defends against user settings of the
  *          LD_LIBRARY_PATH environment variable on Unixes
+ * @library /test/lib
  * @compile -XDignore.symbol.file ExecutionEnvironment.java Test7029048.java
  * @run main Test7029048
  */


### PR DESCRIPTION
JDK-8217340 is in the first batch of a chain of backports for Alpine support to 11u as discussed in the mailing list. For the full set of anticipated changes please refer to the jdk-updates mailing list [1].

Original changeset does not apply cleanly because comment line was changed to javadoc-style from "/*" to "/**" as part of "8216265: [testbug] Introduce Platform.sharedLibraryPathVariableName() and adapt all tests", which is irrelevant and too large to backport.

Testing: JCK + JTreg on Windows, Linux, Solaris, Mac without regressions.

[1] https://mail.openjdk.java.net/pipermail/jdk-updates-dev/2022-February/012271.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8217340](https://bugs.openjdk.java.net/browse/JDK-8217340): Compilation failed: tools/launcher/Test7029048.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/848/head:pull/848` \
`$ git checkout pull/848`

Update a local copy of the PR: \
`$ git checkout pull/848` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 848`

View PR using the GUI difftool: \
`$ git pr show -t 848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/848.diff">https://git.openjdk.java.net/jdk11u-dev/pull/848.diff</a>

</details>
