### PR TITLE
8245938: Remove unused print_stack(void) method from XToolkit.c

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
+++ b/src/java.desktop/unix/native/libawt_xawt/xawt/XToolkit.c
@@ -27,9 +27,6 @@
 #include <X11/Xutil.h>
 #include <X11/Xos.h>
 #include <X11/Xatom.h>
-#ifdef __linux__
-#include <execinfo.h>
-#endif
 
 #include <jvm.h>
 #include <jni.h>
@@ -786,26 +783,6 @@ JNIEXPORT jstring JNICALL Java_sun_awt_X11_XToolkit_getEnv
     }
     return ret;
 }
-
-#ifdef __linux__
-void print_stack(void)
-{
-  void *array[10];
-  size_t size;
-  char **strings;
-  size_t i;
-
-  size = backtrace (array, 10);
-  strings = backtrace_symbols (array, size);
-
-  fprintf (stderr, "Obtained %zd stack frames.\n", size);
-
-  for (i = 0; i < size; i++)
-     fprintf (stderr, "%s\n", strings[i]);
-
-  free (strings);
-}
-#endif
 
 Window get_xawt_root_shell(JNIEnv *env) {
   static jclass classXRootWindow = NULL;


### PR DESCRIPTION
JDK-8245938 is in the first batch of a chain of backports for Alpine support to 11u as discussed in the mailing list. For the full set of anticipated changes please refer to the jdk-updates mailing list [1].

Applies cleanly.

Testing: JCK + JTreg on Windows, Linux, Solaris, Mac without regressions.

[1] https://mail.openjdk.java.net/pipermail/jdk-updates-dev/2022-February/012271.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8245938](https://bugs.openjdk.java.net/browse/JDK-8245938): Remove unused print_stack(void) method from XToolkit.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/849/head:pull/849` \
`$ git checkout pull/849`

Update a local copy of the PR: \
`$ git checkout pull/849` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 849`

View PR using the GUI difftool: \
`$ git pr show -t 849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/849.diff">https://git.openjdk.java.net/jdk11u-dev/pull/849.diff</a>

</details>
