### PR TITLE
8252248: __SIGRTMAX is not declared in musl libc

### DIFF
--- a/src/java.base/linux/native/libnet/linux_close.c
+++ b/src/java.base/linux/native/libnet/linux_close.c
@@ -60,7 +60,7 @@ typedef struct {
 /*
  * Signal to unblock thread
  */
-static int sigWakeup = (__SIGRTMAX - 2);
+#define WAKEUP_SIGNAL (SIGRTMAX - 2)
 
 /*
  * fdTable holds one entry per file descriptor, up to a certain
@@ -152,10 +152,10 @@ static void __attribute((constructor)) init() {
     sa.sa_handler = sig_wakeup;
     sa.sa_flags   = 0;
     sigemptyset(&sa.sa_mask);
-    sigaction(sigWakeup, &sa, NULL);
+    sigaction(WAKEUP_SIGNAL, &sa, NULL);
 
     sigemptyset(&sigset);
-    sigaddset(&sigset, sigWakeup);
+    sigaddset(&sigset, WAKEUP_SIGNAL);
     sigprocmask(SIG_UNBLOCK, &sigset, NULL);
 }
 
@@ -305,7 +305,7 @@ static int closefd(int fd1, int fd2) {
         threadEntry_t *curr = fdEntry->threads;
         while (curr != NULL) {
             curr->intr = 1;
-            pthread_kill( curr->thr, sigWakeup );
+            pthread_kill( curr->thr, WAKEUP_SIGNAL);
             curr = curr->next;
         }
     }

--- a/src/java.base/unix/native/libnio/ch/NativeThread.c
+++ b/src/java.base/unix/native/libnio/ch/NativeThread.c
@@ -36,7 +36,7 @@
 #ifdef __linux__
   #include <pthread.h>
   /* Also defined in net/linux_close.c */
-  #define INTERRUPT_SIGNAL (__SIGRTMAX - 2)
+  #define INTERRUPT_SIGNAL (SIGRTMAX - 2)
 #elif _AIX
   #include <pthread.h>
   /* Also defined in net/aix_close.c */


### PR DESCRIPTION
JDK-8252248 is in the first batch of a chain of backports for Alpine support to 11u as discussed in the mailing list. For the full set of anticipated changes please refer to the jdk-updates mailing list [1].

Compared to original changeset this backport looks cosmetically different in #ifdefs in NativeThread.c because of another code layout due to "8244224: Implementation of JEP 381: Remove the Solaris and SPARC Ports".

Testing: JCK + JTreg on Windows, Linux, Solaris, Mac without regressions.

[1] https://mail.openjdk.java.net/pipermail/jdk-updates-dev/2022-February/012271.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252248](https://bugs.openjdk.java.net/browse/JDK-8252248): __SIGRTMAX is not declared in musl libc


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/850/head:pull/850` \
`$ git checkout pull/850`

Update a local copy of the PR: \
`$ git checkout pull/850` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 850`

View PR using the GUI difftool: \
`$ git pr show -t 850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/850.diff">https://git.openjdk.java.net/jdk11u-dev/pull/850.diff</a>

</details>
