### PR TITLE
8252250: isnanf is obsolete

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -204,7 +204,7 @@ inline int g_isnan(double f) { return isnand(f); }
 #elif defined(__APPLE__)
 inline int g_isnan(double f) { return isnan(f); }
 #elif defined(LINUX) || defined(_ALLBSD_SOURCE)
-inline int g_isnan(float  f) { return isnanf(f); }
+inline int g_isnan(float  f) { return isnan(f); }
 inline int g_isnan(double f) { return isnan(f); }
 #else
 #error "missing platform-specific definition here"

--- a/src/java.base/unix/native/libjava/jdk_util_md.h
+++ b/src/java.base/unix/native/libjava/jdk_util_md.h
@@ -37,7 +37,7 @@
 #define ISNAND(d) isnan(d)
 #elif defined(__linux__) || defined(_ALLBSD_SOURCE)
 #include <math.h>
-#define ISNANF(f) isnanf(f)
+#define ISNANF(f) isnan(f)
 #define ISNAND(d) isnan(d)
 #elif defined(_AIX)
 #include <math.h>


### PR DESCRIPTION
JDK-8252250 is in the first batch of a chain of backports for Alpine support to 11u as discussed in the mailing list. For the full set of anticipated changes please refer to the jdk-updates mailing list [1].

Unlike original changeset this backport also changes src/java.base/unix/native/libjava/jdk_util_md.h because it also contains isnanf, which was removed in JDK16 by "JDK-8249612: Remove unused ISNANF and ISNAND from jdk_util_md.h" after removing its usage by "JDK-8199424: consider removing ObjectInputStream and ObjectOutputStream native methods" in JDK14.

Testing: JCK + JTreg on Windows, Linux, Solaris, Mac without regressions.

[1] https://mail.openjdk.java.net/pipermail/jdk-updates-dev/2022-February/012271.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252250](https://bugs.openjdk.java.net/browse/JDK-8252250): isnanf is obsolete


### Reviewers
 * [Vladimir Kempik](https://openjdk.java.net/census#vkempik) (@VladimirKempik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/851/head:pull/851` \
`$ git checkout pull/851`

Update a local copy of the PR: \
`$ git checkout pull/851` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 851`

View PR using the GUI difftool: \
`$ git pr show -t 851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/851.diff">https://git.openjdk.java.net/jdk11u-dev/pull/851.diff</a>

</details>
