### PR TITLE
8276990: Memory leak in invoker.c fillInvokeRequest() during JDI operations

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
@@ -281,6 +281,7 @@ fillInvokeRequest(JNIEnv *env, InvokeRequest *request,
     /*
      * Squirrel away the method signature
      */
+    JDI_ASSERT_MSG(request->methodSignature == NULL, "Request methodSignature not null");
     error = methodSignature(method, NULL, &request->methodSignature,  NULL);
     if (error != JVMTI_ERROR_NONE) {
         return error;
@@ -821,6 +822,10 @@ invoker_completeInvokeRequest(jthread thread)
      * after writing the respone.
      */
     deleteGlobalArgumentRefs(env, request);
+
+    JDI_ASSERT_MSG(request->methodSignature != NULL, "methodSignature is NULL");
+    jvmtiDeallocate(request->methodSignature);
+    request->methodSignature = NULL;
 
     /* From now on, do not access the request structure anymore
      * for this request id, because once we give up the invokerLock it may


### PR DESCRIPTION
Hi all,

This backports a fix for a memory leak in the JDWP.
The original change applies cleanly:

https://github.com/openjdk/jdk/commit/5ab22e88da8d79f9e19e8afffdd06206f42bab94

See issue:
https://bugs.openjdk.java.net/browse/JDK-8276990
and original PR:
https://github.com/openjdk/jdk/pull/7306

Thanks!