### PR TITLE
8211962: Implicit narrowing in MacOSX java.desktop jsound

### DIFF
--- a/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_Ports.cpp
+++ b/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_Ports.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -619,7 +619,7 @@ void PORT_GetControls(void* id, INT32 portIndex, PortControlCreator* creator) {
                 // get the channel name
                 char *channelName;
                 CFStringRef cfname = NULL;
-                const AudioObjectPropertyAddress address = {kAudioObjectPropertyElementName, port->scope, ch};
+                const AudioObjectPropertyAddress address = {kAudioObjectPropertyElementName, port->scope, (unsigned)ch};
                 UInt32 size = sizeof(cfname);
                 OSStatus err = AudioObjectGetPropertyData(mixer->deviceID, &address, 0, NULL, &size, &cfname);
                 if (err == noErr) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [47e7b141](https://github.com/openjdk/jdk/commit/47e7b141c03b338ef7bbadc3c554e50c8fb210a9) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Kim Barrett on 11 Oct 2018 and was reviewed by Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211962](https://bugs.openjdk.java.net/browse/JDK-8211962): Implicit narrowing in MacOSX java.desktop jsound


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/854/head:pull/854` \
`$ git checkout pull/854`

Update a local copy of the PR: \
`$ git checkout pull/854` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 854`

View PR using the GUI difftool: \
`$ git pr show -t 854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/854.diff">https://git.openjdk.java.net/jdk11u-dev/pull/854.diff</a>

</details>
