### PR TITLE
8208246: flags duplications in vmTestbase_vm_g1classunloading tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_inMemoryCompilation_keep_class/TestDescription.java
@@ -51,13 +51,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_inMemoryCompilation_keep_obj/TestDescription.java
@@ -51,13 +51,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_keep_class/TestDescription.java
@@ -51,13 +51,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_anonclassloader_keep_obj/TestDescription.java
@@ -51,13 +51,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level1_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level2_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level3_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_compilation_level4_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_humongous_class_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_jni_classloading_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_global_ref_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_jni_local_ref_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_cl/TestDescription.java
@@ -55,13 +55,6 @@
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
  *      -Xbootclasspath/a:classPool.jar
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_class/TestDescription.java
@@ -55,13 +55,6 @@
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
  *      -Xbootclasspath/a:classPool.jar
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_obj/TestDescription.java
@@ -55,13 +55,6 @@
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
  *      -Xbootclasspath/a:classPool.jar
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_keep_cl/TestDescription.java
@@ -55,13 +55,6 @@
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
  *      -Xbootclasspath/a:classPool.jar
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_keep_class/TestDescription.java
@@ -55,13 +55,6 @@
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
  *      -Xbootclasspath/a:classPool.jar
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_keep_obj/TestDescription.java
@@ -55,13 +55,6 @@
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
  *      -Xbootclasspath/a:classPool.jar
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_stackLocal_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_staticField_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_strongRef_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_keepRef_threadItself_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_phantom_ref_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_prot_domains_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_reflection_classloading_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_inMemoryCompilation_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_inMemoryCompilation_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_inMemoryCompilation_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_keep_cl/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_keep_class/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_weak_ref_keep_obj/TestDescription.java
@@ -50,13 +50,6 @@
  *      -XX:+WhiteBoxAPI
  *      -XX:+UseG1GC
  *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xbootclasspath/a:.
- *      -XX:+UnlockDiagnosticVMOptions
- *      -XX:+WhiteBoxAPI
- *      -XX:+UseG1GC
- *      -XX:+ExplicitGCInvokesConcurrent
- *      -Xlog:gc:gc.log
- *      -XX:-UseGCOverheadLimit
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8208246](https://bugs.openjdk.java.net/browse/JDK-8208246): flags duplications in vmTestbase_vm_g1classunloading tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/857/head:pull/857` \
`$ git checkout pull/857`

Update a local copy of the PR: \
`$ git checkout pull/857` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 857`

View PR using the GUI difftool: \
`$ git pr show -t 857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/857.diff">https://git.openjdk.java.net/jdk11u-dev/pull/857.diff</a>

</details>
