### PR TITLE
8186548: move jdk.testlibrary.JcmdBase closer to tests

### DIFF
--- a/test/jdk/sun/tools/jcmd/JcmdBase.java
+++ b/test/jdk/sun/tools/jcmd/JcmdBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,9 +21,11 @@
  * questions.
  */
 
-package jdk.testlibrary;
-
 import java.util.Arrays;
+
+import jdk.testlibrary.OutputAnalyzer;
+import jdk.testlibrary.ProcessTools;
+import jdk.testlibrary.JDKToolLauncher;
 
 /**
  * Helper class for starting jcmd process.

--- a/test/jdk/sun/tools/jcmd/TestJcmdDefaults.java
+++ b/test/jdk/sun/tools/jcmd/TestJcmdDefaults.java
@@ -30,7 +30,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import jdk.testlibrary.JcmdBase;
 import jdk.testlibrary.OutputAnalyzer;
 import jdk.testlibrary.Utils;
 

--- a/test/jdk/sun/tools/jcmd/TestJcmdSanity.java
+++ b/test/jdk/sun/tools/jcmd/TestJcmdSanity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import jdk.testlibrary.JcmdBase;
 import jdk.testlibrary.OutputAnalyzer;
 import jdk.testlibrary.ProcessTools;
 import jdk.testlibrary.Utils;


### PR DESCRIPTION
I backport this to simplify follow up backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8186548](https://bugs.openjdk.java.net/browse/JDK-8186548): move jdk.testlibrary.JcmdBase closer to tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/878/head:pull/878` \
`$ git checkout pull/878`

Update a local copy of the PR: \
`$ git checkout pull/878` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 878`

View PR using the GUI difftool: \
`$ git pr show -t 878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/878.diff">https://git.openjdk.java.net/jdk11u-dev/pull/878.diff</a>

</details>
