### PR TITLE
8283018: 11u GHA: Update GCC 9 minor versions

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install gcc-9=9.3.0-17ubuntu1~20.04 g++-9=9.3.0-17ubuntu1~20.04 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
+          sudo apt-get install gcc-9=9.4.0-1ubuntu1~20.04 g++-9=9.4.0-1ubuntu1~20.04 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 
       - name: Configure
@@ -502,12 +502,12 @@ jobs:
 
       - name: Install native host dependencies
         run: |
-          sudo apt-get install gcc-9=9.3.0-17ubuntu1~20.04 g++-9=9.3.0-17ubuntu1~20.04 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
+          sudo apt-get install gcc-9=9.4.0-1ubuntu1~20.04 g++-9=9.4.0-1ubuntu1~20.04 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
         if: matrix.debian-arch == ''
 
       - name: Install cross-compilation host dependencies
-        run: sudo apt-get install gcc-9-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}=9.3.0-17ubuntu1~20.04cross2 g++-9-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}=9.3.0-17ubuntu1~20.04cross2
+        run: sudo apt-get install gcc-9-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}=9.4.0-1ubuntu1~20.04cross2 g++-9-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}=9.4.0-1ubuntu1~20.04cross2
         if: matrix.debian-arch != ''
 
       - name: Cache sysroot


### PR DESCRIPTION
Current GHA runs in 11u fail with:

```
E: Version '9.3.0-17ubuntu1~20.04cross2' for 'gcc-9-aarch64-linux-gnu' was not found
E: Version '9.3.0-17ubuntu1~20.04cross2' for 'g++-9-aarch64-linux-gnu' was not found
```

We should update these. 11u GHA workflow runs GCC 9, not GCC 10 like the rest of releases, so this is the 11u-specific bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283018](https://bugs.openjdk.java.net/browse/JDK-8283018): 11u GHA: Update GCC 9 minor versions


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/879/head:pull/879` \
`$ git checkout pull/879`

Update a local copy of the PR: \
`$ git checkout pull/879` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/879/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 879`

View PR using the GUI difftool: \
`$ git pr show -t 879`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/879.diff">https://git.openjdk.java.net/jdk11u-dev/pull/879.diff</a>

</details>
