### PR TITLE
8211822: Some tests fail after JDK-8210039

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -463,7 +463,6 @@ java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java 82
 java/awt/datatransfer/ConstructFlavoredObjectTest/ConstructFlavoredObjectTest.java 8202860 linux-all
 java/awt/dnd/DisposeFrameOnDragCrash/DisposeFrameOnDragTest.java 8202790 macosx-all,linux-all
 java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882 linux-all
-java/awt/MenuBar/8007006/bug8007006.java 8202886 macosx-all
 java/awt/Frame/FramesGC/FramesGC.java 8079069 macosx-all
 java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java 8030121 macosx-all
 java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java 8202931 macosx-all,linux-all

--- a/test/jdk/javax/swing/JComboBox/4199622/bug4199622.java
+++ b/test/jdk/javax/swing/JComboBox/4199622/bug4199622.java
@@ -27,10 +27,9 @@
    @bug 4199622
    @requires (os.family == "windows")
    @summary RFE: JComboBox shouldn't send ActionEvents for keyboard navigation
-   @author Vladislav Karnaukhov
    @library /test/lib
    @modules java.desktop/com.sun.java.swing.plaf.windows
-   @build jdk.test.libr.Platform
+   @build jdk.test.lib.Platform
    @run main bug4199622
  */
 

--- a/test/jdk/javax/swing/JFrame/NSTexturedJFrame/NSTexturedJFrame.java
+++ b/test/jdk/javax/swing/JFrame/NSTexturedJFrame/NSTexturedJFrame.java
@@ -35,9 +35,10 @@ import jdk.test.lib.Platform;
  * @test
  * @key headful
  * @bug 7124513
+ * @requires (os.family == "mac")
  * @summary We should support NSTexturedBackgroundWindowMask style on OSX.
- * @author Sergey Bylokhov
  * @library /test/lib
+ *          /test/jdk/lib/testlibrary/
  * @build ExtendedRobot jdk.test.lib.Platform
  * @run main NSTexturedJFrame
  */

--- a/test/jdk/javax/swing/JPopupMenu/7154841/bug7154841.java
+++ b/test/jdk/javax/swing/JPopupMenu/7154841/bug7154841.java
@@ -25,9 +25,10 @@
  * @test
  * @key headful
  * @bug 7154841
+ * @requires (os.family == "mac")
  * @summary JPopupMenu is overlapped by a Dock on Mac OS X
- * @author Petr Pchelko
  * @library /test/lib
+ *          /test/jdk/lib/testlibrary/
  * @build ExtendedRobot jdk.test.lib.Platform
  * @run main bug7154841
  */


### PR DESCRIPTION
A test fix. Had to adapt ProblemList, rest applies clean.
Marking as /clean

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8211822](https://bugs.openjdk.java.net/browse/JDK-8211822): Some tests fail after JDK-8210039
 * [JDK-8202886](https://bugs.openjdk.java.net/browse/JDK-8202886): [macos] Test java/awt/MenuBar/8007006/bug8007006.java fails on MacOS


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to d6675957e3d0829ced2c44250e36f3e24cdc0bad


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/882/head:pull/882` \
`$ git checkout pull/882`

Update a local copy of the PR: \
`$ git checkout pull/882` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 882`

View PR using the GUI difftool: \
`$ git pr show -t 882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/882.diff">https://git.openjdk.java.net/jdk11u-dev/pull/882.diff</a>

</details>
