### PR TITLE
8225475: Node budget asserts on x86_32/64

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2511,9 +2511,11 @@ uint IdealLoopTree::est_loop_clone_sz(uint factor) const {
       }
     }
   }
-  // Add data (x1.5) and control (x1.0) count to estimate iff both are > 0.
+  // Add data and control count (x2.0) to estimate iff both are > 0. This is
+  // a rather pessimistic estimate for the most part, in particular for some
+  // complex loops, but still not enough to capture all loops.
   if (ctrl_edge_out_cnt > 0 && data_edge_out_cnt > 0) {
-    estimate += ctrl_edge_out_cnt + data_edge_out_cnt + data_edge_out_cnt / 2;
+    estimate += 2 * (ctrl_edge_out_cnt + data_edge_out_cnt);
   }
 
   return estimate;


### PR DESCRIPTION
Clean backport of JDK-8225475.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8225475](https://bugs.openjdk.java.net/browse/JDK-8225475): Node budget asserts on x86_32/64


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/883/head:pull/883` \
`$ git checkout pull/883`

Update a local copy of the PR: \
`$ git checkout pull/883` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 883`

View PR using the GUI difftool: \
`$ git pr show -t 883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/883.diff">https://git.openjdk.java.net/jdk11u-dev/pull/883.diff</a>

</details>
