### PR TITLE
8223389: Shenandoah optimizations fail with assert(!phase->exceeding_node_budget())

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -2038,6 +2038,9 @@ void ShenandoahBarrierC2Support::optimize_after_expansion(VectorSet &visited, No
               head->as_Loop()->verify_strip_mined(0);
             }
             move_gc_state_test_out_of_loop(iff, phase);
+
+            AutoNodeBudget node_budget(phase);
+
             if (loop->policy_unswitching(phase)) {
               if (head->as_Loop()->is_strip_mined()) {
                 OuterStripMinedLoopNode* outer = head->as_CountedLoop()->outer_loop();


### PR DESCRIPTION
Backport of trivial Shenandoah fix [JDK-8223389](https://bugs.openjdk.java.net/browse/JDK-8223389) after JDK-8223502 and JDK-8216137 were backported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8223389](https://bugs.openjdk.java.net/browse/JDK-8223389): Shenandoah optimizations fail with assert(!phase->exceeding_node_budget())


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/884/head:pull/884` \
`$ git checkout pull/884`

Update a local copy of the PR: \
`$ git checkout pull/884` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 884`

View PR using the GUI difftool: \
`$ git pr show -t 884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/884.diff">https://git.openjdk.java.net/jdk11u-dev/pull/884.diff</a>

</details>
