### PR TITLE
8246741: NetworkInterface/UniqueMacAddressesTest: mac address uniqueness test failed

### DIFF
--- a/test/jdk/java/net/NetworkInterface/UniqueMacAddressesTest.java
+++ b/test/jdk/java/net/NetworkInterface/UniqueMacAddressesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,87 +21,75 @@
  * questions.
  */
 
-import java.net.InetAddress;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Enumeration;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import jdk.test.lib.NetworkConfiguration;
 
 /*
  * @test
  * @bug 8021372
  * @summary Tests that the MAC addresses returned by NetworkInterface.getNetworkInterfaces are unique for each adapter.
- *
+ * @library /test/lib
+ * @build jdk.test.lib.NetworkConfiguration
+ * @run main/othervm UniqueMacAddressesTest
  */
 public class UniqueMacAddressesTest {
 
+    static PrintStream log = System.err;
+
+    // A record pair (NetworkInterface::name,  NetworkInterface::hardwareAddress)
+    class NetIfPair {
+        String interfaceName;
+        byte[] address;
+        public NetIfPair(String name, byte[] adr) {
+            interfaceName = name;
+            address = adr;
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         new UniqueMacAddressesTest().execute();
-        System.out.println("UniqueMacAddressesTest: OK");
+        log.println("UniqueMacAddressesTest: OK");
     }
 
     public UniqueMacAddressesTest() {
-        System.out.println("UniqueMacAddressesTest: start ");
+        log.println("UniqueMacAddressesTest: start");
     }
 
     public void execute() throws Exception {
-        Enumeration<NetworkInterface> networkInterfaces;
-        boolean areMacAddressesUnique = false;
-        List<NetworkInterface> networkInterfaceList = new ArrayList<NetworkInterface>();
-            networkInterfaces = NetworkInterface.getNetworkInterfaces();
-
-        // build a list of NetworkInterface objects to test MAC address
-        // uniqueness
-        createNetworkInterfaceList(networkInterfaces, networkInterfaceList);
-        areMacAddressesUnique = checkMacAddressesAreUnique(networkInterfaceList);
-        if (!areMacAddressesUnique) {
+        // build a list of NetworkInterface name address pairs
+        // to test MAC address uniqueness
+        List<NetIfPair> netIfList = createNetworkInterfaceList(NetworkConfiguration.probe());
+        if (!macAddressesAreUnique(netIfList))
             throw new RuntimeException("mac address uniqueness test failed");
-        }
     }
 
-    private boolean checkMacAddressesAreUnique (
-            List<NetworkInterface> networkInterfaces) throws Exception {
-        boolean uniqueMacAddresses = true;
-        for (NetworkInterface networkInterface : networkInterfaces) {
-            for (NetworkInterface comparisonNetIf : networkInterfaces) {
-                System.out.println("Comparing netif "
-                        + networkInterface.getName() + " and netif "
-                        + comparisonNetIf.getName());
-                if (testMacAddressesEqual(networkInterface, comparisonNetIf)) {
-                    uniqueMacAddresses = false;
-                    break;
-                }
+    private boolean macAddressesAreUnique(List<NetIfPair> netIfPairs) {
+        for (NetIfPair netIfPair : netIfPairs) {
+            for (NetIfPair compNetIfPair : netIfPairs) {
+                if (!netIfPair.interfaceName.equals(compNetIfPair.interfaceName) &&
+                        testMacAddressesEqual(netIfPair, compNetIfPair))
+                    return false;
             }
-            if (uniqueMacAddresses != true)
-                break;
         }
-        return uniqueMacAddresses;
+        return true;
     }
 
-    private boolean testMacAddressesEqual(NetworkInterface netIf1,
-            NetworkInterface netIf2) throws Exception {
-
-        byte[] rawMacAddress1 = null;
-        byte[] rawMacAddress2 = null;
-        boolean macAddressesEqual = false;
-        if (!netIf1.getName().equals(netIf2.getName())) {
-            System.out.println("compare hardware addresses "
-                +  createMacAddressString(netIf1) + " and " + createMacAddressString(netIf2));
-            rawMacAddress1 = netIf1.getHardwareAddress();
-            rawMacAddress2 = netIf2.getHardwareAddress();
-            macAddressesEqual = Arrays.equals(rawMacAddress1, rawMacAddress2);
-        } else {
-            // same interface
-            macAddressesEqual = false;
-        }
-        return macAddressesEqual;
+    private boolean testMacAddressesEqual(NetIfPair if1, NetIfPair if2) {
+        log.println("Compare hardware addresses of " + if1.interfaceName + " ("
+                +  createMacAddressString(if1.address) + ")" + " and " + if2.interfaceName
+                + " (" + createMacAddressString(if2.address) + ")");
+        return (Arrays.equals(if1.address, if2.address));
     }
 
-    private String createMacAddressString (NetworkInterface netIf) throws Exception {
-        byte[] macAddr = netIf.getHardwareAddress();
+    private String createMacAddressString(byte[] macAddr) {
         StringBuilder sb =  new StringBuilder();
         if (macAddr != null) {
             for (int i = 0; i < macAddr.length; i++) {
@@ -112,21 +100,18 @@ public class UniqueMacAddressesTest {
         return sb.toString();
     }
 
-    private void createNetworkInterfaceList(Enumeration<NetworkInterface> nis,
-            List<NetworkInterface> networkInterfaceList) throws Exception {
-        byte[] macAddr = null;
-        NetworkInterface netIf = null;
-        while (nis.hasMoreElements()) {
-            netIf = (NetworkInterface) nis.nextElement();
-            if (netIf.isUp()) {
-                macAddr = netIf.getHardwareAddress();
-                if (macAddr != null) {
-                    System.out.println("Adding NetworkInterface "
-                            + netIf.getName() + " with mac address "
-                            + createMacAddressString(netIf));
-                    networkInterfaceList.add(netIf);
-                }
-            }
+    private byte[] getNetworkInterfaceHardwareAddress(NetworkInterface inf) {
+        try {
+            return inf.getHardwareAddress();
+        } catch (SocketException se) {
+            throw new UncheckedIOException(se);
         }
+    }
+
+    private List<NetIfPair> createNetworkInterfaceList(NetworkConfiguration netConf) {
+        return netConf.interfaces()
+                .map(netIf -> new NetIfPair(netIf.getName(), getNetworkInterfaceHardwareAddress(netIf)))
+                .collect(Collectors.filtering(netIfPair -> netIfPair.address != null,
+                        Collectors.toCollection(ArrayList::new)));
     }
 }


### PR DESCRIPTION
I backport this because it fixes a test failure we see on mac aarch.
I had to remove the record from the test UniqueMacAddressesTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246741](https://bugs.openjdk.java.net/browse/JDK-8246741): NetworkInterface/UniqueMacAddressesTest: mac address uniqueness test failed


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/885/head:pull/885` \
`$ git checkout pull/885`

Update a local copy of the PR: \
`$ git checkout pull/885` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 885`

View PR using the GUI difftool: \
`$ git pr show -t 885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/885.diff">https://git.openjdk.java.net/jdk11u-dev/pull/885.diff</a>

</details>
