### PR TITLE
8279356: Method linking fails with guarantee(mh->adapter() != NULL) failed: Adapter blob must already exist!

### DIFF
--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1086,7 +1086,7 @@ void Method::link_method(const methodHandle& h_method, TRAPS) {
     }
     assert(entry == _from_interpreted_entry,
            "should be correctly set during dump time");
-  } else if (_i2i_entry != NULL) {
+  } else if (adapter() != NULL) {
     return;
   }
   assert( _code == NULL, "nothing compiled yet" );

--- a/test/hotspot/jtreg/compiler/codecache/OverflowCodeCacheTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/OverflowCodeCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test OverflowCodeCacheTest
- * @bug 8059550
+ * @bug 8059550 8279356
  * @summary testing of code cache segments overflow
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
@@ -34,11 +34,14 @@
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
- *                   -XX:-SegmentedCodeCache
- *                   compiler.codecache.OverflowCodeCacheTest
+ *                   -XX:-SegmentedCodeCache -Xmixed
+ *                   compiler.codecache.OverflowCodeCacheTest CompilationDisabled
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:CompileCommand=compileonly,null::*
- *                   -XX:+SegmentedCodeCache
+ *                   -XX:+SegmentedCodeCache -Xmixed
+ *                   compiler.codecache.OverflowCodeCacheTest CompilationDisabled
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -XX:-SegmentedCodeCache -Xmixed
  *                   compiler.codecache.OverflowCodeCacheTest
  */
 
@@ -50,13 +53,21 @@ import sun.hotspot.code.BlobType;
 import sun.hotspot.code.CodeBlob;
 
 import java.lang.management.MemoryPoolMXBean;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.EnumSet;
 
+class Helper {
+    // Uncommon signature to prevent sharing and force creation of a new adapter
+    public void method(float a, float b, float c, Object o) { }
+}
+
 public class OverflowCodeCacheTest {
     private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+    private static boolean COMPILATION_DISABLED = false;
 
     public static void main(String[] args) {
+        COMPILATION_DISABLED = args.length > 0;
         EnumSet<BlobType> blobTypes = BlobType.getAvailable();
         for (BlobType type : blobTypes) {
             new OverflowCodeCacheTest(type).test();
@@ -75,6 +86,8 @@ public class OverflowCodeCacheTest {
         System.out.println("allocating till possible...");
         ArrayList<Long> blobs = new ArrayList<>();
         int compilationActivityMode = -1;
+        // Lock compilation to be able to better control code cache space
+        WHITE_BOX.lockCompilation();
         try {
             long addr;
             int size = (int) (getHeapSize() >> 7);
@@ -89,15 +102,43 @@ public class OverflowCodeCacheTest {
                 }
             }
             /* now, remember compilationActivityMode to check it later, after freeing, since we
-               possibly have no free cache for futher work */
+               possibly have no free cache for further work */
             compilationActivityMode = WHITE_BOX.getCompilationActivityMode();
+
+            // Use smallest allocation size to make sure all of the available space
+            // is filled up. Don't free these below to put some pressure on the sweeper.
+            while ((addr = WHITE_BOX.allocateCodeBlob(1, type.id)) != 0) { }
         } finally {
+            try {
+                // Trigger creation of a new adapter for Helper::method
+                // which will fail because we are out of code cache space.
+                Helper helper = new Helper();
+            } catch (VirtualMachineError e) {
+                // Expected
+            }
+            // Free code cache space
             for (Long blob : blobs) {
                 WHITE_BOX.freeCodeBlob(blob);
             }
+
+            // Convert some nmethods to zombie and then free them to re-enable compilation
+            WHITE_BOX.unlockCompilation();
+            WHITE_BOX.forceNMethodSweep();
+            WHITE_BOX.forceNMethodSweep();
+
+            // Trigger compilation of Helper::method which will hit an assert because
+            // adapter creation failed above due to a lack of code cache space.
+            Helper helper = new Helper();
+            for (int i = 0; i < 100_000; i++) {
+                helper.method(0, 0, 0, null);
+            }
         }
-        Asserts.assertNotEquals(compilationActivityMode, 1 /* run_compilation*/,
-                "Compilation must be disabled when CodeCache(CodeHeap) overflows");
+        // Only check this if compilation is disabled, otherwise the sweeper might have
+        // freed enough nmethods to allow for re-enabling compilation.
+        if (COMPILATION_DISABLED) {
+            Asserts.assertNotEquals(compilationActivityMode, 1 /* run_compilation*/,
+                    "Compilation must be disabled when CodeCache(CodeHeap) overflows");
+        }
     }
 
     private long getHeapSize() {


### PR DESCRIPTION
Backport of https://bugs.openjdk.java.net/browse/JDK-8279356
Fix needs manual integration because 11u has additional CDS code in `Method::link_method`. Copyright year updates were also integrated manually.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279356](https://bugs.openjdk.java.net/browse/JDK-8279356): Method linking fails with guarantee(mh->adapter() != NULL) failed: Adapter blob must already exist!


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/891/head:pull/891` \
`$ git checkout pull/891`

Update a local copy of the PR: \
`$ git checkout pull/891` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 891`

View PR using the GUI difftool: \
`$ git pr show -t 891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/891.diff">https://git.openjdk.java.net/jdk11u-dev/pull/891.diff</a>

</details>
