### PR TITLE
8253727: [cgroups v2] Memory and swap limits reported incorrectly

### DIFF
--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -157,9 +157,20 @@ char* CgroupV2Subsystem::mem_soft_limit_val() {
   return os::strdup(mem_soft_limit_str);
 }
 
+// Note that for cgroups v2 the actual limits set for swap and
+// memory live in two different files, memory.swap.max and memory.max
+// respectively. In order to properly report a cgroup v1 like
+// compound value we need to sum the two values. Setting a swap limit
+// without also setting a memory limit is not allowed.
 jlong CgroupV2Subsystem::memory_and_swap_limit_in_bytes() {
   char* mem_swp_limit_str = mem_swp_limit_val();
-  return limit_from_str(mem_swp_limit_str);
+  jlong swap_limit = limit_from_str(mem_swp_limit_str);
+  if (swap_limit >= 0) {
+    jlong memory_limit = read_memory_limit_in_bytes();
+    assert(memory_limit >= 0, "swap limit without memory limit?");
+    return memory_limit + swap_limit;
+  }
+  return swap_limit;
 }
 
 char* CgroupV2Subsystem::mem_swp_limit_val() {

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
@@ -279,15 +279,37 @@ public class CgroupV2Subsystem implements CgroupSubsystem {
         return CgroupV2SubsystemController.getLongEntry(unified, "memory.stat", "sock");
     }
 
+    /**
+     * Note that for cgroups v2 the actual limits set for swap and
+     * memory live in two different files, memory.swap.max and memory.max
+     * respectively. In order to properly report a cgroup v1 like
+     * compound value we need to sum the two values. Setting a swap limit
+     * without also setting a memory limit is not allowed.
+     */
     @Override
     public long getMemoryAndSwapLimit() {
         String strVal = CgroupSubsystemController.getStringValue(unified, "memory.swap.max");
-        return limitFromString(strVal);
+        long swapLimit = limitFromString(strVal);
+        if (swapLimit >= 0) {
+            long memoryLimit = getMemoryLimit();
+            assert memoryLimit >= 0;
+            return memoryLimit + swapLimit;
+        }
+        return swapLimit;
     }
 
+    /**
+     * Note that for cgroups v2 the actual values set for swap usage and
+     * memory usage live in two different files, memory.current and memory.swap.current
+     * respectively. In order to properly report a cgroup v1 like
+     * compound value we need to sum the two values. Setting a swap limit
+     * without also setting a memory limit is not allowed.
+     */
     @Override
     public long getMemoryAndSwapUsage() {
-        return getLongVal("memory.swap.current");
+        long swapUsage = getLongVal("memory.swap.current");
+        long memoryUsage = getMemoryUsage();
+        return memoryUsage + swapUsage;
     }
 
     @Override

--- a/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
+++ b/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
@@ -233,13 +233,22 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
         }
 
         oldVal = metrics.getMemoryAndSwapLimit();
-        newVal = getLongLimitValueFromFile("memory.swap.max");
+        long valSwap = getLongLimitValueFromFile("memory.swap.max");
+        long valMemory = getLongLimitValueFromFile("memory.max");
+        if (valSwap == UNLIMITED) {
+            newVal = valSwap;
+        } else {
+            assert valMemory >= 0;
+            newVal = valSwap + valMemory;
+        }
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
             fail("memory.swap.max", oldVal, newVal);
         }
 
         oldVal = metrics.getMemoryAndSwapUsage();
-        newVal = getLongValueFromFile("memory.swap.current");
+        long swapUsage = getLongValueFromFile("memory.swap.current");
+        long memUsage = getLongValueFromFile("memory.current");
+        newVal = swapUsage + memUsage;
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
             fail("memory.swap.current", oldVal, newVal);
         }


### PR DESCRIPTION
Backport JDK-8253727 to 11u-dev. Depends on #863.

Testing: container tests on a cgroups v2 system

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253727](https://bugs.openjdk.java.net/browse/JDK-8253727): [cgroups v2] Memory and swap limits reported incorrectly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/894/head:pull/894` \
`$ git checkout pull/894`

Update a local copy of the PR: \
`$ git checkout pull/894` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 894`

View PR using the GUI difftool: \
`$ git pr show -t 894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/894.diff">https://git.openjdk.java.net/jdk11u-dev/pull/894.diff</a>

</details>
