### PR TITLE
8166727: javac crashed: [jimage.dll+0x1942]  ImageStrings::find+0x28

### DIFF
--- a/src/java.base/share/native/libjimage/imageFile.cpp
+++ b/src/java.base/share/native/libjimage/imageFile.cpp
@@ -211,17 +211,6 @@ ImageFileReaderTable::ImageFileReaderTable() : _count(0), _max(_growth) {
     assert(_table != NULL && "allocation failed");
 }
 
-ImageFileReaderTable::~ImageFileReaderTable() {
-    for (u4 i = 0; i < _count; i++) {
-        ImageFileReader* image = _table[i];
-
-        if (image != NULL) {
-            delete image;
-        }
-    }
-    free(_table);
-}
-
 // Add a new image entry to the table.
 void ImageFileReaderTable::add(ImageFileReader* image) {
     if (_count == _max) {

--- a/src/java.base/share/native/libjimage/imageFile.hpp
+++ b/src/java.base/share/native/libjimage/imageFile.hpp
@@ -371,7 +371,12 @@ private:
 
 public:
     ImageFileReaderTable();
-    ~ImageFileReaderTable();
+// ~ImageFileReaderTable()
+// Bug 8166727
+//
+// WARNING: Should never close jimage files.
+//          Threads may still be running during shutdown.
+//
 
     // Return the number of entries.
     inline u4 count() { return _count; }


### PR DESCRIPTION
I'd like to backport JDK-8166727 to jdk11u.
The original patch applied cleanly.
All regular tests passed (Linux x64, Windows x64, macOS x64).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8166727](https://bugs.openjdk.java.net/browse/JDK-8166727): javac crashed: [jimage.dll+0x1942]  ImageStrings::find+0x28


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/896/head:pull/896` \
`$ git checkout pull/896`

Update a local copy of the PR: \
`$ git checkout pull/896` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 896`

View PR using the GUI difftool: \
`$ git pr show -t 896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/896.diff">https://git.openjdk.java.net/jdk11u-dev/pull/896.diff</a>

</details>
