### PR TITLE
8207364: nsk/jvmti/ResourceExhausted/resexhausted003 fails to start

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java
@@ -42,9 +42,9 @@
  *      -agentlib:resexhausted=-waittime=5
  *      -Xms64m
  *      -Xmx64m
- *      -XX:MaxMetaspaceSize=8m
+ *      -XX:MaxMetaspaceSize=9m
  *      -XX:-UseGCOverheadLimit
  *      nsk.jvmti.ResourceExhausted.resexhausted003
- *      ./bin/classes
+ *      ../../classes/0/vmTestbase
  */
 


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8207364](https://bugs.openjdk.java.net/browse/JDK-8207364): nsk/jvmti/ResourceExhausted/resexhausted003 fails to start


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/900/head:pull/900` \
`$ git checkout pull/900`

Update a local copy of the PR: \
`$ git checkout pull/900` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 900`

View PR using the GUI difftool: \
`$ git pr show -t 900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/900.diff">https://git.openjdk.java.net/jdk11u-dev/pull/900.diff</a>

</details>
