### PR TITLE
8229486: Replace wildcard address with loopback or local host in tests - part 21

### DIFF
--- a/test/jdk/java/net/SocketOption/TcpKeepAliveTest.java
+++ b/test/jdk/java/net/SocketOption/TcpKeepAliveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
  */
 import java.io.IOException;
 import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.MulticastSocket;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -37,15 +39,14 @@ import jdk.net.ExtendedSocketOptions;
 
 public class TcpKeepAliveTest {
 
-    private static final String LOCAL_HOST = "127.0.0.1";
     private static final int DEFAULT_KEEP_ALIVE_PROBES = 7;
     private static final int DEFAULT_KEEP_ALIVE_TIME = 1973;
     private static final int DEFAULT_KEEP_ALIVE_INTVL = 53;
 
     public static void main(String args[]) throws IOException {
-
-        try (ServerSocket ss = new ServerSocket(0);
-                Socket s = new Socket(LOCAL_HOST, ss.getLocalPort());
+        var loopback = InetAddress.getLoopbackAddress();
+        try (ServerSocket ss = boundServer(loopback);
+                Socket s = new Socket(loopback, ss.getLocalPort());
                 DatagramSocket ds = new DatagramSocket(0);
                 MulticastSocket mc = new MulticastSocket(0)) {
             if (ss.supportedOptions().contains(ExtendedSocketOptions.TCP_KEEPIDLE)) {
@@ -109,5 +110,12 @@ public class TcpKeepAliveTest {
                         + " for TCP Sockets only");
             }
         }
+    }
+
+    private static ServerSocket boundServer(InetAddress address) throws IOException {
+        var socketAddress = new InetSocketAddress(address, 0);
+        var server = new ServerSocket();
+        server.bind(socketAddress);
+        return server;
     }
 }

--- a/test/jdk/java/net/URLConnection/SetIfModifiedSince.java
+++ b/test/jdk/java/net/URLConnection/SetIfModifiedSince.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4397096
+ * @library /test/lib
  * @run main/othervm SetIfModifiedSince
  * @summary setIfModifiedSince() of HttpURLConnection sets invalid date of default locale
  */
@@ -31,7 +32,11 @@ import java.net.*;
 import java.io.*;
 import java.util.*;
 
+import jdk.test.lib.net.URIBuilder;
+
 public class SetIfModifiedSince {
+    static volatile boolean successfulHeaderCheck = false;
+    static final String MARKER = "A-test-name";
 
     static class XServer extends Thread {
         ServerSocket srv;
@@ -48,46 +53,82 @@ public class SetIfModifiedSince {
         }
 
         public void run() {
-            try {
+            boolean foundMarker = false;
+            while (!foundMarker) {
                 String x;
-                s = srv.accept ();
-                is = s.getInputStream ();
-                BufferedReader r = new BufferedReader(new InputStreamReader(is));
-                os = s.getOutputStream ();
-                while ((x=r.readLine()) != null) {
-                    String header = "If-Modified-Since: ";
-                    if (x.startsWith(header)) {
-                        if (x.charAt(header.length()) == '?') {
-                            s.close ();
-                            srv.close (); // or else the HTTPURLConnection will retry
-                            throw new RuntimeException
-                                    ("Invalid HTTP date specification");
-                        }
-                        break;
-                    }
+                try {
+                    s = srv.accept();
+                    System.out.println("Server: accepting connection from: " + s);
+                    is = s.getInputStream ();
+                } catch (IOException io) {
+                    System.err.println("Server: Failed to accept connection: " + io);
+                    io.printStackTrace();
+                    try { srv.close(); } catch (IOException ioc) { }
+                    break;
                 }
-                s.close ();
-                srv.close (); // or else the HTTPURLConnection will retry
-            } catch (IOException e) {}
+                try {
+                    BufferedReader r = new BufferedReader(new InputStreamReader(is));
+                    os = s.getOutputStream ();
+                    boolean foundHeader;
+                    while ((x=r.readLine()) != null) {
+                        String testname = MARKER + ": ";
+                        String header = "If-Modified-Since: ";
+                        if (x.startsWith(header)) {
+                            foundHeader = true;
+                            System.out.println("Server: found header: " + x);
+                            if (x.charAt(header.length()) == '?') {
+                                s.close ();
+                                srv.close (); // or else the HTTPURLConnection will retry
+                                throw new RuntimeException
+                                        ("Invalid HTTP date specification");
+                            }
+                            if (foundMarker) break;
+                        } else if (x.startsWith(testname)) {
+                           foundMarker = true;
+                           System.out.println("Server: found marker: " + x);
+                        }
+                    }
+                    successfulHeaderCheck = true;
+                    s.close ();
+                    // only close server if connected from this test.
+                    if (foundMarker) {
+                        srv.close (); // or else the HTTPURLConnection will retry
+                    }
+                } catch (IOException e) {}
+            }
         }
     }
 
-    public static void main (String[] args) {
+    public static void main(String[] args) throws Exception {
         Locale reservedLocale = Locale.getDefault();
         try {
             Locale.setDefault(Locale.JAPAN);
-            ServerSocket serversocket = new ServerSocket (0);
+            ServerSocket serversocket = new ServerSocket();
+            serversocket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
             int port = serversocket.getLocalPort ();
             XServer server = new XServer (serversocket);
             server.start ();
             Thread.sleep (2000);
-            URL url = new URL ("http://localhost:"+port+"/index.html");
-            URLConnection urlc = url.openConnection ();
+            URL url = URIBuilder.newBuilder()
+                    .scheme("http")
+                    .loopback()
+                    .port(port)
+                    .path("/index.html")
+                    .toURLUnchecked();
+            URLConnection urlc = url.openConnection(Proxy.NO_PROXY);
+            urlc.setRequestProperty(MARKER, "SetIfModifiedSince");
             urlc.setIfModifiedSince (10000000);
             InputStream is = urlc.getInputStream ();
-            int i=0, c;
-            Thread.sleep (5000);
-        } catch (Exception e) {
+            int i = 0, c;
+            Thread.sleep(5000);
+            if (!successfulHeaderCheck) {
+                throw new RuntimeException("Header check was unsuccessful");
+            }
+        } catch (SocketException ce) {
+            if (!successfulHeaderCheck) {
+                throw ce;
+            }
+            System.out.println("ConnectionException expected on successful check of If-modified-since header");
         } finally {
             // restore the reserved locale
             Locale.setDefault(reservedLocale);

--- a/test/jdk/sun/net/www/http/HttpClient/GetProxyPort.java
+++ b/test/jdk/sun/net/www/http/HttpClient/GetProxyPort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,15 +27,25 @@
  * @summary REGRESSION: Sun implementation for HttpURLConnection could throw NPE
  * @modules java.base/sun.net
  *          java.base/sun.net.www.http
+ * @library /test/lib
  */
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.URL;
 import sun.net.www.http.HttpClient;
+import jdk.test.lib.net.URIBuilder;
 
 public class GetProxyPort {
     public static void main(String[] args) throws Exception {
-        ServerSocket ss = new ServerSocket(0);
-        URL myURL = new URL("http://localhost:" + ss.getLocalPort());
+        ServerSocket ss = new ServerSocket();
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        ss.bind(new InetSocketAddress(loopback, 0));
+        URL myURL = URIBuilder.newBuilder()
+            .scheme("http")
+            .loopback()
+            .port(ss.getLocalPort())
+            .toURL();
         HttpClient httpC = new HttpClient(myURL, null, -1);
         int port = httpC.getProxyPortUsed();
     }

--- a/test/jdk/sun/net/www/http/HttpClient/ImplicitFileName.java
+++ b/test/jdk/sun/net/www/http/HttpClient/ImplicitFileName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,19 +27,29 @@
  * @summary Make sure that implicit filenames will be returned as "/"
  * @modules java.base/sun.net
  *          java.base/sun.net.www.http
+ * @library /test/lib
  */
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.URL;
 import java.net.ServerSocket;
 import sun.net.www.http.HttpClient;
+import jdk.test.lib.net.URIBuilder;
 
 public class ImplicitFileName {
 
     public static void main(String[] args) throws Exception {
 
-        ServerSocket ss = new ServerSocket(0);
+        ServerSocket ss = new ServerSocket();
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        ss.bind(new InetSocketAddress(loopback, 0));
 
-        URL url = new URL("http://localhost:" + ss.getLocalPort());
+        URL url = URIBuilder.newBuilder()
+            .scheme("http")
+            .loopback()
+            .port(ss.getLocalPort())
+            .toURL();
 
         HttpClient c = HttpClient.New(url);
 

--- a/test/jdk/sun/net/www/http/HttpClient/OpenServer.java
+++ b/test/jdk/sun/net/www/http/HttpClient/OpenServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,22 +27,31 @@
  * @summary Make sure HttpClient has
  *    doPrivileged() calls at appropriate places.
  * @modules java.base/sun.net.www.http
+ * @library /test/lib
  * @run main/othervm/policy=OpenServer.policy OpenServer
  */
 
 import java.net.*;
 import sun.net.www.http.HttpClient;
+import jdk.test.lib.net.URIBuilder;
 
 public class OpenServer {
 
     OpenServer() throws Exception {
 
-        ServerSocket ss = new ServerSocket(0);
+        ServerSocket ss = new ServerSocket();
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        ss.bind(new InetSocketAddress(loopback, 0));
 
-        URL myURL = new URL("http://localhost:" + ss.getLocalPort());
-        HttpClient httpC = new HttpClient(myURL, null, -1);
+        try (ServerSocket toClose = ss) {
+            URL myURL = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(ss.getLocalPort())
+                .toURL();
 
-        ss.close();
+            HttpClient httpC = new HttpClient(myURL, null, -1);
+        }
     }
 
     public static void main(String [] args) throws Exception {

--- a/test/jdk/sun/net/www/protocol/http/StreamingOutputStream.java
+++ b/test/jdk/sun/net/www/protocol/http/StreamingOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class StreamingOutputStream
             InetSocketAddress address = httpServer.getAddress();
 
             URL url = new URL("http://" + address.getHostName() + ":" + address.getPort() + "/test/");
-            HttpURLConnection uc = (HttpURLConnection)url.openConnection();
+            HttpURLConnection uc = (HttpURLConnection)url.openConnection(Proxy.NO_PROXY);
 
             uc.setDoOutput(true);
             uc.setFixedLengthStreamingMode(1);
@@ -87,7 +87,18 @@ public class StreamingOutputStream
      * Http Server
      */
     void startHttpServer() throws IOException {
-        httpServer = com.sun.net.httpserver.HttpServer.create(new InetSocketAddress(0), 0);
+        InetAddress address = InetAddress.getLocalHost();
+        if (!InetAddress.getByName(address.getHostName()).equals(address)) {
+            // if this happens then we should possibly change the client
+            // side to use the address literal in its URL instead of
+            // the host name.
+            throw new IOException(address.getHostName()
+                                  + " resolves to "
+                                  + InetAddress.getByName(address.getHostName())
+                                  + " not to "
+                                  + address + ": check host configuration.");
+        }
+        httpServer = com.sun.net.httpserver.HttpServer.create(new InetSocketAddress(address, 0), 0);
         HttpContext ctx = httpServer.createContext("/test/", new MyHandler());
         httpServer.start();
     }

--- a/test/jdk/sun/net/www/protocol/http/UserAuth.java
+++ b/test/jdk/sun/net/www/protocol/http/UserAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,19 @@ public class UserAuth
      * Http Server
      */
     void startHttpServer() throws IOException {
-        httpServer = com.sun.net.httpserver.HttpServer.create(new InetSocketAddress(0), 0);
+        InetAddress address = InetAddress.getLocalHost();
+        if (!InetAddress.getByName(address.getHostName()).equals(address)) {
+            // if this happens then we should possibly change the client
+            // side to use the address literal in its URL instead of
+            // the host name.
+            throw new IOException(address.getHostName()
+                                  + " resolves to "
+                                  + InetAddress.getByName(address.getHostName())
+                                  + " not to "
+                                  + address + ": check host configuration.");
+        }
+
+        httpServer = com.sun.net.httpserver.HttpServer.create(new InetSocketAddress(address, 0), 0);
 
         // create HttpServer context
         HttpContext ctx = httpServer.createContext("/redirect/", new RedirectHandler());

--- a/test/jdk/sun/net/www/protocol/http/UserCookie.java
+++ b/test/jdk/sun/net/www/protocol/http/UserCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,19 @@ public class UserCookie
      * Http Server
      */
     void startHttpServer() throws IOException {
-        httpServer = com.sun.net.httpserver.HttpServer.create(new InetSocketAddress(0), 0);
+        InetAddress address = InetAddress.getLocalHost();
+        if (!InetAddress.getByName(address.getHostName()).equals(address)) {
+            // if this happens then we should possibly change the client
+            // side to use the address literal in its URL instead of
+            // the host name.
+            throw new IOException(address.getHostName()
+                                  + " resolves to "
+                                  + InetAddress.getByName(address.getHostName())
+                                  + " not to "
+                                  + address + ": check host configuration.");
+        }
+
+        httpServer = com.sun.net.httpserver.HttpServer.create(new InetSocketAddress(address, 0), 0);
 
         // create HttpServer context
         HttpContext ctx = httpServer.createContext("/test/", new MyHandler());


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

TcpKeepAliveTest.java does not apply because
   8220083: Use InetAddress.getLoopbackAddress() in place of 127.0.0.1 f...
is missing 

SetIfModifiedSince.java does not apply because
   8226756: Replace wildcard address with loopback or local host in tests - part 18
is missing. 

I included the respective previous changes to these two files in this patch. Backporting these larger
dependencies will cause recursive backports or require resolving. I want to avoid this additional 
effort. In case backports of these other changes are necessary later, one will just have to 
skip the patches to the corresponding files. As the changes are quite simple, this should
be easy enough to do.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8229486](https://bugs.openjdk.java.net/browse/JDK-8229486): Replace wildcard address with loopback or local host in tests - part 21


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/902/head:pull/902` \
`$ git checkout pull/902`

Update a local copy of the PR: \
`$ git checkout pull/902` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 902`

View PR using the GUI difftool: \
`$ git pr show -t 902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/902.diff">https://git.openjdk.java.net/jdk11u-dev/pull/902.diff</a>

</details>
