### PR TITLE
8241707: introduce randomness k/w to hotspot test suite

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -27,7 +27,8 @@
 # It also contains test-suite configuration information.
 
 # The list of keywords supported in this test suite
-keys=cte_test jcmd nmt regression gc stress metaspace headful intermittent
+# randomness:           test uses randomness, test cases differ from run to run
+keys=cte_test jcmd nmt regression gc stress metaspace headful intermittent randomness
 
 groups=TEST.groups TEST.quick-groups
 

--- a/test/hotspot/jtreg/testlibrary_tests/RandomGeneratorTest.java
+++ b/test/hotspot/jtreg/testlibrary_tests/RandomGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,8 @@
 
 /*
  * @test
- * @summary Verify correctnes of the random generator from Utility.java
+ * @key randomness
+ * @summary Verify correctnes of the random generator from Utils.java
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8241707](https://bugs.openjdk.java.net/browse/JDK-8241707): introduce randomness k/w to hotspot test suite


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/905/head:pull/905` \
`$ git checkout pull/905`

Update a local copy of the PR: \
`$ git checkout pull/905` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 905`

View PR using the GUI difftool: \
`$ git pr show -t 905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/905.diff">https://git.openjdk.java.net/jdk11u-dev/pull/905.diff</a>

</details>
