### PR TITLE
8269933: test/jdk/javax/net/ssl/compatibility/JdkInfo incorrect verification of protocol and cipher support

### DIFF
--- a/test/jdk/javax/net/ssl/compatibility/JdkInfo.java
+++ b/test/jdk/javax/net/ssl/compatibility/JdkInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,9 @@
  */
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /*
@@ -37,10 +39,10 @@ public class JdkInfo {
     public final Path javaPath;
 
     public final String version;
-    public final String supportedProtocols;
-    public final String enabledProtocols;
-    public final String supportedCipherSuites;
-    public final String enabledCipherSuites;
+    public final List<String> supportedProtocols;
+    public final List<String> enabledProtocols;
+    public final List<String> supportedCipherSuites;
+    public final List<String> enabledCipherSuites;
     public final boolean supportsSNI;
     public final boolean supportsALPN;
 
@@ -54,13 +56,26 @@ public class JdkInfo {
         }
 
         String[] attributes = Utilities.split(output, Utilities.PARAM_DELIMITER);
-        version = attributes[0].replaceAll(".*=", "");
-        supportedProtocols = attributes[1].replaceAll(".*=", "");
-        enabledProtocols = attributes[2].replaceAll(".*=", "");
-        supportedCipherSuites = attributes[3].replaceAll(".*=", "");
-        enabledCipherSuites = attributes[4].replaceAll(".*=", "");
-        supportsSNI = Boolean.valueOf(attributes[5].replaceAll(".*=", ""));
-        supportsALPN = Boolean.valueOf(attributes[6].replaceAll(".*=", ""));
+        version = parseAttribute(attributes[0]);
+        supportedProtocols = parseListAttribute(attributes[1]);
+        enabledProtocols = parseListAttribute(attributes[2]);
+        supportedCipherSuites = parseListAttribute(attributes[3]);
+        enabledCipherSuites = parseListAttribute(attributes[4]);
+        supportsSNI = parseBooleanAttribute(attributes[5]);
+        supportsALPN = parseBooleanAttribute(attributes[6]);
+    }
+
+    private List<String> parseListAttribute(String attribute) {
+        attribute = parseAttribute(attribute);
+        return Arrays.asList(attribute.split(","));
+    }
+
+    private boolean parseBooleanAttribute(String attribute) {
+        attribute = parseAttribute(attribute);
+        return Boolean.parseBoolean(attribute);
+    }
+    private String parseAttribute(String attribute) {
+        return attribute.replaceAll(".*=", "");
     }
 
     // Determines the specific attributes for the specified JDK.


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269933](https://bugs.openjdk.java.net/browse/JDK-8269933): test/jdk/javax/net/ssl/compatibility/JdkInfo incorrect verification of protocol and cipher support


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/906/head:pull/906` \
`$ git checkout pull/906`

Update a local copy of the PR: \
`$ git checkout pull/906` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 906`

View PR using the GUI difftool: \
`$ git pr show -t 906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/906.diff">https://git.openjdk.java.net/jdk11u-dev/pull/906.diff</a>

</details>
