### PR TITLE
8274233: Minor cleanup for ToolBox

### DIFF
--- a/test/langtools/tools/lib/toolbox/ToolBox.java
+++ b/test/langtools/tools/lib/toolbox/ToolBox.java
@@ -34,10 +34,8 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URI;
 import java.nio.charset.Charset;
-import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
@@ -65,8 +63,6 @@ import javax.tools.FileObject;
 import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
-import javax.tools.JavaFileObject.Kind;
-import javax.tools.JavaFileManager.Location;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.ToolProvider;
 
@@ -107,11 +103,11 @@ public class ToolBox {
     public static final float timeoutFactor;
     static {
         String ttf = System.getProperty("test.timeout.factor");
-        timeoutFactor = (ttf == null) ? 1.0f : Float.valueOf(ttf);
+        timeoutFactor = (ttf == null) ? 1.0f : Float.parseFloat(ttf);
     }
 
     /** The current directory. */
-    public static final Path currDir = Paths.get(".");
+    public static final Path currDir = Path.of(".");
 
     /** The stream used for logging output. */
     public PrintStream out = System.err;
@@ -127,6 +123,7 @@ public class ToolBox {
     /**
      * Splits a string around matches of the given regular expression.
      * If the string is empty, an empty list will be returned.
+     *
      * @param text the string to be split
      * @param sep  the delimiting regular expression
      * @return the strings between the separators
@@ -139,6 +136,7 @@ public class ToolBox {
 
     /**
      * Checks if two lists of strings are equal.
+     *
      * @param l1 the first list of strings to be compared
      * @param l2 the second list of strings to be compared
      * @throws Error if the lists are not equal
@@ -165,6 +163,7 @@ public class ToolBox {
 
     /**
      * Filters a list of strings according to the given regular expression.
+     *
      * @param regex the regular expression
      * @param lines the strings to be filtered
      * @return the strings matching the regular expression
@@ -175,8 +174,9 @@ public class ToolBox {
 
     /**
      * Filters a list of strings according to the given regular expression.
+     *
      * @param pattern the regular expression
-     * @param lines the strings to be filtered
+     * @param lines   the strings to be filtered
      * @return the strings matching the regular expression
      */
     public List<String> grep(Pattern pattern, List<String> lines) {
@@ -191,12 +191,13 @@ public class ToolBox {
      * in that directory.  Otherwise, the copy will be placed at the destination,
      * possibly overwriting any existing file.
      * <p>Similar to the shell "cp" command: {@code cp from to}.
+     *
      * @param from the file to be copied
-     * @param to where to copy the file
+     * @param to   where to copy the file
      * @throws IOException if any error occurred while copying the file
      */
     public void copyFile(String from, String to) throws IOException {
-        copyFile(Paths.get(from), Paths.get(to));
+        copyFile(Path.of(from), Path.of(to));
     }
 
     /**
@@ -205,8 +206,9 @@ public class ToolBox {
      * in that directory.  Otherwise, the copy will be placed at the destination,
      * possibly overwriting any existing file.
      * <p>Similar to the shell "cp" command: {@code cp from to}.
+     *
      * @param from the file to be copied
-     * @param to where to copy the file
+     * @param to   where to copy the file
      * @throws IOException if an error occurred while copying the file
      */
     public void copyFile(Path from, Path to) throws IOException {
@@ -223,6 +225,7 @@ public class ToolBox {
      * For each of the series of paths, a directory will be created,
      * including any necessary parent directories.
      * <p>Similar to the shell command: {@code mkdir -p paths}.
+     *
      * @param paths the directories to be created
      * @throws IOException if an error occurred while creating the directories
      */
@@ -230,7 +233,7 @@ public class ToolBox {
         if (paths.length == 0)
             throw new IllegalArgumentException("no directories specified");
         for (String p : paths)
-            Files.createDirectories(Paths.get(p));
+            Files.createDirectories(Path.of(p));
     }
 
     /**
@@ -238,6 +241,7 @@ public class ToolBox {
      * For each of the series of paths, a directory will be created,
      * including any necessary parent directories.
      * <p>Similar to the shell command: {@code mkdir -p paths}.
+     *
      * @param paths the directories to be created
      * @throws IOException if an error occurred while creating the directories
      */
@@ -252,6 +256,7 @@ public class ToolBox {
      * Deletes one or more files, awaiting confirmation that the files
      * no longer exist. Any directories to be deleted must be empty.
      * <p>Similar to the shell command: {@code rm files}.
+     *
      * @param files the names of the files to be deleted
      * @throws IOException if an error occurred while deleting the files
      */
@@ -263,6 +268,7 @@ public class ToolBox {
      * Deletes one or more files, awaiting confirmation that the files
      * no longer exist. Any directories to be deleted must be empty.
      * <p>Similar to the shell command: {@code rm files}.
+     *
      * @param paths the paths for the files to be deleted
      * @throws IOException if an error occurred while deleting the files
      */
@@ -274,6 +280,7 @@ public class ToolBox {
      * Deletes one or more files, awaiting confirmation that the files
      * no longer exist. Any directories to be deleted must be empty.
      * <p>Similar to the shell command: {@code rm files}.
+     *
      * @param paths the paths for the files to be deleted
      * @throws IOException if an error occurred while deleting the files
      */
@@ -293,6 +300,7 @@ public class ToolBox {
     /**
      * Deletes all content of a directory (but not the directory itself),
      * awaiting confirmation that the content has been deleted.
+     *
      * @param root the directory to be cleaned
      * @throws IOException if an error occurs while cleaning the directory
      */
@@ -300,20 +308,20 @@ public class ToolBox {
         if (!Files.isDirectory(root)) {
             throw new IOException(root + " is not a directory");
         }
-        Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
             private IOException ioe = null;
             // for each directory we visit, maintain a list of the files that we try to delete
-            private Deque<List<Path>> dirFiles = new LinkedList<>();
+            private final Deque<List<Path>> dirFiles = new LinkedList<>();
 
             @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes a) throws IOException {
+            public FileVisitResult visitFile(Path file, BasicFileAttributes a) {
                 ioe = deleteFile(file, ioe);
                 dirFiles.peekFirst().add(file);
                 return FileVisitResult.CONTINUE;
             }
 
             @Override
-            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes a) throws IOException {
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes a) {
                 if (!dir.equals(root)) {
                     dirFiles.peekFirst().add(dir);
                 }
@@ -343,10 +351,11 @@ public class ToolBox {
      * It does not wait to confirm deletion, nor does it retry.
      * If an exception occurs it is either returned or added to the set of
      * suppressed exceptions for an earlier exception.
+     *
      * @param path the path for the file to be deleted
-     * @param ioe the earlier exception, or null
+     * @param ioe  the earlier exception, or null
      * @return the earlier exception or an exception that occurred while
-     *  trying to delete the file
+     * trying to delete the file
      */
     private IOException deleteFile(Path path, IOException ioe) {
         try {
@@ -363,6 +372,7 @@ public class ToolBox {
 
     /**
      * Wait until it is confirmed that a set of files have been deleted.
+     *
      * @param paths the paths for the files to be deleted
      * @throws IOException if a file has not been deleted
      */
@@ -375,6 +385,7 @@ public class ToolBox {
 
     /**
      * Wait until it is confirmed that a file has been deleted.
+     *
      * @param path the path for the file to be deleted
      * @throws IOException if problems occur while deleting the file
      */
@@ -405,12 +416,13 @@ public class ToolBox {
      * to that directory.  Otherwise, the file will be moved to the destination,
      * possibly overwriting any existing file.
      * <p>Similar to the shell "mv" command: {@code mv from to}.
+     *
      * @param from the file to be moved
-     * @param to where to move the file
+     * @param to   where to move the file
      * @throws IOException if an error occurred while moving the file
      */
     public void moveFile(String from, String to) throws IOException {
-        moveFile(Paths.get(from), Paths.get(to));
+        moveFile(Path.of(from), Path.of(to));
     }
 
     /**
@@ -419,8 +431,9 @@ public class ToolBox {
      * to that directory.  Otherwise, the file will be moved to the destination,
      * possibly overwriting any existing file.
      * <p>Similar to the shell "mv" command: {@code mv from to}.
+     *
      * @param from the file to be moved
-     * @param to where to move the file
+     * @param to   where to move the file
      * @throws IOException if an error occurred while moving the file
      */
     public void moveFile(Path from, Path to) throws IOException {
@@ -435,6 +448,7 @@ public class ToolBox {
     /**
      * Reads the lines of a file.
      * The file is read using the default character encoding.
+     *
      * @param path the file to be read
      * @return the lines of the file
      * @throws IOException if an error occurred while reading the file
@@ -446,6 +460,7 @@ public class ToolBox {
     /**
      * Reads the lines of a file.
      * The file is read using the default character encoding.
+     *
      * @param path the file to be read
      * @return the lines of the file
      * @throws IOException if an error occurred while reading the file
@@ -456,18 +471,20 @@ public class ToolBox {
 
     /**
      * Reads the lines of a file using the given encoding.
-     * @param path the file to be read
+     *
+     * @param path     the file to be read
      * @param encoding the encoding to be used to read the file
      * @return the lines of the file.
      * @throws IOException if an error occurred while reading the file
      */
     public List<String> readAllLines(String path, String encoding) throws IOException {
-        return readAllLines(Paths.get(path), encoding);
+        return readAllLines(Path.of(path), encoding);
     }
 
     /**
      * Reads the lines of a file using the given encoding.
-     * @param path the file to be read
+     *
+     * @param path     the file to be read
      * @param encoding the encoding to be used to read the file
      * @return the lines of the file
      * @throws IOException if an error occurred while reading the file
@@ -483,6 +500,7 @@ public class ToolBox {
     /**
      * Find .java files in one or more directories.
      * <p>Similar to the shell "find" command: {@code find paths -name \*.java}.
+     *
      * @param paths the directories in which to search for .java files
      * @return the .java files found
      * @throws IOException if an error occurred while searching for files
@@ -494,18 +512,18 @@ public class ToolBox {
     /**
      * Find files matching the file extension, in one or more directories.
      * <p>Similar to the shell "find" command: {@code find paths -name \*.ext}.
+     *
      * @param fileExtension the extension to search for
-     * @param paths the directories in which to search for files
+     * @param paths         the directories in which to search for files
      * @return the files matching the file extension
      * @throws IOException if an error occurred while searching for files
      */
     public Path[] findFiles(String fileExtension, Path... paths) throws IOException {
         Set<Path> files = new TreeSet<>();  // use TreeSet to force a consistent order
         for (Path p : paths) {
-            Files.walkFileTree(p, new SimpleFileVisitor<Path>() {
+            Files.walkFileTree(p, new SimpleFileVisitor<>() {
                 @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                        throws IOException {
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                     if (file.getFileName().toString().endsWith(fileExtension)) {
                         files.add(file);
                     }
@@ -513,24 +531,26 @@ public class ToolBox {
                 }
             });
         }
-        return files.toArray(new Path[files.size()]);
+        return files.toArray(new Path[0]);
     }
 
     /**
      * Writes a file containing the given content.
      * Any necessary directories for the file will be created.
-     * @param path where to write the file
+     *
+     * @param path    where to write the file
      * @param content the content for the file
      * @throws IOException if an error occurred while writing the file
      */
     public void writeFile(String path, String content) throws IOException {
-        writeFile(Paths.get(path), content);
+        writeFile(Path.of(path), content);
     }
 
     /**
      * Writes a file containing the given content.
      * Any necessary directories for the file will be created.
-     * @param path where to write the file
+     *
+     * @param path    where to write the file
      * @param content the content for the file
      * @throws IOException if an error occurred while writing the file
      */
@@ -554,7 +574,8 @@ public class ToolBox {
      * <p>Note: the content is analyzed using regular expressions;
      * errors can occur if any contents have initial comments that might trip
      * up the analysis.
-     * @param dir the base directory
+     *
+     * @param dir      the base directory
      * @param contents the contents of the files to be written
      * @throws IOException if an error occurred while writing any of the files.
      */
@@ -567,17 +588,19 @@ public class ToolBox {
     }
 
     /**
-     * Returns the path for the binary of a JDK tool within {@link testJDK}.
+     * Returns the path for the binary of a JDK tool within {@link #testJDK}.
+     *
      * @param tool the name of the tool
      * @return the path of the tool
      */
     public Path getJDKTool(String tool) {
-        return Paths.get(testJDK, "bin", tool);
+        return Path.of(testJDK, "bin", tool);
     }
 
     /**
      * Returns a string representing the contents of an {@code Iterable} as a list.
-     * @param <T> the type parameter of the {@code Iterable}
+     *
+     * @param <T>   the type parameter of the {@code Iterable}
      * @param items the iterable
      * @return the string
      */
@@ -598,8 +621,9 @@ public class ToolBox {
 
         /**
          * Creates a in-memory file object for Java source code.
+         *
          * @param className the name of the class
-         * @param source the source text
+         * @param source    the source text
          */
         public JavaSource(String className, String source) {
             super(URI.create(className), JavaFileObject.Kind.SOURCE);
@@ -609,6 +633,7 @@ public class ToolBox {
         /**
          * Creates a in-memory file object for Java source code.
          * The name of the class will be inferred from the source code.
+         *
          * @param source the source text
          */
         public JavaSource(String source) {
@@ -619,6 +644,7 @@ public class ToolBox {
 
         /**
          * Writes the source code to a file in the current directory.
+         *
          * @throws IOException if there is a problem writing the file
          */
         public void write() throws IOException {
@@ -627,6 +653,7 @@ public class ToolBox {
 
         /**
          * Writes the source code to a file in a specified directory.
+         *
          * @param dir the directory
          * @throws IOException if there is a problem writing the file
          */
@@ -643,13 +670,13 @@ public class ToolBox {
             return source;
         }
 
-        private static Pattern commentPattern =
+        private final static Pattern commentPattern =
                 Pattern.compile("(?s)(\\s+//.*?\n|/\\*.*?\\*/)");
-        private static Pattern modulePattern =
+        private final static Pattern modulePattern =
                 Pattern.compile("module\\s+((?:\\w+\\.)*)");
-        private static Pattern packagePattern =
-                Pattern.compile("package\\s+(((?:\\w+\\.)*)(?:\\w+))");
-        private static Pattern classPattern =
+        private final static Pattern packagePattern =
+                Pattern.compile("package\\s+(((?:\\w+\\.)*)\\w+)");
+        private final static Pattern classPattern =
                 Pattern.compile("(?:public\\s+)?(?:class|enum|interface)\\s+(\\w+)");
 
         /**
@@ -663,7 +690,7 @@ public class ToolBox {
             Matcher matcher = commentPattern.matcher(source);
             int start = 0;
             while (matcher.find()) {
-                sb.append(source.substring(start, matcher.start()));
+                sb.append(source, start, matcher.start());
                 start = matcher.end();
             }
             sb.append(source.substring(start));
@@ -699,10 +726,11 @@ public class ToolBox {
      * Extracts the Java file name from the class declaration.
      * This method is intended for simple files and uses regular expressions,
      * so comments matching the pattern can make the method fail.
-     * @deprecated This is a legacy method for compatibility with ToolBox v1.
-     *      Use {@link JavaSource#getName JavaSource.getName} instead.
+     *
      * @param source the source text
      * @return the Java file name inferred from the source
+     * @deprecated This is a legacy method for compatibility with ToolBox v1.
+     * Use {@link JavaSource#getName JavaSource.getName} instead.
      */
     @Deprecated
     public static String getJavaFileNameFromSource(String source) {
@@ -715,11 +743,15 @@ public class ToolBox {
         "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8",  "lpt9"
     );
 
-    /**Validate if a given name is a valid file name
+    /**
+     * Validates if a given name is a valid file name
      * or path name on known platforms.
+     *
+     * @param name the name
+     * @throws IllegalArgumentException if the name is a reserved name
      */
     public static void validateName(String name) {
-        for (String part : name.split("\\.|/|\\\\")) {
+        for (String part : name.split("[./\\\\]")) {
             if (RESERVED_NAMES.contains(part.toLowerCase(Locale.US))) {
                 throw new IllegalArgumentException("Name: " + name + " is" +
                                                    "a reserved name on Windows, " +
@@ -727,12 +759,8 @@ public class ToolBox {
             }
         }
     }
-    /**
-     * A memory file manager, for saving generated files in memory.
-     * The file manager delegates to a separate file manager for listing and
-     * reading input files.
-     */
-    public static class MemoryFileManager extends ForwardingJavaFileManager {
+
+    public static class MemoryFileManager extends ForwardingJavaFileManager<JavaFileManager> {
         private interface Content {
             byte[] getBytes();
             String getString();
@@ -744,7 +772,7 @@ public class ToolBox {
         private final Map<Location, Map<String, Content>> files;
 
         /**
-         * Construct a memory file manager which stores output files in memory,
+         * Constructs a memory file manager which stores output files in memory,
          * and delegates to a default file manager for input files.
          */
         public MemoryFileManager() {
@@ -752,8 +780,9 @@ public class ToolBox {
         }
 
         /**
-         * Construct a memory file manager which stores output files in memory,
+         * Constructs a memory file manager which stores output files in memory,
          * and delegates to a specified file manager for input files.
+         *
          * @param fileManager the file manager to be used for input files
          */
         public MemoryFileManager(JavaFileManager fileManager) {
@@ -773,6 +802,7 @@ public class ToolBox {
         /**
          * Returns the set of names of files that have been written to a given
          * location.
+         *
          * @param location the location
          * @return the set of file names
          */
@@ -785,8 +815,9 @@ public class ToolBox {
         /**
          * Returns the content written to a file in a given location,
          * or null if no such file has been written.
+         *
          * @param location the location
-         * @param name the name of the file
+         * @param name     the name of the file
          * @return the content as an array of bytes
          */
         public byte[] getFileBytes(Location location, String name) {
@@ -797,8 +828,9 @@ public class ToolBox {
         /**
          * Returns the content written to a file in a given location,
          * or null if no such file has been written.
+         *
          * @param location the location
-         * @param name the name of the file
+         * @param name     the name of the file
          * @return the content as a string
          */
         public String getFileString(Location location, String name) {
@@ -812,10 +844,8 @@ public class ToolBox {
         }
 
         private void save(Location location, String name, Content content) {
-            Map<String, Content> filesForLocation = files.get(location);
-            if (filesForLocation == null)
-                files.put(location, filesForLocation = new HashMap<>());
-            filesForLocation.put(name, content);
+            files.computeIfAbsent(location, k -> new HashMap<>())
+                    .put(name, content);
         }
 
         /**
@@ -827,7 +857,10 @@ public class ToolBox {
 
             /**
              * Constructs a memory file object.
-             * @param name binary name of the class to be stored in this file object
+             *
+             * @param location the location in which to save the file object
+             * @param name     binary name of the class to be stored in this file object
+             * @param kind     the kind of file object
              */
             MemoryFileObject(Location location, String name, JavaFileObject.Kind kind) {
                 super(URI.create("mfm:///" + name.replace('.','/') + kind.extension),
@@ -864,7 +897,7 @@ public class ToolBox {
                     @Override
                     public void close() throws IOException {
                         out.close();
-                        String text = ((StringWriter) out).toString();
+                        String text = out.toString();
                         save(location, name, new Content() {
                             @Override
                             public byte[] getBytes() {


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

I had to resolve some comment changes because previous changes are missing. 
They are formatting changes, so pretty pointless.
One code block had to be resolved because of context changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274233](https://bugs.openjdk.java.net/browse/JDK-8274233): Minor cleanup for ToolBox


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/907/head:pull/907` \
`$ git checkout pull/907`

Update a local copy of the PR: \
`$ git checkout pull/907` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 907`

View PR using the GUI difftool: \
`$ git pr show -t 907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/907.diff">https://git.openjdk.java.net/jdk11u-dev/pull/907.diff</a>

</details>
