### PR TITLE
8277422: tools/jar/JarEntryTime.java fails with modified time mismatch

### DIFF
--- a/test/jdk/tools/jar/JarEntryTime.java
+++ b/test/jdk/tools/jar/JarEntryTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 4225317 6969651
+ * @bug 4225317 6969651 8277422
  * @modules jdk.jartool
  * @summary Check extracted files have date as per those in the .jar file
  */
@@ -31,6 +31,7 @@
 import java.io.File;
 import java.io.PrintWriter;
 import java.nio.file.attribute.FileTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.spi.ToolProvider;
@@ -92,6 +93,14 @@ public class JarEntryTime {
         cleanup(dirOuter);
         jarFile.delete();
         testFile.delete();
+
+        var date = new Date();
+        var defZone = ZoneId.systemDefault();
+        if (defZone.getRules().getTransition(
+                date.toInstant().atZone(defZone).toLocalDateTime()) != null) {
+            System.out.println("At the offset transition.  JarEntryTime test skipped.");
+            return;
+        }
 
         /* Create a directory structure
          * outer/


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277422](https://bugs.openjdk.java.net/browse/JDK-8277422): tools/jar/JarEntryTime.java fails with modified time mismatch


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/908/head:pull/908` \
`$ git checkout pull/908`

Update a local copy of the PR: \
`$ git checkout pull/908` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 908`

View PR using the GUI difftool: \
`$ git pr show -t 908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/908.diff">https://git.openjdk.java.net/jdk11u-dev/pull/908.diff</a>

</details>
