### PR TITLE
8247591: Document Alpine Linux build steps in OpenJDK build guide

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -75,6 +75,7 @@
 <li><a href="#native-libraries">Native Libraries</a></li>
 <li><a href="#cross-compiling-with-debian-sysroots">Cross compiling with Debian sysroots</a></li>
 <li><a href="#building-for-armaarch64">Building for ARM/aarch64</a></li>
+<li><a href="#building-for-musl">Building for musl</a></li>
 <li><a href="#verifying-the-build">Verifying the Build</a></li>
 </ul></li>
 <li><a href="#build-performance">Build Performance</a><ul>
@@ -224,6 +225,8 @@
 <pre><code>sudo apt-get install build-essential</code></pre>
 <p>For rpm-based distributions (Fedora, Red Hat, etc), try this:</p>
 <pre><code>sudo yum groupinstall &quot;Development Tools&quot;</code></pre>
+<p>For Alpine Linux, aside from basic tooling, install the GNU versions of some programs:</p>
+<pre><code>sudo apk add build-base bash grep zip</code></pre>
 <h3 id="aix">AIX</h3>
 <p>The regular builds by SAP is using AIX version 7.1, but AIX 5.3 is also supported. See the <a href="http://cr.openjdk.java.net/~simonis/ppc-aix-port">OpenJDK PowerPC Port Status Page</a> for details.</p>
 <h2 id="native-compiler-toolchain-requirements">Native Compiler (Toolchain) Requirements</h2>
@@ -380,6 +383,7 @@ CC: Sun C++ 5.13 SunOS_i386 151846-10 2015/10/30</code></pre>
 <ul>
 <li>To install on an apt-based Linux, try running <code>sudo apt-get install libfreetype6-dev</code>.</li>
 <li>To install on an rpm-based Linux, try running <code>sudo yum install freetype-devel</code>.</li>
+<li>To install on Alpine Linux, try running <code>sudo apk add freetype-dev</code>.</li>
 <li>To install on Solaris, try running <code>pkg install system/library/freetype-2</code>.</li>
 </ul>
 <p>Use <code>--with-freetype-include=&lt;path&gt;</code> and <code>--with-freetype-lib=&lt;path&gt;</code> if <code>configure</code> does not automatically locate the platform FreeType files.</p>
@@ -388,6 +392,7 @@ CC: Sun C++ 5.13 SunOS_i386 151846-10 2015/10/30</code></pre>
 <ul>
 <li>To install on an apt-based Linux, try running <code>sudo apt-get install libcups2-dev</code>.</li>
 <li>To install on an rpm-based Linux, try running <code>sudo yum install cups-devel</code>.</li>
+<li>To install on Alpine Linux, try running <code>sudo apk add cups-dev</code>.</li>
 <li>To install on Solaris, try running <code>pkg install print/cups</code>.</li>
 </ul>
 <p>Use <code>--with-cups=&lt;path&gt;</code> if <code>configure</code> does not properly locate your CUPS files.</p>
@@ -396,6 +401,7 @@ CC: Sun C++ 5.13 SunOS_i386 151846-10 2015/10/30</code></pre>
 <ul>
 <li>To install on an apt-based Linux, try running <code>sudo apt-get install libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev</code>.</li>
 <li>To install on an rpm-based Linux, try running <code>sudo yum install libXtst-devel libXt-devel libXrender-devel libXi-devel</code>.</li>
+<li>To install on Alpine Linux, try running <code>sudo apk add libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev</code>.</li>
 <li>To install on Solaris, try running <code>pkg install x11/header/x11-protocols x11/library/libice x11/library/libpthread-stubs x11/library/libsm x11/library/libx11 x11/library/libxau x11/library/libxcb x11/library/libxdmcp x11/library/libxevie x11/library/libxext x11/library/libxrender x11/library/libxscrnsaver x11/library/libxtst x11/library/toolkit/libxt</code>.</li>
 </ul>
 <p>Use <code>--with-x=&lt;path&gt;</code> if <code>configure</code> does not properly locate your X11 files.</p>
@@ -404,6 +410,7 @@ CC: Sun C++ 5.13 SunOS_i386 151846-10 2015/10/30</code></pre>
 <ul>
 <li>To install on an apt-based Linux, try running <code>sudo apt-get install libasound2-dev</code>.</li>
 <li>To install on an rpm-based Linux, try running <code>sudo yum install alsa-lib-devel</code>.</li>
+<li>To install on Alpine Linux, try running <code>sudo apk add alsa-lib-dev</code>.</li>
 </ul>
 <p>Use <code>--with-alsa=&lt;path&gt;</code> if <code>configure</code> does not properly locate your ALSA files.</p>
 <h3 id="libffi">libffi</h3>
@@ -411,6 +418,7 @@ CC: Sun C++ 5.13 SunOS_i386 151846-10 2015/10/30</code></pre>
 <ul>
 <li>To install on an apt-based Linux, try running <code>sudo apt-get install libffi-dev</code>.</li>
 <li>To install on an rpm-based Linux, try running <code>sudo yum install libffi-devel</code>.</li>
+<li>To install on Alpine Linux, try running <code>sudo apk add libffi-dev</code>.</li>
 </ul>
 <p>Use <code>--with-libffi=&lt;path&gt;</code> if <code>configure</code> does not properly locate your libffi files.</p>
 <h2 id="build-tools-requirements">Build Tools Requirements</h2>
@@ -419,6 +427,7 @@ CC: Sun C++ 5.13 SunOS_i386 151846-10 2015/10/30</code></pre>
 <ul>
 <li>To install on an apt-based Linux, try running <code>sudo apt-get install autoconf</code>.</li>
 <li>To install on an rpm-based Linux, try running <code>sudo yum install autoconf</code>.</li>
+<li>To install on Alpine Linux, try running <code>sudo apk add autoconf</code>.</li>
 <li>To install on macOS, try running <code>brew install autoconf</code>.</li>
 <li>To install on Windows, try running <code>&lt;path to Cygwin setup&gt;/setup-x86_64 -q -P autoconf</code>.</li>
 </ul>
@@ -819,6 +828,15 @@ ls build/linux-aarch64-normal-server-release/</code></pre></li>
 <h3 id="building-for-armaarch64">Building for ARM/aarch64</h3>
 <p>A common cross-compilation target is the ARM CPU. When building for ARM, it is useful to set the ABI profile. A number of pre-defined ABI profiles are available using <code>--with-abi-profile</code>: arm-vfp-sflt, arm-vfp-hflt, arm-sflt, armv5-vfp-sflt, armv6-vfp-hflt. Note that soft-float ABIs are no longer properly supported by the JDK.</p>
 <p>The JDK contains two different ports for the aarch64 platform, one is the original aarch64 port from the <a href="http://openjdk.java.net/projects/aarch64-port">AArch64 Port Project</a> and one is a 64-bit version of the Oracle contributed ARM port. When targeting aarch64, by the default the original aarch64 port is used. To select the Oracle ARM 64 port, use <code>--with-cpu-port=arm64</code>. Also set the corresponding value (<code>aarch64</code> or <code>arm64</code>) to --with-abi-profile, to ensure a consistent build.</p>
+<h3 id="building-for-musl">Building for musl</h3>
+<p>Just like it's possible to cross-compile for a different CPU, it's possible to cross-compile for musl libc on a glibc-based <em>build</em> system. A devkit suitable for most target CPU architectures can be obtained from <a href="https://musl.cc">musl.cc</a>. After installing the required packages in the sysroot, configure the build with <code>--openjdk-target</code>:</p>
+<pre><code>sh ./configure --with-jvm-variants=server \
+--with-boot-jdk=$BOOT_JDK \
+--with-build-jdk=$BUILD_JDK \
+--openjdk-target=x86_64-unknown-linux-musl \
+--with-devkit=$DEVKIT \
+--with-sysroot=$SYSROOT</code></pre>
+<p>and run <code>make</code> normally.</p>
 <h3 id="verifying-the-build">Verifying the Build</h3>
 <p>The build will end up in a directory named like <code>build/linux-arm-normal-server-release</code>.</p>
 <p>Inside this build output directory, the <code>images/jdk</code> will contain the newly built JDK, for your <em>target</em> system.</p>

--- a/doc/building.md
+++ b/doc/building.md
@@ -272,6 +272,13 @@ For rpm-based distributions (Fedora, Red Hat, etc), try this:
 sudo yum groupinstall "Development Tools"
 ```
 
+For Alpine Linux, aside from basic tooling, install the GNU versions of some
+programs:
+
+```
+sudo apk add build-base bash grep zip
+```
+
 ### AIX
 
 The regular builds by SAP is using AIX version 7.1, but AIX 5.3 is also
@@ -465,6 +472,7 @@ rather than bundling the JDK's own copy.
     libfreetype6-dev`.
   * To install on an rpm-based Linux, try running `sudo yum install
     freetype-devel`.
+  * To install on Alpine Linux, try running `sudo apk add freetype-dev`.
   * To install on Solaris, try running `pkg install system/library/freetype-2`.
 
 Use `--with-freetype-include=<path>` and `--with-freetype-lib=<path>`
@@ -480,6 +488,7 @@ your operating system.
     libcups2-dev`.
   * To install on an rpm-based Linux, try running `sudo yum install
     cups-devel`.
+  * To install on Alpine Linux, try running `sudo apk add cups-dev`.
   * To install on Solaris, try running `pkg install print/cups`.
 
 Use `--with-cups=<path>` if `configure` does not properly locate your CUPS
@@ -494,6 +503,8 @@ Linux and Solaris.
     libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev`.
   * To install on an rpm-based Linux, try running `sudo yum install
     libXtst-devel libXt-devel libXrender-devel libXi-devel`.
+  * To install on Alpine Linux, try running `sudo apk add libx11-dev
+    libxext-dev libxrender-dev libxrandr-dev libxtst-dev libxt-dev`.
   * To install on Solaris, try running `pkg install x11/header/x11-protocols
     x11/library/libice x11/library/libpthread-stubs x11/library/libsm
     x11/library/libx11 x11/library/libxau x11/library/libxcb
@@ -512,6 +523,7 @@ required on Linux. At least version 0.9.1 of ALSA is required.
     libasound2-dev`.
   * To install on an rpm-based Linux, try running `sudo yum install
     alsa-lib-devel`.
+  * To install on Alpine Linux, try running `sudo apk add alsa-lib-dev`.
 
 Use `--with-alsa=<path>` if `configure` does not properly locate your ALSA
 files.
@@ -526,6 +538,7 @@ Hotspot.
     libffi-dev`.
   * To install on an rpm-based Linux, try running `sudo yum install
     libffi-devel`.
+  * To install on Alpine Linux, try running `sudo apk add libffi-dev`.
 
 Use `--with-libffi=<path>` if `configure` does not properly locate your libffi
 files.
@@ -541,6 +554,7 @@ platforms. At least version 2.69 is required.
     autoconf`.
   * To install on an rpm-based Linux, try running `sudo yum install
     autoconf`.
+  * To install on Alpine Linux, try running `sudo apk add autoconf`.
   * To install on macOS, try running `brew install autoconf`.
   * To install on Windows, try running `<path to Cygwin setup>/setup-x86_64 -q
     -P autoconf`.
@@ -1177,6 +1191,25 @@ the Oracle contributed ARM port. When targeting aarch64, by the default the
 original aarch64 port is used. To select the Oracle ARM 64 port, use
 `--with-cpu-port=arm64`. Also set the corresponding value (`aarch64` or
 `arm64`) to --with-abi-profile, to ensure a consistent build.
+
+### Building for musl
+
+Just like it's possible to cross-compile for a different CPU, it's possible to
+cross-compile for musl libc on a glibc-based *build* system.
+A devkit suitable for most target CPU architectures can be obtained from
+[musl.cc](https://musl.cc). After installing the required packages in the
+sysroot, configure the build with `--openjdk-target`:
+
+```
+sh ./configure --with-jvm-variants=server \
+--with-boot-jdk=$BOOT_JDK \
+--with-build-jdk=$BUILD_JDK \
+--openjdk-target=x86_64-unknown-linux-musl \
+--with-devkit=$DEVKIT \
+--with-sysroot=$SYSROOT
+```
+
+and run `make` normally.
 
 ### Verifying the Build
 


### PR DESCRIPTION
JDK-8247591 is in the docs issue in the third batch of a chain of backports for Alpine support to 11u as discussed in the mailing list. For the full set of anticipated changes please refer to the jdk-updates mailing list [1].

Original changeset does not apply cleanly because of:

8220164: Fix build instructions for AIX
8244224: Implementation of JEP 381: Remove the Solaris and SPARC Ports

Testing: JCK + JTreg on Windows, Linux, Solaris, Mac without regressions.

[1] https://mail.openjdk.java.net/pipermail/jdk-updates-dev/2022-February/012271.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247591](https://bugs.openjdk.java.net/browse/JDK-8247591): Document Alpine Linux build steps in OpenJDK build guide


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/911/head:pull/911` \
`$ git checkout pull/911`

Update a local copy of the PR: \
`$ git checkout pull/911` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/911/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 911`

View PR using the GUI difftool: \
`$ git pr show -t 911`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/911.diff">https://git.openjdk.java.net/jdk11u-dev/pull/911.diff</a>

</details>
