### PR TITLE
8215544: SA: Modify ClhsdbLauncher to add sudo privileges to enable MacOS tests on Mach5

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import jdk.test.lib.apps.LingeredApp;
  * @requires vm.hasSA
  * @requires vm.compiler1.enabled
  * @library /test/lib
- * @run main/othervm ClhsdbFindPC
+ * @run main/othervm/timeout=480 ClhsdbFindPC
  */
 
 public class ClhsdbFindPC {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJstack.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJstack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import jdk.test.lib.apps.LingeredApp;
  * @summary Test clhsdb Jstack command
  * @requires vm.hasSA
  * @library /test/lib
- * @run main/othervm ClhsdbJstack
+ * @run main/othervm/timeout=480 ClhsdbJstack
  */
 
 public class ClhsdbJstack {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,15 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
 
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.Platform;
 import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.SA.SATestUtils;
+
 
 /**
  * This is a framework to run 'jhsdb clhsdb' commands.
@@ -41,9 +44,11 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class ClhsdbLauncher {
 
     private Process toolProcess;
+    private boolean needPrivileges;
 
     public ClhsdbLauncher() {
         toolProcess = null;
+        needPrivileges = false;
     }
 
     /**
@@ -53,7 +58,6 @@ public class ClhsdbLauncher {
      */
     private void attach(long lingeredAppPid)
         throws IOException {
-
         JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jhsdb");
         launcher.addToolArg("clhsdb");
         if (lingeredAppPid != -1) {
@@ -61,9 +65,12 @@ public class ClhsdbLauncher {
             System.out.println("Starting clhsdb against " + lingeredAppPid);
         }
 
-        ProcessBuilder processBuilder = new ProcessBuilder(launcher.getCommand());
+        List<String> cmdStringList = Arrays.asList(launcher.getCommand());
+        if (needPrivileges) {
+            cmdStringList = SATestUtils.addPrivileges(cmdStringList);
+        }
+        ProcessBuilder processBuilder = new ProcessBuilder(cmdStringList);
         processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
-
         toolProcess = processBuilder.start();
     }
 
@@ -173,9 +180,19 @@ public class ClhsdbLauncher {
         throws IOException, InterruptedException {
 
         if (!Platform.shouldSAAttach()) {
-            // Silently skip the test if we don't have enough permissions to attach
-            System.out.println("SA attach not expected to work - test skipped.");
-            return null;
+            if (Platform.isOSX()) {
+                if (!SATestUtils.canAddPrivileges()) {
+                   // Skip the test if we don't have enough permissions to attach
+                   // and cannot add privileges.
+                   System.out.println("SA attach not expected to work - test skipped.");
+                   return null;
+               } else {
+                   needPrivileges = true;
+               }
+            } else {
+                System.out.println("SA attach not expected to work. Insufficient privileges.");
+                throw new Error("Cannot attach.");
+            }
         }
 
         attach(lingeredAppPid);
@@ -199,12 +216,6 @@ public class ClhsdbLauncher {
                             Map<String, List<String>> expectedStrMap,
                             Map<String, List<String>> unExpectedStrMap)
         throws IOException, InterruptedException {
-
-        if (!Platform.shouldSAAttach()) {
-            // Silently skip the test if we don't have enough permissions to attach
-            System.out.println("SA attach not expected to work - test skipped.");
-            return null;
-        }
 
         loadCore(coreFileName);
         return runCmd(commands, expectedStrMap, unExpectedStrMap);

--- a/test/lib/jdk/test/lib/SA/SATestUtils.java
+++ b/test/lib/jdk/test/lib/SA/SATestUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.test.lib.SA;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Platform;
+import java.util.concurrent.TimeUnit;
+
+public class SATestUtils {
+
+    public static boolean canAddPrivileges()
+       throws IOException, InterruptedException {
+       List<String> echoList = new ArrayList<String>();
+       echoList.add("sudo");
+       echoList.add("-E");
+       echoList.add("/bin/echo");
+       echoList.add("'Checking for sudo'");
+       ProcessBuilder pb = new ProcessBuilder(echoList);
+       Process echoProcess = pb.start();
+       if (echoProcess.waitFor(60, TimeUnit.SECONDS) == false) {
+           // 'sudo' has been added but we don't have a no-password
+           // entry for the user in the /etc/sudoers list. Could
+           // have timed out waiting for the password. Skip the
+           // test if there is a timeout here.
+           System.out.println("Timed out waiting for the password to be entered.");
+           echoProcess.destroyForcibly();
+           return false;
+       }
+       if (echoProcess.exitValue() == 0) {
+           return true;
+       }
+       java.io.InputStream is = echoProcess.getErrorStream();
+       String err = new String(is.readAllBytes());
+       System.out.println(err);
+       // 'sudo' has been added but we don't have a no-password
+       // entry for the user in the /etc/sudoers list. Check for
+       // the sudo error message and skip the test.
+       if (err.contains("no tty present") ||
+           err.contains("a password is required")) {
+           return false;
+       } else {
+           throw new Error("Unknown Error from 'sudo'");
+       }
+    }
+
+    public static List<String> addPrivileges(List<String> cmdStringList)
+        throws IOException {
+        Asserts.assertTrue(Platform.isOSX());
+
+        System.out.println("Adding 'sudo -E' to the command.");
+        List<String> outStringList = new ArrayList<String>();
+        outStringList.add("sudo");
+        outStringList.add("-E");
+        outStringList.addAll(cmdStringList);
+        return outStringList;
+    }
+}


### PR DESCRIPTION
I backport this to improve mac testing and to fix a test failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8215544](https://bugs.openjdk.java.net/browse/JDK-8215544): SA: Modify ClhsdbLauncher to add sudo privileges to enable MacOS tests on Mach5


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/912/head:pull/912` \
`$ git checkout pull/912`

Update a local copy of the PR: \
`$ git checkout pull/912` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 912`

View PR using the GUI difftool: \
`$ git pr show -t 912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/912.diff">https://git.openjdk.java.net/jdk11u-dev/pull/912.diff</a>

</details>
