### PR TITLE
8217473: SA: Tests using ClhsdbLauncher fail on SAP docker containers

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbAttach.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbAttach.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -68,6 +69,8 @@ public class ClhsdbAttach {
                     "longConstant markOopDesc::locked_value"));
 
             test.run(-1, cmds, expStrMap, null);
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbField.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -63,6 +64,8 @@ public class ClhsdbField {
                 "field nmethod _entry_bci int",
                 "field Universe _collectedHeap CollectedHeap"));
             test.run(theApp.getPid(), cmds, expStrMap, null);
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import jdk.test.lib.apps.LingeredApp;
  * @requires vm.hasSA
  * @requires vm.compiler1.enabled
  * @library /test/lib
- * @run main/othervm ClhsdbFindPC
+ * @run main/othervm/timeout=480 ClhsdbFindPC
  */
 
 public class ClhsdbFindPC {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.ArrayList;
 
 import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
+
 /**
  * @test
  * @bug 8193124
@@ -96,6 +98,8 @@ public class ClhsdbFindPC {
 
                 test.run(theApp.getPid(), cmds, expStrMap, null);
             }
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFlags.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFlags.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.Utils;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -80,6 +81,8 @@ public class ClhsdbFlags {
                     "MaxJavaStackTraceDepth = 1024"));
 
             test.run(theApp.getPid(), cmds, expStrMap, null);
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbInspect.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbInspect.java
@@ -57,13 +57,6 @@ public class ClhsdbInspect {
 
             String jstackOutput = test.run(theApp.getPid(), cmds, null, null);
 
-            if (jstackOutput == null) {
-                // Output could be null due to attach permission issues
-                // and if we are skipping this.
-                LingeredApp.stopApp(theApp);
-                throw new SkippedException("attach permission issues");
-            }
-
             Map<String, String> tokensMap = new HashMap<>();
             tokensMap.put("(a java.lang.Class for LingeredAppWithLock)",
                           "instance of Oop for java/lang/Class");

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJdis.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJdis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,11 +57,6 @@ public class ClhsdbJdis {
             // the 'jstack -v' command
             cmds = new ArrayList<String>();
 
-            // Output could be null if the test was skipped due to
-            // attach permission issues.
-            if (output == null) {
-                throw new SkippedException("attach permission issues");
-            }
             String cmdStr = null;
             String[] parts = output.split("LingeredApp.main");
             String[] tokens = parts[1].split(" ");

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJhisto.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJhisto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.Utils;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -67,6 +68,8 @@ public class ClhsdbJhisto {
                     "ParselTongue"));
 
             test.run(theApp.getPid(), cmds, expStrMap, null);
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJstack.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJstack.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -63,6 +64,8 @@ public class ClhsdbJstack {
                     "LingeredApp.main"));
 
             test.run(theApp.getPid(), cmds, expStrMap, null);
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR (with -Xcomp=" + withXcomp + ") " + ex, ex);
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJstack.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJstack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import jdk.test.lib.apps.LingeredApp;
  * @summary Test clhsdb Jstack command
  * @requires vm.hasSA
  * @library /test/lib
- * @run main/othervm ClhsdbJstack
+ * @run main/othervm/timeout=480 ClhsdbJstack
  */
 
 public class ClhsdbJstack {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,15 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
 
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.Platform;
 import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.SA.SATestUtils;
+
 
 /**
  * This is a framework to run 'jhsdb clhsdb' commands.
@@ -41,9 +44,11 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class ClhsdbLauncher {
 
     private Process toolProcess;
+    private boolean needPrivileges;
 
     public ClhsdbLauncher() {
         toolProcess = null;
+        needPrivileges = false;
     }
 
     /**
@@ -53,7 +58,6 @@ public class ClhsdbLauncher {
      */
     private void attach(long lingeredAppPid)
         throws IOException {
-
         JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jhsdb");
         launcher.addToolArg("clhsdb");
         if (lingeredAppPid != -1) {
@@ -61,9 +65,12 @@ public class ClhsdbLauncher {
             System.out.println("Starting clhsdb against " + lingeredAppPid);
         }
 
-        ProcessBuilder processBuilder = new ProcessBuilder(launcher.getCommand());
+        List<String> cmdStringList = Arrays.asList(launcher.getCommand());
+        if (needPrivileges) {
+            cmdStringList = SATestUtils.addPrivileges(cmdStringList);
+        }
+        ProcessBuilder processBuilder = new ProcessBuilder(cmdStringList);
         processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
-
         toolProcess = processBuilder.start();
     }
 
@@ -173,9 +180,19 @@ public class ClhsdbLauncher {
         throws IOException, InterruptedException {
 
         if (!Platform.shouldSAAttach()) {
-            // Silently skip the test if we don't have enough permissions to attach
-            System.out.println("SA attach not expected to work - test skipped.");
-            return null;
+            if (Platform.isOSX()) {
+                if (!SATestUtils.canAddPrivileges()) {
+                   // Skip the test if we don't have enough permissions to attach
+                   // and cannot add privileges.
+                   System.out.println("SA attach not expected to work - test skipped.");
+                   return null;
+               } else {
+                   needPrivileges = true;
+               }
+            } else {
+                System.out.println("SA attach not expected to work. Insufficient privileges.");
+                throw new Error("Cannot attach.");
+            }
         }
 
         attach(lingeredAppPid);
@@ -199,12 +216,6 @@ public class ClhsdbLauncher {
                             Map<String, List<String>> expectedStrMap,
                             Map<String, List<String>> unExpectedStrMap)
         throws IOException, InterruptedException {
-
-        if (!Platform.shouldSAAttach()) {
-            // Silently skip the test if we don't have enough permissions to attach
-            System.out.println("SA attach not expected to work - test skipped.");
-            return null;
-        }
 
         loadCore(coreFileName);
         return runCmd(commands, expectedStrMap, unExpectedStrMap);

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbLauncher.java
@@ -33,6 +33,7 @@ import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.SA.SATestUtils;
+import jtreg.SkippedException;
 
 
 /**
@@ -177,22 +178,18 @@ public class ClhsdbLauncher {
                       List<String> commands,
                       Map<String, List<String>> expectedStrMap,
                       Map<String, List<String>> unExpectedStrMap)
-        throws IOException, InterruptedException {
+        throws Exception {
 
         if (!Platform.shouldSAAttach()) {
-            if (Platform.isOSX()) {
-                if (!SATestUtils.canAddPrivileges()) {
-                   // Skip the test if we don't have enough permissions to attach
-                   // and cannot add privileges.
-                   System.out.println("SA attach not expected to work - test skipped.");
-                   return null;
-               } else {
-                   needPrivileges = true;
-               }
-            } else {
-                System.out.println("SA attach not expected to work. Insufficient privileges.");
-                throw new Error("Cannot attach.");
+            if (Platform.isOSX() && SATestUtils.canAddPrivileges()) {
+                needPrivileges = true;
             }
+            else {
+               // Skip the test if we don't have enough permissions to attach
+               // and cannot add privileges.
+               throw new SkippedException(
+                   "SA attach not expected to work. Insufficient privileges.");
+           }
         }
 
         attach(lingeredAppPid);

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbLongConstant.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbLongConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,9 +75,6 @@ public class ClhsdbLongConstant {
 
             String longConstantOutput = test.run(theApp.getPid(), cmds, expStrMap, unExpStrMap);
 
-            if (longConstantOutput == null) {
-                throw new SkippedException("attach permission issues");
-            }
             checkForTruncation(longConstantOutput);
         } catch (SkippedException e) {
             throw e;

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -56,6 +57,8 @@ public class ClhsdbPmap {
                     "jimage", "zip", "verify"));
 
             test.run(theApp.getPid(), cmds, expStrMap, null);
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPrintAll.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPrintAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -68,6 +69,8 @@ public class ClhsdbPrintAll {
             unExpStrMap.put("printall", List.of(
                 "cannot be cast to"));
             test.run(theApp.getPid(), cmds, expStrMap, unExpStrMap);
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPrintAs.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPrintAs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,11 +54,6 @@ public class ClhsdbPrintAs {
             Map<String, List<String>> expStrMap;
 
             String jstackOutput = test.run(theApp.getPid(), cmds, null, null);
-
-            if (jstackOutput == null) {
-                LingeredApp.stopApp(theApp);
-                throw new SkippedException("attach permission issues");
-            }
 
             String[] snippets = jstackOutput.split("LingeredApp.main");
             String addressString = null;

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPrintStatics.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPrintStatics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -83,6 +84,8 @@ public class ClhsdbPrintStatics {
                     "bool JvmtiExport::_can_post_on_exceptions"));
 
             test.run(theApp.getPid(), cmds, expStrMap, null);
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -57,6 +58,8 @@ public class ClhsdbPstack {
                     "Reference Handler", "Finalizer", "main"));
 
             test.run(theApp.getPid(), cmds, expStrMap, null);
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbScanOops.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbScanOops.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,11 +57,6 @@ public class ClhsdbScanOops {
             List<String> cmds = List.of("universe");
 
             String universeOutput = test.run(theApp.getPid(), cmds, null, null);
-
-            if (universeOutput == null) {
-                LingeredApp.stopApp(theApp);
-                throw new SkippedException("attach permission issues");
-            }
 
             cmds = new ArrayList<String>();
             Map<String, List<String>> expStrMap = new HashMap<>();

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbSource.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -74,6 +75,8 @@ public class ClhsdbSource {
 
             test.run(theApp.getPid(), cmds, expStrMap, unExpStrMap);
             Files.delete(file);
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbThread.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -76,14 +77,6 @@ public class ClhsdbThread {
                 expStrMap,
                 unExpStrMap);
 
-            if (consolidatedOutput == null) {
-                // Output could be null due to attach permission issues.
-                System.out.println(
-                    "Output is empty. Probably due to attach permission issues.");
-                LingeredApp.stopApp(theApp);
-                return;
-            }
-
             // Test the thread <id> command now. Obtain <id> from the
             // output of the previous 'threads' command. The word before
             // the token 'Finalizer' should denote the thread id of the
@@ -109,6 +102,8 @@ public class ClhsdbThread {
                 "Last_Java_SP"));
             cmds = List.of(cmd);
             test.run(theApp.getPid(), cmds, expStrMap, null);
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbVmStructsDump.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbVmStructsDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -63,6 +64,8 @@ public class ClhsdbVmStructsDump {
                 "type Universe null",
                 "type ConstantPoolCache MetaspaceObj"));
             test.run(theApp.getPid(), cmds, expStrMap, null);
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbWhere.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbWhere.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -62,6 +63,8 @@ public class ClhsdbWhere {
                     "public static void main"));
 
             test.run(theApp.getPid(), cmds, expStrMap, null);
+        } catch (SkippedException se) {
+            throw se;
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);
         } finally {

--- a/test/lib/jdk/test/lib/SA/SATestUtils.java
+++ b/test/lib/jdk/test/lib/SA/SATestUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.test.lib.SA;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Platform;
+import java.util.concurrent.TimeUnit;
+
+public class SATestUtils {
+
+    public static boolean canAddPrivileges()
+       throws IOException, InterruptedException {
+       List<String> echoList = new ArrayList<String>();
+       echoList.add("sudo");
+       echoList.add("-E");
+       echoList.add("/bin/echo");
+       echoList.add("'Checking for sudo'");
+       ProcessBuilder pb = new ProcessBuilder(echoList);
+       Process echoProcess = pb.start();
+       if (echoProcess.waitFor(60, TimeUnit.SECONDS) == false) {
+           // 'sudo' has been added but we don't have a no-password
+           // entry for the user in the /etc/sudoers list. Could
+           // have timed out waiting for the password. Skip the
+           // test if there is a timeout here.
+           System.out.println("Timed out waiting for the password to be entered.");
+           echoProcess.destroyForcibly();
+           return false;
+       }
+       if (echoProcess.exitValue() == 0) {
+           return true;
+       }
+       java.io.InputStream is = echoProcess.getErrorStream();
+       String err = new String(is.readAllBytes());
+       System.out.println(err);
+       // 'sudo' has been added but we don't have a no-password
+       // entry for the user in the /etc/sudoers list. Check for
+       // the sudo error message and skip the test.
+       if (err.contains("no tty present") ||
+           err.contains("a password is required")) {
+           return false;
+       } else {
+           throw new Error("Unknown Error from 'sudo'");
+       }
+    }
+
+    public static List<String> addPrivileges(List<String> cmdStringList)
+        throws IOException {
+        Asserts.assertTrue(Platform.isOSX());
+
+        System.out.println("Adding 'sudo -E' to the command.");
+        List<String> outStringList = new ArrayList<String>();
+        outStringList.add("sudo");
+        outStringList.add("-E");
+        outStringList.addAll(cmdStringList);
+        return outStringList;
+    }
+}


### PR DESCRIPTION
I backport this to improve testing and to fix the test bug in ClhsdbRegionDetailsScanOopsForG1.java.

I had to resolve the imports in the following files:

test/hotspot/jtreg/serviceability/sa/ClhsdbJstack.java
test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
test/hotspot/jtreg/serviceability/sa/ClhsdbPrintStatics.java
test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
test/hotspot/jtreg/serviceability/sa/ClhsdbWhere.java

The hunk to ClhsdbRegionDetailsScanOopsForG1.java is left out.
The hunk was included accidentially when the test was move to resourcehogs.
This is also the cause of the failure of this test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8217473](https://bugs.openjdk.java.net/browse/JDK-8217473): SA: Tests using ClhsdbLauncher fail on SAP docker containers


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to dbd9293a5595cff047aa88d9e2b55ceaa923d772


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/913/head:pull/913` \
`$ git checkout pull/913`

Update a local copy of the PR: \
`$ git checkout pull/913` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 913`

View PR using the GUI difftool: \
`$ git pr show -t 913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/913.diff">https://git.openjdk.java.net/jdk11u-dev/pull/913.diff</a>

</details>
