### PR TITLE
8240734: ModuleHashes attribute not reproducible between builds

### DIFF
--- a/src/java.base/share/classes/jdk/internal/module/ModuleHashes.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleHashes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -134,7 +135,7 @@ public final class ModuleHashes {
      * @return ModuleHashes that encapsulates the hashes
      */
     public static ModuleHashes generate(Map<String, Path> map, String algorithm) {
-        Map<String, byte[]> nameToHash = new HashMap<>();
+        Map<String, byte[]> nameToHash = new TreeMap<>();
         for (Map.Entry<String, Path> entry: map.entrySet()) {
             String name = entry.getKey();
             Path path = entry.getValue();

--- a/src/java.base/share/classes/jdk/internal/module/ModuleHashesBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleHashesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -98,7 +99,7 @@ public class ModuleHashesBuilder {
         // the modules to record the hashes - it is the first matching
         // module and has not been hashed during the traversal.
         Set<String> mods = new HashSet<>();
-        Map<String, ModuleHashes> hashes = new HashMap<>();
+        Map<String, ModuleHashes> hashes = new TreeMap<>();
         builder.build()
                .orderedNodes()
                .filter(mn -> roots.contains(mn) && !mods.contains(mn))


### PR DESCRIPTION
This is a clean backport of JDK-8240734. I'm backporting this as a predecessor of JDK-8243666.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8240734](https://bugs.openjdk.java.net/browse/JDK-8240734): ModuleHashes attribute not reproducible between builds


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/915/head:pull/915` \
`$ git checkout pull/915`

Update a local copy of the PR: \
`$ git checkout pull/915` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 915`

View PR using the GUI difftool: \
`$ git pr show -t 915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/915.diff">https://git.openjdk.java.net/jdk11u-dev/pull/915.diff</a>

</details>
