### PR TITLE
8246494: introduce vm.flagless at-requires property

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,7 @@ requires.properties= \
     vm.graal.enabled \
     vm.compiler1.enabled \
     vm.compiler2.enabled \
+    vm.flagless \
     docker.support
 
 # Minimum jtreg version

--- a/test/hotspot/jtreg/applications/scimark/Scimark.java
+++ b/test/hotspot/jtreg/applications/scimark/Scimark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @library /test/lib
+ * @requires vm.flagless
  * @run driver Scimark
  */
 

--- a/test/hotspot/jtreg/gtest/GTestWrapper.java
+++ b/test/hotspot/jtreg/gtest/GTestWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @summary a jtreg wrapper for gtest tests
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ * @requires vm.flagless
  * @run main/native GTestWrapper
  */
 

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package requires;
 
 import java.io.BufferedInputStream;
@@ -31,10 +32,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -117,6 +120,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.compiler2.enabled", this::isCompiler2Enabled);
         map.put("docker.support", this::dockerSupport);
         map.put("release.implementor", this::implementor);
+        map.put("vm.flagless", this::isFlagless);
         vmGC(map); // vm.gc.X = true/false
         vmOptFinalFlags(map);
 
@@ -513,6 +517,65 @@ public class VMProps implements Callable<Map<String, String>> {
             e.printStackTrace();
             return errorWithMessage("Failed to read 'release' file " + e);
         }
+    }
+
+    /**
+     * Checks if we are in <i>almost</i> out-of-box configuration, i.e. the flags
+     * which JVM is started with don't affect its behavior "significantly".
+     * {@code TEST_VM_FLAGLESS} enviroment variable can be used to force this
+     * method to return true and allow any flags.
+     *
+     * @return true if there are no JVM flags
+     */
+    private String isFlagless() {
+        boolean result = true;
+        if (System.getenv("TEST_VM_FLAGLESS") != null) {
+            return "" + result;
+        }
+
+        List<String> allFlags = new ArrayList<String>();
+        Collections.addAll(allFlags, System.getProperty("test.vm.opts", "").trim().split("\\s+"));
+        Collections.addAll(allFlags, System.getProperty("test.java.opts", "").trim().split("\\s+"));
+
+        // check -XX flags
+        var ignoredXXFlags = Set.of(
+                // added by run-test framework
+                "MaxRAMPercentage",
+                // added by test environment
+                "CreateCoredumpOnCrash"
+        );
+        result &= allFlags.stream()
+                          .filter(s -> s.startsWith("-XX:"))
+                          // map to names:
+                              // remove -XX:
+                              .map(s -> s.substring(4))
+                              // remove +/- from bool flags
+                              .map(s -> s.charAt(0) == '+' || s.charAt(0) == '-' ? s.substring(1) : s)
+                              // remove =.* from others
+                              .map(s -> s.contains("=") ? s.substring(0, s.indexOf('=')) : s)
+                          // skip known-to-be-there flags
+                          .filter(s -> !ignoredXXFlags.contains(s))
+                          .findAny()
+                          .isEmpty();
+
+        // check -X flags
+        var ignoredXFlags = Set.of(
+                // default, yet still seen to be explicitly set
+                "mixed"
+        );
+        result &= allFlags.stream()
+                          .filter(s -> s.startsWith("-X") && !s.startsWith("-XX:"))
+                          // map to names:
+                              // remove -X
+                              .map(s -> s.substring(2))
+                              // remove :.* from flags with values
+                              .map(s -> s.contains(":") ? s.substring(0, s.indexOf(':')) : s)
+                          // skip known-to-be-there flags
+                          .filter(s -> !ignoredXFlags.contains(s))
+                          .findAny()
+                          .isEmpty();
+
+        return "" + result;
     }
 
     /**


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

TEST.ROOT, GTestWrapper.java, VMProps.java
context, Copyright.

LargePageGtests.java, MetaspaceGtests.java:
not in 11

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246494](https://bugs.openjdk.java.net/browse/JDK-8246494): introduce vm.flagless at-requires property


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/917/head:pull/917` \
`$ git checkout pull/917`

Update a local copy of the PR: \
`$ git checkout pull/917` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 917`

View PR using the GUI difftool: \
`$ git pr show -t 917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/917.diff">https://git.openjdk.java.net/jdk11u-dev/pull/917.diff</a>

</details>
