### PR TITLE
8210649: AssertionError @ jdk.compiler/com.sun.tools.javac.comp.Modules.enter(Modules.java:244)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -1029,16 +1029,12 @@ public class JavaCompiler {
         return trees.toList();
     }
 
-    /**
-     * Enter the symbols found in a list of parse trees if the compilation
-     * is expected to proceed beyond anno processing into attr.
-     * As a side-effect, this puts elements on the "todo" list.
-     * Also stores a list of all top level classes in rootClasses.
-     */
-    public List<JCCompilationUnit> enterTreesIfNeeded(List<JCCompilationUnit> roots) {
-       if (shouldStop(CompileState.ATTR))
-           return List.nil();
-        return enterTrees(initModules(roots));
+   /**
+    * Returns true iff the compilation will continue after annotation processing
+    * is done.
+    */
+    public boolean continueAfterProcessAnnotations() {
+        return !shouldStop(CompileState.ATTR);
     }
 
     public List<JCCompilationUnit> initModules(List<JCCompilationUnit> roots) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
@@ -1386,21 +1386,25 @@ public class JavacProcessingEnvironment implements ProcessingEnvironment, Closea
 
         errorStatus = errorStatus || (compiler.errorCount() > 0);
 
-        round.finalCompiler();
 
         if (newSourceFiles.size() > 0)
             roots = roots.appendList(compiler.parseFiles(newSourceFiles));
 
         errorStatus = errorStatus || (compiler.errorCount() > 0);
 
-        // Free resources
-        this.close();
-
         if (errorStatus && compiler.errorCount() == 0) {
             compiler.log.nerrors++;
         }
 
-        compiler.enterTreesIfNeeded(roots);
+        if (compiler.continueAfterProcessAnnotations()) {
+            round.finalCompiler();
+            compiler.enterTrees(compiler.initModules(roots));
+        } else {
+            compiler.todo.clear();
+        }
+
+        // Free resources
+        this.close();
 
         if (!taskListener.isEmpty())
             taskListener.finished(new TaskEvent(TaskEvent.Kind.ANNOTATION_PROCESSING));

--- a/test/langtools/tools/javac/processing/T8210649.java
+++ b/test/langtools/tools/javac/processing/T8210649.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8210649
+ * @summary Check that diagnostics can be printed even after the compilation
+ *          stopped.
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.TestRunner toolbox.ToolBox T8210649
+ * @run main T8210649
+ */
+
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.function.Consumer;
+import javax.tools.DiagnosticListener;
+import toolbox.JavacTask;
+import toolbox.TestRunner;
+import toolbox.TestRunner.Test;
+import toolbox.ToolBox;
+
+public class T8210649 extends TestRunner {
+
+    public static void main(String... args) throws Exception {
+        new T8210649().runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    private final ToolBox tb = new ToolBox();
+
+    public T8210649() {
+        super(System.err);
+    }
+
+    @Test
+    public void testErrorsAfter(Path outerBase) throws Exception {
+        Path libSrc = outerBase.resolve("libsrc");
+        tb.writeJavaFiles(libSrc,
+                          "package lib;\n" +
+                          "@lib2.Helper(1)\n" +
+                          "public @interface Lib {\n" +
+                          "}",
+                          "package lib2;\n" +
+                          "public @interface Helper {\n" +
+                          "    public int value() default 0;\n" +
+                          "}");
+        Path libClasses = outerBase.resolve("libclasses");
+        Files.createDirectories(libClasses);
+        new JavacTask(tb)
+                .outdir(libClasses.toString())
+                .files(tb.findJavaFiles(libSrc))
+                .run()
+                .writeAll();
+        Files.delete(libClasses.resolve("lib2").resolve("Helper.class"));
+        Path src = outerBase.resolve("src");
+        tb.writeJavaFiles(src,
+                          "package t;\n" +
+                          "import lib.Lib;\n" +
+                          "public class T {\n" +
+                          "  Undefined<String> undef() {}\n" +
+                          "}");
+        Path classes = outerBase.resolve("classes");
+        Files.createDirectories(classes);
+        Path tTarget = classes.resolve("t").resolve("T.class");
+        Files.createDirectories(tTarget.getParent());
+        try (OutputStream in = Files.newOutputStream(tTarget)) {}
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        try (StandardJavaFileManager sjfm = compiler.getStandardFileManager(null, null, null)) {
+            Consumer<DiagnosticListener<JavaFileObject>> runCompiler = dl -> {
+                try {
+                    List<String> options = List.of("-processor", "T8210649$P",
+                                                   "-processorpath", System.getProperty("test.classes"),
+                                                   "-classpath", libClasses.toString() + ":" + classes.toString(),
+                                                   "-d", classes.toString());
+                    ToolProvider.getSystemJavaCompiler()
+                                .getTask(null, null, dl, options, null, sjfm.getJavaFileObjects(tb.findJavaFiles(src)))
+                                .call();
+                } catch (IOException ex) {
+                    throw new IllegalStateException(ex);
+                }
+            };
+
+            List<String> expected = new ArrayList<>();
+            runCompiler.accept(d -> expected.add(d.getMessage(null)));
+
+            DiagnosticCollector<JavaFileObject> dc = new DiagnosticCollector<>();
+            runCompiler.accept(dc);
+
+            List<String> actual = dc.getDiagnostics()
+                                    .stream()
+                                    .map(d -> d.getMessage(null))
+                                    .collect(Collectors.toList());
+            if (!expected.equals(actual)) {
+                throw new IllegalStateException("Unexpected output: " + actual);
+            }
+        }
+    }
+
+    @SupportedAnnotationTypes("*")
+    public static class P extends AbstractProcessor {
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            return false;
+        }
+
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latest();
+        }
+    }
+
+}


### PR DESCRIPTION
Hi all,

This pull request contains a clean backport of commit [44ae643b2b49b66b1fff4c151c17972c6b683cc0](https://github.com/openjdk/jdk/commit/44ae643b2b4) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Jan Lahoda on June 1, 2020, and was reviewed by Vicente Romero.

See [JDK-8210649](https://bugs.openjdk.java.net/browse/JDK-8210649) and [MCOMPILER-346](https://issues.apache.org/jira/browse/MCOMPILER-346) for more information.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210649](https://bugs.openjdk.java.net/browse/JDK-8210649): AssertionError @ jdk.compiler/com.sun.tools.javac.comp.Modules.enter(Modules.java:244)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/919/head:pull/919` \
`$ git checkout pull/919`

Update a local copy of the PR: \
`$ git checkout pull/919` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 919`

View PR using the GUI difftool: \
`$ git pr show -t 919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/919.diff">https://git.openjdk.java.net/jdk11u-dev/pull/919.diff</a>

</details>
