### PR TITLE
8244500: jtreg test error in test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java

### DIFF
--- a/test/hotspot/jtreg/containers/docker/CheckOperatingSystemMXBean.java
+++ b/test/hotspot/jtreg/containers/docker/CheckOperatingSystemMXBean.java
@@ -24,11 +24,20 @@
 
 import com.sun.management.OperatingSystemMXBean;
 import java.lang.management.ManagementFactory;
+import jdk.internal.platform.Metrics;
 
 public class CheckOperatingSystemMXBean {
 
     public static void main(String[] args) {
         System.out.println("Checking OperatingSystemMXBean");
+        Metrics metrics = jdk.internal.platform.Container.metrics();
+        System.out.println("Metrics instance: " + (metrics == null ? "null" : "non-null"));
+        if (metrics != null) {
+            System.out.println("Metrics.getMemoryAndSwapLimit() == " + metrics.getMemoryAndSwapLimit());
+            System.out.println("Metrics.getMemoryLimit() == " + metrics.getMemoryLimit());
+            System.out.println("Metrics.getMemoryAndSwapUsage() == " + metrics.getMemoryAndSwapUsage());
+            System.out.println("Metrics.getMemoryUsage() == " + metrics.getMemoryUsage());
+        }
 
         OperatingSystemMXBean osBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
         System.out.println(String.format("Runtime.availableProcessors: %d", Runtime.getRuntime().availableProcessors()));

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -28,6 +28,7 @@
  * @requires docker.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @build PrintContainerInfo CheckOperatingSystemMXBean
@@ -224,7 +225,11 @@ public class TestCPUAwareness {
         DockerRunOptions opts = Common.newOpts(imageName, "CheckOperatingSystemMXBean")
             .addDockerOpts(
                 "--cpus", cpuAllocation
-            );
+            )
+            // CheckOperatingSystemMXBean uses Metrics (jdk.internal.platform) for
+            // diagnostics
+            .addJavaOpts("--add-exports")
+            .addJavaOpts("java.base/jdk.internal.platform=ALL-UNNAMED");
 
         DockerTestUtils.dockerRunJava(opts)
             .shouldHaveExitValue(0)

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -28,6 +28,7 @@
  * @requires docker.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @build AttemptOOM sun.hotspot.WhiteBox PrintContainerInfo CheckOperatingSystemMXBean
@@ -142,7 +143,11 @@ public class TestMemoryAwareness {
             .addDockerOpts(
                 "--memory", memoryAllocation,
                 "--memory-swap", swapAllocation
-            );
+            )
+            // CheckOperatingSystemMXBean uses Metrics (jdk.internal.platform) for
+            // diagnostics
+            .addJavaOpts("--add-exports")
+            .addJavaOpts("java.base/jdk.internal.platform=ALL-UNNAMED");
 
         OutputAnalyzer out = DockerTestUtils.dockerRunJava(opts);
         out.shouldHaveExitValue(0)


### PR DESCRIPTION
Doesn't apply cleanly because of newer backport "JDK-8250984: Memory Docker tests fail on some Linux kernels w/o cgroupv1".

In test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java:
- One hunk in testOperatingSystemMXBeanAwareness doesn't apply because of newer fix JDK-8250984 backported ahead of this fix.
  - testOperatingSystemMXBeanAwareness in 11u already matches the what it looked like after the original JDK-8250984 commit, with JDK-8244500 already present in that version: https://github.com/openjdk/jdk/blob/0187567704d79ecf394d4cb656d0ba4c886351f1/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java#L160-L175.
  - Dropping this hunk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244500](https://bugs.openjdk.java.net/browse/JDK-8244500): jtreg test error in test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/920/head:pull/920` \
`$ git checkout pull/920`

Update a local copy of the PR: \
`$ git checkout pull/920` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 920`

View PR using the GUI difftool: \
`$ git pr show -t 920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/920.diff">https://git.openjdk.java.net/jdk11u-dev/pull/920.diff</a>

</details>
