### PR TITLE
8210108: sun/tools/jstatd test build failures after JDK-8210022

### DIFF
--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -28,11 +28,11 @@ import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
 import java.util.Arrays;
 
-import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.thread.ProcessThread;
 import static jdk.testlibrary.Asserts.*;
 import jdk.testlibrary.JDKToolLauncher;
 import jdk.testlibrary.Utils;
+import jdk.testlibrary.OutputAnalyzer;
 import jdk.testlibrary.ProcessTools;
 
 /**
@@ -325,7 +325,7 @@ public final class JstatdTest {
         }
 
         // Verify output from jstatd
-        OutputAnalyzer output = jstatdThread.getOutput();
+        jdk.test.lib.process.OutputAnalyzer output = jstatdThread.getOutput();
         assertTrue(output.getOutput().isEmpty(),
                 "jstatd should get an empty output, got: "
                 + Utils.NEW_LINE + output.getOutput());


### PR DESCRIPTION
Hi all,

I'd like to backport this patch to fix the following testing failures.
```
sun/tools/jstatd/TestJstatdDefaults.java
sun/tools/jstatd/TestJstatdServer.java
sun/tools/jstatd/TestJstatdPort.java
sun/tools/jstatd/TestJstatdExternalRegistry.java
sun/tools/jstatd/TestJstatdPortAndServer.java
```

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210108](https://bugs.openjdk.java.net/browse/JDK-8210108): sun/tools/jstatd test build failures after JDK-8210022


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/922/head:pull/922` \
`$ git checkout pull/922`

Update a local copy of the PR: \
`$ git checkout pull/922` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 922`

View PR using the GUI difftool: \
`$ git pr show -t 922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/922.diff">https://git.openjdk.java.net/jdk11u-dev/pull/922.diff</a>

</details>
