### PR TITLE
8283420: [AOT] Exclude TrackedFlagTest/NotTrackedFlagTest in 11u because of intermittent java.lang.AssertionError: duplicate classes for name Ljava/lang/Boolean;

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -40,6 +40,8 @@
 
 # :hotspot_compiler
 
+compiler/aot/verification/vmflags/TrackedFlagTest.java 8215224 generic-all
+compiler/aot/verification/vmflags/NotTrackedFlagTest.java 8215224 generic-all
 compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/codecache/stress/OverloadCompileQueueTest.java 8166554 generic-all
 compiler/codegen/Test6896617.java 8193479 generic-all


### PR DESCRIPTION
We see intermittent errors in our CI systems, like here:
https://ci.sapmachine.io/job/build-11-pr-validation-linux_x86_64/61/
https://ci.sapmachine.io/job/build-11-pr-validation-linux_x86_64/53/

The issue would only be fixed with a Graal update (https://bugs.openjdk.java.net/browse/JDK-8215224 from OpenJDK 12) which is probably not going to happen in OpenJDK 11u.
So we shall exclude these two tests to reduce noise in CI systems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283420](https://bugs.openjdk.java.net/browse/JDK-8283420): [AOT] Exclude TrackedFlagTest/NotTrackedFlagTest in 11u because of intermittent java.lang.AssertionError: duplicate classes for name Ljava/lang/Boolean;


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/923/head:pull/923` \
`$ git checkout pull/923`

Update a local copy of the PR: \
`$ git checkout pull/923` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 923`

View PR using the GUI difftool: \
`$ git pr show -t 923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/923.diff">https://git.openjdk.java.net/jdk11u-dev/pull/923.diff</a>

</details>
