### PR TITLE
8283424: compiler/loopopts/LoopUnswitchingBadNodeBudget.java fails with release VMs due to lack of -XX:+UnlockDiagnosticVMOptions

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/LoopUnswitchingBadNodeBudget.java
+++ b/test/hotspot/jtreg/compiler/loopopts/LoopUnswitchingBadNodeBudget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation
  *      -XX:-UseOnStackReplacement -XX:CompileOnly=LoopUnswitchingBadNodeBudget::test
  *      -XX:CompileCommand=dontinline,LoopUnswitchingBadNodeBudget::helper
- *      -XX:+UnlockExperimentalVMOptions -XX:-UseSwitchProfiling LoopUnswitchingBadNodeBudget
+ *      -XX:+UnlockDiagnosticVMOptions -XX:-UseSwitchProfiling LoopUnswitchingBadNodeBudget
  *
  */
 


### PR DESCRIPTION
Hi all,

I'd like to fix the failure of compiler/loopopts/LoopUnswitchingBadNodeBudget.java with release VMs due to lack of -XX:+UnlockDiagnosticVMOptions.

Testing:
  - compiler/loopopts/LoopUnswitchingBadNodeBudget.java with {fastdebug, release} VMs

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283424](https://bugs.openjdk.java.net/browse/JDK-8283424): compiler/loopopts/LoopUnswitchingBadNodeBudget.java fails with release VMs due to lack of -XX:+UnlockDiagnosticVMOptions


### Reviewers
 * [Roland Westrelin](https://openjdk.java.net/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/924/head:pull/924` \
`$ git checkout pull/924`

Update a local copy of the PR: \
`$ git checkout pull/924` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 924`

View PR using the GUI difftool: \
`$ git pr show -t 924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/924.diff">https://git.openjdk.java.net/jdk11u-dev/pull/924.diff</a>

</details>
