### PR TITLE
Replace homebrew with macports

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -216,7 +216,7 @@
 <h3 id="macos">macOS</h3>
 <p>Apple is using a quite aggressive scheme of pushing OS updates, and coupling these updates with required updates of Xcode. Unfortunately, this makes it difficult for a project such as the JDK to keep pace with a continuously updated machine running macOS. See the section on <a href="#apple-xcode">Apple Xcode</a> on some strategies to deal with this.</p>
 <p>It is recommended that you use at least Mac OS X 10.13 (High Sierra). At the time of writing, the JDK has been successfully compiled on macOS 10.12 (Sierra).</p>
-<p>The standard macOS environment contains the basic tooling needed to build, but for external libraries a package manager is recommended. The JDK uses <a href="https://brew.sh/">homebrew</a> in the examples, but feel free to use whatever manager you want (or none).</p>
+<p>The standard macOS environment contains the basic tooling needed to build, but for external libraries a package manager is recommended. The JDK uses <a href="https://www.macports.org/">macports</a> in the examples, but feel free to use whatever manager you want (or none).</p>
 <h3 id="linux">Linux</h3>
 <p>It is often not much problem to build the JDK on Linux. The only general advice is to try to use the compilers, external libraries and header files as provided by your distribution.</p>
 <p>The basic tooling is provided as part of the core operating system, but you will most likely need to install developer packages.</p>
@@ -419,7 +419,7 @@ CC: Sun C++ 5.13 SunOS_i386 151846-10 2015/10/30</code></pre>
 <ul>
 <li>To install on an apt-based Linux, try running <code>sudo apt-get install autoconf</code>.</li>
 <li>To install on an rpm-based Linux, try running <code>sudo yum install autoconf</code>.</li>
-<li>To install on macOS, try running <code>brew install autoconf</code>.</li>
+<li>To install on macOS, try running <code>sudo port install autoconf</code>.</li>
 <li>To install on Windows, try running <code>&lt;path to Cygwin setup&gt;/setup-x86_64 -q -P autoconf</code>.</li>
 </ul>
 <p>If <code>configure</code> has problems locating your installation of autoconf, you can specify it using the <code>AUTOCONF</code> environment variable, like this:</p>

--- a/doc/building.md
+++ b/doc/building.md
@@ -250,7 +250,7 @@ of writing, the JDK has been successfully compiled on macOS 10.12 (Sierra).
 
 The standard macOS environment contains the basic tooling needed to build, but
 for external libraries a package manager is recommended. The JDK uses
-[homebrew](https://brew.sh/) in the examples, but feel free to use whatever
+[macports](https://www.macports.org/) in the examples, but feel free to use whatever
 manager you want (or none).
 
 ### Linux
@@ -541,7 +541,7 @@ platforms. At least version 2.69 is required.
     autoconf`.
   * To install on an rpm-based Linux, try running `sudo yum install
     autoconf`.
-  * To install on macOS, try running `brew install autoconf`.
+  * To install on macOS, try running `sudo port install autoconf`.
   * To install on Windows, try running `<path to Cygwin setup>/setup-x86_64 -q
     -P autoconf`.
 


### PR DESCRIPTION
Replace Homebrew with Macports as Homebrew supports newer versions of MacOS aka MacOS Mojave or later while 
It has been mentioned to build on MacOS High Sierra or Later and thus, Switching to Macports is suggested.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/925/head:pull/925` \
`$ git checkout pull/925`

Update a local copy of the PR: \
`$ git checkout pull/925` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 925`

View PR using the GUI difftool: \
`$ git pr show -t 925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/925.diff">https://git.openjdk.java.net/jdk11u-dev/pull/925.diff</a>

</details>
