### PR TITLE
8242310: use reproducible random in hotspot compiler tests

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/PolynomialRoot.java
+++ b/test/hotspot/jtreg/compiler/c2/PolynomialRoot.java
@@ -11,6 +11,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8005956
  * @summary C2: assert(!def_outside->member(r)) failed: Use of external LRG overlaps the same LRG defined in this block
  * @library /test/lib

--- a/test/hotspot/jtreg/compiler/c2/Test6661247.java
+++ b/test/hotspot/jtreg/compiler/c2/Test6661247.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,11 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 6661247
  * @summary Internal bug in 32-bit HotSpot optimizer while bit manipulations
  *
+ * @library /test/lib
  * @run main compiler.c2.Test6661247
  */
 
@@ -33,6 +35,7 @@ package compiler.c2;
 
 import java.nio.LongBuffer;
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 // This isn't a completely reliable test for 6661247 since the results
 // depend on what the local schedule looks like but it does reproduce
@@ -133,7 +136,7 @@ public class Test6661247 {
         }
     }
     public static void main(String[] args) {
-        Random r = new Random();
+        Random r = Utils.getRandomInstance();
         int entries = 1000;
         boolean[] src = new boolean[entries * 64];
         long[] dest = new long[entries];

--- a/test/hotspot/jtreg/compiler/c2/Test7047069.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7047069.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,16 +23,20 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 7047069
  * @summary Array can dynamically change size when assigned to an object field
  * @modules java.desktop
  *
+ * @library /test/lib
  * @run main/othervm -Xbatch compiler.c2.Test7047069
  */
 
 package compiler.c2;
 
 import java.awt.geom.Line2D;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class Test7047069 {
     static boolean verbose;
@@ -119,12 +123,13 @@ public class Test7047069 {
         this.squareflat = .0001f * .0001f;
         holdIndex = hold.length - 6;
         holdEnd = hold.length - 2;
-        hold[holdIndex + 0] = (float) (Math.random() * 100);
-        hold[holdIndex + 1] = (float) (Math.random() * 100);
-        hold[holdIndex + 2] = (float) (Math.random() * 100);
-        hold[holdIndex + 3] = (float) (Math.random() * 100);
-        hold[holdIndex + 4] = (float) (Math.random() * 100);
-        hold[holdIndex + 5] = (float) (Math.random() * 100);
+        Random rng = Utils.getRandomInstance();
+        hold[holdIndex + 0] = (float) (rng.nextDouble() * 100);
+        hold[holdIndex + 1] = (float) (rng.nextDouble() * 100);
+        hold[holdIndex + 2] = (float) (rng.nextDouble() * 100);
+        hold[holdIndex + 3] = (float) (rng.nextDouble() * 100);
+        hold[holdIndex + 4] = (float) (rng.nextDouble() * 100);
+        hold[holdIndex + 5] = (float) (rng.nextDouble() * 100);
         levelIndex = 0;
         this.limit = 10;
         this.levels = new int[limit + 1];

--- a/test/hotspot/jtreg/compiler/c2/Test7160610.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7160610.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,13 +23,18 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 7160610
  * @summary Unknown Native Code compilation issue.
- *
+ * @library /test/lib
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-OptimizeFill compiler.c2.Test7160610
  */
 
 package compiler.c2;
+
+import jdk.test.lib.Utils;
+
+import java.util.Random;
 
 public class Test7160610 {
   private static final byte[] BYTE_ARRAY = new byte[7];
@@ -37,14 +42,15 @@ public class Test7160610 {
   private static int[] anIntArray1191 = new int[32768];
 
   public static void main(String arg[]) {
+    Random rng = Utils.getRandomInstance();
     int i = 256;
     for(int j = BYTE_ARRAY[2]; j < anIntArray1190.length; j++) {
       anIntArray1190[j] = BYTE_ARRAY[2];
     }
 
     for(int k = BYTE_ARRAY[2]; (k ^ BYTE_ARRAY[1]) > -5001; k++) {
-      int i1 = (int)(Math.random() * 128D * (double)i);
-      anIntArray1190[i1] = (int)(Math.random() * 256D);
+      int i1 = (int)(rng.nextDouble() * 128D * (double)i);
+      anIntArray1190[i1] = (int)(rng.nextDouble() * 256D);
     }
 
     for(int l = BYTE_ARRAY[2]; (l ^ BYTE_ARRAY[1]) > -21; l++) {

--- a/test/hotspot/jtreg/compiler/c2/Test7177917.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7177917.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 7177917
  * @summary Micro-benchmark for Math.pow() and Math.exp()
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8015774
  * @summary Verify processing of options related to code heaps sizing.
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/codecache/dtrace/SegmentedCodeCacheDtraceTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/dtrace/SegmentedCodeCacheDtraceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test SegmentedCodeCacheDtraceTest
+ * @key randomness
  * @bug 8015774
  * @summary testing of dtrace for segmented code cache
  * @requires os.family=="solaris"

--- a/test/hotspot/jtreg/compiler/codecache/stress/Helper.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/Helper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,18 +26,15 @@ package compiler.codecache.stress;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.ByteCodeLoader;
 import jdk.test.lib.InfiniteLoop;
-import jdk.test.lib.Utils;
 import sun.hotspot.WhiteBox;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Random;
 import java.util.concurrent.Callable;
 
 public final class Helper {
     public static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
-    public static final Random RNG = Utils.getRandomInstance();
 
     private static final long THRESHOLD = WHITE_BOX.getIntxVMFlag("CompileThreshold");
     private static final String TEST_CASE_IMPL_CLASS_NAME = "compiler.codecache.stress.Helper$TestCaseImpl";

--- a/test/hotspot/jtreg/compiler/codecache/stress/OverloadCompileQueueTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/OverloadCompileQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test OverloadCompileQueueTest
+ * @key stress randomness
  * @summary stressing code cache by overloading compile queues
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
@@ -46,9 +47,11 @@
 package compiler.codecache.stress;
 
 import jdk.test.lib.Platform;
+import jdk.test.lib.Utils;
 
 import java.lang.reflect.Method;
 import java.util.stream.IntStream;
+import java.util.Random;
 
 public class OverloadCompileQueueTest implements Runnable {
     private static final int MAX_SLEEP = 10000;
@@ -60,6 +63,7 @@ public class OverloadCompileQueueTest implements Runnable {
     private static final int TIERED_STOP_AT_LEVEL
             = Helper.WHITE_BOX.getIntxVMFlag("TieredStopAtLevel").intValue();
     private static final int[] AVAILABLE_LEVELS;
+    private final Random rng = Utils.getRandomInstance();
     static {
         if (TIERED_COMPILATION) {
             AVAILABLE_LEVELS = IntStream
@@ -104,7 +108,7 @@ public class OverloadCompileQueueTest implements Runnable {
 
     private void lockUnlock() {
         try {
-            int sleep = Helper.RNG.nextInt(MAX_SLEEP);
+            int sleep = rng.nextInt(MAX_SLEEP);
             Helper.WHITE_BOX.lockCompilation();
             Thread.sleep(sleep);
         } catch (InterruptedException e) {

--- a/test/hotspot/jtreg/compiler/codecache/stress/RandomAllocationTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/RandomAllocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test RandomAllocationTest
- * @key stress
+ * @key stress randomness
  * @summary stressing code cache by allocating randomly sized "dummy" code blobs
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
@@ -49,6 +49,8 @@ package compiler.codecache.stress;
 import sun.hotspot.code.BlobType;
 
 import java.util.ArrayList;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class RandomAllocationTest implements Runnable {
     private static final long CODE_CACHE_SIZE
@@ -56,6 +58,7 @@ public class RandomAllocationTest implements Runnable {
     private static final int MAX_BLOB_SIZE = (int) (CODE_CACHE_SIZE >> 7);
     private static final BlobType[] BLOB_TYPES
             = BlobType.getAvailable().toArray(new BlobType[0]);
+    private final Random rng = Utils.getRandomInstance();
 
     public static void main(String[] args) {
         new CodeCacheStressRunner(new RandomAllocationTest()).runTest();
@@ -64,16 +67,16 @@ public class RandomAllocationTest implements Runnable {
     private final ArrayList<Long> blobs = new ArrayList<>();
     @Override
     public void run() {
-        boolean allocate = blobs.isEmpty() || Helper.RNG.nextBoolean();
+        boolean allocate = blobs.isEmpty() || rng.nextBoolean();
         if (allocate) {
-            int type = Helper.RNG.nextInt(BLOB_TYPES.length);
+            int type = rng.nextInt(BLOB_TYPES.length);
             long addr = Helper.WHITE_BOX.allocateCodeBlob(
-                    Helper.RNG.nextInt(MAX_BLOB_SIZE), BLOB_TYPES[type].id);
+                    rng.nextInt(MAX_BLOB_SIZE), BLOB_TYPES[type].id);
             if (addr != 0) {
                 blobs.add(addr);
             }
         } else {
-            int index = Helper.RNG.nextInt(blobs.size());
+            int index = rng.nextInt(blobs.size());
             Helper.WHITE_BOX.freeCodeBlob(blobs.remove(index));
         }
     }

--- a/test/hotspot/jtreg/compiler/codecache/stress/UnexpectedDeoptimizationTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/UnexpectedDeoptimizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test UnexpectedDeoptimizationTest
- * @key stress
+ * @key stress randomness
  * @summary stressing code cache by forcing unexpected deoptimizations
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
@@ -46,7 +46,11 @@
 
 package compiler.codecache.stress;
 
+import java.util.Random;
+import jdk.test.lib.Utils;
+
 public class UnexpectedDeoptimizationTest implements Runnable {
+    private final Random rng = Utils.getRandomInstance();
 
     public static void main(String[] args) {
         new CodeCacheStressRunner(new UnexpectedDeoptimizationTest()).runTest();
@@ -54,7 +58,7 @@ public class UnexpectedDeoptimizationTest implements Runnable {
 
     @Override
     public void run() {
-        Helper.WHITE_BOX.deoptimizeFrames(Helper.RNG.nextBoolean());
+        Helper.WHITE_BOX.deoptimizeFrames(rng.nextBoolean());
     }
 
 }

--- a/test/hotspot/jtreg/compiler/codegen/Test6896617.java
+++ b/test/hotspot/jtreg/compiler/codegen/Test6896617.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 6896617
  * @summary Optimize sun.nio.cs.ISO_8859_1$Encode.encodeArrayLoop() with SSE instructions on x86
  * @library /test/lib

--- a/test/hotspot/jtreg/compiler/codegen/Test7100757.java
+++ b/test/hotspot/jtreg/compiler/codegen/Test7100757.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 7100757
  * @summary The BitSet.nextSetBit() produces incorrect result in 32bit VM on Sparc
  * @library /test/lib

--- a/test/hotspot/jtreg/compiler/codegen/aes/TestAESMain.java
+++ b/test/hotspot/jtreg/compiler/codegen/aes/TestAESMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 7184394
  * @key stress
+ * @comment the test isn't marked w/ randomness as it uses predefined key b/c of keySize==128
  * @summary add intrinsics to use AES instructions
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/codegen/aes/TestCipherBlockChainingEncrypt.java
+++ b/test/hotspot/jtreg/compiler/codegen/aes/TestCipherBlockChainingEncrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8209951
  * @summary SIGBUS in com.sun.crypto.provider.CipherBlockChaining
  * @library /test/lib /
@@ -47,6 +48,7 @@ import javax.crypto.spec.PBEKeySpec;
 
 import compiler.whitebox.CompilerWhiteBoxTest;
 import sun.hotspot.code.Compiler;
+import jdk.test.lib.Utils;
 import jtreg.SkippedException;
 
 public class TestCipherBlockChainingEncrypt {
@@ -83,7 +85,7 @@ public class TestCipherBlockChainingEncrypt {
         // generate input data
         byte[] inputText = new byte[INPUT_LENGTH + NUM_PAD_BYTES
                 + PBKDF2_ADD_PAD_BYTES];
-        new Random().nextBytes(inputText);
+        Utils.getRandomInstance().nextBytes(inputText);
 
         try {
             // Encrypt

--- a/test/hotspot/jtreg/compiler/compilercontrol/commandfile/CompileOnlyTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/commandfile/CompileOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests CompileCommand=compileonly
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/commandfile/ExcludeTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/commandfile/ExcludeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests CompileCommand=exclude
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/commandfile/LogTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/commandfile/LogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests CompileCommand=log
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/commandfile/PrintTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/commandfile/PrintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests CompileCommand=print
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/commands/CompileOnlyTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/commands/CompileOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests CompileCommand=compileonly
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/commands/ExcludeTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/commands/ExcludeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests CompileCommand=exclude
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/commands/LogTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/commands/LogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests CompileCommand=log
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/commands/PrintTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/commands/PrintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests CompileCommand=print
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/directives/CompileOnlyTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/directives/CompileOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests directives to be able to compile only specified  methods
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/directives/ExcludeTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/directives/ExcludeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests directives to be able to exclude methods from compilation
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/directives/LogTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/directives/LogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests directives to be able to turn on LogCompilation
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/directives/PrintTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/directives/PrintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests directives to be able to turn on print_assembly
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/jcmd/AddAndRemoveTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/jcmd/AddAndRemoveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests directives to be able to add and remove directives
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/jcmd/AddCompileOnlyTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/jcmd/AddCompileOnlyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests jcmd to be able to add a directive to compile only specified methods
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/jcmd/AddExcludeTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/jcmd/AddExcludeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests jcmd to be able to add a directive to exclude only specified methods
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/jcmd/AddLogTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/jcmd/AddLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests jcmd to be able to add a directive to log only specified methods
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/jcmd/AddPrintAssemblyTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/jcmd/AddPrintAssemblyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests jcmd to be able to add a directive to print assembly
  *          only for specified methods

--- a/test/hotspot/jtreg/compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests jcmd to be able to clear directives added via options
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/jcmd/ClearDirectivesStackTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/jcmd/ClearDirectivesStackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests clear JCMD command
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/jcmd/PrintDirectivesTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/jcmd/PrintDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests jcmd to be able to add a directive to compile only specified methods
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/jcmd/StressAddMultiThreadedTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/jcmd/StressAddMultiThreadedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Tests jcmd to be able to add a lot of huge directive files with
  *          parallel executed jcmds until timeout has reached
@@ -68,8 +69,9 @@ public class StressAddMultiThreadedTest extends StressAddJcmdBase {
 
     @Override
     protected boolean makeConnection(int pid) {
+        String nextCommand = nextCommand();
         executor.submit(() -> new PidJcmdExecutor(String.valueOf(pid))
-                .execute(nextCommand()));
+                .execute(nextCommand));
         return (--commands != 0);
     }
 

--- a/test/hotspot/jtreg/compiler/compilercontrol/matcher/MethodMatcherTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/matcher/MethodMatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8135068
  * @summary Tests CompilerCommand's method matcher
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/mixed/RandomCommandsTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/mixed/RandomCommandsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Randomly generates commands with random types
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/mixed/RandomValidCommandsTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/mixed/RandomValidCommandsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Randomly generates valid commands with random types
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/parser/DirectiveStressTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/parser/DirectiveStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8137167
  * @summary Stress directive json parser
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/compiler/compilercontrol/parser/HugeDirectiveUtil.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/parser/HugeDirectiveUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
  * Creates a huge directive file
  */
 public final class HugeDirectiveUtil {
-    private static final Random RANDOM = Utils.getRandomInstance();
     protected static final String EXPECTED_ERROR_STRING = "Parsing of compiler "
             + "directives failed";
 
@@ -77,23 +76,24 @@ public final class HugeDirectiveUtil {
         // get random amount of methods for the match
         List<String> methods = getRandomDescriptors(descriptors);
         file.match(methods.toArray(new String[methods.size()]));
+        Random random = Utils.getRandomInstance();
         for (int i = 0; i < objectSize; i++) {
             // emit compiler block
             file.emitCompiler(Utils.getRandomElement(
                     Scenario.Compiler.values()));
             // add option inside the compiler block
             file.option(Utils.getRandomElement(DirectiveWriter.Option.values()),
-                    RANDOM.nextBoolean());
+                    random.nextBoolean());
             file.end(); // ends compiler block
 
             // add standalone option, enable can't be used standalone
             EnumSet<DirectiveWriter.Option> options = EnumSet.complementOf(
                     EnumSet.of(DirectiveWriter.Option.ENABLE));
-            file.option(Utils.getRandomElement(options), RANDOM.nextBoolean());
+            file.option(Utils.getRandomElement(options), random.nextBoolean());
         }
         // add inline block with random inlinees
         methods = getRandomDescriptors(descriptors).stream()
-                .map(s -> (RANDOM.nextBoolean() ? "+" : "-") + s)
+                .map(s -> (random.nextBoolean() ? "+" : "-") + s)
                 .collect(Collectors.toList());
         file.inline(methods);
 
@@ -103,8 +103,9 @@ public final class HugeDirectiveUtil {
 
     private static List<String> getRandomDescriptors(
             List<MethodDescriptor> descriptors) {
-        int amount = 1 + RANDOM.nextInt(descriptors.size() - 1);
-        int skipAmount = RANDOM.nextInt(descriptors.size() - amount);
+        Random random = Utils.getRandomInstance();
+        int amount = 1 + random.nextInt(descriptors.size() - 1);
+        int skipAmount = random.nextInt(descriptors.size() - amount);
         return descriptors.stream()
                 .skip(skipAmount)
                 .limit(amount)

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestSelfArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestSelfArrayCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8229016 8231055
  * @summary Test correct elimination of array allocation with arraycopy to itself.
  * @library /test/lib

--- a/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/UnsafeIntrinsicsTest.java
@@ -23,10 +23,12 @@
 
 /*
  * @test id=z
+ * @key randomness
  * @bug 8059022
  * @modules java.base/jdk.internal.misc:+open
  * @summary Validate barriers after Unsafe getObject, CAS and swap (GetAndSet)
  * @requires vm.gc.Z & !vm.graal.enabled
+ * @library /test/lib
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:+UseZGC
@@ -38,10 +40,12 @@
 
  /*
  * @test id=shenandoah
+ * @key randomness
  * @bug 8059022
  * @modules java.base/jdk.internal.misc:+open
  * @summary Validate barriers after Unsafe getObject, CAS and swap (GetAndSet)
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  * @run main/othervm -Xmx256m
  *                   -XX:+UseShenandoahGC
  *                   -XX:+UnlockDiagnosticVMOptions
@@ -56,6 +60,7 @@ package compiler.gcbarriers;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Random;
+import jdk.test.lib.Utils;
 import sun.misc.Unsafe;
 
 public class UnsafeIntrinsicsTest {
@@ -96,7 +101,7 @@ public class UnsafeIntrinsicsTest {
 
         // start mutator threads
         ArrayList<Thread> thread_list = new ArrayList<Thread>();
-        Random r = new Random(System.nanoTime());
+        Random r = Utils.getRandomInstance();
         for (int i = 0; i < thread_count; i++) {
 
             setup(); // each thread has its own circle of nodes
@@ -114,7 +119,7 @@ public class UnsafeIntrinsicsTest {
 
         setup(); // All nodes are shared between threads
         ArrayList<Thread> thread_list = new ArrayList<Thread>();
-        Random r = new Random(System.nanoTime());
+        Random r = Utils.getRandomInstance();
         for (int i = 0; i < thread_count; i++) {
             Thread t = new Thread(new Runner(first_node, time, r.nextLong(), optype));
             t.start();

--- a/test/hotspot/jtreg/compiler/interpreter/DisableOSRTest.java
+++ b/test/hotspot/jtreg/compiler/interpreter/DisableOSRTest.java
@@ -48,7 +48,7 @@ import java.util.Random;
 
 public class DisableOSRTest {
     private static final WhiteBox WB = WhiteBox.getWhiteBox();
-    private static final Random RANDOM = new Random();
+    private static final Random RANDOM = new Random(42);
 
     public static int foo() {
         return RANDOM.nextInt();

--- a/test/hotspot/jtreg/compiler/intrinsics/base64/TestBase64.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/base64/TestBase64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,6 @@ import java.util.Base64;
 import java.util.Base64.Decoder;
 import java.util.Base64.Encoder;
 import java.util.Objects;
-import java.util.Random;
 
 import compiler.whitebox.CompilerWhiteBoxTest;
 import sun.hotspot.code.Compiler;

--- a/test/hotspot/jtreg/compiler/intrinsics/bigInteger/MontgomeryMultiplyTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bigInteger/MontgomeryMultiplyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -201,7 +201,7 @@ public class MontgomeryMultiplyTest {
         }
     }
 
-    Random rnd = new Random(0);
+    Random rnd = new Random(42);
 
     // Return a random value of length <= bits in an array of even length
     int[] random_val(int bits) {

--- a/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestMulAdd.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestMulAdd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,13 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8081778
  * @summary Add C2 x86 intrinsic for BigInteger::mulAdd() method
  * @comment the test disables intrinsics, so it can't be run w/ AOT'ed java.base
  * @requires !vm.aot.enabled
  *
+ * @library /test/lib
  * @run main/othervm/timeout=600 -XX:-TieredCompilation -Xbatch
  *      -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:-UseSquareToLenIntrinsic -XX:-UseMultiplyToLenIntrinsic
  *      -XX:CompileCommand=dontinline,compiler.intrinsics.bigInteger.TestMulAdd::main
@@ -47,6 +49,7 @@ package compiler.intrinsics.bigInteger;
 
 import java.math.BigInteger;
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestMulAdd {
 
@@ -88,12 +91,8 @@ public class TestMulAdd {
 
       BigInteger b1, b2, oldres, newres;
 
-      Random rand = new Random();
-      long seed = System.nanoTime();
-      Random rand1 = new Random();
-      long seed1 = System.nanoTime();
-      rand.setSeed(seed);
-      rand1.setSeed(seed1);
+      Random rand = new Random(Utils.getRandomInstance().nextLong());
+      Random rand1 = new Random(Utils.getRandomInstance().nextLong());
 
       for (int j = 0; j < 100000; j++) {
         int rand_int = rand1.nextInt(3136)+32;

--- a/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestMultiplyToLen.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestMultiplyToLen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,11 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8055494
  * @summary Add C2 x86 intrinsic for BigInteger::multiplyToLen() method
  *
+ * @library /test/lib
  * @run main/othervm/timeout=600 -XX:-TieredCompilation -Xbatch
  *      -XX:CompileCommand=exclude,compiler.intrinsics.bigInteger.TestMultiplyToLen::main
  *      -XX:CompileCommand=option,compiler.intrinsics.bigInteger.TestMultiplyToLen::base_multiply,ccstr,DisableIntrinsic,_multiplyToLen
@@ -39,6 +41,7 @@ package compiler.intrinsics.bigInteger;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestMultiplyToLen {
 
@@ -80,12 +83,8 @@ public class TestMultiplyToLen {
 
       BigInteger b1, b2, oldres, newres;
 
-      Random rand = new Random();
-      long seed = System.nanoTime();
-      Random rand1 = new Random();
-      long seed1 = System.nanoTime();
-      rand.setSeed(seed);
-      rand1.setSeed(seed1);
+      Random rand = new Random(Utils.getRandomInstance().nextLong());
+      Random rand1 = new Random(Utils.getRandomInstance().nextLong());
 
       for (int j = 0; j < 1000000; j++) {
         int rand_int = rand1.nextInt(3136)+32;

--- a/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestSquareToLen.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bigInteger/TestSquareToLen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,10 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8081778
  * @summary Add C2 x86 intrinsic for BigInteger::squareToLen() method
+ * @library /test/lib
  *
  * @run main/othervm/timeout=600 -XX:-TieredCompilation -Xbatch
  *      -XX:CompileCommand=exclude,compiler.intrinsics.bigInteger.TestSquareToLen::main
@@ -42,6 +44,7 @@ package compiler.intrinsics.bigInteger;
 
 import java.math.BigInteger;
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestSquareToLen {
 
@@ -83,12 +86,8 @@ public class TestSquareToLen {
 
       BigInteger b1, b2, oldres, newres;
 
-      Random rand = new Random();
-      long seed = System.nanoTime();
-      Random rand1 = new Random();
-      long seed1 = System.nanoTime();
-      rand.setSeed(seed);
-      rand1.setSeed(seed1);
+      Random rand = new Random(Utils.getRandomInstance().nextLong());
+      Random rand1 = new Random(Utils.getRandomInstance().nextLong());
 
       for (int j = 0; j < 100000; j++) {
         int rand_int = rand1.nextInt(3136)+32;

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,9 +59,6 @@ public class BMITestRunner {
      *   <li>-iterations=&lt;N&gt; each operation implemented by
      *       <b>expr</b> will be executed <i>N</i> times. Default value
      *       is 4000.</li>
-     *   <li>-seed=&lt;SEED&gt; arguments for <b>expr</b>'s methods
-     *       obtained via RNG initiated with seed <i>SEED</i>. By default
-     *       some random seed will be used.</li>
      * </ul>
      *
      * @param expr operation that should be tested
@@ -75,15 +72,15 @@ public class BMITestRunner {
                                 String... additionalVMOpts)
                          throws Throwable {
 
-        int seed = Utils.getRandomInstance().nextInt();
+        // ensure seed got printed out
+        Utils.getRandomInstance();
+        long seed = Utils.SEED;
         int iterations = DEFAULT_ITERATIONS_COUNT;
 
         for (String testOption : testOpts) {
             if (testOption.startsWith("-iterations=")) {
                 iterations = Integer.valueOf(testOption.
                                              replace("-iterations=", ""));
-            } else if (testOption.startsWith("-seed=")) {
-                seed = Integer.valueOf(testOption.replace("-seed=", ""));
             }
         }
 
@@ -119,7 +116,7 @@ public class BMITestRunner {
     public static OutputAnalyzer runTest(Class<? extends Expr> expr,
                                          VMMode testVMMode,
                                          String additionalVMOpts[],
-                                         int seed, int iterations)
+                                         long seed, int iterations)
                                   throws Throwable {
 
         List<String> vmOpts = new LinkedList<String>();

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestAndnI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestAndnI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8031321
  * @summary Verify that results of computations are the same w/
  *          and w/o usage of ANDN instruction

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestAndnL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestAndnL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8031321
  * @summary Verify that results of computations are the same w/
  *          and w/o usage of ANDN instruction

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBlsiI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBlsiI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8031321
  * @summary Verify that results of computations are the same w/
  *          and w/o usage of BLSI instruction

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBlsiL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBlsiL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8031321
  * @summary Verify that results of computations are the same w/
  *          and w/o usage of BLSI instruction

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBlsmskI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBlsmskI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8031321
  * @summary Verify that results of computations are the same w/
  *          and w/o usage of BLSMSK instruction

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBlsmskL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBlsmskL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8031321
  * @summary Verify that results of computations are the same w/
  *          and w/o usage of BLSMSK instruction

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBlsrI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBlsrI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8031321
  * @summary Verify that results of computations are the same w/
  *          and w/o usage of BLSR instruction

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBlsrL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestBlsrL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8031321
  * @summary Verify that results of computations are the same w/
  *          and w/o usage of BLSR instruction

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestLzcntI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestLzcntI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8031321
  * @summary Verify that results of computations are the same w/
  *          and w/o usage of intrinsic

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestLzcntL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestLzcntL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8031321
  * @summary Verify that results of computations are the same w/
  *          and w/o usage of intrinsic

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestTzcntI.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestTzcntI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8031321
  * @summary Verify that results of computations are the same w/
  *          and w/o usage of intrinsic

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/TestTzcntL.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/TestTzcntL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8031321
  * @summary Verify that results of computations are the same w/
  *          and w/o usage of intrinsic

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestFpMinMaxIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestFpMinMaxIntrinsics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2019, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -26,7 +26,9 @@
  * @test
  * @bug 8212043
  * @summary Test compiler intrinsics of floating-point Math.min/max
+ * @library /test/lib
  *
+ * @comment the test isn't marked by 'randomness' b/c randomSearchTree case isn't used
  * @run main/othervm -Xint compiler.intrinsics.math.TestFpMinMaxIntrinsics sanityTests 1
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions
  *                   -Xcomp -XX:TieredStopAtLevel=1
@@ -52,6 +54,7 @@ package compiler.intrinsics.math;
 import java.util.Arrays;
 import java.util.Random;
 import java.lang.reflect.Method;
+import jdk.test.lib.Utils;
 
 public class TestFpMinMaxIntrinsics {
 
@@ -198,7 +201,7 @@ public class TestFpMinMaxIntrinsics {
     private static final int COUNT = 1000;
     private static final int LOOPS = 100;
 
-    private static Random r = new Random();
+    private static Random r = Utils.getRandomInstance();
 
     private static Node[] pool = new Node[COUNT];
 

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/AddExactILoadTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/AddExactILoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8024924
  * @summary Test non constant addExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/AddExactILoopDependentTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/AddExactILoopDependentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8024924
  * @summary Test non constant addExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/AddExactINonConstantTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/AddExactINonConstantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8024924
  * @summary Test non constant addExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/AddExactIRepeatTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/AddExactIRepeatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8025657
  * @summary Test repeating addExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/AddExactLNonConstantTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/AddExactLNonConstantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test non constant addExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/MulExactILoadTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/MulExactILoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test multiplyExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/MulExactILoopDependentTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/MulExactILoopDependentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test loop dependent multiplyExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/MulExactINonConstantTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/MulExactINonConstantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test non constant multiplyExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/MulExactIRepeatTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/MulExactIRepeatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test repeating multiplyExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/MulExactLNonConstantTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/MulExactLNonConstantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test non constant mulExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/NegExactILoadTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/NegExactILoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test negExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/NegExactILoopDependentTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/NegExactILoopDependentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test negExact loop dependent
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/NegExactINonConstantTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/NegExactINonConstantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test non constant negExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/NegExactLNonConstantTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/NegExactLNonConstantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test constant negExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/SubExactILoadTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/SubExactILoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test non constant subtractExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/SubExactILoopDependentTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/SubExactILoopDependentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test non constant subtractExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/SubExactINonConstantTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/SubExactINonConstantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test non constant subtractExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/SubExactIRepeatTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/SubExactIRepeatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @summary Test repeating subtractExact
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/mathexact/SubExactLNonConstantTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/mathexact/SubExactLNonConstantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8026844
  * @bug 8027353
  * @summary Test non constant subtractExact

--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/DirectByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/DirectByteBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,8 +27,8 @@
  * @bug 8026049 8151163
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-UseUnalignedAccesses -Djdk.test.lib.random.seed=0 DirectByteBufferTest
- * @run main/othervm -Djdk.test.lib.random.seed=0 DirectByteBufferTest
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-UseUnalignedAccesses -Djdk.test.lib.random.seed=42 DirectByteBufferTest
+ * @run main/othervm -Djdk.test.lib.random.seed=42 DirectByteBufferTest
  * @summary Verify that direct byte buffers are correctly accessed.
  */
 

--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/HeapByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/HeapByteBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,9 +29,9 @@
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  *
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-UseUnalignedAccesses -Djdk.test.lib.random.seed=0
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-UseUnalignedAccesses -Djdk.test.lib.random.seed=42
  *      HeapByteBufferTest
- * @run main/othervm -Djdk.test.lib.random.seed=0
+ * @run main/othervm -Djdk.test.lib.random.seed=42
  *      HeapByteBufferTest
  */
 

--- a/test/hotspot/jtreg/compiler/jsr292/ConcurrentClassLoadingTest.java
+++ b/test/hotspot/jtreg/compiler/jsr292/ConcurrentClassLoadingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8022595
  * @summary JSR292: deadlock during class loading of MethodHandles, MethodHandleImpl & MethodHandleNatives
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/AllocateCompileIdTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/AllocateCompileIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8136421
  * @requires vm.jvmci
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/HasCompiledCodeForOSRTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/HasCompiledCodeForOSRTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key randomness
  * @bug 8136421
  * @requires vm.jvmci
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/types/correctness/OffTest.java
+++ b/test/hotspot/jtreg/compiler/types/correctness/OffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test CorrectnessTest
+ * @key randomness
  * @bug 8038418
  * @requires vm.flavor == "server" & !vm.emulatedClient
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeRaw.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeRaw.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key randomness
  * @bug 8058744
  * @summary Invalid pattern-matching of address computations in raw unsafe
  * @library /test/lib

--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeSmallOffsetBooleanAccessTest.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeSmallOffsetBooleanAccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import jdk.internal.misc.Unsafe;
 public class UnsafeSmallOffsetBooleanAccessTest {
     static final Unsafe UNSAFE = Unsafe.getUnsafe();
     static final long F_OFFSET;
-    static final Random random = new Random();
+    static final Random random = new Random(42);
 
     static {
         try {

--- a/test/hotspot/jtreg/compiler/whitebox/BlockingCompilation.java
+++ b/test/hotspot/jtreg/compiler/whitebox/BlockingCompilation.java
@@ -50,7 +50,7 @@ import java.util.Random;
 
 public class BlockingCompilation {
     private static final WhiteBox WB = WhiteBox.getWhiteBox();
-    private static final Random RANDOM = new Random();
+    private static final Random RANDOM = new Random(42);
 
     public static int foo() {
         return RANDOM.nextInt();


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

I had to adapt the change in some places, all quite trivial:

TestTrichotomyExpressions.java
TestShift.java
Vec_MulAddS2I.java
These tests are not in 11. Skipped.

ClearDirectivesFileStackTest.java
Resolved Copyright.

UnsafeIntrinsicsTest.java
A later change doubling the test description was already backported. 
Applying the patch was trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242310](https://bugs.openjdk.java.net/browse/JDK-8242310): use reproducible random in hotspot compiler tests


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/930/head:pull/930` \
`$ git checkout pull/930`

Update a local copy of the PR: \
`$ git checkout pull/930` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 930`

View PR using the GUI difftool: \
`$ git pr show -t 930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/930.diff">https://git.openjdk.java.net/jdk11u-dev/pull/930.diff</a>

</details>
