### PR TITLE
8242313: use reproducible random in hotspot svc tests

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithNativeMethod.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithNativeMethod.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,16 @@
  * questions.
  */
 
+import java.util.Random;
 import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.Utils;
 
 public class LingeredAppWithNativeMethod extends LingeredApp {
 
     public static final String THREAD_NAME = "NoFramePointerJNIFib";
     private static final int UPPER_BOUND = 55;
     private static final int LOWER_BOUND = 40;
+    private static final Random RNG = Utils.getRandomInstance();
 
     static {
         // JNI library compiled with no frame pointer info
@@ -43,9 +46,9 @@ public class LingeredAppWithNativeMethod extends LingeredApp {
         // Results of fibonacci calculation from JNI are
         // reported via callback(). That's where the process
         // of calculating fibonacci restarts.
-        int num = (int) (Math.random() * UPPER_BOUND);
+        int num = (int) (RNG.nextDouble() * UPPER_BOUND);
         while (num < LOWER_BOUND) {
-            num = (int) (Math.random() * UPPER_BOUND);
+            num = (int) (RNG.nextDouble() * UPPER_BOUND);
         }
         System.out.print("fib(" + num + ") = ");
         callJNI(this, num);

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackMixed.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackMixed.java
@@ -33,6 +33,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 /**
  * @test
+ * @key randomness
  * @bug 8208091
  * @requires (os.family == "linux") & (vm.hasSAandCanAttach)
  * @library /test/lib

--- a/test/hotspot/jtreg/serviceability/threads/TestFalseDeadLock.java
+++ b/test/hotspot/jtreg/serviceability/threads/TestFalseDeadLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import java.util.Random;
 
 /*
  * @test
+ * @key randomness
  * @bug 8016304
  * @summary Make sure no deadlock is reported for this program which has no deadlocks.
  * @modules java.base/jdk.internal.misc
@@ -48,8 +49,9 @@ public class TestFalseDeadLock {
     public static void main(String[] args) throws Exception {
         bean = ManagementFactory.getThreadMXBean();
         Thread[] threads = new Thread[500];
+        Random random = Utils.getRandomInstance();
         for (int i = 0; i < threads.length; i++) {
-            Test t = new Test();
+            Test t = new Test(random.nextLong());
             threads[i] = new Thread(t);
             threads[i].start();
         }
@@ -67,8 +69,12 @@ public class TestFalseDeadLock {
     }
 
     public static class Test implements Runnable {
+        private final long seed;
+        public Test(long seed) {
+            this.seed = seed;
+        }
         public void run() {
-            Random r = Utils.getRandomInstance();
+            Random r = new Random(seed);
             while (running) {
                 try {
                     synchronized (this) {


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8242313](https://bugs.openjdk.java.net/browse/JDK-8242313): use reproducible random in hotspot svc tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/931/head:pull/931` \
`$ git checkout pull/931`

Update a local copy of the PR: \
`$ git checkout pull/931` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 931`

View PR using the GUI difftool: \
`$ git pr show -t 931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/931.diff">https://git.openjdk.java.net/jdk11u-dev/pull/931.diff</a>

</details>
