### PR TITLE
8242311: use reproducible random in hotspot runtime tests

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/HugeArenaTracking.java
+++ b/test/hotspot/jtreg/runtime/NMT/HugeArenaTracking.java
@@ -24,7 +24,7 @@
 
 /*
  * @test
- * @key nmt jcmd
+ * @key nmt jcmd randomness
  * @library /test/lib
  * @requires vm.bits == 64
  * @modules java.base/jdk.internal.misc
@@ -39,6 +39,7 @@ import java.util.Random;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.Utils;
 import sun.hotspot.WhiteBox;
 
 public class HugeArenaTracking {
@@ -60,7 +61,7 @@ public class HugeArenaTracking {
     output = new OutputAnalyzer(pb.start());
     output.shouldContain("Test (reserved=2KB, committed=2KB)");
 
-    Random rand = new Random();
+    Random rand = Utils.getRandomInstance();
 
     // Allocate 2GB+ from arena
     long total = 0;

--- a/test/hotspot/jtreg/runtime/NMT/MallocStressTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/MallocStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Stress test for malloc tracking
- * @key nmt jcmd stress
+ * @key nmt jcmd stress randomness
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Random;
 import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.Platform;
+import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import sun.hotspot.WhiteBox;
@@ -159,6 +160,7 @@ public class MallocStressTest {
     }
 
     static class AllocThread extends Thread {
+        private final Random random = new Random(Utils.getRandomInstance().nextLong());
         AllocThread() {
             this.setName("MallocThread");
             this.start();
@@ -166,7 +168,6 @@ public class MallocStressTest {
 
         // AllocThread only runs "Alloc" phase
         public void run() {
-            Random random = new Random();
             // MallocStressTest.phase == TestPhase.alloc
             for (int loops = 0; loops < 100; loops++) {
                 int r = random.nextInt(Integer.MAX_VALUE);
@@ -201,7 +202,7 @@ public class MallocStressTest {
     }
 
     static class ReleaseThread extends Thread {
-        private Random random = new Random();
+        private final Random random = new Random(Utils.getRandomInstance().nextLong());
         ReleaseThread() {
             this.setName("ReleaseThread");
             this.start();

--- a/test/hotspot/jtreg/runtime/NMT/MallocTrackingVerify.java
+++ b/test/hotspot/jtreg/runtime/NMT/MallocTrackingVerify.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8054836
  * @summary Test to verify correctness of malloc tracking
- * @key nmt jcmd
+ * @key nmt jcmd randomness
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -41,6 +41,7 @@ import java.util.Random;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.Utils;
 
 import sun.hotspot.WhiteBox;
 
@@ -58,7 +59,7 @@ public class MallocTrackingVerify {
         String pid = Long.toString(ProcessTools.getProcessId());
         ProcessBuilder pb = new ProcessBuilder();
 
-        Random random = new Random();
+        Random random = Utils.getRandomInstance();
         // Allocate small amounts of memory with random pseudo call stack
         while (mallocd_total < MAX_ALLOC) {
             int size = random.nextInt(31) + 1;

--- a/test/hotspot/jtreg/runtime/appcds/SharedArchiveConsistency.java
+++ b/test/hotspot/jtreg/runtime/appcds/SharedArchiveConsistency.java
@@ -24,6 +24,7 @@
 
 /*
  * @test
+ * @key randomness
  * @summary SharedArchiveConsistency
  * @requires vm.cds
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/GCStressApp.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/GCStressApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 
 import java.io.*;
 import java.util.*;
+import jdk.test.lib.Utils;
 import sun.hotspot.WhiteBox;
 
 // All strings in archived classes are shared
@@ -43,7 +44,7 @@ public class GCStressApp {
 
     static void allocAlot() {
         try {
-            Random random = new Random();
+            Random random = Utils.getRandomInstance();
             for (int i = 0; i < 1024 * 1024; i++) {
                 int len = random.nextInt(10000);
                 arr = new int[len];

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/GCStressTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/GCStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,15 +24,16 @@
 
 /*
  * @test
+ * @key randomness
  * @summary
  * @requires vm.cds.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/appcds
  * @modules java.base/jdk.internal.misc
  * @modules java.management
  *          jdk.jartool/sun.tools.jar
- * @build sun.hotspot.WhiteBox
+ * @build sun.hotspot.WhiteBox jdk.test.lib.Utils
  * @compile GCStressApp.java
- * @run driver ClassFileInstaller -jar gcstress.jar GCStressApp
+ * @run driver ClassFileInstaller -jar gcstress.jar GCStressApp jdk.test.lib.Utils
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
  * @run main GCStressTest
  */


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

SharedArchiveConsistency.java
GCStressApp.java
GCStressTest.java
Test were moved, patch applies with the following edits if the paths are adapted:
Copyright in GCStressApp.java
Copyright, test description in GCStressTest.java

This test is not in 11: NullPointerExceptionTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242311](https://bugs.openjdk.java.net/browse/JDK-8242311): use reproducible random in hotspot runtime tests


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/932/head:pull/932` \
`$ git checkout pull/932`

Update a local copy of the PR: \
`$ git checkout pull/932` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 932`

View PR using the GUI difftool: \
`$ git pr show -t 932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/932.diff">https://git.openjdk.java.net/jdk11u-dev/pull/932.diff</a>

</details>
