### PR TITLE
8222926: Shenandoah build fails with --with-jvm-features=-compiler1

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -31,6 +31,7 @@
 #include "code/vtableStubs.hpp"
 #include "compiler/disassembler.hpp"
 #include "interpreter/bytecode.hpp"
+#include "interpreter/interpreter.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/heap.hpp"
 #include "memory/resourceArea.hpp"

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@
 #include "oops/oopHandle.hpp"
 #include "oops/objArrayKlass.hpp"
 #include "runtime/flags/jvmFlag.hpp"
+#include "runtime/deoptimization.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/thread.hpp"


### PR DESCRIPTION
Hi all,

As discussed here https://github.com/openjdk/jdk11u-dev/pull/921#issuecomment-1073341167 , I'd like to backport this patch to fix the build failure of jdk11u when c1 is disabled.

The patch doesn't apply cleanly since most of the changes are already in the jdk11u repo.
Actually, only two include statements are added in the backport, so the risk is low.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8222926](https://bugs.openjdk.java.net/browse/JDK-8222926): Shenandoah build fails with --with-jvm-features=-compiler1


### Reviewers
 * [Vladimir Kempik](https://openjdk.java.net/census#vkempik) (@VladimirKempik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/933/head:pull/933` \
`$ git checkout pull/933`

Update a local copy of the PR: \
`$ git checkout pull/933` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/933/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 933`

View PR using the GUI difftool: \
`$ git pr show -t 933`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/933.diff">https://git.openjdk.java.net/jdk11u-dev/pull/933.diff</a>

</details>
