### PR TITLE
8278472: Invalid value set to CANDIDATEFORM structure

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3917,11 +3917,11 @@ void AwtComponent::SetCandidateWindow(int iCandType, int x, int y)
     HIMC hIMC = ImmGetContext(hwnd);
     if (hIMC) {
         CANDIDATEFORM cf;
-        cf.dwStyle = CFS_POINT;
+        cf.dwStyle = CFS_CANDIDATEPOS;
         ImmGetCandidateWindow(hIMC, 0, &cf);
         if (x != cf.ptCurrentPos.x || y != cf.ptCurrentPos.y) {
             cf.dwIndex = iCandType;
-            cf.dwStyle = CFS_POINT;
+            cf.dwStyle = CFS_CANDIDATEPOS;
             cf.ptCurrentPos = {x, y};
             cf.rcArea = {0, 0, 0, 0};
             ImmSetCandidateWindow(hIMC, &cf);


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278472](https://bugs.openjdk.java.net/browse/JDK-8278472): Invalid value set to CANDIDATEFORM structure


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/934/head:pull/934` \
`$ git checkout pull/934`

Update a local copy of the PR: \
`$ git checkout pull/934` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 934`

View PR using the GUI difftool: \
`$ git pr show -t 934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/934.diff">https://git.openjdk.java.net/jdk11u-dev/pull/934.diff</a>

</details>
