### PR TITLE
8281275: Upgrading from 8 to 11 no longer accepts '/' as filepath separator in gc paths

### DIFF
--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -339,9 +339,9 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
     // Find the next colon or quote
     char* next = strpbrk(str, ":\"");
 #ifdef _WINDOWS
-    // Skip over Windows paths such as "C:\..."
-    // Handle both C:\... and file=C:\..."
-    if (next != NULL && next[0] == ':' && next[1] == '\\') {
+    // Skip over Windows paths such as "C:\..." and "C:/...".
+    // Handles both "C:\..." and "file=C:\...".
+    if (next != NULL && next[0] == ':' && (next[1] == '\\' || next[1] == '/')) {
       if (next == str + 1 || (strncmp(str, "file=", 5) == 0)) {
         next = strpbrk(next + 1, ":\"");
       }

--- a/test/hotspot/gtest/logging/test_logConfiguration.cpp
+++ b/test/hotspot/gtest/logging/test_logConfiguration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -273,6 +273,29 @@ TEST_VM_F(LogConfigurationTest, parse_command_line_arguments) {
   ret = jio_snprintf(buf, sizeof(buf), ":%s", TestLogFileName);
   ASSERT_NE(-1, ret);
   EXPECT_TRUE(LogConfiguration::parse_command_line_arguments(buf));
+
+#ifdef _WINDOWS
+  // We need to test the special-case parsing for drive letters in
+  // log file paths e.g. c:\log.txt and c:/log.txt. Our temp directory
+  // based TestLogFileName should already be the \ format (we print it
+  // below to visually verify) so we only need to convert to /.
+  printf("Checked: %s\n", buf);
+  // First disable logging so the current log file will be closed and we
+  // can delete it, so that UL won't try to perform log file rotation.
+  // The rotated file would not be auto-deleted.
+  set_log_config(TestLogFileName, "all=off");
+  delete_file(TestLogFileName);
+
+  // now convert \ to /
+  char* current_pos = strchr(buf,'\\');
+  while (current_pos != nullptr) {
+    *current_pos = '/';
+    current_pos = strchr(current_pos + 1, '\\');
+  }
+  printf("Checking: %s\n", buf);
+  EXPECT_TRUE(LogConfiguration::parse_command_line_arguments(buf));
+#endif
+
 }
 
 // Test split up log configuration arguments


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

I had to resolve the copyrights, the rest applied clean. Marking as clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281275](https://bugs.openjdk.java.net/browse/JDK-8281275): Upgrading from 8 to 11 no longer accepts '/' as filepath separator in gc paths


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/935/head:pull/935` \
`$ git checkout pull/935`

Update a local copy of the PR: \
`$ git checkout pull/935` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 935`

View PR using the GUI difftool: \
`$ git pr show -t 935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/935.diff">https://git.openjdk.java.net/jdk11u-dev/pull/935.diff</a>

</details>
