### PR TITLE
8266545: 8261169 broke Harfbuzz build with gcc 7 and 8

### DIFF
--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -561,7 +561,7 @@ else
 
   HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing
   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
-       maybe-uninitialized class-memaccess unused-result
+       maybe-uninitialized class-memaccess unused-result extra
   HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
        tautological-constant-out-of-range-compare int-to-pointer-cast \
        undef missing-field-initializers deprecated-declarations c++11-narrowing range-loop-analysis


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266545](https://bugs.openjdk.java.net/browse/JDK-8266545): 8261169 broke Harfbuzz build with gcc 7 and 8


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/940/head:pull/940` \
`$ git checkout pull/940`

Update a local copy of the PR: \
`$ git checkout pull/940` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 940`

View PR using the GUI difftool: \
`$ git pr show -t 940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/940.diff">https://git.openjdk.java.net/jdk11u-dev/pull/940.diff</a>

</details>
