### PR TITLE
8253714: [cgroups v2] Soft memory limit incorrectly using memory.high

### DIFF
--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -149,7 +149,7 @@ jlong CgroupV2Subsystem::memory_max_usage_in_bytes() {
 }
 
 char* CgroupV2Subsystem::mem_soft_limit_val() {
-  GET_CONTAINER_INFO_CPTR(cptr, _unified, "/memory.high",
+  GET_CONTAINER_INFO_CPTR(cptr, _unified, "/memory.low",
                          "Memory Soft Limit is: %s", "%s", mem_soft_limit_str, 1024);
   if (mem_soft_limit_str == NULL) {
     return NULL;

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
@@ -292,7 +292,7 @@ public class CgroupV2Subsystem implements CgroupSubsystem {
 
     @Override
     public long getMemorySoftLimit() {
-        String softLimitStr = CgroupSubsystemController.getStringValue(unified, "memory.high");
+        String softLimitStr = CgroupSubsystemController.getStringValue(unified, "memory.low");
         return limitFromString(softLimitStr);
     }
 

--- a/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
+++ b/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
@@ -245,9 +245,9 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
         }
 
         oldVal = metrics.getMemorySoftLimit();
-        newVal = getLongLimitValueFromFile("memory.high");
+        newVal = getLongLimitValueFromFile("memory.low");
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
-            fail("memory.high", oldVal, newVal);
+            fail("memory.low", oldVal, newVal);
         }
 
     }


### PR DESCRIPTION
A clean backport to replace dependency PR [865](https://github.com/openjdk/jdk11u-dev/pull/865) that resulted many conflicts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253714](https://bugs.openjdk.java.net/browse/JDK-8253714): [cgroups v2] Soft memory limit incorrectly using memory.high


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/941/head:pull/941` \
`$ git checkout pull/941`

Update a local copy of the PR: \
`$ git checkout pull/941` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/941/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 941`

View PR using the GUI difftool: \
`$ git pr show -t 941`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/941.diff">https://git.openjdk.java.net/jdk11u-dev/pull/941.diff</a>

</details>
