### PR TITLE
JDK-8283614: [11] Repair compiler versions handling after 8233787

### DIFF
--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -229,6 +229,16 @@ const char* Abstract_VM_Version::internal_vm_info_string() {
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 15.7 (VS2017)"
       #elif _MSC_VER == 1915
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 15.8 (VS2017)"
+      #elif _MSC_VER == 1916
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 15.9 (VS2017)"
+      #elif _MSC_VER == 1920
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.0 (VS2019)"
+      #elif _MSC_VER == 1921
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.1 (VS2019)"
+      #elif _MSC_VER == 1922
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.2 (VS2019)"
+      #elif _MSC_VER == 1923
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.3 (VS2019)"
       #else
         #define HOTSPOT_BUILD_COMPILER "unknown MS VC++:" XSTR(_MSC_VER)
       #endif


### PR DESCRIPTION
Looks like "8233787: Break cycle in vm_version* includes" removed the handling of some VS versions (like _MSC_VER == 1923) from abstract_vm_version.cpp; this should be repaired.
see
https://github.com/openjdk/jdk11u-dev/commit/95c7d073e24227962e04f859d9c8bb06ceab861d
compare the new src/hotspot/share/runtime/abstract_vm_version.cpp  with what we had in src/hotspot/share/runtime/vm_version.cpp .
see
https://github.com/openjdk/jdk11u-dev/commit/95c7d073e24227962e04f859d9c8bb06ceab861d#diff-e1be9153f5c542ba094a1a0052a8fb549363aeb73a6e316448bd2b5c8074f3cbR231
and
https://github.com/openjdk/jdk11u-dev/commit/95c7d073e24227962e04f859d9c8bb06ceab861d#diff-ab4abdc4613ecb623211a17dff37909553374e4287fc80114e917d609989223eL241

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283614](https://bugs.openjdk.java.net/browse/JDK-8283614): [11] Repair compiler versions handling after 8233787


### Reviewers
 * [Lutz Schmidt](https://openjdk.java.net/census#lucy) (@RealLucy - Committer)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/943/head:pull/943` \
`$ git checkout pull/943`

Update a local copy of the PR: \
`$ git checkout pull/943` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 943`

View PR using the GUI difftool: \
`$ git pr show -t 943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/943.diff">https://git.openjdk.java.net/jdk11u-dev/pull/943.diff</a>

</details>
