### PR TITLE
8254997: Remove unimplemented OSContainer::read_memory_limit_in_bytes

### DIFF
--- a/src/hotspot/os/linux/osContainer_linux.hpp
+++ b/src/hotspot/os/linux/osContainer_linux.hpp
@@ -41,8 +41,6 @@ class OSContainer: AllStatic {
   static bool   _is_containerized;
   static int    _active_processor_count;
 
-  static jlong read_memory_limit_in_bytes();
-
  public:
   static void init();
   static inline bool is_containerized();


### PR DESCRIPTION
Clean backport removing an unimplemented left-over after the cgroups v2 support patches.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8254997](https://bugs.openjdk.java.net/browse/JDK-8254997): Remove unimplemented OSContainer::read_memory_limit_in_bytes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/948/head:pull/948` \
`$ git checkout pull/948`

Update a local copy of the PR: \
`$ git checkout pull/948` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 948`

View PR using the GUI difftool: \
`$ git pr show -t 948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/948.diff">https://git.openjdk.java.net/jdk11u-dev/pull/948.diff</a>

</details>
