### PR TITLE
8252957: Wrong comment in CgroupV1Subsystem::cpu_quota

### DIFF
--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -203,11 +203,11 @@ char * CgroupV1Subsystem::cpu_cpuset_memory_nodes() {
 
 /* cpu_quota
  *
- * Return the number of milliseconds per period
+ * Return the number of microseconds per period
  * process is guaranteed to run.
  *
  * return:
- *    quota time in milliseconds
+ *    quota time in microseconds
  *    -1 for no quota
  *    OSCONTAINER_ERROR for not supported
  */

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -74,11 +74,11 @@ int CgroupV2Subsystem::cpu_shares() {
 
 /* cpu_quota
  *
- * Return the number of milliseconds per period
+ * Return the number of microseconds per period
  * process is guaranteed to run.
  *
  * return:
- *    quota time in milliseconds
+ *    quota time in microseconds
  *    -1 for no quota
  *    OSCONTAINER_ERROR for not supported
  */


### PR DESCRIPTION
Comment only change so that correct units are documented. Makes sense now since we've carried it over via the cgroups v2 backport. Low risk, comment only.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8252957](https://bugs.openjdk.java.net/browse/JDK-8252957): Wrong comment in CgroupV1Subsystem::cpu_quota


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/949/head:pull/949` \
`$ git checkout pull/949`

Update a local copy of the PR: \
`$ git checkout pull/949` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 949`

View PR using the GUI difftool: \
`$ git pr show -t 949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/949.diff">https://git.openjdk.java.net/jdk11u-dev/pull/949.diff</a>

</details>
