### PR TITLE
8266391: Replace use of reflection in jdk.internal.platform.Metrics

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/SystemMetrics.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/SystemMetrics.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.platform;
+
+public class SystemMetrics {
+    public static Metrics instance() {
+        return CgroupMetrics.getInstance();
+    }
+}

--- a/src/java.base/share/classes/jdk/internal/platform/Metrics.java
+++ b/src/java.base/share/classes/jdk/internal/platform/Metrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,15 +55,7 @@ public interface Metrics {
      * @return Metrics object or null if not supported on this platform.
      */
     public static Metrics systemMetrics() {
-        try {
-            Class<?> c = Class.forName("jdk.internal.platform.CgroupMetrics");
-            Method m = c.getMethod("getInstance");
-            return (Metrics) m.invoke(null);
-        } catch (ClassNotFoundException e) {
-            return null;
-        } catch (ReflectiveOperationException e) {
-            throw new InternalError(e);
-        }
+        return SystemMetrics.instance();
     }
 
     /**

--- a/src/java.base/unix/classes/jdk/internal/platform/SystemMetrics.java
+++ b/src/java.base/unix/classes/jdk/internal/platform/SystemMetrics.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.platform;
+
+public class SystemMetrics {
+    public static Metrics instance() {
+        return null;
+    }
+}

--- a/src/java.base/windows/classes/jdk/internal/platform/SystemMetrics.java
+++ b/src/java.base/windows/classes/jdk/internal/platform/SystemMetrics.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.platform;
+
+public class SystemMetrics {
+    public static Metrics instance() {
+        return null;
+    }
+}


### PR DESCRIPTION
The cgroups metrics is a Linux-only feature. Instead of using reflection and returning `null` on CNFE platform specific classes can be used instead. This is a no-op from a functionality perspective and avoids reflection, which is a good thing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266391](https://bugs.openjdk.java.net/browse/JDK-8266391): Replace use of reflection in jdk.internal.platform.Metrics


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/950/head:pull/950` \
`$ git checkout pull/950`

Update a local copy of the PR: \
`$ git checkout pull/950` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 950`

View PR using the GUI difftool: \
`$ git pr show -t 950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/950.diff">https://git.openjdk.java.net/jdk11u-dev/pull/950.diff</a>

</details>
