### PR TITLE
8259517: Incorrect test path in test cases

### DIFF
--- a/test/jdk/javax/net/ssl/SSLEngine/ArgCheck.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/ArgCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,7 +152,7 @@ public class ArgCheck {
 
         // For unwrap(), the BUFFER_OVERFLOW will not be generated
         // until received SSL/TLS application data.
-        // Test test/javax/net/ssl/NewAPIs/SSLEngine/LargePacket will check
+        // Test test/jdk/javax/net/ssl/SSLEngine/LargePacket.java will check
         // BUFFER_OVERFLOW/UNDERFLOW for both wrap() and unwrap().
         //
         //res = ssle.unwrap(netBB, smallAppBB);
@@ -172,7 +172,7 @@ public class ArgCheck {
 
         // For unwrap(), the BUFFER_OVERFLOW will not be generated
         // until received SSL/TLS application data.
-        // Test test/javax/net/ssl/NewAPIs/SSLEngine/LargePacket will check
+        // Test test/jdk/javax/net/ssl/SSLEngine/LargePacket.java will check
         // BUFFER_OVERFLOW/UNDERFLOW for both wrap() and unwrap().
         //
         //res = ssle.unwrap(netBB, smallAppBB, 0, appBB.length);

--- a/test/jdk/javax/net/ssl/SSLEngine/Basics.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/Basics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,7 +177,7 @@ public class Basics {
 
         // For unwrap(), the BUFFER_OVERFLOW will not be generated
         // until received SSL/TLS application data.
-        // Test test/javax/net/ssl/NewAPIs/SSLEngine/LargePacket will check
+        // Test test/jdk/javax/net/ssl/SSLEngine/LargePacket.java will check
         // BUFFER_OVERFLOW/UNDERFLOW for both wrap() and unwrap().
         //
         //if (ssle.unwrap(smallBB, smallBB).getStatus() !=

--- a/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
+++ b/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,8 +62,8 @@ import java.util.concurrent.TimeUnit;
  * Template to help speed your client/server tests.
  *
  * Two examples that use this template:
- *    test/sun/security/ssl/ServerHandshaker/AnonCipherWithWantClientAuth.java
- *    test/sun/net/www/protocol/https/HttpsClient/ServerIdentityTest.java
+ * test/jdk/sun/security/ssl/ServerHandshaker/AnonCipherWithWantClientAuth.java
+ * test/jdk/sun/net/www/protocol/https/HttpsClient/ServerIdentityTest.java
  */
 public class SSLSocketTemplate {
 


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8259517](https://bugs.openjdk.java.net/browse/JDK-8259517): Incorrect test path in test cases


### Reviewers
 * [Xue-Lei Andrew Fan](https://openjdk.java.net/census#xuelei) (@XueleiFan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/952/head:pull/952` \
`$ git checkout pull/952`

Update a local copy of the PR: \
`$ git checkout pull/952` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 952`

View PR using the GUI difftool: \
`$ git pr show -t 952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/952.diff">https://git.openjdk.java.net/jdk11u-dev/pull/952.diff</a>

</details>
