### PR TITLE
8273176: handle latest VS2019 in abstract_vm_version

### DIFF
--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -248,7 +248,9 @@ const char* Abstract_VM_Version::internal_vm_info_string() {
       #elif _MSC_VER == 1927
         #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.7 (VS2019)"
       #elif _MSC_VER == 1928
-        #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.8 (VS2019)"
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.8 / 16.9 (VS2019)"
+      #elif _MSC_VER == 1929
+        #define HOTSPOT_BUILD_COMPILER "MS VC++ 16.10 / 16.11 (VS2019)"
       #else
         #define HOTSPOT_BUILD_COMPILER "unknown MS VC++:" XSTR(_MSC_VER)
       #endif


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273176](https://bugs.openjdk.java.net/browse/JDK-8273176): handle latest VS2019 in abstract_vm_version


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/953/head:pull/953` \
`$ git checkout pull/953`

Update a local copy of the PR: \
`$ git checkout pull/953` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 953`

View PR using the GUI difftool: \
`$ git pr show -t 953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/953.diff">https://git.openjdk.java.net/jdk11u-dev/pull/953.diff</a>

</details>
