### PR TITLE
8253872: ArgumentHandler must use the same delimiters as in jvmti_tools.cpp

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/ArgumentHandler.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/ArgumentHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,7 +154,7 @@ public class ArgumentHandler extends ArgumentParser {
         if (optionString == null)
             return;
 
-        StringTokenizer st = new StringTokenizer(optionString);
+        StringTokenizer st = new StringTokenizer(optionString, " ,~");
         while (st.hasMoreTokens()) {
             String token = st.nextToken();
             int start = token.startsWith("-")? 1 : 0;


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253872](https://bugs.openjdk.java.net/browse/JDK-8253872): ArgumentHandler must use the same delimiters as in jvmti_tools.cpp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/961/head:pull/961` \
`$ git checkout pull/961`

Update a local copy of the PR: \
`$ git checkout pull/961` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 961`

View PR using the GUI difftool: \
`$ git pr show -t 961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/961.diff">https://git.openjdk.java.net/jdk11u-dev/pull/961.diff</a>

</details>
