### PR TITLE
8270797: ShortECDSA.java test is not complete

### DIFF
--- a/test/jdk/com/sun/org/apache/xml/internal/security/ShortECDSA.java
+++ b/test/jdk/com/sun/org/apache/xml/internal/security/ShortECDSA.java
@@ -25,9 +25,12 @@
  * @test
  * @bug 8259535
  * @summary ECDSA SignatureValue do not always have the specified length
- * @modules java.xml.crypto
+ * @modules java.xml.crypto/com.sun.org.apache.xml.internal.security
+ *          java.xml.crypto/com.sun.org.apache.xml.internal.security.signature
  */
 
+import com.sun.org.apache.xml.internal.security.Init;
+import com.sun.org.apache.xml.internal.security.signature.XMLSignature;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
@@ -93,6 +96,21 @@ public class ShortECDSA {
                 System.out.print(String.format(i == 0 ? "%02x" : ":%02x", sig[i]));
             }
             System.out.println();
+            throw new RuntimeException("Failed");
+        }
+
+        // Internal way
+        Init.init();
+        XMLSignature signature = new XMLSignature(document, null,
+                SignatureMethod.ECDSA_SHA256, CanonicalizationMethod.INCLUSIVE);
+        signature.sign(privateKey);
+        sig = signature.getSignatureValue();
+        if (sig.length != 64) {
+            System.out.println("Length: " + sig.length);
+            //System.out.println(HexFormat.ofDelimiter(":").formatHex(sig));
+            for (int i = 0; i < sig.length; ++i) {
+                System.out.print(String.format(i == 0 ? "%02x" : ":%02x", sig[i]));
+            }
             throw new RuntimeException("Failed");
         }
     }


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

I had to fix the call to HexFormat in one place. That class is not in 11.
Similar fix has been made before to the same test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270797](https://bugs.openjdk.java.net/browse/JDK-8270797): ShortECDSA.java test is not complete


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/963/head:pull/963` \
`$ git checkout pull/963`

Update a local copy of the PR: \
`$ git checkout pull/963` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 963`

View PR using the GUI difftool: \
`$ git pr show -t 963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/963.diff">https://git.openjdk.java.net/jdk11u-dev/pull/963.diff</a>

</details>
