### PR TITLE
Merge jdk11u:master

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install gcc-9=9.4.0-1ubuntu1~20.04 g++-9=9.4.0-1ubuntu1~20.04 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
+          sudo apt-get install gcc-9=9.4.0-1ubuntu1~20.04.1 g++-9=9.4.0-1ubuntu1~20.04.1 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 
       - name: Configure
@@ -502,12 +502,12 @@ jobs:
 
       - name: Install native host dependencies
         run: |
-          sudo apt-get install gcc-9=9.4.0-1ubuntu1~20.04 g++-9=9.4.0-1ubuntu1~20.04 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
+          sudo apt-get install gcc-9=9.4.0-1ubuntu1~20.04.1 g++-9=9.4.0-1ubuntu1~20.04.1 libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9
         if: matrix.debian-arch == ''
 
       - name: Install cross-compilation host dependencies
-        run: sudo apt-get install gcc-9-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}=9.4.0-1ubuntu1~20.04cross2 g++-9-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}=9.4.0-1ubuntu1~20.04cross2
+        run: sudo apt-get install gcc-9-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}=9.4.0-1ubuntu1~20.04.1cross2 g++-9-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-flavor}}=9.4.0-1ubuntu1~20.04.1cross2
         if: matrix.debian-arch != ''
 
       - name: Cache sysroot


### PR DESCRIPTION
Merge build tag 11.0.16+8 from jdk11u to jdk11u-dev

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/964/head:pull/964` \
`$ git checkout pull/964`

Update a local copy of the PR: \
`$ git checkout pull/964` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 964`

View PR using the GUI difftool: \
`$ git pr show -t 964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/964.diff">https://git.openjdk.java.net/jdk11u-dev/pull/964.diff</a>

</details>
