### PR TITLE
8282887: Potential memory leak in sun.util.locale.provider.HostLocaleProviderAdapterImpl.getNumberPattern() on Windows

### DIFF
--- a/src/java.base/windows/native/libjava/HostLocaleProviderAdapter_md.c
+++ b/src/java.base/windows/native/libjava/HostLocaleProviderAdapter_md.c
@@ -376,18 +376,17 @@ JNIEXPORT jobjectArray JNICALL Java_sun_util_locale_provider_HostLocaleProviderA
 JNIEXPORT jstring JNICALL Java_sun_util_locale_provider_HostLocaleProviderAdapterImpl_getNumberPattern
   (JNIEnv *env, jclass cls, jint numberStyle, jstring jlangtag) {
     const jchar *langtag;
-    jstring ret;
+    jstring ret = NULL;
     WCHAR * pattern;
 
     langtag = (*env)->GetStringChars(env, jlangtag, JNI_FALSE);
     CHECK_NULL_RETURN(langtag, NULL);
     pattern = getNumberPattern(langtag, numberStyle);
-    CHECK_NULL_RETURN(pattern, NULL);
-
+    if (!IS_NULL(pattern)) {
+        ret = (*env)->NewString(env, pattern, (jsize)wcslen(pattern));
+        free(pattern);
+    }
     (*env)->ReleaseStringChars(env, jlangtag, langtag);
-    ret = (*env)->NewString(env, pattern, (jsize)wcslen(pattern));
-    free(pattern);
-
     return ret;
 }
 


### PR DESCRIPTION
A clean and low risk backport to fix a memory leak.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282887](https://bugs.openjdk.java.net/browse/JDK-8282887): Potential memory leak in sun.util.locale.provider.HostLocaleProviderAdapterImpl.getNumberPattern() on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/965/head:pull/965` \
`$ git checkout pull/965`

Update a local copy of the PR: \
`$ git checkout pull/965` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 965`

View PR using the GUI difftool: \
`$ git pr show -t 965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/965.diff">https://git.openjdk.java.net/jdk11u-dev/pull/965.diff</a>

</details>
