### PR TITLE
8214799: Add package declaration to each JTREG test case in the gc folder

### DIFF
--- a/test/hotspot/jtreg/gc/CondCardMark/Basic.java
+++ b/test/hotspot/jtreg/gc/CondCardMark/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,20 +21,22 @@
  * questions.
  */
 
+package gc.CondCardMark;
+
 /**
  * @test
  * @bug 8076987
  * @bug 8078438
  * @summary Verify UseCondCardMark works
  * @modules java.base/jdk.internal.misc
- * @run main/othervm -Xint Basic
- * @run main/othervm -Xint -XX:+UseCondCardMark Basic
- * @run main/othervm -XX:TieredStopAtLevel=1 Basic
- * @run main/othervm -XX:TieredStopAtLevel=1 -XX:+UseCondCardMark Basic
- * @run main/othervm -XX:TieredStopAtLevel=4 Basic
- * @run main/othervm -XX:TieredStopAtLevel=4 -XX:+UseCondCardMark Basic
- * @run main/othervm -XX:-TieredCompilation Basic
- * @run main/othervm -XX:-TieredCompilation -XX:+UseCondCardMark Basic
+ * @run main/othervm -Xint gc.CondCardMark.Basic
+ * @run main/othervm -Xint -XX:+UseCondCardMark gc.CondCardMark.Basic
+ * @run main/othervm -XX:TieredStopAtLevel=1 gc.CondCardMark.Basic
+ * @run main/othervm -XX:TieredStopAtLevel=1 -XX:+UseCondCardMark gc.CondCardMark.Basic
+ * @run main/othervm -XX:TieredStopAtLevel=4 gc.CondCardMark.Basic
+ * @run main/othervm -XX:TieredStopAtLevel=4 -XX:+UseCondCardMark gc.CondCardMark.Basic
+ * @run main/othervm -XX:-TieredCompilation gc.CondCardMark.Basic
+ * @run main/othervm -XX:-TieredCompilation -XX:+UseCondCardMark gc.CondCardMark.Basic
 */
 public class Basic {
 

--- a/test/hotspot/jtreg/gc/TestAgeOutput.java
+++ b/test/hotspot/jtreg/gc/TestAgeOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 /*
  * @test TestAgeOutput
  * @bug 8164936
@@ -31,8 +33,8 @@
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -XX:+UseSerialGC TestAgeOutput UseSerialGC
- * @run main/othervm -XX:+UseG1GC TestAgeOutput UseG1GC
+ * @run main/othervm -XX:+UseSerialGC gc.TestAgeOutput UseSerialGC
+ * @run main/othervm -XX:+UseG1GC gc.TestAgeOutput UseG1GC
  */
 
 /*
@@ -45,7 +47,7 @@
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -XX:+UseConcMarkSweepGC TestAgeOutput UseConcMarkSweepGC
+ * @run main/othervm -XX:+UseConcMarkSweepGC gc.TestAgeOutput UseConcMarkSweepGC
  */
 
 import sun.hotspot.WhiteBox;

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,15 @@
  * questions.
  */
 
+package gc;
+
 /* @test TestAllocateHeapAt.java
  * @key gc
  * @summary Test to check allocation of Java Heap with AllocateHeapAt option
  * @requires vm.gc != "Z" & os.family != "aix"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ * @run main gc.TestAllocateHeapAt
  */
 
 import jdk.test.lib.JDKToolFinder;

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAtError.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAtError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,15 @@
  * questions.
  */
 
+package gc;
+
 /* @test TestAllocateHeapAtError.java
  * @key gc
  * @summary Test to check correct handling of non-existent directory passed to AllocateHeapAt option
  * @requires vm.gc != "Z" & os.family != "aix"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ * @run main gc.TestAllocateHeapAtError
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
@@ -21,13 +21,15 @@
  * questions.
  */
 
+package gc;
+
 /* @test TestAllocateHeapAtMultiple.java
  * @key gc
  * @summary Test to check allocation of Java Heap with AllocateHeapAt option. Has multiple sub-tests to cover different code paths.
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @requires vm.bits == "64" & vm.gc != "Z" & os.family != "aix"
- * @run main/timeout=360 TestAllocateHeapAtMultiple
+ * @run main/timeout=360 gc.TestAllocateHeapAtMultiple
  */
 
 import jdk.test.lib.JDKToolFinder;

--- a/test/hotspot/jtreg/gc/TestBigObj.java
+++ b/test/hotspot/jtreg/gc/TestBigObj.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,13 @@
  * questions.
  */
 
+package gc;
+
 /*
  * @test TestBigObj
  * @bug 6845368
  * @summary ensure gc updates references > 64K bytes from the start of the obj
- * @run main/othervm/timeout=720 -Xmx256m -verbose:gc TestBigObj
+ * @run main/othervm/timeout=720 -Xmx256m -verbose:gc gc.TestBigObj
  */
 
 // Allocate an object with a block of reference fields that starts more

--- a/test/hotspot/jtreg/gc/TestCardTablePageCommits.java
+++ b/test/hotspot/jtreg/gc/TestCardTablePageCommits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -34,7 +36,7 @@ import jdk.test.lib.Platform;
  * @requires vm.gc.Parallel
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run driver TestCardTablePageCommits
+ * @run driver gc.TestCardTablePageCommits
  */
 public class TestCardTablePageCommits {
     public static void main(String args[]) throws Exception {

--- a/test/hotspot/jtreg/gc/TestDisableExplicitGC.java
+++ b/test/hotspot/jtreg/gc/TestDisableExplicitGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 /*
  * @test TestDisableExplicitGC
  * @requires vm.opt.DisableExplicitGC == null
@@ -28,9 +30,9 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules jdk.management/com.sun.management.internal
- * @run main/othervm                             -Xlog:gc=debug TestDisableExplicitGC
- * @run main/othervm/fail -XX:+DisableExplicitGC -Xlog:gc=debug TestDisableExplicitGC
- * @run main/othervm      -XX:-DisableExplicitGC -Xlog:gc=debug TestDisableExplicitGC
+ * @run main/othervm                             -Xlog:gc=debug gc.TestDisableExplicitGC
+ * @run main/othervm/fail -XX:+DisableExplicitGC -Xlog:gc=debug gc.TestDisableExplicitGC
+ * @run main/othervm      -XX:-DisableExplicitGC -Xlog:gc=debug gc.TestDisableExplicitGC
  */
 import java.lang.management.GarbageCollectorMXBean;
 import java.util.List;

--- a/test/hotspot/jtreg/gc/TestFullGCALot.java
+++ b/test/hotspot/jtreg/gc/TestFullGCALot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,14 +21,16 @@
  * questions.
  */
 
+package gc;
+
 /*
  * @test TestFullGCALot
  * @key gc
  * @bug 4187687 8187819 8251118
  * @summary Ensure no access violation when using FullGCALot
  * @requires vm.debug
- * @run main/othervm -XX:NewSize=10m -XX:+FullGCALot -XX:FullGCALotInterval=120 TestFullGCALot
- * @run main/othervm -XX:NewSize=10m -XX:+FullGCALot -XX:FullGCALotInterval=120 -XX:+UseBiasedLocking TestFullGCALot
+ * @run main/othervm -XX:NewSize=10m -XX:+FullGCALot -XX:FullGCALotInterval=120 gc.TestFullGCALot
+ * @run main/othervm -XX:NewSize=10m -XX:+FullGCALot -XX:FullGCALotInterval=120 -XX:+UseBiasedLocking gc.TestFullGCALot
  */
 
 public class TestFullGCALot {

--- a/test/hotspot/jtreg/gc/TestFullGCCount.java
+++ b/test/hotspot/jtreg/gc/TestFullGCCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 /**
  * @test TestFullGCCount.java
  * @bug 7072527
@@ -29,7 +31,7 @@
  * @comment Shenandoah has "ExplicitGCInvokesConcurrent" on by default
  * @requires !(vm.gc == "Shenandoah"    & vm.opt.ExplicitGCInvokesConcurrent != false)
  * @modules java.management
- * @run main/othervm -Xlog:gc TestFullGCCount
+ * @run main/othervm -Xlog:gc gc.TestFullGCCount
  */
 
 import java.lang.management.GarbageCollectorMXBean;

--- a/test/hotspot/jtreg/gc/TestGenerationPerfCounter.java
+++ b/test/hotspot/jtreg/gc/TestGenerationPerfCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 import static jdk.test.lib.Asserts.*;
 import gc.testlibrary.PerfCounter;
 import gc.testlibrary.PerfCounters;
@@ -35,9 +37,9 @@ import gc.testlibrary.PerfCounters;
  *          java.compiler
  *          java.management/sun.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run main/othervm -XX:+UsePerfData -XX:+UseSerialGC TestGenerationPerfCounter
- * @run main/othervm -XX:+UsePerfData -XX:+UseParallelGC TestGenerationPerfCounter
- * @run main/othervm -XX:+UsePerfData -XX:+UseG1GC TestGenerationPerfCounter
+ * @run main/othervm -XX:+UsePerfData -XX:+UseSerialGC gc.TestGenerationPerfCounter
+ * @run main/othervm -XX:+UsePerfData -XX:+UseParallelGC gc.TestGenerationPerfCounter
+ * @run main/othervm -XX:+UsePerfData -XX:+UseG1GC gc.TestGenerationPerfCounter
  */
 
 /* @test TestGenerationPerfCounterCMS
@@ -50,7 +52,7 @@ import gc.testlibrary.PerfCounters;
  *          java.compiler
  *          java.management/sun.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run main/othervm -XX:+UsePerfData -XX:+UseConcMarkSweepGC TestGenerationPerfCounter
+ * @run main/othervm -XX:+UsePerfData -XX:+UseConcMarkSweepGC gc.TestGenerationPerfCounter
  */
 
 public class TestGenerationPerfCounter {

--- a/test/hotspot/jtreg/gc/TestHumongousReferenceObject.java
+++ b/test/hotspot/jtreg/gc/TestHumongousReferenceObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 import jdk.internal.vm.annotation.Contended;
 
 /*
@@ -29,11 +31,11 @@ import jdk.internal.vm.annotation.Contended;
  * @requires vm.gc == "null"
  * @bug 8151499 8153734
  * @modules java.base/jdk.internal.vm.annotation
- * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseParallelGC -XX:ContendedPaddingWidth=8192 TestHumongousReferenceObject
- * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseG1GC -XX:G1HeapRegionSize=1M -XX:ContendedPaddingWidth=8192 TestHumongousReferenceObject
- * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseG1GC -XX:G1HeapRegionSize=2M -XX:ContendedPaddingWidth=8192 TestHumongousReferenceObject
- * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:ContendedPaddingWidth=8192 TestHumongousReferenceObject
- * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseG1GC -XX:G1HeapRegionSize=8M -XX:ContendedPaddingWidth=8192 TestHumongousReferenceObject
+ * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseParallelGC -XX:ContendedPaddingWidth=8192 gc.TestHumongousReferenceObject
+ * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseG1GC -XX:G1HeapRegionSize=1M -XX:ContendedPaddingWidth=8192 gc.TestHumongousReferenceObject
+ * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseG1GC -XX:G1HeapRegionSize=2M -XX:ContendedPaddingWidth=8192 gc.TestHumongousReferenceObject
+ * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:ContendedPaddingWidth=8192 gc.TestHumongousReferenceObject
+ * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseG1GC -XX:G1HeapRegionSize=8M -XX:ContendedPaddingWidth=8192 gc.TestHumongousReferenceObject
  */
 
 /*
@@ -42,8 +44,8 @@ import jdk.internal.vm.annotation.Contended;
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @bug 8151499 8153734
  * @modules java.base/jdk.internal.vm.annotation
- * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xms128m -Xmx128m -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahRegionSize=8M -XX:ContendedPaddingWidth=8192 TestHumongousReferenceObject
- * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xms128m -Xmx128m -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahRegionSize=8M -XX:ContendedPaddingWidth=8192 -XX:+UnlockDiagnosticVMOptions -XX:+ShenandoahVerify TestHumongousReferenceObject
+ * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xms128m -Xmx128m -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahRegionSize=8M -XX:ContendedPaddingWidth=8192 gc.TestHumongousReferenceObject
+ * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xms128m -Xmx128m -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahRegionSize=8M -XX:ContendedPaddingWidth=8192 -XX:+UnlockDiagnosticVMOptions -XX:+ShenandoahVerify gc.TestHumongousReferenceObject
  */
 public class TestHumongousReferenceObject {
 

--- a/test/hotspot/jtreg/gc/TestMemoryInitialization.java
+++ b/test/hotspot/jtreg/gc/TestMemoryInitialization.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2002, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc;
 
 /*
  * test TestMemoryInitialization

--- a/test/hotspot/jtreg/gc/TestMemoryInitializationWithCMS.java
+++ b/test/hotspot/jtreg/gc/TestMemoryInitializationWithCMS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,16 @@
  * questions.
  */
 
+package gc;
+
 /*
  * @test TestMemoryInitializationWithCMS
  * @key gc
  * @bug 4668531
+ * @library /
  * @requires vm.debug & vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @summary Simple test for -XX:+CheckMemoryInitialization doesn't crash VM
- * @run main/othervm -XX:+UseConcMarkSweepGC -XX:+CheckMemoryInitialization TestMemoryInitializationWithCMS
+ * @run main/othervm -XX:+UseConcMarkSweepGC -XX:+CheckMemoryInitialization gc.TestMemoryInitializationWithCMS
  */
 
 public class TestMemoryInitializationWithCMS {

--- a/test/hotspot/jtreg/gc/TestMemoryInitializationWithSerial.java
+++ b/test/hotspot/jtreg/gc/TestMemoryInitializationWithSerial.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2002, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,16 @@
  * questions.
  */
 
+package gc;
+
 /*
- * @test TestMemoryInitializationWithSerial`
+ * @test TestMemoryInitializationWithSerial
  * @key gc
  * @bug 4668531
+ * @library /
  * @requires vm.debug & vm.gc.Serial
  * @summary Simple test for -XX:+CheckMemoryInitialization doesn't crash VM
- * @run main/othervm -XX:+UseSerialGC -XX:+CheckMemoryInitialization TestMemoryInitializationWithSerial
+ * @run main/othervm -XX:+UseSerialGC -XX:+CheckMemoryInitialization gc.TestMemoryInitializationWithSerial
  */
 
 public class TestMemoryInitializationWithSerial {

--- a/test/hotspot/jtreg/gc/TestMemoryMXBeansAndPoolsPresence.java
+++ b/test/hotspot/jtreg/gc/TestMemoryMXBeansAndPoolsPresence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 import java.util.List;
 import java.util.ArrayList;
 import java.lang.management.*;
@@ -34,9 +36,9 @@ import java.util.stream.*;
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @requires vm.gc == null
- * @run main/othervm -XX:+UseG1GC TestMemoryMXBeansAndPoolsPresence G1
- * @run main/othervm -XX:+UseParallelGC TestMemoryMXBeansAndPoolsPresence Parallel
- * @run main/othervm -XX:+UseSerialGC TestMemoryMXBeansAndPoolsPresence Serial
+ * @run main/othervm -XX:+UseG1GC gc.TestMemoryMXBeansAndPoolsPresence G1
+ * @run main/othervm -XX:+UseParallelGC gc.TestMemoryMXBeansAndPoolsPresence Parallel
+ * @run main/othervm -XX:+UseSerialGC gc.TestMemoryMXBeansAndPoolsPresence Serial
  */
 
 /* @test TestMemoryMXBeansAndPoolsPresenceCMS
@@ -46,7 +48,7 @@ import java.util.stream.*;
  *          java.management
  * @comment Graal does not support CMS
  * @requires vm.gc == null & !vm.graal.enabled
- * @run main/othervm -XX:+UseConcMarkSweepGC TestMemoryMXBeansAndPoolsPresence CMS
+ * @run main/othervm -XX:+UseConcMarkSweepGC gc.TestMemoryMXBeansAndPoolsPresence CMS
  */
 
 class GCBeanDescription {

--- a/test/hotspot/jtreg/gc/TestNUMAPageSize.java
+++ b/test/hotspot/jtreg/gc/TestNUMAPageSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,15 @@
  * questions.
  */
 
+package gc;
+
 /**
  * @test TestNUMAPageSize
  * @key gc regression
  * @summary Make sure that start up with NUMA support does not cause problems.
  * @bug 8061467
  * @requires (vm.opt.AggressiveOpts == null) | (vm.opt.AggressiveOpts == false)
- * @run main/othervm -Xmx128m -XX:+UseNUMA TestNUMAPageSize
+ * @run main/othervm -Xmx128m -XX:+UseNUMA gc.TestNUMAPageSize
  */
 
 public class TestNUMAPageSize {

--- a/test/hotspot/jtreg/gc/TestNumWorkerOutput.java
+++ b/test/hotspot/jtreg/gc/TestNumWorkerOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 /*
  * @test TestNumWorkerOutput
  * @bug 8165292
@@ -31,7 +33,7 @@
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -XX:+UseG1GC TestNumWorkerOutput UseG1GC
+ * @run main/othervm -XX:+UseG1GC gc.TestNumWorkerOutput UseG1GC
  */
 
 /*
@@ -44,7 +46,7 @@
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -XX:+UseConcMarkSweepGC TestNumWorkerOutput UseConcMarkSweepGC
+ * @run main/othervm -XX:+UseConcMarkSweepGC gc.TestNumWorkerOutput UseConcMarkSweepGC
  */
 
 import sun.hotspot.WhiteBox;

--- a/test/hotspot/jtreg/gc/TestObjectAlignment.java
+++ b/test/hotspot/jtreg/gc/TestObjectAlignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 /**
  * @test TestObjectAlignment
  * @key gc
@@ -28,18 +30,18 @@
  * @summary G1: Concurrent marking crashes with -XX:ObjectAlignmentInBytes>=32 in 64bit VMs
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run main/othervm TestObjectAlignment -Xmx20M -XX:+ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=8
- * @run main/othervm TestObjectAlignment -Xmx20M -XX:+ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
- * @run main/othervm TestObjectAlignment -Xmx20M -XX:+ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=32
- * @run main/othervm TestObjectAlignment -Xmx20M -XX:+ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=64
- * @run main/othervm TestObjectAlignment -Xmx20M -XX:+ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=128
- * @run main/othervm TestObjectAlignment -Xmx20M -XX:+ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=256
- * @run main/othervm TestObjectAlignment -Xmx20M -XX:-ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=8
- * @run main/othervm TestObjectAlignment -Xmx20M -XX:-ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
- * @run main/othervm TestObjectAlignment -Xmx20M -XX:-ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=32
- * @run main/othervm TestObjectAlignment -Xmx20M -XX:-ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=64
- * @run main/othervm TestObjectAlignment -Xmx20M -XX:-ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=128
- * @run main/othervm TestObjectAlignment -Xmx20M -XX:-ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=256
+ * @run main/othervm gc.TestObjectAlignment -Xmx20M -XX:+ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=8
+ * @run main/othervm gc.TestObjectAlignment -Xmx20M -XX:+ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ * @run main/othervm gc.TestObjectAlignment -Xmx20M -XX:+ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=32
+ * @run main/othervm gc.TestObjectAlignment -Xmx20M -XX:+ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=64
+ * @run main/othervm gc.TestObjectAlignment -Xmx20M -XX:+ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=128
+ * @run main/othervm gc.TestObjectAlignment -Xmx20M -XX:+ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=256
+ * @run main/othervm gc.TestObjectAlignment -Xmx20M -XX:-ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=8
+ * @run main/othervm gc.TestObjectAlignment -Xmx20M -XX:-ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
+ * @run main/othervm gc.TestObjectAlignment -Xmx20M -XX:-ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=32
+ * @run main/othervm gc.TestObjectAlignment -Xmx20M -XX:-ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=64
+ * @run main/othervm gc.TestObjectAlignment -Xmx20M -XX:-ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=128
+ * @run main/othervm gc.TestObjectAlignment -Xmx20M -XX:-ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=256
  */
 
 import jdk.test.lib.process.ProcessTools;

--- a/test/hotspot/jtreg/gc/TestPolicyNamePerfCounter.java
+++ b/test/hotspot/jtreg/gc/TestPolicyNamePerfCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 import static jdk.test.lib.Asserts.*;
 import gc.testlibrary.PerfCounter;
 import gc.testlibrary.PerfCounters;
@@ -35,9 +37,9 @@ import gc.testlibrary.PerfCounters;
  *          java.compiler
  *          java.management/sun.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run main/othervm -XX:+UsePerfData -XX:+UseSerialGC TestPolicyNamePerfCounter Copy:MSC
- * @run main/othervm -XX:+UsePerfData -XX:+UseParallelGC TestPolicyNamePerfCounter ParScav:MSC
- * @run main/othervm -XX:+UsePerfData -XX:+UseG1GC TestPolicyNamePerfCounter GarbageFirst
+ * @run main/othervm -XX:+UsePerfData -XX:+UseSerialGC gc.TestPolicyNamePerfCounter Copy:MSC
+ * @run main/othervm -XX:+UsePerfData -XX:+UseParallelGC gc.TestPolicyNamePerfCounter ParScav:MSC
+ * @run main/othervm -XX:+UsePerfData -XX:+UseG1GC gc.TestPolicyNamePerfCounter GarbageFirst
  */
 
 /* @test TestPolicyNamePerfCounterCMS
@@ -50,7 +52,7 @@ import gc.testlibrary.PerfCounters;
  *          java.compiler
  *          java.management/sun.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run main/othervm -XX:+UsePerfData -XX:+UseConcMarkSweepGC TestPolicyNamePerfCounter ParNew:CMS
+ * @run main/othervm -XX:+UsePerfData -XX:+UseConcMarkSweepGC gc.TestPolicyNamePerfCounter ParNew:CMS
  */
 
 public class TestPolicyNamePerfCounter {

--- a/test/hotspot/jtreg/gc/TestSmallHeap.java
+++ b/test/hotspot/jtreg/gc/TestSmallHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 /**
  * @test TestSmallHeap
  * @bug 8067438 8152239
@@ -30,7 +32,7 @@
  * @modules java.base/jdk.internal.misc
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestSmallHeap
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI gc.TestSmallHeap
  */
 
 /* Note: It would be nice to verify the minimal supported heap size here,

--- a/test/hotspot/jtreg/gc/TestSoftReferencesBehaviorOnOOME.java
+++ b/test/hotspot/jtreg/gc/TestSoftReferencesBehaviorOnOOME.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 /**
  * @test TestSoftReferencesBehaviorOnOOME
  * @key gc
@@ -28,9 +30,9 @@
  * @requires vm.gc != "Z"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run main/othervm -Xmx128m TestSoftReferencesBehaviorOnOOME 512 2k
- * @run main/othervm -Xmx128m TestSoftReferencesBehaviorOnOOME 128k 256k
- * @run main/othervm -Xmx128m TestSoftReferencesBehaviorOnOOME 2k 32k
+ * @run main/othervm -Xmx128m gc.TestSoftReferencesBehaviorOnOOME 512 2k
+ * @run main/othervm -Xmx128m gc.TestSoftReferencesBehaviorOnOOME 128k 256k
+ * @run main/othervm -Xmx128m gc.TestSoftReferencesBehaviorOnOOME 2k 32k
  */
 import jdk.test.lib.Utils;
 import jdk.test.lib.Asserts;

--- a/test/hotspot/jtreg/gc/TestStackOverflow.java
+++ b/test/hotspot/jtreg/gc/TestStackOverflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,14 @@
  * questions.
  */
 
+package gc;
+
 /*
  * @test TestStackOverflow
  * @key gc
  * @bug 4396719
  * @summary Test verifies only that VM doesn't crash but throw expected Error.
- * @run main/othervm TestStackOverflow
+ * @run main/othervm gc.TestStackOverflow
  */
 
 public class TestStackOverflow {

--- a/test/hotspot/jtreg/gc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/TestSystemGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,19 +21,21 @@
  * questions.
  */
 
+package gc;
+
 /*
  * @test TestSystemGC
  * @key gc
  * @requires vm.gc=="null"
  * @summary Runs System.gc() with different flags.
- * @run main/othervm TestSystemGC
- * @run main/othervm -XX:+UseSerialGC TestSystemGC
- * @run main/othervm -XX:+UseParallelGC TestSystemGC
- * @run main/othervm -XX:+UseParallelGC -XX:-UseParallelOldGC TestSystemGC
- * @run main/othervm -XX:+UseG1GC TestSystemGC
- * @run main/othervm -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent TestSystemGC
- * @run main/othervm -XX:+UseLargePages TestSystemGC
- * @run main/othervm -XX:+UseLargePages -XX:+UseLargePagesInMetaspace TestSystemGC
+ * @run main/othervm gc.TestSystemGC
+ * @run main/othervm -XX:+UseSerialGC gc.TestSystemGC
+ * @run main/othervm -XX:+UseParallelGC gc.TestSystemGC
+ * @run main/othervm -XX:+UseParallelGC -XX:-UseParallelOldGC gc.TestSystemGC
+ * @run main/othervm -XX:+UseG1GC gc.TestSystemGC
+ * @run main/othervm -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
+ * @run main/othervm -XX:+UseLargePages gc.TestSystemGC
+ * @run main/othervm -XX:+UseLargePages -XX:+UseLargePagesInMetaspace gc.TestSystemGC
  */
 
 /*
@@ -41,8 +43,8 @@
  * @key gc
  * @comment Graal does not support CMS
  * @requires vm.gc=="null" & !vm.graal.enabled
- * @run main/othervm -XX:+UseConcMarkSweepGC TestSystemGC
- * @run main/othervm -XX:+UseConcMarkSweepGC -XX:+ExplicitGCInvokesConcurrent TestSystemGC
+ * @run main/othervm -XX:+UseConcMarkSweepGC gc.TestSystemGC
+ * @run main/othervm -XX:+UseConcMarkSweepGC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
  */
 
 /*
@@ -50,8 +52,8 @@
  * @key gc
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @summary Runs System.gc() with different flags.
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC TestSystemGC
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+ExplicitGCInvokesConcurrent TestSystemGC
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC gc.TestSystemGC
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
  */
 public class TestSystemGC {
   public static void main(String args[]) throws Exception {

--- a/test/hotspot/jtreg/gc/TestVerifyDuringStartup.java
+++ b/test/hotspot/jtreg/gc/TestVerifyDuringStartup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 /* @test TestVerifyDuringStartup.java
  * @key gc
  * @bug 8010463 8011343 8011898
@@ -28,6 +30,7 @@
  * @requires vm.gc != "Z"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ * @run main gc.TestVerifyDuringStartup
  */
 
 import jdk.test.lib.JDKToolFinder;

--- a/test/hotspot/jtreg/gc/TestVerifySilently.java
+++ b/test/hotspot/jtreg/gc/TestVerifySilently.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc;
+
 /* @test TestVerifySilently.java
  * @key gc
  * @bug 8032771
@@ -28,6 +30,7 @@
  * @requires vm.gc != "Z"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ * @run main gc.TestVerifySilently
  */
 
 import jdk.test.lib.process.ProcessTools;
@@ -36,7 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import jdk.test.lib.Utils;
 
-class RunSystemGC {
+class TestVerifySilentlyRunSystemGC {
   public static void main(String args[]) throws Exception {
     System.gc();
   }
@@ -54,7 +57,7 @@ public class TestVerifySilently {
                                              "-XX:+VerifyBeforeGC",
                                              "-XX:+VerifyAfterGC",
                                              (verifySilently ? "-Xlog:gc":"-Xlog:gc+verify=debug"),
-                                             RunSystemGC.class.getName()});
+                                             TestVerifySilentlyRunSystemGC.class.getName()});
     ProcessBuilder pb =
       ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/gc/TestVerifySubSet.java
+++ b/test/hotspot/jtreg/gc/TestVerifySubSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,15 @@
  * questions.
  */
 
+package gc;
+
 /* @test TestVerifySubSet.java
  * @key gc
  * @bug 8072725
  * @summary Test VerifySubSet option
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ * @run main gc.TestVerifySubSet
  */
 
 import jdk.test.lib.process.ProcessTools;
@@ -35,7 +38,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import jdk.test.lib.Utils;
 
-class RunSystemGC {
+class TestVerifySubSetRunSystemGC {
     public static void main(String args[]) throws Exception {
         System.gc();
     }
@@ -52,7 +55,7 @@ public class TestVerifySubSet {
                                                  "-XX:+VerifyAfterGC",
                                                  "-Xlog:gc+verify=debug",
                                                  "-XX:VerifySubSet="+subset,
-                                                 RunSystemGC.class.getName()});
+                                                 TestVerifySubSetRunSystemGC.class.getName()});
         ProcessBuilder pb =
             ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
         OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/gc/arguments/AllocationHelper.java
+++ b/test/hotspot/jtreg/gc/arguments/AllocationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.arguments;
 
 import java.util.LinkedList;
 import java.util.concurrent.Callable;

--- a/test/hotspot/jtreg/gc/arguments/FlagsValue.java
+++ b/test/hotspot/jtreg/gc/arguments/FlagsValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.arguments;
 
 import java.util.regex.*;
 

--- a/test/hotspot/jtreg/gc/arguments/GCTypes.java
+++ b/test/hotspot/jtreg/gc/arguments/GCTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.arguments;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;

--- a/test/hotspot/jtreg/gc/arguments/HeapRegionUsageTool.java
+++ b/test/hotspot/jtreg/gc/arguments/HeapRegionUsageTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.arguments;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryPoolMXBean;

--- a/test/hotspot/jtreg/gc/arguments/TestAggressiveHeap.java
+++ b/test/hotspot/jtreg/gc/arguments/TestAggressiveHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestAggressiveHeap
  * @key gc
@@ -29,7 +31,7 @@
  * @summary Test argument processing for -XX:+AggressiveHeap.
  * @library /test/lib
  * @modules java.base java.management
- * @run driver TestAggressiveHeap
+ * @run driver gc.arguments.TestAggressiveHeap
  */
 
 import java.lang.management.ManagementFactory;

--- a/test/hotspot/jtreg/gc/arguments/TestAlignmentToUseLargePages.java
+++ b/test/hotspot/jtreg/gc/arguments/TestAlignmentToUseLargePages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /**
  * @test TestAlignmentToUseLargePages
  * @key gc regression
@@ -28,14 +30,14 @@
  * heap alignment is large page aligned. Other collectors also need to start up with odd sized heaps.
  * @bug 8024396
  * @requires vm.gc=="null"
- * @run main/othervm -Xms71M -Xmx91M -XX:+UseParallelGC -XX:-UseParallelOldGC -XX:+UseLargePages TestAlignmentToUseLargePages
- * @run main/othervm -Xms71M -Xmx91M -XX:+UseParallelGC -XX:-UseParallelOldGC -XX:-UseLargePages TestAlignmentToUseLargePages
- * @run main/othervm -Xms71M -Xmx91M -XX:+UseParallelGC -XX:+UseParallelOldGC -XX:+UseLargePages TestAlignmentToUseLargePages
- * @run main/othervm -Xms71M -Xmx91M -XX:+UseParallelGC -XX:+UseParallelOldGC -XX:-UseLargePages TestAlignmentToUseLargePages
- * @run main/othervm -Xms71M -Xmx91M -XX:+UseSerialGC -XX:+UseLargePages TestAlignmentToUseLargePages
- * @run main/othervm -Xms71M -Xmx91M -XX:+UseSerialGC -XX:-UseLargePages TestAlignmentToUseLargePages
- * @run main/othervm -Xms71M -Xmx91M -XX:+UseG1GC -XX:+UseLargePages TestAlignmentToUseLargePages
- * @run main/othervm -Xms71M -Xmx91M -XX:+UseG1GC -XX:-UseLargePages TestAlignmentToUseLargePages
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UseParallelGC -XX:-UseParallelOldGC -XX:+UseLargePages gc.arguments.TestAlignmentToUseLargePages
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UseParallelGC -XX:-UseParallelOldGC -XX:-UseLargePages gc.arguments.TestAlignmentToUseLargePages
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UseParallelGC -XX:+UseParallelOldGC -XX:+UseLargePages gc.arguments.TestAlignmentToUseLargePages
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UseParallelGC -XX:+UseParallelOldGC -XX:-UseLargePages gc.arguments.TestAlignmentToUseLargePages
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UseSerialGC -XX:+UseLargePages gc.arguments.TestAlignmentToUseLargePages
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UseSerialGC -XX:-UseLargePages gc.arguments.TestAlignmentToUseLargePages
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UseG1GC -XX:+UseLargePages gc.arguments.TestAlignmentToUseLargePages
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UseG1GC -XX:-UseLargePages gc.arguments.TestAlignmentToUseLargePages
  */
 
 /**
@@ -44,8 +46,8 @@
  * @bug 8024396
  * @comment Graal does not support CMS
  * @requires vm.gc=="null" & !vm.graal.enabled
- * @run main/othervm -Xms71M -Xmx91M -XX:+UseConcMarkSweepGC -XX:+UseLargePages TestAlignmentToUseLargePages
- * @run main/othervm -Xms71M -Xmx91M -XX:+UseConcMarkSweepGC -XX:-UseLargePages TestAlignmentToUseLargePages
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UseConcMarkSweepGC -XX:+UseLargePages gc.arguments.TestAlignmentToUseLargePages
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UseConcMarkSweepGC -XX:-UseLargePages gc.arguments.TestAlignmentToUseLargePages
  */
 
 /**
@@ -54,8 +56,8 @@
  * @bug 8024396
  * @comment Graal does not support Shenandoah
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
- * @run main/othervm -Xms71M -Xmx91M -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+UseLargePages TestAlignmentToUseLargePages
- * @run main/othervm -Xms71M -Xmx91M -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:-UseLargePages TestAlignmentToUseLargePages
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+UseLargePages gc.arguments.TestAlignmentToUseLargePages
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:-UseLargePages gc.arguments.TestAlignmentToUseLargePages
  */
 
 public class TestAlignmentToUseLargePages {

--- a/test/hotspot/jtreg/gc/arguments/TestArrayAllocatorMallocLimit.java
+++ b/test/hotspot/jtreg/gc/arguments/TestArrayAllocatorMallocLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestArrayAllocatorMallocLimit
  * @summary Sanity check that the ArrayAllocatorMallocLimit flag can be set.
@@ -30,7 +32,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver TestArrayAllocatorMallocLimit
+ * @run driver gc.arguments.TestArrayAllocatorMallocLimit
  */
 
 import jdk.test.lib.Asserts;

--- a/test/hotspot/jtreg/gc/arguments/TestCMSHeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestCMSHeapSizeFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestCMSHeapSizeFlags
  * @key gc
@@ -28,12 +30,13 @@
  * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @summary Tests argument processing for initial and maximum heap size for the CMS collector
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm TestCMSHeapSizeFlags
+ * @run main/othervm gc.arguments.TestCMSHeapSizeFlags
  * @author thomas.schatzl@oracle.com
  */
 

--- a/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.Platform;
@@ -33,6 +35,7 @@ import jdk.test.lib.Platform;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.arguments.TestCompressedClassFlags
  */
 public class TestCompressedClassFlags {
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/gc/arguments/TestDisableDefaultGC.java
+++ b/test/hotspot/jtreg/gc/arguments/TestDisableDefaultGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestDisableDefaultGC
  * @summary Test that the VM complains when the default GC is disabled and no other GC is specified
@@ -30,7 +32,7 @@
  * @requires vm.gc=="null"
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver TestDisableDefaultGC
+ * @run driver gc.arguments.TestDisableDefaultGC
  */
 
 import jdk.test.lib.process.ProcessTools;

--- a/test/hotspot/jtreg/gc/arguments/TestDynMaxHeapFreeRatio.java
+++ b/test/hotspot/jtreg/gc/arguments/TestDynMaxHeapFreeRatio.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 import static jdk.test.lib.Asserts.assertEQ;
 import static jdk.test.lib.Asserts.assertFalse;
 import static jdk.test.lib.Asserts.assertTrue;
@@ -33,12 +35,12 @@ import jdk.test.lib.management.DynamicVMOption;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.management
- * @run main TestDynMaxHeapFreeRatio
- * @run main/othervm -XX:MinHeapFreeRatio=0 -XX:MaxHeapFreeRatio=100 TestDynMaxHeapFreeRatio
- * @run main/othervm -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:-UseAdaptiveSizePolicy TestDynMaxHeapFreeRatio
- * @run main/othervm -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 TestDynMaxHeapFreeRatio
- * @run main/othervm -XX:MinHeapFreeRatio=51 -XX:MaxHeapFreeRatio=52 TestDynMaxHeapFreeRatio
- * @run main/othervm -XX:MinHeapFreeRatio=75 -XX:MaxHeapFreeRatio=100 TestDynMaxHeapFreeRatio
+ * @run main gc.arguments.TestDynMaxHeapFreeRatio
+ * @run main/othervm -XX:MinHeapFreeRatio=0 -XX:MaxHeapFreeRatio=100 gc.arguments.TestDynMaxHeapFreeRatio
+ * @run main/othervm -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:-UseAdaptiveSizePolicy gc.arguments.TestDynMaxHeapFreeRatio
+ * @run main/othervm -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 gc.arguments.TestDynMaxHeapFreeRatio
+ * @run main/othervm -XX:MinHeapFreeRatio=51 -XX:MaxHeapFreeRatio=52 gc.arguments.TestDynMaxHeapFreeRatio
+ * @run main/othervm -XX:MinHeapFreeRatio=75 -XX:MaxHeapFreeRatio=100 gc.arguments.TestDynMaxHeapFreeRatio
  */
 public class TestDynMaxHeapFreeRatio {
 

--- a/test/hotspot/jtreg/gc/arguments/TestDynMinHeapFreeRatio.java
+++ b/test/hotspot/jtreg/gc/arguments/TestDynMinHeapFreeRatio.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /**
  * @test TestDynMinHeapFreeRatio
  * @bug 8028391
@@ -28,12 +30,12 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.management
- * @run main TestDynMinHeapFreeRatio
- * @run main/othervm -XX:MinHeapFreeRatio=0 -XX:MaxHeapFreeRatio=100 TestDynMinHeapFreeRatio
- * @run main/othervm -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:-UseAdaptiveSizePolicy TestDynMinHeapFreeRatio
- * @run main/othervm -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 TestDynMinHeapFreeRatio
- * @run main/othervm -XX:MinHeapFreeRatio=51 -XX:MaxHeapFreeRatio=52 TestDynMinHeapFreeRatio
- * @run main/othervm -XX:MinHeapFreeRatio=75 -XX:MaxHeapFreeRatio=100 TestDynMinHeapFreeRatio
+ * @run main gc.arguments.TestDynMinHeapFreeRatio
+ * @run main/othervm -XX:MinHeapFreeRatio=0 -XX:MaxHeapFreeRatio=100 gc.arguments.TestDynMinHeapFreeRatio
+ * @run main/othervm -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 -XX:-UseAdaptiveSizePolicy gc.arguments.TestDynMinHeapFreeRatio
+ * @run main/othervm -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=50 gc.arguments.TestDynMinHeapFreeRatio
+ * @run main/othervm -XX:MinHeapFreeRatio=51 -XX:MaxHeapFreeRatio=52 gc.arguments.TestDynMinHeapFreeRatio
+ * @run main/othervm -XX:MinHeapFreeRatio=75 -XX:MaxHeapFreeRatio=100 gc.arguments.TestDynMinHeapFreeRatio
  */
 import static jdk.test.lib.Asserts.assertEQ;
 import static jdk.test.lib.Asserts.assertFalse;

--- a/test/hotspot/jtreg/gc/arguments/TestG1ConcMarkStepDurationMillis.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1ConcMarkStepDurationMillis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestG1ConcMarkStepDurationMillis
  * @key gc
@@ -29,6 +31,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.arguments.TestG1ConcMarkStepDurationMillis
  */
 
 import jdk.test.lib.process.ProcessTools;

--- a/test/hotspot/jtreg/gc/arguments/TestG1ConcRefinementThreads.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1ConcRefinementThreads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestG1ConcRefinementThreads
  * @key gc
@@ -30,6 +32,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.arguments.TestG1ConcRefinementThreads
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestG1HeapRegionSize
  * @key gc
@@ -30,7 +32,7 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.management/sun.management
  * @library /test/lib
- * @run main TestG1HeapRegionSize
+ * @run main gc.arguments.TestG1HeapRegionSize
  */
 
 import java.util.regex.Matcher;

--- a/test/hotspot/jtreg/gc/arguments/TestG1HeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1HeapSizeFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestG1HeapSizeFlags
  * @key gc
@@ -28,12 +30,13 @@
  * @requires vm.gc.G1
  * @summary Tests argument processing for initial and maximum heap size for the G1 collector
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm TestG1HeapSizeFlags
+ * @run main/othervm gc.arguments.TestG1HeapSizeFlags
  * @author thomas.schatzl@oracle.com
  */
 

--- a/test/hotspot/jtreg/gc/arguments/TestG1PercentageOptions.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1PercentageOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestG1PercentageOptions
  * @key gc
@@ -30,7 +32,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver TestG1PercentageOptions
+ * @run driver gc.arguments.TestG1PercentageOptions
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
+++ b/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestHeapFreeRatio
  * @key gc
@@ -29,7 +31,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm TestHeapFreeRatio
+ * @run main/othervm gc.arguments.TestHeapFreeRatio
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/arguments/TestInitialTenuringThreshold.java
+++ b/test/hotspot/jtreg/gc/arguments/TestInitialTenuringThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestInitialTenuringThreshold
  * @key gc
@@ -30,7 +32,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm TestInitialTenuringThreshold
+ * @run main/othervm gc.arguments.TestInitialTenuringThreshold
  * @author thomas.schatzl@oracle.com
  */
 

--- a/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.arguments;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/test/hotspot/jtreg/gc/arguments/TestMaxMinHeapFreeRatioFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxMinHeapFreeRatioFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,15 +21,18 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestMaxMinHeapFreeRatioFlags
  * @key gc
  * @summary Verify that heap size changes according to max and min heap free ratios.
  * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver/timeout=240 TestMaxMinHeapFreeRatioFlags
+ * @run driver/timeout=240 gc.arguments.TestMaxMinHeapFreeRatioFlags
  */
 
 import java.util.LinkedList;

--- a/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestMaxNewSize
  * @key gc
@@ -31,9 +33,9 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main TestMaxNewSize -XX:+UseSerialGC
- * @run main TestMaxNewSize -XX:+UseParallelGC
- * @run main TestMaxNewSize -XX:+UseG1GC
+ * @run main gc.arguments.TestMaxNewSize -XX:+UseSerialGC
+ * @run main gc.arguments.TestMaxNewSize -XX:+UseParallelGC
+ * @run main gc.arguments.TestMaxNewSize -XX:+UseG1GC
  * @author thomas.schatzl@oracle.com, jesper.wilhelmsson@oracle.com
  */
 
@@ -46,7 +48,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main TestMaxNewSize -XX:+UseConcMarkSweepGC
+ * @run main gc.arguments.TestMaxNewSize -XX:+UseConcMarkSweepGC
  */
 
 import java.util.regex.Matcher;

--- a/test/hotspot/jtreg/gc/arguments/TestMinAndInitialSurvivorRatioFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMinAndInitialSurvivorRatioFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,16 +21,19 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestMinAndInitialSurvivorRatioFlags
  * @key gc
  * @summary Verify that MinSurvivorRatio and InitialSurvivorRatio flags work
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run driver/timeout=240 TestMinAndInitialSurvivorRatioFlags
+ * @run driver/timeout=240 gc.arguments.TestMinAndInitialSurvivorRatioFlags
  */
 
 import java.lang.management.MemoryUsage;

--- a/test/hotspot/jtreg/gc/arguments/TestMinInitialErgonomics.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMinInitialErgonomics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,18 +21,21 @@
  * questions.
  */
 
+package gc.arguments;
+
 /**
  * @test TestMinInitialErgonomics
  * @key gc
  * @bug 8006088
  * @summary Test ergonomics decisions related to minimum and initial heap size.
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm TestMinInitialErgonomics
+ * @run main/othervm gc.arguments.TestMinInitialErgonomics
  * @author thomas.schatzl@oracle.com
  */
 

--- a/test/hotspot/jtreg/gc/arguments/TestNewRatioFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestNewRatioFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestNewRatioFlag
  * @key gc
@@ -28,11 +30,12 @@
  * @summary Verify that heap devided among generations according to NewRatio
  * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run driver TestNewRatioFlag
+ * @run driver gc.arguments.TestNewRatioFlag
  */
 
 import java.util.Arrays;

--- a/test/hotspot/jtreg/gc/arguments/TestNewSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestNewSizeFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestNewSizeFlags
  * @key gc
@@ -28,11 +30,12 @@
  * @summary Verify that young gen size conforms values specified by NewSize, MaxNewSize and Xmn options
  * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run driver/timeout=240  TestNewSizeFlags
+ * @run driver/timeout=240  gc.arguments.TestNewSizeFlags
  */
 
 import java.io.IOException;

--- a/test/hotspot/jtreg/gc/arguments/TestNewSizeThreadIncrease.java
+++ b/test/hotspot/jtreg/gc/arguments/TestNewSizeThreadIncrease.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestNewSizeThreadIncrease
  * @key gc
@@ -30,6 +32,7 @@
  * @requires vm.gc.Serial
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.arguments.TestNewSizeThreadIncrease
  */
 
 

--- a/test/hotspot/jtreg/gc/arguments/TestObjectTenuringFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestObjectTenuringFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestObjectTenuringFlags
  * @key gc
@@ -29,9 +31,10 @@
  * @summary Tests argument processing for NeverTenure, AlwaysTenure,
  * and MaxTenuringThreshold
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm TestObjectTenuringFlags
+ * @run main/othervm gc.arguments.TestObjectTenuringFlags
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,15 +21,18 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestParallelGCThreads
  * @key gc
  * @bug 8059527 8081382
  * @summary Tests argument processing for ParallelGCThreads
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver TestParallelGCThreads
+ * @run driver gc.arguments.TestParallelGCThreads
  */
 
 import jdk.test.lib.Asserts;

--- a/test/hotspot/jtreg/gc/arguments/TestParallelHeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelHeapSizeFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestParallelHeapSizeFlags
  * @key gc
@@ -29,12 +31,13 @@
  * parallel collectors.
  * @requires vm.gc=="null"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm TestParallelHeapSizeFlags
+ * @run main/othervm gc.arguments.TestParallelHeapSizeFlags
  * @author thomas.schatzl@oracle.com
  */
 

--- a/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,14 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestParallelRefProc
  * @key gc
  * @summary Test defaults processing for -XX:+ParallelRefProcEnabled.
  * @library /test/lib
- * @run driver TestParallelRefProc
+ * @run driver gc.arguments.TestParallelRefProc
  */
 
 import java.util.Arrays;

--- a/test/hotspot/jtreg/gc/arguments/TestSelectDefaultGC.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSelectDefaultGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestSelectDefaultGC
  * @summary Test selection of GC when no GC option is specified
@@ -30,7 +32,7 @@
  * @requires vm.gc=="null"
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver TestSelectDefaultGC
+ * @run driver gc.arguments.TestSelectDefaultGC
  */
 
 import jdk.test.lib.Platform;

--- a/test/hotspot/jtreg/gc/arguments/TestSerialHeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSerialHeapSizeFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,18 +21,21 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestSerialHeapSizeFlags
  * @key gc
  * @bug 8006088
  * @summary Tests argument processing for initial and maximum heap size for the Serial collector
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm TestSerialHeapSizeFlags
+ * @run main/othervm gc.arguments.TestSerialHeapSizeFlags
  * @author thomas.schatzl@oracle.com
  */
 

--- a/test/hotspot/jtreg/gc/arguments/TestShrinkHeapInSteps.java
+++ b/test/hotspot/jtreg/gc/arguments/TestShrinkHeapInSteps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,15 +21,18 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestShrinkHeapInSteps
  * @key gc
  * @summary Verify that -XX:-ShrinkHeapInSteps works properly.
  * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver/timeout=240 TestShrinkHeapInSteps
+ * @run driver/timeout=240 gc.arguments.TestShrinkHeapInSteps
  */
 
 import java.util.LinkedList;

--- a/test/hotspot/jtreg/gc/arguments/TestSmallInitialHeapWithLargePageAndNUMA.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSmallInitialHeapWithLargePageAndNUMA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestSmallInitialHeapWithLargePageAndNUMA
  * @bug 8023905
@@ -32,7 +34,7 @@
  * @modules java.management/sun.management
  * @build TestSmallInitialHeapWithLargePageAndNUMA
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UseHugeTLBFS -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestSmallInitialHeapWithLargePageAndNUMA
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UseHugeTLBFS -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI gc.arguments.TestSmallInitialHeapWithLargePageAndNUMA
 */
 
 import jdk.test.lib.process.ProcessTools;

--- a/test/hotspot/jtreg/gc/arguments/TestSurvivorAlignmentInBytesOption.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSurvivorAlignmentInBytesOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 import jdk.test.lib.process.ExitCode;
 import jdk.test.lib.cli.CommandLineOptionTest;
 
@@ -36,7 +38,7 @@ import jdk.test.lib.cli.CommandLineOptionTest;
  *              | vm.opt.IgnoreUnrecognizedVMOptions == "false")
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main TestSurvivorAlignmentInBytesOption
+ * @run main gc.arguments.TestSurvivorAlignmentInBytesOption
  */
 public class TestSurvivorAlignmentInBytesOption {
     public static void main(String args[]) throws Throwable {

--- a/test/hotspot/jtreg/gc/arguments/TestSurvivorRatioFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSurvivorRatioFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,17 +21,20 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestSurvivorRatioFlag
  * @key gc
  * @summary Verify that actual survivor ratio is equal to specified SurvivorRatio value
  * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run driver TestSurvivorRatioFlag
+ * @run driver gc.arguments.TestSurvivorRatioFlag
  */
 
 import java.lang.management.MemoryUsage;

--- a/test/hotspot/jtreg/gc/arguments/TestTargetSurvivorRatioFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestTargetSurvivorRatioFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestTargetSurvivorRatioFlag
  * @key gc
@@ -29,11 +31,12 @@
  * @requires (vm.opt.UseJVMCICompiler == null) | (vm.opt.UseJVMCICompiler == false)
  * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run driver TestTargetSurvivorRatioFlag
+ * @run driver gc.arguments.TestTargetSurvivorRatioFlag
  */
 
 import java.lang.management.GarbageCollectorMXBean;

--- a/test/hotspot/jtreg/gc/arguments/TestUnrecognizedVMOptionsHandling.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUnrecognizedVMOptionsHandling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestUnrecognizedVMOptionsHandling
  * @key gc
@@ -29,7 +31,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm TestUnrecognizedVMOptionsHandling
+ * @run main/othervm gc.arguments.TestUnrecognizedVMOptionsHandling
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgo.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestUseCompressedOopsErgo
  * @key gc
@@ -28,15 +30,16 @@
  * @summary Tests ergonomics for UseCompressedOops.
  * @requires vm.gc=="null"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm TestUseCompressedOopsErgo -XX:+UseG1GC
- * @run main/othervm TestUseCompressedOopsErgo -XX:+UseParallelGC
- * @run main/othervm TestUseCompressedOopsErgo -XX:+UseParallelGC -XX:-UseParallelOldGC
- * @run main/othervm TestUseCompressedOopsErgo -XX:+UseSerialGC
+ * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseG1GC
+ * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC
+ * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC -XX:-UseParallelOldGC
+ * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseSerialGC
  */
 
 /*
@@ -46,12 +49,13 @@
  * @comment Graal does not support CMS
  * @requires vm.gc=="null" & !vm.graal.enabled
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm TestUseCompressedOopsErgo -XX:+UseConcMarkSweepGC
+ * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseConcMarkSweepGC
  */
 
 /*
@@ -61,12 +65,13 @@
  * @comment Graal does not support Shenandoah
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm TestUseCompressedOopsErgo -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC
+ * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC
  */
 
 public class TestUseCompressedOopsErgo {

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.arguments;
 
 import com.sun.management.HotSpotDiagnosticMXBean;
 import com.sun.management.VMOption;

--- a/test/hotspot/jtreg/gc/arguments/TestUseNUMAInterleaving.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseNUMAInterleaving.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /**
  * @test TestUseNUMAInterleaving
  * @summary Tests that UseNUMAInterleaving enabled for all collectors by
@@ -30,7 +32,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver TestUseNUMAInterleaving
+ * @run driver gc.arguments.TestUseNUMAInterleaving
  */
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;

--- a/test/hotspot/jtreg/gc/arguments/TestVerifyBeforeAndAfterGCFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestVerifyBeforeAndAfterGCFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.arguments;
+
 /*
  * @test TestVerifyBeforeAndAfterGCFlags
  * @key gc
@@ -32,7 +34,7 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.management
  * @library /test/lib
- * @run driver TestVerifyBeforeAndAfterGCFlags
+ * @run driver gc.arguments.TestVerifyBeforeAndAfterGCFlags
  */
 
 import java.util.ArrayList;

--- a/test/hotspot/jtreg/gc/class_unloading/TestCMSClassUnloadingEnabledHWM.java
+++ b/test/hotspot/jtreg/gc/class_unloading/TestCMSClassUnloadingEnabledHWM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.class_unloading;
+
 /*
  * @test
  * @key gc
@@ -32,7 +34,7 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run driver TestCMSClassUnloadingEnabledHWM
+ * @run driver gc.class_unloading.TestCMSClassUnloadingEnabledHWM
  * @summary Test that -XX:-CMSClassUnloadingEnabled will trigger a Full GC when more than MetaspaceSize metadata is allocated.
  */
 

--- a/test/hotspot/jtreg/gc/class_unloading/TestClassUnloadingDisabled.java
+++ b/test/hotspot/jtreg/gc/class_unloading/TestClassUnloadingDisabled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.class_unloading;
+
 /*
  * @test
  * @key gc
@@ -36,13 +38,13 @@
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  *
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -XX:-ClassUnloading -XX:+UseG1GC TestClassUnloadingDisabled
+ *                   -XX:-ClassUnloading -XX:+UseG1GC gc.class_unloading.TestClassUnloadingDisabled
  *
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -XX:-ClassUnloading -XX:+UseSerialGC TestClassUnloadingDisabled
+ *                   -XX:-ClassUnloading -XX:+UseSerialGC gc.class_unloading.TestClassUnloadingDisabled
  *
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -XX:-ClassUnloading -XX:+UseParallelGC TestClassUnloadingDisabled
+ *                   -XX:-ClassUnloading -XX:+UseParallelGC gc.class_unloading.TestClassUnloadingDisabled
  *
  */
 
@@ -61,7 +63,7 @@
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -XX:-ClassUnloading -XX:+UseConcMarkSweepGC TestClassUnloadingDisabled
+ *                   -XX:-ClassUnloading -XX:+UseConcMarkSweepGC gc.class_unloading.TestClassUnloadingDisabled
  */
 
 /*
@@ -79,7 +81,7 @@
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -XX:-ClassUnloading -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC TestClassUnloadingDisabled
+ *                   -XX:-ClassUnloading -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC gc.class_unloading.TestClassUnloadingDisabled
  */
 
 import java.io.File;
@@ -98,7 +100,7 @@ public class TestClassUnloadingDisabled {
         // Fetch the dir where the test class and the class
         // to be loaded resides.
         String classDir = TestClassUnloadingDisabled.class.getProtectionDomain().getCodeSource().getLocation().getPath();
-        String className = "ClassToLoadUnload";
+        String className = "gc.class_unloading.ClassToLoadUnload"; // can not use ClassToLoadUnload.class.getName() as that would load the class
 
         assertFalse(wb.isClassAlive(className), "Should not be loaded yet");
 

--- a/test/hotspot/jtreg/gc/class_unloading/TestG1ClassUnloadingHWM.java
+++ b/test/hotspot/jtreg/gc/class_unloading/TestG1ClassUnloadingHWM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.class_unloading;
+
 /*
  * @test
  * @key gc
@@ -31,7 +33,7 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run driver TestG1ClassUnloadingHWM
+ * @run driver gc.class_unloading.TestG1ClassUnloadingHWM
  * @summary Test that -XX:-ClassUnloadingWithConcurrentMark will trigger a Full GC when more than MetaspaceSize metadata is allocated.
  */
 

--- a/test/hotspot/jtreg/gc/cms/DisableResizePLAB.java
+++ b/test/hotspot/jtreg/gc/cms/DisableResizePLAB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.cms;
+
 /*
  * @test DisableResizePLAB
  * @key gc
@@ -28,7 +30,7 @@
  * @author filipp.zhinkin@oracle.com, john.coomes@oracle.com
  * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @summary Run CMS with PLAB resizing disabled and a small OldPLABSize
- * @run main/othervm -XX:+UseConcMarkSweepGC -XX:-ResizePLAB -XX:OldPLABSize=1k -Xmx256m -Xlog:gc=debug DisableResizePLAB
+ * @run main/othervm -XX:+UseConcMarkSweepGC -XX:-ResizePLAB -XX:OldPLABSize=1k -Xmx256m -Xlog:gc=debug gc.cms.DisableResizePLAB
  */
 
 public class DisableResizePLAB {

--- a/test/hotspot/jtreg/gc/cms/GuardShrinkWarning.java
+++ b/test/hotspot/jtreg/gc/cms/GuardShrinkWarning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.cms;
+
 /**
  * @test GuardShrinkWarning
  * @key gc regression
@@ -30,7 +32,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm GuardShrinkWarning
+ * @run main/othervm gc.cms.GuardShrinkWarning
  * @author jon.masamitsu@oracle.com
  */
 
@@ -44,7 +46,7 @@ public class GuardShrinkWarning {
       "-showversion",
       "-XX:+UseConcMarkSweepGC",
       "-XX:+ExplicitGCInvokesConcurrent",
-      "GuardShrinkWarning$SystemGCCaller"
+      SystemGCCaller.class.getName()
       );
 
     OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/gc/cms/TestBubbleUpRef.java
+++ b/test/hotspot/jtreg/gc/cms/TestBubbleUpRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.cms;
+
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.LinkedList;
@@ -35,7 +37,7 @@ import java.util.ListIterator;
  *          stays nearly full.
  * @run main/othervm
  *  -XX:+UseConcMarkSweepGC -XX:-CMSYield -XX:-CMSPrecleanRefLists1
- *  -XX:CMSInitiatingOccupancyFraction=0 -Xmx80m TestBubbleUpRef 16000 50 10000
+ *  -XX:CMSInitiatingOccupancyFraction=0 -Xmx80m gc.cms.TestBubbleUpRef 16000 50 10000
  */
 
 /**

--- a/test/hotspot/jtreg/gc/cms/TestCMSScavengeBeforeRemark.java
+++ b/test/hotspot/jtreg/gc/cms/TestCMSScavengeBeforeRemark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,15 @@
  * questions.
  */
 
+package gc.cms;
+
 /*
  * @test TestCMSScavengeBeforeRemark
  * @key gc
  * @bug 8139868
  * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @summary Run CMS with CMSScavengeBeforeRemark
- * @run main/othervm -XX:+UseConcMarkSweepGC -XX:+CMSScavengeBeforeRemark -XX:+ExplicitGCInvokesConcurrent -Xmx256m -Xlog:gc=debug TestCMSScavengeBeforeRemark
+ * @run main/othervm -XX:+UseConcMarkSweepGC -XX:+CMSScavengeBeforeRemark -XX:+ExplicitGCInvokesConcurrent -Xmx256m -Xlog:gc=debug gc.cms.TestCMSScavengeBeforeRemark
  */
 
 public class TestCMSScavengeBeforeRemark {

--- a/test/hotspot/jtreg/gc/cms/TestCriticalPriority.java
+++ b/test/hotspot/jtreg/gc/cms/TestCriticalPriority.java
@@ -21,13 +21,15 @@
  * questions.
  */
 
+package gc.cms;
+
 /*
  * @test TestCriticalPriority
  * @key gc
  * @bug 8217378
  * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @summary Test critical priority is accepted
- * @run main/othervm -XX:+UseConcMarkSweepGC -XX:+UnlockExperimentalVMOptions -XX:+UseCriticalCMSThreadPriority TestCriticalPriority
+ * @run main/othervm -XX:+UseConcMarkSweepGC -XX:+UnlockExperimentalVMOptions -XX:+UseCriticalCMSThreadPriority gc.cms.TestCriticalPriority
  */
 
 public class TestCriticalPriority {

--- a/test/hotspot/jtreg/gc/cms/TestMBeanCMS.java
+++ b/test/hotspot/jtreg/gc/cms/TestMBeanCMS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,15 @@
  * questions.
  */
 
+package gc.cms;
+
 /*
  * @test TestMBeanCMS.java
  * @bug 6581734
  * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @summary CMS Old Gen's collection usage is zero after GC which is incorrect
  * @modules java.management
- * @run main/othervm -Xmx512m -verbose:gc -XX:+UseConcMarkSweepGC TestMBeanCMS
+ * @run main/othervm -Xmx512m -verbose:gc -XX:+UseConcMarkSweepGC gc.cms.TestMBeanCMS
  *
  */
 

--- a/test/hotspot/jtreg/gc/concurrent_phase_control/TestConcurrentPhaseControlCMS.java
+++ b/test/hotspot/jtreg/gc/concurrent_phase_control/TestConcurrentPhaseControlCMS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.concurrent_phase_control;
+
 /*
  * @test TestConcurrentPhaseControlCMS
  * @bug 8169517
@@ -35,7 +37,7 @@
  * @run main/othervm -XX:+UseConcMarkSweepGC
  *   -Xbootclasspath/a:.
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *   TestConcurrentPhaseControlCMS
+ *   gc.concurrent_phase_control.TestConcurrentPhaseControlCMS
  */
 
 import gc.concurrent_phase_control.CheckUnsupported;

--- a/test/hotspot/jtreg/gc/concurrent_phase_control/TestConcurrentPhaseControlG1.java
+++ b/test/hotspot/jtreg/gc/concurrent_phase_control/TestConcurrentPhaseControlG1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.concurrent_phase_control;
+
 /*
  * @test TestConcurrentPhaseControlG1
  * @bug 8169517
@@ -32,7 +34,7 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *    sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run driver TestConcurrentPhaseControlG1
+ * @run driver gc.concurrent_phase_control.TestConcurrentPhaseControlG1
  */
 
 import gc.concurrent_phase_control.CheckControl;

--- a/test/hotspot/jtreg/gc/concurrent_phase_control/TestConcurrentPhaseControlG1Basics.java
+++ b/test/hotspot/jtreg/gc/concurrent_phase_control/TestConcurrentPhaseControlG1Basics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.concurrent_phase_control;
+
 /*
  * @test TestConcurrentPhaseControlG1Basics
  * @bug 8169517
@@ -36,7 +38,7 @@
  * @run main/othervm -XX:+UseG1GC
  *   -Xbootclasspath/a:.
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *   TestConcurrentPhaseControlG1Basics
+ *   gc.concurrent_phase_control.TestConcurrentPhaseControlG1Basics
  */
 
 import gc.concurrent_phase_control.CheckSupported;

--- a/test/hotspot/jtreg/gc/concurrent_phase_control/TestConcurrentPhaseControlParallel.java
+++ b/test/hotspot/jtreg/gc/concurrent_phase_control/TestConcurrentPhaseControlParallel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.concurrent_phase_control;
+
 /*
  * @test TestConcurrentPhaseControlParallel
  * @bug 8169517
@@ -35,7 +37,7 @@
  * @run main/othervm -XX:+UseParallelGC
  *   -Xbootclasspath/a:.
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *   TestConcurrentPhaseControlParallel
+ *   gc.concurrent_phase_control.TestConcurrentPhaseControlParallel
  */
 
 import gc.concurrent_phase_control.CheckUnsupported;

--- a/test/hotspot/jtreg/gc/concurrent_phase_control/TestConcurrentPhaseControlSerial.java
+++ b/test/hotspot/jtreg/gc/concurrent_phase_control/TestConcurrentPhaseControlSerial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.concurrent_phase_control;
+
 /*
  * @test TestConcurrentPhaseControlSerial
  * @bug 8169517
@@ -35,7 +37,7 @@
  * @run main/othervm -XX:+UseSerialGC
  *   -Xbootclasspath/a:.
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *   TestConcurrentPhaseControlSerial
+ *   gc.concurrent_phase_control.TestConcurrentPhaseControlSerial
  */
 
 import gc.concurrent_phase_control.CheckUnsupported;

--- a/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
+++ b/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.cslocker;
+
 /*
  * @test TestCSLocker
  * @key gc
@@ -28,7 +30,7 @@
  * @summary This short test check RFE 6186200 changes. One thread locked
  * @summary completely in JNI CS, while other is trying to allocate memory
  * @summary provoking GC. OOM means FAIL, deadlock means PASS.
- * @run main/native/othervm -Xmx256m TestCSLocker
+ * @run main/native/othervm -Xmx256m gc.cslocker.TestCSLocker
  */
 
 public class TestCSLocker extends Thread

--- a/test/hotspot/jtreg/gc/cslocker/libTestCSLocker.c
+++ b/test/hotspot/jtreg/gc/cslocker/libTestCSLocker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 
 static volatile int release_critical = 0;
 
-JNIEXPORT jboolean JNICALL Java_CSLocker_lock
+JNIEXPORT jboolean JNICALL Java_gc_cslocker_CSLocker_lock
   (JNIEnv *env, jobject obj, jintArray array)
 {
     jboolean retval = JNI_TRUE;
@@ -42,7 +42,7 @@ JNIEXPORT jboolean JNICALL Java_CSLocker_lock
     return retval;
 }
 
-JNIEXPORT void JNICALL Java_CSLocker_unlock
+JNIEXPORT void JNICALL Java_gc_cslocker_CSLocker_unlock
   (JNIEnv *env, jobject obj)
 {
     release_critical = 1;

--- a/test/hotspot/jtreg/gc/epsilon/TestAlignment.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestAlignment.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestAlignment
  * @key gc
@@ -30,21 +32,21 @@
  *
  * @run main/othervm -Xmx64m -XX:+UseTLAB
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestAlignment
+ *                   gc.epsilon.TestAlignment
  *
  * @run main/othervm -Xmx64m -XX:-UseTLAB
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestAlignment
+ *                   gc.epsilon.TestAlignment
  *
  * @run main/othervm -Xmx64m -XX:+UseTLAB
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
- *                   TestAlignment
+ *                   gc.epsilon.TestAlignment
  *
  * @run main/othervm -Xmx64m -XX:-UseTLAB
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
- *                   TestAlignment
+ *                   gc.epsilon.TestAlignment
  */
 
 public class TestAlignment {

--- a/test/hotspot/jtreg/gc/epsilon/TestAlwaysPretouch.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestAlwaysPretouch.java
@@ -51,7 +51,7 @@
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   gc.epsilon.TestAlwaysPretouch
  */
- 
+
 package gc.epsilon;
 
 public class TestAlwaysPretouch {

--- a/test/hotspot/jtreg/gc/epsilon/TestAlwaysPretouch.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestAlwaysPretouch.java
@@ -29,28 +29,30 @@
  *
  * @run main/othervm -Xms64m -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestAlwaysPretouch
+ *                   gc.epsilon.TestAlwaysPretouch
  *
  * @run main/othervm -Xms64m -Xmx256m -XX:-AlwaysPreTouch
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestAlwaysPretouch
+ *                   gc.epsilon.TestAlwaysPretouch
  *
  * @run main/othervm -Xms64m -Xmx256m -XX:+AlwaysPreTouch
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestAlwaysPretouch
+ *                   gc.epsilon.TestAlwaysPretouch
  *
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestAlwaysPretouch
+ *                   gc.epsilon.TestAlwaysPretouch
  *
  * @run main/othervm -Xmx256m -XX:-AlwaysPreTouch
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestAlwaysPretouch
+ *                   gc.epsilon.TestAlwaysPretouch
  *
  * @run main/othervm -Xmx256m -XX:+AlwaysPreTouch
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestAlwaysPretouch
+ *                   gc.epsilon.TestAlwaysPretouch
  */
+ 
+package gc.epsilon;
 
 public class TestAlwaysPretouch {
   public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/gc/epsilon/TestArraycopyCheckcast.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestArraycopyCheckcast.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestArraycopyCheckcast
  * @key gc
@@ -31,22 +33,22 @@
  *
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestArraycopyCheckcast
+ *                   gc.epsilon.TestArraycopyCheckcast
  *
  * @run main/othervm -Xmx256m
  *                   -Xint
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestArraycopyCheckcast
+ *                   gc.epsilon.TestArraycopyCheckcast
  *
  * @run main/othervm -Xmx256m
  *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestArraycopyCheckcast
+ *                   gc.epsilon.TestArraycopyCheckcast
  *
  * @run main/othervm -Xmx256m
  *                   -Xbatch -Xcomp -XX:-TieredCompilation
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestArraycopyCheckcast
+ *                   gc.epsilon.TestArraycopyCheckcast
  */
 
 import java.util.Random;

--- a/test/hotspot/jtreg/gc/epsilon/TestByteArrays.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestByteArrays.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestByteArrays
  * @key gc
@@ -29,41 +31,41 @@
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestByteArrays
+ *                   gc.epsilon.TestByteArrays
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -Xint
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestByteArrays
+ *                   gc.epsilon.TestByteArrays
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestByteArrays
+ *                   gc.epsilon.TestByteArrays
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -Xbatch -Xcomp -XX:-TieredCompilation
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestByteArrays
+ *                   gc.epsilon.TestByteArrays
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestByteArrays
+ *                   gc.epsilon.TestByteArrays
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m
  *                   -Xint
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestByteArrays
+ *                   gc.epsilon.TestByteArrays
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m
  *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestByteArrays
+ *                   gc.epsilon.TestByteArrays
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m
  *                   -Xbatch -Xcomp -XX:-TieredCompilation
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestByteArrays
+ *                   gc.epsilon.TestByteArrays
  */
 
 import java.util.Random;

--- a/test/hotspot/jtreg/gc/epsilon/TestClasses.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestClasses.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestClasses
  * @key gc
@@ -33,7 +35,7 @@
  * @run main/othervm -Xmx256m
  *                   -XX:MetaspaceSize=1m -XX:MaxMetaspaceSize=64m -Xlog:gc -Xlog:gc+metaspace
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestClasses
+ *                   gc.epsilon.TestClasses
  */
 
 import jdk.internal.org.objectweb.asm.ClassWriter;

--- a/test/hotspot/jtreg/gc/epsilon/TestDieDefault.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieDefault.java
@@ -21,13 +21,15 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestDieDefault
  * @key gc
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Epsilon GC should die on heap exhaustion
  * @library /test/lib
- * @run main TestDieDefault
+ * @run main gc.epsilon.TestDieDefault
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/epsilon/TestDieWithHeapDump.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieWithHeapDump.java
@@ -21,13 +21,15 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestDieWithHeapDump
  * @key gc
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Epsilon GC should die on heap exhaustion with error handler attached
  * @library /test/lib
- * @run main TestDieWithHeapDump
+ * @run main gc.epsilon.TestDieWithHeapDump
  */
 
 import java.io.*;

--- a/test/hotspot/jtreg/gc/epsilon/TestDieWithOnError.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestDieWithOnError.java
@@ -21,13 +21,15 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestDieWithOnError
  * @key gc
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Epsilon GC should die on heap exhaustion with error handler attached
  * @library /test/lib
- * @run main TestDieWithOnError
+ * @run main gc.epsilon.TestDieWithOnError
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/epsilon/TestElasticTLAB.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestElasticTLAB.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestElasticTLAB
  * @key gc
@@ -30,27 +32,27 @@
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:-EpsilonElasticTLAB
- *                   TestElasticTLAB
+ *                   gc.epsilon.TestElasticTLAB
  *
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=1
- *                   TestElasticTLAB
+ *                   gc.epsilon.TestElasticTLAB
  *
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=1.1
- *                   TestElasticTLAB
+ *                   gc.epsilon.TestElasticTLAB
  *
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=2.0
- *                   TestElasticTLAB
+ *                   gc.epsilon.TestElasticTLAB
  *
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:+EpsilonElasticTLAB -XX:EpsilonTLABElasticity=100
- *                   TestElasticTLAB
+ *                   gc.epsilon.TestElasticTLAB
  */
 
 import java.util.Random;

--- a/test/hotspot/jtreg/gc/epsilon/TestElasticTLABDecay.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestElasticTLABDecay.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestElasticTLABDecay
  * @key gc
@@ -30,17 +32,17 @@
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:+EpsilonElasticTLAB -XX:-EpsilonElasticTLABDecay
- *                   TestElasticTLABDecay
+ *                    gc.epsilon.TestElasticTLABDecay
  *
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:+EpsilonElasticTLAB -XX:+EpsilonElasticTLABDecay -XX:EpsilonTLABDecayTime=1
- *                   TestElasticTLABDecay
+ *                    gc.epsilon.TestElasticTLABDecay
  *
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:+EpsilonElasticTLAB -XX:+EpsilonElasticTLABDecay -XX:EpsilonTLABDecayTime=100
- *                   TestElasticTLABDecay
+ *                    gc.epsilon.TestElasticTLABDecay
  */
 
 import java.util.Random;

--- a/test/hotspot/jtreg/gc/epsilon/TestEpsilonEnabled.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestEpsilonEnabled.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestAlwaysPretouch
  * @key gc
@@ -30,7 +32,7 @@
  *
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestEpsilonEnabled
+ *                   gc.epsilon.TestEpsilonEnabled
  */
 
 import jdk.test.lib.Platform;

--- a/test/hotspot/jtreg/gc/epsilon/TestHelloWorld.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestHelloWorld.java
@@ -21,13 +21,15 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestHelloWorld
  * @key gc
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Basic sanity test for Epsilon
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestHelloWorld
+ *                   gc.epsilon.TestHelloWorld
  */
 
 public class TestHelloWorld {

--- a/test/hotspot/jtreg/gc/epsilon/TestLogTrace.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestLogTrace.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestLogTrace
  * @key gc
@@ -28,7 +30,7 @@
  * @summary Test that tracing does not crash Epsilon
  * @run main/othervm -Xmx256m -Xlog:gc*=trace
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestLogTrace
+ *                   gc.epsilon.TestLogTrace
  */
 
 public class TestLogTrace {

--- a/test/hotspot/jtreg/gc/epsilon/TestManyThreads.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestManyThreads.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestManyThreads
  * @key gc
@@ -29,41 +31,41 @@
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m -Xss512k
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestManyThreads
+ *                   gc.epsilon.TestManyThreads
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m -Xss512k
  *                   -Xint
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestManyThreads
+ *                   gc.epsilon.TestManyThreads
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m -Xss512k
  *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestManyThreads
+ *                   gc.epsilon.TestManyThreads
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m -Xss512k
  *                   -Xbatch -Xcomp -XX:-TieredCompilation
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestManyThreads
+ *                   gc.epsilon.TestManyThreads
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m -Xss512k
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestManyThreads
+ *                   gc.epsilon.TestManyThreads
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m -Xss512k
  *                   -Xint
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestManyThreads
+ *                   gc.epsilon.TestManyThreads
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m -Xss512k
  *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestManyThreads
+ *                   gc.epsilon.TestManyThreads
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m -Xss512k
  *                   -Xbatch -Xcomp -XX:-TieredCompilation
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestManyThreads
+ *                   gc.epsilon.TestManyThreads
  */
 
 import java.util.concurrent.atomic.*;

--- a/test/hotspot/jtreg/gc/epsilon/TestMaxTLAB.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestMaxTLAB.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestMaxTLAB
  * @key gc
@@ -31,46 +33,46 @@
  * @run main/othervm -Xmx64m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonMaxTLABSize=1
- *                   TestMaxTLAB
+ *                   gc.epsilon.TestMaxTLAB
  *
  * @run main/othervm -Xmx64m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonMaxTLABSize=1K
- *                   TestMaxTLAB
+ *                   gc.epsilon.TestMaxTLAB
  *
  * @run main/othervm -Xmx64m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonMaxTLABSize=1M
- *                   TestMaxTLAB
+ *                   gc.epsilon.TestMaxTLAB
  *
  * @run main/othervm -Xmx64m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonMaxTLABSize=12345
- *                   TestMaxTLAB
+ *                   gc.epsilon.TestMaxTLAB
  *
  * @run main/othervm -Xmx64m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonMaxTLABSize=1
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
- *                   TestMaxTLAB
+ *                   gc.epsilon.TestMaxTLAB
  *
  * @run main/othervm -Xmx64m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonMaxTLABSize=1K
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
- *                   TestMaxTLAB
+ *                   gc.epsilon.TestMaxTLAB
  *
  * @run main/othervm -Xmx64m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonMaxTLABSize=1M
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
- *                   TestMaxTLAB
+ *                   gc.epsilon.TestMaxTLAB
  *
  * @run main/othervm -Xmx64m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonMaxTLABSize=12345
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=16
- *                   TestMaxTLAB
+ *                   gc.epsilon.TestMaxTLAB
  */
 
 public class TestMaxTLAB {

--- a/test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java
@@ -22,6 +22,8 @@
  *
  */
 
+package gc.epsilon;
+
 /**
  * @test TestMemoryMXBeans
  * @key gc
@@ -32,17 +34,17 @@
  *
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestMemoryMXBeans
+ *                   gc.epsilon.TestMemoryMXBeans
  *                   -1 256
  *
  * @run main/othervm -Xmx256m -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestMemoryMXBeans
+ *                   gc.epsilon.TestMemoryMXBeans
  *                   256 256
  *
  * @run main/othervm -Xms64m -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestMemoryMXBeans
+ *                   gc.epsilon.TestMemoryMXBeans
  *                   64 256
  */
 

--- a/test/hotspot/jtreg/gc/epsilon/TestMemoryPools.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestMemoryPools.java
@@ -22,6 +22,8 @@
  *
  */
 
+package gc.epsilon;
+
 /**
  * @test TestMemoryPools
  * @key gc
@@ -32,7 +34,7 @@
  *
  * @run main/othervm -Xms64m -Xmx64m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestMemoryPools
+ *                   gc.epsilon.TestMemoryPools
  */
 
 import java.lang.management.*;

--- a/test/hotspot/jtreg/gc/epsilon/TestObjects.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestObjects.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestObjects
  * @key gc
@@ -29,41 +31,41 @@
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestObjects
+ *                   gc.epsilon.TestObjects
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -Xint
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestObjects
+ *                   gc.epsilon.TestObjects
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestObjects
+ *                   gc.epsilon.TestObjects
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -Xbatch -Xcomp -XX:-TieredCompilation
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestObjects
+ *                   gc.epsilon.TestObjects
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestObjects
+ *                   gc.epsilon.TestObjects
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m
  *                   -Xint
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestObjects
+ *                   gc.epsilon.TestObjects
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m
  *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestObjects
+ *                   gc.epsilon.TestObjects
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m
  *                   -Xbatch -Xcomp -XX:-TieredCompilation
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestObjects
+ *                   gc.epsilon.TestObjects
  */
 
 import java.util.Random;

--- a/test/hotspot/jtreg/gc/epsilon/TestPrintHeapSteps.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestPrintHeapSteps.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestPrintSteps
  * @key gc
@@ -30,17 +32,17 @@
  * @run main/othervm -Xmx64m -Xlog:gc
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonPrintHeapSteps=0
- *                   TestPrintHeapSteps
+ *                   gc.epsilon.TestPrintHeapSteps
  *
  * @run main/othervm -Xmx64m -Xlog:gc
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonPrintHeapSteps=1
- *                   TestPrintHeapSteps
+ *                   gc.epsilon.TestPrintHeapSteps
  *
  * @run main/othervm -Xmx64m -Xlog:gc
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonPrintHeapSteps=1000
- *                   TestPrintHeapSteps
+ *                   gc.epsilon.TestPrintHeapSteps
  */
 
 public class TestPrintHeapSteps {

--- a/test/hotspot/jtreg/gc/epsilon/TestRefArrays.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestRefArrays.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestRefArrays
  * @key gc
@@ -30,41 +32,41 @@
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestRefArrays
+ *                   gc.epsilon.TestRefArrays
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -Xint
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestRefArrays
+ *                   gc.epsilon.TestRefArrays
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestRefArrays
+ *                   gc.epsilon.TestRefArrays
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -Xbatch -Xcomp -XX:-TieredCompilation
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestRefArrays
+ *                   gc.epsilon.TestRefArrays
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestRefArrays
+ *                   gc.epsilon.TestRefArrays
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m
  *                   -Xint
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestRefArrays
+ *                   gc.epsilon.TestRefArrays
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m
  *                   -Xbatch -Xcomp -XX:TieredStopAtLevel=1
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestRefArrays
+ *                   gc.epsilon.TestRefArrays
  *
  * @run main/othervm -XX:-UseTLAB -Xmx256m
  *                   -Xbatch -Xcomp -XX:-TieredCompilation
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
- *                   TestRefArrays
+ *                   gc.epsilon.TestRefArrays
  */
 
 import java.util.Random;

--- a/test/hotspot/jtreg/gc/epsilon/TestUpdateCountersSteps.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestUpdateCountersSteps.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.epsilon;
+
 /**
  * @test TestUpdateCountersSteps
  * @key gc
@@ -30,22 +32,22 @@
  * @run main/othervm -Xmx64m -Xlog:gc
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonUpdateCountersStep=1
- *                   TestUpdateCountersSteps
+ *                   gc.epsilon.TestUpdateCountersSteps
  *
  * @run main/othervm -Xmx64m -Xlog:gc
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonUpdateCountersStep=10
- *                   TestUpdateCountersSteps
+ *                   gc.epsilon.TestUpdateCountersSteps
  *
  * @run main/othervm -Xmx64m -Xlog:gc
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonUpdateCountersStep=100
- *                   TestUpdateCountersSteps
+ *                   gc.epsilon.TestUpdateCountersSteps
  *
  * @run main/othervm -Xmx64m -Xlog:gc
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   -XX:EpsilonUpdateCountersStep=1000
- *                   TestUpdateCountersSteps
+ *                   gc.epsilon.TestUpdateCountersSteps
  */
 
 public class TestUpdateCountersSteps {

--- a/test/hotspot/jtreg/gc/ergonomics/TestDynamicNumberOfGCThreads.java
+++ b/test/hotspot/jtreg/gc/ergonomics/TestDynamicNumberOfGCThreads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.ergonomics;
+
 /*
  * @test TestDynamicNumberOfGCThreads
  * @bug 8017462
@@ -31,7 +33,7 @@
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestDynamicNumberOfGCThreads
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI gc.ergonomics.TestDynamicNumberOfGCThreads
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/ergonomics/TestInitialGCThreadLogging.java
+++ b/test/hotspot/jtreg/gc/ergonomics/TestInitialGCThreadLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.ergonomics;
+
 /*
  * @test TestInitialGCThreadLogging
  * @bug 8157240
@@ -31,7 +33,7 @@
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestInitialGCThreadLogging
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI gc.ergonomics.TestInitialGCThreadLogging
  */
 
 import jdk.test.lib.process.ProcessTools;

--- a/test/hotspot/jtreg/gc/g1/Test2GbHeap.java
+++ b/test/hotspot/jtreg/gc/g1/Test2GbHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test Test2GbHeap
  * @key gc regression
@@ -32,6 +34,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.g1.Test2GbHeap
  */
 
 import java.util.ArrayList;

--- a/test/hotspot/jtreg/gc/g1/TestConcurrentSystemGC.java
+++ b/test/hotspot/jtreg/gc/g1/TestConcurrentSystemGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestConcurrentSystemGC
  * @bug 8195158
@@ -31,7 +33,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -Xmx8m -Xms8m -XX:G1HeapRegionSize=1m TestConcurrentSystemGC
+ * @run main/othervm -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -Xmx8m -Xms8m -XX:G1HeapRegionSize=1m gc.g1.TestConcurrentSystemGC
  */
 
 import java.util.ArrayList;

--- a/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegions.java
+++ b/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestEagerReclaimHumongousRegions
  * @bug 8027959
@@ -31,6 +33,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.g1.TestEagerReclaimHumongousRegions
  */
 
 import java.util.regex.Pattern;
@@ -41,7 +44,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.Asserts;
 
-class ReclaimRegionFast {
+class TestEagerReclaimHumongousRegionsReclaimRegionFast {
     public static final int M = 1024*1024;
 
     public static LinkedList<Object> garbageList = new LinkedList<Object>();
@@ -84,7 +87,7 @@ public class TestEagerReclaimHumongousRegions {
             "-Xmx128M",
             "-Xmn16M",
             "-Xlog:gc",
-            ReclaimRegionFast.class.getName());
+            TestEagerReclaimHumongousRegionsReclaimRegionFast.class.getName());
 
         Pattern p = Pattern.compile("Full GC");
 

--- a/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsClearMarkBits.java
+++ b/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsClearMarkBits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestEagerReclaimHumongousRegionsClearMarkBits
  * @bug 8051973
@@ -31,6 +33,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.g1.TestEagerReclaimHumongousRegionsClearMarkBits
  */
 
 import java.util.ArrayList;
@@ -48,7 +51,7 @@ class ObjectWithSomeRefs {
     public ObjectWithSomeRefs other4;
 }
 
-class ReclaimRegionFast {
+class TestEagerReclaimHumongousRegionsClearMarkBitsReclaimRegionFast {
     public static final long MAX_MILLIS_FOR_RUN = 50 * 1000; // The maximum runtime for the actual test.
 
     public static final int M = 1024*1024;
@@ -127,7 +130,7 @@ public class TestEagerReclaimHumongousRegionsClearMarkBits {
             "-XX:ConcGCThreads=1", // Want to make marking as slow as possible.
             "-XX:+IgnoreUnrecognizedVMOptions", // G1VerifyBitmaps is develop only.
             "-XX:+G1VerifyBitmaps",
-            ReclaimRegionFast.class.getName());
+            TestEagerReclaimHumongousRegionsClearMarkBitsReclaimRegionFast.class.getName());
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
     }

--- a/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsLog.java
+++ b/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestEagerReclaimHumongousRegionsLog
  * @summary Check that G1 reports humongous eager reclaim statistics correctly.
@@ -31,7 +33,7 @@
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run driver TestEagerReclaimHumongousRegionsLog
+ * @run driver gc.g1.TestEagerReclaimHumongousRegionsLog
  */
 
 import sun.hotspot.WhiteBox;

--- a/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsWithRefs.java
+++ b/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsWithRefs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestEagerReclaimHumongousRegionsWithRefs
  * @bug 8048179
@@ -34,6 +36,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.g1.TestEagerReclaimHumongousRegionsWithRefs
  */
 
 import java.util.regex.Pattern;
@@ -48,7 +51,7 @@ class RefHolder {
   Object ref;
 }
 
-class ReclaimRegionFast {
+class TestEagerReclaimHumongousRegionsWithRefsReclaimRegionFast {
 
     public static final int M = 1024*1024;
 
@@ -96,7 +99,7 @@ public class TestEagerReclaimHumongousRegionsWithRefs {
             "-Xmx128M",
             "-Xmn16M",
             "-Xlog:gc",
-            ReclaimRegionFast.class.getName());
+            TestEagerReclaimHumongousRegionsWithRefsReclaimRegionFast.class.getName());
 
         Pattern p = Pattern.compile("Full GC");
 

--- a/test/hotspot/jtreg/gc/g1/TestFromCardCacheIndex.java
+++ b/test/hotspot/jtreg/gc/g1/TestFromCardCacheIndex.java
@@ -1,4 +1,27 @@
 /*
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
  * @test TestFromCardCacheIndex.java
  * @bug 8196485
  * @summary Ensure that G1 does not miss a remembered set entry due to from card cache default value indices.
@@ -11,8 +34,9 @@
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. -Xms20M -Xmx20M -XX:+UseCompressedOops -XX:G1HeapRegionSize=1M -XX:HeapBaseMinAddress=2199011721216 -XX:+UseG1GC -verbose:gc TestFromCardCacheIndex
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. -Xms20M -Xmx20M -XX:+UseCompressedOops -XX:G1HeapRegionSize=1M -XX:HeapBaseMinAddress=2199011721216 -XX:+UseG1GC -verbose:gc gc.g1.TestFromCardCacheIndex
  */
+package gc.g1;
 
 import sun.hotspot.WhiteBox;
 

--- a/test/hotspot/jtreg/gc/g1/TestG1TraceEagerReclaimHumongousObjects.java
+++ b/test/hotspot/jtreg/gc/g1/TestG1TraceEagerReclaimHumongousObjects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestG1TraceEagerReclaimHumongousObjects
  * @bug 8058801 8048179
@@ -31,6 +33,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.g1.TestG1TraceEagerReclaimHumongousObjects
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
+++ b/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestGCLogMessages
  * @bug 8035406 8027295 8035398 8019342 8027959 8048179 8027962 8069330 8076463 8150630 8160055 8177059 8166191
@@ -33,7 +35,7 @@
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main TestGCLogMessages
+ * @run main gc.g1.TestGCLogMessages
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/g1/TestGreyReclaimedHumongousObjects.java
+++ b/test/hotspot/jtreg/gc/g1/TestGreyReclaimedHumongousObjects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestGreyReclaimedHumongousObjects.java
  * @bug 8069367 8185278
@@ -32,7 +34,7 @@
  *      -XX:+UnlockExperimentalVMOptions
  *          -XX:+G1EagerReclaimHumongousObjects
  *          -XX:+G1EagerReclaimHumongousObjectsWithStaleRefs
- *      TestGreyReclaimedHumongousObjects 1048576 90
+ *      gc.g1.TestGreyReclaimedHumongousObjects 1048576 90
  */
 
 // This test spawns a bunch of threads, each of them rapidly

--- a/test/hotspot/jtreg/gc/g1/TestHumongousAllocInitialMark.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousAllocInitialMark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestHumongousAllocInitialMark
  * @bug 7168848
@@ -29,6 +31,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.g1.TestHumongousAllocInitialMark
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/g1/TestHumongousAllocNearlyFullRegion.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousAllocNearlyFullRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestHumongousAllocNearlyFullRegion
  * @bug 8143587
@@ -29,7 +31,7 @@
  * @requires vm.gc.G1
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
- * @run driver TestHumongousAllocNearlyFullRegion
+ * @run driver gc.g1.TestHumongousAllocNearlyFullRegion
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/g1/TestHumongousCodeCacheRoots.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousCodeCacheRoots.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test
  * @key regression gc
@@ -33,7 +35,7 @@
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @summary Humongous objects may have references from the code cache
- * @run main TestHumongousCodeCacheRoots
+ * @run main gc.g1.TestHumongousCodeCacheRoots
 */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/g1/TestHumongousRemsetsMatch.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousRemsetsMatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestHumongousRemSetsMatch
  * @bug 8205426
@@ -30,7 +32,7 @@
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -Xmx512M -Xms512M -Xmn10M -XX:ParallelGCThreads=2 -XX:-UseDynamicNumberOfGCThreads -XX:+UseG1GC -XX:+WhiteBoxAPI -XX:G1HeapRegionSize=1M -XX:+VerifyAfterGC -Xlog:gc,gc+remset+tracking=trace TestHumongousRemsetsMatch
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -Xmx512M -Xms512M -Xmn10M -XX:ParallelGCThreads=2 -XX:-UseDynamicNumberOfGCThreads -XX:+UseG1GC -XX:+WhiteBoxAPI -XX:G1HeapRegionSize=1M -XX:+VerifyAfterGC -Xlog:gc,gc+remset+tracking=trace gc.g1.TestHumongousRemsetsMatch
  */
 
 import sun.hotspot.WhiteBox;

--- a/test/hotspot/jtreg/gc/g1/TestHumongousShrinkHeap.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousShrinkHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /**
  * @test TestHumongousShrinkHeap
  * @bug 8036025 8056043
@@ -32,7 +34,7 @@
  * @modules java.management/sun.management
  * @run main/othervm -XX:-ExplicitGCInvokesConcurrent -XX:MinHeapFreeRatio=10
  * -XX:MaxHeapFreeRatio=12 -XX:+UseG1GC -XX:G1HeapRegionSize=1M -verbose:gc
- * TestHumongousShrinkHeap
+ * gc.g1.TestHumongousShrinkHeap
  */
 
 import com.sun.management.HotSpotDiagnosticMXBean;

--- a/test/hotspot/jtreg/gc/g1/TestInvalidateArrayCopy.java
+++ b/test/hotspot/jtreg/gc/g1/TestInvalidateArrayCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestInvalidateArrayCopy
  * @bug 8182050
@@ -28,7 +30,7 @@
  * @requires vm.gc.G1
  * @requires vm.debug
  * @key gc
- * @run main/othervm -XX:NewSize=1M -Xlog:gc -XX:MaxNewSize=1m -XX:-UseTLAB -XX:OldSize=63M -XX:MaxHeapSize=64M TestInvalidateArrayCopy
+ * @run main/othervm -XX:NewSize=1M -Xlog:gc -XX:MaxNewSize=1m -XX:-UseTLAB -XX:OldSize=63M -XX:MaxHeapSize=64M gc.g1.TestInvalidateArrayCopy
  */
 
 // The test allocates zero-sized arrays of j.l.O and tries to arraycopy random data into it so

--- a/test/hotspot/jtreg/gc/g1/TestJNIWeakG1/TestJNIWeakG1.java
+++ b/test/hotspot/jtreg/gc/g1/TestJNIWeakG1/TestJNIWeakG1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1.TestJNIWeakG1;
+
 /* @test
  * @bug 8166188 8178813
  * @summary Test return of JNI weak global refs during concurrent
@@ -38,13 +40,13 @@
  *    -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *    -XX:+UseG1GC -XX:MaxTenuringThreshold=2
  *    -Xint
- *    TestJNIWeakG1
+ *    gc.g1.TestJNIWeakG1.TestJNIWeakG1
  * @run main/othervm/native
  *    -Xbootclasspath/a:.
  *    -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *    -XX:+UseG1GC -XX:MaxTenuringThreshold=2
  *    -Xcomp
- *    TestJNIWeakG1
+ *    gc.g1.TestJNIWeakG1.TestJNIWeakG1
  */
 
 import sun.hotspot.WhiteBox;

--- a/test/hotspot/jtreg/gc/g1/TestJNIWeakG1/libTestJNIWeakG1.c
+++ b/test/hotspot/jtreg/gc/g1/TestJNIWeakG1/libTestJNIWeakG1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,13 +30,13 @@
 static jweak registered = NULL;
 
 JNIEXPORT void JNICALL
-Java_TestJNIWeakG1_registerObject(JNIEnv* env, jclass jclazz, jobject value) {
+Java_gc_g1_TestJNIWeakG1_TestJNIWeakG1_registerObject(JNIEnv* env, jclass jclazz, jobject value) {
   // assert registered == NULL
   registered = (*env)->NewWeakGlobalRef(env, value);
 }
 
 JNIEXPORT void JNICALL
-Java_TestJNIWeakG1_unregisterObject(JNIEnv* env, jclass jclazz) {
+Java_gc_g1_TestJNIWeakG1_TestJNIWeakG1_unregisterObject(JNIEnv* env, jclass jclazz) {
   if (registered != NULL) {
     (*env)->DeleteWeakGlobalRef(env, registered);
     registered = NULL;
@@ -45,14 +45,14 @@ Java_TestJNIWeakG1_unregisterObject(JNIEnv* env, jclass jclazz) {
 
 // Directly return jweak, to be resolved by native call's return value handling.
 JNIEXPORT jobject JNICALL
-Java_TestJNIWeakG1_getReturnedWeak(JNIEnv* env, jclass jclazz) {
+Java_gc_g1_TestJNIWeakG1_TestJNIWeakG1_getReturnedWeak(JNIEnv* env, jclass jclazz) {
   // assert registered != NULL
   return registered;
 }
 
 // Directly resolve jweak and return the result.
 JNIEXPORT jobject JNICALL
-Java_TestJNIWeakG1_getResolvedWeak(JNIEnv* env, jclass jclazz) {
+Java_gc_g1_TestJNIWeakG1_TestJNIWeakG1_getResolvedWeak(JNIEnv* env, jclass jclazz) {
   // assert registered != NULL
   return (*env)->NewLocalRef(env, registered);
 }

--- a/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
+++ b/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestLargePageUseForAuxMemory.java
  * @summary Test that auxiliary data structures are allocated using large pages if available.
@@ -32,7 +34,7 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xbootclasspath/a:. -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+IgnoreUnrecognizedVMOptions -XX:+UseLargePages TestLargePageUseForAuxMemory
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+IgnoreUnrecognizedVMOptions -XX:+UseLargePages gc.g1.TestLargePageUseForAuxMemory
  */
 
 import java.lang.Math;

--- a/test/hotspot/jtreg/gc/g1/TestNoEagerReclaimOfHumongousRegions.java
+++ b/test/hotspot/jtreg/gc/g1/TestNoEagerReclaimOfHumongousRegions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestNoEagerReclaimOfHumongousRegions
  * @bug 8139424
@@ -34,7 +36,7 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xbootclasspath/a:. -Xlog:gc,gc+humongous=debug -XX:+UseG1GC -XX:MaxTenuringThreshold=0 -XX:G1RSetSparseRegionEntries=32 -XX:G1HeapRegionSize=1m -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestNoEagerReclaimOfHumongousRegions
+ * @run main/othervm -Xbootclasspath/a:. -Xlog:gc,gc+humongous=debug -XX:+UseG1GC -XX:MaxTenuringThreshold=0 -XX:G1RSetSparseRegionEntries=32 -XX:G1HeapRegionSize=1m -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI gc.g1.TestNoEagerReclaimOfHumongousRegions
  */
 
 import java.util.LinkedList;

--- a/test/hotspot/jtreg/gc/g1/TestPLABOutput.java
+++ b/test/hotspot/jtreg/gc/g1/TestPLABOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestPLABOutput
  * @bug 8140585
@@ -31,7 +33,7 @@
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run driver TestPLABOutput
+ * @run driver gc.g1.TestPLABOutput
  */
 
 import sun.hotspot.WhiteBox;

--- a/test/hotspot/jtreg/gc/g1/TestPLABSizeBounds.java
+++ b/test/hotspot/jtreg/gc/g1/TestPLABSizeBounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestPLABSizeBounds
  * @bug 8134857
@@ -30,6 +32,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.g1.TestPLABSizeBounds
  */
 
 import java.util.ArrayList;

--- a/test/hotspot/jtreg/gc/g1/TestParallelAlwaysPreTouch.java
+++ b/test/hotspot/jtreg/gc/g1/TestParallelAlwaysPreTouch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test
  * @key gc regression
@@ -29,7 +31,7 @@
  * Allocates a few humongous objects that will be allocated by expanding the heap, causing concurrent parallel
  * pre-touch.
  * @requires vm.gc.G1
- * @run main/othervm -XX:+UseG1GC -Xms10M -Xmx100m -XX:G1HeapRegionSize=1M -XX:+AlwaysPreTouch -XX:PreTouchParallelChunkSize=512k -Xlog:gc+ergo+heap=debug,gc+heap=debug,gc=debug TestParallelAlwaysPreTouch
+ * @run main/othervm -XX:+UseG1GC -Xms10M -Xmx100m -XX:G1HeapRegionSize=1M -XX:+AlwaysPreTouch -XX:PreTouchParallelChunkSize=512k -Xlog:gc+ergo+heap=debug,gc+heap=debug,gc=debug gc.g1.TestParallelAlwaysPreTouch
  */
 
 public class TestParallelAlwaysPreTouch {

--- a/test/hotspot/jtreg/gc/g1/TestPrintRegionRememberedSetInfo.java
+++ b/test/hotspot/jtreg/gc/g1/TestPrintRegionRememberedSetInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /**
  * @test TestPrintRegionRememberedSetInfo
  * @key gc
@@ -30,7 +32,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main TestPrintRegionRememberedSetInfo
+ * @run main gc.g1.TestPrintRegionRememberedSetInfo
  * @author thomas.schatzl@oracle.com
  */
 

--- a/test/hotspot/jtreg/gc/g1/TestRegionAlignment.java
+++ b/test/hotspot/jtreg/gc/g1/TestRegionAlignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,14 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestRegionAlignment.java
  * @bug 8013791
  * @requires vm.gc.G1
  * @summary Make sure that G1 ergonomics pick a heap size that is aligned with the region size
- * @run main/othervm -XX:+UseG1GC -XX:G1HeapRegionSize=32m -XX:MaxRAM=555m TestRegionAlignment
+ * @run main/othervm -XX:+UseG1GC -XX:G1HeapRegionSize=32m -XX:MaxRAM=555m gc.g1.TestRegionAlignment
  *
  * When G1 ergonomically picks a maximum heap size it must be aligned to the region size.
  * This test tries to get the VM to pick a small and unaligned heap size (by using MaxRAM=555) and a

--- a/test/hotspot/jtreg/gc/g1/TestRegionLivenessPrint.java
+++ b/test/hotspot/jtreg/gc/g1/TestRegionLivenessPrint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestRegionLivenessPrint.java
  * @bug 8151920
@@ -32,7 +34,7 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseG1GC -Xmx128M -XX:G1HeapRegionSize=1m -Xlog:gc+liveness=trace TestRegionLivenessPrint
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseG1GC -Xmx128M -XX:G1HeapRegionSize=1m -Xlog:gc+liveness=trace gc.g1.TestRegionLivenessPrint
  */
 
 import sun.hotspot.WhiteBox;

--- a/test/hotspot/jtreg/gc/g1/TestRemsetLogging.java
+++ b/test/hotspot/jtreg/gc/g1/TestRemsetLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,18 +21,21 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestRemsetLogging.java
  * @requires vm.gc.G1
  * @bug 8013895 8129977 8145534
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @summary Verify output of -Xlog:gc+remset*=trace
- * @run main TestRemsetLogging
+ * @run main gc.g1.TestRemsetLogging
  *
  * Test the output of -Xlog:gc+remset*=trace in conjunction with G1SummarizeRSetStatsPeriod.
  */

--- a/test/hotspot/jtreg/gc/g1/TestRemsetLoggingPerRegion.java
+++ b/test/hotspot/jtreg/gc/g1/TestRemsetLoggingPerRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,18 +21,21 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestRemsetLoggingPerRegion.java
  * @requires vm.gc.G1
  * @bug 8014078 8129977 8145534
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @summary Verify output of -Xlog:gc+remset*=trace in regards to per-region type output
- * @run main TestRemsetLoggingPerRegion
+ * @run main gc.g1.TestRemsetLoggingPerRegion
  */
 
 public class TestRemsetLoggingPerRegion {

--- a/test/hotspot/jtreg/gc/g1/TestRemsetLoggingThreads.java
+++ b/test/hotspot/jtreg/gc/g1/TestRemsetLoggingThreads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestRemsetLoggingThreads
  * @requires vm.gc.G1
@@ -31,6 +33,7 @@
  *          java.management/sun.management
  * @summary Ensure that various values of worker threads/concurrent
  * refinement threads do not crash the VM.
+ * @run main gc.g1.TestRemsetLoggingThreads
  */
 
 import java.util.regex.Matcher;

--- a/test/hotspot/jtreg/gc/g1/TestRemsetLoggingTools.java
+++ b/test/hotspot/jtreg/gc/g1/TestRemsetLoggingTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.g1;
 
 /*
  * Common helpers for TestRemsetLogging* tests

--- a/test/hotspot/jtreg/gc/g1/TestSharedArchiveWithPreTouch.java
+++ b/test/hotspot/jtreg/gc/g1/TestSharedArchiveWithPreTouch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /**
  * @test
  * @bug 8169703
@@ -31,7 +33,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main TestSharedArchiveWithPreTouch
+ * @run main gc.g1.TestSharedArchiveWithPreTouch
  */
 
 import java.util.List;

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.g1;
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.Platform;

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData00.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData00.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /**
  * @test TestShrinkAuxiliaryData00
  * @bug 8038423 8061715
@@ -29,12 +31,13 @@
  * @requires vm.gc.G1
  * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/timeout=720 TestShrinkAuxiliaryData00
+ * @run main/timeout=720 gc.g1.TestShrinkAuxiliaryData00
  */
 public class TestShrinkAuxiliaryData00 {
 

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData05.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData05.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /**
  * @test TestShrinkAuxiliaryData05
  * @bug 8038423 8061715 8078405
@@ -29,12 +31,13 @@
  * @requires vm.gc.G1
  * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/timeout=720 TestShrinkAuxiliaryData05
+ * @run main/timeout=720 gc.g1.TestShrinkAuxiliaryData05
  */
 public class TestShrinkAuxiliaryData05 {
 

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData10.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData10.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /**
  * @test TestShrinkAuxiliaryData10
  * @bug 8038423 8061715 8078405
@@ -29,12 +31,13 @@
  * @requires vm.gc.G1
  * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/timeout=720 TestShrinkAuxiliaryData10
+ * @run main/timeout=720 gc.g1.TestShrinkAuxiliaryData10
  */
 public class TestShrinkAuxiliaryData10 {
 

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData15.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData15.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /**
  * @test TestShrinkAuxiliaryData15
  * @bug 8038423 8061715 8078405
@@ -29,12 +31,13 @@
  * @requires vm.gc.G1
  * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/timeout=720 TestShrinkAuxiliaryData15
+ * @run main/timeout=720 gc.g1.TestShrinkAuxiliaryData15
  */
 public class TestShrinkAuxiliaryData15 {
 

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData20.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData20.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /**
  * @test TestShrinkAuxiliaryData20
  * @bug 8038423 8061715 8078405
@@ -29,12 +31,13 @@
  * @requires vm.gc.G1
  * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
   *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/timeout=720 TestShrinkAuxiliaryData20
+ * @run main/timeout=720 gc.g1.TestShrinkAuxiliaryData20
  */
 public class TestShrinkAuxiliaryData20 {
 

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData25.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData25.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /**
  * @test TestShrinkAuxiliaryData25
  * @bug 8038423 8061715 8078405
@@ -29,12 +31,13 @@
  * @requires vm.gc.G1
  * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/timeout=720 TestShrinkAuxiliaryData25
+ * @run main/timeout=720 gc.g1.TestShrinkAuxiliaryData25
  */
 public class TestShrinkAuxiliaryData25 {
 

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData30.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData30.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /**
  * @test TestShrinkAuxiliaryData30
  * @bug 8038423 8061715 8078405
@@ -29,12 +31,13 @@
  * @requires vm.gc.G1
  * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/timeout=720 TestShrinkAuxiliaryData30
+ * @run main/timeout=720 gc.g1.TestShrinkAuxiliaryData30
  */
 public class TestShrinkAuxiliaryData30 {
 

--- a/test/hotspot/jtreg/gc/g1/TestShrinkDefragmentedHeap.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkDefragmentedHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /**
  * @test TestShrinkDefragmentedHeap
  * @bug 8038423 8129590
@@ -34,6 +36,7 @@
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management/sun.management
+ * @run main gc.g1.TestShrinkDefragmentedHeap
  */
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryUsage;

--- a/test/hotspot/jtreg/gc/g1/TestShrinkToOneRegion.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkToOneRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,14 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestShrinkToOneRegion.java
  * @bug 8013872
  * @requires vm.gc.G1
  * @summary Shrinking the heap down to one region used to hit an assert
- * @run main/othervm -XX:+UseG1GC -XX:G1HeapRegionSize=32m -Xmx256m TestShrinkToOneRegion
+ * @run main/othervm -XX:+UseG1GC -XX:G1HeapRegionSize=32m -Xmx256m gc.g1.TestShrinkToOneRegion
  *
  * Doing a System.gc() without having allocated many objects will shrink the heap.
  * With a large region size we will shrink the heap to one region.

--- a/test/hotspot/jtreg/gc/g1/TestStringDeduplicationAgeThreshold.java
+++ b/test/hotspot/jtreg/gc/g1/TestStringDeduplicationAgeThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestStringDeduplicationAgeThreshold
  * @summary Test string deduplication age threshold
@@ -28,9 +30,11 @@
  * @key gc
  * @requires vm.gc.G1
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
+ * @run main gc.g1.TestStringDeduplicationAgeThreshold
  */
 
 public class TestStringDeduplicationAgeThreshold {

--- a/test/hotspot/jtreg/gc/g1/TestStringDeduplicationFullGC.java
+++ b/test/hotspot/jtreg/gc/g1/TestStringDeduplicationFullGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestStringDeduplicationFullGC
  * @summary Test string deduplication during full GC
@@ -28,9 +30,11 @@
  * @key gc
  * @requires vm.gc.G1
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
+ * @run main gc.g1.TestStringDeduplicationFullGC
  */
 
 public class TestStringDeduplicationFullGC {

--- a/test/hotspot/jtreg/gc/g1/TestStringDeduplicationInterned.java
+++ b/test/hotspot/jtreg/gc/g1/TestStringDeduplicationInterned.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestStringDeduplicationInterned
  * @summary Test string deduplication of interned strings
@@ -28,9 +30,11 @@
  * @key gc
  * @requires vm.gc.G1
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
+ * @run main gc.g1.TestStringDeduplicationInterned
  */
 
 public class TestStringDeduplicationInterned {

--- a/test/hotspot/jtreg/gc/g1/TestStringDeduplicationPrintOptions.java
+++ b/test/hotspot/jtreg/gc/g1/TestStringDeduplicationPrintOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestStringDeduplicationPrintOptions
  * @summary Test string deduplication print options
@@ -28,9 +30,11 @@
  * @key gc
  * @requires vm.gc.G1
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
+ * @run main gc.g1.TestStringDeduplicationPrintOptions
  */
 
 public class TestStringDeduplicationPrintOptions {

--- a/test/hotspot/jtreg/gc/g1/TestStringDeduplicationTableRehash.java
+++ b/test/hotspot/jtreg/gc/g1/TestStringDeduplicationTableRehash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestStringDeduplicationTableRehash
  * @summary Test string deduplication table rehash
@@ -28,9 +30,11 @@
  * @key gc
  * @requires vm.gc.G1
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
+ * @run main gc.g1.TestStringDeduplicationTableRehash
  */
 
 public class TestStringDeduplicationTableRehash {

--- a/test/hotspot/jtreg/gc/g1/TestStringDeduplicationTableResize.java
+++ b/test/hotspot/jtreg/gc/g1/TestStringDeduplicationTableResize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestStringDeduplicationTableResize
  * @summary Test string deduplication table resize
@@ -28,9 +30,11 @@
  * @key gc
  * @requires vm.gc.G1
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
+ * @run main gc.g1.TestStringDeduplicationTableResize
  */
 
 public class TestStringDeduplicationTableResize {

--- a/test/hotspot/jtreg/gc/g1/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/g1/TestStringDeduplicationTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.g1;
 
 /*
  * Common code for string deduplication tests

--- a/test/hotspot/jtreg/gc/g1/TestStringDeduplicationYoungGC.java
+++ b/test/hotspot/jtreg/gc/g1/TestStringDeduplicationYoungGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestStringDeduplicationYoungGC
  * @summary Test string deduplication during young GC
@@ -28,9 +30,11 @@
  * @key gc
  * @requires vm.gc.G1
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
+ * @run main gc.g1.TestStringDeduplicationYoungGC
  */
 
 public class TestStringDeduplicationYoungGC {

--- a/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
+++ b/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.g1;
+
 /*
  * @test TestVerifyGCType
  * @summary Test the VerifyGCType flag to ensure basic functionality.
@@ -29,7 +31,7 @@
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run driver TestVerifyGCType
+ * @run driver gc.g1.TestVerifyGCType
  */
 
 import java.util.ArrayList;

--- a/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
+++ b/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
@@ -12,7 +12,7 @@
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
- * You should have received a copy of the GNU General Public License version
+ * You should have received a copy of the GNU General Public License versionte
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.g1.mixedgc;
 
 /*
  * @test TestOldGenCollectionUsage.java
@@ -32,7 +34,7 @@
  * @modules java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -verbose:gc -XX:SurvivorRatio=1 -Xmx12m -Xms12m -XX:MaxTenuringThreshold=1 -XX:InitiatingHeapOccupancyPercent=100 -XX:-G1UseAdaptiveIHOP -XX:G1MixedGCCountTarget=4 -XX:MaxGCPauseMillis=30000 -XX:G1HeapRegionSize=1m -XX:G1HeapWastePercent=0 -XX:G1MixedGCLiveThresholdPercent=100 TestOldGenCollectionUsage
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -verbose:gc -XX:SurvivorRatio=1 -Xmx12m -Xms12m -XX:MaxTenuringThreshold=1 -XX:InitiatingHeapOccupancyPercent=100 -XX:-G1UseAdaptiveIHOP -XX:G1MixedGCCountTarget=4 -XX:MaxGCPauseMillis=30000 -XX:G1HeapRegionSize=1m -XX:G1HeapWastePercent=0 -XX:G1MixedGCLiveThresholdPercent=100 gc.g1.mixedgc.TestOldGenCollectionUsage
  */
 
 import jdk.test.lib.Asserts;

--- a/test/hotspot/jtreg/gc/logging/TestDeprecatedPrintFlags.java
+++ b/test/hotspot/jtreg/gc/logging/TestDeprecatedPrintFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.logging;
+
 /*
  * @test TestDeprecatedPrintFlags
  * @bug 8145180
@@ -29,6 +31,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.logging.TestDeprecatedPrintFlags
  */
 
 import jdk.test.lib.process.OutputAnalyzer;
@@ -42,7 +45,7 @@ import java.util.stream.Collectors;
 public class TestDeprecatedPrintFlags {
 
     public static void testPrintGC() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintGC", "DoGC");
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintGC", DoGC.class.getName());
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("-XX:+PrintGC is deprecated. Will use -Xlog:gc instead.");
         output.shouldNotContain("PrintGCDetails");
@@ -52,7 +55,7 @@ public class TestDeprecatedPrintFlags {
     }
 
     public static void testPrintGCDetails() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintGCDetails", "DoGC");
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintGCDetails", DoGC.class.getName());
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("-XX:+PrintGCDetails is deprecated. Will use -Xlog:gc* instead.");
         output.shouldNotContain("PrintGC is deprecated");
@@ -63,7 +66,7 @@ public class TestDeprecatedPrintFlags {
 
     public static void testXloggc() throws Exception {
         String fileName = "gc-test.log";
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xloggc:" + fileName, "DoGC");
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xloggc:" + fileName, DoGC.class.getName());
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("-Xloggc is deprecated. Will use -Xlog:gc:gc-test.log instead.");
         output.shouldNotContain("PrintGCDetails");
@@ -80,7 +83,7 @@ public class TestDeprecatedPrintFlags {
 
     public static void testXloggcWithPrintGCDetails() throws Exception {
         String fileName = "gc-test.log";
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintGCDetails", "-Xloggc:" + fileName, "DoGC");
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintGCDetails", "-Xloggc:" + fileName, DoGC.class.getName());
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("-XX:+PrintGCDetails is deprecated. Will use -Xlog:gc* instead.");
         output.shouldContain("-Xloggc is deprecated. Will use -Xlog:gc:gc-test.log instead.");

--- a/test/hotspot/jtreg/gc/logging/TestGCId.java
+++ b/test/hotspot/jtreg/gc/logging/TestGCId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.logging;
+
 /*
  * @test TestGCId
  * @bug 8043607
@@ -32,7 +34,7 @@
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestGCId
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI gc.logging.TestGCId
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
+++ b/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.logging;
+
 /*
  * @test TestPrintReferences
  * @bug 8136991 8186402 8186465 8188245
@@ -29,6 +31,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.logging.TestPrintReferences
  */
 
 import java.lang.ref.SoftReference;

--- a/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
+++ b/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.metaspace;
+
 /**
  * @test CompressedClassSpaceSizeInJmapHeap
  * @bug 8004924
@@ -30,7 +32,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:CompressedClassSpaceSize=50m CompressedClassSpaceSizeInJmapHeap
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:CompressedClassSpaceSize=50m gc.metaspace.CompressedClassSpaceSizeInJmapHeap
  */
 
 import jdk.test.lib.JDKToolLauncher;

--- a/test/hotspot/jtreg/gc/metaspace/G1AddMetaspaceDependency.java
+++ b/test/hotspot/jtreg/gc/metaspace/G1AddMetaspaceDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,15 @@
  * questions.
  */
 
+package gc.metaspace;
+
 /*
  * @test G1AddMetaspaceDependency
  * @bug 8010196
  * @requires vm.gc.G1
+ * @library /
  * @summary Checks that we don't get locking problems when adding metaspace dependencies with the G1 update buffer monitor
- * @run main/othervm -XX:+UseG1GC -XX:G1UpdateBufferSize=1 G1AddMetaspaceDependency
+ * @run main/othervm -XX:+UseG1GC -XX:G1UpdateBufferSize=1 gc.metaspace.G1AddMetaspaceDependency
  */
 
 import java.io.InputStream;
@@ -47,12 +50,12 @@ public class G1AddMetaspaceDependency {
     }
   }
 
-  static final String a_name = G1AddMetaspaceDependency.class.getName() + "$A";
-  static final String b_name = G1AddMetaspaceDependency.class.getName() + "$B";
+  static final String a_name = A.class.getName();
+  static final String b_name = B.class.getName();
 
   public static void main(String... args) throws Exception {
-    final byte[] a_bytes = getClassBytes(a_name + ".class");
-    final byte[] b_bytes = getClassBytes(b_name + ".class");
+    final byte[] a_bytes = getClassBytes(a_name.replace('.', '/') + ".class");
+    final byte[] b_bytes = getClassBytes(b_name.replace('.', '/') + ".class");
 
     for (int i = 0; i < 1000; i += 1) {
       runTest(a_bytes, b_bytes);

--- a/test/hotspot/jtreg/gc/metaspace/InputArguments.java
+++ b/test/hotspot/jtreg/gc/metaspace/InputArguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.metaspace;
 
 import java.lang.management.RuntimeMXBean;
 import java.lang.management.ManagementFactory;

--- a/test/hotspot/jtreg/gc/metaspace/TestCapacityUntilGCWrapAround.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestCapacityUntilGCWrapAround.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.metaspace;
+
 /*
  * @test
  * @key gc
@@ -31,7 +33,7 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI TestCapacityUntilGCWrapAround
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI gc.metaspace.TestCapacityUntilGCWrapAround
  */
 
 import sun.hotspot.WhiteBox;

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspaceCMSCancel.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspaceCMSCancel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.metaspace;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Asserts;
@@ -33,7 +35,7 @@ import sun.hotspot.WhiteBox;
  * @modules java.base/jdk.internal.misc
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm TestMetaspaceCMSCancel
+ * @run main/othervm gc.metaspace.TestMetaspaceCMSCancel
  */
 
 

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspaceInitialization.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspaceInitialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,15 @@
  * questions.
  */
 
+package gc.metaspace;
+
 import java.util.ArrayList;
 
 /* @test TestMetaspaceInitialization
  * @bug 8024945
  * @summary Tests to initialize metaspace with a very low MetaspaceSize
  * @modules java.base/jdk.internal.misc
- * @run main/othervm -XX:MetaspaceSize=0 TestMetaspaceInitialization
+ * @run main/othervm -XX:MetaspaceSize=0 gc.metaspace.TestMetaspaceInitialization
  */
 public class TestMetaspaceInitialization {
     private class Internal {

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspaceMemoryPool.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspaceMemoryPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.metaspace;
+
 import java.util.List;
 import java.lang.management.*;
 import jdk.test.lib.Platform;
@@ -34,12 +36,13 @@ import static jdk.test.lib.Asserts.*;
  *          MemoryManagerMXBean is created.
  * @requires vm.bits == 64 & vm.opt.final.UseCompressedOops == true
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops TestMetaspaceMemoryPool
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:MaxMetaspaceSize=60m TestMetaspaceMemoryPool
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers TestMetaspaceMemoryPool
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:CompressedClassSpaceSize=60m TestMetaspaceMemoryPool
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops gc.metaspace.TestMetaspaceMemoryPool
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:MaxMetaspaceSize=60m gc.metaspace.TestMetaspaceMemoryPool
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers gc.metaspace.TestMetaspaceMemoryPool
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:CompressedClassSpaceSize=60m gc.metaspace.TestMetaspaceMemoryPool
  */
 public class TestMetaspaceMemoryPool {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.metaspace;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.util.List;
@@ -45,13 +47,13 @@ import gc.testlibrary.PerfCounters;
  *          java.compiler
  *          java.management/sun.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UsePerfData -XX:+UseSerialGC TestMetaspacePerfCounters
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UsePerfData -XX:+UseParallelGC -XX:+UseParallelOldGC TestMetaspacePerfCounters
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UsePerfData -XX:+UseG1GC TestMetaspacePerfCounters
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UsePerfData -XX:+UseSerialGC gc.metaspace.TestMetaspacePerfCounters
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UsePerfData -XX:+UseParallelGC -XX:+UseParallelOldGC gc.metaspace.TestMetaspacePerfCounters
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UsePerfData -XX:+UseG1GC gc.metaspace.TestMetaspacePerfCounters
  *
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UsePerfData -XX:+UseSerialGC TestMetaspacePerfCounters
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UsePerfData -XX:+UseParallelGC -XX:+UseParallelOldGC TestMetaspacePerfCounters
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UsePerfData -XX:+UseG1GC TestMetaspacePerfCounters
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UsePerfData -XX:+UseSerialGC gc.metaspace.TestMetaspacePerfCounters
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UsePerfData -XX:+UseParallelGC -XX:+UseParallelOldGC gc.metaspace.TestMetaspacePerfCounters
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UsePerfData -XX:+UseG1GC gc.metaspace.TestMetaspacePerfCounters
  */
 
 /* @test TestMetaspacePerfCountersShenandoah
@@ -64,8 +66,8 @@ import gc.testlibrary.PerfCounters;
  *          java.compiler
  *          java.management/sun.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UsePerfData -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC TestMetaspacePerfCounters
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UsePerfData -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC TestMetaspacePerfCounters
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UsePerfData -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC gc.metaspace.TestMetaspacePerfCounters
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UsePerfData -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC gc.metaspace.TestMetaspacePerfCounters
  */
 public class TestMetaspacePerfCounters {
     public static Class fooClass = null;

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspaceSizeFlags.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspaceSizeFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.metaspace;
+
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -33,6 +35,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.metaspace.TestMetaspaceSizeFlags
  */
 public class TestMetaspaceSizeFlags {
   public static final long K = 1024L;

--- a/test/hotspot/jtreg/gc/metaspace/TestPerfCountersAndMemoryPools.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestPerfCountersAndMemoryPools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.metaspace;
+
 import java.util.List;
 import java.lang.management.*;
 
@@ -38,8 +40,8 @@ import gc.testlibrary.PerfCounters;
  * @modules java.base/jdk.internal.misc
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint TestPerfCountersAndMemoryPools
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint TestPerfCountersAndMemoryPools
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint gc.metaspace.TestPerfCountersAndMemoryPools
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UseSerialGC -XX:+UsePerfData -Xint gc.metaspace.TestPerfCountersAndMemoryPools
  */
 public class TestPerfCountersAndMemoryPools {
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/gc/parallel/AdaptiveGCBoundary.java
+++ b/test/hotspot/jtreg/gc/parallel/AdaptiveGCBoundary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.parallel;
+
 /**
  * @test AdaptiveGCBoundary
  * @key gc regression
@@ -29,7 +31,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm AdaptiveGCBoundary
+ * @run main/othervm gc.parallel.AdaptiveGCBoundary
  * @author jon.masamitsu@oracle.com
  */
 

--- a/test/hotspot/jtreg/gc/parallel/TestDynShrinkHeap.java
+++ b/test/hotspot/jtreg/gc/parallel/TestDynShrinkHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.parallel;
+
 /**
  * @test TestDynShrinkHeap
  * @bug 8016479
@@ -29,7 +31,7 @@
  * @modules java.base/jdk.internal.misc
  * @modules jdk.management
  * @library /test/lib /
- * @run main/othervm -XX:+UseAdaptiveSizePolicyWithSystemGC -XX:+UseParallelGC -XX:MinHeapFreeRatio=0 -XX:MaxHeapFreeRatio=100 -Xmx1g -verbose:gc TestDynShrinkHeap
+ * @run main/othervm -XX:+UseAdaptiveSizePolicyWithSystemGC -XX:+UseParallelGC -XX:MinHeapFreeRatio=0 -XX:MaxHeapFreeRatio=100 -Xmx1g -verbose:gc gc.parallel.TestDynShrinkHeap
  */
 import jdk.test.lib.management.DynamicVMOption;
 import java.lang.management.ManagementFactory;

--- a/test/hotspot/jtreg/gc/parallel/TestPrintGCDetailsVerbose.java
+++ b/test/hotspot/jtreg/gc/parallel/TestPrintGCDetailsVerbose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.parallel;
+
 /*
  * @test TestPrintGCDetailsVerbose
  * @bug 8016740 8177963
@@ -28,8 +30,8 @@
  * @key gc
  * @requires vm.gc.Parallel
  * @modules java.base/jdk.internal.misc
- * @run main/othervm -Xmx50m -XX:+UseParallelGC -Xlog:gc*=trace TestPrintGCDetailsVerbose
- * @run main/othervm -Xmx50m -XX:+UseParallelGC -XX:GCTaskTimeStampEntries=1 -Xlog:gc*=trace TestPrintGCDetailsVerbose
+ * @run main/othervm -Xmx50m -XX:+UseParallelGC -Xlog:gc*=trace gc.parallel.TestPrintGCDetailsVerbose
+ * @run main/othervm -Xmx50m -XX:+UseParallelGC -XX:GCTaskTimeStampEntries=1 -Xlog:gc*=trace gc.parallel.TestPrintGCDetailsVerbose
  */
 public class TestPrintGCDetailsVerbose {
 

--- a/test/hotspot/jtreg/gc/serial/HeapChangeLogging.java
+++ b/test/hotspot/jtreg/gc/serial/HeapChangeLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.serial;
+
 /*
  * @test HeapChangeLogging.java
  * @bug 8027440
@@ -28,7 +30,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @summary Allocate to get a promotion failure and verify that that heap change logging is present.
- * @run main HeapChangeLogging
+ * @run main gc.serial.HeapChangeLogging
  */
 
 import java.util.regex.Matcher;
@@ -39,7 +41,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class HeapChangeLogging {
   public static void main(String[] args) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xmx128m", "-Xmn100m", "-XX:+UseSerialGC", "-Xlog:gc", "HeapFiller");
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xmx128m", "-Xmn100m", "-XX:+UseSerialGC", "-Xlog:gc", HeapFiller.class.getName());
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     String stdout = output.getStdout();
     System.out.println(stdout);

--- a/test/hotspot/jtreg/gc/shenandoah/jni/CriticalNative.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/CriticalNative.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Red Hat, Inc. and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,31 +22,15 @@
  * questions.
  */
 
-package gc.startup_warnings;
+package gc.shenandoah.jni;
 
-/*
-* @test TestParallelScavengeSerialOld
-* @key gc
-* @bug 8006398
-* @summary Test that the ParallelScavenge+SerialOld combination does not print a warning message
-* @library /test/lib
-* @modules java.base/jdk.internal.misc
-*          java.management
-* @run main gc.startup_warnings.TestParallelScavengeSerialOld
-*/
+public class CriticalNative {
+    static {
+        System.loadLibrary("CriticalNative");
+    }
 
-import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.process.OutputAnalyzer;
-
-
-public class TestParallelScavengeSerialOld {
-
-  public static void main(String args[]) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+UseParallelGC", "-XX:-UseParallelOldGC", "-version");
-    OutputAnalyzer output = new OutputAnalyzer(pb.start());
-    output.shouldNotContain("deprecated");
-    output.shouldNotContain("error");
-    output.shouldHaveExitValue(0);
-  }
-
+    public static native boolean isNull(int[] a);
+    public static native long sum1(long[] a);
+    // More than 6 parameters
+    public static native long sum2(long a1, int[] a2, int[] a3, long[] a4, int[] a5);
 }

--- a/test/hotspot/jtreg/gc/shenandoah/jni/CriticalNativeArgs.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/CriticalNativeArgs.java
@@ -21,17 +21,20 @@
  *
  */
 
+package gc.shenandoah.jni;
+
 /* @test
+ * @library /
  * @requires (os.arch =="x86_64" | os.arch == "amd64" | os.arch=="x86" | os.arch=="i386") & !vm.graal.enabled & vm.gc.Shenandoah
  *
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive    -XX:+ShenandoahDegeneratedGC -Xcomp -Xmx512M -XX:+CriticalJNINatives CriticalNativeArgs
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive    -XX:-ShenandoahDegeneratedGC -Xcomp -Xmx512M -XX:+CriticalJNINatives CriticalNativeArgs
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive    -XX:+ShenandoahDegeneratedGC -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeArgs
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive    -XX:-ShenandoahDegeneratedGC -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeArgs
  *
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive -Xcomp -Xmx512M -XX:+CriticalJNINatives CriticalNativeArgs
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeArgs
  *
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC                                                                        -Xcomp -Xmx256M -XX:+CriticalJNINatives CriticalNativeArgs
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+UnlockExperimentalVMOptions -XX:ShenandoahGCMode=iu        -Xcomp -Xmx512M -XX:+CriticalJNINatives CriticalNativeArgs
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+UnlockExperimentalVMOptions -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive -Xcomp -Xmx512M -XX:+CriticalJNINatives CriticalNativeArgs
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC                                                                        -Xcomp -Xmx256M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeArgs
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+UnlockExperimentalVMOptions -XX:ShenandoahGCMode=iu        -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeArgs
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+UnlockExperimentalVMOptions -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeArgs
  */
 public class CriticalNativeArgs {
     static {

--- a/test/hotspot/jtreg/gc/shenandoah/jni/CriticalNativeStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/CriticalNativeStress.java
@@ -21,19 +21,23 @@
  *
  */
 
+package gc.shenandoah.jni;
+
 import java.util.Random;
+
+import gc.shenandoah.jni.CriticalNative;
 
 /* @test
  * @requires (os.arch =="x86_64" | os.arch == "amd64" | os.arch=="x86" | os.arch=="i386") & !vm.graal.enabled & vm.gc.Shenandoah
  *
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive    -XX:+ShenandoahDegeneratedGC -Xcomp -Xmx512M -XX:+CriticalJNINatives CriticalNativeStress
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive    -XX:-ShenandoahDegeneratedGC -Xcomp -Xmx512M -XX:+CriticalJNINatives CriticalNativeStress
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive    -XX:+ShenandoahDegeneratedGC -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeStress
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive    -XX:-ShenandoahDegeneratedGC -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeStress
  *
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive -Xcomp -Xmx512M -XX:+CriticalJNINatives CriticalNativeStress
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeStress
  *
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC                                       -Xcomp -Xmx256M -XX:+CriticalJNINatives CriticalNativeStress
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu        -Xcomp -Xmx512M -XX:+CriticalJNINatives CriticalNativeStress
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive -Xcomp -Xmx512M -XX:+CriticalJNINatives CriticalNativeStress
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC                                       -Xcomp -Xmx256M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeStress
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu        -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeStress
+ * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeStress
  */
 public class CriticalNativeStress {
     private static Random rand = new Random();

--- a/test/hotspot/jtreg/gc/shenandoah/jni/libCriticalNative.c
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/libCriticalNative.c
@@ -23,7 +23,7 @@
 
 #include "jni.h"
 
-JNIEXPORT jlong JNICALL JavaCritical_CriticalNativeStress_sum1
+JNIEXPORT jlong JNICALL JavaCritical_gc_shenandoah_jni_CriticalNative_sum1
   (jint length, jlong* a) {
   jlong sum = 0;
   jint index;
@@ -34,7 +34,7 @@ JNIEXPORT jlong JNICALL JavaCritical_CriticalNativeStress_sum1
   return sum;
 }
 
-JNIEXPORT jlong JNICALL  JavaCritical_CriticalNativeStress_sum2
+JNIEXPORT jlong JNICALL  JavaCritical_gc_shenandoah_jni_CriticalNative_sum2
   (jlong a1, jint a2_length, jint* a2, jint a4_length, jint* a4, jint a6_length, jlong* a6, jint a8_length, jint* a8) {
   jlong sum = a1;
   jint index;
@@ -56,7 +56,7 @@ JNIEXPORT jlong JNICALL  JavaCritical_CriticalNativeStress_sum2
   return sum;
 }
 
-JNIEXPORT jlong JNICALL Java_CriticalNativeStress_sum1
+JNIEXPORT jlong JNICALL Java_gc_shenandoah_jni_CriticalNative_sum1
   (JNIEnv *env, jclass jclazz, jlongArray a) {
   jlong sum = 0;
   jsize len = (*env)->GetArrayLength(env, a);
@@ -70,7 +70,7 @@ JNIEXPORT jlong JNICALL Java_CriticalNativeStress_sum1
   return sum;
 }
 
-JNIEXPORT jlong JNICALL Java_CriticalNativeStress_sum2
+JNIEXPORT jlong JNICALL Java_gc_shenandoah_jni_CriticalNative_sum2
   (JNIEnv *env, jclass jclazz, jlong a1, jintArray a2, jintArray a3, jlongArray a4, jintArray a5) {
   jlong sum = a1;
   jsize index;
@@ -105,12 +105,12 @@ JNIEXPORT jlong JNICALL Java_CriticalNativeStress_sum2
   return sum;
 }
 
-JNIEXPORT jboolean JNICALL JavaCritical_CriticalNativeArgs_isNull
+JNIEXPORT jboolean JNICALL JavaCritical_gc_shenandoah_jni_CriticalNative_isNull
   (jint length, jint* a) {
   return (a == NULL) && (length == 0);
 }
 
-JNIEXPORT jboolean JNICALL Java_CriticalNativeArgs_isNull
+JNIEXPORT jboolean JNICALL Java_gc_shenandoah_jni_CriticalNative_isNull
   (JNIEnv *env, jclass jclazz, jintArray a) {
   jboolean is_null;
   jsize len = (*env)->GetArrayLength(env, a);

--- a/test/hotspot/jtreg/gc/startup_warnings/TestCMS.java
+++ b/test/hotspot/jtreg/gc/startup_warnings/TestCMS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.startup_warnings;
+
 /*
  * @test TestCMS
  * @key gc
@@ -30,6 +32,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @run main gc.startup_warnings.TestCMS
  */
 
 import jdk.test.lib.process.ProcessTools;

--- a/test/hotspot/jtreg/gc/startup_warnings/TestG1.java
+++ b/test/hotspot/jtreg/gc/startup_warnings/TestG1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.startup_warnings;
+
 /*
 * @test TestG1
 * @key gc
@@ -29,6 +31,7 @@
 * @library /test/lib
 * @modules java.base/jdk.internal.misc
 *          java.management
+* @run main gc.startup_warnings.TestG1
 */
 
 import jdk.test.lib.process.ProcessTools;

--- a/test/hotspot/jtreg/gc/startup_warnings/TestParallelGC.java
+++ b/test/hotspot/jtreg/gc/startup_warnings/TestParallelGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.startup_warnings;
+
 /*
 * @test TestParallelGC
 * @key gc
@@ -29,6 +31,7 @@
 * @library /test/lib
 * @modules java.base/jdk.internal.misc
 *          java.management
+* @run main gc.startup_warnings.TestParallelGC
 */
 
 import jdk.test.lib.process.ProcessTools;

--- a/test/hotspot/jtreg/gc/startup_warnings/TestSerialGC.java
+++ b/test/hotspot/jtreg/gc/startup_warnings/TestSerialGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.startup_warnings;
+
 /*
 * @test TestSerialGC
 * @key gc
@@ -29,6 +31,7 @@
 * @library /test/lib
 * @modules java.base/jdk.internal.misc
 *          java.management
+* @run main gc.startup_warnings.TestSerialGC
 */
 
 import jdk.test.lib.process.ProcessTools;

--- a/test/hotspot/jtreg/gc/startup_warnings/TestShenandoah.java
+++ b/test/hotspot/jtreg/gc/startup_warnings/TestShenandoah.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.startup_warnings;
+
 /*
 * @test TestShenandoah
 * @key gc
@@ -30,6 +32,7 @@
 * @library /test/lib
 * @modules java.base/jdk.internal.misc
 *          java.management
+* @run main gc.startup_warnings.TestShenandoah
 */
 
 import jdk.test.lib.process.ProcessTools;

--- a/test/hotspot/jtreg/gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java
+++ b/test/hotspot/jtreg/gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, SAP SE and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -22,12 +22,14 @@
  * questions.
  */
 
+package gc.stress.TestJNIBlockFullGC;
+
 /*
  * @test TestJNIBlockFullGC
  * @summary Check that in G1 a Full GC to reclaim space can not be blocked out by the GC locker.
  * @key gc
  * @requires vm.gc.G1
- * @run main/othervm/native -Xmx64m -XX:+UseG1GC -Xlog:gc=info,gc+alloc=trace -XX:MaxGCPauseMillis=10 TestJNIBlockFullGC 10 10000 10000 10000 30000 10000 0.7
+ * @run main/othervm/native -Xmx64m -XX:+UseG1GC -Xlog:gc=info,gc+alloc=trace -XX:MaxGCPauseMillis=10 gc.stress.TestJNIBlockFullGC.TestJNIBlockFullGC 10 10000 10000 10000 30000 10000 0.7
  */
 
 import java.lang.ref.SoftReference;

--- a/test/hotspot/jtreg/gc/stress/TestMultiThreadStressRSet.java
+++ b/test/hotspot/jtreg/gc/stress/TestMultiThreadStressRSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.stress;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -43,15 +45,15 @@ import sun.hotspot.WhiteBox;
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+UseG1GC -XX:G1SummarizeRSetStatsPeriod=1 -Xlog:gc
- *   -Xmx500m -XX:G1HeapRegionSize=1m -XX:MaxGCPauseMillis=1000 TestMultiThreadStressRSet 10 4
+ *   -Xmx500m -XX:G1HeapRegionSize=1m -XX:MaxGCPauseMillis=1000 gc.stress.TestMultiThreadStressRSet 10 4
  *
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+UseG1GC -XX:G1SummarizeRSetStatsPeriod=100 -Xlog:gc
- *   -Xmx1G -XX:G1HeapRegionSize=8m -XX:MaxGCPauseMillis=1000 TestMultiThreadStressRSet 60 16
+ *   -Xmx1G -XX:G1HeapRegionSize=8m -XX:MaxGCPauseMillis=1000 gc.stress.TestMultiThreadStressRSet 60 16
  *
  * @run main/othervm/timeout=700 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+UseG1GC -XX:G1SummarizeRSetStatsPeriod=100 -Xlog:gc
- *   -Xmx500m -XX:G1HeapRegionSize=1m -XX:MaxGCPauseMillis=1000 TestMultiThreadStressRSet 600 32
+ *   -Xmx500m -XX:G1HeapRegionSize=1m -XX:MaxGCPauseMillis=1000 gc.stress.TestMultiThreadStressRSet 600 32
  */
 public class TestMultiThreadStressRSet {
 

--- a/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
+++ b/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.stress;
+
 /*
  * @test TestReclaimStringsLeaksMemory
  * @bug 8180048
@@ -29,12 +31,12 @@
  * @key gc
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run main/othervm TestReclaimStringsLeaksMemory
- * @run main/othervm TestReclaimStringsLeaksMemory -XX:+UseSerialGC
- * @run main/othervm TestReclaimStringsLeaksMemory -XX:+UseParallelGC
- * @run main/othervm TestReclaimStringsLeaksMemory -XX:+UseParallelGC -XX:-UseParallelOldGC
- * @run main/othervm TestReclaimStringsLeaksMemory -XX:+UseConcMarkSweepGC
- * @run main/othervm TestReclaimStringsLeaksMemory -XX:+UseG1GC
+ * @run main/othervm gc.stress.TestReclaimStringsLeaksMemory
+ * @run main/othervm gc.stress.TestReclaimStringsLeaksMemory -XX:+UseSerialGC
+ * @run main/othervm gc.stress.TestReclaimStringsLeaksMemory -XX:+UseParallelGC
+ * @run main/othervm gc.stress.TestReclaimStringsLeaksMemory -XX:+UseParallelGC -XX:-UseParallelOldGC
+ * @run main/othervm gc.stress.TestReclaimStringsLeaksMemory -XX:+UseConcMarkSweepGC
+ * @run main/othervm gc.stress.TestReclaimStringsLeaksMemory -XX:+UseG1GC
  */
 
 import java.util.Arrays;

--- a/test/hotspot/jtreg/gc/stress/TestStressG1Humongous.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressG1Humongous.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.stress;
+
 /*
  * @test TestStressG1Humongous
  * @key gc stress
@@ -29,7 +31,7 @@
  * @requires !vm.flightRecorder
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run driver/timeout=1300 TestStressG1Humongous
+ * @run driver/timeout=1300 gc.stress.TestStressG1Humongous
  */
 
 import java.util.ArrayList;

--- a/test/hotspot/jtreg/gc/stress/TestStressIHOPMultiThread.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressIHOPMultiThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.stress;
+
  /*
  * @test TestStressIHOPMultiThread
  * @bug 8148397
@@ -31,27 +33,27 @@
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=1m -XX:+G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread1.log
  *              -Dtimeout=2 -DheapUsageMinBound=30 -DheapUsageMaxBound=80
- *              -Dthreads=2 TestStressIHOPMultiThread
+ *              -Dthreads=2 gc.stress.TestStressIHOPMultiThread
  * @run main/othervm/timeout=200 -Xmx256m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=2m -XX:+G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread2.log
  *              -Dtimeout=2 -DheapUsageMinBound=60 -DheapUsageMaxBound=90
- *              -Dthreads=3 TestStressIHOPMultiThread
+ *              -Dthreads=3 gc.stress.TestStressIHOPMultiThread
  * @run main/othervm/timeout=200 -Xmx256m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=4m -XX:-G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread3.log
  *              -Dtimeout=2 -DheapUsageMinBound=40 -DheapUsageMaxBound=90
- *              -Dthreads=5 TestStressIHOPMultiThread
+ *              -Dthreads=5 gc.stress.TestStressIHOPMultiThread
  * @run main/othervm/timeout=200 -Xmx128m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=8m -XX:+G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread4.log
  *              -Dtimeout=2 -DheapUsageMinBound=20 -DheapUsageMaxBound=90
- *              -Dthreads=10 TestStressIHOPMultiThread
+ *              -Dthreads=10 gc.stress.TestStressIHOPMultiThread
  * @run main/othervm/timeout=200 -Xmx512m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:+G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread5.log
  *              -Dtimeout=2 -DheapUsageMinBound=20 -DheapUsageMaxBound=90
- *              -Dthreads=17 TestStressIHOPMultiThread
+ *              -Dthreads=17 gc.stress.TestStressIHOPMultiThread
  */
 
 import java.util.ArrayList;

--- a/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.stress;
+
 import java.util.concurrent.TimeoutException;
 import sun.hotspot.WhiteBox;
 
@@ -41,27 +43,27 @@ import sun.hotspot.WhiteBox;
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx500m -XX:G1HeapRegionSize=1m TestStressRSetCoarsening  1  0 300
+ *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening  1  0 300
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx500m -XX:G1HeapRegionSize=8m TestStressRSetCoarsening  1 10 300
+ *     -Xmx500m -XX:G1HeapRegionSize=8m gc.stress.TestStressRSetCoarsening  1 10 300
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx500m -XX:G1HeapRegionSize=32m TestStressRSetCoarsening 42 10 300
+ *     -Xmx500m -XX:G1HeapRegionSize=32m gc.stress.TestStressRSetCoarsening 42 10 300
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx500m -XX:G1HeapRegionSize=1m TestStressRSetCoarsening  2 0 300
+ *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening  2 0 300
  * @run main/othervm/timeout=1800
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx1G -XX:G1HeapRegionSize=1m TestStressRSetCoarsening 500 0  1800
+ *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 500 0  1800
  * @run main/othervm/timeout=1800
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx1G -XX:G1HeapRegionSize=1m TestStressRSetCoarsening 10  10 1800
+ *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 10  10 1800
  */
 
 /**

--- a/test/hotspot/jtreg/gc/stress/gcbasher/ByteCursor.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/ByteCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  *
  */
+
+package gc.stress.gcbasher;
 
 class ByteCursor {
     private int offset;

--- a/test/hotspot/jtreg/gc/stress/gcbasher/Bytecode.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/Bytecode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  *
  */
+
+package gc.stress.gcbasher;
 
 class Bytecode {
     public static final int IINC               = 132;

--- a/test/hotspot/jtreg/gc/stress/gcbasher/ClassInfo.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/ClassInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  *
  */
+
+package gc.stress.gcbasher;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/test/hotspot/jtreg/gc/stress/gcbasher/ConstantPoolEntry.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/ConstantPoolEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  *
  */
+
+package gc.stress.gcbasher;
 
 class ConstantPoolEntry {
     private int index;

--- a/test/hotspot/jtreg/gc/stress/gcbasher/Decompiler.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/Decompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  *
  */
+
+package gc.stress.gcbasher;
 
 class Decompiler {
     private ByteCursor cursor;

--- a/test/hotspot/jtreg/gc/stress/gcbasher/Dependency.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/Dependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  *
  */
+
+package gc.stress.gcbasher;
 
 class Dependency {
     private String methodName;

--- a/test/hotspot/jtreg/gc/stress/gcbasher/MethodInfo.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/MethodInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  *
  */
+
+package gc.stress.gcbasher;
 
 class MethodInfo {
     private String name;

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasher.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  *
  */
+
+package gc.stress.gcbasher;
 
 import java.io.IOException;
 import java.net.URI;

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithAllocateHeapAt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,18 @@
  *
  */
 
+package gc.stress.gcbasher;
+
 import java.io.IOException;
 
 /*
  * @test TestGCBasherWithAllocateHeapAt
  * @key gc stress
+ * @library /
  * @requires vm.gc.G1
  * @requires vm.flavor == "server" & !vm.emulatedClient & os.family != "aix"
  * @summary Stress Java heap allocation with AllocateHeapAt flag using GC basher.
- * @run main/othervm/timeout=500 -Xlog:gc*=info -Xmx256m -server -XX:+UseG1GC -XX:AllocateHeapAt=. TestGCBasherWithAllocateHeapAt 120000
+ * @run main/othervm/timeout=500 -Xlog:gc*=info -Xmx256m -server -XX:+UseG1GC -XX:AllocateHeapAt=. gc.stress.gcbasher.TestGCBasherWithAllocateHeapAt 120000
  */
 public class TestGCBasherWithAllocateHeapAt {
     public static void main(String[] args) throws IOException {

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithCMS.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithCMS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,18 @@
  *
  */
 
+package gc.stress.gcbasher;
+
 import java.io.IOException;
 
 /*
  * @test TestGCBasherWithCMS
  * @key gc stress
+ * @library /
  * @requires vm.gc.ConcMarkSweep
  * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
  * @summary Stress the CMS GC by trying to make old objects more likely to be garbage than young objects.
- * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -server -XX:+UseConcMarkSweepGC TestGCBasherWithCMS 120000
+ * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -server -XX:+UseConcMarkSweepGC gc.stress.gcbasher.TestGCBasherWithCMS 120000
  */
 public class TestGCBasherWithCMS {
     public static void main(String[] args) throws IOException {

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithG1.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithG1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,18 @@
  *
  */
 
+package gc.stress.gcbasher;
+
 import java.io.IOException;
 
 /*
  * @test TestGCBasherWithG1
  * @key gc stress
+ * @library /
  * @requires vm.gc.G1
  * @requires vm.flavor == "server" & !vm.emulatedClient
  * @summary Stress the G1 GC by trying to make old objects more likely to be garbage than young objects.
- * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -server -XX:+UseG1GC TestGCBasherWithG1 120000
+ * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -server -XX:+UseG1GC gc.stress.gcbasher.TestGCBasherWithG1 120000
  */
 public class TestGCBasherWithG1 {
     public static void main(String[] args) throws IOException {

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithParallel.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithParallel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,18 @@
  *
  */
 
+package gc.stress.gcbasher;
+
 import java.io.IOException;
 
 /*
  * @test TestGCBasherWithParallel
  * @key gc stress
+ * @library /
  * @requires vm.gc.Parallel
  * @requires vm.flavor == "server" & !vm.emulatedClient
  * @summary Stress the Parallel GC by trying to make old objects more likely to be garbage than young objects.
- * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -server -XX:+UseParallelGC -XX:-UseGCOverheadLimit TestGCBasherWithParallel 120000
+ * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -server -XX:+UseParallelGC -XX:-UseGCOverheadLimit gc.stress.gcbasher.TestGCBasherWithParallel 120000
  */
 public class TestGCBasherWithParallel {
     public static void main(String[] args) throws IOException {

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithSerial.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithSerial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,18 @@
  *
  */
 
+package gc.stress.gcbasher;
+
 import java.io.IOException;
 
 /*
  * @test TestGCBasherWithSerial
  * @key gc stress
+ * @library /
  * @requires vm.gc.Serial
  * @requires vm.flavor == "server" & !vm.emulatedClient
  * @summary Stress the Serial GC by trying to make old objects more likely to be garbage than young objects.
- * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -server -XX:+UseSerialGC TestGCBasherWithSerial 120000
+ * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx256m -server -XX:+UseSerialGC gc.stress.gcbasher.TestGCBasherWithSerial 120000
  */
 public class TestGCBasherWithSerial {
     public static void main(String[] args) throws IOException {

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithShenandoah.java
@@ -21,6 +21,8 @@
  *
  */
 
+package gc.stress.gcbasher;
+
 import java.io.IOException;
 
 /*
@@ -34,12 +36,12 @@ import java.io.IOException;
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
  *      -XX:+ShenandoahVerify -XX:+ShenandoahDegeneratedGC
- *      TestGCBasherWithShenandoah 120000
+ *      gc.stress.gcbasher.TestGCBasherWithShenandoah 120000
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
  *      -XX:+ShenandoahVerify -XX:-ShenandoahDegeneratedGC
- *      TestGCBasherWithShenandoah 120000
+ *      gc.stress.gcbasher.TestGCBasherWithShenandoah 120000
  */
 
 /*
@@ -54,16 +56,16 @@ import java.io.IOException;
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
  *      -XX:+ShenandoahOOMDuringEvacALot
- *      TestGCBasherWithShenandoah 120000
+ *      gc.stress.gcbasher.TestGCBasherWithShenandoah 120000
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
  *      -XX:+ShenandoahAllocFailureALot
- *      TestGCBasherWithShenandoah 120000
+ *      gc.stress.gcbasher.TestGCBasherWithShenandoah 120000
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
- *      TestGCBasherWithShenandoah 120000
+ *      gc.stress.gcbasher.TestGCBasherWithShenandoah 120000
  */
 
 /*
@@ -78,11 +80,11 @@ import java.io.IOException;
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
  *      -XX:+ShenandoahVerify
- *      TestGCBasherWithShenandoah 120000
+ *      gc.stress.gcbasher.TestGCBasherWithShenandoah 120000
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
- *      TestGCBasherWithShenandoah 120000
+ *      gc.stress.gcbasher.TestGCBasherWithShenandoah 120000
  */
 
 /*
@@ -96,7 +98,7 @@ import java.io.IOException;
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact
- *      TestGCBasherWithShenandoah 120000
+ *      gc.stress.gcbasher.TestGCBasherWithShenandoah 120000
  */
 
 /*
@@ -111,16 +113,16 @@ import java.io.IOException;
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
  *      -XX:+ShenandoahOOMDuringEvacALot
- *      TestGCBasherWithShenandoah 120000
+ *      gc.stress.gcbasher.TestGCBasherWithShenandoah 120000
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
  *      -XX:+ShenandoahAllocFailureALot
- *      TestGCBasherWithShenandoah 120000
+ *      gc.stress.gcbasher.TestGCBasherWithShenandoah 120000
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
- *      TestGCBasherWithShenandoah 120000
+ *      gc.stress.gcbasher.TestGCBasherWithShenandoah 120000
  */
 
 /*
@@ -135,11 +137,11 @@ import java.io.IOException;
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
  *      -XX:+ShenandoahVerify
- *      TestGCBasherWithShenandoah 120000
+ *      gc.stress.gcbasher.TestGCBasherWithShenandoah 120000
  *
  * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
- *      TestGCBasherWithShenandoah 120000
+ *      gc.stress.gcbasher.TestGCBasherWithShenandoah 120000
  */
 public class TestGCBasherWithShenandoah {
     public static void main(String[] args) throws IOException {

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithZ.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithZ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,15 +22,18 @@
  *
  */
 
+package gc.stress.gcbasher;
+
 import java.io.IOException;
 
 /*
  * @test TestGCBasherWithZ
  * @key gc stress
+ * @library /
  * @requires vm.gc.Z
  * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
  * @summary Stress ZGC
- * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx384m -server -XX:+UnlockExperimentalVMOptions -XX:+UseZGC TestGCBasherWithZ 120000
+ * @run main/othervm/timeout=200 -Xlog:gc*=info -Xmx384m -server -XX:+UnlockExperimentalVMOptions -XX:+UseZGC gc.stress.gcbasher.TestGCBasherWithZ 120000
  */
 public class TestGCBasherWithZ {
     public static void main(String[] args) throws IOException {

--- a/test/hotspot/jtreg/gc/stress/gclocker/TestGCLocker.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestGCLocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  *
  */
+
+package gc.stress.gclocker;
 
 // Stress the GC locker by calling GetPrimitiveArrayCritical while
 // concurrently filling up old gen.

--- a/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithCMS.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithCMS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,15 @@
  *
  */
 
+package gc.stress.gclocker;
+
 /*
  * @test TestGCLockerWithCMS
  * @key gc
+ * @library /
  * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @summary Stress CMS' GC locker by calling GetPrimitiveArrayCritical while concurrently filling up old gen.
- * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UseConcMarkSweepGC TestGCLockerWithCMS
+ * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UseConcMarkSweepGC gc.stress.gclocker.TestGCLockerWithCMS
  */
 public class TestGCLockerWithCMS {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithG1.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithG1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,15 @@
  *
  */
 
+package gc.stress.gclocker;
+
 /*
  * @test TestGCLockerWithG1
  * @key gc
+ * @library /
  * @requires vm.gc.G1
  * @summary Stress G1's GC locker by calling GetPrimitiveArrayCritical while concurrently filling up old gen.
- * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UseG1GC TestGCLockerWithG1
+ * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UseG1GC gc.stress.gclocker.TestGCLockerWithG1
  */
 public class TestGCLockerWithG1 {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithParallel.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithParallel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,15 @@
  *
  */
 
+package gc.stress.gclocker;
+
 /*
  * @test TestGCLockerWithParallel
  * @key gc
+ * @library /
  * @requires vm.gc.Parallel
  * @summary Stress Parallel's GC locker by calling GetPrimitiveArrayCritical while concurrently filling up old gen.
- * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UseParallelGC TestGCLockerWithParallel
+ * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UseParallelGC gc.stress.gclocker.TestGCLockerWithParallel
  */
 public class TestGCLockerWithParallel {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithSerial.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithSerial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,16 @@
  *
  */
 
+package gc.stress.gclocker;
+
 /*
  * @test TestGCLockerWithSerial
  * @key gc
+ * @library /
  * @requires vm.gc.Serial
  * @requires vm.flavor != "minimal"
  * @summary Stress Serial's GC locker by calling GetPrimitiveArrayCritical while concurrently filling up old gen.
- * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UseSerialGC TestGCLockerWithSerial
+ * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UseSerialGC gc.stress.gclocker.TestGCLockerWithSerial
  */
 public class TestGCLockerWithSerial {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithShenandoah.java
@@ -22,6 +22,8 @@
  *
  */
 
+package gc.stress.gclocker;
+
 /*
  * @test TestGCLockerWithShenandoah
  * @key gc
@@ -31,11 +33,11 @@
  * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
  *      -XX:+UseShenandoahGC
  *      -XX:+ShenandoahVerify
- *      TestGCLockerWithShenandoah
+ *      gc.stress.gclocker.TestGCLockerWithShenandoah
  *
  * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
  *      -XX:+UseShenandoahGC
- *      TestGCLockerWithShenandoah
+ *      gc.stress.gclocker.TestGCLockerWithShenandoah
  */
 
 /*
@@ -47,12 +49,12 @@
  * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
  *      -XX:+ShenandoahOOMDuringEvacALot
- *      TestGCLockerWithShenandoah
+ *      gc.stress.gclocker.TestGCLockerWithShenandoah
  *
  * @run main/native/othervm/timeout=200 -Xlog:gc*=info -Xms1500m -Xmx1500m -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
  *      -XX:+ShenandoahAllocFailureALot
- *      TestGCLockerWithShenandoah
+ *      gc.stress.gclocker.TestGCLockerWithShenandoah
  */
 public class TestGCLockerWithShenandoah {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/gc/stress/gclocker/libTestGCLocker.c
+++ b/test/hotspot/jtreg/gc/stress/gclocker/libTestGCLocker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 #include <jni.h>
 
 JNIEXPORT void JNICALL
-Java_GCLockerStresser_fillWithRandomValues(JNIEnv* env, jclass clz, jbyteArray arr) {
+Java_gc_stress_gclocker_GCLockerStresser_fillWithRandomValues(JNIEnv* env, jclass clz, jbyteArray arr) {
   jsize size = (*env)->GetArrayLength(env, arr);
   jbyte* p = (*env)->GetPrimitiveArrayCritical(env, arr, NULL);
   jsize i;

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOld.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.stress.gcold;
 
 import java.text.*;
 import java.util.Random;

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithCMS.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithCMS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,15 @@
  *
  */
 
+package gc.stress.gcold;
+
 /*
  * @test TestGCOldWithCMS
  * @key gc
+ * @library /
  * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @summary Stress the CMS GC by trying to make old objects more likely to be garbage than young objects.
- * @run main/othervm -Xmx384M -XX:+UseConcMarkSweepGC TestGCOldWithCMS 50 1 20 10 10000
+ * @run main/othervm -Xmx384M -XX:+UseConcMarkSweepGC gc.stress.gcold.TestGCOldWithCMS 50 1 20 10 10000
  */
 public class TestGCOldWithCMS {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithG1.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithG1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,14 +22,17 @@
  *
  */
 
+package gc.stress.gcold;
+
 /*
  * @test TestGCOldWithG1
  * @key gc
+ * @library /
  * @requires vm.gc.G1
  * @summary Stress the G1 GC by trying to make old objects more likely to be garbage than young objects.
- * @run main/othervm -Xmx384M -XX:+UseG1GC TestGCOldWithG1 50 1 20 10 10000
- * @run main/othervm -Xms64m -Xmx128m -XX:+UseG1GC -XX:+UseDynamicNumberOfGCThreads -Xlog:gc,gc+task=trace TestGCOldWithG1 50 5 20 1 5000
- * @run main/othervm -Xms64m -Xmx128m -XX:+UseG1GC -XX:+UseDynamicNumberOfGCThreads  -XX:+UnlockDiagnosticVMOptions -XX:+InjectGCWorkerCreationFailure -Xlog:gc,gc+task=trace TestGCOldWithG1 50 5 20 1 5000
+ * @run main/othervm -Xmx384M -XX:+UseG1GC gc.stress.gcold.TestGCOldWithG1 50 1 20 10 10000
+ * @run main/othervm -Xms64m -Xmx128m -XX:+UseG1GC -XX:+UseDynamicNumberOfGCThreads -Xlog:gc,gc+task=trace gc.stress.gcold.TestGCOldWithG1 50 5 20 1 5000
+ * @run main/othervm -Xms64m -Xmx128m -XX:+UseG1GC -XX:+UseDynamicNumberOfGCThreads  -XX:+UnlockDiagnosticVMOptions -XX:+InjectGCWorkerCreationFailure -Xlog:gc,gc+task=trace gc.stress.gcold.TestGCOldWithG1 50 5 20 1 5000
  */
 public class TestGCOldWithG1 {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithParallel.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithParallel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,16 @@
  *
  */
 
+package gc.stress.gcold;
+
 /*
  * @test TestGCOldWithParallel
  * @key gc
+ * @library /
  * @requires vm.gc.Parallel
  * @summary Stress the Parallel GC by trying to make old objects more likely to be garbage than young objects.
- * @run main/othervm -Xmx384M -XX:+UseParallelGC TestGCOld 50 1 20 10 10000
- * @run main/othervm -Xmx384M -XX:+UseParallelGC -XX:-UseParallelOldGC TestGCOld 50 1 20 10 10000
+ * @run main/othervm -Xmx384M -XX:+UseParallelGC gc.stress.gcold.TestGCOld 50 1 20 10 10000
+ * @run main/othervm -Xmx384M -XX:+UseParallelGC -XX:-UseParallelOldGC gc.stress.gcold.TestGCOld 50 1 20 10 10000
  */
 public class TestGCOldWithParallel {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithSerial.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithSerial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,12 +22,15 @@
  *
  */
 
+package gc.stress.gcold;
+
 /*
  * @test TestGCOldWithSerial
  * @key gc
+ * @library /
  * @requires vm.gc.Serial
  * @summary Stress the Serial GC by trying to make old objects more likely to be garbage than young objects.
- * @run main/othervm -Xmx384M -XX:+UseSerialGC TestGCOldWithSerial 50 1 20 10 10000
+ * @run main/othervm -Xmx384M -XX:+UseSerialGC gc.stress.gcold.TestGCOldWithSerial 50 1 20 10 10000
  */
 public class TestGCOldWithSerial {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithShenandoah.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -21,32 +21,35 @@
 * questions.
 */
 
+package gc.stress.gcold;
+
 /*
  * @test TestGCOldWithShenandoah
  * @key gc
  * @key stress
+ * @library /
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @summary Stress the GC by trying to make old objects more likely to be garbage than young objects.
  *
  * @run main/othervm/timeout=600 -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
  *      -XX:+ShenandoahDegeneratedGC -XX:+ShenandoahVerify
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  *
  * @run main/othervm/timeout=600 -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
  *      -XX:-ShenandoahDegeneratedGC -XX:+ShenandoahVerify
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  *
  * @run main/othervm/timeout=600 -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
  *      -XX:+ShenandoahDegeneratedGC
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  *
  * @run main/othervm/timeout=600 -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
  *      -XX:-ShenandoahDegeneratedGC
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  */
 
 /*
@@ -60,16 +63,16 @@
  * @run main/othervm -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
  *      -XX:+ShenandoahOOMDuringEvacALot
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  *
  * @run main/othervm -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
  *      -XX:+ShenandoahAllocFailureALot
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  *
  * @run main/othervm -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  */
 
 /*
@@ -82,11 +85,11 @@
  * @run main/othervm/timeout=600 -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
  *      -XX:+ShenandoahVerify
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  *
  * @run main/othervm -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  */
 
 /*
@@ -98,7 +101,7 @@
  *
  * @run main/othervm -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  */
 
 /*
@@ -112,16 +115,16 @@
  * @run main/othervm -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
  *      -XX:+ShenandoahOOMDuringEvacALot
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  *
  * @run main/othervm -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
  *      -XX:+ShenandoahAllocFailureALot
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  *
  * @run main/othervm -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  */
 
 /*
@@ -134,11 +137,11 @@
  * @run main/othervm/timeout=600 -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
  *      -XX:+ShenandoahVerify
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  *
  * @run main/othervm -Xmx384M -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
- *      TestGCOld 50 1 20 10 10000
+ *      gc.stress.gcold.TestGCOld 50 1 20 10 10000
  */
 
 public class TestGCOldWithShenandoah {

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithZ.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithZ.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,16 @@
  *
  */
 
+package gc.stress.gcold;
+
 /*
  * @test TestGCOldWithZ
  * @key gc
+ * @library /
  * @requires vm.gc.Z & !vm.graal.enabled
  * @summary Stress the Z
- * @run main/othervm -Xmx384M -XX:+UnlockExperimentalVMOptions -XX:+UseZGC TestGCOldWithZ 50 1 20 10 10000
- * @run main/othervm -Xmx256m -XX:+UnlockExperimentalVMOptions -XX:+UseZGC TestGCOldWithZ 50 5 20 1 5000
+ * @run main/othervm -Xmx384M -XX:+UnlockExperimentalVMOptions -XX:+UseZGC gc.stress.gcold.TestGCOldWithZ 50 1 20 10 10000
+ * @run main/othervm -Xmx256m -XX:+UnlockExperimentalVMOptions -XX:+UseZGC gc.stress.gcold.TestGCOldWithZ 50 5 20 1 5000
  */
 public class TestGCOldWithZ {
     public static void main(String[] args) {

--- a/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.stress.systemgc;
 
 // A test that stresses a full GC by allocating objects of different lifetimes
 // and concurrently calling System.gc().

--- a/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithCMS.java
+++ b/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithCMS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,16 @@
  *
  */
 
+package gc.stress.systemgc;
+
 /*
  * @test TestSystemGCWithCMS
  * @key gc stress
  * @bug 8190703
+ * @library /
  * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @summary Stress the CMS GC full GC by allocating objects of different lifetimes concurrently with System.gc().
- * @run main/othervm/timeout=300 -Xlog:gc*=info -Xmx512m -XX:+UseConcMarkSweepGC TestSystemGCWithCMS 270
+ * @run main/othervm/timeout=300 -Xlog:gc*=info -Xmx512m -XX:+UseConcMarkSweepGC gc.stress.systemgc.TestSystemGCWithCMS 270
  */
 public class TestSystemGCWithCMS {
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithG1.java
+++ b/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithG1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,16 @@
  *
  */
 
+package gc.stress.systemgc;
+
 /*
  * @test TestSystemGCWithG1
  * @key gc stress
  * @bug 8190703
+ * @library /
  * @requires vm.gc.G1
  * @summary Stress the G1 GC full GC by allocating objects of different lifetimes concurrently with System.gc().
- * @run main/othervm/timeout=300 -Xlog:gc*=info -Xmx512m -XX:+UseG1GC TestSystemGCWithG1 270
+ * @run main/othervm/timeout=300 -Xlog:gc*=info -Xmx512m -XX:+UseG1GC gc.stress.systemgc.TestSystemGCWithG1 270
  */
 public class TestSystemGCWithG1 {
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithParallel.java
+++ b/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithParallel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,16 @@
  *
  */
 
+package gc.stress.systemgc;
+
 /*
  * @test TestSystemGCWithParallel
  * @key gc stress
  * @bug 8190703
+ * @library /
  * @requires vm.gc.Parallel
  * @summary Stress the Parallel GC full GC by allocating objects of different lifetimes concurrently with System.gc().
- * @run main/othervm/timeout=300 -Xlog:gc=info -Xmx512m -XX:+UseParallelGC TestSystemGCWithParallel 270
+ * @run main/othervm/timeout=300 -Xlog:gc=info -Xmx512m -XX:+UseParallelGC gc.stress.systemgc.TestSystemGCWithParallel 270
  */
 public class TestSystemGCWithParallel {
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithSerial.java
+++ b/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithSerial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,16 @@
  *
  */
 
+package gc.stress.systemgc;
+
 /*
  * @test TestSystemGCWithSerial
  * @key gc stress
  * @bug 8190703
+ * @library /
  * @requires vm.gc.Serial
  * @summary Stress the Serial GC full GC by allocating objects of different lifetimes concurrently with System.gc().
- * @run main/othervm/timeout=300 -Xlog:gc*=info -Xmx512m -XX:+UseSerialGC TestSystemGCWithSerial 270
+ * @run main/othervm/timeout=300 -Xlog:gc*=info -Xmx512m -XX:+UseSerialGC gc.stress.systemgc.TestSystemGCWithSerial 270
  */
 public class TestSystemGCWithSerial {
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithShenandoah.java
@@ -22,6 +22,8 @@
  *
  */
 
+package gc.stress.systemgc;
+
 /*
  * @test TestSystemGCWithShenandoah
  * @key gc
@@ -32,11 +34,11 @@
  * @run main/othervm/timeout=300 -Xlog:gc*=info -Xmx512m -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
  *      -XX:+UseShenandoahGC
  *      -XX:+ShenandoahVerify
- *      TestSystemGCWithShenandoah 270
+ *      gc.stress.systemgc.TestSystemGCWithShenandoah 270
  *
  * @run main/othervm/timeout=300 -Xlog:gc*=info -Xmx512m -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
  *      -XX:+UseShenandoahGC
- *      TestSystemGCWithShenandoah 270
+ *      gc.stress.systemgc.TestSystemGCWithShenandoah 270
  */
 
 /*
@@ -50,7 +52,7 @@
  * @run main/othervm/timeout=300 -Xlog:gc*=info -Xmx512m -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
  *      -XX:+ShenandoahVerify
- *      TestSystemGCWithShenandoah 270
+ *      gc.stress.systemgc.TestSystemGCWithShenandoah 270
  *
  */
 public class TestSystemGCWithShenandoah {

--- a/test/hotspot/jtreg/gc/survivorAlignment/AlignmentHelper.java
+++ b/test/hotspot/jtreg/gc/survivorAlignment/AlignmentHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.survivorAlignment;
 
 import java.lang.management.MemoryPoolMXBean;
 import java.util.Optional;

--- a/test/hotspot/jtreg/gc/survivorAlignment/SurvivorAlignmentTestMain.java
+++ b/test/hotspot/jtreg/gc/survivorAlignment/SurvivorAlignmentTestMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+package gc.survivorAlignment;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryPoolMXBean;

--- a/test/hotspot/jtreg/gc/survivorAlignment/TestAllocationInEden.java
+++ b/test/hotspot/jtreg/gc/survivorAlignment/TestAllocationInEden.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.survivorAlignment;
+
 /**
  * @test
  * @bug 8031323
@@ -28,6 +30,7 @@
  *          SurvivorAlignmentInBytes option.
  * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
@@ -39,42 +42,42 @@
  *                   -XX:SurvivorAlignmentInBytes=32 -XX:-UseTLAB -XX:-ResizePLAB
  *                   -XX:OldSize=128m -XX:MaxHeapSize=192m
  *                   -XX:-ExplicitGCInvokesConcurrent
- *                   TestAllocationInEden 10m 9 EDEN
+ *                   gc.survivorAlignment.TestAllocationInEden 10m 9 EDEN
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=64m -XX:MaxNewSize=64m
  *                   -XX:SurvivorRatio=1 -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=32 -XX:-UseTLAB -XX:-ResizePLAB
  *                   -XX:OldSize=128m -XX:MaxHeapSize=192m
  *                   -XX:-ExplicitGCInvokesConcurrent
- *                   TestAllocationInEden 10m 47 EDEN
+ *                   gc.survivorAlignment.TestAllocationInEden 10m 47 EDEN
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=64m -XX:MaxNewSize=64m
  *                   -XX:SurvivorRatio=1 -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=64 -XX:-UseTLAB -XX:-ResizePLAB
  *                   -XX:OldSize=128m  -XX:MaxHeapSize=192m
  *                   -XX:-ExplicitGCInvokesConcurrent
- *                   TestAllocationInEden 10m 9 EDEN
+ *                   gc.survivorAlignment.TestAllocationInEden 10m 9 EDEN
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=64m -XX:MaxNewSize=64m
  *                   -XX:SurvivorRatio=1 -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=64 -XX:-UseTLAB -XX:-ResizePLAB
  *                   -XX:OldSize=128m  -XX:MaxHeapSize=192m
  *                   -XX:-ExplicitGCInvokesConcurrent
- *                   TestAllocationInEden 10m 87 EDEN
+ *                   gc.survivorAlignment.TestAllocationInEden 10m 87 EDEN
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=64m -XX:MaxNewSize=64m
  *                   -XX:SurvivorRatio=1 -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=128 -XX:-UseTLAB -XX:-ResizePLAB
  *                   -XX:OldSize=128m -XX:MaxHeapSize=192m
  *                   -XX:-ExplicitGCInvokesConcurrent
- *                   TestAllocationInEden 10m 9 EDEN
+ *                   gc.survivorAlignment.TestAllocationInEden 10m 9 EDEN
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=64m -XX:MaxNewSize=64m
  *                   -XX:SurvivorRatio=1 -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=128 -XX:-UseTLAB -XX:-ResizePLAB
  *                   -XX:OldSize=128m -XX:MaxHeapSize=192m
  *                   -XX:-ExplicitGCInvokesConcurrent
- *                   TestAllocationInEden 10m 147 EDEN
+ *                   gc.survivorAlignment.TestAllocationInEden 10m 147 EDEN
  */
 public class TestAllocationInEden {
     public static void main(String args[]) {

--- a/test/hotspot/jtreg/gc/survivorAlignment/TestPromotionFromEdenToTenured.java
+++ b/test/hotspot/jtreg/gc/survivorAlignment/TestPromotionFromEdenToTenured.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.survivorAlignment;
+
 /**
  * @test
  * @bug 8031323
@@ -28,6 +30,7 @@
  *          full GC are not aligned to SurvivorAlignmentInBytes value.
  * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
@@ -39,42 +42,42 @@
  *                   -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=32
- *                   TestPromotionFromEdenToTenured 10m 9 TENURED
+ *                   gc.survivorAlignment.TestPromotionFromEdenToTenured 10m 9 TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=64m -XX:MaxNewSize=64m
  *                   -XX:OldSize=32m -XX:MaxHeapSize=96m -XX:SurvivorRatio=1
  *                   -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=32
- *                   TestPromotionFromEdenToTenured 10m 47 TENURED
+ *                   gc.survivorAlignment.TestPromotionFromEdenToTenured 10m 47 TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=64m -XX:MaxNewSize=64m
  *                   -XX:OldSize=32m  -XX:MaxHeapSize=96m
  *                   -XX:SurvivorRatio=1 -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=64
- *                   TestPromotionFromEdenToTenured 10m 9 TENURED
+ *                   gc.survivorAlignment.TestPromotionFromEdenToTenured 10m 9 TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=64m -XX:MaxNewSize=64m
  *                   -XX:OldSize=32m -XX:MaxHeapSize=128m
  *                   -XX:SurvivorRatio=1 -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=64
- *                   TestPromotionFromEdenToTenured 10m 87 TENURED
+ *                   gc.survivorAlignment.TestPromotionFromEdenToTenured 10m 87 TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=64m -XX:MaxNewSize=64m
  *                   -XX:OldSize=32M -XX:MaxHeapSize=96m -XX:SurvivorRatio=1
  *                   -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=128
- *                   TestPromotionFromEdenToTenured 10m 9 TENURED
+ *                   gc.survivorAlignment.TestPromotionFromEdenToTenured 10m 9 TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=64m -XX:MaxNewSize=64m
  *                   -XX:OldSize=32m -XX:MaxHeapSize=96m -XX:SurvivorRatio=1
  *                   -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=128
- *                   TestPromotionFromEdenToTenured 10m 147 TENURED
+ *                   gc.survivorAlignment.TestPromotionFromEdenToTenured 10m 147 TENURED
  */
 public class TestPromotionFromEdenToTenured {
     public static void main(String args[]) {

--- a/test/hotspot/jtreg/gc/survivorAlignment/TestPromotionFromSurvivorToTenuredAfterFullGC.java
+++ b/test/hotspot/jtreg/gc/survivorAlignment/TestPromotionFromSurvivorToTenuredAfterFullGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.survivorAlignment;
+
 /**
  * @test
  * @bug 8031323
@@ -28,6 +30,7 @@
  *          during full GC are not aligned to SurvivorAlignmentInBytes value.
  * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build sun.hotspot.WhiteBox
@@ -39,14 +42,14 @@
  *                   -XX:SurvivorRatio=1 -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=32
- *                   TestPromotionFromSurvivorToTenuredAfterFullGC 10m 9 TENURED
+ *                   gc.survivorAlignment.TestPromotionFromSurvivorToTenuredAfterFullGC 10m 9 TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=128m -XX:MaxNewSize=128m
  *                   -XX:OldSize=32m -XX:MaxHeapSize=160m -XX:-ResizePLAB
  *                   -XX:SurvivorRatio=1 -XX:-ExplicitGCInvokesConcurrent
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=32
- *                   TestPromotionFromSurvivorToTenuredAfterFullGC 20m 47
+ *                   gc.survivorAlignment.TestPromotionFromSurvivorToTenuredAfterFullGC 20m 47
  *                   TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=200m -XX:MaxNewSize=200m
@@ -54,14 +57,14 @@
  *                   -XX:SurvivorRatio=1 -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=64
- *                   TestPromotionFromSurvivorToTenuredAfterFullGC 10m 9 TENURED
+ *                   gc.survivorAlignment.TestPromotionFromSurvivorToTenuredAfterFullGC 10m 9 TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=128m -XX:MaxNewSize=128m
  *                   -XX:OldSize=32m -XX:MaxHeapSize=160m
  *                   -XX:SurvivorRatio=1 -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=64
- *                   TestPromotionFromSurvivorToTenuredAfterFullGC 20m 87
+ *                   gc.survivorAlignment.TestPromotionFromSurvivorToTenuredAfterFullGC 20m 87
  *                   TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=256m -XX:MaxNewSize=256m
@@ -69,7 +72,7 @@
  *                   -XX:SurvivorRatio=1 -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=128
- *                    TestPromotionFromSurvivorToTenuredAfterFullGC 10m 9
+ *                    gc.survivorAlignment.TestPromotionFromSurvivorToTenuredAfterFullGC 10m 9
  *                    TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=128m -XX:MaxNewSize=128m
@@ -77,7 +80,7 @@
  *                   -XX:SurvivorRatio=1 -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=128
- *                   TestPromotionFromSurvivorToTenuredAfterFullGC 20m 147
+ *                   gc.survivorAlignment.TestPromotionFromSurvivorToTenuredAfterFullGC 20m 147
  *                   TENURED
  */
 public class TestPromotionFromSurvivorToTenuredAfterFullGC {

--- a/test/hotspot/jtreg/gc/survivorAlignment/TestPromotionFromSurvivorToTenuredAfterMinorGC.java
+++ b/test/hotspot/jtreg/gc/survivorAlignment/TestPromotionFromSurvivorToTenuredAfterMinorGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.survivorAlignment;
+
 /**
  * @test
  * @bug 8031323
@@ -40,7 +42,7 @@
  *                   -XX:-ExplicitGCInvokesConcurrent
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=32
- *                   TestPromotionFromSurvivorToTenuredAfterMinorGC 10m 9
+ *                   gc.survivorAlignment.TestPromotionFromSurvivorToTenuredAfterMinorGC 10m 9
  *                   TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=128m -XX:MaxNewSize=128m
@@ -48,7 +50,7 @@
  *                   -XX:-ExplicitGCInvokesConcurrent
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=32
- *                   TestPromotionFromSurvivorToTenuredAfterMinorGC 20m 47
+ *                   gc.survivorAlignment.TestPromotionFromSurvivorToTenuredAfterMinorGC 20m 47
  *                   TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=200m -XX:MaxNewSize=200m
@@ -56,7 +58,7 @@
  *                   -XX:-ExplicitGCInvokesConcurrent
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=64
- *                   TestPromotionFromSurvivorToTenuredAfterMinorGC 10m 9
+ *                   gc.survivorAlignment.TestPromotionFromSurvivorToTenuredAfterMinorGC 10m 9
  *                   TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=128m -XX:MaxNewSize=128m
@@ -64,7 +66,7 @@
  *                   -XX:-ExplicitGCInvokesConcurrent
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=64
- *                   TestPromotionFromSurvivorToTenuredAfterMinorGC 20m 87
+ *                   gc.survivorAlignment.TestPromotionFromSurvivorToTenuredAfterMinorGC 20m 87
  *                   TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=256m -XX:MaxNewSize=256m
@@ -72,7 +74,7 @@
  *                   -XX:-ExplicitGCInvokesConcurrent
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=128
- *                    TestPromotionFromSurvivorToTenuredAfterMinorGC 10m 9
+ *                    gc.survivorAlignment.TestPromotionFromSurvivorToTenuredAfterMinorGC 10m 9
  *                    TENURED
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=128m -XX:MaxNewSize=128m
@@ -80,7 +82,7 @@
  *                   -XX:-ExplicitGCInvokesConcurrent
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=128
- *                   TestPromotionFromSurvivorToTenuredAfterMinorGC 20m 147
+ *                   gc.survivorAlignment.TestPromotionFromSurvivorToTenuredAfterMinorGC 20m 147
  *                   TENURED
  */
 public class TestPromotionFromSurvivorToTenuredAfterMinorGC {

--- a/test/hotspot/jtreg/gc/survivorAlignment/TestPromotionLABLargeSurvivorAlignment.java
+++ b/test/hotspot/jtreg/gc/survivorAlignment/TestPromotionLABLargeSurvivorAlignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.survivorAlignment;
+
 /**
  * @test
  * @bug 8060463
@@ -31,32 +33,32 @@
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=8 -XX:SurvivorRatio=1
  *                   -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
- *                   TestPromotionLABLargeSurvivorAlignment
+ *                   gc.survivorAlignment.TestPromotionLABLargeSurvivorAlignment
  * @run main/othervm -Xmx128m
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=16 -XX:SurvivorRatio=1
  *                   -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
- *                   TestPromotionLABLargeSurvivorAlignment
+ *                   gc.survivorAlignment.TestPromotionLABLargeSurvivorAlignment
  * @run main/othervm -Xmx128m
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=512 -XX:SurvivorRatio=1
  *                   -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
- *                   TestPromotionLABLargeSurvivorAlignment
+ *                   gc.survivorAlignment.TestPromotionLABLargeSurvivorAlignment
  * @run main/othervm -Xmx128m
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=1k -XX:SurvivorRatio=1
  *                   -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
- *                   TestPromotionLABLargeSurvivorAlignment
+ *                   gc.survivorAlignment.TestPromotionLABLargeSurvivorAlignment
  * @run main/othervm -Xmx128m
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=4k -XX:SurvivorRatio=1
  *                   -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
- *                   TestPromotionLABLargeSurvivorAlignment
+ *                   gc.survivorAlignment.TestPromotionLABLargeSurvivorAlignment
  * @run main/othervm -Xmx128m
  *                   -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=16k -XX:SurvivorRatio=1
  *                   -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
- *                   TestPromotionLABLargeSurvivorAlignment
+ *                   gc.survivorAlignment.TestPromotionLABLargeSurvivorAlignment
  */
 public class TestPromotionLABLargeSurvivorAlignment {
     public static void main(String args[]) {

--- a/test/hotspot/jtreg/gc/survivorAlignment/TestPromotionToSurvivor.java
+++ b/test/hotspot/jtreg/gc/survivorAlignment/TestPromotionToSurvivor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.survivorAlignment;
+
 /**
  * @test
  * @bug 8031323
@@ -38,37 +40,37 @@
  *                   -XX:SurvivorRatio=1 -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=32 -XX:OldSize=128m
  *                   -XX:MaxHeapSize=256m -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
- *                   TestPromotionToSurvivor 10m 9 SURVIVOR
+ *                   gc.survivorAlignment.TestPromotionToSurvivor 10m 9 SURVIVOR
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=128m -XX:MaxNewSize=128m
  *                   -XX:SurvivorRatio=1 -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=32 -XX:OldSize=128m
  *                   -XX:MaxHeapSize=256m -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
- *                   TestPromotionToSurvivor 20m 47 SURVIVOR
+ *                   gc.survivorAlignment.TestPromotionToSurvivor 20m 47 SURVIVOR
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=128m -XX:MaxNewSize=128m
  *                   -XX:SurvivorRatio=1 -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=64 -XX:OldSize=128m
  *                   -XX:MaxHeapSize=256m -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
- *                   TestPromotionToSurvivor 8m 9 SURVIVOR
+ *                   gc.survivorAlignment.TestPromotionToSurvivor 8m 9 SURVIVOR
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=128m -XX:MaxNewSize=128m
  *                   -XX:SurvivorRatio=1 -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=64 -XX:OldSize=128m
  *                   -XX:MaxHeapSize=256m -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
- *                   TestPromotionToSurvivor 20m 87 SURVIVOR
+ *                   gc.survivorAlignment.TestPromotionToSurvivor 20m 87 SURVIVOR
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=256m -XX:MaxNewSize=256m
  *                   -XX:SurvivorRatio=1 -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=128 -XX:OldSize=128m
  *                   -XX:MaxHeapSize=384m  -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
- *                   TestPromotionToSurvivor 10m 9 SURVIVOR
+ *                   gc.survivorAlignment.TestPromotionToSurvivor 10m 9 SURVIVOR
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:NewSize=128m -XX:MaxNewSize=128m
  *                   -XX:SurvivorRatio=1 -XX:+UnlockExperimentalVMOptions
  *                   -XX:SurvivorAlignmentInBytes=128 -XX:OldSize=128m
  *                   -XX:MaxHeapSize=256m -XX:-ExplicitGCInvokesConcurrent -XX:-ResizePLAB
- *                   TestPromotionToSurvivor 20m 147 SURVIVOR
+ *                   gc.survivorAlignment.TestPromotionToSurvivor 20m 147 SURVIVOR
  */
 public class TestPromotionToSurvivor {
     public static void main(String args[]) {

--- a/test/hotspot/jtreg/gc/whitebox/TestConcMarkCycleWB.java
+++ b/test/hotspot/jtreg/gc/whitebox/TestConcMarkCycleWB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.whitebox;
+
 /*
  * @test TestConMarkCycleWB
  * @bug 8065579
@@ -33,7 +35,7 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseG1GC TestConcMarkCycleWB
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseG1GC gc.whitebox.TestConcMarkCycleWB
  * @summary Verifies that ConcurrentMarking-related WB works properly
  */
 import static jdk.test.lib.Asserts.assertFalse;

--- a/test/hotspot/jtreg/gc/whitebox/TestWBGC.java
+++ b/test/hotspot/jtreg/gc/whitebox/TestWBGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package gc.whitebox;
+
 /*
  * @test TestWBGC
  * @bug 8055098
@@ -31,7 +33,7 @@
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run driver TestWBGC
+ * @run driver gc.whitebox.TestWBGC
  */
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.ProcessTools;


### PR DESCRIPTION
I want to backport this ot simplify follow-up test backports.

I had to do a row of straight-forward edits:


The backport of shenandoah put the CriticalNative tests
into a different location. This affects four files in this patch.

test/hotspot/jtreg/gc/CriticalNative.java
I moved this to gc/shenandoah/jni because the other
critical native test are located there, too.

test/hotspot/jtreg/gc/CriticalNativeArgs.java is at different 
location in 11. Applied the patch to 
test/hotspot/jtreg/gc/shenandoah/jni/CriticalNativeArgs.java

Additional @run commands had to be edited:
 test/hotspot/jtreg/gc/TestFullGCALot.java

Differing context:
 test/hotspot/jtreg/gc/TestHumongousReferenceObject.java

Copyright; @run has less VM arguments.
 test/hotspot/jtreg/gc/TestNUMAPageSize.java

Test not in 11:
test/hotspot/jtreg/gc/TestNoPerfCounter.java

Copyright: (It seems the shenandoah backport 8214259 omitted the copyright updates of these tests)
 test/hotspot/jtreg/gc/arguments/TestDisableDefaultGC.java
 test/hotspot/jtreg/gc/arguments/TestMaxMinHeapFreeRatioFlags.java
 test/hotspot/jtreg/gc/arguments/TestNewRatioFlag.java
 test/hotspot/jtreg/gc/arguments/TestNewSizeFlags.java                
 test/hotspot/jtreg/gc/arguments/TestShrinkHeapInSteps.java
 test/hotspot/jtreg/gc/arguments/TestSurvivorRatioFlag.java
 test/hotspot/jtreg/gc/arguments/TestTargetSurvivorRatioFlag.java
 test/hotspot/jtreg/gc/arguments/TestVerifyBeforeAndAfterGCFlags.java

@run commands were changed. Simple resolve. "8272783: Epsilon: Refactor tests to improve performance" was already backported.
 test/hotspot/jtreg/gc/epsilon/TestAlignment.java
 test/hotspot/jtreg/gc/epsilon/TestAlwaysPretouch.java
 test/hotspot/jtreg/gc/epsilon/TestArraycopyCheckcast.java
 test/hotspot/jtreg/gc/epsilon/TestByteArrays.java
 test/hotspot/jtreg/gc/epsilon/TestClasses.java
 test/hotspot/jtreg/gc/epsilon/TestElasticTLAB.java
 test/hotspot/jtreg/gc/epsilon/TestElasticTLABDecay.java
 test/hotspot/jtreg/gc/epsilon/TestEpsilonEnabled.java
 test/hotspot/jtreg/gc/epsilon/TestHelloWorld.java
 test/hotspot/jtreg/gc/epsilon/TestLogTrace.java
 test/hotspot/jtreg/gc/epsilon/TestManyThreads.java
 test/hotspot/jtreg/gc/epsilon/TestMaxTLAB.java
 test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java
 test/hotspot/jtreg/gc/epsilon/TestMemoryPools.java
 test/hotspot/jtreg/gc/epsilon/TestObjects.java          
 test/hotspot/jtreg/gc/epsilon/TestPrintHeapSteps.java
 test/hotspot/jtreg/gc/epsilon/TestRefArrays.java
 test/hotspot/jtreg/gc/epsilon/TestUpdateCountersSteps.java

Not in 11: 
test/hotspot/jtreg/gc/g1/TestEdenSurvivorLessThanMax.java
test/hotspot/jtreg/gc/g1/TestPeriodicCollection.java
test/hotspot/jtreg/gc/g1/TestPeriodicLogMessages.java

Copyright:
 test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData00.java
 test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData05.java
 test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData10.java
 test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData15.java
 test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData20.java
 test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData25.java
 test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData30.java

Not in 11: 
test/hotspot/jtreg/gc/g1/TestStringTableStats.java

Resolved:
 test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java

test/hotspot/jtreg/gc/libCriticalNative.c  is at different 
location in 11. Applied the patch to 
test/hotspot/jtreg/gc/shenandoah/jni/libCriticalNative.c

Not in 11: 
test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
test/hotspot/jtreg/gc/nvdimm/TestAllocateOldGenAt.java
test/hotspot/jtreg/gc/nvdimm/TestAllocateOldGenAtError.java
test/hotspot/jtreg/gc/nvdimm/TestAllocateOldGenAtMultiple.java
test/hotspot/jtreg/gc/nvdimm/TestHumongousObjectsOnNvdimm.java
test/hotspot/jtreg/gc/nvdimm/TestOldObjectsOnNvdimm.java
test/hotspot/jtreg/gc/nvdimm/TestYoungObjectsOnDram.java

test/hotspot/jtreg/gc/stress/CriticalNativeStress.java is at different 
location in 11. Applied the patch to
test/hotspot/jtreg/gc/shenandoah/jni/CriticalNativeStress.java 

Copyright:
 test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
 test/hotspot/jtreg/gc/stress/TestStressIHOPMultiThread.java

Resolved due to "8278115: gc/stress/gclocker/TestGCLockerWithSerial.java has duplicate -Xmx" and various shenandoah changes.
 test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithShenandoah.java
 test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithSerial.java
 test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithShenandoah.java
 test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithShenandoah.java
 test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithShenandoah.java

Copyright:
 test/hotspot/jtreg/gc/survivorAlignment/TestAllocationInEden.java
 test/hotspot/jtreg/gc/survivorAlignment/TestPromotionFromEdenToTenured.java
 test/hotspot/jtreg/gc/survivorAlignment/TestPromotionFromSurvivorToTenuredAfterFullGC.java
 test/hotspot/jtreg/gc/survivorAlignment/TestPromotionFromSurvivorToTenuredAfterMinorGC.java
 test/hotspot/jtreg/gc/survivorAlignment/TestPromotionToSurvivor.java
 test/hotspot/jtreg/gc/whitebox/TestWBGC.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8214799](https://bugs.openjdk.java.net/browse/JDK-8214799): Add package declaration to each JTREG test case in the gc folder


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to 6629e7c596c8b472f22812adbafa6179feecb039


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/966/head:pull/966` \
`$ git checkout pull/966`

Update a local copy of the PR: \
`$ git checkout pull/966` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 966`

View PR using the GUI difftool: \
`$ git pr show -t 966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/966.diff">https://git.openjdk.java.net/jdk11u-dev/pull/966.diff</a>

</details>
