### PR TITLE
8255604: java/nio/channels/DatagramChannel/Connect.java fails with java.net.BindException: Cannot assign requested address: connect

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/Connect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Connect.java
@@ -133,7 +133,7 @@ public class Connect {
         final DatagramChannel dc;
 
         Reactor() throws IOException {
-            dc = DatagramChannel.open().bind(new InetSocketAddress(0));
+            dc = DatagramChannel.open().bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         }
 
         SocketAddress getSocketAddress() throws IOException {


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255604](https://bugs.openjdk.java.net/browse/JDK-8255604): java/nio/channels/DatagramChannel/Connect.java fails with java.net.BindException: Cannot assign requested address: connect


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/967/head:pull/967` \
`$ git checkout pull/967`

Update a local copy of the PR: \
`$ git checkout pull/967` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 967`

View PR using the GUI difftool: \
`$ git pr show -t 967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/967.diff">https://git.openjdk.java.net/jdk11u-dev/pull/967.diff</a>

</details>
