### PR TITLE
8272358: Some tests may fail when executed with other locales than the US

### DIFF
--- a/test/langtools/jdk/jshell/ToolBasicTest.java
+++ b/test/langtools/jdk/jshell/ToolBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -552,7 +552,7 @@ public class ToolBasicTest extends ReplToolTesting {
     }
 
     public void testOpenResource() {
-        test(
+        test(new String[]{"-R", "-Duser.language=en", "-R", "-Duser.country=US"},
                 (a) -> assertCommand(a, "/open PRINTING", ""),
                 (a) -> assertCommandOutputContains(a, "/list",
                         "void println", "System.out.printf"),

--- a/test/langtools/jdk/jshell/ToolSimpleTest.java
+++ b/test/langtools/jdk/jshell/ToolSimpleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -675,7 +675,8 @@ public class ToolSimpleTest extends ReplToolTesting {
 
     @Test
     public void testCompoundStart() {
-        test(new String[]{"--startup", "DEFAULT", "--startup", "PRINTING"},
+        test(new String[]{"-R", "-Duser.language=en", "-R", "-Duser.country=US",
+                          "--startup", "DEFAULT", "--startup", "PRINTING"},
                 (a) -> assertCommand(a, "printf(\"%4.2f\", Math.PI)",
                         "", "", null, "3.14", "")
         );

--- a/test/langtools/tools/javac/lambda/lambdaExecution/LambdaTranslationTest1.java
+++ b/test/langtools/tools/javac/lambda/lambdaExecution/LambdaTranslationTest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8003639
  * @summary convert lambda testng tests to jtreg and add them
- * @run testng LambdaTranslationTest1
+ * @run testng/othervm -Duser.language=en -Duser.country=US LambdaTranslationTest1
  */
 
 import org.testng.annotations.Test;

--- a/test/langtools/tools/javac/lambda/lambdaExecution/LambdaTranslationTest2.java
+++ b/test/langtools/tools/javac/lambda/lambdaExecution/LambdaTranslationTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8003639
  * @summary convert lambda testng tests to jtreg and add them
- * @run testng LambdaTranslationTest2
+ * @run testng/othervm -Duser.language=en -Duser.country=US LambdaTranslationTest2
  */
 
 import org.testng.annotations.Test;


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

I had to resolve a copyright, marking as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272358](https://bugs.openjdk.java.net/browse/JDK-8272358): Some tests may fail when executed with other locales than the US


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/973/head:pull/973` \
`$ git checkout pull/973`

Update a local copy of the PR: \
`$ git checkout pull/973` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 973`

View PR using the GUI difftool: \
`$ git pr show -t 973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/973.diff">https://git.openjdk.java.net/jdk11u-dev/pull/973.diff</a>

</details>
