### PR TITLE
8283497: [windows] print TMP and TEMP in hs_err and VM.info

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -96,7 +96,7 @@ const char *env_list[] = {
   "DYLD_INSERT_LIBRARIES",
 
   // defined on Windows
-  "OS", "PROCESSOR_IDENTIFIER", "_ALT_JAVA_HOME_DIR",
+  "OS", "PROCESSOR_IDENTIFIER", "_ALT_JAVA_HOME_DIR", "TMP", "TEMP",
 
   (const char *)0
 };


### PR DESCRIPTION
I'd like to have this in jdk11. Super trivial, applies cleanly. Helps with error analysis e.g. with jdk.attach.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283497](https://bugs.openjdk.java.net/browse/JDK-8283497): [windows] print TMP and TEMP in hs_err and VM.info


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/974/head:pull/974` \
`$ git checkout pull/974`

Update a local copy of the PR: \
`$ git checkout pull/974` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/974/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 974`

View PR using the GUI difftool: \
`$ git pr show -t 974`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/974.diff">https://git.openjdk.java.net/jdk11u-dev/pull/974.diff</a>

</details>
