### PR TITLE
8220813: update hotspot tier1_gc tests depending on GC to use @requires vm.gc.X

### DIFF
--- a/test/hotspot/jtreg/gc/TestAgeOutput.java
+++ b/test/hotspot/jtreg/gc/TestAgeOutput.java
@@ -24,16 +24,27 @@
 package gc;
 
 /*
- * @test TestAgeOutput
+ * @test TestAgeOutputSerial
  * @bug 8164936
- * @summary Check that collectors using age table based aging print an age table even for the first garbage collection
  * @key gc
- * @requires vm.gc=="null"
+ * @requires vm.gc.Serial
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -XX:+UseSerialGC gc.TestAgeOutput UseSerialGC
+ */
+
+/*
+ * @test TestAgeOutputG1
+ * @bug 8164936
+ * @summary Check that collectors using age table based aging print an age table even for the first garbage collection
+ * @key gc
+ * @requires vm.gc.G1
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm -XX:+UseG1GC gc.TestAgeOutput UseG1GC
  */
 
@@ -42,7 +53,7 @@ package gc;
  * @bug 8164936
  * @key gc
  * @comment Graal does not support CMS
- * @requires vm.gc=="null" & !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/gc/TestGenerationPerfCounter.java
+++ b/test/hotspot/jtreg/gc/TestGenerationPerfCounter.java
@@ -28,9 +28,9 @@ import gc.testlibrary.PerfCounter;
 import gc.testlibrary.PerfCounters;
 
 
-/* @test TestGenerationPerfCounter
+/* @test TestGenerationPerfCounterSerial
  * @bug 8080345
- * @requires vm.gc=="null"
+ * @requires vm.gc.Serial
  * @library /test/lib /
  * @summary Tests that the sun.gc.policy.generations returns 2 for all GCs.
  * @modules java.base/jdk.internal.misc
@@ -38,14 +38,36 @@ import gc.testlibrary.PerfCounters;
  *          java.management/sun.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @run main/othervm -XX:+UsePerfData -XX:+UseSerialGC gc.TestGenerationPerfCounter
+ */
+
+/* @test TestGenerationPerfCounterParallel
+ * @bug 8080345
+ * @requires vm.gc.Parallel
+ * @library /test/lib /
+ * @summary Tests that the sun.gc.policy.generations returns 2 for all GCs.
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management/sun.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @run main/othervm -XX:+UsePerfData -XX:+UseParallelGC gc.TestGenerationPerfCounter
+ */
+
+/* @test TestGenerationPerfCounterG1
+ * @bug 8080345
+ * @requires vm.gc.G1
+ * @library /test/lib /
+ * @summary Tests that the sun.gc.policy.generations returns 2 for all GCs.
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management/sun.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @run main/othervm -XX:+UsePerfData -XX:+UseG1GC gc.TestGenerationPerfCounter
  */
 
 /* @test TestGenerationPerfCounterCMS
  * @bug 8080345
  * @comment Graal does not support CMS
- * @requires vm.gc=="null" & !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @library /test/lib /
  * @summary Tests that the sun.gc.policy.generations returns 2 for all GCs.
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/TestHumongousReferenceObject.java
+++ b/test/hotspot/jtreg/gc/TestHumongousReferenceObject.java
@@ -26,12 +26,20 @@ package gc;
 import jdk.internal.vm.annotation.Contended;
 
 /*
- * @test
- * @summary Test that verifies that iteration over large, plain Java objects, that potentially cross region boundaries on G1, with references in them works.
- * @requires vm.gc == "null"
+ * @test TestHumongousReferenceObjectParallel
+ * @summary Test that verifies that iteration over large, plain Java objects, that potentially cross region boundaries, with references in them works.
+ * @requires vm.gc.Parallel
  * @bug 8151499 8153734
  * @modules java.base/jdk.internal.vm.annotation
  * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseParallelGC -XX:ContendedPaddingWidth=8192 gc.TestHumongousReferenceObject
+ */
+
+/*
+ * @test TestHumongousReferenceObjectG1
+ * @summary Test that verifies that iteration over large, plain Java objects, that potentially cross region boundaries on G1, with references in them works.
+ * @requires vm.gc.G1
+ * @bug 8151499 8153734
+ * @modules java.base/jdk.internal.vm.annotation
  * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseG1GC -XX:G1HeapRegionSize=1M -XX:ContendedPaddingWidth=8192 gc.TestHumongousReferenceObject
  * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseG1GC -XX:G1HeapRegionSize=2M -XX:ContendedPaddingWidth=8192 gc.TestHumongousReferenceObject
  * @run main/othervm -XX:+EnableContended -XX:-RestrictContended -Xmx128m -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:ContendedPaddingWidth=8192 gc.TestHumongousReferenceObject

--- a/test/hotspot/jtreg/gc/TestMemoryMXBeansAndPoolsPresence.java
+++ b/test/hotspot/jtreg/gc/TestMemoryMXBeansAndPoolsPresence.java
@@ -29,15 +29,33 @@ import java.lang.management.*;
 import static jdk.test.lib.Asserts.*;
 import java.util.stream.*;
 
-/* @test TestMemoryMXBeansAndPoolsPresence
+/* @test TestMemoryMXBeansAndPoolsPresenceG1
  * @bug 8191564
  * @summary Tests that GarbageCollectorMXBeans and GC MemoryPools are created.
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @requires vm.gc == null
+ * @requires vm.gc.G1
  * @run main/othervm -XX:+UseG1GC gc.TestMemoryMXBeansAndPoolsPresence G1
+ */
+
+/* @test TestMemoryMXBeansAndPoolsPresenceParallel
+ * @bug 8191564
+ * @summary Tests that GarbageCollectorMXBeans and GC MemoryPools are created.
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @requires vm.gc.Parallel
  * @run main/othervm -XX:+UseParallelGC gc.TestMemoryMXBeansAndPoolsPresence Parallel
+ */
+
+/* @test TestMemoryMXBeansAndPoolsPresenceSerial
+ * @bug 8191564
+ * @summary Tests that GarbageCollectorMXBeans and GC MemoryPools are created.
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @requires vm.gc.Serial
  * @run main/othervm -XX:+UseSerialGC gc.TestMemoryMXBeansAndPoolsPresence Serial
  */
 
@@ -47,7 +65,7 @@ import java.util.stream.*;
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @comment Graal does not support CMS
- * @requires vm.gc == null & !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @run main/othervm -XX:+UseConcMarkSweepGC gc.TestMemoryMXBeansAndPoolsPresence CMS
  */
 

--- a/test/hotspot/jtreg/gc/TestNumWorkerOutput.java
+++ b/test/hotspot/jtreg/gc/TestNumWorkerOutput.java
@@ -24,11 +24,11 @@
 package gc;
 
 /*
- * @test TestNumWorkerOutput
+ * @test TestNumWorkerOutputG1
  * @bug 8165292
  * @summary Check that when PrintGCDetails is enabled, gc,task output is printed only once per collection.
  * @key gc
- * @requires vm.gc=="null"
+ * @requires vm.gc.G1
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
@@ -41,7 +41,7 @@ package gc;
  * @bug 8165292
  * @key gc
  * @comment Graal does not support CMS
- * @requires vm.gc=="null" & !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/gc/TestPolicyNamePerfCounter.java
+++ b/test/hotspot/jtreg/gc/TestPolicyNamePerfCounter.java
@@ -28,9 +28,9 @@ import gc.testlibrary.PerfCounter;
 import gc.testlibrary.PerfCounters;
 
 
-/* @test TestPolicyNamePerfCounter
+/* @test TestPolicyNamePerfCounterSerial
  * @bug 8210192
- * @requires vm.gc=="null"
+ * @requires vm.gc.Serial
  * @library /test/lib /
  * @summary Tests that sun.gc.policy.name returns expected values for different GCs.
  * @modules java.base/jdk.internal.misc
@@ -38,14 +38,36 @@ import gc.testlibrary.PerfCounters;
  *          java.management/sun.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @run main/othervm -XX:+UsePerfData -XX:+UseSerialGC gc.TestPolicyNamePerfCounter Copy:MSC
+ */
+
+/* @test TestPolicyNamePerfCounterParallel
+ * @bug 8210192
+ * @requires vm.gc.Parallel
+ * @library /test/lib /
+ * @summary Tests that sun.gc.policy.name returns expected values for different GCs.
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management/sun.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @run main/othervm -XX:+UsePerfData -XX:+UseParallelGC gc.TestPolicyNamePerfCounter ParScav:MSC
+ */
+
+/* @test TestPolicyNamePerfCounterG1
+ * @bug 8210192
+ * @requires vm.gc.G1
+ * @library /test/lib /
+ * @summary Tests that sun.gc.policy.name returns expected values for different GCs.
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management/sun.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @run main/othervm -XX:+UsePerfData -XX:+UseG1GC gc.TestPolicyNamePerfCounter GarbageFirst
  */
 
 /* @test TestPolicyNamePerfCounterCMS
  * @bug 8210192
  * @comment Graal does not support CMS
- * @requires vm.gc=="null" & !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @library /test/lib /
  * @summary Tests that sun.gc.policy.name returns expected values for different GCs.
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/TestSystemGC.java
@@ -24,14 +24,27 @@
 package gc;
 
 /*
- * @test TestSystemGC
+ * @test TestSystemGCSerial
  * @key gc
- * @requires vm.gc=="null"
+ * @requires vm.gc.Serial
  * @summary Runs System.gc() with different flags.
- * @run main/othervm gc.TestSystemGC
  * @run main/othervm -XX:+UseSerialGC gc.TestSystemGC
+ */
+
+/*
+ * @test TestSystemGCParallel
+ * @key gc
+ * @requires vm.gc.Parallel
+ * @summary Runs System.gc() with different flags.
  * @run main/othervm -XX:+UseParallelGC gc.TestSystemGC
  * @run main/othervm -XX:+UseParallelGC -XX:-UseParallelOldGC gc.TestSystemGC
+ */
+
+/*
+ * @test TestSystemGCG1
+ * @key gc
+ * @requires vm.gc.G1
+ * @summary Runs System.gc() with different flags.
  * @run main/othervm -XX:+UseG1GC gc.TestSystemGC
  * @run main/othervm -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
  * @run main/othervm -XX:+UseLargePages gc.TestSystemGC
@@ -42,7 +55,7 @@ package gc;
  * @test TestSystemGCCMS
  * @key gc
  * @comment Graal does not support CMS
- * @requires vm.gc=="null" & !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @run main/othervm -XX:+UseConcMarkSweepGC gc.TestSystemGC
  * @run main/othervm -XX:+UseConcMarkSweepGC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
  */

--- a/test/hotspot/jtreg/gc/arguments/TestAlignmentToUseLargePages.java
+++ b/test/hotspot/jtreg/gc/arguments/TestAlignmentToUseLargePages.java
@@ -24,18 +24,31 @@
 package gc.arguments;
 
 /**
- * @test TestAlignmentToUseLargePages
+ * @test TestAlignmentToUseLargePagesSerial
  * @key gc regression
- * @summary All parallel GC variants may use large pages without the requirement that the
- * heap alignment is large page aligned. Other collectors also need to start up with odd sized heaps.
  * @bug 8024396
- * @requires vm.gc=="null"
+ * @requires vm.gc.Serial
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UseSerialGC -XX:+UseLargePages gc.arguments.TestAlignmentToUseLargePages
+ * @run main/othervm -Xms71M -Xmx91M -XX:+UseSerialGC -XX:-UseLargePages gc.arguments.TestAlignmentToUseLargePages
+ */
+
+/**
+ * @test TestAlignmentToUseLargePagesParallel
+ * @key gc regression
+ * @summary All parallel GC variants may use large pages without the requirement that the heap alignment is large page aligned. Other collectors also need to start up with odd sized heaps.
+ * @bug 8024396
+ * @requires vm.gc.Parallel
  * @run main/othervm -Xms71M -Xmx91M -XX:+UseParallelGC -XX:-UseParallelOldGC -XX:+UseLargePages gc.arguments.TestAlignmentToUseLargePages
  * @run main/othervm -Xms71M -Xmx91M -XX:+UseParallelGC -XX:-UseParallelOldGC -XX:-UseLargePages gc.arguments.TestAlignmentToUseLargePages
  * @run main/othervm -Xms71M -Xmx91M -XX:+UseParallelGC -XX:+UseParallelOldGC -XX:+UseLargePages gc.arguments.TestAlignmentToUseLargePages
  * @run main/othervm -Xms71M -Xmx91M -XX:+UseParallelGC -XX:+UseParallelOldGC -XX:-UseLargePages gc.arguments.TestAlignmentToUseLargePages
- * @run main/othervm -Xms71M -Xmx91M -XX:+UseSerialGC -XX:+UseLargePages gc.arguments.TestAlignmentToUseLargePages
- * @run main/othervm -Xms71M -Xmx91M -XX:+UseSerialGC -XX:-UseLargePages gc.arguments.TestAlignmentToUseLargePages
+ */
+
+/**
+ * @test TestAlignmentToUseLargePagesG1
+ * @key gc regression
+ * @bug 8024396
+ * @requires vm.gc.G1
  * @run main/othervm -Xms71M -Xmx91M -XX:+UseG1GC -XX:+UseLargePages gc.arguments.TestAlignmentToUseLargePages
  * @run main/othervm -Xms71M -Xmx91M -XX:+UseG1GC -XX:-UseLargePages gc.arguments.TestAlignmentToUseLargePages
  */
@@ -45,7 +58,7 @@ package gc.arguments;
  * @key gc regression
  * @bug 8024396
  * @comment Graal does not support CMS
- * @requires vm.gc=="null" & !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @run main/othervm -Xms71M -Xmx91M -XX:+UseConcMarkSweepGC -XX:+UseLargePages gc.arguments.TestAlignmentToUseLargePages
  * @run main/othervm -Xms71M -Xmx91M -XX:+UseConcMarkSweepGC -XX:-UseLargePages gc.arguments.TestAlignmentToUseLargePages
  */

--- a/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
@@ -24,17 +24,43 @@
 package gc.arguments;
 
 /*
- * @test TestMaxNewSize
+ * @test TestMaxNewSizeSerial
  * @key gc
  * @bug 7057939
  * @summary Make sure that MaxNewSize always has a useful value after argument
  * processing.
- * @requires vm.gc=="null"
+ * @requires vm.gc.Serial
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run main gc.arguments.TestMaxNewSize -XX:+UseSerialGC
+ * @author thomas.schatzl@oracle.com, jesper.wilhelmsson@oracle.com
+ */
+
+/*
+ * @test TestMaxNewSizeParallel
+ * @key gc
+ * @bug 7057939
+ * @summary Make sure that MaxNewSize always has a useful value after argument
+ * processing.
+ * @requires vm.gc.Parallel
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
  * @run main gc.arguments.TestMaxNewSize -XX:+UseParallelGC
+ * @author thomas.schatzl@oracle.com, jesper.wilhelmsson@oracle.com
+ */
+
+/*
+ * @test TestMaxNewSizeG1
+ * @key gc
+ * @bug 7057939
+ * @summary Make sure that MaxNewSize always has a useful value after argument
+ * processing.
+ * @requires vm.gc.G1
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
  * @run main gc.arguments.TestMaxNewSize -XX:+UseG1GC
  * @author thomas.schatzl@oracle.com, jesper.wilhelmsson@oracle.com
  */
@@ -44,7 +70,7 @@ package gc.arguments;
  * @key gc
  * @bug 7057939
  * @comment Graal does not support CMS
- * @requires vm.gc=="null" & !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/gc/arguments/TestMinInitialErgonomics.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMinInitialErgonomics.java
@@ -27,7 +27,8 @@ package gc.arguments;
  * @test TestMinInitialErgonomics
  * @key gc
  * @bug 8006088
- * @summary Test ergonomics decisions related to minimum and initial heap size.
+ * @requires vm.gc.Parallel
+ * @summary Test Parallel GC ergonomics decisions related to minimum and initial heap size.
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java
@@ -32,12 +32,18 @@ package gc.arguments;
  * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver gc.arguments.TestParallelGCThreads
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI gc.arguments.TestParallelGCThreads
  */
 
+import java.util.ArrayList;
+import java.util.List;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
+import sun.hotspot.gc.GC;
 
 public class TestParallelGCThreads {
 
@@ -75,7 +81,23 @@ public class TestParallelGCThreads {
 
   public static void testFlags() throws Exception {
     // For each parallel collector (G1, Parallel, ParNew/CMS)
-    for (String gc : new String[] {"G1", "Parallel", "ConcMarkSweep"}) {
+    List<String> supportedGC = new ArrayList<String>();
+
+    if (GC.G1.isSupported()) {
+      supportedGC.add("G1");
+    }
+    if (GC.Parallel.isSupported()) {
+      supportedGC.add("Parallel");
+    }
+    if (GC.ConcMarkSweep.isSupported()) {
+      supportedGC.add("ConcMarkSweep");
+    }
+
+    if (supportedGC.isEmpty()) {
+      throw new SkippedException("Skipping test because none of G1/Parallel/ConcMarkSweep is supported.");
+    }
+
+    for (String gc : supportedGC) {
 
       // Make sure the VM does not allow ParallelGCThreads set to 0
       String[] flags = new String[] {"-XX:+Use" + gc + "GC", "-XX:ParallelGCThreads=0", "-XX:+PrintFlagsFinal", "-version"};

--- a/test/hotspot/jtreg/gc/arguments/TestParallelHeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelHeapSizeFlags.java
@@ -29,7 +29,7 @@ package gc.arguments;
  * @bug 8006088
  * @summary Tests argument processing for initial and maximum heap size for the
  * parallel collectors.
- * @requires vm.gc=="null"
+ * @requires vm.gc.Parallel
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/arguments/TestSelectDefaultGC.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSelectDefaultGC.java
@@ -29,7 +29,7 @@ package gc.arguments;
  * @bug 8068582
  * @key gc
  * @library /test/lib
- * @requires vm.gc=="null"
+ * @requires vm.gc.Serial & vm.gc.G1
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run driver gc.arguments.TestSelectDefaultGC

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgo.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgo.java
@@ -24,11 +24,44 @@
 package gc.arguments;
 
 /*
- * @test TestUseCompressedOopsErgo
+ * @test TestUseCompressedOopsErgoSerial
  * @key gc
  * @bug 8010722
  * @summary Tests ergonomics for UseCompressedOops.
- * @requires vm.gc=="null"
+ * @requires vm.gc.Serial
+ * @library /test/lib
+ * @library /
+ * @modules java.base/jdk.internal.misc
+ *          java.management/sun.management
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *                              sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseSerialGC
+ */
+
+/*
+ * @test TestUseCompressedOopsErgoParallel
+ * @key gc
+ * @bug 8010722
+ * @summary Tests ergonomics for UseCompressedOops.
+ * @requires vm.gc.Parallel
+ * @library /test/lib
+ * @library /
+ * @modules java.base/jdk.internal.misc
+ *          java.management/sun.management
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *                              sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC
+ * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC -XX:-UseParallelOldGC
+ */
+
+/*
+ * @test TestUseCompressedOopsErgoG1
+ * @key gc
+ * @bug 8010722
+ * @summary Tests ergonomics for UseCompressedOops.
+ * @requires vm.gc.G1
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc
@@ -37,9 +70,6 @@ package gc.arguments;
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseG1GC
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC -XX:-UseParallelOldGC
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseSerialGC
  */
 
 /*
@@ -47,7 +77,7 @@ package gc.arguments;
  * @key gc
  * @bug 8010722
  * @comment Graal does not support CMS
- * @requires vm.gc=="null" & !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/class_unloading/TestCMSClassUnloadingEnabledHWM.java
+++ b/test/hotspot/jtreg/gc/class_unloading/TestCMSClassUnloadingEnabledHWM.java
@@ -27,7 +27,7 @@ package gc.class_unloading;
  * @test
  * @key gc
  * @bug 8049831
- * @requires !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/gc/class_unloading/TestClassUnloadingDisabled.java
+++ b/test/hotspot/jtreg/gc/class_unloading/TestClassUnloadingDisabled.java
@@ -24,12 +24,50 @@
 package gc.class_unloading;
 
 /*
- * @test
+ * @test TestClassUnloadingDisabledSerial
  * @key gc
  * @bug 8114823
- * @requires vm.gc == null
  * @requires vm.opt.ExplicitGCInvokesConcurrent != true
  * @requires vm.opt.ClassUnloading != true
+ * @requires vm.gc.Serial
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *                              sun.hotspot.WhiteBox$WhiteBoxPermission
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:-ClassUnloading -XX:+UseSerialGC gc.class_unloading.TestClassUnloadingDisabled
+ *
+ */
+
+/*
+ * @test TestClassUnloadingDisabledParallel
+ * @key gc
+ * @bug 8114823
+ * @requires vm.opt.ExplicitGCInvokesConcurrent != true
+ * @requires vm.opt.ClassUnloading != true
+ * @requires vm.gc.Parallel
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *                              sun.hotspot.WhiteBox$WhiteBoxPermission
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -XX:-ClassUnloading -XX:+UseParallelGC gc.class_unloading.TestClassUnloadingDisabled
+ *
+ */
+
+/*
+ * @test TestClassUnloadingDisabledG1
+ * @key gc
+ * @bug 8114823
+ * @requires vm.opt.ExplicitGCInvokesConcurrent != true
+ * @requires vm.opt.ClassUnloading != true
+ * @requires vm.gc.G1
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -40,20 +78,14 @@ package gc.class_unloading;
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -XX:-ClassUnloading -XX:+UseG1GC gc.class_unloading.TestClassUnloadingDisabled
  *
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -XX:-ClassUnloading -XX:+UseSerialGC gc.class_unloading.TestClassUnloadingDisabled
- *
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *                   -XX:-ClassUnloading -XX:+UseParallelGC gc.class_unloading.TestClassUnloadingDisabled
- *
  */
 
 /*
- * @test
+ * @test TestClassUnloadingDisabledCMS
  * @key gc
  * @bug 8114823
  * @comment Graal does not support CMS
- * @requires vm.gc=="null" & !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @requires vm.opt.ExplicitGCInvokesConcurrent != true
  * @requires vm.opt.ClassUnloading != true
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/class_unloading/TestG1ClassUnloadingHWM.java
+++ b/test/hotspot/jtreg/gc/class_unloading/TestG1ClassUnloadingHWM.java
@@ -27,6 +27,7 @@ package gc.class_unloading;
  * @test
  * @key gc
  * @bug 8049831
+ * @requires vm.gc.G1
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/gc/cms/GuardShrinkWarning.java
+++ b/test/hotspot/jtreg/gc/cms/GuardShrinkWarning.java
@@ -28,7 +28,7 @@ package gc.cms;
  * @key gc regression
  * @summary Remove warning about CMS generation shrinking.
  * @bug 8012111
- * @requires !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/gc/ergonomics/TestDynamicNumberOfGCThreads.java
+++ b/test/hotspot/jtreg/gc/ergonomics/TestDynamicNumberOfGCThreads.java
@@ -27,7 +27,6 @@ package gc.ergonomics;
  * @test TestDynamicNumberOfGCThreads
  * @bug 8017462
  * @summary Ensure that UseDynamicNumberOfGCThreads runs
- * @requires vm.gc=="null"
  * @key gc
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -38,19 +37,35 @@ package gc.ergonomics;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
 import sun.hotspot.gc.GC;
 
 public class TestDynamicNumberOfGCThreads {
   public static void main(String[] args) throws Exception {
+    boolean noneGCSupported = true;
 
-    testDynamicNumberOfGCThreads("UseConcMarkSweepGC");
+    if (GC.ConcMarkSweep.isSupported()) {
+      noneGCSupported = false;
+      testDynamicNumberOfGCThreads("UseConcMarkSweepGC");
+    }
 
-    testDynamicNumberOfGCThreads("UseG1GC");
+    if (GC.G1.isSupported()) {
+      noneGCSupported = false;
+      testDynamicNumberOfGCThreads("UseG1GC");
+    }
 
-    testDynamicNumberOfGCThreads("UseParallelGC");
+    if (GC.Parallel.isSupported()) {
+      noneGCSupported = false;
+      testDynamicNumberOfGCThreads("UseParallelGC");
+    }
 
     if (GC.Shenandoah.isSupported()) {
-        testDynamicNumberOfGCThreads("UseShenandoahGC");
+      noneGCSupported = false;
+      testDynamicNumberOfGCThreads("UseShenandoahGC");
+    }
+
+    if (noneGCSupported) {
+      throw new SkippedException("Skipping test because none of ConcMarkSweep/G1/Parallel/Shenandoah is supported.");
     }
   }
 

--- a/test/hotspot/jtreg/gc/ergonomics/TestInitialGCThreadLogging.java
+++ b/test/hotspot/jtreg/gc/ergonomics/TestInitialGCThreadLogging.java
@@ -27,7 +27,6 @@ package gc.ergonomics;
  * @test TestInitialGCThreadLogging
  * @bug 8157240
  * @summary Check trace logging of initial GC threads.
- * @requires vm.gc=="null"
  * @key gc
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -38,19 +37,35 @@ package gc.ergonomics;
 
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
+import jtreg.SkippedException;
 import sun.hotspot.gc.GC;
 
 public class TestInitialGCThreadLogging {
   public static void main(String[] args) throws Exception {
+    boolean noneGCSupported = true;
 
-    testInitialGCThreadLogging("UseConcMarkSweepGC", "GC Thread");
+    if (GC.ConcMarkSweep.isSupported()) {
+      noneGCSupported = false;
+      testInitialGCThreadLogging("UseConcMarkSweepGC", "GC Thread");
+    }
 
-    testInitialGCThreadLogging("UseG1GC", "GC Thread");
+    if (GC.G1.isSupported()) {
+      noneGCSupported = false;
+      testInitialGCThreadLogging("UseG1GC", "GC Thread");
+    }
 
-    testInitialGCThreadLogging("UseParallelGC", "ParGC Thread");
+    if (GC.Parallel.isSupported()) {
+      noneGCSupported = false;
+      testInitialGCThreadLogging("UseParallelGC", "ParGC Thread");
+    }
 
     if (GC.Shenandoah.isSupported()) {
-        testInitialGCThreadLogging("UseShenandoahGC", "Shenandoah GC Thread");
+      noneGCSupported = false;
+      testInitialGCThreadLogging("UseShenandoahGC", "Shenandoah GC Thread");
+    }
+
+    if (noneGCSupported) {
+      throw new SkippedException("Skipping test because none of ConcMarkSweep/G1/Parallel/Shenandoah is supported.");
     }
   }
 

--- a/test/hotspot/jtreg/gc/g1/TestShrinkDefragmentedHeap.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkDefragmentedHeap.java
@@ -34,6 +34,7 @@ package gc.g1;
  *     3. invoke gc and check that memory returned to the system (amount of committed memory got down)
  *
  * @library /test/lib /
+ * @requires vm.gc.G1
  * @modules java.base/jdk.internal.misc
  *          java.management/sun.management
  * @run main gc.g1.TestShrinkDefragmentedHeap

--- a/test/hotspot/jtreg/gc/logging/TestGCId.java
+++ b/test/hotspot/jtreg/gc/logging/TestGCId.java
@@ -27,7 +27,6 @@ package gc.logging;
  * @test TestGCId
  * @bug 8043607
  * @summary Ensure that the GCId is logged
- * @requires vm.gc=="null"
  * @key gc
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
@@ -39,16 +38,36 @@ package gc.logging;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
 import sun.hotspot.gc.GC;
 
 public class TestGCId {
   public static void main(String[] args) throws Exception {
-    testGCId("UseParallelGC");
-    testGCId("UseG1GC");
-    testGCId("UseConcMarkSweepGC");
-    testGCId("UseSerialGC");
+    boolean noneGCSupported = true;
+
+    if (GC.Parallel.isSupported()) {
+      noneGCSupported = false;
+      testGCId("UseParallelGC");
+    }
+    if (GC.G1.isSupported()) {
+      noneGCSupported = false;
+      testGCId("UseG1GC");
+    }
+    if (GC.ConcMarkSweep.isSupported()) {
+      noneGCSupported = false;
+      testGCId("UseConcMarkSweepGC");
+    }
+    if (GC.Serial.isSupported()) {
+      noneGCSupported = false;
+      testGCId("UseSerialGC");
+    }
     if (GC.Shenandoah.isSupported()) {
-        testGCId("UseShenandoahGC");
+      noneGCSupported = false;
+      testGCId("UseShenandoahGC");
+    }
+
+    if (noneGCSupported) {
+      throw new SkippedException("Skipping test because none of Parallel/G1/ConcMarkSweep/Serial/Shenandoah is supported.");
     }
   }
 

--- a/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
+++ b/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
@@ -27,6 +27,7 @@ package gc.logging;
  * @test TestPrintReferences
  * @bug 8136991 8186402 8186465 8188245
  * @summary Validate the reference processing logging
+ * @requires vm.gc.G1
  * @key gc
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspaceCMSCancel.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspaceCMSCancel.java
@@ -30,7 +30,7 @@ import sun.hotspot.WhiteBox;
 /* @test TestMetaspaceCMSCancel
  * @bug 8026752
  * @summary Tests cancel of CMS concurrent cycle for Metaspace after a full GC
- * @requires !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @build sun.hotspot.WhiteBox

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
@@ -37,9 +37,9 @@ import static jdk.test.lib.Asserts.*;
 import gc.testlibrary.PerfCounter;
 import gc.testlibrary.PerfCounters;
 
-/* @test TestMetaspacePerfCounters
+/* @test TestMetaspacePerfCountersSerial
  * @bug 8014659
- * @requires vm.gc=="null"
+ * @requires vm.gc.Serial
  * @library /test/lib /
  * @summary Tests that performance counters for metaspace and compressed class
  *          space exists and works.
@@ -48,11 +48,34 @@ import gc.testlibrary.PerfCounters;
  *          java.management/sun.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UsePerfData -XX:+UseSerialGC gc.metaspace.TestMetaspacePerfCounters
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UsePerfData -XX:+UseParallelGC -XX:+UseParallelOldGC gc.metaspace.TestMetaspacePerfCounters
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UsePerfData -XX:+UseG1GC gc.metaspace.TestMetaspacePerfCounters
- *
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UsePerfData -XX:+UseSerialGC gc.metaspace.TestMetaspacePerfCounters
+ */
+
+/* @test TestMetaspacePerfCountersParallel
+ * @bug 8014659
+ * @requires vm.gc.Parallel
+ * @library /test/lib /
+ * @summary Tests that performance counters for metaspace and compressed class
+ *          space exists and works.
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management/sun.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UsePerfData -XX:+UseParallelGC -XX:+UseParallelOldGC gc.metaspace.TestMetaspacePerfCounters
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UsePerfData -XX:+UseParallelGC -XX:+UseParallelOldGC gc.metaspace.TestMetaspacePerfCounters
+ */
+
+/* @test TestMetaspacePerfCountersG1
+ * @bug 8014659
+ * @requires vm.gc.G1
+ * @library /test/lib /
+ * @summary Tests that performance counters for metaspace and compressed class
+ *          space exists and works.
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management/sun.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:+UsePerfData -XX:+UseG1GC gc.metaspace.TestMetaspacePerfCounters
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UsePerfData -XX:+UseG1GC gc.metaspace.TestMetaspacePerfCounters
  */
 

--- a/test/hotspot/jtreg/gc/parallel/AdaptiveGCBoundary.java
+++ b/test/hotspot/jtreg/gc/parallel/AdaptiveGCBoundary.java
@@ -26,6 +26,7 @@ package gc.parallel;
 /**
  * @test AdaptiveGCBoundary
  * @key gc regression
+ * @requires vm.gc.Parallel
  * @summary UseAdaptiveGCBoundary is broken
  * @bug 8014546
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/startup_warnings/TestCMS.java
+++ b/test/hotspot/jtreg/gc/startup_warnings/TestCMS.java
@@ -28,7 +28,7 @@ package gc.startup_warnings;
  * @key gc
  * @bug 8006398 8155948 8179013
  * @summary Test that CMS prints a warning message
- * @requires !vm.graal.enabled
+ * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/gc/startup_warnings/TestG1.java
+++ b/test/hotspot/jtreg/gc/startup_warnings/TestG1.java
@@ -27,6 +27,7 @@ package gc.startup_warnings;
 * @test TestG1
 * @key gc
 * @bug 8006398
+* @requires vm.gc.G1
 * @summary Test that the G1 collector does not print a warning message
 * @library /test/lib
 * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/startup_warnings/TestParallelGC.java
+++ b/test/hotspot/jtreg/gc/startup_warnings/TestParallelGC.java
@@ -27,6 +27,7 @@ package gc.startup_warnings;
 * @test TestParallelGC
 * @key gc
 * @bug 8006398
+* @requires vm.gc.Parallel
 * @summary Test that ParallelGC does not print a warning message
 * @library /test/lib
 * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/startup_warnings/TestParallelScavengeSerialOld.java
+++ b/test/hotspot/jtreg/gc/startup_warnings/TestParallelScavengeSerialOld.java
@@ -27,6 +27,7 @@ package gc.startup_warnings;
 * @test TestParallelScavengeSerialOld
 * @key gc
 * @bug 8006398
+* @requires vm.gc.Parallel
 * @summary Test that the ParallelScavenge+SerialOld combination does not print a warning message
 * @library /test/lib
 * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

Applies clean except for patch to TestMetaSpaceLog.java because that test is not in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8220813](https://bugs.openjdk.java.net/browse/JDK-8220813): update hotspot tier1_gc tests depending on GC to use @requires vm.gc.X


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/977/head:pull/977` \
`$ git checkout pull/977`

Update a local copy of the PR: \
`$ git checkout pull/977` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 977`

View PR using the GUI difftool: \
`$ git pr show -t 977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/977.diff">https://git.openjdk.java.net/jdk11u-dev/pull/977.diff</a>

</details>
