### PR TITLE
8240335: C2: assert(found_sfpt) failed: no node in loop that's not input to safepoint

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -1657,6 +1657,43 @@ bool PhiNode::is_unsafe_data_reference(Node *in) const {
   return false; // The phi is not reachable from its inputs
 }
 
+// Is this Phi's region or some inputs to the region enqueued for IGVN
+// and so could cause the region to be optimized out?
+bool PhiNode::wait_for_region_igvn(PhaseGVN* phase) {
+  PhaseIterGVN* igvn = phase->is_IterGVN();
+  Unique_Node_List& worklist = igvn->_worklist;
+  bool delay = false;
+  Node* r = in(0);
+  for (uint j = 1; j < req(); j++) {
+    Node* rc = r->in(j);
+    Node* n = in(j);
+    if (rc != NULL &&
+        rc->is_Proj()) {
+      if (worklist.member(rc)) {
+        delay = true;
+      } else if (rc->in(0) != NULL &&
+                 rc->in(0)->is_If()) {
+        if (worklist.member(rc->in(0))) {
+          delay = true;
+        } else if (rc->in(0)->in(1) != NULL &&
+                   rc->in(0)->in(1)->is_Bool()) {
+          if (worklist.member(rc->in(0)->in(1))) {
+            delay = true;
+          } else if (rc->in(0)->in(1)->in(1) != NULL &&
+                     rc->in(0)->in(1)->in(1)->is_Cmp()) {
+            if (worklist.member(rc->in(0)->in(1)->in(1))) {
+              delay = true;
+            }
+          }
+        }
+      }
+    }
+  }
+  if (delay) {
+    worklist.push(this);
+  }
+  return delay;
+}
 
 //------------------------------Ideal------------------------------------------
 // Return a node which is more "ideal" than the current node.  Must preserve
@@ -1710,7 +1747,10 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
   bool uncasted = false;
   Node* uin = unique_input(phase, false);
-  if (uin == NULL && can_reshape) {
+  if (uin == NULL && can_reshape &&
+      // If there is a chance that the region can be optimized out do
+      // not add a cast node that we can't remove yet.
+      !wait_for_region_igvn(phase)) {
     uncasted = true;
     uin = unique_input(phase, true);
   }

--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -135,6 +135,7 @@ class PhiNode : public TypeNode {
 
   // Determine if CMoveNode::is_cmove_id can be used at this join point.
   Node* is_cmove_id(PhaseTransform* phase, int true_path);
+  bool wait_for_region_igvn(PhaseGVN* phase);
 
 public:
   // Node layout (parallels RegionNode):

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestCastIIAfterUnrollingInOuterLoop.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestCastIIAfterUnrollingInOuterLoop.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8240335
+ * @summary C2: assert(found_sfpt) failed: no node in loop that's not input to safepoint
+ *
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestCastIIAfterUnrollingInOuterLoop TestCastIIAfterUnrollingInOuterLoop
+ *
+ */
+
+public class TestCastIIAfterUnrollingInOuterLoop {
+    public static final int N = 400;
+
+    public static long instanceCount=727275458L;
+    public static int iFld=-10;
+    public static volatile short sFld=-2966;
+    public static float fFld=1.682F;
+    public static int iArrFld[]=new int[N];
+
+    public static void vMeth1(int i1) {
+        int i3=4;
+        long lArr[]=new long[N], lArr1[]=new long[N];
+
+        boolean b = (Integer.reverseBytes(i1 << 5) < (instanceCount++));
+        for (int i2 = 1; i2 < 146; i2++) {
+            iFld >>= (++i3);
+        }
+        if (b) {
+            for (int i4 = 4; i4 < 218; ++i4) {
+                instanceCount = iArrFld[i4 - 1];
+                int i10 = 1;
+                while (++i10 < 8) {
+                    lArr1[i4] += 61384L;
+                }
+                lArr[i4 + 1] = i4;
+                i3 += sFld;
+            }
+        }
+    }
+
+    public void mainTest(String[] strArr1) {
+        vMeth1(iFld);
+        for (int i19 = 2; i19 < 190; i19++) {
+            int i20 = (int)instanceCount;
+            instanceCount += (((i19 * i20) + i20) - fFld);
+        }
+    }
+    public static void main(String[] strArr) {
+        TestCastIIAfterUnrollingInOuterLoop _instance = new TestCastIIAfterUnrollingInOuterLoop();
+        for (int i = 0; i < 10; i++) {
+            _instance.mainTest(strArr);
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8240335](https://bugs.openjdk.java.net/browse/JDK-8240335): C2: assert(found_sfpt) failed: no node in loop that's not input to safepoint


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/978/head:pull/978` \
`$ git checkout pull/978`

Update a local copy of the PR: \
`$ git checkout pull/978` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 978`

View PR using the GUI difftool: \
`$ git pr show -t 978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/978.diff">https://git.openjdk.java.net/jdk11u-dev/pull/978.diff</a>

</details>
