### PR TITLE
8243429: use reproducible random in :vmTestbase_nsk_stress

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/except/except012.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/except/except012.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -302,7 +302,7 @@ public class except012 {
 
         static {
             crazyBytecode = new byte[1000];
-            Random random = new Random(0);
+            Random random = new Random(42);
             for (int i = 0; i < crazyBytecode.length; i++)
                 crazyBytecode[i] = (byte) random.nextInt(256);
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/gclocker/gcl001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/gclocker/gcl001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,8 +68,6 @@ import nsk.share.gc.gp.array.LongArrayProducer;
 import nsk.share.gc.gp.array.ShortArrayProducer;
 import nsk.share.test.ExecutionController;
 import nsk.share.test.LocalRandom;
-
-import java.util.Random;
 
 public class gcl001 extends ThreadedGCTest {
 
@@ -281,10 +279,9 @@ public class gcl001 extends ThreadedGCTest {
 
         void doit(int size) {
             char[] array = gp.create(size);
-            Random rand = new Random();
             char min = 0xffff, max = 0;
             for (int i = 0; i < array.length; ++i) {
-                array[i] = (char) rand.nextInt();
+                array[i] = (char) LocalRandom.nextInt();
                 if (array[i] > max) {
                     max = array[i];
                 }
@@ -455,7 +452,6 @@ public class gcl001 extends ThreadedGCTest {
         void doit(int size) {
 
             double[] array = gp.create(size);
-            Random rand = new Random();
             double min = Double.MAX_VALUE, max = Double.MIN_VALUE;
             for (int i = 0; i < array.length; ++i) {
                 if (array[i] > max) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnistress002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@
 
 /*
  * @test
- * @key stress
+ * @key stress randomness
  *
  * @summary converted from VM testbase nsk/stress/jni/jnistress002.
  * VM testbase keywords: [stress, quick, feature_283, nonconcurrent]
@@ -61,6 +61,7 @@ package nsk.stress.jni;
 import nsk.share.Consts;
 import nsk.share.Debug;
 import nsk.share.test.StressOptions;
+import jdk.test.lib.Utils;
 
 import java.lang.reflect.Field;
 import java.util.Random;
@@ -433,7 +434,7 @@ class JNIter002 extends Thread {
         System.loadLibrary("jnistress002");
     }
 
-    static Random myRandom = new Random();
+    Random myRandom = new Random(Utils.getRandomInstance().nextLong());
 
     public JNIter002(Synchronizer[] aSync) {
         sync = aSync;

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @key stress
+ * @key stress randomness
  *
  * @summary converted from VM testbase nsk/stress/numeric/numeric001.
  * VM testbase keywords: [stress, slow, nonconcurrent, quick]
@@ -49,12 +49,15 @@
  *     which is used by this test:
  *         4242172 (P3/S5) 2.0: poor performance in matrix calculations
  *
+ * @library /test/lib
  * @run main/othervm nsk.stress.numeric.numeric001.numeric001 300 300
  */
 
 package nsk.stress.numeric.numeric001;
 
 import java.io.PrintStream;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 /**
  * This test calculates the product <b>A</b><sup>.</sup><b>A</b> for
@@ -82,6 +85,7 @@ import java.io.PrintStream;
  * 4242172 (P3/S5) 2.0: poor performance in matrix calculations
  */
 public class numeric001 {
+    private static final Random RNG = Utils.getRandomInstance();
     /**
      * When testing performance, single thread calculation is allowed to
      * be 10% slower than multi-threads calculation (<code>TOLERANCE</code>
@@ -288,7 +292,7 @@ public class numeric001 {
             value = new double[size][size];
             for (int line = 0; line < size; line++)
                 for (int column = 0; column < size; column++)
-                    value[line][column] = Math.random() * size;
+                    value[line][column] = RNG.nextDouble() * size;
         }
 
         /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @key stress
+ * @key stress randomness
  *
  * @summary converted from VM testbase nsk/stress/numeric/numeric002.
  * VM testbase keywords: [stress, slow, nonconcurrent, quick]
@@ -49,12 +49,15 @@
  *     which is used by this test:
  *         4242172 (P3/S5) 2.0: poor performance in matrix calculations
  *
+ * @library /test/lib
  * @run main/othervm nsk.stress.numeric.numeric002.numeric002 300 300
  */
 
 package nsk.stress.numeric.numeric002;
 
 import java.io.PrintStream;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 /**
  * This test calculates the product <b>A</b><sup>.</sup><b>A</b> for
@@ -82,6 +85,7 @@ import java.io.PrintStream;
  * 4242172 (P3/S5) 2.0: poor performance in matrix calculations
  */
 public class numeric002 {
+    private static final Random RNG = Utils.getRandomInstance();
     /**
      * When testing performance, single thread calculation is allowed to
      * be 10% slower than multi-threads calculation (<code>TOLERANCE</code>
@@ -306,7 +310,7 @@ public class numeric002 {
             value = new float[size][size];
             for (int line = 0; line < size; line++)
                 for (int column = 0; column < size; column++)
-                    value[line][column] = (float) (Math.random() * size);
+                    value[line][column] = (float) (RNG.nextDouble() * size);
             isConsistent = true;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @key stress
+ * @key stress randomness
  *
  * @summary converted from VM testbase nsk/stress/numeric/numeric003.
  * VM testbase keywords: [stress, slow, nonconcurrent, quick]
@@ -49,12 +49,15 @@
  *     which is used by this test:
  *         4242172 (P3/S5) 2.0: poor performance in matrix calculations
  *
+ * @library /test/lib
  * @run main/othervm nsk.stress.numeric.numeric003.numeric003 300 300
  */
 
 package nsk.stress.numeric.numeric003;
 
 import java.io.PrintStream;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 /**
  * This test calculates the product <b>A</b><sup>.</sup><b>A</b> for
@@ -82,6 +85,7 @@ import java.io.PrintStream;
  * 4242172 (P3/S5) 2.0: poor performance in matrix calculations
  */
 public class numeric003 {
+    private static final Random RNG = Utils.getRandomInstance();
     /**
      * When testing performance, single thread calculation is allowed to
      * be 10% slower than multi-threads calculation (<code>TOLERANCE</code>
@@ -288,7 +292,7 @@ public class numeric003 {
             value = new long[size][size];
             for (int line = 0; line < size; line++)
                 for (int column = 0; column < size; column++)
-                    value[line][column] = Math.round(Math.random() * size);
+                    value[line][column] = Math.round(RNG.nextDouble() * size);
         }
 
         /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @key stress
+ * @key stress randomness
  *
  * @summary converted from VM testbase nsk/stress/numeric/numeric004.
  * VM testbase keywords: [stress, slow, nonconcurrent, quick]
@@ -49,12 +49,15 @@
  *     which is used by this test:
  *         4242172 (P3/S5) 2.0: poor performance in matrix calculations
  *
+ * @library /test/lib
  * @run main/othervm nsk.stress.numeric.numeric004.numeric004 300 300
  */
 
 package nsk.stress.numeric.numeric004;
 
 import java.io.PrintStream;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 /**
  * This test calculates the product <b>A</b><sup>.</sup><b>A</b> for
@@ -82,6 +85,7 @@ import java.io.PrintStream;
  * 4242172 (P3/S5) 2.0: poor performance in matrix calculations
  */
 public class numeric004 {
+    private static final Random RNG = Utils.getRandomInstance();
     /**
      * When testing performance, single thread calculation is allowed to
      * be 10% slower than multi-threads calculation (<code>TOLERANCE</code>
@@ -288,7 +292,7 @@ public class numeric004 {
             value = new int[size][size];
             for (int line = 0; line < size; line++)
                 for (int column = 0; column < size; column++)
-                    value[line][column] = Math.round((float) (Math.random() * size));
+                    value[line][column] = Math.round((float) (RNG.nextDouble() * size));
         }
 
         /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @key stress
+ * @key stress randomness
  *
  * @summary converted from VM testbase nsk/stress/numeric/numeric005.
  * VM testbase keywords: [stress, slow, nonconcurrent, quick]
@@ -61,12 +61,15 @@
  *     See the bug-report:
  *         #4242172 (P3/S5) 2.0: poor performance in matrix calculations
  *
+ * @library /test/lib
  * @run main/othervm nsk.stress.numeric.numeric005.numeric005 300 3
  */
 
 package nsk.stress.numeric.numeric005;
 
 import java.io.PrintStream;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 /**
  * This test calculates the product <code>A<sup>.</sup>A</code> for
@@ -110,6 +113,7 @@ import java.io.PrintStream;
  * #4242172 (P3/S5) 2.0: poor performance in matrix calculations
  */
 public class numeric005 {
+    private static final Random RNG = Utils.getRandomInstance();
     /**
      * When testing performance, single thread calculation is allowed to
      * be 10% slower than multi-threads calculation (<code>TOLERANCE</code>
@@ -374,7 +378,7 @@ public class numeric005 {
 
         for (int line = 0; line < size; line++)
             for (int column = 0; column < size; column++)
-                A[line][column] = (1 - 2 * Math.random()) * size;
+                A[line][column] = (1 - 2 * RNG.nextDouble()) * size;
 
         return A;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric006.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @key stress
+ * @key stress randomness
  *
  * @summary converted from VM testbase nsk/stress/numeric/numeric006.
  * VM testbase keywords: [stress, slow, nonconcurrent, quick]
@@ -60,12 +60,15 @@
  * COMMENTS
  *     See the bug-report:
  *         #4242172 (P3/S5) 2.0: poor performance in matrix calculations
+ * @library /test/lib
  * @run main/othervm nsk.stress.numeric.numeric006.numeric006 300 3
  */
 
 package nsk.stress.numeric.numeric006;
 
 import java.io.PrintStream;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 /**
  * This test calculates the product <code>A<sup>.</sup>A</code> for
@@ -109,6 +112,7 @@ import java.io.PrintStream;
  * #4242172 (P3/S5) 2.0: poor performance in matrix calculations
  */
 public class numeric006 {
+    private static final Random RNG = Utils.getRandomInstance();
     /**
      * When testing performance, single thread calculation is allowed to
      * be 10% slower than multi-threads calculation (<code>TOLERANCE</code>
@@ -373,7 +377,7 @@ public class numeric006 {
 
         for (int line = 0; line < size; line++)
             for (int column = 0; column < size; column++)
-                A[line][column] = (float) ((1 - 2 * Math.random()) * size);
+                A[line][column] = (float) ((1 - 2 * RNG.nextDouble()) * size);
 
         return A;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @key stress
+ * @key stress randomness
  *
  * @summary converted from VM testbase nsk/stress/numeric/numeric007.
  * VM testbase keywords: [stress, slow, nonconcurrent, quick]
@@ -60,12 +60,15 @@
  * COMMENTS
  *     See the bug-report:
  *         #4242172 (P3/S5) 2.0: poor performance in matrix calculations
+ * @library /test/lib
  * @run main/othervm nsk.stress.numeric.numeric007.numeric007 300 3
  */
 
 package nsk.stress.numeric.numeric007;
 
 import java.io.PrintStream;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 /**
  * This test calculates the product <code>A<sup>.</sup>A</code> for
@@ -109,6 +112,7 @@ import java.io.PrintStream;
  * #4242172 (P3/S5) 2.0: poor performance in matrix calculations
  */
 public class numeric007 {
+    private static final Random RNG = Utils.getRandomInstance();
     /**
      * When testing performance, single thread calculation is allowed to
      * be 10% slower than multi-threads calculation (<code>TOLERANCE</code>
@@ -373,7 +377,7 @@ public class numeric007 {
 
         for (int line = 0; line < size; line++)
             for (int column = 0; column < size; column++)
-                A[line][column] = Math.round((1 - 2 * Math.random()) * size);
+                A[line][column] = Math.round((1 - 2 * RNG.nextDouble()) * size);
 
         return A;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric008.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @key stress
+ * @key stress randomness
  *
  * @summary converted from VM testbase nsk/stress/numeric/numeric008.
  * VM testbase keywords: [stress, slow, nonconcurrent, quick]
@@ -60,12 +60,15 @@
  * COMMENTS
  *     See the bug-report:
  *         #4242172 (P3/S5) 2.0: poor performance in matrix calculations
+ * @library /test/lib
  * @run main/othervm nsk.stress.numeric.numeric008.numeric008 300 3
  */
 
 package nsk.stress.numeric.numeric008;
 
 import java.io.PrintStream;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 /**
  * This test calculates the product <code>A<sup>.</sup>A</code> for
@@ -109,6 +112,7 @@ import java.io.PrintStream;
  * #4242172 (P3/S5) 2.0: poor performance in matrix calculations
  */
 public class numeric008 {
+    private static final Random RNG = Utils.getRandomInstance();
     /**
      * When testing performance, single thread calculation is allowed to
      * be 10% slower than multi-threads calculation (<code>TOLERANCE</code>
@@ -373,7 +377,7 @@ public class numeric008 {
 
         for (int line = 0; line < size; line++)
             for (int column = 0; column < size; column++)
-                A[line][column] = Math.round((float) ((1 - 2 * Math.random()) * size));
+                A[line][column] = Math.round((float) ((1 - 2 * RNG.nextDouble()) * size));
 
         return A;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric009.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @key stress
+ * @key stress randomness
  *
  * @summary converted from VM testbase nsk/stress/numeric/numeric009.
  * VM testbase keywords: [stress, slow, nonconcurrent, quick]
@@ -62,12 +62,15 @@
  *     See the bug-report:
  *         #4242172 (P3/S5) 2.0: poor performance in matrix calculations
  *
+ * @library /test/lib
  * @run main/othervm nsk.stress.numeric.numeric009.numeric009 200 2
  */
 
 package nsk.stress.numeric.numeric009;
 
 import java.io.PrintStream;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 /**
  * This test calculates the product <code>A<sup>.</sup>A</code> for a square
@@ -115,6 +118,7 @@ import java.io.PrintStream;
  * #4242172 (P3/S5) 2.0: poor performance in matrix calculations
  */
 public class numeric009 {
+    private static final Random RNG = Utils.getRandomInstance();
     /**
      * When testing performance, 1st iteration is allowed to be 10% slower
      * than 2nd iteration (<code>tolerance</code> is assigned to 10 now).
@@ -500,7 +504,7 @@ public class numeric009 {
         for (int line = 0; line < size; line++)
             for (int column = 0; column < size; column++)
                 A[line][column] =
-                        Math.round((float) ((1 - 2 * Math.random()) * size));
+                        Math.round((float) ((1 - 2 * RNG.nextDouble()) * size));
 
         return A;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/numeric/numeric010.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @key stress
+ * @key stress randomness
  *
  * @summary converted from VM testbase nsk/stress/numeric/numeric010.
  * VM testbase keywords: [stress, slow, nonconcurrent, quick]
@@ -68,12 +68,15 @@
  *     Note, that despite HotSpot works faster in milti-thread calculations,
  *     it still remains essentially slower than classic VM with JIT on.
  *
+ * @library /test/lib
  * @run main/othervm nsk.stress.numeric.numeric010.numeric010 200 200
  */
 
 package nsk.stress.numeric.numeric010;
 
 import java.io.PrintStream;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 /**
  * This test calculates the product <code>A<sup>.</sup>A</code> for a square
@@ -125,6 +128,7 @@ import java.io.PrintStream;
  * 4242172 (P3/S5) 2.0: poor performance in matrix calculations
  */
 public class numeric010 {
+    private static final Random RNG = Utils.getRandomInstance();
     /**
      * When testing performance, 1-thread calculation is allowed to be 10%
      * slower than multi-thread calculation (<code>tolerance</code> is
@@ -432,7 +436,7 @@ public class numeric010 {
             for (int line = 0; line < size; line++)
                 for (int column = 0; column < size; column++)
                     value[line][column] =
-                            Math.round((float) ((1 - 2 * Math.random()) * size));
+                            Math.round((float) ((1 - 2 * RNG.nextDouble()) * size));
         }
 
         /**


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8243429](https://bugs.openjdk.java.net/browse/JDK-8243429): use reproducible random in :vmTestbase_nsk_stress


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/979/head:pull/979` \
`$ git checkout pull/979`

Update a local copy of the PR: \
`$ git checkout pull/979` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 979`

View PR using the GUI difftool: \
`$ git pr show -t 979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/979.diff">https://git.openjdk.java.net/jdk11u-dev/pull/979.diff</a>

</details>
