### PR TITLE
8272964: java/nio/file/Files/InterruptCopy.java fails with java.lang.RuntimeException: Copy was not interrupted

### DIFF
--- a/test/jdk/java/nio/file/Files/InterruptCopy.java
+++ b/test/jdk/java/nio/file/Files/InterruptCopy.java
@@ -45,7 +45,6 @@ public class InterruptCopy {
 
     private static final long FILE_SIZE_TO_COPY = 1024L * 1024L * 1024L;
     private static final int INTERRUPT_DELAY_IN_MS = 50;
-    private static final int DURATION_MAX_IN_MS = 3*INTERRUPT_DELAY_IN_MS;
     private static final int CANCEL_DELAY_IN_MS = 10;
 
     public static void main(String[] args) throws Exception {
@@ -109,8 +108,15 @@ public class InterruptCopy {
                 long theEnd = System.currentTimeMillis();
                 System.out.printf("Done copying at %d ms...%n", theEnd);
                 long duration = theEnd - theBeginning;
-                if (duration > DURATION_MAX_IN_MS)
-                    throw new RuntimeException("Copy was not interrupted");
+
+                // If the copy was interrupted the target file should have been
+                // deleted, so if the file does not exist, then the copy must
+                // have been interrupted without throwing an exception; if the
+                // file exists, then the copy finished before being interrupted
+                // so not throwing an exception is not considered a failure
+                if (Files.notExists(target))
+                    throw new RuntimeException("Copy was not interrupted in " +
+                        duration + " ms");
             } catch (IOException e) {
                 boolean interrupted = Thread.interrupted();
                 if (!interrupted)


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272964](https://bugs.openjdk.java.net/browse/JDK-8272964): java/nio/file/Files/InterruptCopy.java fails with java.lang.RuntimeException: Copy was not interrupted


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/981/head:pull/981` \
`$ git checkout pull/981`

Update a local copy of the PR: \
`$ git checkout pull/981` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 981`

View PR using the GUI difftool: \
`$ git pr show -t 981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/981.diff">https://git.openjdk.java.net/jdk11u-dev/pull/981.diff</a>

</details>
