### PR TITLE
8278951: containers/cgroup/PlainRead.java fails on Ubuntu 21.10

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -156,8 +156,10 @@ PRAGMA_DIAG_POP
                                      NULL,                                \
                                      scan_fmt,                            \
                                      &variable);                          \
-  if (err != 0)                                                           \
+  if (err != 0) {                                                         \
+    log_trace(os, container)(logstring, (return_type) OSCONTAINER_ERROR); \
     return (return_type) OSCONTAINER_ERROR;                               \
+  }                                                                       \
                                                                           \
   log_trace(os, container)(logstring, variable);                          \
 }

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat Inc.
+ * Copyright (c) 2020, 2022, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -36,7 +36,7 @@
  */
 int CgroupV2Subsystem::cpu_shares() {
   GET_CONTAINER_INFO(int, _unified, "/cpu.weight",
-                     "Raw value for CPU shares is: %d", "%d", shares);
+                     "Raw value for CPU Shares is: %d", "%d", shares);
   // Convert default value of 100 to no shares setup
   if (shares == 100) {
     log_debug(os, container)("CPU Shares is: %d", -1);


### PR DESCRIPTION
Part of cgroups v2 backport works. Conflict on copyright line. local testing: v1 system passed; v2 system with no user delegated cpu controller failed, this is fixed by later bug 8250984. I am about to verify v2 with delegated cpu controller locally and will update this when I have the result.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278951](https://bugs.openjdk.java.net/browse/JDK-8278951): containers/cgroup/PlainRead.java fails on Ubuntu 21.10


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/984/head:pull/984` \
`$ git checkout pull/984`

Update a local copy of the PR: \
`$ git checkout pull/984` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 984`

View PR using the GUI difftool: \
`$ git pr show -t 984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/984.diff">https://git.openjdk.java.net/jdk11u-dev/pull/984.diff</a>

</details>
