### PR TITLE
8277093: Vector should throw ClassNotFoundException for a missing class of an element

### DIFF
--- a/src/java.base/share/classes/java/util/Vector.java
+++ b/src/java.base/share/classes/java/util/Vector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1188,6 +1188,12 @@ public class Vector<E>
         ObjectInputStream.GetField gfields = in.readFields();
         int count = gfields.get("elementCount", 0);
         Object[] data = (Object[])gfields.get("elementData", null);
+        if (data == null && !gfields.defaulted("elementData") && count > 0) {
+            // If elementData is null due to 8276665 throwing this exception will not
+            // overwrite the original ClassNotFoundException exception.
+            // That exception has been recorded and will be thrown from OIS.readObject.
+            throw new ClassNotFoundException("elementData is null");
+        }
         if (count < 0 || data == null || count > data.length) {
             throw new StreamCorruptedException("Inconsistent vector internals");
         }

--- a/test/jdk/java/util/Vector/VectorElementCNFE.java
+++ b/test/jdk/java/util/Vector/VectorElementCNFE.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8273660
+ * @summary The class of an element of a Vector may not be found; test that Vector allows
+ *          the CNFE to be thrown.
+ * @run testng VectorElementCNFE
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.io.StreamCorruptedException;
+import java.nio.charset.StandardCharsets;
+import java.util.Vector;
+
+import org.testng.annotations.Test;
+
+import org.testng.Assert;
+
+public class VectorElementCNFE {
+
+    /**
+     * Test a Vector holding a reference to a class instance that will not be found.
+     * @throws IOException If any other exception occurs
+     */
+    @Test
+    private static void test1() throws IOException {
+
+        Role role = new Role();
+        Vector<Role> vector = new Vector<>();
+        vector.add(role);
+
+        // Modify the byte stream to change the classname to be deserialized to
+        // XectorElementCNFE$Role.
+        byte[] bytes = writeObject(vector);
+
+        String s = new String(bytes, StandardCharsets.ISO_8859_1);  // Map bytes to chars
+        int off = s.indexOf(Role.class.getName());
+        Assert.assertTrue(off >= 0, "classname Role not found");
+
+        System.out.println("Clasname Role offset: " + off);
+        bytes[off] = (byte) 'X';  // replace V with X -> Class not found
+
+        // Deserialize the Vector expecting a ClassNotFoundException
+        ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes));
+        try {
+            Object obj = in.readObject();
+            System.out.println("Read: " + obj);
+            Assert.fail("Should not reach here, an exception should always occur");
+        } catch (ClassNotFoundException cnfe) {
+            // Expected ClassNotFoundException
+            String expected = "XectorElementCNFE$Role";
+            Assert.assertEquals(expected, cnfe.getMessage(), "Wrong classname");
+            System.out.println("Normal: " + cnfe);
+        }
+        // Other exceptions cause the test to fail
+    }
+
+    /**
+     * Test deserializing a Vector in which there is no "elementData" field.
+     * @throws IOException If any other exception occurs
+     */
+    @Test
+    private static void test2() throws IOException {
+
+        Role role = new Role();
+        Vector<Role> vector = new Vector<>();
+        vector.add(role);
+
+        // Modify the byte stream effectively remove the "elementData" field
+        // by changing fieldName to be deserialized to "XelementData".
+        byte[] bytes = writeObject(vector);
+
+        String s = new String(bytes, StandardCharsets.ISO_8859_1);  // Map bytes to chars
+        int off = s.indexOf("elementData");
+        Assert.assertTrue(off >= 0, "field elementData not found");
+
+        System.out.println("elementData offset: " + off);
+        bytes[off] = (byte) 'X';  // replace 'e' with X -> field elementData not found
+
+        // Deserialize the Vector expecting a StreamCorruptedException
+        ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes));
+        try {
+            Object obj = in.readObject();
+            System.out.println("Read: " + obj);
+            Assert.fail("Should not reach here, an exception should always occur");
+        } catch (StreamCorruptedException sce) {
+            // Expected StreamCorruptedException
+            String expected = "Inconsistent vector internals";
+            Assert.assertEquals(expected, sce.getMessage(), "Wrong exception message");
+            System.out.println("Normal: " + sce);
+        } catch (ClassNotFoundException cnfe) {
+            Assert.fail("CNFE not expected", cnfe);
+        }
+        // Other exceptions cause the test to fail
+    }
+
+    private static byte[] writeObject(Object o) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream os = new ObjectOutputStream(baos)) {
+            os.writeObject(o);
+        }
+        return baos.toByteArray();
+    }
+
+    static class Role implements Serializable {
+        private static final long serialVersionUID = 0L;
+
+        Role() {}
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

I resolved a copyright.  Marking as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8277093](https://bugs.openjdk.java.net/browse/JDK-8277093): Vector should throw ClassNotFoundException for a missing class of an element
 * [JDK-8277153](https://bugs.openjdk.java.net/browse/JDK-8277153): Vector should throw ClassNotFoundException for a missing class of an element (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/985/head:pull/985` \
`$ git checkout pull/985`

Update a local copy of the PR: \
`$ git checkout pull/985` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 985`

View PR using the GUI difftool: \
`$ git pr show -t 985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/985.diff">https://git.openjdk.java.net/jdk11u-dev/pull/985.diff</a>

</details>
