### PR TITLE
8253435: Cgroup: 'stomping of _mount_path' crash if manually mounted cpusets exist

### DIFF
--- a/test/hotspot/jtreg/containers/cgroup/CgroupSubsystemFactory.java
+++ b/test/hotspot/jtreg/containers/cgroup/CgroupSubsystemFactory.java
@@ -61,6 +61,8 @@ public class CgroupSubsystemFactory {
     private Path cgroupv1CgInfoNonZeroHierarchy;
     private Path cgroupv1MntInfoNonZeroHierarchyOtherOrder;
     private Path cgroupv1MntInfoNonZeroHierarchy;
+    private Path cgroupv1MntInfoDoubleCpuset;
+    private Path cgroupv1MntInfoDoubleCpuset2;
     private String mntInfoEmpty = "";
     private Path cgroupV1SelfCgroup;
     private Path cgroupV2SelfCgroup;
@@ -103,11 +105,14 @@ public class CgroupSubsystemFactory {
             "41 30 0:37 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:13 - cgroup none rw,seclabel,devices\n" +
             "42 30 0:38 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:14 - cgroup none rw,seclabel,cpuset\n" +
             "43 30 0:39 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:15 - cgroup none rw,seclabel,blkio\n" +
-            "44 30 0:40 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:16 - cgroup none rw,seclabel,freezer";
+            "44 30 0:40 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:16 - cgroup none rw,seclabel,freezer\n";
     private String mntInfoHybridRest = cgroupv1MountInfoLineMemory + mntInfoHybridStub;
     private String mntInfoHybridMissingMemory = mntInfoHybridStub;
     private String mntInfoHybrid = cgroupV2LineHybrid + mntInfoHybridRest;
     private String mntInfoHybridFlippedOrder = mntInfoHybridRest + cgroupV2LineHybrid;
+    private String mntInfoCgroupv1MoreCpusetLine = "121 32 0:37 / /cpusets rw,relatime shared:69 - cgroup none rw,cpuset\n";
+    private String mntInfoCgroupv1DoubleCpuset = mntInfoCgroupv1MoreCpusetLine + mntInfoHybrid;
+    private String mntInfoCgroupv1DoubleCpuset2 =  mntInfoHybrid + mntInfoCgroupv1MoreCpusetLine;
     private String cgroupsNonZeroHierarchy =
             "#subsys_name hierarchy   num_cgroups enabled\n" +
             "cpuset  3   1   1\n" +
@@ -158,6 +163,12 @@ public class CgroupSubsystemFactory {
 
             cgroupV2MntInfoMissingCgroupv2 = Paths.get(existingDirectory.toString(), "mnt_info_missing_cgroup2");
             Files.writeString(cgroupV2MntInfoMissingCgroupv2, mntInfoHybridStub);
+
+            cgroupv1MntInfoDoubleCpuset = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_cpuset");
+            Files.writeString(cgroupv1MntInfoDoubleCpuset, mntInfoCgroupv1DoubleCpuset);
+
+            cgroupv1MntInfoDoubleCpuset2 = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_cpuset2");
+            Files.writeString(cgroupv1MntInfoDoubleCpuset2, mntInfoCgroupv1DoubleCpuset2);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -173,6 +184,16 @@ public class CgroupSubsystemFactory {
 
     private boolean isValidCgroup(int value) {
         return value == CGROUPS_V1 || value == CGROUPS_V2;
+    }
+
+    public void testCgroupv1MultipleCpusetMounts(WhiteBox wb, Path mountInfo) {
+        String procCgroups = cgroupv1CgInfoNonZeroHierarchy.toString();
+        String procSelfCgroup = cgroupV1SelfCgroup.toString();
+        String procSelfMountinfo = mountInfo.toString();
+        int retval = wb.validateCgroup(procCgroups, procSelfCgroup, procSelfMountinfo);
+        Asserts.assertEQ(CGROUPS_V1, retval, "Multiple cpuset controllers, but only one in /sys/fs/cgroup");
+        Asserts.assertTrue(isValidCgroup(retval));
+        System.out.println("testCgroupv1MultipleCpusetMounts PASSED!");
     }
 
     public void testCgroupv1NoMounts(WhiteBox wb) {
@@ -247,6 +268,8 @@ public class CgroupSubsystemFactory {
             test.testCgroupV1HybridMntInfoOrder(wb);
             test.testCgroupv1MissingMemoryController(wb);
             test.testCgroupv2NoCgroup2Fs(wb);
+            test.testCgroupv1MultipleCpusetMounts(wb, test.cgroupv1MntInfoDoubleCpuset);
+            test.testCgroupv1MultipleCpusetMounts(wb, test.cgroupv1MntInfoDoubleCpuset2);
         } finally {
             test.teardown();
         }


### PR DESCRIPTION
This is a backport of JDK-8253435 (Cgroup: 'stomping of _mount_ path' crash if
manually mounted cpusets exist) as part of an effort to backport cgroups v2
support for JDK 11.

It applies clean after the dependent pr/986 (8252359: HotSpot Not Identifying
it is Running in a Container) and the included test passes for me on a pure
cgroups v2 system.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253435](https://bugs.openjdk.java.net/browse/JDK-8253435): Cgroup: 'stomping of _mount_path' crash if manually mounted cpusets exist


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/992/head:pull/992` \
`$ git checkout pull/992`

Update a local copy of the PR: \
`$ git checkout pull/992` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 992`

View PR using the GUI difftool: \
`$ git pr show -t 992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/992.diff">https://git.openjdk.java.net/jdk11u-dev/pull/992.diff</a>

</details>
