### PR TITLE
8245543: Cgroups: Incorrect detection logic on some systems (still reproducible)

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -294,14 +294,15 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
         // Skip cgroup2 fs lines on hybrid or unified hierarchy.
         continue;
       }
-      any_cgroup_mounts_found = true;
       while ((token = strsep(&cptr, ",")) != NULL) {
         if (strcmp(token, "memory") == 0) {
+          any_cgroup_mounts_found = true;
           assert(cg_infos[MEMORY_IDX]._mount_path == NULL, "stomping of _mount_path");
           cg_infos[MEMORY_IDX]._mount_path = os::strdup(tmpmount);
           cg_infos[MEMORY_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[MEMORY_IDX]._data_complete = true;
         } else if (strcmp(token, "cpuset") == 0) {
+          any_cgroup_mounts_found = true;
           if (cg_infos[CPUSET_IDX]._mount_path != NULL) {
             // On some systems duplicate cpuset controllers get mounted in addition to
             // the main cgroup controllers most likely under /sys/fs/cgroup. In that
@@ -321,11 +322,13 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
           cg_infos[CPUSET_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[CPUSET_IDX]._data_complete = true;
         } else if (strcmp(token, "cpu") == 0) {
+          any_cgroup_mounts_found = true;
           assert(cg_infos[CPU_IDX]._mount_path == NULL, "stomping of _mount_path");
           cg_infos[CPU_IDX]._mount_path = os::strdup(tmpmount);
           cg_infos[CPU_IDX]._root_mount_path = os::strdup(tmproot);
           cg_infos[CPU_IDX]._data_complete = true;
         } else if (strcmp(token, "cpuacct") == 0) {
+          any_cgroup_mounts_found = true;
           assert(cg_infos[CPUACCT_IDX]._mount_path == NULL, "stomping of _mount_path");
           cg_infos[CPUACCT_IDX]._mount_path = os::strdup(tmpmount);
           cg_infos[CPUACCT_IDX]._root_mount_path = os::strdup(tmproot);
@@ -339,7 +342,7 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
   // Neither cgroup2 nor cgroup filesystems mounted via /proc/self/mountinfo
   // No point in continuing.
   if (!any_cgroup_mounts_found) {
-    log_trace(os, container)("No cgroup controllers mounted.");
+    log_trace(os, container)("No relevant cgroup controllers mounted.");
     cleanup(cg_infos);
     *flags = INVALID_CGROUPS_NO_MOUNT;
     return false;

--- a/test/hotspot/jtreg/containers/cgroup/CgroupSubsystemFactory.java
+++ b/test/hotspot/jtreg/containers/cgroup/CgroupSubsystemFactory.java
@@ -63,6 +63,7 @@ public class CgroupSubsystemFactory {
     private Path cgroupv1MntInfoNonZeroHierarchy;
     private Path cgroupv1MntInfoDoubleCpuset;
     private Path cgroupv1MntInfoDoubleCpuset2;
+    private Path cgroupv1MntInfoSystemdOnly;
     private String mntInfoEmpty = "";
     private Path cgroupV1SelfCgroup;
     private Path cgroupV2SelfCgroup;
@@ -129,6 +130,9 @@ public class CgroupSubsystemFactory {
             "pids    3   80  1";
     private String mntInfoCgroupsV2Only =
             "28 21 0:25 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:4 - cgroup2 none rw,seclabel,nsdelegate";
+    private String mntInfoCgroupsV1SystemdOnly =
+            "35 26 0:26 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime - cgroup systemd rw,name=systemd\n" +
+            "26 18 0:19 / /sys/fs/cgroup rw,relatime - tmpfs none rw,size=4k,mode=755\n";
 
     private void setup() {
         try {
@@ -169,6 +173,9 @@ public class CgroupSubsystemFactory {
 
             cgroupv1MntInfoDoubleCpuset2 = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_double_cpuset2");
             Files.writeString(cgroupv1MntInfoDoubleCpuset2, mntInfoCgroupv1DoubleCpuset2);
+
+            cgroupv1MntInfoSystemdOnly = Paths.get(existingDirectory.toString(), "mnt_info_cgroupv1_systemd_only");
+            Files.writeString(cgroupv1MntInfoSystemdOnly, mntInfoCgroupsV1SystemdOnly);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -194,6 +201,16 @@ public class CgroupSubsystemFactory {
         Asserts.assertEQ(CGROUPS_V1, retval, "Multiple cpuset controllers, but only one in /sys/fs/cgroup");
         Asserts.assertTrue(isValidCgroup(retval));
         System.out.println("testCgroupv1MultipleCpusetMounts PASSED!");
+    }
+
+    public void testCgroupv1SystemdOnly(WhiteBox wb) {
+        String procCgroups = cgroupv1CgInfoZeroHierarchy.toString();
+        String procSelfCgroup = cgroupV1SelfCgroup.toString();
+        String procSelfMountinfo = cgroupv1MntInfoSystemdOnly.toString();
+        int retval = wb.validateCgroup(procCgroups, procSelfCgroup, procSelfMountinfo);
+        Asserts.assertEQ(INVALID_CGROUPS_NO_MOUNT, retval, "Only systemd mounted. Invalid");
+        Asserts.assertFalse(isValidCgroup(retval));
+        System.out.println("testCgroupv1SystemdOnly PASSED!");
     }
 
     public void testCgroupv1NoMounts(WhiteBox wb) {
@@ -262,6 +279,7 @@ public class CgroupSubsystemFactory {
         CgroupSubsystemFactory test = new CgroupSubsystemFactory();
         test.setup();
         try {
+            test.testCgroupv1SystemdOnly(wb);
             test.testCgroupv1NoMounts(wb);
             test.testCgroupv2(wb);
             test.testCgroupV1Hybrid(wb);


### PR DESCRIPTION
Clean backport part of the cgroups v2 support work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8245543](https://bugs.openjdk.java.net/browse/JDK-8245543): Cgroups: Incorrect detection logic on some systems (still reproducible)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/994/head:pull/994` \
`$ git checkout pull/994`

Update a local copy of the PR: \
`$ git checkout pull/994` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 994`

View PR using the GUI difftool: \
`$ git pr show -t 994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/994.diff">https://git.openjdk.java.net/jdk11u-dev/pull/994.diff</a>

</details>
