### PR TITLE
8227171: provide function names in native stack trace on aix with xlc16

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -532,8 +532,9 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     fi
 
   elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    TOOLCHAIN_CFLAGS_JDK="-qchars=signed -qfullpath -qsaveopt -qstackprotect"  # add on both CFLAGS
-    TOOLCHAIN_CFLAGS_JVM="-qtune=balanced \
+    # set -qtbtable=full for a better traceback table/better stacks in hs_err when xlc16 is used
+    TOOLCHAIN_CFLAGS_JDK="-qtbtable=full -qchars=signed -qfullpath -qsaveopt -qstackprotect"  # add on both CFLAGS
+    TOOLCHAIN_CFLAGS_JVM="-qtbtable=full -qtune=balanced \
         -qalias=noansi -qstrict -qtls=default -qlanglvl=c99vla \
         -qlanglvl=noredefmac -qnortti -qnoeh -qignerrno -qstackprotect"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then


### PR DESCRIPTION
#993

Backport of:

8227171: provide function names in native stack trace on aix with xlc16

Reviewed-by: stuefe

Backport Notes:

- flags-cflags.m4: Minor change. One flag (-qstackprotect) expected by backported commit and not removed by it. Resolved by adding -qstackprotect.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8227171](https://bugs.openjdk.java.net/browse/JDK-8227171): provide function names in native stack trace on aix with xlc16


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/998/head:pull/998` \
`$ git checkout pull/998`

Update a local copy of the PR: \
`$ git checkout pull/998` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 998`

View PR using the GUI difftool: \
`$ git pr show -t 998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/998.diff">https://git.openjdk.java.net/jdk11u-dev/pull/998.diff</a>

</details>
