### PR TITLE
Backport only 8227389

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -121,7 +121,11 @@ AC_DEFUN([FLAGS_SETUP_DEBUG_SYMBOLS],
     # -g0 enables debug symbols without disabling inlining.
     CFLAGS_DEBUG_SYMBOLS="-g0 -xs"
   elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    CFLAGS_DEBUG_SYMBOLS="-g"
+    if test "x$XLC_USES_CLANG" = xtrue; then
+      CFLAGS_DEBUG_SYMBOLS="-g1"
+    else
+      CFLAGS_DEBUG_SYMBOLS="-g"
+    fi
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     CFLAGS_DEBUG_SYMBOLS="-Z7 -d2Zi+"
   fi

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -121,11 +121,7 @@ AC_DEFUN([FLAGS_SETUP_DEBUG_SYMBOLS],
     # -g0 enables debug symbols without disabling inlining.
     CFLAGS_DEBUG_SYMBOLS="-g0 -xs"
   elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    if test "x$XLC_USES_CLANG" = xtrue; then
-      CFLAGS_DEBUG_SYMBOLS="-g1"
-    else
-      CFLAGS_DEBUG_SYMBOLS="-g"
-    fi
+    CFLAGS_DEBUG_SYMBOLS="-g1"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     CFLAGS_DEBUG_SYMBOLS="-Z7 -d2Zi+"
   fi

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -528,8 +528,10 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     fi
 
   elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    TOOLCHAIN_CFLAGS_JDK="-qchars=signed -qfullpath -qsaveopt"  # add on both CFLAGS
-    TOOLCHAIN_CFLAGS_JVM="-qtune=balanced \
+    # Suggested additions: -qsrcmsg to get improved error reporting
+    # set -qtbtable=full for a better traceback table/better stacks in hs_err when xlc16 is used
+    TOOLCHAIN_CFLAGS_JDK="-qtbtable=full -qchars=signed -qfullpath -qsaveopt -qstackprotect"  # add on both CFLAGS
+    TOOLCHAIN_CFLAGS_JVM="-qtbtable=full -qtune=balanced \
         -qalias=noansi -qstrict -qtls=default -qlanglvl=c99vla \
         -qlanglvl=noredefmac -qnortti -qnoeh -qignerrno"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -532,8 +532,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     # set -qtbtable=full for a better traceback table/better stacks in hs_err when xlc16 is used
     TOOLCHAIN_CFLAGS_JDK="-qtbtable=full -qchars=signed -qfullpath -qsaveopt -qstackprotect"  # add on both CFLAGS
     TOOLCHAIN_CFLAGS_JVM="-qtbtable=full -qtune=balanced \
-        -qalias=noansi -qstrict -qtls=default -qlanglvl=c99vla \
-        -qlanglvl=noredefmac -qnortti -qnoeh -qignerrno"
+        -qalias=noansi -qstrict -qtls=default -qnortti -qnoeh -qignerrno -qstackprotect"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     TOOLCHAIN_CFLAGS_JVM="-nologo -MD -MP"
     TOOLCHAIN_CFLAGS_JDK="-nologo -MD -Zc:wchar_t-"

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -278,6 +278,20 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
   fi
   AC_SUBST(TOOLCHAIN_TYPE)
 
+  # on AIX, check for xlclang++ on the PATH and TOOLCHAIN_PATH and use it if it is available
+  if test "x$OPENJDK_TARGET_OS" = xaix; then
+    if test "x$TOOLCHAIN_PATH" != x; then
+      XLC_TEST_PATH=${TOOLCHAIN_PATH}/
+    fi
+
+    XLCLANG_VERSION_OUTPUT=`${XLC_TEST_PATH}xlclang++ -qversion 2>&1 | $HEAD -n 1`
+    $ECHO "$XLCLANG_VERSION_OUTPUT" | $GREP "IBM XL C/C++ for AIX" > /dev/null
+    if test $? -eq 0; then
+      AC_MSG_NOTICE([xlclang++ output: $XLCLANG_VERSION_OUTPUT])
+      XLC_USES_CLANG=true
+    fi
+  fi
+
   TOOLCHAIN_CC_BINARY_clang="clang"
   TOOLCHAIN_CC_BINARY_gcc="gcc"
   TOOLCHAIN_CC_BINARY_microsoft="cl"
@@ -289,6 +303,14 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
   TOOLCHAIN_CXX_BINARY_microsoft="cl"
   TOOLCHAIN_CXX_BINARY_solstudio="CC"
   TOOLCHAIN_CXX_BINARY_xlc="xlC_r"
+
+  if test "x$OPENJDK_TARGET_OS" = xaix; then
+    if test "x$XLC_USES_CLANG" = xtrue; then
+      AC_MSG_NOTICE([xlclang++ detected, using it])
+      TOOLCHAIN_CC_BINARY_xlc="xlclang"
+      TOOLCHAIN_CXX_BINARY_xlc="xlclang++"
+    fi
+  fi
 
   # Use indirect variable referencing
   toolchain_var_name=TOOLCHAIN_DESCRIPTION_$TOOLCHAIN_TYPE

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -288,7 +288,8 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
     $ECHO "$XLCLANG_VERSION_OUTPUT" | $GREP "IBM XL C/C++ for AIX" > /dev/null
     if test $? -eq 0; then
       AC_MSG_NOTICE([xlclang++ output: $XLCLANG_VERSION_OUTPUT])
-      XLC_USES_CLANG=true
+    else
+      AC_MSG_ERROR([xlclang++ version output check failed, output: $XLCLANG_VERSION_OUTPUT])
     fi
   fi
 
@@ -296,21 +297,13 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
   TOOLCHAIN_CC_BINARY_gcc="gcc"
   TOOLCHAIN_CC_BINARY_microsoft="cl"
   TOOLCHAIN_CC_BINARY_solstudio="cc"
-  TOOLCHAIN_CC_BINARY_xlc="xlc_r"
+  TOOLCHAIN_CC_BINARY_xlc="xlclang"
 
   TOOLCHAIN_CXX_BINARY_clang="clang++"
   TOOLCHAIN_CXX_BINARY_gcc="g++"
   TOOLCHAIN_CXX_BINARY_microsoft="cl"
   TOOLCHAIN_CXX_BINARY_solstudio="CC"
-  TOOLCHAIN_CXX_BINARY_xlc="xlC_r"
-
-  if test "x$OPENJDK_TARGET_OS" = xaix; then
-    if test "x$XLC_USES_CLANG" = xtrue; then
-      AC_MSG_NOTICE([xlclang++ detected, using it])
-      TOOLCHAIN_CC_BINARY_xlc="xlclang"
-      TOOLCHAIN_CXX_BINARY_xlc="xlclang++"
-    fi
-  fi
+  TOOLCHAIN_CXX_BINARY_xlc="xlclang++"
 
   # Use indirect variable referencing
   toolchain_var_name=TOOLCHAIN_DESCRIPTION_$TOOLCHAIN_TYPE

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -518,7 +518,7 @@ query_multipage_support_end:
       describe_pagesize(g_multipage_support.pthr_stack_pagesize));
   trcVerbose("Default shared memory page size: %s",
       describe_pagesize(g_multipage_support.shmpsize));
-  trcVerbose("Can use 64K pages dynamically with shared meory: %s",
+  trcVerbose("Can use 64K pages dynamically with shared memory: %s",
       (g_multipage_support.can_use_64K_pages ? "yes" :"no"));
   trcVerbose("Can use 16M pages dynamically with shared memory: %s",
       (g_multipage_support.can_use_16M_pages ? "yes" :"no"));
@@ -1433,7 +1433,7 @@ void os::print_memory_info(outputStream* st) {
     describe_pagesize(g_multipage_support.pthr_stack_pagesize));
   st->print_cr("  Default shared memory page size:        %s",
     describe_pagesize(g_multipage_support.shmpsize));
-  st->print_cr("  Can use 64K pages dynamically with shared meory:  %s",
+  st->print_cr("  Can use 64K pages dynamically with shared memory:  %s",
     (g_multipage_support.can_use_64K_pages ? "yes" :"no"));
   st->print_cr("  Can use 16M pages dynamically with shared memory: %s",
     (g_multipage_support.can_use_16M_pages ? "yes" :"no"));

--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,15 @@
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 
+// distinguish old xlc and xlclang++, where
+// <ibmdemangle.h> is suggested but not found in GA release (might come with a fix)
+#if defined(__clang__)
+#define DISABLE_DEMANGLE
+// #include <ibmdemangle.h>
+#else
 #include <demangle.h>
+#endif
+
 #include <sys/debug.h>
 #include <pthread.h>
 #include <ucontext.h>
@@ -237,6 +245,7 @@ bool AixSymbols::get_function_name (
       p_name[i] = '\0';
 
       // If it is a C++ name, try and demangle it using the Demangle interface (see demangle.h).
+#ifndef DISABLE_DEMANGLE
       if (demangle) {
         char* rest;
         Name* const name = Demangle(p_name, rest);
@@ -249,6 +258,7 @@ bool AixSymbols::get_function_name (
           delete name;
         }
       }
+#endif
     } else {
       strncpy(p_name, "<nameless function>", namelen-1);
       p_name[namelen-1] = '\0';

--- a/src/hotspot/os_cpu/aix_ppc/prefetch_aix_ppc.inline.hpp
+++ b/src/hotspot/os_cpu/aix_ppc/prefetch_aix_ppc.inline.hpp
@@ -43,7 +43,7 @@ inline void Prefetch::read(void *loc, intx interval) {
 }
 
 inline void Prefetch::write(void *loc, intx interval) {
-#if !defined(USE_XLC_PREFETCH_WRITE_BUILTIN)
+#if !defined(USE_XLC_BUILTINS)
   __asm__ __volatile__ (
     "   dcbtst 0, %0       \n"
     :

--- a/src/hotspot/share/gc/shared/oopStorage.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.hpp
@@ -167,10 +167,7 @@ public:
   // private types by providing public typedefs for them.
   class TestAccess;
 
-  // xlC on AIX can't compile test_oopStorage.cpp with following private
-  // classes. C++03 introduced access for nested classes with DR45, but xlC
-  // version 12 rejects it.
-NOT_AIX( private: )
+private:
   class Block;                  // Fixed-size array of oops, plus bookkeeping.
   class ActiveArray;            // Array of Blocks, plus bookkeeping.
   class AllocationListEntry;    // Provides AllocationList links in a Block.
@@ -209,7 +206,6 @@ private:
   ActiveArray* _active_array;
   AllocationList _allocation_list;
   Block* volatile _deferred_updates;
-
   Mutex* _allocation_mutex;
   Mutex* _active_mutex;
 

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -220,9 +220,6 @@ class StackObj ALLOCATION_SUPER_CLASS_SPEC {
  private:
   void* operator new(size_t size) throw();
   void* operator new [](size_t size) throw();
-#ifdef __IBMCPP__
- public:
-#endif
   void  operator delete(void* p);
   void  operator delete [](void* p);
 };

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3904,7 +3904,7 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
 #endif
 
 #if defined(AIX)
-  UNSUPPORTED_OPTION(AllocateHeapAt);
+  UNSUPPORTED_OPTION_NULL(AllocateHeapAt);
 #endif
 
   ArgumentsExt::report_unsupported_options();

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -665,4 +665,16 @@ do {                                                     \
   }                                                      \
 } while(0)
 
-#endif // SHARE_VM_RUNTIME_ARGUMENTS_HPP
+// similar to UNSUPPORTED_OPTION but sets flag to NULL
+#define UNSUPPORTED_OPTION_NULL(opt)                     \
+do {                                                     \
+  if (opt) {                                             \
+    if (FLAG_IS_CMDLINE(opt)) {                          \
+      warning("-XX flag " #opt " not supported in this VM"); \
+    }                                                    \
+    FLAG_SET_DEFAULT(opt, NULL);                         \
+  }                                                      \
+} while(0)
+
+
+#endif // SHARE_RUNTIME_ARGUMENTS_HPP

--- a/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
@@ -51,6 +51,19 @@
 
 #include <stdint.h>
 
+// check for xlc16 or higher
+#ifdef __ibmxl_version__
+  #if __ibmxl_version__ < 16
+  #error "xlc < 16 not supported"
+  #endif
+#else
+  #error "xlc < 16 not supported, macro __ibmxl_version__ not found"
+#endif
+
+#ifndef _AIX
+#error "missing AIX-specific definition _AIX"
+#endif
+
 // Use XLC compiler builtins instead of inline assembler
 #define USE_XLC_BUILTINS
 #ifdef USE_XLC_BUILTINS

--- a/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2017 SAP SE. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,49 +66,30 @@
 
 // Use XLC compiler builtins instead of inline assembler
 #define USE_XLC_BUILTINS
+
 #ifdef USE_XLC_BUILTINS
 #include <builtins.h>
-  #if __IBMCPP__ < 1000
-  // the funtion prototype for __dcbtst(void *) is missing in XLC V8.0
-  // I could compile a little test, where I provided the prototype.
-  // The generated code was correct there. This is the prototype:
-  // extern "builtin" void __dcbtst (void *);
-  // For now we don't make use of it when compiling with XLC V8.0
-  #else
-  // __IBMCPP__ >= 1000
-  // XLC V10 provides the prototype for __dcbtst (void *);
-  #define USE_XLC_PREFETCH_WRITE_BUILTIN
-  #endif
+// XLC V10 and higher provide the prototype for __dcbtst (void *);
 #endif // USE_XLC_BUILTINS
 
 // NULL vs NULL_WORD:
-// On Linux NULL is defined as a special type '__null'. Assigning __null to
-// integer variable will cause gcc warning. Use NULL_WORD in places where a
-// pointer is stored as integer value.  On some platforms, sizeof(intptr_t) >
-// sizeof(void*), so here we want something which is integer type, but has the
-// same size as a pointer.
-#ifdef __GNUC__
-  #error XLC and __GNUC__?
-#else
-  #define NULL_WORD  NULL
-#endif
+// Some platform/tool-chain combinations can't assign NULL to an integer
+// type so we define NULL_WORD to use in those contexts. For xlc they are the same.
+#define NULL_WORD  NULL
 
 // AIX also needs a 64 bit NULL to work as a null address pointer.
 // Most system includes on AIX would define it as an int 0 if not already defined with one
 // exception: /usr/include/dirent.h will unconditionally redefine NULL to int 0 again.
 // In this case you need to copy the following defines to a position after #include <dirent.h>
-// (see jmv_aix.h).
-#ifdef AIX
-  #include <dirent.h>
-  #ifdef _LP64
-    #undef NULL
-    #define NULL 0L
-  #else
-    #ifndef NULL
-      #define NULL 0
-    #endif
+#include <dirent.h>
+#ifdef _LP64
+  #undef NULL
+  #define NULL 0L
+#else
+  #ifndef NULL
+    #define NULL 0
   #endif
-#endif // AIX
+#endif
 
 // Compiler-specific primitive types
 // All defs of int (uint16_6 etc) are defined in AIX' /usr/include/stdint.h
@@ -121,21 +102,14 @@ typedef uint32_t juint;
 typedef uint64_t julong;
 
 // checking for nanness
-#ifdef AIX
 inline int g_isnan(float  f) { return isnan(f); }
 inline int g_isnan(double f) { return isnan(f); }
-#else
-#error "missing platform-specific definition here"
-#endif
 
 // Checking for finiteness
-
 inline int g_isfinite(jfloat  f)                 { return finite(f); }
 inline int g_isfinite(jdouble f)                 { return finite(f); }
 
-
 // Wide characters
-
 inline int wcslen(const jchar* x) { return wcslen((const wchar_t*)x); }
 
 


### PR DESCRIPTION
#993 

8227389: Remove unsupported xlc16 compile options on aix

Reviewed-by: clanger, mdoerr

Backport Conflicts:
- make/autoconf/flags-cflags.m4: Minor change. Accept backported
addition of -qstackprotect.