### PR TITLE
8283217: Leak FcObjectSet in getFontConfigLocations() in fontpath.c

### DIFF
--- a/src/java.desktop/unix/native/common/awt/fontpath.c
+++ b/src/java.desktop/unix/native/common/awt/fontpath.c
@@ -712,6 +712,7 @@ typedef FcResult (*FcPatternGetStringFuncType)(const FcPattern *p,
                                                FcChar8 ** s);
 typedef FcChar8* (*FcStrDirnameFuncType)(const FcChar8 *file);
 typedef void (*FcPatternDestroyFuncType)(FcPattern *p);
+typedef void (*FcObjectSetDestroyFuncType)(FcObjectSet *os);
 typedef void (*FcFontSetDestroyFuncType)(FcFontSet *s);
 typedef FcPattern* (*FcNameParseFuncType)(const FcChar8 *name);
 typedef FcBool (*FcPatternAddStringFuncType)(FcPattern *p,
@@ -758,6 +759,7 @@ static char **getFontConfigLocations() {
     FcPatternGetStringFuncType FcPatternGetString;
     FcStrDirnameFuncType FcStrDirname;
     FcPatternDestroyFuncType FcPatternDestroy;
+    FcObjectSetDestroyFuncType FcObjectSetDestroy;
     FcFontSetDestroyFuncType FcFontSetDestroy;
 
     FcConfig *fontconfig;
@@ -787,6 +789,8 @@ static char **getFontConfigLocations() {
         (FcStrDirnameFuncType)dlsym(libfontconfig, "FcStrDirname");
     FcPatternDestroy   =
         (FcPatternDestroyFuncType)dlsym(libfontconfig, "FcPatternDestroy");
+    FcObjectSetDestroy =
+        (FcObjectSetDestroyFuncType)dlsym(libfontconfig, "FcObjectSetDestroy");
     FcFontSetDestroy   =
         (FcFontSetDestroyFuncType)dlsym(libfontconfig, "FcFontSetDestroy");
 
@@ -796,6 +800,7 @@ static char **getFontConfigLocations() {
         FcFontList         == NULL ||
         FcStrDirname       == NULL ||
         FcPatternDestroy   == NULL ||
+        FcObjectSetDestroy == NULL ||
         FcFontSetDestroy   == NULL) { /* problem with the library: return. */
         closeFontConfig(libfontconfig, JNI_FALSE);
         return NULL;
@@ -852,6 +857,7 @@ static char **getFontConfigLocations() {
 
 cleanup:
     /* Free memory and close the ".so" */
+    (*FcObjectSetDestroy)(objset);
     (*FcPatternDestroy)(pattern);
     closeFontConfig(libfontconfig, JNI_TRUE);
     return fontdirs;


### PR DESCRIPTION
A clean and low risk backport to fix memory leak

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283217](https://bugs.openjdk.java.net/browse/JDK-8283217): Leak FcObjectSet in getFontConfigLocations() in fontpath.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1005/head:pull/1005` \
`$ git checkout pull/1005`

Update a local copy of the PR: \
`$ git checkout pull/1005` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1005`

View PR using the GUI difftool: \
`$ git pr show -t 1005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1005.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1005.diff</a>

</details>
