### PR TITLE
8273655: content-types.properties files are missing some common types

### DIFF
--- a/src/java.base/unix/classes/sun/net/www/content-types.properties
+++ b/src/java.base/unix/classes/sun/net/www/content-types.properties
@@ -27,7 +27,7 @@ temp.file.template: /tmp/%s
 #
 application/octet-stream: \
 	description=Generic Binary Stream;\
-	file_extensions=.saveme,.dump,.hqx,.arc,.o,.a,.bin,.exe,.z,.gz
+	file_extensions=.saveme,.dump,.hqx,.arc,.o,.a,.bin,.exe,.z
 
 application/oda: \
 	description=ODA Document;\
@@ -253,14 +253,26 @@ image/bmp: \
 	description=Bitmap Image;\
 	file_extensions=.bmp;
 
+image/webp: \
+	description=WEBP image;\
+	file_extensions=.webp;
+
+text/css: \
+    description=CSS File;\
+    file_extensions=.css;
+
 text/html: \
 	description=HTML Document;\
 	file_extensions=.htm,.html;\
 	icon=html
 
+text/javascript: \
+    description=JavaScript File;\
+    file_extensions=.js;
+
 text/plain: \
 	description=Plain Text;\
-	file_extensions=.text,.c,.cc,.c++,.h,.pl,.txt,.java,.el;\
+	file_extensions=.text,.c,.cc,.c++,.h,.pl,.txt,.java,.el,.php,.adoc,.py;\
 	icon=text;\
 	action=browser
 
@@ -271,6 +283,14 @@ text/tab-separated-values: \
 text/x-setext: \
 	description=Structure Enhanced Text;\
 	file_extensions=.etx
+
+text/csv: \
+	description=CSV File;\
+	file_extensions=.csv;
+
+text/markdown: \
+    description=Markdown File;\
+    file_extensions=.md,.markdown
 
 video/mp4: \
 	description=MPEG-4 Video;\
@@ -311,3 +331,67 @@ message/rfc822: \
 application/xml: \
 	description=XML document;\
 	file_extensions=.xml
+
+application/rtf: \
+	description=WordPad Document;\
+	file_extensions=.rtf;
+
+application/gzip: \
+	description=GZip File;\
+	file_extensions=.gz;
+
+application/vnd.oasis.opendocument.presentation: \
+	description=OpenDocument presentation document;\
+	file_extensions=.odp;
+
+application/vnd.oasis.opendocument.spreadsheet: \
+	description=OpenDocument spreadsheet document;\
+	file_extensions=.ods;
+
+application/vnd.oasis.opendocument.text: \
+	description=OpenDocument text document;\
+	file_extensions=.odt;
+
+application/vnd.ms-excel: \
+    description=Microsoft Excel File;\
+	file_extensions=.xls;
+
+application/vnd.openxmlformats-officedocument.spreadsheetml.sheet: \
+	description=XLSX File;\
+	file_extensions=.xlsx;
+
+application/vnd.openxmlformats-officedocument.presentationml.presentation: \
+	description=PPTX File;\
+	file_extensions=.pptx;
+
+application/vnd.ms-powerpoint: \
+	description=Microsoft PowerPoint File;\
+	file_extensions=.ppt;
+
+application/x-7z-compressed: \
+	description=7-Zip File;\
+	file_extensions=.7z;
+
+application/msword: \
+	description=Microsoft Word File;\
+	file_extensions=.doc;
+
+application/vnd.openxmlformats-officedocument.wordprocessingml.document: \
+	description=DOCX File;\
+	file_extensions=.docx;
+
+application/vnd.rar: \
+	description=RAR File;\
+	file_extensions=.rar;
+
+application/json: \
+	description=JSON File;\
+	file_extensions=.json;
+
+application/bz2: \
+	description=BZ2 File;\
+	file_extensions=.bz2;
+
+application/java-archive: \
+	description=JAR File;\
+	file_extensions=.jar;

--- a/src/java.base/windows/classes/sun/net/www/content-types.properties
+++ b/src/java.base/windows/classes/sun/net/www/content-types.properties
@@ -27,7 +27,7 @@ temp.file.template: c:\\temp\\%s
 #
 application/octet-stream: \
 	description=Generic Binary Stream;\
-	file_extensions=.saveme,.dump,.hqx,.arc,.obj,.lib,.bin,.exe,.zip,.gz
+	file_extensions=.saveme,.dump,.hqx,.arc,.obj,.lib,.bin,.exe
 
 application/oda: \
 	description=ODA Document;\
@@ -43,10 +43,14 @@ application/postscript: \
 	icon=ps
 
 application/rtf: \
-	description=Wordpad Document;\
+	description=WordPad Document;\
 	file_extensions=.rtf;\
 	action=application;\
 	application=wordpad.exe %s
+
+application/gzip: \
+	description=GZip File;\
+	file_extensions=.gz;
 
 application/x-dvi: \
 	description=TeX DVI File;\
@@ -250,14 +254,26 @@ image/bmp: \
 	description=Bitmap Image;\
 	file_extensions=.bmp;
 
+image/webp: \
+	description=WEBP image;\
+	file_extensions=.webp;
+
+text/css: \
+    description=CSS File;\
+    file_extensions=.css;
+
 text/html: \
 	description=HTML Document;\
 	file_extensions=.htm,.html;\
 	icon=html
 
+text/javascript: \
+    description=JavaScript File;\
+    file_extensions=.js;
+
 text/plain: \
 	description=Plain Text;\
-	file_extensions=.text,.c,.cc,.c++,.h,.pl,.txt,.java,.el;\
+	file_extensions=.text,.c,.cc,.c++,.h,.pl,.txt,.java,.el,.php,.adoc,.py;\
 	icon=text;\
 	action=browser
 
@@ -268,6 +284,14 @@ text/tab-separated-values: \
 text/x-setext: \
 	description=Structure Enhanced Text;\
 	file_extensions=.etx
+
+text/csv: \
+	description=CSV File;\
+	file_extensions=.csv;
+
+text/markdown: \
+    description=Markdown File;\
+    file_extensions=.md,.markdown
 
 video/mp4: \
 	description=MPEG-4 Video;\
@@ -308,3 +332,59 @@ message/rfc822: \
 application/xml: \
 	description=XML document;\
 	file_extensions=.xml
+
+application/vnd.oasis.opendocument.presentation: \
+	description=OpenDocument presentation document;\
+	file_extensions=.odp;
+
+application/vnd.oasis.opendocument.spreadsheet: \
+	description=OpenDocument spreadsheet document;\
+	file_extensions=.ods;
+
+application/vnd.oasis.opendocument.text: \
+	description=OpenDocument text document;\
+	file_extensions=.odt;
+
+application/vnd.ms-excel: \
+	description=Microsoft Excel File;\
+	file_extensions=.xls;
+
+application/vnd.openxmlformats-officedocument.spreadsheetml.sheet: \
+	description=XLSX File;\
+	file_extensions=.xlsx;
+
+application/vnd.openxmlformats-officedocument.presentationml.presentation: \
+	description=PPTX File;\
+	file_extensions=.pptx;
+
+application/vnd.ms-powerpoint: \
+	description=Microsoft PowerPoint File;\
+	file_extensions=.ppt;
+
+application/x-7z-compressed: \
+	description=7-Zip File;\
+	file_extensions=.7z;
+
+application/msword: \
+	description=Microsoft Word File;\
+	file_extensions=.doc;
+
+application/vnd.openxmlformats-officedocument.wordprocessingml.document: \
+	description=DOCX File;\
+	file_extensions=.docx;
+
+application/vnd.rar: \
+	description=RAR File;\
+	file_extensions=.rar;
+
+application/json: \
+	description=JSON File;\
+	file_extensions=.json;
+
+application/bz2: \
+	description=BZ2 File;\
+	file_extensions=.bz2;
+
+application/java-archive: \
+	description=JAR File;\
+    file_extensions=.jar;

--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 8129632 8129633 8162624 8146215 8162745
+ * @bug 4313887 8129632 8129633 8162624 8146215 8162745 8273655
  * @summary Unit test for probeContentType method
  * @library ../..
  * @build Basic SimpleFileTypeDetector
@@ -31,6 +31,7 @@
 
 import java.io.*;
 import java.nio.file.*;
+import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -95,16 +96,12 @@ public class Basic {
         return 0;
     }
 
-    static int checkContentTypes(String[] extensions, String[] expectedTypes)
+    static int checkContentTypes(ExType[] exTypes)
         throws IOException {
-        if (extensions.length != expectedTypes.length) {
-            System.err.println("Parameter array lengths differ");
-            return 1;
-        }
-
         int failures = 0;
-        for (int i = 0; i < extensions.length; i++) {
-            String extension = extensions[i];
+        for (int i = 0; i < exTypes.length; i++) {
+            String extension = exTypes[i].extension();
+            List<String> expectedTypes = exTypes[i].expectedTypes();
             Path file = Files.createTempFile("foo", "." + extension);
             try {
                 String type = Files.probeContentType(file);
@@ -112,9 +109,9 @@ public class Basic {
                     System.err.println("Content type of " + extension
                             + " cannot be determined");
                     failures++;
-                } else if (!type.equals(expectedTypes[i])) {
+                } else if (!expectedTypes.contains(type)) {
                     System.err.printf("Content type: %s; expected: %s%n",
-                        type, expectedTypes[i]);
+                        type, expectedTypes);
                     failures++;
                 }
             } finally {
@@ -155,27 +152,46 @@ public class Basic {
             Files.delete(file);
         }
 
-        // Verify that certain media extensions are mapped to the correct type.
-        String[] extensions = new String[]{
-            "jpg",
-            "mp3",
-            "mp4",
-            "pdf",
-            "png",
-            "webm"
+        // Verify that certain extensions are mapped to the correct type.
+        var exTypes = new ExType[] {
+                new ExType("adoc", List.of("text/plain")),
+                new ExType("bz2", List.of("application/bz2", "application/x-bzip2")),
+                new ExType("css", List.of("text/css")),
+                new ExType("csv", List.of("text/csv")),
+                new ExType("doc", List.of("application/msword")),
+                new ExType("docx", List.of("application/vnd.openxmlformats-officedocument.wordprocessingml.document")),
+                new ExType("gz", List.of("application/gzip", "application/x-gzip")),
+                new ExType("jar", List.of("application/java-archive", "application/x-java-archive")),
+                new ExType("jpg", List.of("image/jpeg")),
+                new ExType("js", List.of("text/javascript", "application/javascript")),
+                new ExType("json", List.of("application/json")),
+                new ExType("markdown", List.of("text/markdown")),
+                new ExType("md", List.of("text/markdown")),
+                new ExType("mp3", List.of("audio/mpeg")),
+                new ExType("mp4", List.of("video/mp4")),
+                new ExType("odp", List.of("application/vnd.oasis.opendocument.presentation")),
+                new ExType("ods", List.of("application/vnd.oasis.opendocument.spreadsheet")),
+                new ExType("odt", List.of("application/vnd.oasis.opendocument.text")),
+                new ExType("pdf", List.of("application/pdf")),
+                new ExType("php", List.of("text/plain", "text/php")),
+                new ExType("png", List.of("image/png")),
+                new ExType("ppt", List.of("application/vnd.ms-powerpoint")),
+                new ExType("pptx",List.of("application/vnd.openxmlformats-officedocument.presentationml.presentation")),
+                new ExType("py", List.of("text/plain", "text/x-python-script")),
+                new ExType("rar", List.of("application/vnd.rar")),
+                new ExType("rtf", List.of("application/rtf", "text/rtf")),
+                new ExType("webm", List.of("video/webm")),
+                new ExType("webp", List.of("image/webp")),
+                new ExType("xls", List.of("application/vnd.ms-excel")),
+                new ExType("xlsx", List.of("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")),
+                new ExType("7z", List.of("application/x-7z-compressed")),
         };
-        String[] expectedTypes = new String[] {
-            "image/jpeg",
-            "audio/mpeg",
-            "video/mp4",
-            "application/pdf",
-            "image/png",
-            "video/webm"
-        };
-        failures += checkContentTypes(extensions, expectedTypes);
+        failures += checkContentTypes(exTypes);
 
         if (failures > 0) {
             throw new RuntimeException("Test failed!");
         }
     }
+
+    record ExType(String extension, List<String> expectedTypes) { }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [65ed0a74](https://github.com/openjdk/jdk/commit/65ed0a742e65fe7e661e8da2adea6cd41992869e) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.  

The commit being backported was authored by Julia Boes on 21 Sep 2021 and was reviewed by Brian Burkhalter and Daniel Fuchs.

This is a clean update of the OpenJDK mime types which has already been backported to 17u.  The risk of extending the list of recognised types is low and will enable OpenJDK to correctly identify more file types.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273655](https://bugs.openjdk.java.net/browse/JDK-8273655): content-types.properties files are missing some common types


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1007/head:pull/1007` \
`$ git checkout pull/1007`

Update a local copy of the PR: \
`$ git checkout pull/1007` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1007`

View PR using the GUI difftool: \
`$ git pr show -t 1007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1007.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1007.diff</a>

</details>
