### PR TITLE
8280373: Update Xalan serializer / SystemIDResolver to align with JDK-8270492

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/utils/SystemIDResolver.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/utils/SystemIDResolver.java
@@ -1,6 +1,5 @@
 /*
- * reserved comment block
- * DO NOT REMOVE OR ALTER!
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -42,6 +41,8 @@ import com.sun.org.apache.xml.internal.serializer.utils.URI.MalformedURIExceptio
  * used in com.sun.org.apache.xml.internal.serializer.
  *
  * @xsl.usage internal
+ *
+ * @LastModified: Jan 2022
  */
 public final class SystemIDResolver
 {
@@ -282,7 +283,7 @@ public final class SystemIDResolver
   public static String getAbsoluteURI(String urlString, String base)
           throws TransformerException
   {
-    if (base == null)
+    if (base == null || base.length() == 0)
       return getAbsoluteURI(urlString);
 
     String absoluteBase = getAbsoluteURI(base);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c180070c](https://github.com/openjdk/jdk/commit/c180070cb59b8e075376ae913c5db9a4ed868303) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Matthias Baesken on 26 Jan 2022 and was reviewed by Yuri Nesterenko and Joe Wang.

JDK-8270492 was a security fix in the January security update which was backported to 8u, 11u & 17u. This fix synchronises `src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/utils/SystemIDResolver.java` to match the change in `src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/SystemIDResolver.java` made in JDK-8270492. The fix has already been backported to 17u.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280373](https://bugs.openjdk.java.net/browse/JDK-8280373): Update Xalan serializer / SystemIDResolver to align with JDK-8270492


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1008/head:pull/1008` \
`$ git checkout pull/1008`

Update a local copy of the PR: \
`$ git checkout pull/1008` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1008`

View PR using the GUI difftool: \
`$ git pr show -t 1008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1008.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1008.diff</a>

</details>
