### PR TITLE
8265297: javax/net/ssl/SSLSession/TestEnabledProtocols.java failed with "RuntimeException: java.net.SocketException: Connection reset"

### DIFF
--- a/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
+++ b/test/jdk/javax/net/ssl/SSLSession/TestEnabledProtocols.java
@@ -38,6 +38,7 @@
  * @author Ram Marti
  */
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
@@ -135,13 +136,13 @@ public class TestEnabledProtocols extends SSLSocketTemplate {
                 e.printStackTrace(System.out);
                 System.out.println("** Success **");
             }
-        } catch (SSLException ssle) {
+        } catch (SSLException | SocketException se) {
             // The server side may have closed the socket.
-            if (isConnectionReset(ssle)) {
-                System.out.println("Client SSLException:");
-                ssle.printStackTrace(System.out);
+            if (isConnectionReset(se)) {
+                System.out.println("Client SocketException:");
+                se.printStackTrace(System.out);
             } else {
-                failTest(ssle, "Client got UNEXPECTED SSLException:");
+                failTest(se, "Client got UNEXPECTED Exception:");
             }
 
         } catch (Exception e) {
@@ -149,8 +150,11 @@ public class TestEnabledProtocols extends SSLSocketTemplate {
         }
     }
 
-    private boolean isConnectionReset(SSLException ssle) {
-        Throwable cause = ssle.getCause();
+    private boolean isConnectionReset(IOException ioe) {
+        Throwable cause = ioe;
+        if (ioe instanceof SSLException) {
+            cause = ioe.getCause();
+        }
         return cause instanceof SocketException
                 && "Connection reset".equals(cause.getMessage());
     }


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

I had to change an instanceof operator to use Java 11 syntax.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265297](https://bugs.openjdk.java.net/browse/JDK-8265297): javax/net/ssl/SSLSession/TestEnabledProtocols.java failed with "RuntimeException: java.net.SocketException: Connection reset"


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1009/head:pull/1009` \
`$ git checkout pull/1009`

Update a local copy of the PR: \
`$ git checkout pull/1009` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1009`

View PR using the GUI difftool: \
`$ git pr show -t 1009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1009.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1009.diff</a>

</details>
