### PR TITLE
8282172: CompileBroker::log_metaspace_failure is called from non-Java/compiler threads

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -220,11 +220,13 @@ class CompilationLog : public StringEventLog {
   }
 
   void log_metaspace_failure(const char* reason) {
+    // Note: This method can be called from non-Java/compiler threads to
+    // log the global metaspace failure that might affect profiling.
     ResourceMark rm;
     StringLogMessage lm;
     lm.print("%4d   COMPILE PROFILING SKIPPED: %s", -1, reason);
     lm.print("\n");
-    log(JavaThread::current(), "%s", (const char*)lm);
+    log(Thread::current(), "%s", (const char*)lm);
   }
 };
 


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282172](https://bugs.openjdk.java.net/browse/JDK-8282172): CompileBroker::log_metaspace_failure is called from non-Java/compiler threads


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1010/head:pull/1010` \
`$ git checkout pull/1010`

Update a local copy of the PR: \
`$ git checkout pull/1010` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1010`

View PR using the GUI difftool: \
`$ git pr show -t 1010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1010.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1010.diff</a>

</details>
