### PR TITLE
8272493: Suboptimal code generation around Preconditions.checkIndex intrinsic with AVX2

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1282,7 +1282,6 @@ bool LibraryCallKit::inline_preconditions_checkIndex() {
   result = _gvn.transform(result);
   set_result(result);
   replace_in_map(index, result);
-  clear_upper_avx();
   return true;
 }
 


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272493](https://bugs.openjdk.java.net/browse/JDK-8272493): Suboptimal code generation around Preconditions.checkIndex intrinsic with AVX2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1012/head:pull/1012` \
`$ git checkout pull/1012`

Update a local copy of the PR: \
`$ git checkout pull/1012` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1012`

View PR using the GUI difftool: \
`$ git pr show -t 1012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1012.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1012.diff</a>

</details>
