### PR TITLE
8283641: Large value for CompileThresholdScaling causes assert

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -76,10 +76,17 @@ intx CompilerConfig::scaled_freq_log(intx freq_log) {
 // Returns threshold scaled with the value of scale.
 // If scale < 0.0, threshold is returned without scaling.
 intx CompilerConfig::scaled_compile_threshold(intx threshold, double scale) {
+  assert(threshold >= 0, "must be");
   if (scale == 1.0 || scale < 0.0) {
     return threshold;
   } else {
-    return (intx)(threshold * scale);
+    double v = threshold * scale;
+    assert(v >= 0, "must be");
+    if (v > max_intx) {
+      return max_intx;
+    } else {
+      return (intx)(v);
+    }
   }
 }
 


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283641](https://bugs.openjdk.java.net/browse/JDK-8283641): Large value for CompileThresholdScaling causes assert


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1016/head:pull/1016` \
`$ git checkout pull/1016`

Update a local copy of the PR: \
`$ git checkout pull/1016` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1016`

View PR using the GUI difftool: \
`$ git pr show -t 1016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1016.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1016.diff</a>

</details>
