### PR TITLE
8242312: use reproducible random in hotspot gc tests

### DIFF
--- a/test/hotspot/jtreg/gc/TestSoftReferencesBehaviorOnOOME.java
+++ b/test/hotspot/jtreg/gc/TestSoftReferencesBehaviorOnOOME.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@ package gc;
 
 /**
  * @test TestSoftReferencesBehaviorOnOOME
- * @key gc
+ * @key gc randomness
  * @summary Tests that all SoftReferences has been cleared at time of OOM.
  * @requires vm.gc != "Z"
  * @library /test/lib

--- a/test/hotspot/jtreg/gc/epsilon/TestByteArrays.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestByteArrays.java
@@ -25,9 +25,10 @@ package gc.epsilon;
 
 /**
  * @test TestByteArrays
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Epsilon is able to allocate arrays, and does not corrupt their state
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
@@ -69,16 +70,15 @@ package gc.epsilon;
  */
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestByteArrays {
-
-  static long SEED = Long.getLong("seed", System.nanoTime());
   static int COUNT = Integer.getInteger("count", 500); // ~100 MB allocation
 
   static byte[][] arr;
 
   public static void main(String[] args) throws Exception {
-    Random r = new Random(SEED);
+    Random r = Utils.getRandomInstance();
 
     arr = new byte[COUNT * 100][];
     for (int c = 0; c < COUNT; c++) {
@@ -88,7 +88,7 @@ public class TestByteArrays {
       }
     }
 
-    r = new Random(SEED);
+    r = new Random(Utils.SEED);
     for (int c = 0; c < COUNT; c++) {
       byte[] b = arr[c];
       if (b.length != (c * 100)) {

--- a/test/hotspot/jtreg/gc/epsilon/TestElasticTLAB.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestElasticTLAB.java
@@ -25,9 +25,10 @@ package gc.epsilon;
 
 /**
  * @test TestElasticTLAB
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Epsilon is able to work with/without elastic TLABs
+ * @library /test/lib
  *
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
@@ -56,16 +57,16 @@ package gc.epsilon;
  */
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestElasticTLAB {
 
-  static long SEED = Long.getLong("seed", System.nanoTime());
   static int COUNT = Integer.getInteger("count", 500); // ~100 MB allocation
 
   static byte[][] arr;
 
   public static void main(String[] args) throws Exception {
-    Random r = new Random(SEED);
+    Random r = Utils.getRandomInstance();
 
     arr = new byte[COUNT * 100][];
     for (int c = 0; c < COUNT; c++) {
@@ -75,7 +76,7 @@ public class TestElasticTLAB {
       }
     }
 
-    r = new Random(SEED);
+    r = new Random(Utils.SEED);
     for (int c = 0; c < COUNT; c++) {
       byte[] b = arr[c];
       if (b.length != (c * 100)) {

--- a/test/hotspot/jtreg/gc/epsilon/TestElasticTLABDecay.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestElasticTLABDecay.java
@@ -25,9 +25,10 @@ package gc.epsilon;
 
 /**
  * @test TestElasticTLABDecay
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Epsilon is able to work with/without elastic TLABs
+ * @library /test/lib
  *
  * @run main/othervm -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
@@ -46,16 +47,15 @@ package gc.epsilon;
  */
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestElasticTLABDecay {
-
-  static long SEED = Long.getLong("seed", System.nanoTime());
   static int COUNT = Integer.getInteger("count", 500); // ~100 MB allocation
 
   static byte[][] arr;
 
   public static void main(String[] args) throws Exception {
-    Random r = new Random(SEED);
+    Random r = Utils.getRandomInstance();
 
     arr = new byte[COUNT * 100][];
     for (int c = 0; c < COUNT; c++) {
@@ -66,7 +66,7 @@ public class TestElasticTLABDecay {
       Thread.sleep(5);
     }
 
-    r = new Random(SEED);
+    r = new Random(Utils.SEED);
     for (int c = 0; c < COUNT; c++) {
       byte[] b = arr[c];
       if (b.length != (c * 100)) {

--- a/test/hotspot/jtreg/gc/epsilon/TestObjects.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestObjects.java
@@ -25,9 +25,10 @@ package gc.epsilon;
 
 /**
  * @test TestObjects
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Epsilon is able to allocate objects, and does not corrupt their state
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UseTLAB -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
@@ -69,23 +70,22 @@ package gc.epsilon;
  */
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestObjects {
-
-  static long SEED = Long.getLong("seed", System.nanoTime());
   static int COUNT = Integer.getInteger("count", 1_000_000); // ~24 MB allocation
 
   static MyObject[] arr;
 
   public static void main(String[] args) throws Exception {
-    Random r = new Random(SEED);
+    Random r = Utils.getRandomInstance();
 
     arr = new MyObject[COUNT];
     for (int c = 0; c < COUNT; c++) {
       arr[c] = new MyObject(r.nextInt());
     }
 
-    r = new Random(SEED);
+    r = new Random(Utils.SEED);
     for (int c = 0; c < COUNT; c++) {
       int expected = r.nextInt();
       int actual = arr[c].id();

--- a/test/hotspot/jtreg/gc/epsilon/TestRefArrays.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestRefArrays.java
@@ -25,7 +25,7 @@ package gc.epsilon;
 
 /**
  * @test TestRefArrays
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Epsilon & !vm.graal.enabled
  * @summary Epsilon is able to allocate arrays, and does not corrupt their state
  * @library /test/lib
@@ -70,16 +70,15 @@ package gc.epsilon;
  */
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestRefArrays {
-
-  static long SEED = Long.getLong("seed", System.nanoTime());
   static int COUNT = Integer.getInteger("count", 200); // ~100 MB allocation
 
   static MyObject[][] arr;
 
   public static void main(String[] args) throws Exception {
-    Random r = new Random(SEED);
+    Random r = Utils.getRandomInstance();
 
     arr = new MyObject[COUNT * 100][];
     for (int c = 0; c < COUNT; c++) {
@@ -89,7 +88,7 @@ public class TestRefArrays {
       }
     }
 
-    r = new Random(SEED);
+    r = new Random(Utils.SEED);
     for (int c = 0; c < COUNT; c++) {
       MyObject[] b = arr[c];
       if (b.length != (c * 100)) {

--- a/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsClearMarkBits.java
+++ b/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsClearMarkBits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ package gc.g1;
  * @bug 8051973
  * @summary Test to make sure that eager reclaim of humongous objects correctly clears
  * mark bitmaps at reclaim.
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.G1
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
@@ -42,6 +42,7 @@ import java.util.Random;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.Utils;
 
 // An object that has a few references to other instances to slow down marking.
 class ObjectWithSomeRefs {
@@ -75,7 +76,7 @@ class TestEagerReclaimHumongousRegionsClearMarkBitsReclaimRegionFast {
              longList.add(new ObjectWithSomeRefs());
         }
 
-        Random rnd = new Random();
+        Random rnd = Utils.getRandomInstance();
         for (int i = 0; i < longList.size(); i++) {
              int len = longList.size();
              longList.get(i).other1 = longList.get(rnd.nextInt(len));

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package gc.g1;
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.Platform;
+import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Utils;
@@ -40,10 +41,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Random;
 import jdk.internal.misc.Unsafe; // for ADDRESS_SIZE
 import sun.hotspot.WhiteBox;
 
 public class TestShrinkAuxiliaryData {
+    private static final Random RNG = Utils.getRandomInstance();
 
     private static final int REGION_SIZE = 1024 * 1024;
 
@@ -215,7 +218,7 @@ public class TestShrinkAuxiliaryData {
 
             public void mutate() {
                 if (!payload.isEmpty() && payload.get(0).length > 0) {
-                    payload.get(0)[0] = (byte) (Math.random() * Byte.MAX_VALUE);
+                    payload.get(0)[0] = (byte) (RNG.nextDouble() * Byte.MAX_VALUE);
                 }
             }
         }
@@ -296,12 +299,12 @@ public class TestShrinkAuxiliaryData {
                 for (int i = 0; i < NUM_LINKS; i++) {
                     int regionToLink;
                     do {
-                        regionToLink = (int) (Math.random() * REGIONS_TO_ALLOCATE);
+                        regionToLink = (int) (RNG.nextDouble() * REGIONS_TO_ALLOCATE);
                     } while (regionToLink == regionNumber);
 
                     // get random garbage object from random region
                     garbage.get(ig).addRef(garbage.get(regionToLink
-                            * NUM_OBJECTS_PER_REGION + (int) (Math.random()
+                            * NUM_OBJECTS_PER_REGION + (int) (RNG.nextDouble()
                             * NUM_OBJECTS_PER_REGION)));
                 }
             }

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData00.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData00.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package gc.g1;
 
 /**
  * @test TestShrinkAuxiliaryData00
+ * @key randomness
  * @bug 8038423 8061715
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData05.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData05.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package gc.g1;
 
 /**
  * @test TestShrinkAuxiliaryData05
+ * @key randomness
  * @bug 8038423 8061715 8078405
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData10.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package gc.g1;
 
 /**
  * @test TestShrinkAuxiliaryData10
+ * @key randomness
  * @bug 8038423 8061715 8078405
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData15.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData15.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package gc.g1;
 /**
  * @test TestShrinkAuxiliaryData15
  * @bug 8038423 8061715 8078405
+ * @key randomness
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc.G1

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData20.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData20.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package gc.g1;
 
 /**
  * @test TestShrinkAuxiliaryData20
+ * @key randomness
  * @bug 8038423 8061715 8078405
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData25.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData25.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package gc.g1;
 
 /**
  * @test TestShrinkAuxiliaryData25
+ * @key randomness
  * @bug 8038423 8061715 8078405
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData30.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData30.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package gc.g1;
 
 /**
  * @test TestShrinkAuxiliaryData30
+ * @key randomness
  * @bug 8038423 8061715 8078405
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values

--- a/test/hotspot/jtreg/gc/g1/humongousObjects/TestHumongousMovement.java
+++ b/test/hotspot/jtreg/gc/g1/humongousObjects/TestHumongousMovement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 
 /**
  * @test TestHumongousMovement
+ * @key randomness
  * @summary Checks that Humongous objects are not moved during GC
  * @requires vm.gc.G1
  * @library /test/lib /

--- a/test/hotspot/jtreg/gc/g1/humongousObjects/TestNoAllocationsInHRegions.java
+++ b/test/hotspot/jtreg/gc/g1/humongousObjects/TestNoAllocationsInHRegions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 
 /**
  * @test TestNoAllocationsInHRegions
+ * @key randomness
  * @summary Checks that no additional allocations are made in humongous regions
  * @requires vm.gc.G1
  * @library /test/lib /
@@ -71,7 +72,7 @@ public class TestNoAllocationsInHRegions {
     private static volatile Error error = null;
 
     static class Allocator implements Runnable {
-
+        private final Random random;
         private final List<byte[]> liveObjects = new LinkedList<>();
         private int usedMemory = 0;
         public final Runnable[] actions;
@@ -87,12 +88,12 @@ public class TestNoAllocationsInHRegions {
         private static final int DEAD_OBJECT_MAX_SIZE = G1_REGION_SIZE / 10;
 
         public Allocator(int maxAllocationMemory) {
-
+            random = new Random(RND.nextLong());
             actions = new Runnable[]{
                     // Allocation
                     () -> {
                         if (maxAllocationMemory - usedMemory != 0) {
-                            int arraySize = RND.nextInt(Math.min(maxAllocationMemory - usedMemory,
+                            int arraySize = random.nextInt(Math.min(maxAllocationMemory - usedMemory,
                                     MAX_ALLOCATION_SIZE));
 
                             if (arraySize != 0) {
@@ -129,7 +130,7 @@ public class TestNoAllocationsInHRegions {
                     // Deallocation
                     () -> {
                         if (liveObjects.size() != 0) {
-                            int elementNum = RND.nextInt(liveObjects.size());
+                            int elementNum = random.nextInt(liveObjects.size());
                             int shouldFree = liveObjects.get(elementNum).length;
                             liveObjects.remove(elementNum);
                             usedMemory -= shouldFree;
@@ -138,7 +139,7 @@ public class TestNoAllocationsInHRegions {
 
                     // Dead object allocation
                     () -> {
-                        int size = RND.nextInt(DEAD_OBJECT_MAX_SIZE);
+                        int size = random.nextInt(DEAD_OBJECT_MAX_SIZE);
                         byte[] deadObject = new byte[size];
                     },
 
@@ -163,7 +164,7 @@ public class TestNoAllocationsInHRegions {
         @Override
         public void run() {
             while (!shouldStop) {
-                actions[RND.nextInt(actions.length)].run();
+                actions[random.nextInt(actions.length)].run();
                 Thread.yield();
             }
         }

--- a/test/hotspot/jtreg/gc/shenandoah/TestAllocHumongousFragment.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestAllocHumongousFragment.java
@@ -24,8 +24,9 @@
 /*
  * @test TestAllocHumongousFragment
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -Xmx1g -Xms1g -Xlog:gc -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:ShenandoahTargetNumRegions=2048
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
@@ -51,8 +52,9 @@
 /*
  * @test TestAllocHumongousFragment
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -Xmx1g -Xms1g -Xlog:gc -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:ShenandoahTargetNumRegions=2048
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
@@ -116,8 +118,9 @@
 /*
  * @test TestAllocHumongousFragment
  * @summary Make sure Shenandoah can recover from humongous allocation fragmentation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -Xlog:gc -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g -XX:ShenandoahTargetNumRegions=2048
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
@@ -157,7 +160,7 @@
  */
 
 import java.util.*;
-import java.util.concurrent.*;
+import jdk.test.lib.Utils;
 
 public class TestAllocHumongousFragment {
 
@@ -176,15 +179,15 @@ public class TestAllocHumongousFragment {
         objects = new ArrayList<>();
         long current = 0;
 
-        Random r = new Random();
+        Random rng = Utils.getRandomInstance();
         for (long c = 0; c < count; c++) {
             while (current > LIVE_MB * 1024 * 1024) {
-                int idx = ThreadLocalRandom.current().nextInt(objects.size());
+                int idx = rng.nextInt(objects.size());
                 int[] remove = objects.remove(idx);
                 current -= remove.length * 4 + 16;
             }
 
-            int[] newObj = new int[min + r.nextInt(max - min)];
+            int[] newObj = new int[min + rng.nextInt(max - min)];
             current += newObj.length * 4 + 16;
             objects.add(newObj);
             sink = new Object();

--- a/test/hotspot/jtreg/gc/shenandoah/TestAllocIntArrays.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestAllocIntArrays.java
@@ -24,8 +24,9 @@
 /*
  * @test TestAllocIntArrays
  * @summary Acceptance tests: collector can withstand allocation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
@@ -51,8 +52,9 @@
 /*
  * @test TestAllocIntArrays
  * @summary Acceptance tests: collector can withstand allocation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
@@ -132,8 +134,9 @@
 /*
  * @test TestAllocIntArrays
  * @summary Acceptance tests: collector can withstand allocation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
@@ -177,6 +180,7 @@
  */
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestAllocIntArrays {
 
@@ -189,7 +193,7 @@ public class TestAllocIntArrays {
         final int max = 384 * 1024;
         long count = TARGET_MB * 1024 * 1024 / (16 + 4 * (min + (max - min) / 2));
 
-        Random r = new Random();
+        Random r = Utils.getRandomInstance();
         for (long c = 0; c < count; c++) {
             sink = new int[min + r.nextInt(max - min)];
         }

--- a/test/hotspot/jtreg/gc/shenandoah/TestAllocObjectArrays.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestAllocObjectArrays.java
@@ -24,8 +24,9 @@
 /*
  * @test TestAllocObjectArrays
  * @summary Acceptance tests: collector can withstand allocation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
@@ -46,12 +47,14 @@
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
  *      -XX:-ShenandoahDegeneratedGC
  *      TestAllocObjectArrays
+ */
 
 /*
  * @test TestAllocObjectArrays
  * @summary Acceptance tests: collector can withstand allocation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
@@ -131,8 +134,9 @@
 /*
  * @test TestAllocObjectArrays
  * @summary Acceptance tests: collector can withstand allocation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
@@ -176,6 +180,7 @@
  */
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestAllocObjectArrays {
 
@@ -188,7 +193,7 @@ public class TestAllocObjectArrays {
         final int max = 384 * 1024;
         long count = TARGET_MB * 1024 * 1024 / (16 + 4 * (min + (max - min) / 2));
 
-        Random r = new Random();
+        Random r = Utils.getRandomInstance();
         for (long c = 0; c < count; c++) {
             sink = new Object[min + r.nextInt(max - min)];
         }

--- a/test/hotspot/jtreg/gc/shenandoah/TestAllocObjects.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestAllocObjects.java
@@ -186,8 +186,6 @@
  *      TestAllocObjects
  */
 
-import java.util.Random;
-
 public class TestAllocObjects {
 
     static final long TARGET_MB = Long.getLong("target", 10_000); // 10 Gb allocation

--- a/test/hotspot/jtreg/gc/shenandoah/TestArrayCopyStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestArrayCopyStress.java
@@ -21,12 +21,14 @@
  *
  */
 
-import java.util.concurrent.*;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 /*
  * @test TestArrayCopyStress
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:TieredStopAtLevel=0 -Xmx16m TestArrayCopyStress
  */
@@ -56,10 +58,10 @@ public class TestArrayCopyStress {
         for (int i = 0; i < ARRAY_SIZE; i++) {
             array[i] = new Foo(i);
         }
-
-        int src_idx = ThreadLocalRandom.current().nextInt(0, ARRAY_SIZE);
-        int dst_idx = ThreadLocalRandom.current().nextInt(0, ARRAY_SIZE);
-        int len = ThreadLocalRandom.current().nextInt(0, Math.min(ARRAY_SIZE - src_idx, ARRAY_SIZE - dst_idx));
+        Random rng = Utils.getRandomInstance();
+        int src_idx = rng.nextInt(ARRAY_SIZE);
+        int dst_idx = rng.nextInt(ARRAY_SIZE);
+        int len = rng.nextInt(Math.min(ARRAY_SIZE - src_idx, ARRAY_SIZE - dst_idx));
         System.arraycopy(array, src_idx, array, dst_idx, len);
 
         for (int i = 0; i < ARRAY_SIZE; i++) {

--- a/test/hotspot/jtreg/gc/shenandoah/TestElasticTLAB.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestElasticTLAB.java
@@ -23,8 +23,10 @@
 
 /*
  * @test TestElasticTLAB
+ * @key randomness
  * @summary Test that Shenandoah is able to work with elastic TLABs
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -Xmx1g -XX:-UseTLAB -XX:-ShenandoahElasticTLAB -XX:+ShenandoahVerify TestElasticTLAB
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -Xmx1g -XX:-UseTLAB -XX:-ShenandoahElasticTLAB                       TestElasticTLAB
@@ -37,6 +39,7 @@
  */
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestElasticTLAB {
 
@@ -49,7 +52,7 @@ public class TestElasticTLAB {
         final int max = 384 * 1024;
         long count = TARGET_MB * 1024 * 1024 / (16 + 4 * (min + (max - min) / 2));
 
-        Random r = new Random();
+        Random r = Utils.getRandomInstance();
         for (long c = 0; c < count; c++) {
             sink = new int[min + r.nextInt(max - min)];
         }

--- a/test/hotspot/jtreg/gc/shenandoah/TestHeapUncommit.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestHeapUncommit.java
@@ -24,8 +24,9 @@
 /*
  * @test TestHeapUncommit
  * @summary Acceptance tests: collector can withstand allocation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahUncommit -XX:ShenandoahUncommitDelay=0
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
@@ -51,8 +52,9 @@
 /*
  * @test TestHeapUncommit
  * @summary Acceptance tests: collector can withstand allocation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahUncommit -XX:ShenandoahUncommitDelay=0
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
@@ -84,8 +86,9 @@
 /*
  * @test TestHeapUncommit
  * @summary Acceptance tests: collector can withstand allocation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahUncommit -XX:ShenandoahUncommitDelay=0
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
@@ -103,8 +106,9 @@
 
 /*
  * @test TestHeapUncommit
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled & (vm.bits == "64")
+ * @library /test/lib
  *
  * @run main/othervm -Xmx1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+ShenandoahUncommit -XX:ShenandoahUncommitDelay=0 -XX:+UseLargePages
  *      -XX:+UseShenandoahGC
@@ -122,6 +126,7 @@
  */
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestHeapUncommit {
 
@@ -134,7 +139,7 @@ public class TestHeapUncommit {
         final int max = 384 * 1024;
         long count = TARGET_MB * 1024 * 1024 / (16 + 4 * (min + (max - min) / 2));
 
-        Random r = new Random();
+        Random r = Utils.getRandomInstance();
         for (long c = 0; c < count; c++) {
             sink = new int[min + r.nextInt(max - min)];
         }

--- a/test/hotspot/jtreg/gc/shenandoah/TestHumongousThreshold.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestHumongousThreshold.java
@@ -23,8 +23,9 @@
 
 /*
  * @test TestHumongousThreshold
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -Xmx1g
  *                   -XX:+ShenandoahVerify
@@ -68,8 +69,9 @@
 
 /*
  * @test TestHumongousThreshold
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled & (vm.bits == "64")
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -Xmx1g
  *                   -XX:ObjectAlignmentInBytes=16 -XX:+ShenandoahVerify
@@ -105,6 +107,7 @@
  */
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestHumongousThreshold {
 
@@ -117,7 +120,7 @@ public class TestHumongousThreshold {
         final int max = 384 * 1024;
         long count = TARGET_MB * 1024 * 1024 / (16 + 4 * (min + (max - min) / 2));
 
-        Random r = new Random();
+        Random r = Utils.getRandomInstance();
         for (long c = 0; c < count; c++) {
             sink = new int[min + r.nextInt(max - min)];
         }

--- a/test/hotspot/jtreg/gc/shenandoah/TestLargeObjectAlignment.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestLargeObjectAlignment.java
@@ -24,8 +24,9 @@
 /*
  * @test TestLargeObjectAlignment
  * @summary Shenandoah crashes with -XX:ObjectAlignmentInBytes=16
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled & (vm.bits == "64")
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ObjectAlignmentInBytes=16 -Xint                   TestLargeObjectAlignment
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ObjectAlignmentInBytes=16 -XX:-TieredCompilation  TestLargeObjectAlignment
@@ -35,7 +36,8 @@
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestLargeObjectAlignment {
 
@@ -49,8 +51,9 @@ public class TestLargeObjectAlignment {
         objects = new Object[SLABS_COUNT];
 
         long start = System.nanoTime();
+        Random rng = Utils.getRandomInstance();
         while (System.nanoTime() - start < TIME_NS) {
-            objects[ThreadLocalRandom.current().nextInt(SLABS_COUNT)] = createSome();
+            objects[rng.nextInt(SLABS_COUNT)] = createSome();
         }
     }
 

--- a/test/hotspot/jtreg/gc/shenandoah/TestSieveObjects.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestSieveObjects.java
@@ -24,8 +24,9 @@
 /*
  * @test TestSieveObjects
  * @summary Acceptance tests: collector can deal with retained objects
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
@@ -51,8 +52,9 @@
 /*
  * @test TestSieveObjects
  * @summary Acceptance tests: collector can deal with retained objects
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
@@ -123,8 +125,9 @@
 /*
  * @test TestSieveObjects
  * @summary Acceptance tests: collector can deal with retained objects
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -Xmx1g -Xms1g -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
@@ -157,7 +160,8 @@
  *      TestSieveObjects
  */
 
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestSieveObjects {
 
@@ -169,17 +173,18 @@ public class TestSieveObjects {
 
     public static void main(String[] args) throws Exception {
         int rIdx = 0;
+        Random rng = Utils.getRandomInstance();
         for (int c = 0; c < COUNT; c++) {
             MyObject v = arr[rIdx];
             if (v != null) {
                 if (v.x != rIdx) {
                     throw new IllegalStateException("Illegal value at index " + rIdx + ": " + v.x);
                 }
-                if (ThreadLocalRandom.current().nextInt(1000) > 100) {
+                if (rng.nextInt(1000) > 100) {
                     arr[rIdx] = null;
                 }
             } else {
-                if (ThreadLocalRandom.current().nextInt(1000) > 500) {
+                if (rng.nextInt(1000) > 500) {
                     arr[rIdx] = new MyObject(rIdx);
                 }
             }

--- a/test/hotspot/jtreg/gc/shenandoah/TestStringDedup.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestStringDedup.java
@@ -24,7 +24,7 @@
 /*
  * @test TestStringDedup
  * @summary Test Shenandoah string deduplication implementation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @library /test/lib
  * @modules java.base/jdk.internal.misc:open
@@ -45,7 +45,7 @@
 /*
  * @test TestStringDedup
  * @summary Test Shenandoah string deduplication implementation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @library /test/lib
  * @modules java.base/jdk.internal.misc:open
@@ -68,7 +68,7 @@
 /*
  * @test TestStringDedup
  * @summary Test Shenandoah string deduplication implementation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @library /test/lib
  * @modules java.base/jdk.internal.misc:open
@@ -86,6 +86,7 @@
 
 import java.lang.reflect.*;
 import java.util.*;
+import jdk.test.lib.Utils;
 
 import sun.misc.*;
 
@@ -135,7 +136,7 @@ public class TestStringDedup {
     }
 
     private static void generateStrings(ArrayList<StringAndId> strs, int unique_strs) {
-        Random rn = new Random();
+        Random rn = Utils.getRandomInstance();
         for (int u = 0; u < unique_strs; u++) {
             int n = rn.nextInt() % 10;
             n = Math.max(n, 2);

--- a/test/hotspot/jtreg/gc/shenandoah/TestStringDedupStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestStringDedupStress.java
@@ -24,7 +24,7 @@
 /*
  * @test TestStringDedupStress
  * @summary Test Shenandoah string deduplication implementation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @library /test/lib
  * @modules java.base/jdk.internal.misc:open
@@ -45,7 +45,7 @@
 /*
  * @test TestStringDedupStress
  * @summary Test Shenandoah string deduplication implementation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @library /test/lib
  * @modules java.base/jdk.internal.misc:open
@@ -76,7 +76,7 @@
  /*
  * @test TestStringDedupStress
  * @summary Test Shenandoah string deduplication implementation
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @library /test/lib
  * @modules java.base/jdk.internal.misc:open
@@ -108,6 +108,7 @@
 import java.lang.management.*;
 import java.lang.reflect.*;
 import java.util.*;
+import jdk.test.lib.Utils;
 
 import sun.misc.*;
 
@@ -162,7 +163,7 @@ public class TestStringDedupStress {
 
     // Generate uniqueStrings number of strings
     private static void generateStrings(ArrayList<StringAndId> strs, int uniqueStrings) {
-        Random rn = new Random();
+        Random rn = Utils.getRandomInstance();
         for (int u = 0; u < uniqueStrings; u++) {
             int n = rn.nextInt(uniqueStrings);
             strs.add(new StringAndId("Unique String " + n, n));
@@ -199,7 +200,7 @@ public class TestStringDedupStress {
     static GarbageCollectorMXBean gcCycleMBean;
 
     public static void main(String[] args) {
-        Random rn = new Random();
+        Random rn = Utils.getRandomInstance();
 
         for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
             if ("Shenandoah Cycles".equals(bean.getName())) {

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestC1VectorizedMismatch.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestC1VectorizedMismatch.java
@@ -23,12 +23,16 @@
 
 /* @test TestC1VectorizedMismatch
  * @summary test C1 vectorized mismatch intrinsic
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
+ *
  * @run main/othervm -XX:TieredStopAtLevel=1 -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive TestC1VectorizedMismatch
  */
 
 import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestC1VectorizedMismatch {
 
@@ -56,8 +60,9 @@ public class TestC1VectorizedMismatch {
     }
 
     private static void fillArray(int[] array) {
+        Random r = Utils.getRandomInstance();
         for (int i = 0; i < ARRAY_SIZE; i++) {
-            int val = (int) (Math.random() * Integer.MAX_VALUE);
+            int val = (int) (r.nextDouble() * Integer.MAX_VALUE);
             array[i] = val;
         }
     }

--- a/test/hotspot/jtreg/gc/shenandoah/jni/CriticalNativeStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/CriticalNativeStress.java
@@ -24,10 +24,13 @@
 package gc.shenandoah.jni;
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 import gc.shenandoah.jni.CriticalNative;
 
 /* @test
+ * @key randomness
+ * @library /test/lib
  * @requires (os.arch =="x86_64" | os.arch == "amd64" | os.arch=="x86" | os.arch=="i386") & !vm.graal.enabled & vm.gc.Shenandoah
  *
  * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive    -XX:+ShenandoahDegeneratedGC -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeStress
@@ -40,8 +43,6 @@ import gc.shenandoah.jni.CriticalNative;
  * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeStress
  */
 public class CriticalNativeStress {
-    private static Random rand = new Random();
-
     static {
         System.loadLibrary("CriticalNative");
     }
@@ -81,7 +82,7 @@ public class CriticalNativeStress {
         garbage_array = array;
     }
 
-    static void run_test_case1() {
+    static void run_test_case1(Random rand) {
         int length = rand.nextInt(50) + 1;
         long[] arr = new long[length];
         for (int index = 0; index < length; index++) {
@@ -102,7 +103,7 @@ public class CriticalNativeStress {
         }
     }
 
-    static void run_test_case2() {
+    static void run_test_case2(Random rand) {
         int index;
         long a1 = rand.nextLong() % 10245;
 
@@ -145,25 +146,29 @@ public class CriticalNativeStress {
     }
 
     static class Case1Runner extends Thread {
+        private final Random rand;
         public Case1Runner() {
+            rand = new Random(Utils.getRandomInstance().nextLong());
             start();
         }
 
         public void run() {
             for (int index = 0; index < CYCLES; index++) {
-                run_test_case1();
+                run_test_case1(rand);
             }
         }
     }
 
     static class Case2Runner extends Thread {
+        private final Random rand;
         public Case2Runner() {
+            rand = new Random(Utils.getRandomInstance().nextLong());
             start();
         }
 
         public void run() {
             for (int index = 0; index < CYCLES; index++) {
-                run_test_case2();
+                run_test_case2(rand);
             }
         }
     }

--- a/test/hotspot/jtreg/gc/shenandoah/jni/TestJNICritical.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/TestJNICritical.java
@@ -23,14 +23,17 @@
 
 /* @test TestJNICritical
  * @summary test JNI critical arrays support in Shenandoah
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+ShenandoahVerify                 TestJNICritical
  * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive TestJNICritical
  */
 
 import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestJNICritical {
     static {
@@ -64,8 +67,9 @@ public class TestJNICritical {
     }
 
     private static void fillArray(int[] array) {
+        Random r = Utils.getRandomInstance();
         for (int i = 0; i < ARRAY_SIZE; i++) {
-            int val = (int) (Math.random() * Integer.MAX_VALUE);
+            int val = (int) (r.nextDouble() * Integer.MAX_VALUE);
             array[i] = val;
         }
     }

--- a/test/hotspot/jtreg/gc/shenandoah/jni/TestPinnedGarbage.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/TestPinnedGarbage.java
@@ -23,8 +23,9 @@
 
 /* @test TestPinnedGarbage
  * @summary Test that garbage in the pinned region does not crash VM
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx128m
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
@@ -39,8 +40,9 @@
 
 /* @test TestPinnedGarbage
  * @summary Test that garbage in the pinned region does not crash VM
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx128m
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
@@ -53,7 +55,8 @@
  */
 
 import java.util.Arrays;
-import java.util.concurrent.*;
+import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestPinnedGarbage {
     static {
@@ -68,13 +71,13 @@ public class TestPinnedGarbage {
     private static native void unpin(int[] a);
 
     public static void main(String[] args) {
-        ThreadLocalRandom rng = ThreadLocalRandom.current();
+        Random rng = Utils.getRandomInstance();
         for (int i = 0; i < NUM_RUNS; i++) {
             test(rng);
         }
     }
 
-    private static void test(ThreadLocalRandom rng) {
+    private static void test(Random rng) {
         Object[] objs = new Object[OBJS_COUNT];
         for (int i = 0; i < OBJS_COUNT; i++) {
             objs[i] = new MyClass();

--- a/test/hotspot/jtreg/gc/shenandoah/options/TestHumongousMoves.java
+++ b/test/hotspot/jtreg/gc/shenandoah/options/TestHumongousMoves.java
@@ -24,8 +24,9 @@
 /*
  * @test TestHumongousMoves
  * @summary Check Shenandoah reacts on setting humongous moves correctly
- * @key gc
+ * @key gc randomness
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
+ * @library /test/lib
  *
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Xmx1g -Xms1g
  *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
@@ -41,6 +42,7 @@
  */
 
 import java.util.Random;
+import jdk.test.lib.Utils;
 
 public class TestHumongousMoves {
 
@@ -53,7 +55,7 @@ public class TestHumongousMoves {
         final int max = 384 * 1024;
         long count = TARGET_MB * 1024 * 1024 / (16 + 4 * (min + (max - min) / 2));
 
-        Random r = new Random();
+        Random r = Utils.getRandomInstance();
         for (long c = 0; c < count; c++) {
             sink = new int[min + r.nextInt(max - min)];
         }

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOld.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@ package gc.stress.gcold;
 
 import java.text.*;
 import java.util.Random;
+
+import jdk.test.lib.Utils;
 
 class TreeNode {
     public TreeNode left, right;
@@ -86,7 +88,7 @@ public class TestGCOld {
 
   private static TreeNode[] trees;
   private static int where = 0;               // roving index into trees
-  private static Random rnd = new Random();
+  private static Random rnd = Utils.getRandomInstance();
 
   // Returns the height of the given tree.
 

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithCMS.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithCMS.java
@@ -26,8 +26,8 @@ package gc.stress.gcold;
 
 /*
  * @test TestGCOldWithCMS
- * @key gc
- * @library /
+ * @key gc randomness
+ * @library / /test/lib
  * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @summary Stress the CMS GC by trying to make old objects more likely to be garbage than young objects.
  * @run main/othervm -Xmx384M -XX:+UseConcMarkSweepGC gc.stress.gcold.TestGCOldWithCMS 50 1 20 10 10000

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithG1.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithG1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@ package gc.stress.gcold;
 
 /*
  * @test TestGCOldWithG1
- * @key gc
- * @library /
+ * @key gc randomness
+ * @library / /test/lib
  * @requires vm.gc.G1
  * @summary Stress the G1 GC by trying to make old objects more likely to be garbage than young objects.
  * @run main/othervm -Xmx384M -XX:+UseG1GC gc.stress.gcold.TestGCOldWithG1 50 1 20 10 10000

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithParallel.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithParallel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@ package gc.stress.gcold;
 
 /*
  * @test TestGCOldWithParallel
- * @key gc
- * @library /
+ * @key gc randomness
+ * @library / /test/lib
  * @requires vm.gc.Parallel
  * @summary Stress the Parallel GC by trying to make old objects more likely to be garbage than young objects.
  * @run main/othervm -Xmx384M -XX:+UseParallelGC gc.stress.gcold.TestGCOld 50 1 20 10 10000

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithSerial.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithSerial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@ package gc.stress.gcold;
 
 /*
  * @test TestGCOldWithSerial
- * @key gc
- * @library /
+ * @key gc randomness
+ * @library / /test/lib
  * @requires vm.gc.Serial
  * @summary Stress the Serial GC by trying to make old objects more likely to be garbage than young objects.
  * @run main/othervm -Xmx384M -XX:+UseSerialGC gc.stress.gcold.TestGCOldWithSerial 50 1 20 10 10000

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithShenandoah.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,8 @@ package gc.stress.gcold;
 
 /*
  * @test TestGCOldWithShenandoah
- * @key gc
- * @key stress
- * @library /
+ * @key gc stress randomness
+ * @library / /test/lib
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @summary Stress the GC by trying to make old objects more likely to be garbage than young objects.
  *
@@ -54,9 +53,8 @@ package gc.stress.gcold;
 
 /*
  * @test TestGCOldWithShenandoah
- * @key gc
- * @key stress
- * @library /
+ * @key gc stress randomness
+ * @library / /test/lib
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @summary Stress the GC by trying to make old objects more likely to be garbage than young objects.
  *
@@ -106,9 +104,8 @@ package gc.stress.gcold;
 
 /*
  * @test TestGCOldWithShenandoah
- * @key gc
- * @key stress
- * @library /
+ * @key gc stress randomness
+ * @library / /test/lib
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @summary Stress the GC by trying to make old objects more likely to be garbage than young objects.
  *

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithZ.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithZ.java
@@ -26,8 +26,8 @@ package gc.stress.gcold;
 
 /*
  * @test TestGCOldWithZ
- * @key gc
- * @library /
+ * @key gc randomness
+ * @library / /test/lib
  * @requires vm.gc.Z & !vm.graal.enabled
  * @summary Stress the Z
  * @run main/othervm -Xmx384M -XX:+UnlockExperimentalVMOptions -XX:+UseZGC gc.stress.gcold.TestGCOldWithZ 50 1 20 10 10000

--- a/test/hotspot/jtreg/gc/stress/jfr/TestStressAllocationGCEventsWithDefNew.java
+++ b/test/hotspot/jtreg/gc/stress/jfr/TestStressAllocationGCEventsWithDefNew.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package jdk.jfr.event.gc.detailed;
 
 /**
  * @test
+ * @key randomness
  * @requires vm.hasJFR
  * @requires vm.gc == "null" | vm.gc == "Serial"
  * @library /test/lib /test/jdk

--- a/test/hotspot/jtreg/gc/stress/jfr/TestStressAllocationGCEventsWithG1.java
+++ b/test/hotspot/jtreg/gc/stress/jfr/TestStressAllocationGCEventsWithG1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package jdk.jfr.event.gc.detailed;
 
 /**
  * @test
+ * @key randomness
  * @requires vm.hasJFR
  * @requires vm.gc == "null" | vm.gc == "G1"
  * @library /test/lib /test/jdk

--- a/test/hotspot/jtreg/gc/stress/jfr/TestStressAllocationGCEventsWithParallel.java
+++ b/test/hotspot/jtreg/gc/stress/jfr/TestStressAllocationGCEventsWithParallel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package jdk.jfr.event.gc.detailed;
 
 /**
  * @test
+ * @key randomness
  * @requires vm.hasJFR
  * @requires vm.gc == "null" | vm.gc == "Parallel"
  * @library /test/lib /test/jdk

--- a/test/hotspot/jtreg/gc/stress/jfr/TestStressBigAllocationGCEventsWithDefNew.java
+++ b/test/hotspot/jtreg/gc/stress/jfr/TestStressBigAllocationGCEventsWithDefNew.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package jdk.jfr.event.gc.detailed;
 
 /**
  * @test
+ * @key randomness
  * @requires vm.hasJFR
  * @requires vm.gc == "null" | vm.gc == "Serial"
  * @library /test/lib /test/jdk

--- a/test/hotspot/jtreg/gc/stress/jfr/TestStressBigAllocationGCEventsWithG1.java
+++ b/test/hotspot/jtreg/gc/stress/jfr/TestStressBigAllocationGCEventsWithG1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package jdk.jfr.event.gc.detailed;
 
 /**
  * @test
+ * @key randomness
  * @summary Test allocates humongous objects with G1 GC. Objects
  * considered humongous when it allocates equals or more than one region. As
  * we're passing the size of byte array we need adjust it that entire structure

--- a/test/hotspot/jtreg/gc/stress/jfr/TestStressBigAllocationGCEventsWithParallel.java
+++ b/test/hotspot/jtreg/gc/stress/jfr/TestStressBigAllocationGCEventsWithParallel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package jdk.jfr.event.gc.detailed;
 
 /**
  * @test
+ * @key randomness
  * @requires vm.hasJFR
  * @requires vm.gc == "null" | vm.gc == "Parallel"
  * @library /test/lib /test/jdk

--- a/test/jdk/jdk/jfr/event/gc/detailed/StressAllocationGCEvents.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/StressAllocationGCEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package jdk.jfr.event.gc.detailed;
 import static jdk.test.lib.Asserts.assertEquals;
 import static jdk.test.lib.Asserts.assertNotEquals;
 import static jdk.test.lib.Asserts.assertTrue;
+import jdk.test.lib.Utils;
 
 import java.util.List;
 import java.util.Random;
@@ -105,6 +106,7 @@ public class StressAllocationGCEvents {
             this.OBJ_SIZE = obj_size;
             this.OLD_OBJ_COUNT = Math.max(1, (int) ((float) Runtime.getRuntime().maxMemory() / 2 / THREAD_COUNT / OBJ_SIZE));
             this.old_garbage = new Object[OLD_OBJ_COUNT];
+            this.r = new Random(Utils.getRandomInstance().nextLong());
 
             System.out.println(String.format("In \"%s\" old objects count  = %d, recursion depth = %d",
                     this.getName(), OLD_OBJ_COUNT, RECURSION_DEPTH));
@@ -122,7 +124,6 @@ public class StressAllocationGCEvents {
                 diver(stack - 1);
             } else {
                 long endTime = startTime + (SECONDS_TO_RUN * 1000);
-                Random r = new Random(startTime);
                 while (endTime > System.currentTimeMillis()) {
                     byte[] garbage = new byte[OBJ_SIZE];
                     if (r.nextInt(100) > OLD_GEN_RATE) {
@@ -136,6 +137,7 @@ public class StressAllocationGCEvents {
         private final Object[] old_garbage;
         private final int OBJ_SIZE;
         private final int OLD_OBJ_COUNT;
+        private final Random r;
     }
 
     ///< check stacktrace depth


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

Resolved context, "8272783: Epsilon: Refactor tests to improve performance" already backported
 test/hotspot/jtreg/gc/epsilon/TestByteArrays.java
 test/hotspot/jtreg/gc/epsilon/TestElasticTLAB.java
 test/hotspot/jtreg/gc/epsilon/TestElasticTLABDecay.java
 test/hotspot/jtreg/gc/epsilon/TestRefArrays.java

I had to "implement" the change for this test. The test was removed with CMS
before the backported change was pushed.
 test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithCMS.java

Copyright
 test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData10.java

Context
 test/hotspot/jtreg/gc/g1/humongousObjects/TestNoAllocationsInHRegions.java
 test/hotspot/jtreg/gc/logging/TestUnifiedLoggingSwitchStress.java

"8256806: Shenandoah: optimize shenandoah/jni/TestPinnedGarbage.java test" was already 
backported. I had to redo the change, differences wrt. random to head are gone now.
 test/hotspot/jtreg/gc/shenandoah/jni/TestPinnedGarbage.java

Test at different location, patched manually
 test/hotspot/jtreg/gc/stress/CriticalNativeStress.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242312](https://bugs.openjdk.java.net/browse/JDK-8242312): use reproducible random in hotspot gc tests


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1021/head:pull/1021` \
`$ git checkout pull/1021`

Update a local copy of the PR: \
`$ git checkout pull/1021` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1021`

View PR using the GUI difftool: \
`$ git pr show -t 1021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1021.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1021.diff</a>

</details>
