### PR TITLE
8284369: TestFailedAllocationBadGraph fails with -XX:TieredStopAtLevel < 4

### DIFF
--- a/test/hotspot/jtreg/compiler/allocation/TestFailedAllocationBadGraph.java
+++ b/test/hotspot/jtreg/compiler/allocation/TestFailedAllocationBadGraph.java
@@ -25,10 +25,11 @@
  * @test
  * bug 8279219
  * @summary C2 crash when allocating array of size too large
+ * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/othervm  -ea -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:-BackgroundCompilation TestFailedAllocationBadGraph
+ * @run main/othervm -ea -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:-BackgroundCompilation TestFailedAllocationBadGraph
  */
 
 import sun.hotspot.WhiteBox;


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

Trivial resolve because of different path  to ClassFileInstaller in context.
Marking as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284369](https://bugs.openjdk.java.net/browse/JDK-8284369): TestFailedAllocationBadGraph fails with -XX:TieredStopAtLevel < 4


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1024/head:pull/1024` \
`$ git checkout pull/1024`

Update a local copy of the PR: \
`$ git checkout pull/1024` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1024`

View PR using the GUI difftool: \
`$ git pr show -t 1024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1024.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1024.diff</a>

</details>
