### PR TITLE
8284507: GHA: Only check test results if testing was not skipped

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -328,6 +328,7 @@ jobs:
           echo "imageroot=`dirname ${imageroot}`" >> $GITHUB_ENV
 
       - name: Run tests
+        id: run_tests
         run: >
           JDK_IMAGE_DIR=${{ env.imageroot }}
           TEST_IMAGE_DIR=${HOME}/jdk-linux-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x64_bin-tests${{ matrix.artifact }}
@@ -343,7 +344,7 @@ jobs:
           JTREG="JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash"
 
       - name: Check that all tests executed successfully
-        if: always()
+        if: steps.run_tests.outcome != 'skipped'
         run: >
           if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
             cat build/*/test-results/*/text/newfailures.txt ;
@@ -797,6 +798,7 @@ jobs:
           echo "imageroot=`dirname ${imageroot}`" >> $GITHUB_ENV
 
       - name: Run tests
+        id: run_tests
         run: >
           JDK_IMAGE_DIR=${{ env.imageroot }}
           TEST_IMAGE_DIR=${HOME}/jdk-linux-x86${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_linux-x86_bin-tests${{ matrix.artifact }}
@@ -812,7 +814,7 @@ jobs:
           JTREG="JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash"
 
       - name: Check that all tests executed successfully
-        if: always()
+        if: steps.run_tests.outcome != 'skipped'
         run: >
           if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
             cat build/*/test-results/*/text/newfailures.txt ;
@@ -1110,6 +1112,7 @@ jobs:
         run: echo ("imageroot=" + (Get-ChildItem -Path $HOME/jdk-windows-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_windows-x64_bin${{ matrix.artifact }} -Filter release -Recurse -ErrorAction SilentlyContinue -Force).DirectoryName) | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
 
       - name: Run tests
+        id: run_tests
         run: >
           $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
           $env:Path = $env:Path -split ";" -match "C:\\Windows|PowerShell|cygwin" -join ";" ;
@@ -1128,7 +1131,7 @@ jobs:
           JTREG="JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash"
 
       - name: Check that all tests executed successfully
-        if: always()
+        if: steps.run_tests.outcome != 'skipped'
         run: >
           if ((Get-ChildItem -Path build\*\test-results\test-summary.txt -Recurse | Select-String -Pattern "TEST SUCCESS" ).Count -eq 0) {
             Get-Content -Path build\*\test-results\*\*\newfailures.txt ;
@@ -1499,6 +1502,7 @@ jobs:
           echo "imageroot=`dirname ${imageroot}`" >> $GITHUB_ENV
 
       - name: Run tests
+        id: run_tests
         run: >
           JDK_IMAGE_DIR=${{ env.imageroot }}
           TEST_IMAGE_DIR=${HOME}/jdk-macos-x64${{ matrix.artifact }}/jdk-${{ env.JDK_VERSION }}-internal+0_osx-x64_bin-tests${{ matrix.artifact }}
@@ -1514,7 +1518,7 @@ jobs:
           JTREG="JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash"
 
       - name: Check that all tests executed successfully
-        if: always()
+        if: steps.run_tests.outcome != 'skipped'
         run: >
           if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
             cat build/*/test-results/*/text/newfailures.txt ;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8284507](https://bugs.openjdk.java.net/browse/JDK-8284507) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Christoph Langer on 8 Apr 2022 and was reviewed by Aleksey Shipilev and Magnus Ihse Bursie.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284507](https://bugs.openjdk.java.net/browse/JDK-8284507): GHA: Only check test results if testing was not skipped


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1026/head:pull/1026` \
`$ git checkout pull/1026`

Update a local copy of the PR: \
`$ git checkout pull/1026` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1026/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1026`

View PR using the GUI difftool: \
`$ git pr show -t 1026`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1026.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1026.diff</a>

</details>
