### PR TITLE
8284756: [11u] Remove unused isUseContainerSupport in CgroupV1Subsystem

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
@@ -506,6 +506,4 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
         return CgroupV1SubsystemController.getLongEntry(blkio, "blkio.throttle.io_serviced", "Total");
     }
 
-    private static native boolean isUseContainerSupport();
-
 }


### PR DESCRIPTION
Please review this trivial clean-up. The method declaration isn't used nor implemented. The actual native method in use is in `CgroupsMetrics.java`. `TestUseContainerSupport` of container tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284756](https://bugs.openjdk.java.net/browse/JDK-8284756): [11u] Remove unused isUseContainerSupport in CgroupV1Subsystem


### Reviewers
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1033/head:pull/1033` \
`$ git checkout pull/1033`

Update a local copy of the PR: \
`$ git checkout pull/1033` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1033/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1033`

View PR using the GUI difftool: \
`$ git pr show -t 1033`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1033.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1033.diff</a>

</details>
