### PR TITLE
8271199: Mutual TLS handshake fails signing client certificate with custom sensitive PKCS11 key

### DIFF
--- a/src/java.base/share/classes/sun/security/rsa/RSAPSSSignature.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPSSSignature.java
@@ -127,12 +127,15 @@ public class RSAPSSSignature extends SignatureSpi {
     @Override
     protected void engineInitVerify(PublicKey publicKey)
             throws InvalidKeyException {
-        if (!(publicKey instanceof RSAPublicKey)) {
+        if (publicKey instanceof RSAPublicKey) {
+            RSAPublicKey rsaPubKey = (RSAPublicKey)publicKey;
+            isPublicKeyValid(rsaPubKey);
+            this.pubKey = rsaPubKey;
+            this.privKey = null;
+            resetDigest();
+        } else {
             throw new InvalidKeyException("key must be RSAPublicKey");
         }
-        this.pubKey = (RSAPublicKey) isValid((RSAKey)publicKey);
-        this.privKey = null;
-        resetDigest();
     }
 
     // initialize for signing. See JCA doc
@@ -146,14 +149,17 @@ public class RSAPSSSignature extends SignatureSpi {
     @Override
     protected void engineInitSign(PrivateKey privateKey, SecureRandom random)
             throws InvalidKeyException {
-        if (!(privateKey instanceof RSAPrivateKey)) {
+        if (privateKey instanceof RSAPrivateKey) {
+            RSAPrivateKey rsaPrivateKey = (RSAPrivateKey)privateKey;
+            isPrivateKeyValid(rsaPrivateKey);
+            this.privKey = rsaPrivateKey;
+            this.pubKey = null;
+            this.random =
+                    (random == null ? JCAUtil.getSecureRandom() : random);
+            resetDigest();
+        } else {
             throw new InvalidKeyException("key must be RSAPrivateKey");
         }
-        this.privKey = (RSAPrivateKey) isValid((RSAKey)privateKey);
-        this.pubKey = null;
-        this.random =
-            (random == null? JCAUtil.getSecureRandom() : random);
-        resetDigest();
     }
 
     /**
@@ -206,10 +212,56 @@ public class RSAPSSSignature extends SignatureSpi {
     }
 
     /**
+     * Validate the specified RSAPrivateKey
+     */
+    private void isPrivateKeyValid(RSAPrivateKey prKey)  throws InvalidKeyException {
+        try {
+            if (prKey instanceof RSAPrivateCrtKey) {
+                RSAPrivateCrtKey crtKey = (RSAPrivateCrtKey)prKey;
+                if (RSAPrivateCrtKeyImpl.checkComponents(crtKey)) {
+                    RSAKeyFactory.checkRSAProviderKeyLengths(
+                            crtKey.getModulus().bitLength(),
+                            crtKey.getPublicExponent());
+                } else {
+                    throw new InvalidKeyException(
+                            "Some of the CRT-specific components are not available");
+                }
+            } else {
+                RSAKeyFactory.checkRSAProviderKeyLengths(
+                        prKey.getModulus().bitLength(),
+                        null);
+            }
+        } catch (InvalidKeyException ikEx) {
+            throw ikEx;
+        } catch (Exception e) {
+            throw new InvalidKeyException(
+                    "Can not access private key components", e);
+        }
+        isValid(prKey);
+    }
+
+    /**
+     * Validate the specified RSAPublicKey
+     */
+    private void isPublicKeyValid(RSAPublicKey pKey)  throws InvalidKeyException {
+        try {
+            RSAKeyFactory.checkRSAProviderKeyLengths(
+                    pKey.getModulus().bitLength(),
+                    pKey.getPublicExponent());
+        } catch (InvalidKeyException ikEx) {
+            throw ikEx;
+        } catch (Exception e) {
+            throw new InvalidKeyException(
+                    "Can not access public key components", e);
+        }
+        isValid(pKey);
+    }
+
+    /**
      * Validate the specified RSAKey and its associated parameters against
      * internal signature parameters.
      */
-    private RSAKey isValid(RSAKey rsaKey) throws InvalidKeyException {
+    private void isValid(RSAKey rsaKey) throws InvalidKeyException {
         try {
             AlgorithmParameterSpec keyParams = rsaKey.getParams();
             // validate key parameters
@@ -227,7 +279,6 @@ public class RSAPSSSignature extends SignatureSpi {
                 }
                 checkKeyLength(rsaKey, hLen, this.sigParams.getSaltLength());
             }
-            return rsaKey;
         } catch (SignatureException e) {
             throw new InvalidKeyException(e);
         }

--- a/src/java.base/share/classes/sun/security/rsa/RSAPrivateCrtKeyImpl.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPrivateCrtKeyImpl.java
@@ -80,20 +80,26 @@ public final class RSAPrivateCrtKeyImpl
         RSAPrivateCrtKeyImpl key = new RSAPrivateCrtKeyImpl(encoded);
         // check all CRT-specific components are available, if any one
         // missing, return a non-CRT key instead
-        if ((key.getPublicExponent().signum() == 0) ||
+        if (checkComponents(key)) {
+            return key;
+        } else {
+            return new RSAPrivateKeyImpl(
+                key.algid,
+                key.getModulus(),
+                key.getPrivateExponent());
+        }
+    }
+
+    /**
+     * Validate if all CRT-specific components are available.
+     */
+    static boolean checkComponents(RSAPrivateCrtKey key) {
+        return !((key.getPublicExponent().signum() == 0) ||
             (key.getPrimeExponentP().signum() == 0) ||
             (key.getPrimeExponentQ().signum() == 0) ||
             (key.getPrimeP().signum() == 0) ||
             (key.getPrimeQ().signum() == 0) ||
-            (key.getCrtCoefficient().signum() == 0)) {
-            return new RSAPrivateKeyImpl(
-                key.algid,
-                key.getModulus(),
-                key.getPrivateExponent()
-            );
-        } else {
-            return key;
-        }
+            (key.getCrtCoefficient().signum() == 0));
     }
 
     /**


### PR DESCRIPTION
Please review backport of JDK-8271199 to 11u
Backport is not clean because of changes introduced by JDK-8023980 and JDK-8172366. These changes are not related to functionality of JDK-8271199 so merge is trivial.
Also, there are simple changes related to instanceof pattern not implemented in JDK11.

sun/security/rsa jtreg and custom test with IAIK provider are passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271199](https://bugs.openjdk.java.net/browse/JDK-8271199): Mutual TLS handshake fails signing client certificate with custom sensitive PKCS11 key


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1036/head:pull/1036` \
`$ git checkout pull/1036`

Update a local copy of the PR: \
`$ git checkout pull/1036` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1036`

View PR using the GUI difftool: \
`$ git pr show -t 1036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1036.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1036.diff</a>

</details>
