### PR TITLE
8284033: Leak XVisualInfo in getAllConfigs in awt_GraphicsEnv.c

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -644,7 +644,8 @@ cleanup:
        XFree (pVI8sg);
     if (n1sg != 0)
        XFree (pVI1sg);
-
+     if (nTrue != 0)
+       XFree (pVITrue);
     AWT_UNLOCK ();
 }
 


### PR DESCRIPTION
I would like to backport this small and low risk patch to fix a memory leak.

The original patch does not apply cleanly, due to context difference. The patch is small, applied manually.

Test:
- [x] jdk_awt on Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284033](https://bugs.openjdk.java.net/browse/JDK-8284033): Leak XVisualInfo in getAllConfigs in awt_GraphicsEnv.c


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1037/head:pull/1037` \
`$ git checkout pull/1037`

Update a local copy of the PR: \
`$ git checkout pull/1037` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1037`

View PR using the GUI difftool: \
`$ git pr show -t 1037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1037.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1037.diff</a>

</details>
