### PR TITLE
8285395: [JVMCI] [11u] Partial backport of JDK-8220623: InstalledCode

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/InstalledCode.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.code/src/jdk/vm/ci/code/InstalledCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,14 +52,14 @@ public class InstalledCode {
     /**
      * @return the address of entity representing this installed code.
      */
-    public final long getAddress() {
+    public long getAddress() {
         return address;
     }
 
     /**
      * @return the address of the normal entry point of the installed code.
      */
-    public final long getEntryPoint() {
+    public long getEntryPoint() {
         return entryPoint;
     }
 


### PR DESCRIPTION
Please review this 11u-only change in the JVMCI area. Latest Graal master introduced a change which overrides `getAddress()` and `getEntryPoint()` in class `InstalledCode`. This isn't an issue in Graal VM CE since labs openjdk is used there which has newer JVMCI level. The same code is present in JDK 13+. I'm only proposing a partial backport since that's sufficient to unbreak the Mandrel build and is a lot less risky than bringing in JDK-8220623 wholesale. See the bug for details.

Testing:
 - [x] jvmci tests
 - [x] Mandrel build with a base JDK including this patch. Builds now, broke earlier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285395](https://bugs.openjdk.java.net/browse/JDK-8285395): [JVMCI] [11u] Partial backport of JDK-8220623: InstalledCode


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**) ⚠️ Review applies to 10c9e98cba3601938acad434aa2f59cdfe75612a


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1038/head:pull/1038` \
`$ git checkout pull/1038`

Update a local copy of the PR: \
`$ git checkout pull/1038` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1038`

View PR using the GUI difftool: \
`$ git pr show -t 1038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1038.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1038.diff</a>

</details>
