### PR TITLE
8284023: java.sun.awt.X11GraphicsDevice.getDoubleBufferVisuals() leaks XdbeScreenVisualInfo

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -1639,6 +1639,9 @@ Java_sun_awt_X11GraphicsDevice_getDoubleBufferVisuals(JNIEnv *env,
             break;
         }
     }
+    AWT_LOCK();
+    XdbeFreeVisualInfo(visScreenInfo);
+    AWT_UNLOCK();
 #endif /* !HEADLESS */
 }
 


### PR DESCRIPTION
I would like to backport this patch to fix a memory.

The original patch does not apply cleanly, due to context difference. The patch is small, can be applied manually.

Test:
- [x] jdk_awt on Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284023](https://bugs.openjdk.java.net/browse/JDK-8284023): java.sun.awt.X11GraphicsDevice.getDoubleBufferVisuals() leaks XdbeScreenVisualInfo


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1041/head:pull/1041` \
`$ git checkout pull/1041`

Update a local copy of the PR: \
`$ git checkout pull/1041` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1041`

View PR using the GUI difftool: \
`$ git pr show -t 1041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1041.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1041.diff</a>

</details>
