### PR TITLE
JDK-8285591: [11] add signum checks in DSA.java engineVerify

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/DSA.java
+++ b/src/java.base/share/classes/sun/security/provider/DSA.java
@@ -357,7 +357,8 @@ abstract class DSA extends SignatureSpi {
             s = new BigInteger(1, s.toByteArray());
         }
 
-        if ((r.compareTo(presetQ) == -1) && (s.compareTo(presetQ) == -1)) {
+        if ((r.compareTo(presetQ) == -1) && (s.compareTo(presetQ) == -1)
+                && r.signum() > 0 && s.signum() > 0) {
             BigInteger w = generateW(presetP, presetQ, presetG, s);
             BigInteger v = generateV(presetY, presetP, presetQ, presetG, w, r);
             return v.equals(r);

--- a/src/java.base/share/classes/sun/security/provider/DSA.java
+++ b/src/java.base/share/classes/sun/security/provider/DSA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
8277233 added signum checks to the engineVerify method in DSA.java in jdk17+.
To be consistent with higher releases, it would be good to check also in jdk11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285591](https://bugs.openjdk.java.net/browse/JDK-8285591): [11] add signum checks in DSA.java engineVerify


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1045/head:pull/1045` \
`$ git checkout pull/1045`

Update a local copy of the PR: \
`$ git checkout pull/1045` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1045`

View PR using the GUI difftool: \
`$ git pr show -t 1045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1045.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1045.diff</a>

</details>
