### PR TITLE
8284458: CodeHeapState::aggregate() leaks blob_name

### DIFF
--- a/src/hotspot/share/code/codeHeapState.cpp
+++ b/src/hotspot/share/code/codeHeapState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2019 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -757,18 +757,17 @@ void CodeHeapState::aggregate(outputStream* out, CodeHeap* heap, size_t granular
         CodeBlob* cb  = (CodeBlob*)heap->find_start(h);
         cbType = get_cbType(cb);  // Will check for cb == NULL and other safety things.
         if (cbType != noType) {
-          const char* blob_name  = os::strdup(cb->name());
+          const char* blob_name  = NULL;
           unsigned int nm_size   = 0;
           int temperature        = 0;
           nmethod*  nm = cb->as_nmethod_or_null();
           if (nm != NULL) { // no is_readable check required, nm = (nmethod*)cb.
             ResourceMark rm;
             Method* method = nm->method();
-            if (nm->is_in_use()) {
+            if (nm->is_in_use() || nm->is_not_entrant()) {
               blob_name = os::strdup(method->name_and_sig_as_C_string());
-            }
-            if (nm->is_not_entrant()) {
-              blob_name = os::strdup(method->name_and_sig_as_C_string());
+            } else {
+              blob_name = os::strdup(cb->name());
             }
 
             nm_size    = nm->total_size();
@@ -816,6 +815,8 @@ void CodeHeapState::aggregate(outputStream* out, CodeHeap* heap, size_t granular
               default:
                 break;
             }
+          } else {
+            blob_name  = os::strdup(cb->name());
           }
 
           //------------------------------------------


### PR DESCRIPTION
I would like to backport this patch to 11u to fix a memory leak.

The original patch does not apply cleanly:

1. JDK-8275729 and JDK-8276429 that are not in 11u. However, the patch is small and conflicts are resolved manually.
2. `nullptr` language feature is not available in 11u, changed to `NULL`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284458](https://bugs.openjdk.java.net/browse/JDK-8284458): CodeHeapState::aggregate() leaks blob_name


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1046/head:pull/1046` \
`$ git checkout pull/1046`

Update a local copy of the PR: \
`$ git checkout pull/1046` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1046`

View PR using the GUI difftool: \
`$ git pr show -t 1046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1046.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1046.diff</a>

</details>
