### PR TITLE
8169004: Fix redundant @requires tags in tests

### DIFF
--- a/test/hotspot/jtreg/gc/TestNUMAPageSize.java
+++ b/test/hotspot/jtreg/gc/TestNUMAPageSize.java
@@ -28,7 +28,7 @@ package gc;
  * @key gc regression
  * @summary Make sure that start up with NUMA support does not cause problems.
  * @bug 8061467
- * @requires (vm.opt.AggressiveOpts == null) | (vm.opt.AggressiveOpts == false)
+ * @requires vm.opt.AggressiveOpts != true
  * @run main/othervm -Xmx128m -XX:+UseNUMA gc.TestNUMAPageSize
  */
 

--- a/test/hotspot/jtreg/gc/arguments/TestTargetSurvivorRatioFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestTargetSurvivorRatioFlag.java
@@ -27,8 +27,8 @@ package gc.arguments;
  * @test TestTargetSurvivorRatioFlag
  * @key gc
  * @summary Verify that option TargetSurvivorRatio affects survivor space occupancy after minor GC.
- * @requires (vm.opt.ExplicitGCInvokesConcurrent == null) | (vm.opt.ExplicitGCInvokesConcurrent == false)
- * @requires (vm.opt.UseJVMCICompiler == null) | (vm.opt.UseJVMCICompiler == false)
+ * @requires vm.opt.ExplicitGCInvokesConcurrent != true
+ * @requires vm.opt.UseJVMCICompiler != true
  * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
  * @library /test/lib
  * @library /

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData00.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData00.java
@@ -30,7 +30,7 @@ package gc.g1;
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc.G1
- * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
+ * @requires vm.opt.AggressiveOpts != true
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData05.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData05.java
@@ -30,7 +30,7 @@ package gc.g1;
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc.G1
- * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
+ * @requires vm.opt.AggressiveOpts != true
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData10.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData10.java
@@ -30,7 +30,7 @@ package gc.g1;
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc.G1
- * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
+ * @requires vm.opt.AggressiveOpts != true
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData15.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData15.java
@@ -30,7 +30,7 @@ package gc.g1;
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc.G1
- * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
+ * @requires vm.opt.AggressiveOpts != true
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData20.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData20.java
@@ -30,7 +30,7 @@ package gc.g1;
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc.G1
- * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
+ * @requires vm.opt.AggressiveOpts != true
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData25.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData25.java
@@ -30,7 +30,7 @@ package gc.g1;
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc.G1
- * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
+ * @requires vm.opt.AggressiveOpts != true
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData30.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData30.java
@@ -30,7 +30,7 @@ package gc.g1;
  * @summary Checks that decommitment occurs for JVM with different
  * G1ConcRSLogCacheSize and ObjectAlignmentInBytes options values
  * @requires vm.gc.G1
- * @requires vm.opt.AggressiveOpts=="false" | vm.opt.AggressiveOpts=="null"
+ * @requires vm.opt.AggressiveOpts != true
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/ReservedStack/ReservedStackTest.java
+++ b/test/hotspot/jtreg/runtime/ReservedStack/ReservedStackTest.java
@@ -24,7 +24,7 @@
 /*
  * @test ReservedStackTest
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.base/jdk.internal.vm.annotation

--- a/test/hotspot/jtreg/runtime/ReservedStack/ReservedStackTestCompiler.java
+++ b/test/hotspot/jtreg/runtime/ReservedStack/ReservedStackTestCompiler.java
@@ -26,7 +26,7 @@
  * @summary Run ReservedStackTest with dedicated compilers C1 and C2.
  *
  * @requires vm.flavor == "server" & !vm.emulatedClient
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.base/jdk.internal.vm.annotation

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack001.java
@@ -51,7 +51,7 @@
  *     4254634     println() while catching StackOverflowError causes hotspot VM crash
  *     4302288 the second stack overflow causes Classic VM to exit on win32
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack002.java
@@ -52,7 +52,7 @@
  *     4254634     println() while catching StackOverflowError causes hotspot VM crash
  *     4302288 the second stack overflow causes Classic VM to exit on win32
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack002
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack003.java
@@ -46,7 +46,7 @@
  *     See the bug:
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack003
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack004.java
@@ -46,7 +46,7 @@
  *     See the bug:
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack004
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack005.java
@@ -46,7 +46,7 @@
  *     See the bug:
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack005
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack006.java
@@ -46,7 +46,7 @@
  *     See the bug:
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack006
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack007.java
@@ -45,7 +45,7 @@
  *     See also the bug:
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack007
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack008.java
@@ -47,7 +47,7 @@
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
  * @ignore 8139875
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack008
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack009.java
@@ -46,7 +46,7 @@
  *     See the bug:
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack009
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack010.java
@@ -46,7 +46,7 @@
  *     See the bug:
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack010
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack011.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack011.java
@@ -46,7 +46,7 @@
  *     See the bug:
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack011
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack012.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack012.java
@@ -47,7 +47,7 @@
  *     See the bug:
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack012
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack013.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack013.java
@@ -46,7 +46,7 @@
  *     See the bug:
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack013
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack014.java
@@ -49,7 +49,7 @@
  *     See the bug:
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack014
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack015.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack015.java
@@ -47,7 +47,7 @@
  *     See the bug:
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack015
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack016.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack016.java
@@ -50,7 +50,7 @@
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
  * @ignore 8139875
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack016 -eager
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack017.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack017.java
@@ -43,7 +43,7 @@
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
  * @ignore 8139875
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack017 -eager
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack018.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack018.java
@@ -48,7 +48,7 @@
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
  * @ignore 8139875
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack018 -eager
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack019.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/stack/stack019.java
@@ -41,7 +41,7 @@
  *     4366625 (P4/S4) multiple stack overflow causes HS crash
  *
  * @ignore 8139875
- * @requires vm.opt.DeoptimizeALot == null | vm.opt.DeoptimizeALot == false
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm/timeout=900 nsk.stress.stack.stack019 -eager
  */
 


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

A whole bunch of trivial resolved due to context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8169004](https://bugs.openjdk.java.net/browse/JDK-8169004): Fix redundant @requires tags in tests


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1050/head:pull/1050` \
`$ git checkout pull/1050`

Update a local copy of the PR: \
`$ git checkout pull/1050` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1050`

View PR using the GUI difftool: \
`$ git pr show -t 1050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1050.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1050.diff</a>

</details>
