### PR TITLE
8213440: Lingering INCLUDE_ALL_GCS in test_oopStorage_parperf.cpp

### DIFF
--- a/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp
@@ -46,9 +46,6 @@
 // object containing a large number of entries, and logs some stats
 // about the distribution and performance of the iteration.
 
-// Parallel iteration not available unless INCLUDE_ALL_GCS
-#if INCLUDE_ALL_GCS
-
 const uint _max_workers = 10;
 static uint _num_workers = 0;
 const size_t _storage_entries = 1000000;
@@ -229,5 +226,3 @@ TEST_VM_F(OopStorageParIterPerf, test) {
     LogConfiguration::configure_stdout(old_level, true, LOG_TAGS(TEST_TAGS));
   }
 }
-
-#endif // INCLUDE_ALL_GCS


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8213440](https://bugs.openjdk.java.net/browse/JDK-8213440): Lingering INCLUDE_ALL_GCS in test_oopStorage_parperf.cpp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1051/head:pull/1051` \
`$ git checkout pull/1051`

Update a local copy of the PR: \
`$ git checkout pull/1051` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1051`

View PR using the GUI difftool: \
`$ git pr show -t 1051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1051.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1051.diff</a>

</details>
