### PR TITLE
8234382: Test tools/javac/processing/model/testgetallmembers/Main.java using too small heap

### DIFF
--- a/test/langtools/tools/javac/processing/model/testgetallmembers/Main.java
+++ b/test/langtools/tools/javac/processing/model/testgetallmembers/Main.java
@@ -27,7 +27,7 @@
  * @summary PackageElement.getEnclosedElements() throws ClassReader$BadClassFileException
  * @author  Peter von der Ah\u00e9
  * @modules jdk.compiler/com.sun.tools.javac.model
- * @run main/othervm -Xmx256m Main
+ * @run main/othervm -Xmx512m Main
  */
 
 import java.io.File;


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8234382](https://bugs.openjdk.java.net/browse/JDK-8234382): Test tools/javac/processing/model/testgetallmembers/Main.java using too small heap


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1052/head:pull/1052` \
`$ git checkout pull/1052`

Update a local copy of the PR: \
`$ git checkout pull/1052` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1052`

View PR using the GUI difftool: \
`$ git pr show -t 1052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1052.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1052.diff</a>

</details>
