### PR TITLE
8233551: [TESTBUG] SelectEditTableCell.java fails on MacOS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -697,7 +697,6 @@ javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 802462
 javax/swing/JComboBox/8033069/bug8033069ScrollBar.java 8163367 generic-all
 javax/swing/JColorChooser/Test6827032.java 8197825 windows-all
 javax/swing/JColorChooser/Test7194184.java 8194126 linux-all,macosx-all
-javax/swing/JTable/7124218/SelectEditTableCell.java 8148958 linux-all,macosx-all
 javax/swing/JSplitPane/4201995/bug4201995.java 8079127 generic-all
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all

--- a/test/jdk/javax/swing/JTable/7124218/SelectEditTableCell.java
+++ b/test/jdk/javax/swing/JTable/7124218/SelectEditTableCell.java
@@ -50,23 +50,28 @@ public class SelectEditTableCell {
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
-        robot.delay(2000);
+        robot.setAutoDelay(100);
         UIManager.LookAndFeelInfo[] lookAndFeelArray
                 = UIManager.getInstalledLookAndFeels();
         for (UIManager.LookAndFeelInfo lookAndFeelItem : lookAndFeelArray) {
             executeCase(lookAndFeelItem.getClassName());
         }
-
     }
 
     private static void executeCase(String lookAndFeelString) throws Exception {
-        if (tryLookAndFeel(lookAndFeelString)) {
-            createUI(lookAndFeelString);
-            robot.delay(2000);
-            runTestCase();
-            robot.delay(2000);
-            cleanUp();
-            robot.delay(2000);
+        try {
+            if (tryLookAndFeel(lookAndFeelString)) {
+                createUI(lookAndFeelString);
+                robot.delay(2000);
+                runTestCase();
+                robot.delay(2000);
+                cleanUp();
+                robot.delay(2000);
+            }
+        } finally {
+            if (frame != null) {
+                SwingUtilities.invokeAndWait(frame::dispose);
+            }
         }
 
     }
@@ -100,6 +105,7 @@ public class SelectEditTableCell {
         robot.mouseMove(centerPoint.x, centerPoint.y);
         robot.mousePress(InputEvent.BUTTON1_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.waitForIdle();
         SwingUtilities.invokeAndWait(new Runnable() {
             @Override
             public void run() {
@@ -112,7 +118,7 @@ public class SelectEditTableCell {
                 }
             }
         });
-        robot.waitForIdle();
+
         int fetchKeyCode;
         keyTap(fetchKeyCode = isMac(lookAndFeel)
                 ? KeyEvent.VK_ENTER : KeyEvent.VK_SPACE);
@@ -129,7 +135,7 @@ public class SelectEditTableCell {
                 }
             }
         });
-        robot.waitForIdle();
+
         keyTap(KeyEvent.VK_SPACE);
         robot.waitForIdle();
         SwingUtilities.invokeAndWait(new Runnable() {
@@ -149,10 +155,12 @@ public class SelectEditTableCell {
                 }
             }
         });
-        robot.waitForIdle();
+
         // hitting a letter key will start editing
         keyTap(KeyEvent.VK_A);
+        robot.waitForIdle();
         keyTap(KeyEvent.VK_SPACE);
+        robot.waitForIdle();
         keyTap(KeyEvent.VK_A);
         robot.waitForIdle();
         SwingUtilities.invokeAndWait(new Runnable() {


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

I had to resolve the ProblemList. The change also fixes linux as noted in the duplicate JDK-8148958

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8233551](https://bugs.openjdk.java.net/browse/JDK-8233551): [TESTBUG] SelectEditTableCell.java fails on MacOS


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1053/head:pull/1053` \
`$ git checkout pull/1053`

Update a local copy of the PR: \
`$ git checkout pull/1053` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1053`

View PR using the GUI difftool: \
`$ git pr show -t 1053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1053.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1053.diff</a>

</details>
