### PR TITLE
8269772: [macos-aarch64] test compilation failed with "SocketException: No buffer space available"

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -23,7 +23,8 @@ javax/management com/sun/awt sun/awt sun/java2d javax/xml/jaxp/testng/validation
 
 # Tests that cannot run concurrently
 exclusiveAccess.dirs=java/rmi/Naming java/util/prefs sun/management/jmxremote sun/tools/jstatd \
-sun/security/mscapi java/util/stream java/util/Arrays/largeMemory java/util/BitSet/stream javax/rmi \
+sun/security/mscapi java/util/stream java/util/Arrays/largeMemory \
+java/util/BitSet/stream javax/rmi java/net/httpclient/websocket \
 sanity/client
 
 # Group definitions


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269772](https://bugs.openjdk.java.net/browse/JDK-8269772): [macos-aarch64] test compilation failed with "SocketException: No buffer space available"


### Reviewers
 * [Vladimir Kempik](https://openjdk.java.net/census#vkempik) (@VladimirKempik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1057/head:pull/1057` \
`$ git checkout pull/1057`

Update a local copy of the PR: \
`$ git checkout pull/1057` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1057`

View PR using the GUI difftool: \
`$ git pr show -t 1057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1057.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1057.diff</a>

</details>
