### PR TITLE
8272167: AbsPathsInImage.java should skip *.dSYM directories

### DIFF
--- a/test/jdk/build/AbsPathsInImage.java
+++ b/test/jdk/build/AbsPathsInImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,6 +142,15 @@ public class AbsPathsInImage {
 
     private void scanFiles(Path root, List<byte[]> searchPatterns) throws IOException {
         Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                String dirName = dir.toString();
+                if (dirName.endsWith(".dSYM")) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                return super.preVisitDirectory(dir, attrs);
+            }
+
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 String fileName = file.toString();


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.
I backported the change from jdk15. This patches clean except of the copyright. 
I will mark this as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272167](https://bugs.openjdk.java.net/browse/JDK-8272167): AbsPathsInImage.java should skip *.dSYM directories


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1058/head:pull/1058` \
`$ git checkout pull/1058`

Update a local copy of the PR: \
`$ git checkout pull/1058` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1058/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1058`

View PR using the GUI difftool: \
`$ git pr show -t 1058`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1058.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1058.diff</a>

</details>
