### PR TITLE
8279520: SPNEGO has not passed channel binding info into the underlying mechanism

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/jgss/spnego/SpNegoContext.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/spnego/SpNegoContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -865,6 +865,7 @@ public class SpNegoContext implements GSSContextSpi {
             mechContext.requestMutualAuth(mutualAuthState);
             mechContext.requestReplayDet(replayDetState);
             mechContext.requestSequenceDet(sequenceDetState);
+            mechContext.setChannelBinding(channelBinding);
             if (mechContext instanceof GSSContextImpl) {
                 ((GSSContextImpl)mechContext).requestDelegPolicy(
                         delegPolicyState);
@@ -898,6 +899,7 @@ public class SpNegoContext implements GSSContextSpi {
                 myCred.getInternalCred());
             }
             mechContext = factory.manager.createContext(cred);
+            mechContext.setChannelBinding(channelBinding);
         }
 
         // pass token to mechanism acceptSecContext


### PR DESCRIPTION
Backport of [JDK-8279520](https://bugs.openjdk.java.net/browse/JDK-8279520)
Clean except Copyright year update.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279520](https://bugs.openjdk.java.net/browse/JDK-8279520): SPNEGO has not passed channel binding info into the underlying mechanism


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1060/head:pull/1060` \
`$ git checkout pull/1060`

Update a local copy of the PR: \
`$ git checkout pull/1060` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1060`

View PR using the GUI difftool: \
`$ git pr show -t 1060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1060.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1060.diff</a>

</details>
