### PR TITLE
8216265: [testbug] Introduce Platform.sharedLibraryPathVariableName() and adapt all tests.

### DIFF
--- a/test/hotspot/jtreg/gtest/GTestWrapper.java
+++ b/test/hotspot/jtreg/gtest/GTestWrapper.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
+import java.io.File;
 import java.nio.file.Paths;
 import java.nio.file.Path;
 
@@ -70,14 +71,10 @@ public class GTestWrapper {
         // may have set LD_LIBRARY_PATH or LIBPATH to point to the jdk libjvm. In
         // that case, prepend the path with the location of the gtest library."
 
-        String ldLibraryPath = System.getenv("LD_LIBRARY_PATH");
+        String pathVar = Platform.sharedLibraryPathVariableName();
+        String ldLibraryPath = System.getenv(pathVar);
         if (ldLibraryPath != null) {
-            env.put("LD_LIBRARY_PATH", path + ":" + ldLibraryPath);
-        }
-
-        String libPath = System.getenv("LIBPATH");
-        if (libPath != null) {
-            env.put("LIBPATH", path + ":" + libPath);
+            env.put(pathVar, path + File.pathSeparator + ldLibraryPath);
         }
 
         pb.command(new String[] {

--- a/test/hotspot/jtreg/runtime/signal/SigTestDriver.java
+++ b/test/hotspot/jtreg/runtime/signal/SigTestDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,8 +68,7 @@ public class SigTestDriver {
         Path test = Paths.get(System.getProperty("test.nativepath"))
                          .resolve("sigtest")
                          .toAbsolutePath();
-        String envVar = Platform.isWindows() ? "PATH" :
-                (Platform.isOSX() ? "DYLD_LIBRARY_PATH" : "LD_LIBRARY_PATH");
+        String envVar = Platform.sharedLibraryPathVariableName();
 
         List<String> cmd = new ArrayList<>();
         Collections.addAll(cmd,

--- a/test/hotspot/jtreg/vmTestbase/ExecDriver.java
+++ b/test/hotspot/jtreg/vmTestbase/ExecDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,7 +103,7 @@ public class ExecDriver {
         if (launcher) {
             Path dir = Paths.get(Utils.TEST_JDK);
             String value;
-            String name;
+            String name = Platform.sharedLibraryPathVariableName();
             if (Platform.isWindows()) {
                 value = dir.resolve("bin")
                            .resolve(variant())
@@ -113,13 +113,11 @@ public class ExecDriver {
                 value += dir.resolve("bin")
                             .toAbsolutePath()
                             .toString();
-                name = "PATH";
             } else {
                 value = dir.resolve("lib")
                            .resolve(variant())
                            .toAbsolutePath()
                            .toString();
-                name = Platform.isOSX() ? "DYLD_LIBRARY_PATH" : "LD_LIBRARY_PATH";
             }
 
             System.out.println("  with " + name + " = " +

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform003/TestDriver.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform003/TestDriver.java
@@ -77,17 +77,7 @@ public class TestDriver {
                 nsk.jvmti.RetransformClasses.retransform003.class.getName()
         );
 
-        String envName;
-        if (Platform.isWindows()) {
-            envName = "PATH";
-        } else if (Platform.isOSX()) {
-            envName = "DYLD_LIBRARY_PATH";
-        } else if (Platform.isAix()) {
-            envName = "LIBPATH";
-        } else {
-            envName = "LD_LIBRARY_PATH";
-        }
-
+        String envName = Platform.sharedLibraryPathVariableName();
         pb.environment()
           .merge(envName, ".", (x, y) -> y + File.pathSeparator + x);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetNativeMethodPrefix/SetNativeMethodPrefix002/TestDriver.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetNativeMethodPrefix/SetNativeMethodPrefix002/TestDriver.java
@@ -67,17 +67,7 @@ public class TestDriver {
                 nsk.jvmti.SetNativeMethodPrefix.SetNativeMethodPrefix002.class.getName()
         );
 
-        String envName;
-        if (Platform.isWindows()) {
-            envName = "PATH";
-        } else if (Platform.isOSX()) {
-            envName = "DYLD_LIBRARY_PATH";
-        } else if (Platform.isAix()) {
-            envName = "LIBPATH";
-        } else {
-            envName = "LD_LIBRARY_PATH";
-        }
-
+        String envName = Platform.sharedLibraryPathVariableName();
         pb.environment()
           .merge(envName, ".", (x, y) -> y + File.pathSeparator + x);
 

--- a/test/jdk/com/sun/jdi/PrivateTransportTest.java
+++ b/test/jdk/com/sun/jdi/PrivateTransportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,10 +33,12 @@
  * @run main/othervm PrivateTransportTest
  */
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
 
 import java.io.IOException;
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -71,17 +73,8 @@ public class PrivateTransportTest {
             }
             transportLib = foundLib.get();
         }
-        if (System.getProperty("os.name").startsWith("Windows")) {
-            pathSep = ";";
-            pathEnvVar = "PATH";
-        } else {
-            pathSep = ":";
-            if (System.getProperty("os.name").equals("AIX")) {
-                pathEnvVar = "LIBPATH";
-            } else {
-                pathEnvVar = "LD_LIBRARY_PATH";
-            }
-        }
+        pathEnvVar = Platform.sharedLibraryPathVariableName();
+        pathSep    = File.pathSeparator;
     }
 
     private void test() throws Throwable {

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public class InheritedChannelTest {
     private static final String ARCH = System.getProperty("os.arch");
     private static final String OS_ARCH = ARCH.equals("i386") ? "i586" : ARCH;
 
-    private static final Path LD_LIBRARY_PATH
+    private static final Path libraryPath
             = Paths.get(System.getProperty("java.library.path"));
 
     @DataProvider
@@ -97,7 +97,8 @@ public class InheritedChannelTest {
 
     @Test(dataProvider = "testCases")
     public void test(String desc, List<String> opts) throws Throwable {
-        System.out.println("LD_LIBRARY_PATH=" + LD_LIBRARY_PATH);
+        String pathVar = Platform.sharedLibraryPathVariableName();
+        System.out.println(pathVar + "=" + libraryPath);
 
         List<String> args = new ArrayList<>();
         args.add(JDKToolFinder.getJDKTool("java"));
@@ -110,9 +111,8 @@ public class InheritedChannelTest {
 
         Map<String, String> env = pb.environment();
         env.put("CLASSPATH", TEST_CLASSES);
-        env.put("LD_LIBRARY_PATH", LD_LIBRARY_PATH.toString());
+        env.put(pathVar, libraryPath.toString());
 
-        ProcessTools.executeCommand(pb)
-                    .shouldHaveExitValue(0);
+        ProcessTools.executeCommand(pb).shouldHaveExitValue(0);
     }
 }

--- a/test/jdk/javax/net/ssl/DTLS/DTLSBufferOverflowUnderflowTest.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSBufferOverflowUnderflowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing DTLS buffer overflow and underflow status when dealing with
  *          application data.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.base/sun.security.util

--- a/test/jdk/javax/net/ssl/DTLS/DTLSDataExchangeTest.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSDataExchangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing DTLS application data exchange using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLS/DTLSEnginesClosureTest.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSEnginesClosureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing DTLS engines closing using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLS/DTLSHandshakeTest.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSHandshakeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing DTLS engines handshake using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLS/DTLSHandshakeWithReplicatedPacketsTest.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSHandshakeWithReplicatedPacketsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing DTLS engines handshake using each of the supported
  *          cipher suites with replicated packets check.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLS/DTLSMFLNTest.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSMFLNTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Testing DTLS engines handshake using each of the supported
  *          cipher suites with different maximum fragment length. Testing of
  *          MFLN extension.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLS/DTLSNotEnabledRC4Test.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSNotEnabledRC4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8043758
  * @summary Testing DTLS engines do not enable RC4 ciphers by default.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          java.security.jgss/sun.security.jgss.krb5
  *          java.security.jgss/sun.security.krb5:+open

--- a/test/jdk/javax/net/ssl/DTLS/DTLSRehandshakeTest.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSRehandshakeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing DTLS engines re-handshaking using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLS/DTLSRehandshakeWithDataExTest.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSRehandshakeWithDataExTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Testing DTLS engines re-handshaking using each of the supported
  *          cipher suites with application data exchange before and after
  *          re-handshake and closing of the engines.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLS/DTLSUnsupportedCiphersTest.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSUnsupportedCiphersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing that try to enable unsupported ciphers
  *          causes IllegalArgumentException.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          java.security.jgss/sun.security.jgss.krb5
  *          java.security.jgss/sun.security.krb5:+open

--- a/test/jdk/javax/net/ssl/DTLSv10/DTLSv10BufferOverflowUnderflowTest.java
+++ b/test/jdk/javax/net/ssl/DTLSv10/DTLSv10BufferOverflowUnderflowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing DTLS buffer overflow and underflow status when dealing with
  *          application data.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLSv10/DTLSv10DataExchangeTest.java
+++ b/test/jdk/javax/net/ssl/DTLSv10/DTLSv10DataExchangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing DTLS application data exchange using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLSv10/DTLSv10EnginesClosureTest.java
+++ b/test/jdk/javax/net/ssl/DTLSv10/DTLSv10EnginesClosureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing DTLS engines closing using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLSv10/DTLSv10HandshakeTest.java
+++ b/test/jdk/javax/net/ssl/DTLSv10/DTLSv10HandshakeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing DTLS engines handshake using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLSv10/DTLSv10HandshakeWithReplicatedPacketsTest.java
+++ b/test/jdk/javax/net/ssl/DTLSv10/DTLSv10HandshakeWithReplicatedPacketsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing DTLS engines handshake using each of the supported
  *          cipher suites with replicated packets check.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /javax/net/ssl/DTLS
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /javax/net/ssl/DTLS /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLSv10/DTLSv10MFLNTest.java
+++ b/test/jdk/javax/net/ssl/DTLSv10/DTLSv10MFLNTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Testing DTLS engines handshake using each of the supported
  *          cipher suites with different maximum fragment length. Testing of
  *          MFLN extension.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLSv10/DTLSv10NotEnabledRC4Test.java
+++ b/test/jdk/javax/net/ssl/DTLSv10/DTLSv10NotEnabledRC4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8043758
  * @summary Testing DTLS engines do not enable RC4 ciphers by default.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          java.security.jgss/sun.security.jgss.krb5
  *          java.security.jgss/sun.security.krb5:+open

--- a/test/jdk/javax/net/ssl/DTLSv10/DTLSv10RehandshakeTest.java
+++ b/test/jdk/javax/net/ssl/DTLSv10/DTLSv10RehandshakeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing DTLS engines re-handshaking using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLSv10/DTLSv10RehandshakeWithDataExTest.java
+++ b/test/jdk/javax/net/ssl/DTLSv10/DTLSv10RehandshakeWithDataExTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Testing DTLS engines re-handshaking using each of the supported
  *          cipher suites with application data exchange before and after
  *          re-handshake and closing of the engines.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLSv10/DTLSv10SequenceNumberTest.java
+++ b/test/jdk/javax/net/ssl/DTLSv10/DTLSv10SequenceNumberTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Testing DTLS records sequence number property support in application
  *          data exchange.
  * @key randomness
- * @library /sun/security/krb5/auto /lib/testlibrary /javax/net/ssl/TLSCommon /javax/net/ssl/DTLS
+ * @library /sun/security/krb5/auto /lib/testlibrary /javax/net/ssl/TLSCommon /javax/net/ssl/DTLS /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/DTLSv10/DTLSv10UnsupportedCiphersTest.java
+++ b/test/jdk/javax/net/ssl/DTLSv10/DTLSv10UnsupportedCiphersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8043758
  * @summary Testing that try to enable unsupported ciphers
  *          causes IllegalArgumentException.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          java.security.jgss/sun.security.jgss.krb5
  *          java.security.jgss/sun.security.krb5:+open

--- a/test/jdk/javax/net/ssl/TLS/TLSDataExchangeTest.java
+++ b/test/jdk/javax/net/ssl/TLS/TLSDataExchangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing TLS application data exchange using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLS/TLSEnginesClosureTest.java
+++ b/test/jdk/javax/net/ssl/TLS/TLSEnginesClosureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing TLS engines closing using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLS/TLSHandshakeTest.java
+++ b/test/jdk/javax/net/ssl/TLS/TLSHandshakeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing TLS engines handshake using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLS/TLSMFLNTest.java
+++ b/test/jdk/javax/net/ssl/TLS/TLSMFLNTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Testing TLS engines handshake using each of the supported
  *          cipher suites with different maximum fragment length. Testing of
  *          MFLN extension.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLS/TLSNotEnabledRC4Test.java
+++ b/test/jdk/javax/net/ssl/TLS/TLSNotEnabledRC4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8085979
  * @summary Testing TLS engines do not enable RC4 ciphers by default.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          java.security.jgss/sun.security.jgss.krb5
  *          java.security.jgss/sun.security.krb5:+open

--- a/test/jdk/javax/net/ssl/TLS/TLSRehandshakeTest.java
+++ b/test/jdk/javax/net/ssl/TLS/TLSRehandshakeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing TLS engines re-handshaking using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLS/TLSRehandshakeWithDataExTest.java
+++ b/test/jdk/javax/net/ssl/TLS/TLSRehandshakeWithDataExTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Testing TLS engines re-handshaking using each of the supported
  *          cipher suites with application data exchange before and after
  *          re-handshake and closing of the engines.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLS/TLSUnsupportedCiphersTest.java
+++ b/test/jdk/javax/net/ssl/TLS/TLSUnsupportedCiphersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing that try to enable unsupported ciphers
  *          causes IllegalArgumentException.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          java.security.jgss/sun.security.jgss.krb5
  *          java.security.jgss/sun.security.krb5:+open

--- a/test/jdk/javax/net/ssl/TLSv1/TLSDataExchangeTest.java
+++ b/test/jdk/javax/net/ssl/TLSv1/TLSDataExchangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing TLS application data exchange using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLSv1/TLSEnginesClosureTest.java
+++ b/test/jdk/javax/net/ssl/TLSv1/TLSEnginesClosureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing TLS engines closing using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLSv1/TLSHandshakeTest.java
+++ b/test/jdk/javax/net/ssl/TLSv1/TLSHandshakeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing TLS engines handshake using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLSv1/TLSMFLNTest.java
+++ b/test/jdk/javax/net/ssl/TLSv1/TLSMFLNTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Testing TLS engines handshake using each of the supported
  *          cipher suites with different maximum fragment length. Testing of
  *          MFLN extension.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLSv1/TLSNotEnabledRC4Test.java
+++ b/test/jdk/javax/net/ssl/TLSv1/TLSNotEnabledRC4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8085979
  * @summary Testing TLS engines do not enable RC4 ciphers by default.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          java.security.jgss/sun.security.jgss.krb5
  *          java.security.jgss/sun.security.krb5:+open

--- a/test/jdk/javax/net/ssl/TLSv1/TLSRehandshakeTest.java
+++ b/test/jdk/javax/net/ssl/TLSv1/TLSRehandshakeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing TLS engines re-handshaking using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLSv1/TLSRehandshakeWithDataExTest.java
+++ b/test/jdk/javax/net/ssl/TLSv1/TLSRehandshakeWithDataExTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Testing TLS engines re-handshaking using each of the supported
  *          cipher suites with application data exchange before and after
  *          re-handshake and closing of the engines.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLSv1/TLSUnsupportedCiphersTest.java
+++ b/test/jdk/javax/net/ssl/TLSv1/TLSUnsupportedCiphersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing that try to enable unsupported ciphers
  *          causes IllegalArgumentException.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          java.security.jgss/sun.security.jgss.krb5
  *          java.security.jgss/sun.security.krb5:+open

--- a/test/jdk/javax/net/ssl/TLSv11/TLSDataExchangeTest.java
+++ b/test/jdk/javax/net/ssl/TLSv11/TLSDataExchangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing TLS application data exchange using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLSv11/TLSEnginesClosureTest.java
+++ b/test/jdk/javax/net/ssl/TLSv11/TLSEnginesClosureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing TLS engines closing using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLSv11/TLSHandshakeTest.java
+++ b/test/jdk/javax/net/ssl/TLSv11/TLSHandshakeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing TLS engines handshake using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLSv11/TLSMFLNTest.java
+++ b/test/jdk/javax/net/ssl/TLSv11/TLSMFLNTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Testing TLS engines handshake using each of the supported
  *          cipher suites with different maximum fragment length. Testing of
  *          MFLN extension.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLSv11/TLSNotEnabledRC4Test.java
+++ b/test/jdk/javax/net/ssl/TLSv11/TLSNotEnabledRC4Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8085979
  * @summary Testing TLS engines do not enable RC4 ciphers by default.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          java.security.jgss/sun.security.jgss.krb5
  *          java.security.jgss/sun.security.krb5:+open

--- a/test/jdk/javax/net/ssl/TLSv11/TLSRehandshakeTest.java
+++ b/test/jdk/javax/net/ssl/TLSv11/TLSRehandshakeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing TLS engines re-handshaking using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLSv11/TLSRehandshakeWithDataExTest.java
+++ b/test/jdk/javax/net/ssl/TLSv11/TLSRehandshakeWithDataExTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Testing TLS engines re-handshaking using each of the supported
  *          cipher suites with application data exchange before and after
  *          re-handshake and closing of the engines.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/javax/net/ssl/TLSv11/TLSUnsupportedCiphersTest.java
+++ b/test/jdk/javax/net/ssl/TLSv11/TLSUnsupportedCiphersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8085979
  * @summary Testing that try to enable unsupported ciphers
  *          causes IllegalArgumentException.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          java.security.jgss/sun.security.jgss.krb5
  *          java.security.jgss/sun.security.krb5:+open

--- a/test/jdk/javax/net/ssl/TLSv12/TLSEnginesClosureTest.java
+++ b/test/jdk/javax/net/ssl/TLSv12/TLSEnginesClosureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8207009
  * @summary Testing TLS engines closing using each of the supported
  *          cipher suites.
- * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon
+ * @library /sun/security/krb5/auto /javax/net/ssl/TLSCommon /test/lib
  * @modules java.security.jgss
  *          jdk.security.auth
  *          java.security.jgss/sun.security.jgss.krb5

--- a/test/jdk/sun/security/krb5/auto/BasicProc.java
+++ b/test/jdk/sun/security/krb5/auto/BasicProc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -307,8 +307,7 @@ public class BasicProc {
                     .prop("sun.security.nativegss.debug", "true");
             int pos = lib.lastIndexOf('/');
             if (pos > 0) {
-                p.env("LD_LIBRARY_PATH", lib.substring(0, pos));
-                p.env("DYLD_LIBRARY_PATH", lib.substring(0, pos));
+                p.env(Platform.sharedLibraryPathVariableName(), lib.substring(0, pos));
             }
         } else {
             p.perm(new java.util.PropertyPermission(

--- a/test/jdk/sun/security/krb5/auto/KDC.java
+++ b/test/jdk/sun/security/krb5/auto/KDC.java
@@ -21,6 +21,8 @@
  * questions.
  */
 
+import jdk.test.lib.Platform;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -1815,8 +1817,7 @@ public class KDC {
             this.env = Map.of(
                     "KRB5_CONFIG", base + "/krb5.conf",
                     "KRB5_TRACE", "/dev/stderr",
-                    "DYLD_LIBRARY_PATH", nativePath + "/lib",
-                    "LD_LIBRARY_PATH", nativePath + "/lib");
+                    Platform.sharedLibraryPathVariableName(), nativePath + "/lib");
         }
 
         @Override
@@ -1908,8 +1909,7 @@ public class KDC {
                     "KRB5_KDC_PROFILE", base + "/kdc.conf",
                     "KRB5_CONFIG", base + "/krb5.conf",
                     "KRB5_TRACE", "/dev/stderr",
-                    "DYLD_LIBRARY_PATH", nativePath + "/lib",
-                    "LD_LIBRARY_PATH", nativePath + "/lib");
+                    Platform.sharedLibraryPathVariableName(), nativePath + "/lib");
         }
 
         @Override

--- a/test/jdk/sun/security/krb5/auto/NoAddresses.java
+++ b/test/jdk/sun/security/krb5/auto/NoAddresses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 7032354
+ * @library /test/lib
  * @run main/othervm NoAddresses setup
  * @run main/othervm -Djdk.net.hosts.file=TestHosts NoAddresses 1
  * @run main/othervm -Djdk.net.hosts.file=TestHosts NoAddresses 2

--- a/test/jdk/sun/security/krb5/auto/ReplayCacheTestProc.java
+++ b/test/jdk/sun/security/krb5/auto/ReplayCacheTestProc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -399,8 +399,7 @@ public class ReplayCacheTestProc {
             if (lib != null) {
                 String libDir = lib.substring(0, lib.lastIndexOf('/'));
                 p.prop("sun.security.jgss.lib", lib)
-                        .env("DYLD_LIBRARY_PATH", libDir)
-                        .env("LD_LIBRARY_PATH", libDir);
+                        .env(Platform.sharedLibraryPathVariableName(), libDir);
             }
         }
         Proc.d(label+suffix+" started");

--- a/test/jdk/sun/security/krb5/auto/principalProperty/PrincipalSystemPropTest.java
+++ b/test/jdk/sun/security/krb5/auto/principalProperty/PrincipalSystemPropTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,10 +21,10 @@
  * questions.
  */
 
-/*
+/**
  * @test
  * @bug 8075301
- * @library /sun/security/krb5/auto
+ * @library /sun/security/krb5/auto /test/lib
  * @summary New test for sun.security.krb5.principal system property.
  * The principal can set using the system property sun.security.krb5.principal.
  * This property is checked during login. If this property is not set,

--- a/test/jdk/tools/launcher/ExecutionEnvironment.java
+++ b/test/jdk/tools/launcher/ExecutionEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 4780570 4731671 6354700 6367077 6670965 4882974
  * @summary Checks for LD_LIBRARY_PATH and execution  on *nixes
  * @requires os.family != "windows" & !vm.musl & os.family != "aix"
+ * @library /test/lib
  * @modules jdk.compiler
  *          jdk.zipfs
  * @compile -XDignore.symbol.file ExecutionEnvironment.java
@@ -37,6 +38,7 @@
  * @bug 4780570 4731671 6354700 6367077 6670965 4882974
  * @summary Checks for LD_LIBRARY_PATH and execution  on *nixes
  * @requires os.family == "aix" | vm.musl
+ * @library /test/lib
  * @modules jdk.compiler
  *          jdk.zipfs
  * @compile -XDignore.symbol.file ExecutionEnvironment.java
@@ -66,6 +68,9 @@
  *         launcher may add as implementation details.
  *      b. add a pldd for solaris to ensure only one libjvm.so is linked
  */
+
+import jdk.test.lib.Platform;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
@@ -74,11 +79,7 @@ import java.util.List;
 import java.util.Map;
 
 public class ExecutionEnvironment extends TestHelper {
-    static final String LD_LIBRARY_PATH    = TestHelper.isMacOSX
-            ? "DYLD_LIBRARY_PATH"
-            : TestHelper.isAIX
-                    ? "LIBPATH"
-                    : "LD_LIBRARY_PATH";
+    static final String LD_LIBRARY_PATH    = Platform.sharedLibraryPathVariableName();
     static final String LD_LIBRARY_PATH_32 = LD_LIBRARY_PATH + "_32";
     static final String LD_LIBRARY_PATH_64 = LD_LIBRARY_PATH + "_64";
 

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
I want to backport this because we see a failure on macOS 12 that will be fixed by this change.

I had to resolve a row of files:

Copyright:
  test/hotspot/jtreg/gtest/GTestWrapper.java
  test/jdk/sun/security/krb5/auto/KDC.java

Resolve @library command:
  test/jdk/tools/launcher/ExecutionEnvironment.java

This test was added in 12 only and backported with all the fixes in 8238225.
  test/jdk/tools/launcher/JliLaunchTest.java

Copyright, @library was added in backport of 8217340
  test/jdk/tools/launcher/Test7029048.java

Test not in 11
  test/jdk/vm/JniInvocationTest.java

This was also included in 8238225
  test/lib/jdk/test/lib/Platform.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8216265](https://bugs.openjdk.java.net/browse/JDK-8216265): [testbug] Introduce Platform.sharedLibraryPathVariableName() and adapt all tests.


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1061/head:pull/1061` \
`$ git checkout pull/1061`

Update a local copy of the PR: \
`$ git checkout pull/1061` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1061`

View PR using the GUI difftool: \
`$ git pr show -t 1061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1061.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1061.diff</a>

</details>
