### PR TITLE
8280964: [Linux aarch64] : drawImage dithers TYPE_BYTE_INDEXED images incorrectly

### DIFF
--- a/src/java.desktop/share/native/libawt/awt/image/cvutils/img_globals.c
+++ b/src/java.desktop/share/native/libawt/awt/image/cvutils/img_globals.c
@@ -77,7 +77,7 @@ make_uns_ordered_dither_array(uns_ordered_dither_array oda,
  * color used as an index.
  */
 void
-make_sgn_ordered_dither_array(char* oda, int minerr, int maxerr)
+make_sgn_ordered_dither_array(signed char* oda, int minerr, int maxerr)
 {
     int i, j, k;
 

--- a/src/java.desktop/share/native/libawt/awt/image/cvutils/img_globals.h
+++ b/src/java.desktop/share/native/libawt/awt/image/cvutils/img_globals.h
@@ -137,7 +137,7 @@ typedef int ImgConvertFcn(void *colormodel,
  * The type of the error matrix used in the ordered dithering code.
  */
 typedef unsigned char uns_ordered_dither_array[8][8];
-typedef char sgn_ordered_dither_array[8][8];
+typedef signed char sgn_ordered_dither_array[8][8];
 
 /*
  * The function provided for constructing the ordered dithering error
@@ -148,7 +148,7 @@ typedef char sgn_ordered_dither_array[8][8];
 JNIEXPORT void JNICALL
 make_uns_ordered_dither_array(uns_ordered_dither_array oda,
                               int quantum);
-extern void make_sgn_ordered_dither_array(char* oda, int errmin, int errmax);
+extern void make_sgn_ordered_dither_array(signed char* oda, int errmin, int errmax);
 
 /*
  * The function provided for calculating the contents of the ImgCMData

--- a/src/java.desktop/share/native/libawt/java2d/SurfaceData.h
+++ b/src/java.desktop/share/native/libawt/java2d/SurfaceData.h
@@ -129,9 +129,9 @@ typedef struct {
  * array of bytes indexed by RxGxB where each component is reduced to 5
  * bits of precision before indexing.
  *
- *      char *redErrTable;
- *      char *grnErrTable;
- *      char *bluErrTable;
+ *      signed char *redErrTable;
+ *      signed char *grnErrTable;
+ *      signed char *bluErrTable;
  * [Requires SD_LOCK_INVCOLOR]
  * Pointers to the beginning of the ordered dither color error tables
  * for the colormap.  The error tables are formatted as an 8x8 array
@@ -159,9 +159,9 @@ typedef struct {
     unsigned int        lutSize;                /* # colors in colormap */
     jint                *lutBase;               /* Pointer to colormap[0] */
     unsigned char       *invColorTable;         /* Inverse color table */
-    char                *redErrTable;           /* Red ordered dither table */
-    char                *grnErrTable;           /* Green ordered dither table */
-    char                *bluErrTable;           /* Blue ordered dither table */
+    signed char         *redErrTable;           /* Red ordered dither table */
+    signed char         *grnErrTable;           /* Green ordered dither table */
+    signed char         *bluErrTable;           /* Blue ordered dither table */
     int                 *invGrayTable;          /* Inverse gray table */
     int                 representsPrimaries;    /* whether cmap represents primary colors */
     union {

--- a/src/java.desktop/share/native/libawt/java2d/loops/ByteIndexed.h
+++ b/src/java.desktop/share/native/libawt/java2d/loops/ByteIndexed.h
@@ -44,7 +44,7 @@ typedef jubyte  ByteIndexedDataType;
 
 #define DeclareByteIndexedStoreVars(PREFIX) \
     int PREFIX ## XDither, PREFIX ## YDither, PREFIX ## RepPrims; \
-    char *PREFIX ## rerr, *PREFIX ## gerr, *PREFIX ## berr; \
+    signed char *PREFIX ## rerr, *PREFIX ## gerr, *PREFIX ## berr; \
     unsigned char *PREFIX ## InvLut;
 
 #define SetByteIndexedStoreVarsYPos(PREFIX, pRasInfo, LOC) \

--- a/src/java.desktop/share/native/libawt/java2d/loops/UshortIndexed.h
+++ b/src/java.desktop/share/native/libawt/java2d/loops/UshortIndexed.h
@@ -51,7 +51,7 @@ typedef jushort UshortIndexedDataType;
 
 #define DeclareUshortIndexedStoreVars(PREFIX) \
     int PREFIX ## XDither, PREFIX ## YDither; \
-    char *PREFIX ## rerr, *PREFIX ## gerr, *PREFIX ## berr; \
+    signed char *PREFIX ## rerr, *PREFIX ## gerr, *PREFIX ## berr; \
     unsigned char *PREFIX ## InvLut;
 
 #define SetUshortIndexedStoreVarsYPos(PREFIX, pRasInfo, LOC) \

--- a/src/java.desktop/unix/native/common/awt/colordata.h
+++ b/src/java.desktop/unix/native/common/awt/colordata.h
@@ -39,9 +39,9 @@ typedef struct _ColorData {
     unsigned char *awt_icmLUT2Colors;
     unsigned char *img_grays;
     unsigned char *img_clr_tbl;
-    char* img_oda_red;
-    char* img_oda_green;
-    char* img_oda_blue;
+    signed char* img_oda_red;
+    signed char* img_oda_green;
+    signed char* img_oda_blue;
     int *pGrayInverseLutData;
     int screendata;
     int representsPrimaries;

--- a/src/java.desktop/windows/native/libawt/windows/colordata.h
+++ b/src/java.desktop/windows/native/libawt/windows/colordata.h
@@ -28,9 +28,9 @@
 #include "img_globals.h"
 
 typedef struct _ColorData {
-    char* img_oda_red;
-    char* img_oda_green;
-    char* img_oda_blue;
+    signed char* img_oda_red;
+    signed char* img_oda_green;
+    signed char* img_oda_blue;
     unsigned char* img_clr_tbl;
     int *pGrayInverseLutData;
     int representsPrimaries;

--- a/test/jdk/java/awt/image/DrawImage/ByteIndexedDitherTest.java
+++ b/test/jdk/java/awt/image/DrawImage/ByteIndexedDitherTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8280964
+ * @summary Tests that drawing to a ByteIndexed image dithers correctly.
+ */
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+public class ByteIndexedDitherTest {
+
+    public static void main(String[] args) {
+        BufferedImage bgr = createBGRImage();
+        BufferedImage indexed = createIndexedImage(bgr);
+        checkImage(indexed);
+    }
+
+    static BufferedImage createBGRImage() {
+
+        int sz = 8;
+        BufferedImage img;
+        img = new BufferedImage(sz, sz, BufferedImage.TYPE_3BYTE_BGR);
+        Graphics2D g = img.createGraphics();
+        Color c = new Color(0, 0, 254);
+        g.setColor(c);
+        g.fillRect(0, 0, sz, sz);
+        g.dispose();
+
+        return img;
+    }
+
+    static BufferedImage createIndexedImage(BufferedImage srcImage) {
+
+        int w = srcImage.getWidth(null);
+        int h = srcImage.getHeight(null);
+        BufferedImage
+        indexedImg = new BufferedImage(w, h, BufferedImage.TYPE_BYTE_INDEXED);
+        Graphics2D g = indexedImg.createGraphics();
+        g.drawImage(srcImage, 0, 0, w, h, null);
+        g.dispose();
+        return indexedImg;
+    }
+
+     static void checkImage(BufferedImage image) {
+         int wid = image.getWidth();
+         int hgt = image.getHeight();
+         for (int y=0; y<hgt; y++) {
+             for (int x=0; x<wid; x++) {
+                 int v = image.getRGB(x, y);
+                 if ((v & 0x00ffff00) != 0) {
+                     System.err.println("("+x+","+y+") = " +
+                          Integer.toHexString(v));
+                     throw new RuntimeException("Unexpected Red or Green");
+                 }
+             }
+         }
+    }
+}
+


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280964](https://bugs.openjdk.java.net/browse/JDK-8280964): [Linux aarch64] : drawImage dithers TYPE_BYTE_INDEXED images incorrectly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1063/head:pull/1063` \
`$ git checkout pull/1063`

Update a local copy of the PR: \
`$ git checkout pull/1063` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1063`

View PR using the GUI difftool: \
`$ git pr show -t 1063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1063.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1063.diff</a>

</details>
