### PR TITLE
8279529: ProblemList java/nio/channels/DatagramChannel/ManySourcesAndTargets.java on macosx-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -603,6 +603,8 @@ java/rmi/activation/rmidViaInheritedChannel/InheritedChannelNotServerSocket.java
 
 java/rmi/registry/readTest/CodebaseTest.java                    8173324 windows-all
 
+java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64
+
 ############################################################################
 
 # jdk_sctp
@@ -658,6 +660,7 @@ javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
+sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java 8277970 linux-all,macosx-x64
 
 ############################################################################
 


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.
ProblemList context resolve only, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8279529](https://bugs.openjdk.java.net/browse/JDK-8279529): ProblemList java/nio/channels/DatagramChannel/ManySourcesAndTargets.java on macosx-aarch64
 * [JDK-8279532](https://bugs.openjdk.java.net/browse/JDK-8279532): ProblemList sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1064/head:pull/1064` \
`$ git checkout pull/1064`

Update a local copy of the PR: \
`$ git checkout pull/1064` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1064`

View PR using the GUI difftool: \
`$ git pr show -t 1064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1064.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1064.diff</a>

</details>
