### PR TITLE
Backport d67ca11f470b9f458b60f0e4198f4ac5dc3270c4

### DIFF
--- a/src/java.base/share/classes/java/net/doc-files/net-properties.html
+++ b/src/java.base/share/classes/java/net/doc-files/net-properties.html
@@ -212,6 +212,22 @@ of proxies.</P>
 	      property is defined, then its value will be used a the domain
 	      name.</P>
 	</OL>
+	<LI><P><B>{@systemProperty jdk.https.negotiate.cbt}</B> (default: &lt;never&gt;)<BR>
+	This controls the generation and sending of TLS channel binding tokens (CBT) when Kerberos 
+        or the Negotiate authentication scheme using Kerberos are employed over HTTPS with
+        {@code HttpsURLConnection}. There are three possible settings:</P>
+        <OL>
+          <LI><P>"never". This is also the default value if the property is not set. In this case,
+              CBTs are never sent.</P>
+          <LI><P>"always". CBTs are sent for all Kerberos authentication attempts over HTTPS.</P>
+          <LI><P>"domain:&lt;comma separated domain list&gt;" Each domain in the list specifies destination
+          host or hosts for which a CBT is sent. Domains can be single hosts like foo, or foo.com,
+          or literal IP addresses as specified in RFC 2732, or wildcards like *.foo.com which matches 
+          all hosts under foo.com and its sub-domains. CBTs are not sent to any destinations 
+          that don't match one of the list entries</P>
+	</OL>
+	<P>The channel binding tokens generated are of the type "tls-server-end-point" as defined in
+           RFC 5929.</P>
 </UL>
 <P>All these properties are checked only once at startup.</P>
 <a id="AddressCache"></a>

--- a/src/java.base/share/classes/sun/net/www/http/HttpClient.java
+++ b/src/java.base/share/classes/sun/net/www/http/HttpClient.java
@@ -140,10 +140,25 @@ public class HttpClient extends NetworkClient {
     // Traffic capture tool, if configured. See HttpCapture class for info
     private HttpCapture capture = null;
 
+    /* "jdk.https.negotiate.cbt" property can be set to "always" (always sent), "never" (never sent) or
+     * "domain:a,c.d,*.e.f" (sent to host a, or c.d or to the domain e.f and any of its subdomains). This is
+     * a comma separated list of arbitrary length with no white-space allowed.
+     * If enabled (for a particular destination) then Negotiate/SPNEGO authentication requests will include
+     * a channel binding token for the destination server. The default behavior and setting for the
+     * property is "never"
+     */
+    private static final String spnegoCBT;
+
     private static final PlatformLogger logger = HttpURLConnection.getHttpLogger();
+
     private static void logFinest(String msg) {
         if (logger.isLoggable(PlatformLogger.Level.FINEST)) {
             logger.finest(msg);
+        }
+    }
+    private static void logError(String msg) {
+        if (logger.isLoggable(PlatformLogger.Level.SEVERE)) {
+            logger.severe(msg);
         }
     }
 
@@ -161,12 +176,27 @@ public class HttpClient extends NetworkClient {
         return keepAliveTimeout;
     }
 
+    static String normalizeCBT(String s) {
+        if (s == null || s.equals("never")) {
+            return "never";
+        }
+        if (s.equals("always") || s.startsWith("domain:")) {
+            return s;
+        } else {
+            logError("Unexpected value for \"jdk.https.negotiate.cbt\" system property");
+            return "never";
+        }
+    }
+
     static {
         Properties props = GetPropertyAction.privilegedGetProperties();
         String keepAlive = props.getProperty("http.keepAlive");
         String retryPost = props.getProperty("sun.net.http.retryPost");
         String cacheNTLM = props.getProperty("jdk.ntlm.cache");
         String cacheSPNEGO = props.getProperty("jdk.spnego.cache");
+
+        String s = props.getProperty("jdk.https.negotiate.cbt");
+        spnegoCBT = normalizeCBT(s);
 
         if (keepAlive != null) {
             keepAliveProp = Boolean.parseBoolean(keepAlive);
@@ -201,6 +231,10 @@ public class HttpClient extends NetworkClient {
         return keepAliveProp;
     }
 
+
+    public String getSpnegoCBT() {
+        return spnegoCBT;
+    }
 
     protected HttpClient() {
     }

--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpCallerInfo.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpCallerInfo.java
@@ -29,6 +29,7 @@ import java.net.Authenticator;
 import java.net.Authenticator.RequestorType;
 import java.net.InetAddress;
 import java.net.URL;
+import java.security.cert.X509Certificate;
 
 /**
  * Used in HTTP/Negotiate, to feed HTTP request info into JGSS as a HttpCaller,
@@ -51,6 +52,9 @@ public final class HttpCallerInfo {
     public final InetAddress addr;
     public final RequestorType authType;
     public final Authenticator authenticator;
+    // Used to obtain server cert for SPNEGO CBT.
+    // May be null in which case CBT is not set
+    public final X509Certificate serverCert;
 
     /**
      * Create a schemed object based on an un-schemed one.
@@ -65,13 +69,19 @@ public final class HttpCallerInfo {
         this.authType = old.authType;
         this.scheme = scheme;
         this.authenticator =  old.authenticator;
+        this.serverCert =  old.serverCert;
     }
 
     /**
      * Constructor an un-schemed object for site access.
      */
     public HttpCallerInfo(URL url, Authenticator a) {
+        this(url, null, a);
+    }
+
+    public HttpCallerInfo(URL url, X509Certificate serverCert, Authenticator a) {
         this.url= url;
+        this.serverCert= serverCert;
         prompt = "";
         host = url.getHost();
 
@@ -100,9 +110,14 @@ public final class HttpCallerInfo {
      * Constructor an un-schemed object for proxy access.
      */
     public HttpCallerInfo(URL url, String host, int port, Authenticator a) {
+        this(url, host, port, null, a);
+    }
+
+    public HttpCallerInfo(URL url, String host, int port, X509Certificate serverCert, Authenticator a) {
         this.url= url;
         this.host = host;
         this.port = port;
+        this.serverCert = serverCert;
         prompt = "";
         addr = null;
         protocol = url.getProtocol();

--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -1667,7 +1667,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                     AuthenticationHeader authhdr = new AuthenticationHeader (
                             "Proxy-Authenticate",
                             responses,
-                            new HttpCallerInfo(url,
+                            getHttpCallerInfo(url,
                                                http.getProxyHostUsed(),
                                                http.getProxyPortUsed(),
                                                authenticator),
@@ -1742,7 +1742,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
 
                     srvHdr = new AuthenticationHeader (
                             "WWW-Authenticate", responses,
-                            new HttpCallerInfo(url, authenticator),
+                            getHttpCallerInfo(url, authenticator),
                             dontUseNegotiate
                     );
 
@@ -2122,7 +2122,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                     AuthenticationHeader authhdr = new AuthenticationHeader(
                             "Proxy-Authenticate",
                             responses,
-                            new HttpCallerInfo(url,
+                            getHttpCallerInfo(url,
                                                http.getProxyHostUsed(),
                                                http.getProxyPortUsed(),
                                                authenticator),
@@ -2189,6 +2189,21 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
 
         // reset responses
         responses.reset();
+    }
+
+    /**
+     * Overridden in https to also include the server certificate
+     */
+    protected HttpCallerInfo getHttpCallerInfo(URL url, String proxy, int port,
+                                               Authenticator authenticator) {
+        return new HttpCallerInfo(url, proxy, port, authenticator);
+    }
+
+    /**
+     * Overridden in https to also include the server certificate
+     */
+    protected HttpCallerInfo getHttpCallerInfo(URL url, Authenticator authenticator) {
+        return new HttpCallerInfo(url, authenticator);
     }
 
     static String connectRequestURI(URL url) {

--- a/src/java.base/share/classes/sun/net/www/protocol/https/AbstractDelegateHttpsURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/AbstractDelegateHttpsURLConnection.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -25,15 +25,19 @@
 
 package sun.net.www.protocol.https;
 
+import java.net.Authenticator;
 import java.net.URL;
 import java.net.Proxy;
 import java.net.SecureCacheResponse;
 import java.security.Principal;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.io.IOException;
 import java.util.List;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import sun.net.www.http.*;
 import sun.net.www.protocol.http.HttpURLConnection;
+import sun.net.www.protocol.http.HttpCallerInfo;
 
 /**
  * HTTPS URL connection support.
@@ -308,4 +312,72 @@ public abstract class AbstractDelegateHttpsURLConnection extends
         }
     }
 
+    /*
+     * If no SSL Session available or if the system config does not allow it
+     * don't use the extended caller info (the server cert).
+     * Otherwise return true to include the server cert
+     */
+    private boolean useExtendedCallerInfo(URL url) {
+        HttpsClient https = (HttpsClient)http;
+        if (https.getSSLSession() == null) {
+            return false;
+        }
+        String prop = http.getSpnegoCBT();
+        if (prop.equals("never")) {
+            return false;
+        }
+        String target = url.getHost();
+        if (prop.startsWith("domain:")) {
+            String[] domains = prop.substring(7).split(",");
+            for (String domain : domains) {
+                if (target.equals(domain)) {
+                    return true;
+                }
+                if (domain.startsWith("*.") && target.endsWith(domain.substring(1))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    protected HttpCallerInfo getHttpCallerInfo(URL url, String proxy, int port,
+                                               Authenticator authenticator)
+    {
+        if (!useExtendedCallerInfo(url)) {
+            return super.getHttpCallerInfo(url, proxy, port, authenticator);
+        }
+        HttpsClient https = (HttpsClient)http;
+        try {
+            Certificate[] certs = https.getServerCertificates();
+            if (certs[0] instanceof X509Certificate) {
+                X509Certificate x509Cert = (X509Certificate)certs[0];
+                return new HttpCallerInfo(url, proxy, port, x509Cert, authenticator);
+            }
+        } catch (SSLPeerUnverifiedException e) {
+            // ignore
+        }
+        return super.getHttpCallerInfo(url, proxy, port, authenticator);
+    }
+
+    @Override
+    protected HttpCallerInfo getHttpCallerInfo(URL url, Authenticator authenticator)
+    {
+        if (!useExtendedCallerInfo(url)) {
+            return super.getHttpCallerInfo(url, authenticator);
+        }
+        HttpsClient https = (HttpsClient)http;
+        try {
+            Certificate[] certs = https.getServerCertificates();
+            if (certs[0] instanceof X509Certificate) {
+                X509Certificate x509Cert = (X509Certificate)certs[0];
+                return new HttpCallerInfo(url, x509Cert, authenticator);
+            }
+        } catch (SSLPeerUnverifiedException e) {
+            // ignore
+        }
+        return super.getHttpCallerInfo(url, authenticator);
+    }
 }

--- a/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/HttpsClient.java
@@ -744,6 +744,13 @@ final class HttpsClient extends HttpClient
     }
 
     /**
+     * Returns the {@code SSLSession} in use on this connection.
+     */
+    SSLSession getSSLSession() {
+        return session;
+    }
+
+    /**
      * This method implements the SSL HandshakeCompleted callback,
      * remembering the resulting session so that it may be queried
      * for the current cipher suite and peer certificates.  Servers

--- a/src/java.base/share/classes/sun/security/util/ChannelBindingException.java
+++ b/src/java.base/share/classes/sun/security/util/ChannelBindingException.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.security.util;
+
+import java.security.GeneralSecurityException;
+
+/**
+ * Thrown by TlsChannelBinding if an error occurs
+ */
+public class ChannelBindingException extends GeneralSecurityException {
+
+    private static final long serialVersionUID = -5021387249782788460L;
+
+    /**
+     * Constructs a ChannelBindingException with no detail message. A detail
+     * message is a String that describes this particular exception.
+     */
+    public ChannelBindingException() {
+        super();
+    }
+
+    /**
+     * Constructs a ChannelBindingException with a detail message and
+     * specified cause.
+     */
+    public ChannelBindingException(String msg, Exception e) {
+        super(msg, e);
+    }
+
+    /**
+     * Constructs a ChannelBindingException with a detail message
+     */
+    public ChannelBindingException(String msg) {
+        super(msg);
+    }
+}

--- a/src/java.base/share/classes/sun/security/util/TlsChannelBinding.java
+++ b/src/java.base/share/classes/sun/security/util/TlsChannelBinding.java
@@ -22,10 +22,9 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.jndi.ldap.sasl;
 
-import javax.naming.NamingException;
-import javax.security.sasl.SaslException;
+package sun.security.util;
+
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateEncodingException;
@@ -46,14 +45,6 @@ import java.util.Hashtable;
  */
 
 public class TlsChannelBinding {
-
-    // TLS channel binding type property
-    public static final String CHANNEL_BINDING_TYPE =
-            "com.sun.jndi.ldap.tls.cbtype";
-
-    // internal TLS channel binding property
-    public static final String CHANNEL_BINDING =
-            "jdk.internal.sasl.tlschannelbinding";
 
     public enum TlsChannelBindingType {
 
@@ -80,19 +71,18 @@ public class TlsChannelBinding {
     }
 
     /**
-     * Parse value of "com.sun.jndi.ldap.tls.cbtype" property
+     * Parse given value to see if it is a recognized and supported channel binding type
+     *
      * @param  cbType
-     * @return TLS Channel Binding type or null if
-     *         "com.sun.jndi.ldap.tls.cbtype" property has not been set.
-     * @throws NamingException
+     * @return TLS Channel Binding type or null if given string is null
+     * @throws ChannelBindingException
      */
-    public static TlsChannelBindingType parseType(String cbType) throws NamingException {
+    public static TlsChannelBindingType parseType(String cbType) throws ChannelBindingException {
         if (cbType != null) {
             if (cbType.equals(TlsChannelBindingType.TLS_SERVER_END_POINT.getName())) {
                 return TlsChannelBindingType.TLS_SERVER_END_POINT;
             } else {
-                throw new NamingException("Illegal value for " +
-                        CHANNEL_BINDING_TYPE + " property.");
+                throw new ChannelBindingException("Illegal value for channel binding type: " + cbType);
             }
         }
         return null;
@@ -104,9 +94,9 @@ public class TlsChannelBinding {
     /**
      * Construct tls-server-end-point Channel Binding data
      * @param serverCertificate
-     * @throws SaslException
+     * @throws ChannelBindingException
      */
-    public static TlsChannelBinding create(X509Certificate serverCertificate) throws SaslException {
+    public static TlsChannelBinding create(X509Certificate serverCertificate) throws ChannelBindingException {
         try {
             final byte[] prefix =
                 TlsChannelBindingType.TLS_SERVER_END_POINT.getName().concat(":").getBytes();
@@ -127,7 +117,7 @@ public class TlsChannelBinding {
             System.arraycopy(hash, 0, cbData, prefix.length, hash.length);
             return new TlsChannelBinding(TlsChannelBindingType.TLS_SERVER_END_POINT, cbData);
         } catch (NoSuchAlgorithmException | CertificateEncodingException e) {
-            throw new SaslException("Cannot create TLS channel binding data", e);
+            throw new ChannelBindingException("Cannot create TLS channel binding data", e);
         }
     }
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/LdapSasl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/LdapSasl.java
@@ -42,7 +42,9 @@ import javax.security.sasl.*;
 import com.sun.jndi.ldap.Connection;
 import com.sun.jndi.ldap.LdapClient;
 import com.sun.jndi.ldap.LdapResult;
-import com.sun.jndi.ldap.sasl.TlsChannelBinding.TlsChannelBindingType;
+import sun.security.util.ChannelBindingException;
+import sun.security.util.TlsChannelBinding;
+import sun.security.util.TlsChannelBinding.TlsChannelBindingType;
 
 /**
   * Handles SASL support.
@@ -61,6 +63,14 @@ final public class LdapSasl {
 
     private static final int LDAP_SUCCESS = 0;
     private static final int LDAP_SASL_BIND_IN_PROGRESS = 14;   // LDAPv3
+
+    // TLS channel binding type property
+    private static final String CHANNEL_BINDING_TYPE =
+            "com.sun.jndi.ldap.tls.cbtype";
+
+    // internal TLS channel binding property
+    private static final String CHANNEL_BINDING =
+            "jdk.internal.sasl.tlschannelbinding";
 
     private LdapSasl() {
     }
@@ -113,8 +123,8 @@ final public class LdapSasl {
         String[] mechs = getSaslMechanismNames(authMech);
 
         // Internal TLS Channel Binding property cannot be set explicitly
-        if (env.get(TlsChannelBinding.CHANNEL_BINDING) != null) {
-            throw new NamingException(TlsChannelBinding.CHANNEL_BINDING +
+        if (env.get(CHANNEL_BINDING) != null) {
+            throw new NamingException(CHANNEL_BINDING +
                     " property cannot be set explicitly");
         }
 
@@ -123,17 +133,24 @@ final public class LdapSasl {
         try {
             // Prepare TLS Channel Binding data
             if (conn.isTlsConnection()) {
-                TlsChannelBindingType cbType =
-                        TlsChannelBinding.parseType(
-                                (String)env.get(TlsChannelBinding.CHANNEL_BINDING_TYPE));
+                TlsChannelBindingType cbType;
+                try {
+                    cbType = TlsChannelBinding.parseType((String)env.get(CHANNEL_BINDING_TYPE));
+                } catch (ChannelBindingException e) {
+                    throw wrapInNamingException(e);
+                }
                 if (cbType == TlsChannelBindingType.TLS_SERVER_END_POINT) {
                     // set tls-server-end-point channel binding
                     X509Certificate cert = conn.getTlsServerCertificate();
                     if (cert != null) {
-                        TlsChannelBinding tlsCB =
-                                TlsChannelBinding.create(cert);
+                        TlsChannelBinding tlsCB;
+                        try {
+                            tlsCB = TlsChannelBinding.create(cert);
+                        } catch (ChannelBindingException e) {
+                            throw wrapInNamingException(e);
+                        }
                         envProps = (Hashtable<String, Object>) env.clone();
-                        envProps.put(TlsChannelBinding.CHANNEL_BINDING, tlsCB.getData());
+                        envProps.put(CHANNEL_BINDING, tlsCB.getData());
                     } else {
                         throw new SaslException("No suitable certificate to generate " +
                                 "TLS Channel Binding data");
@@ -225,6 +242,12 @@ final public class LdapSasl {
             mechNames[i] = mechs.elementAt(i);
         }
         return mechNames;
+    }
+
+    private static NamingException wrapInNamingException(Exception e) {
+        NamingException ne = new NamingException();
+        ne.setRootCause(e);
+        return ne;
     }
 
     private static final byte[] NO_BYTES = new byte[0];

--- a/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
+++ b/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
@@ -38,6 +38,9 @@ import sun.security.jgss.GSSManagerImpl;
 import sun.security.jgss.GSSContextImpl;
 import sun.security.jgss.GSSUtil;
 import sun.security.jgss.HttpCaller;
+import sun.security.jgss.krb5.internal.TlsChannelBindingImpl;
+import sun.security.util.ChannelBindingException;
+import sun.security.util.TlsChannelBinding;
 
 /**
  * This class encapsulates all JAAS and JGSS API calls in a separate class
@@ -64,7 +67,7 @@ public class NegotiatorImpl extends Negotiator {
      * <li>Creating GSSContext
      * <li>A first call to initSecContext</ul>
      */
-    private void init(HttpCallerInfo hci) throws GSSException {
+    private void init(HttpCallerInfo hci) throws GSSException, ChannelBindingException {
         final Oid oid;
 
         if (hci.scheme.equalsIgnoreCase("Kerberos")) {
@@ -105,6 +108,14 @@ public class NegotiatorImpl extends Negotiator {
         if (context instanceof GSSContextImpl) {
             ((GSSContextImpl)context).requestDelegPolicy(true);
         }
+        if (hci.serverCert != null) {
+            if (DEBUG) {
+                System.out.println("Negotiate: Setting CBT");
+            }
+            // set the channel binding token
+            TlsChannelBinding b = TlsChannelBinding.create(hci.serverCert);
+            context.setChannelBinding(new TlsChannelBindingImpl(b.getData()));
+        }
         oneToken = context.initSecContext(new byte[0], 0, 0);
     }
 
@@ -115,7 +126,7 @@ public class NegotiatorImpl extends Negotiator {
     public NegotiatorImpl(HttpCallerInfo hci) throws IOException {
         try {
             init(hci);
-        } catch (GSSException e) {
+        } catch (GSSException | ChannelBindingException e) {
             if (DEBUG) {
                 System.out.println("Negotiate support not initiated, will " +
                         "fallback to other scheme if allowed. Reason:");

--- a/test/jdk/com/sun/jndi/ldap/LdapCBPropertiesTest.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapCBPropertiesTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8245527
  * @library lib/ /test/lib
+ * @modules java.base/sun.security.util
  * @run main/othervm LdapCBPropertiesTest true  true  com.sun.jndi.ldap.tls.cbtype tls-server-end-point
  * @run main/othervm LdapCBPropertiesTest false false com.sun.jndi.ldap.tls.cbtype tls-server-end-point
  * @run main/othervm LdapCBPropertiesTest true  true  com.sun.jndi.ldap.tls.cbtype tls-server-end-point com.sun.jndi.ldap.connect.timeout 2000
@@ -52,6 +53,8 @@ import javax.net.ssl.SSLServerSocketFactory;
 import javax.security.sasl.SaslException;
 
 import jdk.test.lib.net.URIBuilder;
+
+import sun.security.util.ChannelBindingException;
 
 public class LdapCBPropertiesTest {
     /*
@@ -187,7 +190,8 @@ public class LdapCBPropertiesTest {
                 }
             }
         }
-        if (!shouldPass && ne.getRootCause() == null) {
+        Throwable rc = ne.getRootCause();
+        if (!shouldPass && (rc == null || rc instanceof ChannelBindingException)) {
             // Expected exception caused by Channel Binding parameter inconsistency
             return true;
         }

--- a/test/jdk/sun/security/krb5/auto/HttpsCB.java
+++ b/test/jdk/sun/security/krb5/auto/HttpsCB.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8279842
+ * @library /test/lib /lib/testlibrary
+ * @build jdk.testlibrary.SimpleSSLContext
+ * @modules java.base/sun.security.util
+ *          java.security.jgss/sun.security.jgss
+ *          java.security.jgss/sun.security.jgss.krb5
+ *          java.security.jgss/sun.security.jgss.krb5.internal
+ *          java.security.jgss/sun.security.krb5.internal:+open
+ *          java.security.jgss/sun.security.krb5:+open
+ *          java.security.jgss/sun.security.krb5.internal.ccache
+ *          java.security.jgss/sun.security.krb5.internal.crypto
+ *          java.security.jgss/sun.security.krb5.internal.ktab
+ *          jdk.security.auth
+ *          jdk.security.jgss
+ *          jdk.httpserver
+ * @summary HTTPS Channel Binding support for Java GSS/Kerberos
+ * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *          -Djdk.https.negotiate.cbt=always HttpsCB true true
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *          -Djdk.https.negotiate.cbt=never HttpsCB false true
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *          -Djdk.https.negotiate.cbt=invalid HttpsCB false true
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *          HttpsCB false true
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *          -Djdk.https.negotiate.cbt=domain:other.com HttpsCB false true
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *          -Djdk.https.negotiate.cbt=domain:host.web.domain HttpsCB true true
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *          -Djdk.https.negotiate.cbt=domain:*.web.domain HttpsCB true true
+ */
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpPrincipal;
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsExchange;
+import com.sun.net.httpserver.HttpsServer;
+import com.sun.security.auth.module.Krb5LoginModule;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+import java.net.Socket;
+import java.net.URL;
+import java.security.cert.X509Certificate;
+import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
+import java.util.Map;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import javax.security.auth.Subject;
+
+import jdk.test.lib.Asserts;
+import jdk.testlibrary.SimpleSSLContext;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSManager;
+import sun.security.jgss.GSSUtil;
+import sun.security.jgss.krb5.internal.TlsChannelBindingImpl;
+import sun.security.krb5.Config;
+import sun.security.util.TlsChannelBinding;
+
+import java.util.Base64;
+import java.util.concurrent.Callable;
+
+public class HttpsCB {
+
+    final static String REALM_WEB = "WEB.DOMAIN";
+    final static String KRB5_CONF = "web.conf";
+    final static String KRB5_TAB = "web.ktab";
+
+    final static String WEB_USER = "web";
+    final static char[] WEB_PASS = "webby".toCharArray();
+    final static String WEB_HOST = "host.web.domain";
+    final static String CONTENT = "Hello, World!";
+
+    static int webPort;
+    static URL cbtURL;
+    static URL normalURL;
+
+    public static void main(String[] args)
+            throws Exception {
+
+        boolean expectCBT = Boolean.parseBoolean(args[0]);
+        boolean expectNoCBT = Boolean.parseBoolean(args[1]);
+
+        System.setProperty("sun.security.krb5.debug", "true");
+
+        KDC kdcw = KDC.create(REALM_WEB);
+        kdcw.addPrincipal(WEB_USER, WEB_PASS);
+        kdcw.addPrincipalRandKey("krbtgt/" + REALM_WEB);
+        kdcw.addPrincipalRandKey("HTTP/" + WEB_HOST);
+
+        KDC.saveConfig(KRB5_CONF, kdcw,
+                "default_keytab_name = " + KRB5_TAB,
+                "[domain_realm]",
+                "",
+                ".web.domain="+REALM_WEB);
+
+        System.setProperty("java.security.krb5.conf", KRB5_CONF);
+        Config.refresh();
+        KDC.writeMultiKtab(KRB5_TAB, kdcw);
+
+        // Write a customized JAAS conf file, so that any kinit cache
+        // will be ignored.
+        System.setProperty("java.security.auth.login.config", OneKDC.JAAS_CONF);
+        File f = new File(OneKDC.JAAS_CONF);
+        FileOutputStream fos = new FileOutputStream(f);
+        fos.write((
+                "com.sun.security.jgss.krb5.initiate {\n" +
+                "    com.sun.security.auth.module.Krb5LoginModule required;\n};\n"
+                ).getBytes());
+        fos.close();
+
+        HttpServer h1 = httpd("Negotiate",
+                "HTTP/" + WEB_HOST + "@" + REALM_WEB, KRB5_TAB);
+        webPort = h1.getAddress().getPort();
+
+        cbtURL = new URL("https://" + WEB_HOST +":" + webPort + "/cbt");
+        normalURL = new URL("https://" + WEB_HOST +":" + webPort + "/normal");
+
+        java.net.Authenticator.setDefault(new java.net.Authenticator() {
+            public PasswordAuthentication getPasswordAuthentication () {
+                return new PasswordAuthentication(
+                        WEB_USER+"@"+REALM_WEB, WEB_PASS);
+            }
+        });
+
+        // Client-side SSLContext needs to ignore hostname mismatch
+        // and untrusted certificate.
+        SSLContext sc = SSLContext.getInstance("SSL");
+        sc.init(null, new TrustManager[] {
+                new X509ExtendedTrustManager() {
+                    public X509Certificate[] getAcceptedIssuers() {
+                        return null;
+                    }
+                    public void checkClientTrusted(X509Certificate[] chain,
+                            String authType, Socket socket) { }
+                    public void checkServerTrusted(X509Certificate[] chain,
+                            String authType, Socket socket) { }
+                    public void checkClientTrusted(X509Certificate[] chain,
+                            String authType, SSLEngine engine) { }
+                    public void checkServerTrusted(X509Certificate[] chain,
+                            String authType, SSLEngine engine) { }
+                    public void checkClientTrusted(X509Certificate[] certs,
+                            String authType) { }
+                    public void checkServerTrusted(X509Certificate[] certs,
+                            String authType) { }
+                }
+        }, null);
+
+        Asserts.assertEQ(visit(sc, cbtURL), expectCBT);
+        Asserts.assertEQ(visit(sc, normalURL), expectNoCBT);
+    }
+
+    static boolean visit(SSLContext sc, URL url) {
+        try {
+            HttpsURLConnection conn = (HttpsURLConnection)
+                    url.openConnection(Proxy.NO_PROXY);
+            conn.setSSLSocketFactory(sc.getSocketFactory());
+            BufferedReader reader;
+            reader = new BufferedReader(new InputStreamReader(
+                    conn.getInputStream()));
+            return reader.readLine().equals(CONTENT);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    static HttpServer httpd(String scheme, String principal, String ktab)
+            throws Exception {
+        MyHttpHandler h = new MyHttpHandler();
+        HttpsServer server = HttpsServer.create(new InetSocketAddress(0), 0);
+        server.setHttpsConfigurator(
+                new HttpsConfigurator(new SimpleSSLContext().get()));
+        server.createContext("/", h).setAuthenticator(
+                new MyServerAuthenticator(scheme, principal, ktab));
+        server.start();
+        return server;
+    }
+
+    static class MyHttpHandler implements HttpHandler {
+        public void handle(HttpExchange t) throws IOException {
+            t.sendResponseHeaders(200, 0);
+            t.getResponseBody().write(CONTENT.getBytes());
+            t.close();
+        }
+    }
+
+    static class MyServerAuthenticator
+            extends com.sun.net.httpserver.Authenticator {
+        Subject s = new Subject();
+        GSSManager m;
+        GSSCredential cred;
+        String scheme = null;
+        String reqHdr = "WWW-Authenticate";
+        String respHdr = "Authorization";
+        int err = HttpURLConnection.HTTP_UNAUTHORIZED;
+
+        public MyServerAuthenticator(String scheme,
+                String principal, String ktab) throws Exception {
+
+            this.scheme = scheme;
+            Krb5LoginModule krb5 = new Krb5LoginModule();
+            Map<String, String> map = new HashMap<>();
+            Map<String, Object> shared = new HashMap<>();
+
+            map.put("storeKey", "true");
+            map.put("isInitiator", "false");
+            map.put("useKeyTab", "true");
+            map.put("keyTab", ktab);
+            map.put("principal", principal);
+            krb5.initialize(s, null, shared, map);
+            krb5.login();
+            krb5.commit();
+            m = GSSManager.getInstance();
+            cred = Subject.doAs(s, new PrivilegedExceptionAction<GSSCredential>() {
+                @Override
+                public GSSCredential run() throws Exception {
+                    System.err.println("Creating GSSCredential");
+                    return m.createCredential(
+                            null,
+                            GSSCredential.INDEFINITE_LIFETIME,
+                            MyServerAuthenticator.this.scheme
+                                        .equalsIgnoreCase("Negotiate") ?
+                                    GSSUtil.GSS_SPNEGO_MECH_OID :
+                                    GSSUtil.GSS_KRB5_MECH_OID,
+                            GSSCredential.ACCEPT_ONLY);
+                }
+            });
+        }
+
+        @Override
+        public Result authenticate(HttpExchange exch) {
+            // The GSContext is stored in an HttpContext attribute named
+            // "GSSContext" and is created at the first request.
+            GSSContext c = null;
+            String auth = exch.getRequestHeaders().getFirst(respHdr);
+            try {
+                c = (GSSContext)exch.getHttpContext()
+                        .getAttributes().get("GSSContext");
+                if (auth == null) {                 // First request
+                    Headers map = exch.getResponseHeaders();
+                    map.set (reqHdr, scheme);        // Challenge!
+                    c = Subject.doAs(s, new PrivilegedExceptionAction<GSSContext>() {
+                        @Override
+                        public GSSContext run() throws Exception {
+                            return m.createContext(cred);
+                        }
+                    });
+                    // CBT is required for cbtURL
+                    if (exch instanceof HttpsExchange
+                            && exch.getRequestURI().toString().equals("/cbt")) {
+                        HttpsExchange sexch = (HttpsExchange)exch;
+                        TlsChannelBinding b = TlsChannelBinding.create(
+                                (X509Certificate) sexch.getSSLSession()
+                                        .getLocalCertificates()[0]);
+                        c.setChannelBinding(
+                                new TlsChannelBindingImpl(b.getData()));
+                    }
+                    exch.getHttpContext().getAttributes().put("GSSContext", c);
+                    return new com.sun.net.httpserver.Authenticator.Retry(err);
+                } else {                            // Later requests
+                    byte[] token = Base64.getMimeDecoder()
+                            .decode(auth.split(" ")[1]);
+                    token = c.acceptSecContext(token, 0, token.length);
+                    Headers map = exch.getResponseHeaders();
+                    map.set (reqHdr, scheme + " " + Base64.getMimeEncoder()
+                            .encodeToString(token).replaceAll("\\s", ""));
+                    if (c.isEstablished()) {
+                        return new com.sun.net.httpserver.Authenticator.Success(
+                                new HttpPrincipal(c.getSrcName().toString(), ""));
+                    } else {
+                        return new com.sun.net.httpserver.Authenticator.Retry(err);
+                    }
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8279842](https://bugs.openjdk.java.net/browse/JDK-8279842) taken from 17u (https://github.com/openjdk/jdk17u-dev/commit/d67ca11f470b9f458b60f0e4198f4ac5dc3270c4).

Additional changes for 11u:

- Replacement of `instanceof` patterns (AbstractDelegateHttpsURLConnection.java, HttpsCB.java).
- Addition of package private `getSSLSession()` to HttpsClient.java taken from JDK-8212261.
- Test adaptation: `@library` and `@build` statements in HttpsCB.java