### PR TITLE
8217017: [TESTBUG] Tests fail to compile after JDK-8216265

### DIFF
--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.Platform;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;


### PR DESCRIPTION
I'd like to backport this patch to jdk11u to fix the build failure of test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java.

Patch can be applied cleanly and only test code is affected.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8217017](https://bugs.openjdk.java.net/browse/JDK-8217017): [TESTBUG] Tests fail to compile after JDK-8216265


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1069/head:pull/1069` \
`$ git checkout pull/1069`

Update a local copy of the PR: \
`$ git checkout pull/1069` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1069`

View PR using the GUI difftool: \
`$ git pr show -t 1069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1069.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1069.diff</a>

</details>
