### PR TITLE
8206187: javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java fails with Port already in use

### DIFF
--- a/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -110,17 +111,21 @@ public class DefaultAgentFilterTest {
                 try {
                     AtomicBoolean error = new AtomicBoolean(false);
                     AtomicBoolean bindError = new AtomicBoolean(false);
+                    // The predicate below tries to recognise failures.  On a port clash, it sees e.g.
+                    // Error: Exception thrown by the agent : java.rmi.server.ExportException: Port already in use: 46481; nested exception is:
+                    // ...and will never see "main enter" from TestApp.
                     p = ProcessTools.startProcess(
                             TEST_APP_NAME + "{" + name + "}",
                             pb,
                             (line) -> {
-                                if (line.toLowerCase().contains("exception")
-                                || line.toLowerCase().contains("error")) {
+                                if (line.contains("Exception")) {
                                     error.set(true);
+                                    bindError.set(line.toLowerCase().contains("port already in use"));
+                                    return true; // On Exception, app will never start
                                 }
-                                bindError.set(line.toLowerCase().contains("bindexception"));
-                                return true;
-                            });
+                                return line.contains("main enter");
+                            },
+                            60, TimeUnit.SECONDS);
                     if (bindError.get()) {
                         throw new BindException("Process could not be started");
                     } else if (error.get()) {
@@ -164,9 +169,25 @@ public class DefaultAgentFilterTest {
     }
 
     private static final String TEST_APP_NAME = "TestApp";
+    private static final int FREE_PORT_ATTEMPTS = 10;
 
     private static void testDefaultAgent(String propertyFile) throws Exception {
-        int port = Utils.getFreePort();
+        for (int i = 1; i <= FREE_PORT_ATTEMPTS; i++) {
+            int port = Utils.getFreePort();
+            System.out.println("Attempting testDefaultAgent(" + propertyFile + ") with port: " + port);
+            try {
+                testDefaultAgent(propertyFile, port);
+                break;  // return succesfully
+            } catch (BindException b) {
+                // Retry with new port.  Throw if last iteration:
+                if (i == FREE_PORT_ATTEMPTS) {
+                    throw(b);
+                }
+            }
+        }
+    }
+
+    private static void testDefaultAgent(String propertyFile, int port) throws Exception {
         String propFile = System.getProperty("test.src") + File.separator + propertyFile;
         List<String> pbArgs = new ArrayList<>(Arrays.asList(
                 "-cp",
@@ -235,53 +256,32 @@ public class DefaultAgentFilterTest {
     public static void main(String[] args) throws Exception {
         System.out.println("---" + DefaultAgentFilterTest.class.getName() + "-main: starting ...");
 
-        boolean retry = false;
-        do {
-            try {
-                // filter DefaultAgentFilterTest$MyTestObject
-                testDefaultAgent("mgmt1.properties");
-                System.out.println("----\tTest FAILED !!");
-                throw new RuntimeException("---" + DefaultAgentFilterTest.class.getName() + " - No exception reported");
-            } catch (Exception ex) {
-                if (ex instanceof InvocationTargetException) {
-                    if (ex.getCause() instanceof BindException
-                            || ex.getCause() instanceof java.rmi.ConnectException) {
-                        System.out.println("Failed to allocate ports. Retrying ...");
-                        retry = true;
-                    }
-                } else if (ex instanceof InvalidClassException) {
-                    System.out.println("----\tTest PASSED !!");
-                } else if (ex instanceof UnmarshalException
-                        && ((UnmarshalException) ex).getCause() instanceof InvalidClassException) {
-                    System.out.println("----\tTest PASSED !!");
-                } else {
-                    System.out.println(ex);
-                    System.out.println("----\tTest FAILED !!");
-                    throw ex;
-                }
-            }
-        } while (retry);
-        retry = false;
-        do {
-            try {
-                // filter non-existent class
-                testDefaultAgent("mgmt2.properties");
+        try {
+            // filter DefaultAgentFilterTest$MyTestObject
+            testDefaultAgent("mgmt1.properties");
+            System.out.println("----\tTest FAILED !!");
+            throw new RuntimeException("---" + DefaultAgentFilterTest.class.getName() + " - No exception reported");
+        } catch (Exception ex) {
+            if (ex instanceof InvalidClassException) {
                 System.out.println("----\tTest PASSED !!");
-            } catch (Exception ex) {
-                if (ex instanceof InvocationTargetException) {
-                    if (ex.getCause() instanceof BindException
-                            || ex.getCause() instanceof java.rmi.ConnectException) {
-                        System.out.println("Failed to allocate ports. Retrying ...");
-                        retry = true;
-                    }
-                } else {
-                    System.out.println(ex);
-                    System.out.println("----\tTest FAILED !!");
-                    throw ex;
-                }
+            } else if (ex instanceof UnmarshalException
+                    && ((UnmarshalException) ex).getCause() instanceof InvalidClassException) {
+                System.out.println("----\tTest PASSED !!");
+            } else {
+                System.out.println(ex);
+                System.out.println("----\tTest FAILED !!");
+                throw ex;
             }
-        } while (retry);
-
+        }
+        try {
+            // filter non-existent class
+            testDefaultAgent("mgmt2.properties");
+            System.out.println("----\tTest PASSED !!");
+        } catch (Exception ex) {
+            System.out.println(ex);
+            System.out.println("----\tTest FAILED !!");
+            throw ex;
+        }
         System.out.println("---" + DefaultAgentFilterTest.class.getName() + "-main: finished ...");
     }
 


### PR DESCRIPTION
I want to backport this as we see this issue in 11, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8206187](https://bugs.openjdk.java.net/browse/JDK-8206187): javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java fails with Port already in use


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1070/head:pull/1070` \
`$ git checkout pull/1070`

Update a local copy of the PR: \
`$ git checkout pull/1070` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1070`

View PR using the GUI difftool: \
`$ git pr show -t 1070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1070.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1070.diff</a>

</details>
