### PR TITLE
8283323: libharfbuzz optimization level results in extreme build times

### DIFF
--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -578,7 +578,6 @@ else
 
 endif
 
-
 LIBFONTMANAGER_EXTRA_HEADER_DIRS := \
     libharfbuzz \
     libharfbuzz/hb-ucdn \

--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -594,6 +594,14 @@ BUILD_LIBFONTMANAGER_FONTLIB +=  $(LIBFREETYPE_LIBS)
 
 LIBFONTMANAGER_OPTIMIZATION := HIGHEST
 
+ifneq ($(filter $(TOOLCHAIN_TYPE), gcc clang), )
+  # gcc (and to an extent clang) is particularly bad at optimizing these files,
+  # causing a massive spike in compile time. We don't care about these
+  # particular files anyway, so lower optimization level.
+  BUILD_LIBFONTMANAGER_hb-subset.cc_OPTIMIZATION := SIZE
+  BUILD_LIBFONTMANAGER_hb-subset-plan.cc_OPTIMIZATION := SIZE
+endif
+
 ifeq ($(OPENJDK_TARGET_OS), windows)
   LIBFONTMANAGER_EXCLUDE_FILES += X11FontScaler.c \
       X11TextRenderer.c


### PR DESCRIPTION
This PR backports changes to improve build performance with xlc.

It appears that the file was at `make/modules/java.desktop/lib/Awt2dLibraries.gmk` when  this commit was made, but that file has since been moved to `make/lib/Awt2dLibraries.gmk`. This made the change show up as a conflict when I applied this backport using the Skara tools. I resolved the 'conflict' by copying the changes to the new path and marking the previous path as removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8283323](https://bugs.openjdk.java.net/browse/JDK-8283323): libharfbuzz optimization level results in extreme build times


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1077/head:pull/1077` \
`$ git checkout pull/1077`

Update a local copy of the PR: \
`$ git checkout pull/1077` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1077`

View PR using the GUI difftool: \
`$ git pr show -t 1077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1077.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1077.diff</a>

</details>
