### PR TITLE
8286198: [linux] Fix process-memory information

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2404,23 +2404,26 @@ void os::Linux::print_process_memory_info(outputStream* st) {
   // - Print glibc tunables
 #ifdef __GLIBC__
   size_t total_allocated = 0;
+  size_t free_retained = 0;
   bool might_have_wrapped = false;
   if (_mallinfo2 != NULL) {
     struct glibc_mallinfo2 mi = _mallinfo2();
-    total_allocated = mi.uordblks;
+    total_allocated = mi.uordblks + mi.hblkhd;
+    free_retained = mi.fordblks;
   } else if (_mallinfo != NULL) {
     // mallinfo is an old API. Member names mean next to nothing and, beyond that, are 32-bit signed.
     // So for larger footprints the values may have wrapped around. We try to detect this here: if the
     // process whole resident set size is smaller than 4G, malloc footprint has to be less than that
     // and the numbers are reliable.
     struct glibc_mallinfo mi = _mallinfo();
-    total_allocated = (size_t)(unsigned)mi.uordblks;
+    total_allocated = (size_t)(unsigned)mi.uordblks + (size_t)(unsigned)mi.hblkhd;
+    free_retained = (size_t)(unsigned)mi.fordblks;
     // Since mallinfo members are int, glibc values may have wrapped. Warn about this.
     might_have_wrapped = (vmrss * K) > UINT_MAX && (vmrss * K) > (total_allocated + UINT_MAX);
   }
   if (_mallinfo2 != NULL || _mallinfo != NULL) {
-    st->print_cr("C-Heap outstanding allocations: " SIZE_FORMAT "K%s",
-                 total_allocated / K,
+    st->print_cr("C-Heap outstanding allocations: " SIZE_FORMAT "K, retained: " SIZE_FORMAT "K%s",
+                 total_allocated / K, free_retained / K,
                  might_have_wrapped ? " (may have wrapped)" : "");
   }
   // Tunables


### PR DESCRIPTION
Hi all,

Backport a fix that correct C-heap usage info numbers in hs-err files. Applies cleanly.

This pull request contains a backport of commit [9e320d9a](https://github.com/openjdk/jdk/commit/9e320d9ab1813eda705d7318ef964092c50d1ade) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Thomas Stuefe on 10 May 2022 and was reviewed by David Holmes and Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286198](https://bugs.openjdk.java.net/browse/JDK-8286198): [linux] Fix process-memory information


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1078/head:pull/1078` \
`$ git checkout pull/1078`

Update a local copy of the PR: \
`$ git checkout pull/1078` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1078`

View PR using the GUI difftool: \
`$ git pr show -t 1078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1078.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1078.diff</a>

</details>
