### PR TITLE
8285828: runtime/execstack/TestCheckJDK.java fails with zipped debug symbols

### DIFF
--- a/test/hotspot/jtreg/runtime/execstack/TestCheckJDK.java
+++ b/test/hotspot/jtreg/runtime/execstack/TestCheckJDK.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class TestCheckJDK {
     static void checkExecStack(Path file) {
         String filename = file.toString();
         Path parent = file.getParent();
-        if (parent.endsWith("bin") || filename.endsWith(".so")) {
+        if ((parent.endsWith("bin") && !filename.endsWith(".diz")) || filename.endsWith(".so")) {
             if (!WB.checkLibSpecifiesNoexecstack(filename)) {
                 System.out.println("Library does not have the noexecstack bit set: " + filename);
                 testPassed = false;


### PR DESCRIPTION
Hi all,

I'd like to backport this patch to fix the test failure of jdk11.
The bug was observed while building our Tencent Kona JDK11 with zipped debug symbol files.

The patch doesn't apply cleanly, but only one conflict in the copyright year.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285828](https://bugs.openjdk.java.net/browse/JDK-8285828): runtime/execstack/TestCheckJDK.java fails with zipped debug symbols


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1080/head:pull/1080` \
`$ git checkout pull/1080`

Update a local copy of the PR: \
`$ git checkout pull/1080` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1080`

View PR using the GUI difftool: \
`$ git pr show -t 1080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1080.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1080.diff</a>

</details>
