### PR TITLE
JDK-8286630: [11] avoid -std=c++11 CXX harfbuzz buildflag on Windows

### DIFF
--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -542,10 +542,9 @@ ifeq ($(USE_EXTERNAL_HARFBUZZ), true)
 else
   LIBFONTMANAGER_EXTRA_SRC = libharfbuzz
   HARFBUZZ_CFLAGS := -DHAVE_OT -DHAVE_FALLBACK -DHAVE_UCDN -DHAVE_ROUND
-  # Modern HarfBuzz requires c++11.
-  HARFBUZZ_CXXFLAGS := -std=c++11
-
+  # Modern HarfBuzz requires c++11; but VS does not have the flag
   ifneq ($(OPENJDK_TARGET_OS), windows)
+    HARFBUZZ_CXXFLAGS := -std=c++11
     HARFBUZZ_CFLAGS += -DGETPAGESIZE -DHAVE_MPROTECT -DHAVE_PTHREAD \
                        -DHAVE_SYSCONF -DHAVE_SYS_MMAN_H -DHAVE_UNISTD_H \
                        -DHB_NO_PRAGMA_GCC_DIAGNOSTIC


### PR DESCRIPTION
The Visual Studio compilers (checked VS2013 and VS2017) do not know this flag, output is
cl : Command line warning D9002 : ignoring unknown option '-std=c+11'

So the flag should be avoided on Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286630](https://bugs.openjdk.java.net/browse/JDK-8286630): [11] avoid -std=c++11 CXX harfbuzz buildflag on Windows


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1081/head:pull/1081` \
`$ git checkout pull/1081`

Update a local copy of the PR: \
`$ git checkout pull/1081` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1081`

View PR using the GUI difftool: \
`$ git pr show -t 1081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1081.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1081.diff</a>

</details>
