### PR TITLE
Subject: [PATCH] 8285923: [REDO] JDK-8285802 AArch64: Consistently handle offsets in MacroAssembler as 64-bit quantities

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2182,42 +2182,6 @@ void MacroAssembler::unimplemented(const char* what) {
   stop(buf);
 }
 
-// If a constant does not fit in an immediate field, generate some
-// number of MOV instructions and then perform the operation.
-void MacroAssembler::wrap_add_sub_imm_insn(Register Rd, Register Rn, unsigned imm,
-                                           add_sub_imm_insn insn1,
-                                           add_sub_reg_insn insn2) {
-  assert(Rd != zr, "Rd = zr and not setting flags?");
-  if (operand_valid_for_add_sub_immediate((int)imm)) {
-    (this->*insn1)(Rd, Rn, imm);
-  } else {
-    if (uabs(imm) < (1 << 24)) {
-       (this->*insn1)(Rd, Rn, imm & -(1 << 12));
-       (this->*insn1)(Rd, Rd, imm & ((1 << 12)-1));
-    } else {
-       assert_different_registers(Rd, Rn);
-       mov(Rd, (uint64_t)imm);
-       (this->*insn2)(Rd, Rn, Rd, LSL, 0);
-    }
-  }
-}
-
-// Seperate vsn which sets the flags. Optimisations are more restricted
-// because we must set the flags correctly.
-void MacroAssembler::wrap_adds_subs_imm_insn(Register Rd, Register Rn, unsigned imm,
-                                           add_sub_imm_insn insn1,
-                                           add_sub_reg_insn insn2) {
-  if (operand_valid_for_add_sub_immediate((int)imm)) {
-    (this->*insn1)(Rd, Rn, imm);
-  } else {
-    assert_different_registers(Rd, Rn);
-    assert(Rd != zr, "overflow in immediate operand");
-    mov(Rd, (uint64_t)imm);
-    (this->*insn2)(Rd, Rn, Rd, LSL, 0);
-  }
-}
-
-
 void MacroAssembler::add(Register Rd, Register Rn, RegisterOrConstant increment) {
   if (increment.is_register()) {
     add(Rd, Rn, increment.as_register());


### PR DESCRIPTION
NOTE: This is a draft. Please do not review it yet. The "Convert to draft" button isn't working.

This isn't really a backport because the upstream patch would in no shape or form apply to 11u.

So, rather than create a 64-bit path through the offset handling in MacroAssembler I've made `wrap_add_sub_imm_insn` et al template functions that adapt to their caller.

The upstream patch for this bug depends on "8206895: aarch64: rework error-prone cmp instuction". There is a backport of 8206895 at https://mail.openjdk.java.net/pipermail/jdk-updates-dev/2021-March/005411.html . We never applied that 8206895 backport because it's rather invasive, and technically speaking it's an enhacement.

If we wanted to apply the upstream patch for this bug,we could apply the 8206895 patch to 11u-dev first. That might not be a terrible idea. 

Backport-of: b849efdf154552903faaddd69cac1fe5f1ddf18a

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1082/head:pull/1082` \
`$ git checkout pull/1082`

Update a local copy of the PR: \
`$ git checkout pull/1082` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1082`

View PR using the GUI difftool: \
`$ git pr show -t 1082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1082.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1082.diff</a>

</details>
