### PR TITLE
8235220: ClhsdbScanOops.java fails with sun.jvm.hotspot.types.WrongTypeException

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/RobustOopDeterminator.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/RobustOopDeterminator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,9 +74,10 @@ public class RobustOopDeterminator {
       } else {
         Metadata.instantiateWrapperFor(klassField.getValue(oop));
       }
-          return true;
-        }
-    catch (AddressException e) {
+      return true;
+    } catch (AddressException e) {
+      return false;
+    } catch (WrongTypeException e) {
       return false;
     }
   }

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -127,7 +127,7 @@ serviceability/sa/ClhsdbPrintAs.java 8193639 solaris-all
 serviceability/sa/ClhsdbPrintStatics.java 8193639 solaris-all
 serviceability/sa/ClhsdbPstack.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64
 serviceability/sa/ClhsdbRegionDetailsScanOopsForG1.java 8193639 solaris-all
-serviceability/sa/ClhsdbScanOops.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64
+serviceability/sa/ClhsdbScanOops.java 8193639 solaris-al
 serviceability/sa/ClhsdbSource.java 8193639 solaris-all
 serviceability/sa/ClhsdbSymbol.java 8193639 solaris-all
 serviceability/sa/ClhsdbSymbolTable.java 8193639 solaris-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -127,7 +127,7 @@ serviceability/sa/ClhsdbPrintAs.java 8193639 solaris-all
 serviceability/sa/ClhsdbPrintStatics.java 8193639 solaris-all
 serviceability/sa/ClhsdbPstack.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64
 serviceability/sa/ClhsdbRegionDetailsScanOopsForG1.java 8193639 solaris-all
-serviceability/sa/ClhsdbScanOops.java 8193639 solaris-al
+serviceability/sa/ClhsdbScanOops.java 8193639 solaris-all
 serviceability/sa/ClhsdbSource.java 8193639 solaris-all
 serviceability/sa/ClhsdbSymbol.java 8193639 solaris-all
 serviceability/sa/ClhsdbSymbolTable.java 8193639 solaris-all


### PR DESCRIPTION
I would like to backport this to jdk11u-dev.
Applies clean except for the problem list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8235220](https://bugs.openjdk.java.net/browse/JDK-8235220): ClhsdbScanOops.java fails with sun.jvm.hotspot.types.WrongTypeException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1083/head:pull/1083` \
`$ git checkout pull/1083`

Update a local copy of the PR: \
`$ git checkout pull/1083` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1083`

View PR using the GUI difftool: \
`$ git pr show -t 1083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1083.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1083.diff</a>

</details>
