### PR TITLE
8264179: [TESTBUG] Some compiler tests fail when running without C2

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestRangeCheckPredicatesControl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRangeCheckPredicatesControl.java
@@ -28,7 +28,7 @@
  * @summary A LoadP node has a wrong control input (too early) which results in an out-of-bounds read of an object array with ZGC.
  *
  * @run main/othervm -Xmx256m -XX:+UnlockExperimentalVMOptions -XX:+UseZGC compiler.loopopts.TestRangeCheckPredicatesControl
- * @run main/othervm -Xmx256m -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM compiler.loopopts.TestRangeCheckPredicatesControl
+ * @run main/othervm -Xmx256m -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions -XX:+StressGCM compiler.loopopts.TestRangeCheckPredicatesControl
  */
 
 package compiler.loopopts;

--- a/test/hotspot/jtreg/compiler/loopopts/TestUnswitchCloneSkeletonPredicates.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestUnswitchCloneSkeletonPredicates.java
@@ -27,9 +27,9 @@
  * @summary Test the complete cloning of skeleton predicates to unswitched loops as done when cloning them to the main loop.
  * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.loopopts.TestUnswitchCloneSkeletonPredicates::*
  *                   compiler.loopopts.TestUnswitchCloneSkeletonPredicates
- * @run main/othervm -Xcomp -XX:-PartialPeelLoop -XX:CompileCommand=compileonly,compiler.loopopts.TestUnswitchCloneSkeletonPredicates::*
+ * @run main/othervm -Xcomp -XX:+IgnoreUnrecognizedVMOptions -XX:-PartialPeelLoop -XX:CompileCommand=compileonly,compiler.loopopts.TestUnswitchCloneSkeletonPredicates::*
  *                   compiler.loopopts.TestUnswitchCloneSkeletonPredicates
- * @run main/othervm -XX:-PartialPeelLoop compiler.loopopts.TestUnswitchCloneSkeletonPredicates
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-PartialPeelLoop compiler.loopopts.TestUnswitchCloneSkeletonPredicates
  */
 package compiler.loopopts;
 

--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
@@ -26,7 +26,7 @@
  * @test
  * @bug 8193518 8249608
  * @summary C2: Vector registers are sometimes corrupted at safepoint
- * @run main/othervm -XX:-BackgroundCompilation -XX:+UseCountedLoopSafepoints -XX:LoopStripMiningIter=2 -XX:-TieredCompilation TestVectorsNotSavedAtSafepoint test1
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCountedLoopSafepoints -XX:LoopStripMiningIter=2 -XX:-TieredCompilation TestVectorsNotSavedAtSafepoint test1
  * @run main/othervm -XX:-BackgroundCompilation TestVectorsNotSavedAtSafepoint test2
  */
 


### PR DESCRIPTION
I backport this test-only change for parity with 11.0.17-oracle.

I had to resolve TestRangeCheckPredicatesControl.java.
Two tests are not in 11, so I skipped the patch:
TestSubTypeCheckMacroNodeWrongMem.java came in 15 with JDK-8239367
Vec_MulAddS2I.java came in 12 with JDK-8214751

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8264179](https://bugs.openjdk.java.net/browse/JDK-8264179): [TESTBUG] Some compiler tests fail when running without C2


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1091/head:pull/1091` \
`$ git checkout pull/1091`

Update a local copy of the PR: \
`$ git checkout pull/1091` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1091`

View PR using the GUI difftool: \
`$ git pr show -t 1091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1091.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1091.diff</a>

</details>
