### PR TITLE
8234608: [TESTBUG] Fix G1 redefineClasses tests and a memory leak

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/README
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/README
@@ -69,7 +69,8 @@ s loaded by null classloader.
       This behavior can be adjusted with "-compilationLevel" and "-compilationNumber" options. First
 one has self-explaining name, latter sets number of optimization/deoptimozation of each class.
   - Next aspect is class redefinition.
-      You can enable classes redefinition with "-redefineClasses" flag.
+      You can enable classes redefinition with "-redefineClasses" flag. Valid options are "true" and
+"false".
 
 Test implementation details:
   Test supposed to be ran with G1 gc and -XX:+ExplicitGCProvokesConcurrent option. In the end of exec

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/libdefine.cpp
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/libdefine.cpp
@@ -48,6 +48,8 @@ JNIEXPORT jclass JNICALL Java_gc_g1_unloading_classloaders_JNIClassloader_loadTh
   jbyte * arrayContent = env->GetByteArrayElements(bytecode, NULL);
   jsize bytecodeLength = env->GetArrayLength(bytecode);
   jclass returnValue = env->DefineClass(classNameChar, classLoader, arrayContent, bytecodeLength);
+  env->ReleaseByteArrayElements(bytecode, arrayContent, JNI_ABORT);
+  env->ReleaseStringUTFChars(className, classNameChar);
   if (!returnValue) {
     printf("ERROR: DefineClass call returned NULL by some reason. Classloading failed.\n");
   }
@@ -56,12 +58,12 @@ JNIEXPORT jclass JNICALL Java_gc_g1_unloading_classloaders_JNIClassloader_loadTh
 }
 
  /*
-  * Class:     gc_g1_unloading_unloading_loading_ClassLoadingThread
+  * Class:     gc_g1_unloading_unloading_loading_ClassLoadingHelper
   * Method:    makeRedefinition0
   * Signature: (ILjava/lang/Class;[B)I
   */
-JNIEXPORT jint JNICALL  Java_gc_g1_unloading_loading_ClassLoadingThread_makeRedefinition0(JNIEnv *env,
-                jclass cls, jint fl, jclass redefCls, jbyteArray classBytes) {
+JNIEXPORT jint JNICALL  Java_gc_g1_unloading_loading_ClassLoadingHelper_makeRedefinition0(JNIEnv *env,
+                jclass clazz, jint fl, jclass redefCls, jbyteArray classBytes) {
     JavaVM * jvm;
     jvmtiEnv * jvmti;
     jvmtiError err;
@@ -99,15 +101,15 @@ JNIEXPORT jint JNICALL  Java_gc_g1_unloading_loading_ClassLoadingThread_makeRede
     classDef.klass = redefCls;
     classDef.class_byte_count =
         env->GetArrayLength(classBytes);
-    classDef.class_bytes = (unsigned char *)
-        env->GetByteArrayElements(classBytes,
-            NULL);
+    jbyte * class_bytes = env->GetByteArrayElements(classBytes, NULL);
+    classDef.class_bytes = (unsigned char *)class_bytes;
 
     if (fl == 2) {
         printf(">>>>>>>> Invoke RedefineClasses():\n");
         printf("\tnew class byte count=%d\n", classDef.class_byte_count);
     }
     err = jvmti->RedefineClasses(1, &classDef);
+    env->ReleaseByteArrayElements(classBytes, class_bytes, JNI_ABORT);
     if (err != JVMTI_ERROR_NONE) {
         printf("%s: Failed to call RedefineClasses():\n", __FILE__);
         printf("\tthe function returned error %d\n", err);

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_cl/TestDescription.java
@@ -53,8 +53,8 @@
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest
- *      -redefineClasses
- *      -inMemoryCompilation
+ *      -redefineClasses true
+ *      -inMemoryCompilation true
  *      -keep classloader
  *      -numberOfChecksLimit 4
  *      -stressTime 180

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_class/TestDescription.java
@@ -53,8 +53,8 @@
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest
- *      -redefineClasses
- *      -inMemoryCompilation
+ *      -redefineClasses true
+ *      -inMemoryCompilation true
  *      -keep class
  *      -numberOfChecksLimit 4
  *      -stressTime 180

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_inMemoryCompilation_keep_obj/TestDescription.java
@@ -53,8 +53,8 @@
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest
- *      -redefineClasses
- *      -inMemoryCompilation
+ *      -redefineClasses true
+ *      -inMemoryCompilation true
  *      -keep object
  *      -numberOfChecksLimit 4
  *      -stressTime 180

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_cl/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_cl/TestDescription.java
@@ -53,7 +53,7 @@
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest
- *      -redefineClasses
+ *      -redefineClasses true
  *      -keep classloader
  *      -numberOfChecksLimit 4
  *      -stressTime 180

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_class/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_class/TestDescription.java
@@ -53,7 +53,7 @@
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest
- *      -redefineClasses
+ *      -redefineClasses true
  *      -keep class
  *      -numberOfChecksLimit 4
  *      -stressTime 180

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_obj/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/tests/unloading_redefinition_keep_obj/TestDescription.java
@@ -53,7 +53,7 @@
  *      -Xlog:gc:gc.log
  *      -XX:-UseGCOverheadLimit
  *      gc.g1.unloading.UnloadingTest
- *      -redefineClasses
+ *      -redefineClasses true
  *      -keep object
  *      -numberOfChecksLimit 4
  *      -stressTime 180


### PR DESCRIPTION
I backport this test-only change for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8234608](https://bugs.openjdk.java.net/browse/JDK-8234608): [TESTBUG] Fix G1 redefineClasses tests and a memory leak


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1093/head:pull/1093` \
`$ git checkout pull/1093`

Update a local copy of the PR: \
`$ git checkout pull/1093` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1093`

View PR using the GUI difftool: \
`$ git pr show -t 1093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1093.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1093.diff</a>

</details>
