### PR TITLE
8286293: Tests ShortResponseBody and ShortResponseBodyWithRetry should use less resources

### DIFF
--- a/test/jdk/java/net/httpclient/ShortResponseBody.java
+++ b/test/jdk/java/net/httpclient/ShortResponseBody.java
@@ -336,13 +336,6 @@ public abstract class ShortResponseBody {
         }
     }
 
-    // POST tests are racy in what may be received before writing may cause a
-    // broken pipe or reset exception, before all the received data can be read.
-    // Any message up to, and including, the "expected" error message can occur.
-    // Strictly ordered list, in order of possible occurrence.
-    static final List<String> MSGS_ORDER =
-            List.of("no bytes", "status line", "header");
-
     // Asserts that the "send" method appears in the stack of the given
     // exception. The synchronous API must contain the send method on the stack.
     static void assertSendMethodOnStack(IOException ioe) {

--- a/test/jdk/java/net/httpclient/ShortResponseBody.java
+++ b/test/jdk/java/net/httpclient/ShortResponseBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,17 +21,6 @@
  * questions.
  */
 
-/*
- * @test
- * @summary Tests Exception detail message when too few response bytes are
- *          received before a socket exception or eof.
- * @library /lib/testlibrary
- * @build jdk.testlibrary.SimpleSSLContext
- * @run testng/othervm
- *       -Djdk.httpclient.HttpClient.log=headers,errors,channel
- *       ShortResponseBody
- */
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -43,12 +32,10 @@ import java.net.Socket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -80,7 +67,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
-public class ShortResponseBody {
+public abstract class ShortResponseBody {
 
     Server closeImmediatelyServer;
     Server closeImmediatelyHttpsServer;
@@ -97,10 +84,17 @@ public class ShortResponseBody {
     SSLContext sslContext;
     SSLParameters sslParameters;
 
+    static final long PAUSE_FOR_GC = 5; // 5ms to let gc work
+    static final long PAUSE_FOR_PEER = 5; // 5ms to let server react
+
     static final String EXPECTED_RESPONSE_BODY =
             "<html><body><h1>Heading</h1><p>Some Text</p></body></html>";
 
-    final static AtomicLong ids = new AtomicLong();
+    // A request number used to replace %reqnb% in URLs with a unique
+    // number for better log analysis
+    static final AtomicLong reqnb = new AtomicLong();
+
+    static final AtomicLong ids = new AtomicLong();
     final ThreadFactory factory = new ThreadFactory() {
         @Override
         public Thread newThread(Runnable r) {
@@ -124,6 +118,12 @@ public class ShortResponseBody {
 
     @BeforeMethod
     void beforeMethod(ITestContext context) {
+        System.gc();
+        try {
+            Thread.sleep(PAUSE_FOR_GC);
+        } catch (InterruptedException x) {
+
+        }
         if (context.getFailedTests().size() > 0) {
             if (skiptests.get() == null) {
                 SkipException skip = new SkipException("some tests failed");
@@ -161,10 +161,16 @@ public class ShortResponseBody {
         };
     }
 
+    public static String uniqueURL(String url) {
+        return url.replace("%reqnb%", String.valueOf(reqnb.incrementAndGet()));
+    }
+
     @Test(dataProvider = "sanity")
     void sanity(String url) throws Exception {
         HttpClient client = newHttpClient();
+        url = uniqueURL(url);
         HttpRequest request = HttpRequest.newBuilder(URI.create(url)).build();
+        out.println("Request: " + request);
         HttpResponse<String> response = client.send(request, ofString());
         String body = response.body();
         assertEquals(body, EXPECTED_RESPONSE_BODY);
@@ -262,61 +268,16 @@ public class ShortResponseBody {
                 .build();
     }
 
-    @Test(dataProvider = "uris")
-    void testSynchronousGET(String url, String expectedMsg, boolean sameClient)
-        throws Exception
-    {
-        checkSkip();
-        out.print("---\n");
-        HttpClient client = null;
-        for (int i=0; i< ITERATION_COUNT; i++) {
-            if (!sameClient || client == null)
-                client = newHttpClient();
-            HttpRequest request = HttpRequest.newBuilder(URI.create(url)).build();
-            try {
-                HttpResponse<String> response = client.send(request, ofString());
-                String body = response.body();
-                out.println(response + ": " + body);
-                fail("UNEXPECTED RESPONSE: " + response);
-            } catch (IOException ioe) {
-                out.println("Caught expected exception:" + ioe);
-                String msg = ioe.getMessage();
-                assertTrue(msg.contains(expectedMsg), "exception msg:[" + msg + "]");
-                // synchronous API must have the send method on the stack
-                assertSendMethodOnStack(ioe);
-                assertNoConnectionExpiredException(ioe);
+    HttpClient sharedClient = null;
+    HttpClient newHttpClient(boolean shared) {
+        if (shared) {
+            HttpClient sharedClient = this.sharedClient;
+            if (sharedClient == null) {
+                sharedClient = this.sharedClient = newHttpClient();
             }
+            return sharedClient;
         }
-    }
-
-    @Test(dataProvider = "uris")
-    void testAsynchronousGET(String url, String expectedMsg, boolean sameClient)
-        throws Exception
-    {
-        checkSkip();
-        out.print("---\n");
-        HttpClient client = null;
-        for (int i=0; i< ITERATION_COUNT; i++) {
-            if (!sameClient || client == null)
-                client = newHttpClient();
-            HttpRequest request = HttpRequest.newBuilder(URI.create(url)).build();
-            try {
-                HttpResponse<String> response = client.sendAsync(request, ofString()).get();
-                String body = response.body();
-                out.println(response + ": " + body);
-                fail("UNEXPECTED RESPONSE: " + response);
-            } catch (ExecutionException ee) {
-                if (ee.getCause() instanceof IOException) {
-                    IOException ioe = (IOException) ee.getCause();
-                    out.println("Caught expected exception:" + ioe);
-                    String msg = ioe.getMessage();
-                    assertTrue(msg.contains(expectedMsg), "exception msg:[" + msg + "]");
-                    assertNoConnectionExpiredException(ioe);
-                } else {
-                    throw ee;
-                }
-            }
-        }
+        return newHttpClient();
     }
 
     // can be used to prolong request body publication
@@ -332,6 +293,11 @@ public class ShortResponseBody {
                 k16++;
                 System.out.println("... 16K sent.");
                 count = count % (16 * 1024);
+                try {
+                    Thread.sleep(PAUSE_FOR_PEER);
+                } catch (InterruptedException x) {
+                    // ignore
+                }
             }
             if (k16 > 128) {
                 System.out.println("WARNING: InfiniteInputStream: " +
@@ -354,6 +320,11 @@ public class ShortResponseBody {
                 k16++;
                 System.out.println("... 16K sent.");
                 count = count % (16 * 1024);
+                try {
+                    Thread.sleep(PAUSE_FOR_PEER);
+                } catch (InterruptedException x) {
+                    // ignore
+                }
             }
             if (k16 > 128) {
                 System.out.println("WARNING: InfiniteInputStream: " +
@@ -371,82 +342,6 @@ public class ShortResponseBody {
     // Strictly ordered list, in order of possible occurrence.
     static final List<String> MSGS_ORDER =
             List.of("no bytes", "status line", "header");
-
-
-    @Test(dataProvider = "uris")
-    void testSynchronousPOST(String url, String expectedMsg, boolean sameClient)
-        throws Exception
-    {
-        checkSkip();
-        out.print("---\n");
-        HttpClient client = null;
-        for (int i=0; i< ITERATION_COUNT; i++) {
-            if (!sameClient || client == null)
-                client = newHttpClient();
-            HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                    .POST(BodyPublishers.ofInputStream(() -> new InfiniteInputStream()))
-                    .build();
-            try {
-                HttpResponse<String> response = client.send(request, ofString());
-                String body = response.body();
-                out.println(response + ": " + body);
-                fail("UNEXPECTED RESPONSE: " + response);
-            } catch (IOException ioe) {
-                out.println("Caught expected exception:" + ioe);
-                String msg = ioe.getMessage();
-
-                List<String> expectedMessages = new ArrayList<>();
-                expectedMessages.add(expectedMsg);
-                MSGS_ORDER.stream().takeWhile(s -> !s.equals(expectedMsg))
-                                   .forEach(expectedMessages::add);
-
-                assertTrue(expectedMessages.stream().anyMatch(s -> msg.indexOf(s) != -1),
-                           "exception msg:[" + msg + "], not in [" + expectedMessages);
-                // synchronous API must have the send method on the stack
-                assertSendMethodOnStack(ioe);
-                assertNoConnectionExpiredException(ioe);
-            }
-        }
-    }
-
-    @Test(dataProvider = "uris")
-    void testAsynchronousPOST(String url, String expectedMsg, boolean sameClient)
-        throws Exception
-    {
-        checkSkip();
-        out.print("---\n");
-        HttpClient client = null;
-        for (int i=0; i< ITERATION_COUNT; i++) {
-            if (!sameClient || client == null)
-                client = newHttpClient();
-            HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                    .POST(BodyPublishers.ofInputStream(() -> new InfiniteInputStream()))
-                    .build();
-            try {
-                HttpResponse<String> response = client.sendAsync(request, ofString()).get();
-                String body = response.body();
-                out.println(response + ": " + body);
-                fail("UNEXPECTED RESPONSE: " + response);
-            } catch (ExecutionException ee) {
-                if (ee.getCause() instanceof IOException) {
-                    IOException ioe = (IOException) ee.getCause();
-                    out.println("Caught expected exception:" + ioe);
-                    String msg = ioe.getMessage();
-
-                    List<String> expectedMessages = new ArrayList<>();
-                    expectedMessages.add(expectedMsg);
-                    MSGS_ORDER.stream().takeWhile(s -> !s.equals(expectedMsg))
-                            .forEach(expectedMessages::add);
-
-                    assertTrue(expectedMessages.stream().anyMatch(s -> msg.indexOf(s) != -1),
-                               "exception msg:[" + msg + "], not in [" + expectedMessages);
-                    assertNoConnectionExpiredException(ioe);
-                } else {
-                    throw ee;
-                }
-            }
-        }
-    }
 
     // Asserts that the "send" method appears in the stack of the given
     // exception. The synchronous API must contain the send method on the stack.
@@ -739,27 +634,28 @@ public class ShortResponseBody {
 
         closeImmediatelyServer = new PlainCloseImmediatelyServer();
         httpURIClsImed = "http://" + serverAuthority(closeImmediatelyServer)
-                + "/http1/closeImmediately/foo";
+                + "/http1/closeImmediately/req=%reqnb%/foo";
 
         closeImmediatelyHttpsServer = new SSLCloseImmediatelyServer();
         httpsURIClsImed = "https://" + serverAuthority(closeImmediatelyHttpsServer)
-                + "/https1/closeImmediately/foo";
+                + "/https1/closeImmediately/req=%reqnb%/foo";
 
         variableLengthServer = new PlainVariableLengthServer();
         httpURIVarLen = "http://" + serverAuthority(variableLengthServer)
-                + "/http1/variable/bar";
+                + "/http1/variable/req=%reqnb%/bar";
 
         variableLengthHttpsServer = new SSLVariableLengthServer();
         httpsURIVarLen = "https://" + serverAuthority(variableLengthHttpsServer)
-                + "/https1/variable/bar";
+                + "/https1/variable/req=%reqnb%/bar";
 
         fixedLengthServer = new FixedLengthServer();
         httpURIFixLen = "http://" + serverAuthority(fixedLengthServer)
-                + "/http1/fixed/baz";
+                + "/http1/fixed/req=%reqnb%/baz";
     }
 
     @AfterTest
     public void teardown() throws Exception {
+        if (sharedClient != null) sharedClient = null;
         closeImmediatelyServer.close();
         closeImmediatelyHttpsServer.close();
         variableLengthServer.close();

--- a/test/jdk/java/net/httpclient/ShortResponseBodyGet.java
+++ b/test/jdk/java/net/httpclient/ShortResponseBodyGet.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8216498
+ * @summary Tests Exception detail message when too few response bytes are
+ *          received before a socket exception or eof.
+ * @library /lib/testlibrary
+ * @build jdk.testlibrary.SimpleSSLContext ShortResponseBody ShortResponseBodyGet
+ * @run testng/othervm
+ *       -Djdk.httpclient.HttpClient.log=headers,errors,channel
+ *       ShortResponseBodyGet
+ */
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.concurrent.ExecutionException;
+import org.testng.annotations.Test;
+import static java.lang.System.out;
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class ShortResponseBodyGet extends ShortResponseBody {
+
+    @Test(dataProvider = "uris")
+    void testSynchronousGET(String urlp, String expectedMsg, boolean sameClient)
+        throws Exception
+    {
+        checkSkip();
+        out.print("---\n");
+        HttpClient client = null;
+        for (int i=0; i< ITERATION_COUNT; i++) {
+            String url = uniqueURL(urlp);
+            if (client == null)
+                client = newHttpClient(sameClient);
+            HttpRequest request = HttpRequest.newBuilder(URI.create(url)).build();
+            out.println("Request: " + request);
+            try {
+                HttpResponse<String> response = client.send(request, ofString());
+                String body = response.body();
+                out.println(response + ": " + body);
+                fail("UNEXPECTED RESPONSE: " + response);
+            } catch (IOException ioe) {
+                out.println("Caught expected exception:" + ioe);
+                String msg = ioe.getMessage();
+                assertTrue(msg.contains(expectedMsg), "exception msg:[" + msg + "]");
+                // synchronous API must have the send method on the stack
+                assertSendMethodOnStack(ioe);
+                assertNoConnectionExpiredException(ioe);
+            }
+        }
+    }
+
+    @Test(dataProvider = "uris")
+    void testAsynchronousGET(String urlp, String expectedMsg, boolean sameClient)
+        throws Exception
+    {
+        checkSkip();
+        out.print("---\n");
+        HttpClient client = null;
+        for (int i=0; i< ITERATION_COUNT; i++) {
+            String url = uniqueURL(urlp);
+            if (client == null)
+                client = newHttpClient(sameClient);
+            HttpRequest request = HttpRequest.newBuilder(URI.create(url)).build();
+            out.println("Request: " + request);
+            try {
+                HttpResponse<String> response = client.sendAsync(request, ofString()).get();
+                String body = response.body();
+                out.println(response + ": " + body);
+                fail("UNEXPECTED RESPONSE: " + response);
+            } catch (ExecutionException ee) {
+                if (ee.getCause() instanceof IOException) {
+                    IOException ioe = (IOException) ee.getCause();
+                    out.println("Caught expected exception:" + ioe);
+                    String msg = ioe.getMessage();
+                    assertTrue(msg.contains(expectedMsg), "exception msg:[" + msg + "]");
+                    assertNoConnectionExpiredException(ioe);
+                } else {
+                    throw ee;
+                }
+            }
+        }
+    }
+
+}

--- a/test/jdk/java/net/httpclient/ShortResponseBodyPost.java
+++ b/test/jdk/java/net/httpclient/ShortResponseBodyPost.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8216498
+ * @summary Tests Exception detail message when too few response bytes are
+ *          received before a socket exception or eof.
+ * @library /lib/testlibrary
+ * @build jdk.testlibrary.SimpleSSLContext ShortResponseBody ShortResponseBodyPost
+ * @run testng/othervm
+ *       -Djdk.httpclient.HttpClient.log=headers,errors,channel
+ *       -Djdk.internal.httpclient.debug=true
+ *       ShortResponseBodyPost
+ */
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.testng.annotations.Test;
+import static java.lang.System.out;
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+public class ShortResponseBodyPost extends ShortResponseBody {
+
+    // POST tests are racy in what may be received before writing may cause a
+    // broken pipe or reset exception, before all the received data can be read.
+    // Any message up to, and including, the "expected" error message can occur.
+    // Strictly ordered list, in order of possible occurrence.
+    static final List<String> MSGS_ORDER =
+            List.of("no bytes", "status line", "header");
+
+
+    @Test(dataProvider = "uris")
+    void testSynchronousPOST(String urlp, String expectedMsg, boolean sameClient)
+        throws Exception
+    {
+        checkSkip();
+        out.print("---\n");
+        HttpClient client = null;
+        for (int i=0; i< ITERATION_COUNT; i++) {
+            String url = uniqueURL(urlp);
+            if (client == null)
+                client = newHttpClient(sameClient);
+            HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                    .POST(BodyPublishers.ofInputStream(() -> new InfiniteInputStream()))
+                    .build();
+            out.println("Request: " + request);
+            try {
+                HttpResponse<String> response = client.send(request, ofString());
+                String body = response.body();
+                out.println(response + ": " + body);
+                fail("UNEXPECTED RESPONSE: " + response);
+            } catch (IOException ioe) {
+                out.println("Caught expected exception:" + ioe);
+                String msg = ioe.getMessage();
+
+                List<String> expectedMessages = new ArrayList<>();
+                expectedMessages.add(expectedMsg);
+                MSGS_ORDER.stream().takeWhile(s -> !s.equals(expectedMsg))
+                                   .forEach(expectedMessages::add);
+
+                assertTrue(expectedMessages.stream().anyMatch(s -> msg.indexOf(s) != -1),
+                           "exception msg:[" + msg + "], not in [" + expectedMessages);
+                // synchronous API must have the send method on the stack
+                assertSendMethodOnStack(ioe);
+                assertNoConnectionExpiredException(ioe);
+            }
+        }
+    }
+
+    @Test(dataProvider = "uris")
+    void testAsynchronousPOST(String urlp, String expectedMsg, boolean sameClient)
+        throws Exception
+    {
+        checkSkip();
+        out.print("---\n");
+        HttpClient client = null;
+        for (int i=0; i< ITERATION_COUNT; i++) {
+            String url = uniqueURL(urlp);
+            if (client == null)
+                client = newHttpClient(sameClient);
+            HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                    .POST(BodyPublishers.ofInputStream(() -> new InfiniteInputStream()))
+                    .build();
+            out.println("Request: " + request);
+            try {
+                HttpResponse<String> response = client.sendAsync(request, ofString()).get();
+                String body = response.body();
+                out.println(response + ": " + body);
+                fail("UNEXPECTED RESPONSE: " + response);
+            } catch (ExecutionException ee) {
+                if (ee.getCause() instanceof IOException) {
+                    IOException ioe = (IOException) ee.getCause();
+                    out.println("Caught expected exception:" + ioe);
+                    String msg = ioe.getMessage();
+
+                    List<String> expectedMessages = new ArrayList<>();
+                    expectedMessages.add(expectedMsg);
+                    MSGS_ORDER.stream().takeWhile(s -> !s.equals(expectedMsg))
+                            .forEach(expectedMessages::add);
+
+                    assertTrue(expectedMessages.stream().anyMatch(s -> msg.indexOf(s) != -1),
+                               "exception msg:[" + msg + "], not in [" + expectedMessages);
+                    assertNoConnectionExpiredException(ioe);
+                } else {
+                    throw ee;
+                }
+            }
+        }
+    }
+
+}
+

--- a/test/jdk/java/net/httpclient/ShortResponseBodyPostWithRetry.java
+++ b/test/jdk/java/net/httpclient/ShortResponseBodyPostWithRetry.java
@@ -23,12 +23,13 @@
 
 /*
  * @test
- * @summary Run of ShortResponseBody with -Djdk.httpclient.enableAllMethodRetry
+ * @summary Run of ShortResponseBodyPost with -Djdk.httpclient.enableAllMethodRetry
  * @library /lib/testlibrary
  * @build jdk.testlibrary.SimpleSSLContext
- * @build ShortResponseBody
+ * @build ShortResponseBody ShortResponseBodyPost
  * @run testng/othervm
  *       -Djdk.httpclient.HttpClient.log=headers,errors,channel
  *       -Djdk.httpclient.enableAllMethodRetry
- *       ShortResponseBody
+ *       -Djdk.internal.httpclient.debug=true
+ *       ShortResponseBodyPost
  */


### PR DESCRIPTION
I backport this test-only change for parity with 11.0.17-oracle.

I did the following adaptions:
ShortResponseBody.java
* Adapt test run specification to requirements of 11.
  This did not match in this file, but all other files
  needed fixes, too.
* Resolve includes
* Removal of four methods did not apply clean.
  The methods were moved to the new files.
  I dropped the old implementation and am using the 
  new ones in the new files except for assertExpectedMessage()
  which is not in 11.

ShortResponseBodyPostWithRetry.java
* test run specification: different context

Tests are compiling and passing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286293](https://bugs.openjdk.java.net/browse/JDK-8286293): Tests ShortResponseBody and ShortResponseBodyWithRetry should use less resources


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1095/head:pull/1095` \
`$ git checkout pull/1095`

Update a local copy of the PR: \
`$ git checkout pull/1095` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1095`

View PR using the GUI difftool: \
`$ git pr show -t 1095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1095.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1095.diff</a>

</details>
