### PR TITLE
8214275: CondyRepeatFailedResolution asserts "Dynamic constant has no fixed basic type"

### DIFF
--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -1879,7 +1879,7 @@ void GenerateOopMap::do_ldc(int bci) {
   constantTag tag = cp->tag_at(ldc.pool_index()); // idx is index in resolved_references
   BasicType       bt  = ldc.result_type();
 #ifdef ASSERT
-  BasicType   tag_bt = tag.is_dynamic_constant() ? bt : tag.basic_type();
+  BasicType   tag_bt = (tag.is_dynamic_constant() || tag.is_dynamic_constant_in_error()) ? bt : tag.basic_type();
   assert(bt == tag_bt, "same result");
 #endif
   CellTypeState   cts;


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8214275](https://bugs.openjdk.java.net/browse/JDK-8214275): CondyRepeatFailedResolution asserts "Dynamic constant has no fixed basic type"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1096/head:pull/1096` \
`$ git checkout pull/1096`

Update a local copy of the PR: \
`$ git checkout pull/1096` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1096`

View PR using the GUI difftool: \
`$ git pr show -t 1096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1096.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1096.diff</a>

</details>
