### PR TITLE
8133713: [macosx] Accessible JTables always reported as empty

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityUtilities.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityUtilities.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -423,7 +423,7 @@ void initializeRoles()
     [sRoles setObject:NSAccessibilitySplitGroupRole forKey:@"splitpane"];
     [sRoles setObject:NSAccessibilityValueIndicatorRole forKey:@"statusbar"];
     [sRoles setObject:NSAccessibilityGroupRole forKey:@"swingcomponent"];
-    [sRoles setObject:NSAccessibilityTableRole forKey:@"table"];
+    [sRoles setObject:NSAccessibilityGridRole forKey:@"table"];
     [sRoles setObject:NSAccessibilityTextFieldRole forKey:@"text"];
     [sRoles setObject:NSAccessibilityTextAreaRole forKey:@"textarea"]; // supports top/bottom of document notifications: CAccessability.getAccessibleRole()
     [sRoles setObject:NSAccessibilityCheckBoxRole forKey:@"togglebutton"];


### PR DESCRIPTION
Backport of [JDK-8133713](https://bugs.openjdk.java.net/browse/JDK-8133713)
Required adaptation for JNF removal ([JDK-8257852](https://bugs.openjdk.java.net/browse/JDK-8257852)):
Definition and usage of `jm_getTableInfo` in JavaComponentAccessibility.m.
With this change, VoiceOver works for JTableAccessible.java (attached to JBS issue). Failed without this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8133713](https://bugs.openjdk.java.net/browse/JDK-8133713): [macosx] Accessible JTables always reported as empty


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1097/head:pull/1097` \
`$ git checkout pull/1097`

Update a local copy of the PR: \
`$ git checkout pull/1097` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1097`

View PR using the GUI difftool: \
`$ git pr show -t 1097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1097.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1097.diff</a>

</details>
