### PR TITLE
7124293: [macosx] VoiceOver reads percentages rather than the actual values for sliders.

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -496,8 +496,9 @@ static NSObject *sAttributeNamesLOCK = nil;
     }
 
     // if it's a pagetab / radiobutton, it has a value but no min/max value.
+    // if it is a slider, supplying only the value makes it to voice out the value instead of percentages
     BOOL hasAxValue = attributeStatesArray[2];
-    if ([javaRole isEqualToString:@"pagetab"] || [javaRole isEqualToString:@"radiobutton"]) {
+    if ([javaRole isEqualToString:@"pagetab"] || [javaRole isEqualToString:@"radiobutton"] || [javaRole isEqualToString:@"slider"]) {
         [attributeNames addObject:NSAccessibilityValueAttribute];
     } else {
         // if not a pagetab/radio button, and it has a value, it has a min/max/current value.


### PR DESCRIPTION
Clean backport of [JDK-7124293](https://bugs.openjdk.java.net/browse/JDK-7124293)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7124293](https://bugs.openjdk.java.net/browse/JDK-7124293): [macosx] VoiceOver reads percentages rather than the actual values for sliders.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1098/head:pull/1098` \
`$ git checkout pull/1098`

Update a local copy of the PR: \
`$ git checkout pull/1098` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1098`

View PR using the GUI difftool: \
`$ git pr show -t 1098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1098.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1098.diff</a>

</details>
