### PR TITLE
7124301: [macosx] When in a tab group if you arrow between tabs there are no VoiceOver announcements.

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -32,6 +32,7 @@ import java.beans.PropertyChangeListener;
 import javax.accessibility.Accessible;
 import javax.accessibility.AccessibleContext;
 import javax.swing.JProgressBar;
+import javax.swing.JTabbedPane;
 import javax.swing.JSlider;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -42,6 +43,8 @@ import static javax.accessibility.AccessibleContext.ACCESSIBLE_SELECTION_PROPERT
 import static javax.accessibility.AccessibleContext.ACCESSIBLE_STATE_PROPERTY;
 import static javax.accessibility.AccessibleContext.ACCESSIBLE_TABLE_MODEL_CHANGED;
 import static javax.accessibility.AccessibleContext.ACCESSIBLE_TEXT_PROPERTY;
+import static javax.accessibility.AccessibleContext.ACCESSIBLE_NAME_PROPERTY;
+
 import javax.accessibility.AccessibleRole;
 import javax.accessibility.AccessibleState;
 import sun.awt.AWTAccessor;
@@ -67,6 +70,7 @@ class CAccessible extends CFRetainedResource implements Accessible {
     private static native void valueChanged(long ptr);
     private static native void selectedTextChanged(long ptr);
     private static native void selectionChanged(long ptr);
+    private static native void titleChanged(long ptr);
     private static native void menuOpened(long ptr);
     private static native void menuClosed(long ptr);
     private static native void menuItemSelected(long ptr);
@@ -122,9 +126,9 @@ class CAccessible extends CFRetainedResource implements Accessible {
                 Object oldValue = e.getOldValue();
                 if (name.compareTo(ACCESSIBLE_CARET_PROPERTY) == 0) {
                     selectedTextChanged(ptr);
-                } else if (name.compareTo(ACCESSIBLE_TEXT_PROPERTY) == 0 ) {
+                } else if (name.compareTo(ACCESSIBLE_TEXT_PROPERTY) == 0) {
                     valueChanged(ptr);
-                } else if (name.compareTo(ACCESSIBLE_SELECTION_PROPERTY) == 0 ) {
+                } else if (name.compareTo(ACCESSIBLE_SELECTION_PROPERTY) == 0) {
                     selectionChanged(ptr);
                 } else if (name.compareTo(ACCESSIBLE_TABLE_MODEL_CHANGED) == 0) {
                     valueChanged(ptr);
@@ -159,6 +163,11 @@ class CAccessible extends CFRetainedResource implements Accessible {
                                 menuItemSelected(ptr);
                             }
                         }
+                    }
+                } else if (name.compareTo(ACCESSIBLE_NAME_PROPERTY) == 0) {
+                    //for now trigger only for JTabbedPane.
+                    if (e.getSource() instanceof JTabbedPane) {
+                        titleChanged(ptr);
                     }
                 }
             }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.h
@@ -52,6 +52,7 @@
 - (void)postValueChanged;
 - (void)postSelectedTextChanged;
 - (void)postSelectionChanged;
+- (void)postTitleChanged;
 - (BOOL)isEqual:(id)anObject;
 - (BOOL)isAccessibleWithEnv:(JNIEnv *)env forAccessible:(jobject)accessible;
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -245,6 +245,12 @@ static NSObject *sAttributeNamesLOCK = nil;
     NSAccessibilityPostNotification(self, NSAccessibilitySelectedChildrenChangedNotification);
 }
 
+-(void)postTitleChanged
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    NSAccessibilityPostNotification(self, NSAccessibilityTitleChangedNotification);
+}
+
 - (void)postMenuOpened
 {
     AWT_ASSERT_APPKIT_THREAD;
@@ -544,7 +550,8 @@ static NSObject *sAttributeNamesLOCK = nil;
     if (attributeStatesArray[6]) {
         [attributeNames addObject:NSAccessibilityChildrenAttribute];
         if ([javaRole isEqualToString:@"list"]
-                || [javaRole isEqualToString:@"table"]) {
+                || [javaRole isEqualToString:@"table"]
+                || [javaRole isEqualToString:@"pagetablist"]) {
             [attributeNames addObject:NSAccessibilitySelectedChildrenAttribute];
             [attributeNames addObject:NSAccessibilityVisibleChildrenAttribute];
         }
@@ -1530,6 +1537,19 @@ JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postFocusChanged:) on:[JavaComponentAccessibility class] withObject:nil waitUntilDone:NO];
 JNI_COCOA_EXIT(env);
 }
+
+/*
+ * Class:     sun_lwawt_macosx_CAccessible
+ * Method:    titleChanged
+ * Signature: (I)V
+ */
+ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_titleChanged
+ (JNIEnv *env, jclass jklass, jlong element)
+ {
+JNI_COCOA_ENTER(env);
+    [ThreadUtilities performOnMainThread:@selector(postTitleChanged) on:(JavaComponentAccessibility*)jlong_to_ptr(element) withObject:nil waitUntilDone:NO];
+JNI_COCOA_EXIT(env);
+ }
 
 /*
  * Class:     sun_lwawt_macosx_CAccessible


### PR DESCRIPTION
Backport of [JDK-7124301](https://bugs.openjdk.java.net/browse/JDK-7124301)
Applies cleanly, but requires a trivial replacement:
JNF_COCOA_ENTER => JNI_COCOA_ENTER
JNF_COCOA_EXIT => JNI_COCOA_EXIT

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-7124301](https://bugs.openjdk.java.net/browse/JDK-7124301): [macosx] When in a tab group if you arrow between tabs there are no VoiceOver announcements.


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**) ⚠️ Review applies to [8a7d2b58](https://git.openjdk.java.net/jdk11u-dev/pull/1099/files/8a7d2b581a0f639e2523d9cf8a64ae4073a2831a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1099/head:pull/1099` \
`$ git checkout pull/1099`

Update a local copy of the PR: \
`$ git checkout pull/1099` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1099`

View PR using the GUI difftool: \
`$ git pr show -t 1099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1099.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1099.diff</a>

</details>
