### PR TITLE
Backport 892d998587a0a7a7ed17586f96ae7dc5b236adb2

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -439,8 +439,8 @@ void CompilerConfig::ergo_initialize() {
   if (!IncrementalInline) {
     AlwaysIncrementalInline = false;
   }
-  if (PrintIdealGraphLevel > 0) {
-    FLAG_SET_ERGO(bool, PrintIdealGraph, true);
+  if (FLAG_IS_CMDLINE(PrintIdealGraph) && !PrintIdealGraph) {
+    FLAG_SET_ERGO(intx, PrintIdealGraphLevel, -1);
   }
 #endif
   if (!UseTypeSpeculation && FLAG_IS_DEFAULT(TypeProfileLevel)) {

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -374,10 +374,12 @@
                                                                             \
   notproduct(intx, PrintIdealGraphLevel, 0,                                 \
           "Level of detail of the ideal graph printout. "                   \
-          "System-wide value, 0=nothing is printed, 4=all details printed. "\
+          "System-wide value, -1=printing is disabled, "                    \
+          "0=print nothing except IGVPrintLevel directives, "               \
+          "4=all details printed. "                                         \
           "Level of detail of printouts can be set on a per-method level "  \
           "as well by using CompileCommand=option.")                        \
-          range(0, 4)                                                       \
+          range(-1, 4)                                                      \
                                                                             \
   notproduct(intx, PrintIdealGraphPort, 4444,                               \
           "Ideal graph printer to network port")                            \

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -683,8 +683,8 @@ Compile::Compile( ciEnv* ci_env, C2Compiler* compiler, ciMethod* target, int osr
 #ifndef PRODUCT
                   _trace_opto_output(directive->TraceOptoOutputOption),
                   _in_dump_cnt(0),
-                  _printer(IdealGraphPrinter::printer()),
 #endif
+                  NOT_PRODUCT(_printer(NULL) COMMA)
                   _congraph(NULL),
                   _comp_arena(mtCompiler),
                   _node_arena(mtCompiler),
@@ -706,11 +706,6 @@ Compile::Compile( ciEnv* ci_env, C2Compiler* compiler, ciMethod* target, int osr
                   _max_node_limit(MaxNodeLimit),
                   _has_reserved_stack_access(target->has_reserved_stack_access()) {
   C = this;
-#ifndef PRODUCT
-  if (_printer != NULL) {
-    _printer->set_compile(this);
-  }
-#endif
   CompileWrapper cw(this);
 
   if (CITimeVerbose) {
@@ -869,7 +864,7 @@ Compile::Compile( ciEnv* ci_env, C2Compiler* compiler, ciMethod* target, int osr
   // Drain the list.
   Finish_Warm();
 #ifndef PRODUCT
-  if (_printer && _printer->should_print(1)) {
+  if (should_print(1)) {
     _printer->print_inlining();
   }
 #endif
@@ -1002,8 +997,8 @@ Compile::Compile( ciEnv* ci_env,
 #ifndef PRODUCT
     _trace_opto_output(directive->TraceOptoOutputOption),
     _in_dump_cnt(0),
-    _printer(NULL),
 #endif
+    NOT_PRODUCT(_printer(NULL) COMMA)
     _comp_arena(mtCompiler),
     _node_arena(mtCompiler),
     _old_arena(mtCompiler),

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -745,13 +745,31 @@ class Compile : public Phase {
 
   Ticks _latest_stage_start_counter;
 
-  void begin_method() {
+  void begin_method(int level = 1) {
 #ifndef PRODUCT
-    if (_printer && _printer->should_print(1)) {
+    if (_method != NULL && should_print(level)) {
       _printer->begin_method();
     }
 #endif
     C->_latest_stage_start_counter.stamp();
+  }
+
+  bool should_print(int level = 1) {
+#ifndef PRODUCT
+    if (PrintIdealGraphLevel < 0) { // disabled by the user
+      return false;
+    }
+
+    bool need = directive()->IGVPrintLevelOption >= level;
+    if (need && !_printer) {
+      _printer = IdealGraphPrinter::printer();
+      assert(_printer != NULL, "_printer is NULL when we need it!");
+      _printer->set_compile(this);
+    }
+    return need;
+#else
+    return false;
+#endif
   }
 
   void print_method(CompilerPhaseType cpt, int level = 1) {
@@ -766,7 +784,7 @@ class Compile : public Phase {
 
 
 #ifndef PRODUCT
-    if (_printer && _printer->should_print(level)) {
+    if (_printer && should_print(level)) {
       _printer->print_method(CompilerPhaseTypeHelper::to_string(cpt), level);
     }
 #endif
@@ -783,7 +801,7 @@ class Compile : public Phase {
       event.commit();
     }
 #ifndef PRODUCT
-    if (_printer && _printer->should_print(level)) {
+    if (_printer && should_print(level)) {
       _printer->end_method();
     }
 #endif

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,10 +75,6 @@ const char *IdealGraphPrinter::ASSEMBLY_ELEMENT = "assembly";
 int IdealGraphPrinter::_file_count = 0;
 
 IdealGraphPrinter *IdealGraphPrinter::printer() {
-  if (!PrintIdealGraph) {
-    return NULL;
-  }
-
   JavaThread *thread = JavaThread::current();
   if (!thread->is_Compiler_thread()) return NULL;
 
@@ -670,7 +666,7 @@ void IdealGraphPrinter::print_method(const char *name, int level, bool clear_nod
 // Print current ideal graph
 void IdealGraphPrinter::print(const char *name, Node *node, int level, bool clear_nodes) {
 
-  if (!_current_method || !_should_send_method || !should_print(level)) return;
+  if (!_current_method || !_should_send_method || !C->should_print(level)) return;
 
   // Warning, unsafe cast?
   _chaitin = (PhaseChaitin *)C->regalloc();
@@ -718,11 +714,6 @@ void IdealGraphPrinter::print(const char *name, Node *node, int level, bool clea
   }
   tail(GRAPH_ELEMENT);
   _xml->flush();
-}
-
-// Should method be printed?
-bool IdealGraphPrinter::should_print(int level) {
-  return C->directive()->IGVPrintLevelOption >= level;
 }
 
 extern const char *NodeClassNames[];

--- a/src/hotspot/share/opto/idealGraphPrinter.hpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,7 +133,6 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   void print_method(const char *name, int level=1, bool clear_nodes = false);
   void print(const char *name, Node *root, int level=1, bool clear_nodes = false);
   void print_xml(const char *name);
-  bool should_print(int level);
   void set_compile(Compile* compile) {C = compile; }
 };
 

--- a/src/hotspot/share/opto/parse2.cpp
+++ b/src/hotspot/share/opto/parse2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2855,8 +2855,8 @@ void Parse::do_one_bytecode() {
   }
 
 #ifndef PRODUCT
-  IdealGraphPrinter *printer = C->printer();
-  if (printer && printer->should_print(1)) {
+  if (C->should_print(1)) {
+    IdealGraphPrinter* printer = C->printer();
     char buffer[256];
     sprintf(buffer, "Bytecode %d: %s", bci(), Bytecodes::name(bc()));
     bool old = printer->traverse_outs();


### PR DESCRIPTION
Backport of [JDK-8139046](https://bugs.openjdk.java.net/browse/JDK-8139046)
Doesn't apply cleanly:

- compile.hpp: Had to take `should_print` from https://github.com/openjdk/jdk/commit/75e9d0a2901c149fc0acf3ed042ddedc689d8d23
- compilerDefinitions.cpp, compile.cpp, idealGraphPrinter.cpp, idealGraphPrinter.hpp: Had to do resolve hunks manually.
