### PR TITLE
8231454: File lock in Windows on a loaded jar due to a leak in Introspector::getBeanInfo

### DIFF
--- a/src/java.desktop/share/classes/com/sun/beans/introspect/ClassInfo.java
+++ b/src/java.desktop/share/classes/com/sun/beans/introspect/ClassInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.sun.beans.introspect;
 
-import com.sun.beans.util.Cache;
+package com.sun.beans.introspect;
 
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+
+import com.sun.beans.util.Cache;
 
 import static sun.reflect.misc.ReflectUtil.checkPackageAccess;
 
@@ -52,6 +53,14 @@ public final class ClassInfo {
         } catch (SecurityException exception) {
             return DEFAULT;
         }
+    }
+
+    public static void clear() {
+        CACHE.clear();
+    }
+
+    public static void remove(Class<?> clz) {
+        CACHE.remove(clz);
     }
 
     private final Object mutex = new Object();

--- a/src/java.desktop/share/classes/java/beans/Introspector.java
+++ b/src/java.desktop/share/classes/java/beans/Introspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -364,6 +364,7 @@ public class Introspector {
      */
     public static void flushCaches() {
         ThreadGroupContext.getContext().clearBeanInfoCache();
+        ClassInfo.clear();
     }
 
     /**
@@ -387,6 +388,7 @@ public class Introspector {
             throw new NullPointerException();
         }
         ThreadGroupContext.getContext().removeBeanInfo(clz);
+        ClassInfo.remove(clz);
     }
 
     //======================================================================

--- a/test/jdk/java/beans/Introspector/FlushClassInfoCache.java
+++ b/test/jdk/java/beans/Introspector/FlushClassInfoCache.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * @test
+ * @bug 8231454
+ * @summary Tests cache cleanup by the Introspector.flushXXX()
+ */
+public final class FlushClassInfoCache {
+
+    public static void main(String[] args) throws Exception {
+        verify(getLoader("testClass"));
+        verify(getLoader("testAll"));
+        Reference<ClassLoader> loader = getLoader("test");
+        // Clear the cache in com.sun.beans.introspect.ClassInfo::CACHE
+        Introspector.flushCaches();
+        verify(loader);
+    }
+
+    private static void verify(Reference<?> loader) throws Exception {
+        int attempt = 0;
+        while (loader.get() != null) {
+            if (++attempt > 10) {
+                throw new RuntimeException("Too many attempts: " + attempt);
+            }
+            // Cannot generate OOM here, it will clear the CACHE as well
+            System.gc();
+            Thread.sleep(1000);
+            System.out.println("Not freed :(");
+        }
+    }
+
+    public static void test() {
+        try {
+            Introspector.getBeanInfo(FlushClassInfoCache.class);
+        } catch (IntrospectionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void testClass() {
+        try {
+            Introspector.getBeanInfo(FlushClassInfoCache.class);
+            // Clear the cache in com.sun.beans.introspect.ClassInfo::CACHE
+            Introspector.flushFromCaches(FlushClassInfoCache.class);
+        } catch (IntrospectionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void testAll() {
+        try {
+            Introspector.getBeanInfo(FlushClassInfoCache.class);
+            // Clear the cache in com.sun.beans.introspect.ClassInfo::CACHE
+            Introspector.flushCaches();
+        } catch (IntrospectionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Reference<ClassLoader> getLoader(String m) throws Exception {
+        URL url = FlushClassInfoCache.class.getProtectionDomain()
+                                     .getCodeSource().getLocation();
+        URLClassLoader loader = new URLClassLoader(new URL[]{url}, null);
+        Class<?> cls = Class.forName("FlushClassInfoCache", true, loader);
+        cls.getDeclaredMethod(m).invoke(null);
+        loader.close();
+        return new WeakReference<>(loader);
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8231454](https://bugs.openjdk.java.net/browse/JDK-8231454) (openjdk/jdk@2ee2b4ae19d).

There was a trivial merge conflict in `Introspector.java`.

The commit being backported was authored by @mrserb on October 20, 2020, and was reviewed by @azuev-java.

See [JENKINS-63766](https://issues.jenkins.io/browse/JENKINS-63766) for the motivation behind this backport.

I tested this PR locally by running `make run-test TEST=test/jdk/java/beans/Introspector/FlushClassInfoCache.java`. In addition, I verified that JENKINS-63766 could no longer be reproduced with this backport applied.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8231454](https://bugs.openjdk.java.net/browse/JDK-8231454): File lock in Windows on a loaded jar due to a leak in Introspector::getBeanInfo


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [21b74d28](https://git.openjdk.java.net/jdk11u-dev/pull/1103/files/21b74d28d18897ec5a30fae1b665f1d147b377dc)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1103/head:pull/1103` \
`$ git checkout pull/1103`

Update a local copy of the PR: \
`$ git checkout pull/1103` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1103`

View PR using the GUI difftool: \
`$ git pr show -t 1103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1103.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1103.diff</a>

</details>
