### PR TITLE
Backport 921b46738e0c3aaa2bf8c62e0accb0a5056190d3

### DIFF
--- a/src/java.desktop/share/classes/java/beans/Introspector.java
+++ b/src/java.desktop/share/classes/java/beans/Introspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,33 +22,29 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package java.beans;
 
-import com.sun.beans.TypeResolver;
-import com.sun.beans.WeakCache;
-import com.sun.beans.finder.ClassFinder;
-import com.sun.beans.introspect.ClassInfo;
-import com.sun.beans.introspect.EventSetInfo;
-import com.sun.beans.introspect.PropertyInfo;
-
 import java.awt.Component;
-
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-
-import java.util.Map;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.EventObject;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.EventObject;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 
+import com.sun.beans.TypeResolver;
+import com.sun.beans.finder.ClassFinder;
+import com.sun.beans.introspect.ClassInfo;
+import com.sun.beans.introspect.EventSetInfo;
+import com.sun.beans.introspect.PropertyInfo;
 import jdk.internal.misc.JavaBeansAccess;
 import jdk.internal.misc.SharedSecrets;
 import sun.reflect.misc.ReflectUtil;
@@ -114,9 +110,6 @@ public class Introspector {
      * @since 1.2
      */
     public static final int IGNORE_ALL_BEANINFO        = 3;
-
-    // Static Caches to speed up introspection.
-    private static final WeakCache<Class<?>, Method[]> declaredMethodCache = new WeakCache<>();
 
     private Class<?> beanClass;
     private BeanInfo explicitBeanInfo;
@@ -197,15 +190,10 @@ public class Introspector {
             return (new Introspector(beanClass, null, USE_ALL_BEANINFO)).getBeanInfo();
         }
         ThreadGroupContext context = ThreadGroupContext.getContext();
-        BeanInfo beanInfo;
-        synchronized (declaredMethodCache) {
-            beanInfo = context.getBeanInfo(beanClass);
-        }
+        BeanInfo beanInfo = context.getBeanInfo(beanClass);
         if (beanInfo == null) {
             beanInfo = new Introspector(beanClass, null, USE_ALL_BEANINFO).getBeanInfo();
-            synchronized (declaredMethodCache) {
-                context.putBeanInfo(beanClass, beanInfo);
-            }
+            context.putBeanInfo(beanClass, beanInfo);
         }
         return beanInfo;
     }
@@ -374,12 +362,8 @@ public class Introspector {
      *
      * @since 1.2
      */
-
     public static void flushCaches() {
-        synchronized (declaredMethodCache) {
-            ThreadGroupContext.getContext().clearBeanInfoCache();
-            declaredMethodCache.clear();
-        }
+        ThreadGroupContext.getContext().clearBeanInfoCache();
     }
 
     /**
@@ -402,10 +386,7 @@ public class Introspector {
         if (clz == null) {
             throw new NullPointerException();
         }
-        synchronized (declaredMethodCache) {
-            ThreadGroupContext.getContext().removeBeanInfo(clz);
-            declaredMethodCache.put(clz, null);
-        }
+        ThreadGroupContext.getContext().removeBeanInfo(clz);
     }
 
     //======================================================================

--- a/src/java.desktop/share/classes/java/beans/ThreadGroupContext.java
+++ b/src/java.desktop/share/classes/java/beans/ThreadGroupContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,26 +88,26 @@ final class ThreadGroupContext {
     }
 
 
-    BeanInfo getBeanInfo(Class<?> type) {
+    synchronized BeanInfo getBeanInfo(Class<?> type) {
         return (this.beanInfoCache != null)
                 ? this.beanInfoCache.get(type)
                 : null;
     }
 
-    BeanInfo putBeanInfo(Class<?> type, BeanInfo info) {
+    synchronized BeanInfo putBeanInfo(Class<?> type, BeanInfo info) {
         if (this.beanInfoCache == null) {
             this.beanInfoCache = new WeakHashMap<>();
         }
         return this.beanInfoCache.put(type, info);
     }
 
-    void removeBeanInfo(Class<?> type) {
+    synchronized void removeBeanInfo(Class<?> type) {
         if (this.beanInfoCache != null) {
             this.beanInfoCache.remove(type);
         }
     }
 
-    void clearBeanInfoCache() {
+    synchronized void clearBeanInfoCache() {
         if (this.beanInfoCache != null) {
             this.beanInfoCache.clear();
         }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of JDK-8222799 (openjdk/jdk@921b46738e0).

The only merge conflicts in `Introspector.java` were copyrights and imports, which were trivially fixed.

The commit being backported was authored by @mrserb on October 20, 2020, and was reviewed by `prr`.

See https://github.com/openjdk/jdk11u-dev/pull/1103#pullrequestreview-983336877 for the motivation for this backport; namely, it would be cleaner to backport this first in order to then be able to backport JDK-8231454 without conflicts.

Thanks!