### PR TITLE
8287202: GHA: Add macOS aarch64 to the list of default platforms for workflow_dispatch event

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -10,7 +10,7 @@ on:
       platforms:
         description: "Platform(s) to execute on"
         required: true
-        default: "Linux additional (hotspot only), Linux x64, Linux x86, Windows x64, macOS x64"
+        default: "Linux additional (hotspot only), Linux x64, Linux x86, Windows x64, macOS x64, macOS aarch64"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This is a backport of https://bugs.openjdk.java.net/browse/JDK-8287202 to 11u-dev.
I had to resolve manually since the Windows arm64 port is not in 11u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8287202](https://bugs.openjdk.java.net/browse/JDK-8287202): GHA: Add macOS aarch64 to the list of default platforms for workflow_dispatch event


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Vladimir Kempik](https://openjdk.java.net/census#vkempik) (@VladimirKempik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1107/head:pull/1107` \
`$ git checkout pull/1107`

Update a local copy of the PR: \
`$ git checkout pull/1107` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1107`

View PR using the GUI difftool: \
`$ git pr show -t 1107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1107.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1107.diff</a>

</details>
