### PR TITLE
8181571: printing to CUPS fails on mac sandbox app

### DIFF
--- a/src/java.desktop/unix/classes/sun/print/CUPSPrinter.java
+++ b/src/java.desktop/unix/classes/sun/print/CUPSPrinter.java
@@ -53,6 +53,7 @@ public class CUPSPrinter  {
     private static native String getCupsServer();
     private static native int getCupsPort();
     private static native String getCupsDefaultPrinter();
+    private static native String[] getCupsDefaultPrinters();
     private static native boolean canConnect(String server, int port);
     private static native boolean initIDs();
     // These functions need to be synchronized as
@@ -77,6 +78,7 @@ public class CUPSPrinter  {
 
     private static boolean libFound;
     private static String cupsServer = null;
+    private static String domainSocketPathname = null;
     private static int cupsPort = 0;
 
     static {
@@ -91,6 +93,13 @@ public class CUPSPrinter  {
         libFound = initIDs();
         if (libFound) {
            cupsServer = getCupsServer();
+           // Is this a local domain socket pathname?
+           if (cupsServer != null && cupsServer.startsWith("/")) {
+               if (isSandboxedApp()) {
+                   domainSocketPathname = cupsServer;
+               }
+               cupsServer = "localhost";
+           }
            cupsPort = getCupsPort();
         }
     }
@@ -375,6 +384,20 @@ public class CUPSPrinter  {
      * Get list of all CUPS printers using IPP.
      */
     static String[] getAllPrinters() {
+
+        if (getDomainSocketPathname() != null) {
+            String[] printerNames = getCupsDefaultPrinters();
+            if (printerNames != null && printerNames.length > 0) {
+                String[] printerURIs = new String[printerNames.length];
+                for (int i=0; i< printerNames.length; i++) {
+                    printerURIs[i] = String.format("ipp://%s:%d/printers/%s",
+                            getServer(), getPort(), printerNames[i]);
+                }
+                return printerURIs;
+            }
+            return null;
+        }
+
         try {
             URL url = new URL("http", getServer(), getPort(), "");
 
@@ -458,14 +481,38 @@ public class CUPSPrinter  {
     }
 
     /**
+     * Returns CUPS domain socket pathname.
+     */
+    private static String getDomainSocketPathname() {
+        return domainSocketPathname;
+    }
+
+    @SuppressWarnings("removal")
+    private static boolean isSandboxedApp() {
+        if (PrintServiceLookupProvider.isMac()) {
+            return java.security.AccessController
+                    .doPrivileged((java.security.PrivilegedAction<Boolean>) () ->
+                            System.getenv("APP_SANDBOX_CONTAINER_ID") != null);
+        }
+        return false;
+    }
+
+
+    /**
      * Detects if CUPS is running.
      */
     public static boolean isCupsRunning() {
         IPPPrintService.debug_println(debugPrefix+"libFound "+libFound);
         if (libFound) {
-            IPPPrintService.debug_println(debugPrefix+"CUPS server "+getServer()+
-                                          " port "+getPort());
-            return canConnect(getServer(), getPort());
+            String server = getDomainSocketPathname() != null
+                    ? getDomainSocketPathname()
+                    : getServer();
+            IPPPrintService.debug_println(debugPrefix+"CUPS server "+server+
+                                          " port "+getPort()+
+                                          (getDomainSocketPathname() != null
+                                                  ? " use domain socket pathname"
+                                                  : ""));
+            return canConnect(server, getPort());
         } else {
             return false;
         }

--- a/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
+++ b/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
@@ -181,12 +181,7 @@ Java_sun_print_CUPSPrinter_getCupsServer(JNIEnv *env,
     jstring cServer = NULL;
     const char* server = j2d_cupsServer();
     if (server != NULL) {
-        // Is this a local domain socket?
-        if (strncmp(server, "/", 1) == 0) {
-            cServer = JNU_NewStringPlatform(env, "localhost");
-        } else {
-            cServer = JNU_NewStringPlatform(env, server);
-        }
+        cServer = JNU_NewStringPlatform(env, server);
     }
     return cServer;
 }
@@ -226,6 +221,57 @@ Java_sun_print_CUPSPrinter_getCupsDefaultPrinter(JNIEnv *env,
     }
     j2d_cupsFreeDests(num_dests, dests);
     return cDefPrinter;
+}
+
+/*
+ * Returns list of default local printers
+ */
+JNIEXPORT jobjectArray JNICALL
+Java_sun_print_CUPSPrinter_getCupsDefaultPrinters(JNIEnv *env,
+                                                        jobject printObj)
+{
+    cups_dest_t *dests;
+    int i, j, num_dests;
+    jstring utf_str;
+    jclass cls;
+    jobjectArray nameArray = NULL;
+
+    cls = (*env)->FindClass(env, "java/lang/String");
+    CHECK_NULL_RETURN(cls, NULL);
+
+    num_dests = j2d_cupsGetDests(&dests);
+
+    if (dests == NULL) {
+        return NULL;
+    }
+
+    nameArray = (*env)->NewObjectArray(env, num_dests, cls, NULL);
+    if (nameArray == NULL) {
+        j2d_cupsFreeDests(num_dests, dests);
+        DPRINTF("CUPSfuncs::bad alloc new array\n", "")
+        return NULL;
+    }
+
+    for (i = 0; i < num_dests; i++) {
+            utf_str = JNU_NewStringPlatform(env, dests[i].name);
+            if (utf_str == NULL) {
+                for (j = i - 1; j >= 0; j--) {
+                    utf_str = (*env)->GetObjectArrayElement(env, nameArray, j);
+                    (*env)->SetObjectArrayElement(env, nameArray, j, NULL);
+                    (*env)->DeleteLocalRef(env, utf_str);
+                    utf_str = NULL;
+                }
+                j2d_cupsFreeDests(num_dests, dests);
+                (*env)->DeleteLocalRef(env, nameArray);
+                DPRINTF("CUPSfuncs::bad alloc new string ->name\n", "")
+                return NULL;
+            }
+            (*env)->SetObjectArrayElement(env, nameArray, i, utf_str);
+            (*env)->DeleteLocalRef(env, utf_str);
+    }
+
+    j2d_cupsFreeDests(num_dests, dests);
+    return nameArray;
 }
 
 /*


### PR DESCRIPTION
This is a clean backport of [JDK-8181571](https://bugs.openjdk.java.net/browse/JDK-8181571) printing to CUPS fails on mac sandbox app.

I manually checked that a signed java application with the fix prints a test page when running within the macOS sandbox.

The tests tier1, tier2, tier3 automated tests have been run on Mac M1.
There are two tier2 failed tests which fail without the fix on my system as well:
```
java/nio/file/Files/probeContentType/Basic.java
sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8181571](https://bugs.openjdk.java.net/browse/JDK-8181571): printing to CUPS fails on mac sandbox app


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1108/head:pull/1108` \
`$ git checkout pull/1108`

Update a local copy of the PR: \
`$ git checkout pull/1108` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1108`

View PR using the GUI difftool: \
`$ git pr show -t 1108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1108.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1108.diff</a>

</details>
