### PR TITLE
8285397: JNI exception pending in CUPSfuncs.c:250

### DIFF
--- a/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
+++ b/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
@@ -255,6 +255,7 @@ Java_sun_print_CUPSPrinter_getCupsDefaultPrinters(JNIEnv *env,
     for (i = 0; i < num_dests; i++) {
             utf_str = JNU_NewStringPlatform(env, dests[i].name);
             if (utf_str == NULL) {
+                (*env)->ExceptionClear(env);
                 for (j = i - 1; j >= 0; j--) {
                     utf_str = (*env)->GetObjectArrayElement(env, nameArray, j);
                     (*env)->SetObjectArrayElement(env, nameArray, j, NULL);
@@ -354,8 +355,9 @@ Java_sun_print_CUPSPrinter_getMedia(JNIEnv *env,
             unlink(filename);
             j2d_ppdClose(ppd);
             DPRINTF("CUPSfuncs::bad alloc new array\n", "")
-            (*env)->ExceptionClear(env);
-            JNU_ThrowOutOfMemoryError(env, "OutOfMemoryError");
+            if (!(*env)->ExceptionCheck(env)) {
+                JNU_ThrowOutOfMemoryError(env, "OutOfMemoryError");
+            }
             return NULL;
         }
 
@@ -366,7 +368,9 @@ Java_sun_print_CUPSPrinter_getMedia(JNIEnv *env,
                 unlink(filename);
                 j2d_ppdClose(ppd);
                 DPRINTF("CUPSfuncs::bad alloc new string ->text\n", "")
-                JNU_ThrowOutOfMemoryError(env, "OutOfMemoryError");
+                if (!(*env)->ExceptionCheck(env)) {
+                    JNU_ThrowOutOfMemoryError(env, "OutOfMemoryError");
+                }
                 return NULL;
             }
             (*env)->SetObjectArrayElement(env, nameArray, i*2, utf_str);
@@ -376,7 +380,9 @@ Java_sun_print_CUPSPrinter_getMedia(JNIEnv *env,
                 unlink(filename);
                 j2d_ppdClose(ppd);
                 DPRINTF("CUPSfuncs::bad alloc new string ->choice\n", "")
-                JNU_ThrowOutOfMemoryError(env, "OutOfMemoryError");
+                if (!(*env)->ExceptionCheck(env)) {
+                    JNU_ThrowOutOfMemoryError(env, "OutOfMemoryError");
+                }
                 return NULL;
             }
             (*env)->SetObjectArrayElement(env, nameArray, i*2+1, utf_str);
@@ -390,7 +396,9 @@ Java_sun_print_CUPSPrinter_getMedia(JNIEnv *env,
                 unlink(filename);
                 j2d_ppdClose(ppd);
                 DPRINTF("CUPSfuncs::bad alloc new string text\n", "")
-                JNU_ThrowOutOfMemoryError(env, "OutOfMemoryError");
+                if (!(*env)->ExceptionCheck(env)) {
+                    JNU_ThrowOutOfMemoryError(env, "OutOfMemoryError");
+                }
                 return NULL;
             }
             (*env)->SetObjectArrayElement(env, nameArray,
@@ -401,7 +409,9 @@ Java_sun_print_CUPSPrinter_getMedia(JNIEnv *env,
                 unlink(filename);
                 j2d_ppdClose(ppd);
                 DPRINTF("CUPSfuncs::bad alloc new string choice\n", "")
-                JNU_ThrowOutOfMemoryError(env, "OutOfMemoryError");
+                if (!(*env)->ExceptionCheck(env)) {
+                    JNU_ThrowOutOfMemoryError(env, "OutOfMemoryError");
+                }
                 return NULL;
             }
             (*env)->SetObjectArrayElement(env, nameArray,


### PR DESCRIPTION
This is a pull request which depends on #1108 and fixes some pending JNI exceptions in native code for JDK-8181571 fix.

Manual test from the JDK-8181571 works with both fixes JDK-8181571 and JDK-8285397 when running within the macOS sandbox.

The tests tier1, tier2, tier3 automated tests have been run on Mac M1.
There are two tier2 failed tests which fail without the fix on my system as well:
```
java/nio/file/Files/probeContentType/Basic.java
sun/security/ssl/X509TrustManagerImpl/Symantec/Distrust.java
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285397](https://bugs.openjdk.java.net/browse/JDK-8285397): JNI exception pending in CUPSfuncs.c:250


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1109/head:pull/1109` \
`$ git checkout pull/1109`

Update a local copy of the PR: \
`$ git checkout pull/1109` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1109`

View PR using the GUI difftool: \
`$ git pr show -t 1109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1109.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1109.diff</a>

</details>
