### PR TITLE
8285720: test/jdk/java/nio/file/Files/probeContentType/Basic.java fails to compile after backport of 8273655

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -32,6 +32,7 @@
 import java.io.*;
 import java.nio.file.*;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -193,5 +194,51 @@ public class Basic {
         }
     }
 
-    record ExType(String extension, List<String> expectedTypes) { }
+    private static class ExType {
+
+        private final String extension;
+        private final List<String> expectedTypes;
+
+        public ExType(String extension, List<String> expectedTypes) {
+            this.extension = extension;
+            this.expectedTypes = expectedTypes;
+        }
+
+        public String extension() {
+            return extension;
+        }
+
+        public List<String> expectedTypes() {
+            return expectedTypes;
+        }
+
+        public boolean equals(Object o) {
+            if (o == null) {
+                return false;
+            }
+            if (o == o) {
+                return true;
+            }
+            if (o instanceof ExType) {
+                ExType t = (ExType) o;
+                return (extension == null ?
+                        t.extension() == null :
+                        extension.equals(t.extension()))
+                    && (expectedTypes == null ?
+                        t.expectedTypes() == null :
+                        expectedTypes.equals(t.expectedTypes));
+            }
+            return false;
+        }
+
+        public int hashCode() {
+            return Objects.hash(extension, expectedTypes);
+        }
+
+        public String toString() {
+            return String.format("%s[extension=%s, expectedTypes=%s]",
+                                 getClass().getName(), extension,
+                                 expectedTypes);
+        }
+    }
 }


### PR DESCRIPTION
This fixes the use of records only introduced in JDK 14: https://openjdk.java.net/jeps/359

There are some follow-up fixes for other platforms I'll look into backporting, but the test passes on RHEL 8 with this fix:
```
----------System.out:(33/1376)----------
probe /tmp/foo14488337544781069376.html...
probe /tmp/red3108884171690817066.grape...
probe /tmp/foo6837869089951986269.adoc...
probe /tmp/foo8389174131422317612.bz2...
probe /tmp/foo4988620374111104012.css...
probe /tmp/foo4818065075895620664.csv...
probe /tmp/foo958402751345496963.doc...
probe /tmp/foo16268833507893217383.docx...
probe /tmp/foo13767116725451453342.gz...
probe /tmp/foo2190727723809760358.jar...
probe /tmp/foo2326946718652087402.jpg...
probe /tmp/foo17121899854123140210.js...
probe /tmp/foo1191314404474601575.json...
probe /tmp/foo13006646258648131839.markdown...
probe /tmp/foo241898831150235828.md...
probe /tmp/foo1517835880936399591.mp3...
probe /tmp/foo2549235566859403869.mp4...
probe /tmp/foo12242144981994628768.odp...
probe /tmp/foo16152098178679385661.ods...
probe /tmp/foo18171252621348254871.odt...
probe /tmp/foo10191298994929497654.pdf...
probe /tmp/foo15979417510550432068.php...
probe /tmp/foo16720292814853298418.png...
probe /tmp/foo3639418216222098107.ppt...
probe /tmp/foo13237230432521217475.pptx...
probe /tmp/foo5799266942936446338.py...
probe /tmp/foo17790074177388230321.rar...
probe /tmp/foo13376340736774787502.rtf...
probe /tmp/foo4694357397367454445.webm...
probe /tmp/foo7736758289786048051.webp...
probe /tmp/foo9809786483236460168.xls...
probe /tmp/foo6169776555551953686.xlsx...
probe /tmp/foo12407933371877207699.7z...
----------System.err:(1/15)----------
STATUS:Passed.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285720](https://bugs.openjdk.java.net/browse/JDK-8285720): test/jdk/java/nio/file/Files/probeContentType/Basic.java fails to compile after backport of 8273655


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1111/head:pull/1111` \
`$ git checkout pull/1111`

Update a local copy of the PR: \
`$ git checkout pull/1111` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1111`

View PR using the GUI difftool: \
`$ git pr show -t 1111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1111.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1111.diff</a>

</details>
