### PR TITLE
8287362: FieldAccessWatch testcase failed on AIX platform

### DIFF
--- a/test/hotspot/jtreg/compiler/jsr292/cr8026328/libTest8026328.c
+++ b/test/hotspot/jtreg/compiler/jsr292/cr8026328/libTest8026328.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@ Agent_OnLoad(JavaVM* vm,
              void* reserved) {
 
     jvmtiCapabilities capa;
-    jvmtiEventCallbacks cbs = {0};
+    jvmtiEventCallbacks cbs;
 
     (*vm)->GetEnv(vm, (void**)&jvmti, JVMTI_VERSION_1_0);
 
@@ -110,6 +110,7 @@ Agent_OnLoad(JavaVM* vm,
     capa.can_generate_single_step_events = 1;
     (*jvmti)->AddCapabilities(jvmti, &capa);
 
+    memset(&cbs, 0, sizeof(cbs));
     cbs.ClassPrepare = classprepare;
     cbs.Breakpoint = breakpoint;
     (*jvmti)->SetEventCallbacks(jvmti, &cbs, sizeof(cbs));

--- a/test/hotspot/jtreg/serviceability/jvmti/FieldAccessWatch/libFieldAccessWatch.c
+++ b/test/hotspot/jtreg/serviceability/jvmti/FieldAccessWatch/libFieldAccessWatch.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,14 +208,15 @@ JNIEXPORT jint JNICALL
 Agent_OnLoad(JavaVM *jvm, char *options, void *reserved)
 {
     jvmtiError err;
-    jvmtiCapabilities caps = {0};
-    jvmtiEventCallbacks callbacks = {0};
+    jvmtiCapabilities caps;
+    jvmtiEventCallbacks callbacks;
     jint res = (*jvm)->GetEnv(jvm, (void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         reportError("GetEnv failed", res);
         return JNI_ERR;
     }
 
+    memset(&caps, 0, sizeof(caps));
     caps.can_generate_field_modification_events = 1;
     caps.can_generate_field_access_events = 1;
     caps.can_tag_objects = 1;
@@ -225,6 +226,7 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved)
         return JNI_ERR;
     }
 
+    memset(&callbacks, 0, sizeof(callbacks));
     callbacks.FieldModification = &onFieldModification;
     callbacks.FieldAccess = &onFieldAccess;
 


### PR DESCRIPTION
Backport JDK-8287362

Backport is not clean.
I applied following changes:
* Remove following files, they are not in jdk11u
  * test/hotspot/jtreg/serviceability/jvmti/GetClassMethods/libOverpassMethods.cpp
  * test/hotspot/jtreg/runtime/jni/FastGetField/libFastGetField.c
* Modify following file, just Copyright year
  * test/hotspot/jtreg/serviceability/jvmti/FieldAccessWatch/libFieldAccessWatch.c

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287362](https://bugs.openjdk.java.net/browse/JDK-8287362): FieldAccessWatch testcase failed on AIX platform


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1112/head:pull/1112` \
`$ git checkout pull/1112`

Update a local copy of the PR: \
`$ git checkout pull/1112` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1112`

View PR using the GUI difftool: \
`$ git pr show -t 1112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1112.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1112.diff</a>

</details>
