### PR TITLE
8282422: JTable.print() failed with UnsupportedCharsetException on AIX ko_KR locale

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -964,7 +964,9 @@ public abstract class FontConfiguration {
             return fc.newEncoder();
         }
 
-        if (!charsetName.startsWith("sun.awt.") && !charsetName.equals("default")) {
+        if (!charsetName.startsWith("sun.awt.") &&
+            !charsetName.equals("default") &&
+            !charsetName.startsWith("sun.font.")) {
             fc = Charset.forName(charsetName);
         } else {
             Class<?> fcc = AccessController.doPrivileged(new PrivilegedAction<Class<?>>() {


### PR DESCRIPTION
Backport JDK-8282422

Clean backport except Copyright year

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282422](https://bugs.openjdk.java.net/browse/JDK-8282422): JTable.print() failed with UnsupportedCharsetException on AIX ko_KR locale


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1113/head:pull/1113` \
`$ git checkout pull/1113`

Update a local copy of the PR: \
`$ git checkout pull/1113` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1113`

View PR using the GUI difftool: \
`$ git pr show -t 1113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1113.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1113.diff</a>

</details>
