### PR TITLE
8284094: Memory leak in invoker_completeInvokeRequest()

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
@@ -845,6 +845,7 @@ invoker_completeInvokeRequest(jthread thread)
         (void)outStream_writeObjectTag(env, &out, exc);
         (void)outStream_writeObjectRef(env, &out, exc);
         outStream_sendReply(&out);
+        outStream_destroy(&out);
     }
 
     /*


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [1dfa1eae](https://github.com/openjdk/jdk/commit/1dfa1eaea0c8958f4b793c0766e36607cbde5c7f) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Roman Kennke on 1 Apr 2022 and was reviewed by Chris Plummer and Aleksey Shipilev.

This fixes a memory leak in the JDWP agent. It has baked in trunk for over a month and should now be safe enough to backport to stable releases.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284094](https://bugs.openjdk.java.net/browse/JDK-8284094): Memory leak in invoker_completeInvokeRequest()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1116/head:pull/1116` \
`$ git checkout pull/1116`

Update a local copy of the PR: \
`$ git checkout pull/1116` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1116`

View PR using the GUI difftool: \
`$ git pr show -t 1116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1116.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1116.diff</a>

</details>
