### PR TITLE
8274171: java/nio/file/Files/probeContentType/Basic.java failed on "Content type" mismatches

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 8129632 8129633 8162624 8146215 8162745 8273655
+ * @bug 4313887 8129632 8129633 8162624 8146215 8162745 8273655 8274171
  * @summary Unit test for probeContentType method
  * @library ../..
  * @build Basic SimpleFileTypeDetector
@@ -178,8 +178,8 @@ public class Basic {
                 new ExType("png", List.of("image/png")),
                 new ExType("ppt", List.of("application/vnd.ms-powerpoint")),
                 new ExType("pptx",List.of("application/vnd.openxmlformats-officedocument.presentationml.presentation")),
-                new ExType("py", List.of("text/plain", "text/x-python-script")),
-                new ExType("rar", List.of("application/vnd.rar")),
+                new ExType("py", List.of("text/plain", "text/x-python", "text/x-python-script")),
+                new ExType("rar", List.of("application/rar", "application/vnd.rar")),
                 new ExType("rtf", List.of("application/rtf", "text/rtf")),
                 new ExType("webm", List.of("video/webm")),
                 new ExType("webp", List.of("image/webp")),


### PR DESCRIPTION
Follow-on from PR #1111 
Test continues to pass on RHEL 8.
```
----------configuration:(0/0)----------
----------System.out:(33/1379)----------
probe /tmp/foo18351909635146675566.html...
probe /tmp/red10989402937768536841.grape...
probe /tmp/foo16699977996148445785.adoc...
probe /tmp/foo11740803098261892964.bz2...
probe /tmp/foo15157859636229909119.css...
probe /tmp/foo13916645521568041241.csv...
probe /tmp/foo5702165481706867137.doc...
probe /tmp/foo5340209909488930621.docx...
probe /tmp/foo7813782781201188765.gz...
probe /tmp/foo9878013620332144725.jar...
probe /tmp/foo16808027658999762132.jpg...
probe /tmp/foo17207896756515666147.js...
probe /tmp/foo551282294770037988.json...
probe /tmp/foo8097877074015423846.markdown...
probe /tmp/foo10405954427813878079.md...
probe /tmp/foo9256540324588249305.mp3...
probe /tmp/foo14535825315042733532.mp4...
probe /tmp/foo7545445186850476157.odp...
probe /tmp/foo15492100182638322340.ods...
probe /tmp/foo1996619081775585628.odt...
probe /tmp/foo13446347341207229809.pdf...
probe /tmp/foo16243390421704954641.php...
probe /tmp/foo15464603890560217916.png...
probe /tmp/foo2739408437822689242.ppt...
probe /tmp/foo12332808757620208861.pptx...
probe /tmp/foo309692996789760827.py...
probe /tmp/foo5256642943155291232.rar...
probe /tmp/foo9877699924930126555.rtf...
probe /tmp/foo13195445085315808257.webm...
probe /tmp/foo8472575196421473589.webp...
probe /tmp/foo13930243120480431851.xls...
probe /tmp/foo13180400840321750875.xlsx...
probe /tmp/foo8559403623231321023.7z...
----------System.err:(1/15)----------
STATUS:Passed.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274171](https://bugs.openjdk.java.net/browse/JDK-8274171): java/nio/file/Files/probeContentType/Basic.java failed on "Content type" mismatches


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1120/head:pull/1120` \
`$ git checkout pull/1120`

Update a local copy of the PR: \
`$ git checkout pull/1120` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1120`

View PR using the GUI difftool: \
`$ git pr show -t 1120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1120.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1120.diff</a>

</details>
