### PR TITLE
8223575: add subspace transitions to gc+metaspace=info log lines

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapTransition.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapTransition.cpp
@@ -34,7 +34,6 @@ G1HeapTransition::Data::Data(G1CollectedHeap* g1_heap) {
   _survivor_length = g1_heap->survivor_regions_count();
   _old_length = g1_heap->old_regions_count();
   _humongous_length = g1_heap->humongous_regions_count();
-  _metaspace_used_bytes = MetaspaceUtils::used_bytes();
 }
 
 G1HeapTransition::G1HeapTransition(G1CollectedHeap* g1_heap) : _g1_heap(g1_heap), _before(g1_heap) { }
@@ -117,5 +116,5 @@ void G1HeapTransition::print() {
   log_trace(gc, heap)(" Used: " SIZE_FORMAT "K, Waste: " SIZE_FORMAT "K",
       usage._humongous_used / K, ((after._humongous_length * HeapRegion::GrainBytes) - usage._humongous_used) / K);
 
-  MetaspaceUtils::print_metaspace_change(_before._metaspace_used_bytes);
+  MetaspaceUtils::print_metaspace_change(_before._meta_sizes);
 }

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -38,6 +38,7 @@
 #include "gc/shared/softRefPolicy.hpp"
 #include "gc/shared/strongRootsScope.hpp"
 #include "memory/metaspace.hpp"
+#include "memory/metaspace/metaspaceSizesSnapshot.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/ostream.hpp"
 
@@ -267,19 +268,18 @@ public:
   PreGCValues(ParallelScavengeHeap* heap) :
       _heap_used(heap->used()),
       _young_gen_used(heap->young_gen()->used_in_bytes()),
-      _old_gen_used(heap->old_gen()->used_in_bytes()),
-      _metadata_used(MetaspaceUtils::used_bytes()) { };
+      _old_gen_used(heap->old_gen()->used_in_bytes()) { }
 
   size_t heap_used() const      { return _heap_used; }
   size_t young_gen_used() const { return _young_gen_used; }
   size_t old_gen_used() const   { return _old_gen_used; }
-  size_t metadata_used() const  { return _metadata_used; }
+  const metaspace::MetaspaceSizesSnapshot& metaspace_sizes() const { return _meta_sizes; }
 
 private:
   size_t _heap_used;
   size_t _young_gen_used;
   size_t _old_gen_used;
-  size_t _metadata_used;
+  const metaspace::MetaspaceSizesSnapshot _meta_sizes;
 };
 
 // Class that can be used to print information about the

--- a/src/hotspot/share/gc/parallel/psMarkSweep.cpp
+++ b/src/hotspot/share/gc/parallel/psMarkSweep.cpp
@@ -190,11 +190,7 @@ bool PSMarkSweep::invoke_no_policy(bool clear_all_softrefs) {
     CodeCache::gc_prologue();
     BiasedLocking::preserve_marks();
 
-    // Capture metadata size before collection for sizing.
-    size_t metadata_prev_used = MetaspaceUtils::used_bytes();
-
-    size_t old_gen_prev_used = old_gen->used_in_bytes();
-    size_t young_gen_prev_used = young_gen->used_in_bytes();
+    const PreGCValues pre_gc_values(heap);
 
     allocate_stacks();
 
@@ -351,9 +347,9 @@ bool PSMarkSweep::invoke_no_policy(bool clear_all_softrefs) {
       accumulated_time()->stop();
     }
 
-    young_gen->print_used_change(young_gen_prev_used);
-    old_gen->print_used_change(old_gen_prev_used);
-    MetaspaceUtils::print_metaspace_change(metadata_prev_used);
+    young_gen->print_used_change(pre_gc_values.young_gen_used());
+    old_gen->print_used_change(pre_gc_values.old_gen_used());
+    MetaspaceUtils::print_metaspace_change(pre_gc_values.metaspace_sizes());
 
     // Track memory usage and detect low memory
     MemoryService::track_memory_usage();

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1753,7 +1753,7 @@ bool PSParallelCompact::invoke_no_policy(bool maximum_heap_compaction) {
   // miscellaneous bookkeeping.
   pre_compact();
 
-  PreGCValues pre_gc_values(heap);
+  const PreGCValues pre_gc_values(heap);
 
   // Get the compaction manager reserved for the VM thread.
   ParCompactionManager* const vmthread_cm =
@@ -1902,7 +1902,7 @@ bool PSParallelCompact::invoke_no_policy(bool maximum_heap_compaction) {
 
     young_gen->print_used_change(pre_gc_values.young_gen_used());
     old_gen->print_used_change(pre_gc_values.old_gen_used());
-    MetaspaceUtils::print_metaspace_change(pre_gc_values.metadata_used());
+    MetaspaceUtils::print_metaspace_change(pre_gc_values.metaspace_sizes());
 
     // Track memory usage and detect low memory
     MemoryService::track_memory_usage();

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -328,7 +328,7 @@ bool PSScavenge::invoke_no_policy() {
     reference_processor()->enable_discovery();
     reference_processor()->setup_policy(false);
 
-    PreGCValues pre_gc_values(heap);
+    const PreGCValues pre_gc_values(heap);
 
     // Reset our survivor overflow.
     set_survivor_overflow(false);
@@ -608,7 +608,7 @@ bool PSScavenge::invoke_no_policy() {
 
     young_gen->print_used_change(pre_gc_values.young_gen_used());
     old_gen->print_used_change(pre_gc_values.old_gen_used());
-    MetaspaceUtils::print_metaspace_change(pre_gc_values.metadata_used());
+    MetaspaceUtils::print_metaspace_change(pre_gc_values.metaspace_sizes());
 
     // Track memory usage and detect low memory
     MemoryService::track_memory_usage();

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -588,7 +588,6 @@ void GenCollectedHeap::do_collection(bool           full,
 
     size_t young_prev_used = _young_gen->used();
     size_t old_prev_used = _old_gen->used();
-
     const metaspace::MetaspaceSizesSnapshot prev_meta_sizes;
 
     bool run_verification = total_collections() >= VerifyGCStartAt;

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -564,8 +564,6 @@ void GenCollectedHeap::do_collection(bool           full,
 
   ClearedAllSoftRefs casr(do_clear_all_soft_refs, soft_ref_policy());
 
-  const size_t metadata_prev_used = MetaspaceUtils::used_bytes();
-
   print_heap_before_gc();
 
   {
@@ -590,6 +588,8 @@ void GenCollectedHeap::do_collection(bool           full,
 
     size_t young_prev_used = _young_gen->used();
     size_t old_prev_used = _old_gen->used();
+
+    const metaspace::MetaspaceSizesSnapshot prev_meta_sizes;
 
     bool run_verification = total_collections() >= VerifyGCStartAt;
 
@@ -650,7 +650,7 @@ void GenCollectedHeap::do_collection(bool           full,
     complete = complete || collected_old;
 
     print_heap_change(young_prev_used, old_prev_used);
-    MetaspaceUtils::print_metaspace_change(metadata_prev_used);
+    MetaspaceUtils::print_metaspace_change(prev_meta_sizes);
 
     // Adjust generation sizes.
     if (collected_old) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -187,7 +187,7 @@ void ShenandoahControlThread::run_service() {
       heap->reset_bytes_allocated_since_gc_start();
 
       // Capture metaspace usage before GC.
-      const size_t metadata_prev_used = MetaspaceUtils::used_bytes();
+      const metaspace::MetaspaceSizesSnapshot prev_meta_sizes;
 
       // If GC was requested, we are sampling the counters even without actual triggers
       // from allocation machinery. This captures GC phases more accurately.
@@ -273,7 +273,7 @@ void ShenandoahControlThread::run_service() {
       heap->phase_timings()->flush_cycle_to_global();
 
       // Print Metaspace change following GC (if logging is enabled).
-      MetaspaceUtils::print_metaspace_change(metadata_prev_used);
+      MetaspaceUtils::print_metaspace_change(prev_meta_sizes);
 
       // GC is over, we are at idle now
       if (ShenandoahPacing) {

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -470,9 +470,36 @@ MetaspaceChunkFreeListSummary MetaspaceUtils::chunk_free_list_summary(Metaspace:
   return cm->chunk_free_list_summary();
 }
 
-void MetaspaceUtils::print_metaspace_change(size_t prev_metadata_used) {
-  log_info(gc, metaspace)("Metaspace: "  SIZE_FORMAT "K->" SIZE_FORMAT "K("  SIZE_FORMAT "K)",
-                          prev_metadata_used/K, used_bytes()/K, reserved_bytes()/K);
+void MetaspaceUtils::print_metaspace_change(const metaspace::MetaspaceSizesSnapshot& pre_meta_values) {
+  const metaspace::MetaspaceSizesSnapshot meta_values;
+
+  if (Metaspace::using_class_space()) {
+    log_info(gc, metaspace)(HEAP_CHANGE_FORMAT" "
+                            HEAP_CHANGE_FORMAT" "
+                            HEAP_CHANGE_FORMAT,
+                            HEAP_CHANGE_FORMAT_ARGS("Metaspace",
+                                                    pre_meta_values.used(),
+                                                    pre_meta_values.committed(),
+                                                    meta_values.used(),
+                                                    meta_values.committed()),
+                            HEAP_CHANGE_FORMAT_ARGS("NonClass",
+                                                    pre_meta_values.non_class_used(),
+                                                    pre_meta_values.non_class_committed(),
+                                                    meta_values.non_class_used(),
+                                                    meta_values.non_class_committed()),
+                            HEAP_CHANGE_FORMAT_ARGS("Class",
+                                                    pre_meta_values.class_used(),
+                                                    pre_meta_values.class_committed(),
+                                                    meta_values.class_used(),
+                                                    meta_values.class_committed()));
+  } else {
+    log_info(gc, metaspace)(HEAP_CHANGE_FORMAT,
+                            HEAP_CHANGE_FORMAT_ARGS("Metaspace",
+                                                    pre_meta_values.used(),
+                                                    pre_meta_values.committed(),
+                                                    meta_values.used(),
+                                                    meta_values.committed()));
+  }
 }
 
 void MetaspaceUtils::print_on(outputStream* out) {

--- a/src/hotspot/share/memory/metaspace.hpp
+++ b/src/hotspot/share/memory/metaspace.hpp
@@ -28,6 +28,7 @@
 #include "memory/memRegion.hpp"
 #include "memory/metaspaceChunkFreeListSummary.hpp"
 #include "memory/virtualspace.hpp"
+#include "memory/metaspace/metaspaceSizesSnapshot.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/macros.hpp"
 
@@ -427,8 +428,8 @@ public:
   static bool has_chunk_free_list(Metaspace::MetadataType mdtype);
   static MetaspaceChunkFreeListSummary chunk_free_list_summary(Metaspace::MetadataType mdtype);
 
-  // Print change in used metadata.
-  static void print_metaspace_change(size_t prev_metadata_used);
+  // Log change in used metadata.
+  static void print_metaspace_change(const metaspace::MetaspaceSizesSnapshot& pre_meta_values);
   static void print_on(outputStream * out);
 
   // Prints an ASCII representation of the given space.

--- a/src/hotspot/share/memory/metaspace/metaspaceSizesSnapshot.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceSizesSnapshot.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Twitter, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,32 +23,19 @@
  *
  */
 
-#ifndef SHARE_VM_GC_G1_G1HEAPTRANSITION_HPP
-#define SHARE_VM_GC_G1_G1HEAPTRANSITION_HPP
+#include "precompiled.hpp"
 
-#include "gc/shared/plab.hpp"
+#include "memory/metaspace.hpp"
 #include "memory/metaspace/metaspaceSizesSnapshot.hpp"
 
-class G1CollectedHeap;
+namespace metaspace {
 
-class G1HeapTransition {
-  struct Data {
-    size_t _eden_length;
-    size_t _survivor_length;
-    size_t _old_length;
-    size_t _humongous_length;
-    const metaspace::MetaspaceSizesSnapshot _meta_sizes;
+MetaspaceSizesSnapshot::MetaspaceSizesSnapshot()
+    : _used(MetaspaceUtils::used_bytes()),
+      _committed(MetaspaceUtils::committed_bytes()),
+      _non_class_used(MetaspaceUtils::used_bytes(Metaspace::NonClassType)),
+      _non_class_committed(MetaspaceUtils::committed_bytes(Metaspace::NonClassType)),
+      _class_used(MetaspaceUtils::used_bytes(Metaspace::ClassType)),
+      _class_committed(MetaspaceUtils::committed_bytes(Metaspace::ClassType)) { }
 
-    Data(G1CollectedHeap* g1_heap);
-  };
-
-  G1CollectedHeap* _g1_heap;
-  Data _before;
-
-public:
-  G1HeapTransition(G1CollectedHeap* g1_heap);
-
-  void print();
-};
-
-#endif // SHARE_VM_GC_G1_G1HEAPTRANSITION_HPP
+} // namespace metaspace

--- a/src/hotspot/share/memory/metaspace/metaspaceSizesSnapshot.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceSizesSnapshot.hpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Twitter, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,32 +23,31 @@
  *
  */
 
-#ifndef SHARE_VM_GC_G1_G1HEAPTRANSITION_HPP
-#define SHARE_VM_GC_G1_G1HEAPTRANSITION_HPP
+#ifndef SHARE_MEMORY_METASPACE_METASPACESIZESSNAPSHOT_HPP
+#define SHARE_MEMORY_METASPACE_METASPACESIZESSNAPSHOT_HPP
 
-#include "gc/shared/plab.hpp"
-#include "memory/metaspace/metaspaceSizesSnapshot.hpp"
+namespace metaspace {
 
-class G1CollectedHeap;
-
-class G1HeapTransition {
-  struct Data {
-    size_t _eden_length;
-    size_t _survivor_length;
-    size_t _old_length;
-    size_t _humongous_length;
-    const metaspace::MetaspaceSizesSnapshot _meta_sizes;
-
-    Data(G1CollectedHeap* g1_heap);
-  };
-
-  G1CollectedHeap* _g1_heap;
-  Data _before;
-
+class MetaspaceSizesSnapshot {
 public:
-  G1HeapTransition(G1CollectedHeap* g1_heap);
+  MetaspaceSizesSnapshot();
 
-  void print();
+  size_t used() const { return _used; }
+  size_t committed() const { return _committed; }
+  size_t non_class_used() const { return _non_class_used; }
+  size_t non_class_committed() const { return _non_class_committed; }
+  size_t class_used() const { return _class_used; }
+  size_t class_committed() const { return _class_committed; }
+
+private:
+  const size_t _used;
+  const size_t _committed;
+  const size_t _non_class_used;
+  const size_t _non_class_committed;
+  const size_t _class_used;
+  const size_t _class_committed;
 };
 
-#endif // SHARE_VM_GC_G1_G1HEAPTRANSITION_HPP
+} // namespace metaspace
+
+#endif // SHARE_MEMORY_METASPACE_METASPACESIZESSNAPSHOT_HPP

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -333,6 +333,13 @@ inline size_t byte_size_in_exact_unit(size_t s) {
   return s;
 }
 
+// Memory size transition formatting.
+
+#define HEAP_CHANGE_FORMAT "%s: " SIZE_FORMAT "K(" SIZE_FORMAT "K)->" SIZE_FORMAT "K(" SIZE_FORMAT "K)"
+
+#define HEAP_CHANGE_FORMAT_ARGS(_name_, _prev_used_, _prev_capacity_, _used_, _capacity_) \
+  (_name_), (_prev_used_) / K, (_prev_capacity_) / K, (_used_) / K, (_capacity_) / K
+
 //----------------------------------------------------------------------------------------------------
 // VM type definitions
 


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

src/hotspot/share/gc/shared/genCollectedHeap.cpp had to be resolved because it has a
somewhat different logic.

I had to port the change to Shenandoah.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8223575](https://bugs.openjdk.org/browse/JDK-8223575): add subspace transitions to gc+metaspace=info log lines


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [d1ff462d](https://git.openjdk.java.net/jdk11u-dev/pull/1126/files/d1ff462dc2131bd8a38d611b1bb1f6e58ae4c342)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1126/head:pull/1126` \
`$ git checkout pull/1126`

Update a local copy of the PR: \
`$ git checkout pull/1126` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1126`

View PR using the GUI difftool: \
`$ git pr show -t 1126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1126.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1126.diff</a>

</details>
