### PR TITLE
8239902: [macos] Remove direct usage of JSlider, JProgressBar classes in CAccessible class

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -44,6 +44,7 @@ import static javax.accessibility.AccessibleContext.ACCESSIBLE_STATE_PROPERTY;
 import static javax.accessibility.AccessibleContext.ACCESSIBLE_TABLE_MODEL_CHANGED;
 import static javax.accessibility.AccessibleContext.ACCESSIBLE_TEXT_PROPERTY;
 import static javax.accessibility.AccessibleContext.ACCESSIBLE_NAME_PROPERTY;
+import static javax.accessibility.AccessibleContext.ACCESSIBLE_VALUE_PROPERTY;
 
 import javax.accessibility.AccessibleRole;
 import javax.accessibility.AccessibleState;
@@ -106,13 +107,6 @@ class CAccessible extends CFRetainedResource implements Accessible {
             AccessibleContext ac = ((Accessible)c).getAccessibleContext();
             ac.addPropertyChangeListener(new AXChangeNotifier());
         }
-        if (c instanceof JProgressBar) {
-            JProgressBar pb = (JProgressBar) c;
-            pb.addChangeListener(new AXProgressChangeNotifier());
-        } else if (c instanceof JSlider) {
-            JSlider slider = (JSlider) c;
-            slider.addChangeListener(new AXProgressChangeNotifier());
-        }
     }
 
 
@@ -169,17 +163,18 @@ class CAccessible extends CFRetainedResource implements Accessible {
                     if (e.getSource() instanceof JTabbedPane) {
                         titleChanged(ptr);
                     }
+                } else if (name.compareTo(ACCESSIBLE_VALUE_PROPERTY) == 0) {
+                    AccessibleRole thisRole = accessible.getAccessibleContext()
+                                                        .getAccessibleRole();
+                    if (thisRole == AccessibleRole.SLIDER ||
+                            thisRole == AccessibleRole.PROGRESS_BAR) {
+                        valueChanged(ptr);
+                    }
                 }
             }
         }
     }
 
-    private class AXProgressChangeNotifier implements ChangeListener {
-        @Override
-        public void stateChanged(ChangeEvent e) {
-            if (ptr != 0) valueChanged(ptr);
-        }
-    }
 
     static Accessible getSwingAccessible(final Accessible a) {
         return (a instanceof CAccessible) ? ((CAccessible)a).accessible : a;


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8239902](https://bugs.openjdk.org/browse/JDK-8239902): [macos] Remove direct usage of JSlider, JProgressBar classes in CAccessible class


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1128/head:pull/1128` \
`$ git checkout pull/1128`

Update a local copy of the PR: \
`$ git checkout pull/1128` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1128`

View PR using the GUI difftool: \
`$ git pr show -t 1128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1128.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1128.diff</a>

</details>
