### PR TITLE
8284956: Potential leak awtImageData/color_data when initializes X11GraphicsEnvironment

### DIFF
--- a/src/java.desktop/unix/native/common/awt/X11Color.c
+++ b/src/java.desktop/unix/native/common/awt/X11Color.c
@@ -364,6 +364,33 @@ awt_fill_imgcv(ImgConvertFcn **array, int mask, int value, ImgConvertFcn fcn)
 }
 
 #ifndef HEADLESS
+void cleanup_graphics_config_data(AwtGraphicsConfigDataPtr awt_data) {
+    if (awt_data->awtImage != NULL) {
+        free(awt_data->awtImage);
+        awt_data->awtImage = NULL;
+    }
+
+    if (awt_data->color_data != NULL) {
+        if (awt_data->color_data->img_clr_tbl != NULL) {
+            free(awt_data->color_data->img_clr_tbl);
+        }
+        if (awt_data->color_data->awt_icmLUT2Colors != NULL) {
+            free(awt_data->color_data->awt_icmLUT2Colors);
+        }
+        if (awt_data->color_data->awt_icmLUT != NULL) {
+            free(awt_data->color_data->awt_icmLUT);
+        }
+        if (awt_data->color_data->awt_Colors != NULL) {
+            free(awt_data->color_data->awt_Colors);
+        }
+        if (awt_data->color_data->img_grays != NULL) {
+            free(awt_data->color_data->img_grays);
+        }
+        free(awt_data->color_data);
+        awt_data->color_data = NULL;
+    }
+}
+
 /*
  * called from X11Server_create() in xlib.c
  */
@@ -384,6 +411,9 @@ awt_allocate_colors(AwtGraphicsConfigDataPtr awt_data)
     XVisualInfo *pVI;
     char *forcemono;
     char *forcegray;
+
+    // Clean up awt_data for reuse, avoid memory leak
+    cleanup_graphics_config_data(awt_data);
 
     make_uns_ordered_dither_array(img_oda_alpha, 256);
 
@@ -560,7 +590,7 @@ awt_allocate_colors(AwtGraphicsConfigDataPtr awt_data)
                        OrdColorDcmOpqUnsImageConvert);
 #endif /* NEED_IMAGE_CONVERT */
     } else {
-        free (awt_data->awtImage);
+        cleanup_graphics_config_data(awt_data);
         return 0;
     }
 
@@ -575,14 +605,14 @@ awt_allocate_colors(AwtGraphicsConfigDataPtr awt_data)
     }
 
     if (awt_data->awt_num_colors > paletteSize) {
-        free(awt_data->awtImage);
+        cleanup_graphics_config_data(awt_data);
         return 0;
     }
 
     /* Allocate ColorData structure */
     awt_data->color_data = ZALLOC (_ColorData);
     if (awt_data->color_data == NULL) {
-        free(awt_data->awtImage);
+        cleanup_graphics_config_data(awt_data);
         return 0;
     }
 
@@ -603,8 +633,7 @@ awt_allocate_colors(AwtGraphicsConfigDataPtr awt_data)
     awt_data->color_data->awt_Colors =
         (ColorEntry *)calloc(paletteSize, sizeof (ColorEntry));
     if (awt_data->color_data->awt_Colors == NULL) {
-        free(awt_data->awtImage);
-        free(awt_data->color_data);
+        cleanup_graphics_config_data(awt_data);
         return 0;
     }
 
@@ -681,8 +710,7 @@ awt_allocate_colors(AwtGraphicsConfigDataPtr awt_data)
         awt_data->color_data->img_grays =
             (unsigned char *)calloc(256, sizeof(unsigned char));
         if ( awt_data->color_data->img_grays == NULL) {
-            free(awt_data->awtImage);
-            free(awt_data->color_data);
+            cleanup_graphics_config_data(awt_data);
             return 0;
         }
         for (g = 0; g < 256; g++) {
@@ -829,10 +857,10 @@ awt_allocate_colors(AwtGraphicsConfigDataPtr awt_data)
         (unsigned char *)calloc(LOOKUPSIZE * LOOKUPSIZE * LOOKUPSIZE,
                                 sizeof(unsigned char));
     if (awt_data->color_data->img_clr_tbl == NULL) {
-        free(awt_data->awtImage);
-        free(awt_data->color_data);
+        cleanup_graphics_config_data(awt_data);
         return 0;
     }
+
     img_makePalette(cmapsize, k, LOOKUPSIZE, 50, 250,
                     allocatedColorsNum, TRUE, reds, greens, blues,
                     awt_data->color_data->img_clr_tbl);
@@ -882,8 +910,7 @@ awt_allocate_colors(AwtGraphicsConfigDataPtr awt_data)
         (unsigned char *)calloc(paletteSize, sizeof (unsigned char));
     awt_data->color_data->awt_icmLUT = (int *)calloc(paletteSize, sizeof(int));
     if (awt_data->color_data->awt_icmLUT2Colors == NULL || awt_data->color_data->awt_icmLUT == NULL) {
-        free(awt_data->awtImage);
-        free(awt_data->color_data);
+        cleanup_graphics_config_data(awt_data);
         return 0;
     }
 


### PR DESCRIPTION
A clean backport to fix memory leaks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284956](https://bugs.openjdk.org/browse/JDK-8284956): Potential leak awtImageData/color_data when initializes X11GraphicsEnvironment


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1132/head:pull/1132` \
`$ git checkout pull/1132`

Update a local copy of the PR: \
`$ git checkout pull/1132` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1132`

View PR using the GUI difftool: \
`$ git pr show -t 1132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1132.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1132.diff</a>

</details>
