### PR TITLE
8069343: Improve gc/g1/TestHumongousCodeCacheRoots.java to use jtreg @requires

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestHumongousCodeCacheRoots.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousCodeCacheRoots.java
@@ -121,24 +121,8 @@ public class TestHumongousCodeCacheRoots {
 
     ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs.toArray(new String[0]));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
-    try {
-        output.shouldHaveExitValue(0);
-    } catch (RuntimeException e) {
-        // It's ok if there is no client vm in the jdk.
-        if (output.firstMatch("Unrecognized option: -client") == null) {
-            throw e;
-        }
-    }
-
+    output.shouldHaveExitValue(0);
     return output;
-  }
-
-  public static void runTest(String compiler, String[] other) throws Exception {
-    ArrayList<String> joined = new ArrayList<String>();
-    joined.add(compiler);
-    joined.addAll(Arrays.asList(other));
-    runWhiteBoxTest(joined.toArray(new String[0]), TestHumongousCodeCacheRootsHelper.class.getName(),
-      new String[] {}, false);
   }
 
   public static void main(String[] args) throws Exception {
@@ -148,8 +132,9 @@ public class TestHumongousCodeCacheRoots {
       "-XX:InitiatingHeapOccupancyPercent=1", // strong code root marking
       "-XX:+G1VerifyHeapRegionCodeRoots", "-XX:+VerifyAfterGC", // make sure that verification is run
     };
-    runTest("-client", baseArguments);
-    runTest("-server", baseArguments);
+
+    runWhiteBoxTest(baseArguments, TestHumongousCodeCacheRootsHelper.class.getName(),
+      new String[] {}, false);
   }
 }
 


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8069343](https://bugs.openjdk.org/browse/JDK-8069343): Improve gc/g1/TestHumongousCodeCacheRoots.java to use jtreg @requires


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk11u-dev pull/1133/head:pull/1133` \
`$ git checkout pull/1133`

Update a local copy of the PR: \
`$ git checkout pull/1133` \
`$ git pull https://git.openjdk.java.net/jdk11u-dev pull/1133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1133`

View PR using the GUI difftool: \
`$ git pr show -t 1133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk11u-dev/pull/1133.diff">https://git.openjdk.java.net/jdk11u-dev/pull/1133.diff</a>

</details>
