### PR TITLE
8261160: Add a deserialization JFR event

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import jdk.internal.misc.SharedSecrets;
+import jdk.internal.event.DeserializationEvent;
 import jdk.internal.misc.Unsafe;
 import sun.reflect.misc.ReflectUtil;
 import sun.security.action.GetBooleanAction;
@@ -1314,8 +1315,11 @@ public class ObjectInputStream
     }
 
     /**
-     * Invoke the serialization filter if non-null.
+     * Invokes the serialization filter if non-null.
+     *
      * If the filter rejects or an exception is thrown, throws InvalidClassException.
+     *
+     * Logs and/or commits a {@code DeserializationEvent}, if configured.
      *
      * @param clazz the class; may be null
      * @param arrayLength the array length requested; use {@code -1} if not creating an array
@@ -1324,11 +1328,12 @@ public class ObjectInputStream
      */
     private void filterCheck(Class<?> clazz, int arrayLength)
             throws InvalidClassException {
+        // Info about the stream is not available if overridden by subclass, return 0
+        long bytesRead = (bin == null) ? 0 : bin.getBytesRead();
+        RuntimeException ex = null;
+        ObjectInputFilter.Status status = null;
+
         if (serialFilter != null) {
-            RuntimeException ex = null;
-            ObjectInputFilter.Status status;
-            // Info about the stream is not available if overridden by subclass, return 0
-            long bytesRead = (bin == null) ? 0 : bin.getBytesRead();
             try {
                 status = serialFilter.checkInput(new FilterValues(clazz, arrayLength,
                         totalObjectRefs, depth, bytesRead));
@@ -1346,12 +1351,24 @@ public class ObjectInputStream
                         status, clazz, arrayLength, totalObjectRefs, depth, bytesRead,
                         Objects.toString(ex, "n/a"));
             }
-            if (status == null ||
-                    status == ObjectInputFilter.Status.REJECTED) {
-                InvalidClassException ice = new InvalidClassException("filter status: " + status);
-                ice.initCause(ex);
-                throw ice;
-            }
+        }
+        DeserializationEvent event = new DeserializationEvent();
+        if (event.shouldCommit()) {
+            event.filterConfigured = serialFilter != null;
+            event.filterStatus = status != null ? status.name() : null;
+            event.type = clazz;
+            event.arrayLength = arrayLength;
+            event.objectReferences = totalObjectRefs;
+            event.depth = depth;
+            event.bytesRead = bytesRead;
+            event.exceptionType = ex != null ? ex.getClass() : null;
+            event.exceptionMessage = ex != null ? ex.getMessage() : null;
+            event.commit();
+        }
+        if (serialFilter != null && (status == null || status == ObjectInputFilter.Status.REJECTED)) {
+            InvalidClassException ice = new InvalidClassException("filter status: " + status);
+            ice.initCause(ex);
+            throw ice;
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/event/DeserializationEvent.java
+++ b/src/java.base/share/classes/jdk/internal/event/DeserializationEvent.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.event;
+
+/**
+ * Event details relating to deserialization.
+ */
+
+public final class DeserializationEvent extends Event {
+    public boolean filterConfigured;
+    public String filterStatus;
+    public Class<?> type;
+    public int arrayLength;
+    public long objectReferences;
+    public long depth;
+    public long bytesRead;
+    public Class<?> exceptionType;
+    public String exceptionMessage;
+}

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/DeserializationEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/DeserializationEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.events;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.internal.MirrorEvent;
+
+@Category({"Java Development Kit", "Serialization"})
+@Label("Deserialization")
+@Name("jdk.Deserialization")
+@Description("Results of deserialiation and ObjectInputFilter checks")
+@MirrorEvent(className = "jdk.internal.event.DeserializationEvent")
+public final class DeserializationEvent extends AbstractJDKEvent {
+
+    @Label("Filter Configured")
+    public boolean filterConfigured;
+
+    @Label("Filter Status")
+    public String filterStatus;
+
+    @Label ("Type")
+    public Class<?> type;
+
+    @Label ("Array Length")
+    public int arrayLength;
+
+    @Label ("Object References")
+    public long objectReferences;
+
+    @Label ("Depth")
+    public long depth;
+
+    @Label ("Bytes Read")
+    public long bytesRead;
+
+    @Label ("Exception Type")
+    public Class<?> exceptionType;
+
+    @Label ("Exception Message")
+    public String exceptionMessage;
+}

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import jdk.jfr.events.ExceptionThrownEvent;
 import jdk.jfr.events.FileForceEvent;
 import jdk.jfr.events.FileReadEvent;
 import jdk.jfr.events.FileWriteEvent;
+import jdk.jfr.events.DeserializationEvent;
 import jdk.jfr.events.SecurityPropertyModificationEvent;
 import jdk.jfr.events.SocketReadEvent;
 import jdk.jfr.events.SocketWriteEvent;
@@ -54,6 +55,7 @@ import jdk.jfr.internal.Utils;
 public final class JDKEvents {
 
     private static final Class<?>[] mirrorEventClasses = {
+        DeserializationEvent.class,
         SecurityPropertyModificationEvent.class,
         TLSHandshakeEvent.class,
         X509CertificateEvent.class,
@@ -71,6 +73,7 @@ public final class JDKEvents {
         ErrorThrownEvent.class,
         ActiveSettingEvent.class,
         ActiveRecordingEvent.class,
+        jdk.internal.event.DeserializationEvent.class,
         jdk.internal.event.SecurityPropertyModificationEvent.class,
         jdk.internal.event.TLSHandshakeEvent.class,
         jdk.internal.event.X509CertificateEvent.class,

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -603,6 +603,11 @@
       <setting name="threshold" control="socket-io-threshold">20 ms</setting>
     </event>
 
+    <event name="jdk.Deserialization">
+       <setting name="enabled">false</setting>
+       <setting name="stackTrace">true</setting>
+    </event>
+
     <event name="jdk.SecurityPropertyModification">
        <setting name="enabled">false</setting>
        <setting name="stackTrace">true</setting>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -603,6 +603,11 @@
       <setting name="threshold" control="socket-io-threshold">10 ms</setting>
     </event>
 
+    <event name="jdk.Deserialization">
+       <setting name="enabled">false</setting>
+       <setting name="stackTrace">true</setting>
+    </event>
+
     <event name="jdk.SecurityPropertyModification">
        <setting name="enabled">false</setting>
        <setting name="stackTrace">true</setting>

--- a/test/jdk/java/io/Serializable/serialFilter/GlobalFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/GlobalFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,18 @@ import org.testng.annotations.DataProvider;
  *
  * @summary Test Global Filters
  */
+
+/* @test
+ * @bug 8261160
+ * @summary Add a deserialization JFR event
+ * @build GlobalFilterTest SerialFilterTest
+ * @requires vm.hasJFR
+ * @run testng/othervm/policy=security.policy
+ *        -XX:StartFlightRecording=name=DeserializationEvent,dumponexit=true
+ *        -Djava.security.properties=${test.src}/java.security-extra1
+ *        -Djava.security.debug=properties GlobalFilterTest
+ */
+
 @Test
 public class GlobalFilterTest {
     private static final String serialPropName = "jdk.serialFilter";

--- a/test/jdk/jdk/jfr/event/io/TestDeserializationEvent.java
+++ b/test/jdk/jdk/jfr/event/io/TestDeserializationEvent.java
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectInputFilter.Status;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedClass;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.jfr.EventNames;
+import jdk.test.lib.jfr.Events;
+import jdk.test.lib.serial.SerialObjectBuilder;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static java.lang.System.out;
+import static org.testng.Assert.*;
+
+/*
+ * @test
+ * @bug 8261160
+ * @summary Add a deserialization JFR event
+ * @key jfr
+ * @requires vm.hasJFR
+ * @modules java.base/sun.invoke.util
+ * @library /test/lib
+ * @build jdk.test.lib.serial.SerialObjectBuilder
+ * @run testng/othervm jdk.jfr.event.io.TestDeserializationEvent
+ */
+// sun.invoke.util needed for SerialObjectBuilder.
+public class TestDeserializationEvent {
+
+
+    @DataProvider(name = "scenarios")
+    public Object[][] scenarios() throws Exception {
+        byte[] ba1 = serialize(new R());
+        byte[] ba2 = serialize(new int[] { 56, 67, 58, 59, 60 });
+        byte[] ba3 = serialize(new R[] { new R(), new R() });
+        byte[] ba4 = serialize(new char[][] { new char[] {'a', 'b'}, new char[] {'c'} });
+
+        // data provider columns- 1:id, 2:deserialize-operation, 3:expected-event-checkers
+        return new Object[][] {
+            {   1,  // single stream object, R
+                (Runnable)() -> deserialize(ba1),
+                List.of(
+                    Set.of(
+                        assertFilterStatus(null),
+                        assertType(R.class),
+                        assertArrayLength(-1),
+                        assertObjectReferences(1),
+                        assertDepth(1),
+                        assertHasBytesRead(),
+                        assertExceptionType(null),
+                        assertExceptionMessage(null))) },
+            {   2,  // primitive int array
+                (Runnable)() -> deserialize(ba2),
+                List.of(
+                    Set.of(  // TC_CLASS, for array class int[]
+                        assertType(int[].class),
+                        assertArrayLength(-1)),
+                    Set.of(  // TC_ARRAY, actual array
+                        assertType(int[].class),
+                        assertArrayLength(5))) },
+            {   3,  // reference array, R
+                (Runnable)() -> deserialize(ba3),
+                List.of(
+                    Set.of(  // TC_CLASS, for array class R[]
+                        assertType(R[].class),
+                        assertArrayLength(-1)),
+                    Set.of(  // TC_ARRAY, actual array
+                        assertType(R[].class),
+                        assertArrayLength(2)),
+                    Set.of(  // TC_CLASS, for R
+                        assertType(R.class),
+                        assertArrayLength(-1)),
+                    Set.of(  // TC_REFERENCE, for TC_CLASS relating second stream obj
+                        assertType(null),
+                        assertArrayLength(-1))) },
+            {  4,  // multi-dimensional prim char array
+               (Runnable)() -> deserialize(ba4),
+               List.of(
+                    Set.of(  // TC_CLASS, for array class char[][]
+                        assertType(char[][].class),
+                        assertArrayLength(-1),
+                        assertDepth(1)),
+                    Set.of(  // TC_ARRAY, actual char[][] array
+                        assertType(char[][].class),
+                        assertArrayLength(2),
+                        assertDepth(1)),
+                    Set.of(  // TC_CLASS, for array class char[]
+                        assertType(char[].class),
+                        assertArrayLength(-1),
+                        assertDepth(2)),
+                    Set.of(  // TC_ARRAY, first char[] array
+                        assertType(char[].class),
+                        assertArrayLength(2),
+                        assertDepth(2)),
+                    Set.of(  // TC_REFERENCE, for TC_CLASS relating to second stream array
+                        assertType(null),
+                        assertArrayLength(-1),
+                        assertDepth(2)),
+                    Set.of(  // TC_ARRAY, second char[] array
+                        assertType(char[].class),
+                        assertArrayLength(1),
+                        assertDepth(2))) }
+        };
+    }
+
+    @Test(dataProvider = "scenarios")
+    public void test(int id,
+                     Runnable thunk,
+                     List<Set<Consumer<RecordedEvent>>> expectedValuesChecker)
+       throws IOException
+    {
+        try (Recording recording = new Recording()) {
+            recording.enable(EventNames.Deserialization);
+            recording.start();
+            thunk.run();
+            recording.stop();
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            assertEquals(events.size(), expectedValuesChecker.size());
+            assertEventList(events, expectedValuesChecker);
+        }
+    }
+
+    static final Class<InvalidClassException> ICE = InvalidClassException.class;
+
+    @DataProvider(name = "filterDisallowedValues")
+    public Object[][] filterDisallowedValues() {
+        return new Object[][] {
+                { Status.REJECTED,   "REJECTED" },
+                { null,              null       }
+        };
+    }
+
+    @Test(dataProvider = "filterDisallowedValues")
+    public void testFilterDisallow(Status filterStatus,
+                                   String expectedValue)
+        throws Exception
+    {
+        try (Recording recording = new Recording();
+             var bais = new ByteArrayInputStream(serialize(new R()));
+             var ois = new ObjectInputStream(bais)) {
+            ois.setObjectInputFilter(fv -> filterStatus);
+            recording.enable(EventNames.Deserialization);
+            recording.start();
+            assertThrows(ICE, () -> ois.readObject());
+            recording.stop();
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            assertEquals(events.size(), 1);
+            assertEquals(events.get(0).getEventType().getName(), "jdk.Deserialization");
+            assertFilterConfigured(true).accept(events.get(0));
+            assertFilterStatus(expectedValue).accept(events.get(0));
+        }
+    }
+
+    @DataProvider(name = "filterAllowedValues")
+    public Object[][] filterAllowedValues() {
+        return new Object[][] {
+                { Status.ALLOWED,   "ALLOWED"   },
+                { Status.UNDECIDED, "UNDECIDED" },
+        };
+    }
+
+    @Test(dataProvider = "filterAllowedValues")
+    public void testFilterAllowed(Status filterStatus,
+                                  String expectedValue) throws Exception {
+        try (Recording recording = new Recording();
+             var bais = new ByteArrayInputStream(serialize(new R()));
+             var ois = new ObjectInputStream(bais)) {
+            ois.setObjectInputFilter(fv -> filterStatus);
+            recording.enable(EventNames.Deserialization);
+            recording.start();
+            ois.readObject();
+            recording.stop();
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            assertEquals(events.size(), 1);
+            assertEquals(events.get(0).getEventType().getName(), "jdk.Deserialization");
+            assertFilterConfigured(true).accept(events.get(0));
+            assertFilterStatus(expectedValue).accept(events.get(0));
+        }
+    }
+
+    static class XYZException extends RuntimeException {
+        XYZException(String msg) { super(msg); }
+    }
+
+    @Test
+    public void testException() throws Exception {
+        try (Recording recording = new Recording();
+             var bais = new ByteArrayInputStream(serialize(new R()));
+             var ois = new ObjectInputStream(bais)) {
+            ois.setObjectInputFilter(fv -> { throw new XYZException("I am a bad filter!!!"); });
+            recording.enable(EventNames.Deserialization);
+            recording.start();
+            assertThrows(ICE, () -> ois.readObject());
+            recording.stop();
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            assertEquals(events.size(), 1);
+            assertEquals(events.get(0).getEventType().getName(), "jdk.Deserialization");
+            assertFilterConfigured(true).accept(events.get(0));
+            assertExceptionType(XYZException.class).accept(events.get(0));
+            assertExceptionMessage("I am a bad filter!!!").accept(events.get(0));
+        }
+    }
+
+    static void assertEventList(List<RecordedEvent> actualEvents,
+                                List<Set<Consumer<RecordedEvent>>> expectedValuesChecker) {
+        int found = 0;
+        for (RecordedEvent recordedEvent : actualEvents) {
+            assertEquals(recordedEvent.getEventType().getName(), "jdk.Deserialization");
+            out.println("Checking recorded event:" + recordedEvent);
+            Set<Consumer<RecordedEvent>> checkers = expectedValuesChecker.get(found);
+            for (Consumer<RecordedEvent> checker : checkers) {
+                out.println("  checking:" + checker);
+                checker.accept(recordedEvent);
+            }
+            assertFilterConfigured(false).accept(recordedEvent); // no filter expected
+            assertExceptionType(null).accept(recordedEvent);     // no exception type expected
+            assertExceptionMessage(null).accept(recordedEvent);  // no exception message expected
+            found++;
+        }
+        assertEquals(found, expectedValuesChecker.size());
+    }
+
+    static Consumer<RecordedEvent> assertFilterConfigured(boolean expectedValue) {
+        return new Consumer<>() {
+            @Override public void accept(RecordedEvent recordedEvent) {
+                assertTrue(recordedEvent.hasField("filterConfigured"));
+                assertEquals((boolean)recordedEvent.getValue("filterConfigured"), expectedValue);
+            }
+            @Override public String toString() {
+                return "assertFilterConfigured, expectedValue=" + expectedValue;
+            }
+        };
+    }
+
+    static Consumer<RecordedEvent> assertFilterStatus(String expectedValue) {
+        return new Consumer<>() {
+            @Override public void accept(RecordedEvent recordedEvent) {
+                assertTrue(recordedEvent.hasField("filterStatus"));
+                assertEquals(recordedEvent.getValue("filterStatus"), expectedValue);
+            }
+            @Override public String toString() {
+                return "assertFilterStatus, expectedValue=" + expectedValue;
+            }
+        };
+    }
+
+    static Consumer<RecordedEvent> assertType(Class<?> expectedValue) {
+        return new Consumer<>() {
+            @Override public void accept(RecordedEvent recordedEvent) {
+                assertTrue(recordedEvent.hasField("type"));
+                assertClassOrNull(expectedValue, recordedEvent, "type");
+            }
+            @Override public String toString() {
+                return "assertType, expectedValue=" + expectedValue;
+            }
+        };
+    }
+
+    static Consumer<RecordedEvent> assertArrayLength(int expectedValue) {
+        return new Consumer<>() {
+            @Override public void accept(RecordedEvent recordedEvent) {
+                assertTrue(recordedEvent.hasField("arrayLength"));
+                assertEquals((int)recordedEvent.getValue("arrayLength"), expectedValue);
+            }
+            @Override public String toString() {
+                return "assertArrayLength, expectedValue=" + expectedValue;
+            }
+        };
+    }
+
+    static Consumer<RecordedEvent> assertObjectReferences(long expectedValue) {
+        return new Consumer<>() {
+            @Override public void accept(RecordedEvent recordedEvent) {
+                assertTrue(recordedEvent.hasField("objectReferences"));
+                assertEquals((long)recordedEvent.getValue("objectReferences"), expectedValue);
+            }
+            @Override public String toString() {
+                return "assertObjectReferences, expectedValue=" + expectedValue;
+            }
+        };
+    }
+
+    static Consumer<RecordedEvent> assertDepth(long expectedValue) {
+        return new Consumer<>() {
+            @Override public void accept(RecordedEvent recordedEvent) {
+                assertTrue(recordedEvent.hasField("depth"));
+                assertEquals((long)recordedEvent.getValue("depth"), expectedValue);
+            }
+            @Override public String toString() {
+                return "assertDepth, expectedValue=" + expectedValue;
+            }
+        };
+    }
+
+    static Consumer<RecordedEvent> assertHasBytesRead() {
+        return new Consumer<>() {
+            @Override public void accept(RecordedEvent recordedEvent) {
+                assertTrue(recordedEvent.hasField("bytesRead"));
+            }
+            @Override public String toString() {
+                return "assertHasBytesRead,";
+            }
+        };
+    }
+
+    static Consumer<RecordedEvent> assertBytesRead(long expectedValue) {
+        return new Consumer<>() {
+            @Override public void accept(RecordedEvent recordedEvent) {
+                assertHasBytesRead().accept(recordedEvent);
+                assertEquals((long)recordedEvent.getValue("bytesRead"), expectedValue);
+            }
+            @Override public String toString() {
+                return "assertBytesRead, expectedValue=" + expectedValue;
+            }
+        };
+    }
+
+    static Consumer<RecordedEvent> assertExceptionType(Class<?> expectedValue) {
+        return new Consumer<>() {
+            @Override public void accept(RecordedEvent recordedEvent) {
+                assertTrue(recordedEvent.hasField("exceptionType"));
+                assertClassOrNull(expectedValue, recordedEvent, "exceptionType");
+            }
+            @Override public String toString() {
+                return "assertExceptionType, expectedValue=" + expectedValue;
+            }
+        };
+    }
+
+    static Consumer<RecordedEvent> assertExceptionMessage(String expectedValue) {
+        return new Consumer<>() {
+            @Override public void accept(RecordedEvent recordedEvent) {
+                assertTrue(recordedEvent.hasField("exceptionMessage"));
+                assertEquals(recordedEvent.getValue("exceptionMessage"), expectedValue);
+            }
+            @Override public String toString() {
+                return "assertExceptionMessage, expectedValue=" + expectedValue;
+            }
+        };
+    }
+
+    static void assertClassOrNull(Class<?> expectedValue,
+                                  RecordedEvent recordedEvent,
+                                  String valueName) {
+        if (expectedValue == null && recordedEvent.getValue(valueName) == null)
+            return;
+
+        if (recordedEvent.getValue(valueName) instanceof RecordedClass) {
+            RecordedClass recordedClass = (RecordedClass) recordedEvent.getValue(valueName);
+            assertEquals(recordedClass.getName(), expectedValue.getName());
+        } else {
+            fail("Expected RecordedClass, got:" + recordedEvent.getValue(valueName).getClass());
+        }
+    }
+
+    static <T> byte[] serialize(T obj) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        System.out.println("GL: serializing " + obj.getClass().getName());
+        oos.writeObject(obj);
+        oos.close();
+        return baos.toByteArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> T deserialize(byte[] streamBytes) {
+        try {
+            ByteArrayInputStream bais = new ByteArrayInputStream(streamBytes);
+            ObjectInputStream ois  = new ObjectInputStream(bais);
+            return (T) ois.readObject();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // ---
+    static volatile boolean initializedFoo; // false
+    // Do not inadvertently initialize this class, Foo.
+    static class Foo implements Serializable {
+        static { TestDeserializationEvent.initializedFoo = true; }
+    }
+
+    /**
+     * Checks that the creation and recording of the Deserialization event does
+     * not inadvertently trigger initialization of the class of the stream
+     * object, when deserialization is rejected by the filter.
+     */
+    @Test
+    public void testRejectedClassNotInitialized() throws Exception {
+        byte[] bytes = SerialObjectBuilder.newBuilder("Foo").build();
+        assertFalse(initializedFoo);  // sanity
+
+        try (Recording recording = new Recording();
+             var bais = new ByteArrayInputStream(bytes);
+             var ois = new ObjectInputStream(bais)) {
+            ois.setObjectInputFilter(fv -> Status.REJECTED);
+            recording.enable(EventNames.Deserialization);
+            recording.start();
+            assertThrows(ICE, () -> ois.readObject());
+            recording.stop();
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            assertEquals(events.size(), 1);
+            assertEquals(events.get(0).getEventType().getName(), "jdk.Deserialization");
+            assertFilterConfigured(true).accept(events.get(0));
+            assertFilterStatus("REJECTED").accept(events.get(0));
+            assertFalse(initializedFoo);
+            assertType(Foo.class);
+        }
+    }
+}
+
+class R implements Serializable { }

--- a/test/jdk/jdk/jfr/event/metadata/TestDefaultConfigurations.java
+++ b/test/jdk/jdk/jfr/event/metadata/TestDefaultConfigurations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,6 +177,7 @@ public class TestDefaultConfigurations {
         insertSetting(doc, EventNames.TLSHandshake, "threshold", "0 ns");
         insertSetting(doc, EventNames.X509Certificate, "threshold", "0 ns");
         insertSetting(doc, EventNames.X509Validation, "threshold", "0 ns");
+        insertSetting(doc, EventNames.Deserialization, "threshold", "0 ns");
         return doc;
     }
 

--- a/test/jdk/jdk/jfr/event/metadata/TestEventMetadata.java
+++ b/test/jdk/jdk/jfr/event/metadata/TestEventMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,9 +208,9 @@ public class TestEventMetadata {
         String lowerCased = name.toLowerCase();
         Asserts.assertFalse(lowerCased.contains("info") && !lowerCased.contains("information"), "Use 'information' instead 'info' in name");
         Asserts.assertFalse(lowerCased.contains("alloc") && !lowerCased.contains("alloca"), "Use 'allocation' instead 'alloc' in name");
-        Asserts.assertFalse(lowerCased.contains("config") && !lowerCased.contains("configuration"), "Use 'configuration' instead of 'config' in name");
+        Asserts.assertFalse(lowerCased.contains("config") && !(lowerCased.contains("configuration") || lowerCased.contains("filterconfigured")), "Use 'configuration' instead of 'config' in name");
         Asserts.assertFalse(lowerCased.contains("evac") && !lowerCased.contains("evacu"), "Use 'evacuation' instead of 'evac' in name");
-        Asserts.assertFalse(lowerCased.contains("stat") && !(lowerCased.contains("state") ||lowerCased.contains("statistic")) , "Use 'statistics' instead of 'stat' in name");
+        Asserts.assertFalse(lowerCased.contains("stat") && !(lowerCased.contains("state") ||lowerCased.contains("statistic") ||lowerCased.contains("filterstatus")) , "Use 'statistics' instead of 'stat' in name");
         Asserts.assertFalse(name.contains("ID") , "Use 'id' or 'Id' instead of 'ID' in name");
     }
 }

--- a/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -205,6 +205,7 @@ public final class TestActiveSettingEvent {
         settingValues.put(EventNames.TLSHandshake + "#threshold", "0 ns");
         settingValues.put(EventNames.X509Certificate + "#threshold", "0 ns");
         settingValues.put(EventNames.X509Validation + "#threshold", "0 ns");
+        settingValues.put(EventNames.Deserialization + "#threshold", "0 ns");
 
         try (Recording recording = new Recording(c)) {
             Map<Long, EventType> eventTypes = new HashMap<>();

--- a/test/lib/jdk/test/lib/jfr/EventNames.java
+++ b/test/lib/jdk/test/lib/jfr/EventNames.java
@@ -175,6 +175,7 @@ public class EventNames {
     public final static String X509Certificate = PREFIX + "X509Certificate";
     public final static String X509Validation = PREFIX + "X509Validation";
     public final static String SecurityProperty = PREFIX + "SecurityPropertyModification";
+    public final static String Deserialization = PREFIX + "Deserialization";
 
     // Flight Recorder
     public final static String DumpReason = PREFIX + "DumpReason";

--- a/test/lib/jdk/test/lib/serial/SerialObjectBuilder.java
+++ b/test/lib/jdk/test/lib/serial/SerialObjectBuilder.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.serial;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.UncheckedIOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import static java.io.ObjectStreamConstants.*;
+import sun.invoke.util.Wrapper;
+
+/**
+ * A basic builder of a serial object.
+ */
+public class SerialObjectBuilder {
+
+    private final ObjectOutputStream objectOutputStream;
+    private final ByteArrayOutputStream byteArrayOutputStream;
+
+    private class NameAndType<T> {
+        String name;
+        Class<T> type;
+        public NameAndType(String nm, Class<T>tp) {
+            name = nm;
+            type = tp;
+        }
+        String name() { return name; }
+        Class<T> type() { return type; }
+    }
+
+    private String className;
+    private long suid;
+    private SerialObjectBuilder superClass;
+    private final LinkedHashMap<NameAndType<?>, Object> primFields = new LinkedHashMap<>();
+    private final LinkedHashMap<NameAndType<?>, Object> objectFields = new LinkedHashMap<>();
+
+    private SerialObjectBuilder() {
+        try {
+            byteArrayOutputStream = new ByteArrayOutputStream();
+            objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static SerialObjectBuilder newBuilder(String className) {
+        return (new SerialObjectBuilder()).className(className);
+    }
+
+    private SerialObjectBuilder className(String className) {
+        this.className = className;
+        return this;
+    }
+
+    public SerialObjectBuilder suid(long suid) {
+        this.suid = suid;
+        return this;
+    }
+
+    public SerialObjectBuilder superClass(SerialObjectBuilder superClass) {
+        this.superClass = superClass;
+        return this;
+    }
+
+    public <T> SerialObjectBuilder addPrimitiveField(String name, Class<T> type, T value) {
+        if (!type.isPrimitive())
+            throw new IllegalArgumentException("Unexpected non-primitive field: " + type);
+        primFields.put(new NameAndType<>(name, type), value);
+        return this;
+    }
+
+    public <T> SerialObjectBuilder addField(String name, Class<T> type, T value) {
+        if (type.isPrimitive())
+            throw new IllegalArgumentException("Unexpected primitive field: " + type);
+        objectFields.put(new NameAndType<>(name, type), value);
+        return this;
+    }
+
+    private static void writeUTF(DataOutputStream out, String str) throws IOException {
+        assert str.codePoints().noneMatch(cp -> cp > 127); // only ASCII for now
+        int utflen = str.length();
+        assert utflen <= 0xFFFF;  // only small strings for now
+        out.writeShort(utflen);
+        out.writeBytes(str);
+    }
+
+    private void writePrimFieldsDesc(DataOutputStream out) throws IOException {
+        for (Map.Entry<NameAndType<?>, Object> entry : primFields.entrySet()) {
+            Class<?> primClass = entry.getKey().type();
+            assert primClass.isPrimitive();
+            assert primClass != void.class;
+            String pC = descriptorString(primClass);
+            out.writeByte(pC.getBytes()[0]);   // prim_typecode
+            out.writeUTF(entry.getKey().name());                         // fieldName
+        }
+    }
+
+    private void writePrimFieldsValues(DataOutputStream out) throws IOException {
+        for (Map.Entry<NameAndType<?>, Object> entry : primFields.entrySet()) {
+            Class<?> cl = entry.getKey().type();
+            Object value = entry.getValue();
+            if (cl == Integer.TYPE) out.writeInt((int) value);
+            else if (cl == Byte.TYPE) out.writeByte((byte) value);
+            else if (cl == Long.TYPE) out.writeLong((long) value);
+            else if (cl == Float.TYPE) out.writeFloat((float) value);
+            else if (cl == Double.TYPE) out.writeDouble((double) value);
+            else if (cl == Short.TYPE) out.writeShort((short) value);
+            else if (cl == Character.TYPE) out.writeChar((char) value);
+            else if (cl == Boolean.TYPE) out.writeBoolean((boolean) value);
+            else throw new InternalError();
+        }
+    }
+
+    private void writeObjectFieldDesc(DataOutputStream out) throws IOException {
+        for (Map.Entry<NameAndType<?>, Object> entry : objectFields.entrySet()) {
+            Class<?> cl = entry.getKey().type();
+            assert !cl.isPrimitive();
+            // obj_typecode
+            if (cl.isArray()) {
+                out.writeByte('[');
+            } else {
+                out.writeByte('L');
+            }
+            writeUTF(out, entry.getKey().name());
+            out.writeByte(TC_STRING);
+            writeUTF(out, descriptorString(cl));
+        }
+    }
+
+    private void writeObject(DataOutputStream out, Object value) throws IOException {
+        objectOutputStream.reset();
+        byteArrayOutputStream.reset();
+        objectOutputStream.writeUnshared(value);
+        out.write(byteArrayOutputStream.toByteArray());
+    }
+
+    private void writeObjectFieldValues(DataOutputStream out) throws IOException {
+        for (Map.Entry<NameAndType<?>, Object> entry : objectFields.entrySet()) {
+            Class<?> cl = entry.getKey().type();
+            assert !cl.isPrimitive();
+            if (cl == String.class) {
+                out.writeByte(TC_STRING);
+                writeUTF(out, (String) entry.getValue());
+            } else {
+                writeObject(out, entry.getValue());
+            }
+        }
+    }
+
+    private int numFields() {
+        return primFields.size() + objectFields.size();
+    }
+
+    private static void writeClassDesc(DataOutputStream dos,
+                                       SerialObjectBuilder sb)
+        throws IOException
+    {
+        dos.writeByte(TC_CLASSDESC);
+        dos.writeUTF(sb.className);
+        dos.writeLong(sb.suid);
+        dos.writeByte(SC_SERIALIZABLE);
+        dos.writeShort(sb.numFields());      // number of fields
+        sb.writePrimFieldsDesc(dos);
+        sb.writeObjectFieldDesc(dos);
+        dos.writeByte(TC_ENDBLOCKDATA);   // no annotations
+        if (sb.superClass == null) {
+            dos.writeByte(TC_NULL);       // no superclasses
+        } else {
+            writeClassDesc(dos, sb.superClass);
+        }
+    }
+
+    public byte[] build() {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            DataOutputStream dos = new DataOutputStream(baos);
+            dos.writeShort(STREAM_MAGIC);
+            dos.writeShort(STREAM_VERSION);
+            dos.writeByte(TC_OBJECT);
+            writeClassDesc(dos, this);
+            if (superClass != null) {
+                superClass.writePrimFieldsValues(dos);
+                superClass.writeObjectFieldValues(dos);
+            }
+            writePrimFieldsValues(dos);
+            writeObjectFieldValues(dos);
+            dos.close();
+            return baos.toByteArray();
+        } catch (IOException unexpected) {
+            throw new AssertionError(unexpected);
+        }
+    }
+
+    // Taken from java.lang.Class in OpenJDK 12.
+    // Turned into static function. basicTypeString() not in 11.
+    private static String descriptorString(Class cl) {
+        if (cl.isPrimitive()) {
+            return String.valueOf(Wrapper.forPrimitiveType(cl).basicTypeChar());
+        } else if (cl.isArray()) {
+            return "[" + descriptorString(cl.getComponentType());
+        } else {
+            return "L" + cl.getName().replace('.', '/') + ";";
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

It needed a row of adaptions, but none touching the base functionality.

src/java.base/share/classes/java/io/ObjectInputStream.java
Resolved an import. Trivial.

src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
In this file some cleanup wrt alphabetic ordering was made that does 
not apply to 11. (ProcessStartEvent not in 11.)

test/jdk/jdk/jfr/event/io/TestDeserializationEvent.java
I adapted this test to Java 11 syntax.
It used records and modern instanceof statements.
Also, I included /test/lib/jdk/test/lib/serial/SerialObjectBuilder.java
from "JDK-8254234: Add test library stream object builder".
In that file, I also removed the record and replaced
Class.descriptorString() by a local implementation. DescriptorString() was
introduced in 12.  Backporting 8254234
as prerequisite makes no sense as the adapted test is not 
in 11, thus the backport would be quite incomplete.

test/jdk/jdk/jfr/event/metadata/TestDefaultConfigurations.java
test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
Resolved due to context (ProcessStartEvent not in 11.)

test/lib/jdk/test/lib/jfr/EventNames.java
Resolved due to context (DirectBufferStatistics not in 11.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8261160](https://bugs.openjdk.org/browse/JDK-8261160): Add a deserialization JFR event


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1150/head:pull/1150` \
`$ git checkout pull/1150`

Update a local copy of the PR: \
`$ git checkout pull/1150` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1150`

View PR using the GUI difftool: \
`$ git pr show -t 1150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1150.diff">https://git.openjdk.org/jdk11u-dev/pull/1150.diff</a>

</details>
