### PR TITLE
8213695: gc/TestAllocateHeapAtMultiple.java is slow in some configs

### DIFF
--- a/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,9 +55,8 @@ public class TestAllocateHeapAtMultiple {
       "-Xmx32m -Xms32m -XX:+UseCompressedOops",     // 1. With compressedoops enabled.
       "-Xmx32m -Xms32m -XX:-UseCompressedOops",     // 2. With compressedoops disabled.
       "-Xmx32m -Xms32m -XX:HeapBaseMinAddress=3g",  // 3. With user specified HeapBaseMinAddress.
-      "-Xmx4g -Xms4g",                              // 4. With larger heap size (UnscaledNarrowOop not possible).
-      "-Xmx4g -Xms4g -XX:+UseLargePages",           // 5. Set UseLargePages.
-      "-Xmx4g -Xms4g -XX:+UseNUMA"                  // 6. Set UseNUMA.
+      "-Xmx32m -Xms32m -XX:+UseLargePages",         // 4. Set UseLargePages.
+      "-Xmx32m -Xms32m -XX:+UseNUMA"                // 5. Set UseNUMA.
     };
 
     for(String extraOpts : extraOptsList) {


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8213695](https://bugs.openjdk.org/browse/JDK-8213695): gc/TestAllocateHeapAtMultiple.java is slow in some configs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1151/head:pull/1151` \
`$ git checkout pull/1151`

Update a local copy of the PR: \
`$ git checkout pull/1151` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1151`

View PR using the GUI difftool: \
`$ git pr show -t 1151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1151.diff">https://git.openjdk.org/jdk11u-dev/pull/1151.diff</a>

</details>
