### PR TITLE
Backport f3cb008ce20f3c96fd5d2f3332baf60435d8ea2b

### DIFF
--- a/test/hotspot/jtreg/gc/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAt.java
@@ -40,7 +40,7 @@ import java.util.Collections;
 
 public class TestAllocateHeapAt {
   public static void main(String args[]) throws Exception {
-    ArrayList<String> vmOpts = new ArrayList();
+    ArrayList<String> vmOpts = new ArrayList<>();
 
     String testVmOptsStr = System.getProperty("test.java.opts");
     if (!testVmOptsStr.isEmpty()) {

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAtError.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAtError.java
@@ -42,7 +42,7 @@ import java.util.UUID;
 
 public class TestAllocateHeapAtError {
   public static void main(String args[]) throws Exception {
-    ArrayList<String> vmOpts = new ArrayList();
+    ArrayList<String> vmOpts = new ArrayList<>();
 
     String testVmOptsStr = System.getProperty("test.java.opts");
     if (!testVmOptsStr.isEmpty()) {

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
@@ -40,7 +40,7 @@ import java.util.Collections;
 
 public class TestAllocateHeapAtMultiple {
   public static void main(String args[]) throws Exception {
-    ArrayList<String> vmOpts = new ArrayList();
+    ArrayList<String> vmOpts = new ArrayList<>();
     String[] testVmOpts = null;
 
     String test_dir = System.getProperty("test.dir", ".");

--- a/test/hotspot/jtreg/gc/TestFullGCCount.java
+++ b/test/hotspot/jtreg/gc/TestFullGCCount.java
@@ -52,7 +52,7 @@ public class TestFullGCCount {
         int iterations = 20;
         boolean failed = false;
         String errorMessage = "";
-        HashMap<String, List> counts = new HashMap<>();
+        HashMap<String, List<Long>> counts = new HashMap<>();
 
         // Prime the collection of count lists for all collectors.
         for (int i = 0; i < collectors.size(); i++) {
@@ -91,10 +91,10 @@ public class TestFullGCCount {
         System.out.println("Passed.");
     }
 
-    private static void addCollectionCount(HashMap<String, List> counts, int iteration) {
+    private static void addCollectionCount(HashMap<String, List<Long>> counts, int iteration) {
         for (int i = 0; i < collectors.size(); i++) {
             GarbageCollectorMXBean collector = collectors.get(i);
-            List thisList = counts.get(collector.getName());
+            List<Long> thisList = counts.get(collector.getName());
             thisList.add(collector.getCollectionCount());
         }
     }

--- a/test/hotspot/jtreg/gc/TestSoftReferencesBehaviorOnOOME.java
+++ b/test/hotspot/jtreg/gc/TestSoftReferencesBehaviorOnOOME.java
@@ -71,9 +71,9 @@ public class TestSoftReferencesBehaviorOnOOME {
     void softReferencesOom(long minSize, long maxSize) {
         System.out.format( "minSize = %d, maxSize = %d%n", minSize, maxSize );
 
-        LinkedList<SoftReference> arrSoftRefs = new LinkedList();
+        LinkedList<SoftReference<byte[]>> arrSoftRefs = new LinkedList<>();
         staticRef = arrSoftRefs;
-        LinkedList arrObjects = new LinkedList();
+        LinkedList<byte[]> arrObjects = new LinkedList<>();
         staticRef = arrObjects;
 
         long multiplier = maxSize - minSize;
@@ -89,7 +89,7 @@ public class TestSoftReferencesBehaviorOnOOME {
             while (numSofts-- > 0) {
                 int allocationSize = ((int) (RND_GENERATOR.nextDouble() * multiplier))
                             + (int)minSize;
-                arrSoftRefs.add(new SoftReference(new byte[allocationSize]));
+                arrSoftRefs.add(new SoftReference<byte[]>(new byte[allocationSize]));
             }
 
             System.out.println("free: " + Runtime.getRuntime().freeMemory());
@@ -106,7 +106,7 @@ public class TestSoftReferencesBehaviorOnOOME {
             arrObjects = null;
             long oomSoftArraySize = arrSoftRefs.size();
 
-            for (SoftReference sr : arrSoftRefs) {
+            for (SoftReference<byte[]> sr : arrSoftRefs) {
                 Object o = sr.get();
 
                 if (o != null) {

--- a/test/hotspot/jtreg/gc/TestVerifyDuringStartup.java
+++ b/test/hotspot/jtreg/gc/TestVerifyDuringStartup.java
@@ -41,7 +41,7 @@ import java.util.Collections;
 
 public class TestVerifyDuringStartup {
   public static void main(String args[]) throws Exception {
-    ArrayList<String> vmOpts = new ArrayList();
+    ArrayList<String> vmOpts = new ArrayList<>();
 
     String testVmOptsStr = System.getProperty("test.java.opts");
     if (!testVmOptsStr.isEmpty()) {

--- a/test/hotspot/jtreg/gc/TestVerifySilently.java
+++ b/test/hotspot/jtreg/gc/TestVerifySilently.java
@@ -49,7 +49,7 @@ class TestVerifySilentlyRunSystemGC {
 public class TestVerifySilently {
 
   private static OutputAnalyzer runTest(boolean verifySilently) throws Exception {
-    ArrayList<String> vmOpts = new ArrayList();
+    ArrayList<String> vmOpts = new ArrayList<>();
 
     Collections.addAll(vmOpts, Utils.getFilteredTestJavaOpts("-Xlog.*"));
     Collections.addAll(vmOpts, new String[] {"-XX:+UnlockDiagnosticVMOptions",

--- a/test/hotspot/jtreg/gc/TestVerifySubSet.java
+++ b/test/hotspot/jtreg/gc/TestVerifySubSet.java
@@ -47,7 +47,7 @@ class TestVerifySubSetRunSystemGC {
 public class TestVerifySubSet {
 
     private static OutputAnalyzer runTest(String subset) throws Exception {
-        ArrayList<String> vmOpts = new ArrayList();
+        ArrayList<String> vmOpts = new ArrayList<>();
 
         Collections.addAll(vmOpts, Utils.getFilteredTestJavaOpts("-Xlog.*"));
         Collections.addAll(vmOpts, new String[] {"-XX:+UnlockDiagnosticVMOptions",

--- a/test/hotspot/jtreg/gc/cms/TestMBeanCMS.java
+++ b/test/hotspot/jtreg/gc/cms/TestMBeanCMS.java
@@ -137,7 +137,7 @@ public class TestMBeanCMS {
     public void allocationWork(long target) {
 
         long sizeAllocated = 0;
-        List list = new LinkedList();
+        List<byte[]> list = new LinkedList<>();
         long delay = 50;
         long count = 0;
 

--- a/test/hotspot/jtreg/gc/g1/TestHumongousShrinkHeap.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousShrinkHeap.java
@@ -52,7 +52,7 @@ public class TestHumongousShrinkHeap {
     public static final String MIN_FREE_RATIO_FLAG_NAME = "MinHeapFreeRatio";
     public static final String MAX_FREE_RATIO_FLAG_NAME = "MaxHeapFreeRatio";
 
-    private static final List<List<byte[]>> garbage = new ArrayList();
+    private static final List<List<byte[]>> garbage = new ArrayList<>();
     private static final int REGION_SIZE = 1024 * 1024; // 1M
     private static final int LISTS_COUNT = 10;
     private static final int HUMON_SIZE = Math.round(.9f * REGION_SIZE);
@@ -108,7 +108,7 @@ public class TestHumongousShrinkHeap {
     private void allocate() {
 
         for (int i = 0; i < LISTS_COUNT; i++) {
-            List<byte[]> stuff = new ArrayList();
+            List<byte[]> stuff = new ArrayList<>();
             allocateList(stuff, HUMON_COUNT, HUMON_SIZE);
             MemoryUsagePrinter.printMemoryUsage("allocate #" + (i+1));
             garbage.add(stuff);
@@ -120,12 +120,12 @@ public class TestHumongousShrinkHeap {
         garbage.subList(0, garbage.size() - 1).clear();
 
         // do not free last one element from last list
-        List stuff = garbage.get(garbage.size() - 1);
+        List<byte[]> stuff = garbage.get(garbage.size() - 1);
         stuff.subList(0, stuff.size() - 1).clear();
         System.gc();
     }
 
-    private static void allocateList(List garbage, int count, int size) {
+    private static void allocateList(List<byte[]> garbage, int count, int size) {
         for (int i = 0; i < count; i++) {
             garbage.add(new byte[size]);
         }

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData.java
@@ -71,7 +71,7 @@ public class TestShrinkAuxiliaryData {
     }
 
     protected void test() throws Exception {
-        ArrayList<String> vmOpts = new ArrayList();
+        ArrayList<String> vmOpts = new ArrayList<>();
         Collections.addAll(vmOpts, initialOpts);
 
         int maxCacheSize = Math.max(0, Math.min(31, getMaxCacheSize()));
@@ -87,14 +87,14 @@ public class TestShrinkAuxiliaryData {
 
         // for 32 bits ObjectAlignmentInBytes is not a option
         if (Platform.is32bit()) {
-            ArrayList<String> vmOptsWithoutAlign = new ArrayList(vmOpts);
+            ArrayList<String> vmOptsWithoutAlign = new ArrayList<>(vmOpts);
             vmOptsWithoutAlign.add(ShrinkAuxiliaryDataTest.class.getName());
             performTest(vmOptsWithoutAlign);
             return;
         }
 
         for (int alignment = 3; alignment <= 8; alignment++) {
-            ArrayList<String> vmOptsWithAlign = new ArrayList(vmOpts);
+            ArrayList<String> vmOptsWithAlign = new ArrayList<>(vmOpts);
             vmOptsWithAlign.add("-XX:ObjectAlignmentInBytes="
                     + (int) Math.pow(2, alignment));
             vmOptsWithAlign.add(ShrinkAuxiliaryDataTest.class.getName());
@@ -205,8 +205,8 @@ public class TestShrinkAuxiliaryData {
 
         class GarbageObject {
 
-            private final List<byte[]> payload = new ArrayList();
-            private final List<GarbageObject> ref = new LinkedList();
+            private final List<byte[]> payload = new ArrayList<>();
+            private final List<GarbageObject> ref = new LinkedList<>();
 
             public GarbageObject(int size) {
                 payload.add(new byte[size]);
@@ -223,7 +223,7 @@ public class TestShrinkAuxiliaryData {
             }
         }
 
-        private final List<GarbageObject> garbage = new ArrayList();
+        private final List<GarbageObject> garbage = new ArrayList<>();
 
         public void test() throws IOException {
 

--- a/test/hotspot/jtreg/gc/g1/TestShrinkDefragmentedHeap.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkDefragmentedHeap.java
@@ -140,7 +140,7 @@ public class TestShrinkDefragmentedHeap {
             garbage.subList(0, garbage.size() - 1).clear();
 
             // do not free last one element from last list
-            ArrayList stuff = garbage.get(garbage.size() - 1);
+            ArrayList<byte[]> stuff = garbage.get(garbage.size() - 1);
             if (stuff.size() > 1) {
                 stuff.subList(0, stuff.size() - 1).clear();
             }
@@ -160,7 +160,7 @@ public class TestShrinkDefragmentedHeap {
             );
         }
 
-        private static void allocateList(List garbage, int count, int size) {
+        private static void allocateList(List<byte[]> garbage, int count, int size) {
             for (int i = 0; i < count; i++) {
                 garbage.add(new byte[size]);
             }

--- a/test/hotspot/jtreg/gc/g1/humongousObjects/TestObjectCollected.java
+++ b/test/hotspot/jtreg/gc/g1/humongousObjects/TestObjectCollected.java
@@ -139,7 +139,7 @@ public class TestObjectCollected {
 
         System.out.println(String.format("Testing %s reference behavior after %s", ref.name(), gc.name()));
 
-        Reference reference = ref.create();
+        Reference<byte[]> reference = ref.create();
         Asserts.assertNotNull(reference, "Test Bug: failed to allocate reference");
         long adr = WHITE_BOX.getObjectAddress(reference.get());
 

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
@@ -93,7 +93,7 @@ import gc.testlibrary.PerfCounters;
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:+UsePerfData -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC gc.metaspace.TestMetaspacePerfCounters
  */
 public class TestMetaspacePerfCounters {
-    public static Class fooClass = null;
+    public static Class<?> fooClass = null;
     private static final String[] counterNames = {"minCapacity", "maxCapacity", "capacity", "used"};
     private static final List<GarbageCollectorMXBean> gcBeans = ManagementFactoryHelper.getGarbageCollectorMXBeans();
 

--- a/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
+++ b/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
@@ -55,12 +55,12 @@ public class TestReclaimStringsLeaksMemory {
     public static final int ReservedThreshold = 70000000;
 
     public static void main(String[] args) throws Exception {
-        ArrayList<String> baseargs = new ArrayList(Arrays.asList( "-Xms256M",
-                                                                  "-Xmx256M",
-                                                                  "-Xlog:gc*,stringtable*=debug:gc.log",
-                                                                  "-XX:NativeMemoryTracking=summary",
-                                                                  "-XX:+UnlockDiagnosticVMOptions",
-                                                                  "-XX:+PrintNMTStatistics" ));
+        ArrayList<String> baseargs = new ArrayList<>(Arrays.asList("-Xms256M",
+                                                                   "-Xmx256M",
+                                                                   "-Xlog:gc*,stringtable*=debug:gc.log",
+                                                                   "-XX:NativeMemoryTracking=summary",
+                                                                   "-XX:+UnlockDiagnosticVMOptions",
+                                                                   "-XX:+PrintNMTStatistics" ));
         baseargs.addAll(Arrays.asList(args));
         baseargs.add(GCTest.class.getName());
         ProcessBuilder pb_default =


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.=
Trivial resolve: context in TestReclaimStringsLeaksMemory.java
adaptions to nvdimm tests omitted, the tests are not in 11