### PR TITLE
8226976: SessionTimeOutTests uses == operator for String value check

### DIFF
--- a/test/jdk/javax/net/ssl/SSLSession/SessionTimeOutTests.java
+++ b/test/jdk/javax/net/ssl/SSLSession/SessionTimeOutTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -283,7 +283,7 @@ public class SessionTimeOutTests {
             }
             System.out.print(sess + "      " + lifetime);
             if (((timeout == 0) || (lifetime < timeout)) &&
-                                  (isTimedout == "YES")) {
+                                  (isTimedout.equals("YES"))) {
                 isTimedout = "Invalidated before timeout";
             }
 


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8226976](https://bugs.openjdk.org/browse/JDK-8226976): SessionTimeOutTests uses == operator for String value check


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1154/head:pull/1154` \
`$ git checkout pull/1154`

Update a local copy of the PR: \
`$ git checkout pull/1154` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1154`

View PR using the GUI difftool: \
`$ git pr show -t 1154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1154.diff">https://git.openjdk.org/jdk11u-dev/pull/1154.diff</a>

</details>
