### PR TITLE
8272398: Update DockerTestUtils.buildJdkDockerImage()

### DIFF
--- a/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
+++ b/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
@@ -48,7 +48,7 @@ public class DockerBasicTest {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageNameAndTag, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageNameAndTag);
 
         try {
             testJavaVersion();

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -52,7 +52,7 @@ public class TestCPUAwareness {
         }
 
         System.out.println("Test Environment: detected availableCPUs = " + availableCPUs);
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             // cpuset, period, shares, expected Active Processor Count

--- a/test/hotspot/jtreg/containers/docker/TestCPUSets.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUSets.java
@@ -57,7 +57,7 @@ public class TestCPUSets {
 
 
         Common.prepareWhiteBox();
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             // Sanity test the cpu sets reader and parser

--- a/test/hotspot/jtreg/containers/docker/TestJFREvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFREvents.java
@@ -58,7 +58,7 @@ public class TestJFREvents {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             // leave one CPU for system and tools, otherwise this test may be unstable

--- a/test/hotspot/jtreg/containers/docker/TestJFRNetworkEvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFRNetworkEvents.java
@@ -51,7 +51,7 @@ public class TestJFRNetworkEvents {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             runTest("jdk.SocketWrite");

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -50,7 +50,7 @@ public class TestMemoryAwareness {
         }
 
         Common.prepareWhiteBox();
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             testMemoryLimit("100m", "104857600");

--- a/test/hotspot/jtreg/containers/docker/TestMisc.java
+++ b/test/hotspot/jtreg/containers/docker/TestMisc.java
@@ -50,7 +50,7 @@ public class TestMisc {
         }
 
         Common.prepareWhiteBox();
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             testMinusContainerSupport();

--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -52,7 +52,7 @@ public class TestPids {
         }
 
         Common.prepareWhiteBox();
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             testPids();

--- a/test/jdk/jdk/internal/platform/docker/TestDockerCpuMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerCpuMetrics.java
@@ -54,7 +54,7 @@ public class TestDockerCpuMetrics {
         // container include the Java test class to be run along with the
         // resource to be examined and expected result.
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             int numCpus = CPUSetsReader.getNumCpus();

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -52,7 +52,7 @@ public class TestDockerMemoryMetrics {
         // container include the Java test class to be run along with the
         // resource to be examined and expected result.
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
         try {
             testMemoryLimit("200m");
             testMemoryLimit("1g");

--- a/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
+++ b/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
@@ -43,7 +43,7 @@ public class TestGetFreeSwapSpaceSize {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             testGetFreeSwapSpaceSize(

--- a/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
+++ b/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
@@ -48,7 +48,7 @@ public class TestPidsLimit {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             testPidsLimit("1000");

--- a/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
@@ -45,7 +45,7 @@ public class TestSystemMetrics {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             Common.logNewTestCase("Test SystemMetrics");

--- a/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
+++ b/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
@@ -44,7 +44,7 @@ public class TestUseContainerSupport {
             return;
         }
 
-        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+        DockerTestUtils.buildJdkContainerImage(imageName);
 
         try {
             testUseContainerSupport(true);


### PR DESCRIPTION
backport of 8272398, without
test/hotspot/jtreg/containers/docker/TestJFRWithJMX.java
test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
those files are not present in 11u-dev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272398](https://bugs.openjdk.org/browse/JDK-8272398): Update DockerTestUtils.buildJdkDockerImage()


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1156/head:pull/1156` \
`$ git checkout pull/1156`

Update a local copy of the PR: \
`$ git checkout pull/1156` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1156`

View PR using the GUI difftool: \
`$ git pr show -t 1156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1156.diff">https://git.openjdk.org/jdk11u-dev/pull/1156.diff</a>

</details>
