### PR TITLE
8217170: gc/arguments/TestUseCompressedOopsErgo.java timed out

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/GCArguments.java
+++ b/test/hotspot/jtreg/gc/arguments/GCArguments.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.arguments;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.ProcessTools;
+
+/**
+ * Helper class for adding options to child processes that should be
+ * used by all of the argument tests in this package.  The default
+ * options are added at the front, to allow them to be overridden by
+ * explicit options from any particular test.
+ */
+
+public final class GCArguments {
+
+    // Avoid excessive execution time.
+    static private void disableZapUnusedHeapArea(List<String> arguments) {
+        // Develop option, only available in debug builds.
+        if (Platform.isDebugBuild()) {
+            arguments.add("-XX:-ZapUnusedHeapArea");
+        }
+    }
+
+    // Avoid excessive execution time.
+    static private void disableVerifyBeforeExit(List<String> arguments) {
+        // Diagnostic option, default enabled in debug builds.
+        if (Platform.isDebugBuild()) {
+            arguments.add("-XX:-VerifyBeforeExit");
+        }
+    }
+
+    static private void addDefaults(List<String> arguments) {
+        disableZapUnusedHeapArea(arguments);
+        disableVerifyBeforeExit(arguments);
+    }
+
+    static private String[] withDefaults(String[] arguments) {
+        List<String> augmented = new ArrayList<String>();
+        addDefaults(augmented);
+        Collections.addAll(augmented, arguments);
+        return augmented.toArray(new String[augmented.size()]);
+    }
+
+    static public ProcessBuilder createJavaProcessBuilder(String... arguments) {
+        return createJavaProcessBuilder(false, arguments);
+    }
+
+    static public ProcessBuilder createJavaProcessBuilder(boolean addTestVmAndJavaOptions,
+                                                          String... arguments) {
+        return ProcessTools.createJavaProcessBuilder(addTestVmAndJavaOptions,
+                                                     withDefaults(arguments));
+    }
+
+}

--- a/test/hotspot/jtreg/gc/arguments/TestAggressiveHeap.java
+++ b/test/hotspot/jtreg/gc/arguments/TestAggressiveHeap.java
@@ -30,6 +30,7 @@ package gc.arguments;
  * @requires vm.gc.Parallel
  * @summary Test argument processing for -XX:+AggressiveHeap.
  * @library /test/lib
+ * @library /
  * @modules java.base java.management
  * @run driver gc.arguments.TestAggressiveHeap
  */
@@ -66,7 +67,7 @@ public class TestAggressiveHeap {
         " *bool +UseParallelGC *= *true +\\{product\\} *\\{command line\\}";
 
     private static void testFlag() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
             option, heapSizeOption, "-XX:+PrintFlagsFinal", "-version");
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/gc/arguments/TestArrayAllocatorMallocLimit.java
+++ b/test/hotspot/jtreg/gc/arguments/TestArrayAllocatorMallocLimit.java
@@ -30,6 +30,7 @@ package gc.arguments;
  * @bug 8054823
  * @key gc
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run driver gc.arguments.TestArrayAllocatorMallocLimit
@@ -52,7 +53,7 @@ public class TestArrayAllocatorMallocLimit {
   private static final String printFlagsFinalPattern = " *size_t *" + flagName + " *:?= *(\\d+) *\\{experimental\\} *";
 
   public static void testDefaultValue()  throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
       "-XX:+UnlockExperimentalVMOptions", "-XX:+PrintFlagsFinal", "-version");
 
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
@@ -78,7 +79,7 @@ public class TestArrayAllocatorMallocLimit {
   public static void testSetValue() throws Exception {
     long flagValue = 2048;
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
       "-XX:+UnlockExperimentalVMOptions", "-XX:" + flagName + "=" + flagValue, "-XX:+PrintFlagsFinal", "-version");
 
     OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java
@@ -33,6 +33,7 @@ import jdk.test.lib.Platform;
  * @summary Tests that VM prints a warning when -XX:CompressedClassSpaceSize
  *          is used together with -XX:-UseCompressedClassPointers
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run main gc.arguments.TestCompressedClassFlags
@@ -50,7 +51,7 @@ public class TestCompressedClassFlags {
     }
 
     private static OutputAnalyzer runJava(String ... args) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args);
+        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(args);
         return new OutputAnalyzer(pb.start());
     }
 }

--- a/test/hotspot/jtreg/gc/arguments/TestDisableDefaultGC.java
+++ b/test/hotspot/jtreg/gc/arguments/TestDisableDefaultGC.java
@@ -29,6 +29,7 @@ package gc.arguments;
  * @bug 8068579
  * @key gc
  * @library /test/lib
+ * @library /
  * @requires vm.gc=="null"
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -41,13 +42,13 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class TestDisableDefaultGC {
     public static void main(String[] args) throws Exception {
         // Start VM, disabling all possible default GCs
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:-UseSerialGC",
-                                                                  "-XX:-UseParallelGC",
-                                                                  "-XX:-UseG1GC",
-                                                                  "-XX:-UseConcMarkSweepGC",
-                                                                  "-XX:+UnlockExperimentalVMOptions",
-                                                                  "-XX:-UseZGC",
-                                                                  "-version");
+        ProcessBuilder pb = GCArguments.createJavaProcessBuilder("-XX:-UseSerialGC",
+                                                                 "-XX:-UseParallelGC",
+                                                                 "-XX:-UseG1GC",
+                                                                 "-XX:-UseConcMarkSweepGC",
+                                                                 "-XX:+UnlockExperimentalVMOptions",
+                                                                 "-XX:-UseZGC",
+                                                                 "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldMatch("Garbage collector not selected");
         output.shouldHaveExitValue(1);

--- a/test/hotspot/jtreg/gc/arguments/TestG1ConcMarkStepDurationMillis.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1ConcMarkStepDurationMillis.java
@@ -29,6 +29,7 @@ package gc.arguments;
  * @requires vm.gc.G1
  * @summary Tests argument processing for double type flag, G1ConcMarkStepDurationMillis
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run main gc.arguments.TestG1ConcMarkStepDurationMillis
@@ -79,7 +80,7 @@ public class TestG1ConcMarkStepDurationMillis {
 
     Collections.addAll(vmOpts, "-XX:+UseG1GC", "-XX:G1ConcMarkStepDurationMillis="+expectedValue, "-XX:+PrintFlagsFinal", "-version");
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     output.shouldHaveExitValue(expectedResult == PASS ? 0 : 1);

--- a/test/hotspot/jtreg/gc/arguments/TestG1ConcRefinementThreads.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1ConcRefinementThreads.java
@@ -30,6 +30,7 @@ package gc.arguments;
  * @requires vm.gc.G1
  * @summary Tests argument processing for G1ConcRefinementThreads
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run main gc.arguments.TestG1ConcRefinementThreads
@@ -70,7 +71,7 @@ public class TestG1ConcRefinementThreads {
     }
     Collections.addAll(vmOpts, "-XX:+UseG1GC", "-XX:+PrintFlagsFinal", "-version");
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java
@@ -32,6 +32,7 @@ package gc.arguments;
  * @modules java.base/jdk.internal.misc
  * @modules java.management/sun.management
  * @library /test/lib
+ * @library /
  * @run main gc.arguments.TestG1HeapRegionSize
  */
 
@@ -53,7 +54,7 @@ public class TestG1HeapRegionSize {
     flagList.add("-XX:+PrintFlagsFinal");
     flagList.add("-version");
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(flagList.toArray(new String[0]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flagList.toArray(new String[0]));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(exitValue);
 

--- a/test/hotspot/jtreg/gc/arguments/TestG1PercentageOptions.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1PercentageOptions.java
@@ -30,6 +30,7 @@ package gc.arguments;
  * @requires vm.gc.G1
  * @summary Test argument processing of various percentage options
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run driver gc.arguments.TestG1PercentageOptions
@@ -65,7 +66,7 @@ public class TestG1PercentageOptions {
 
     private static void check(String flag, boolean is_valid) throws Exception {
         String[] flags = new String[] { "-XX:+UseG1GC", flag, "-version" };
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(flags);
+        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flags);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         if (is_valid) {
             output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
+++ b/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
@@ -29,6 +29,7 @@ package gc.arguments;
  * @bug 8025661
  * @summary Test parsing of -Xminf and -Xmaxf
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run main/othervm gc.arguments.TestHeapFreeRatio
@@ -48,7 +49,7 @@ public class TestHeapFreeRatio {
   }
 
   private static void testMinMaxFreeRatio(String min, String max, Validation type) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
         "-Xminf" + min,
         "-Xmaxf" + max,
         "-version");

--- a/test/hotspot/jtreg/gc/arguments/TestInitialTenuringThreshold.java
+++ b/test/hotspot/jtreg/gc/arguments/TestInitialTenuringThreshold.java
@@ -30,6 +30,7 @@ package gc.arguments;
  * @requires vm.gc.Parallel
  * @summary Tests argument processing for initial tenuring threshold
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run main/othervm gc.arguments.TestInitialTenuringThreshold
@@ -42,7 +43,7 @@ import jdk.test.lib.process.ProcessTools;
 public class TestInitialTenuringThreshold {
 
   public static void runWithThresholds(int initial, int max, boolean shouldfail) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
       "-XX:+UseParallelGC",
       "-XX:InitialTenuringThreshold=" + String.valueOf(initial),
       "-XX:MaxTenuringThreshold=" + String.valueOf(max),
@@ -59,7 +60,7 @@ public class TestInitialTenuringThreshold {
 
 
   public static void main(String args[]) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
       // some value below the default value of InitialTenuringThreshold of 7
       "-XX:MaxTenuringThreshold=1",
       "-version"

--- a/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
@@ -98,7 +98,7 @@ class TestMaxHeapSizeTools {
   }
 
   private static void getNewOldSize(String gcflag, long[] values) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(gcflag,
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(gcflag,
       "-XX:+PrintFlagsFinal", "-version");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
@@ -179,7 +179,7 @@ class TestMaxHeapSizeTools {
     finalargs.add(classname);
     finalargs.addAll(Arrays.asList(arguments));
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs.toArray(new String[0]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(new String[0]));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
 
@@ -279,7 +279,7 @@ class TestMaxHeapSizeTools {
   }
 
   private static void expect(String[] flags, boolean hasWarning, boolean hasError, int errorcode) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(flags);
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flags);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     shouldContainOrNot(output, hasWarning, "Warning");
     shouldContainOrNot(output, hasError, "Error");

--- a/test/hotspot/jtreg/gc/arguments/TestMaxMinHeapFreeRatioFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxMinHeapFreeRatioFlags.java
@@ -100,7 +100,7 @@ public class TestMaxMinHeapFreeRatioFlags {
                 Boolean.toString(shrinkHeapInSteps)
         );
 
-        ProcessBuilder procBuilder = ProcessTools.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
         analyzer.shouldHaveExitValue(0);
     }
@@ -125,7 +125,7 @@ public class TestMaxMinHeapFreeRatioFlags {
                 "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
                 "-version"
         );
-        ProcessBuilder procBuilder = ProcessTools.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
         analyzer.shouldHaveExitValue(1);
         analyzer.shouldContain("Error: Could not create the Java Virtual Machine.");

--- a/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
@@ -31,6 +31,7 @@ package gc.arguments;
  * processing.
  * @requires vm.gc.Serial
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run main gc.arguments.TestMaxNewSize -XX:+UseSerialGC
@@ -45,6 +46,7 @@ package gc.arguments;
  * processing.
  * @requires vm.gc.Parallel
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run main gc.arguments.TestMaxNewSize -XX:+UseParallelGC
@@ -59,6 +61,7 @@ package gc.arguments;
  * processing.
  * @requires vm.gc.G1
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run main gc.arguments.TestMaxNewSize -XX:+UseG1GC
@@ -72,6 +75,7 @@ package gc.arguments;
  * @comment Graal does not support CMS
  * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run main gc.arguments.TestMaxNewSize -XX:+UseConcMarkSweepGC
@@ -104,7 +108,7 @@ public class TestMaxNewSize {
     finalargs.addAll(Arrays.asList(flags));
     finalargs.add("-version");
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs.toArray(new String[0]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(new String[0]));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldContain("Initial young gen size set larger than the maximum young gen size");
   }
@@ -127,7 +131,7 @@ public class TestMaxNewSize {
     finalargs.add("-XX:+PrintFlagsFinal");
     finalargs.add("-version");
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs.toArray(new String[0]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(new String[0]));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
     String stdout = output.getStdout();

--- a/test/hotspot/jtreg/gc/arguments/TestMinAndInitialSurvivorRatioFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMinAndInitialSurvivorRatioFlags.java
@@ -104,7 +104,7 @@ public class TestMinAndInitialSurvivorRatioFlags {
                 Boolean.toString(useAdaptiveSizePolicy)
         );
         vmOptions.removeIf((String p) -> p.isEmpty());
-        ProcessBuilder procBuilder = ProcessTools.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
         analyzer.shouldHaveExitValue(0);
     }

--- a/test/hotspot/jtreg/gc/arguments/TestNewRatioFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestNewRatioFlag.java
@@ -84,7 +84,7 @@ public class TestNewRatioFlag {
                 Integer.toString(ratio)
         );
 
-        ProcessBuilder procBuilder = ProcessTools.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
         analyzer.shouldHaveExitValue(0);
         System.out.println(analyzer.getOutput());

--- a/test/hotspot/jtreg/gc/arguments/TestNewSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestNewSizeFlags.java
@@ -168,7 +168,7 @@ public class TestNewSizeFlags {
                 Long.toString(maxHeapSize)
         );
         vmOptions.removeIf(String::isEmpty);
-        ProcessBuilder procBuilder = ProcessTools.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
         return analyzer;
     }

--- a/test/hotspot/jtreg/gc/arguments/TestNewSizeThreadIncrease.java
+++ b/test/hotspot/jtreg/gc/arguments/TestNewSizeThreadIncrease.java
@@ -29,6 +29,7 @@ package gc.arguments;
  * @bug 8144527
  * @summary Tests argument processing for NewSizeThreadIncrease
  * @library /test/lib
+ * @library /
  * @requires vm.gc.Serial
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -67,13 +68,13 @@ public class TestNewSizeThreadIncrease {
   }
 
   static void runNewSizeThreadIncreaseTest(String expectedValue, boolean isNewsizeChanged) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+UseSerialGC",
-                                                              "-Xms96M",
-                                                              "-Xmx128M",
-                                                              "-XX:NewRatio=2",
-                                                              "-Xlog:gc+heap+ergo=debug",
-                                                              "-XX:NewSizeThreadIncrease="+expectedValue,
-                                                              GCTest.class.getName());
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder("-XX:+UseSerialGC",
+                                                             "-Xms96M",
+                                                             "-Xmx128M",
+                                                             "-XX:NewRatio=2",
+                                                             "-Xlog:gc+heap+ergo=debug",
+                                                             "-XX:NewSizeThreadIncrease="+expectedValue,
+                                                             GCTest.class.getName());
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/arguments/TestObjectTenuringFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestObjectTenuringFlags.java
@@ -163,7 +163,7 @@ public class TestObjectTenuringFlags {
     }
     Collections.addAll(vmOpts, "-XX:+UseParallelGC", "-XX:+PrintFlagsFinal", "-version");
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     if (shouldFail) {

--- a/test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java
@@ -58,7 +58,7 @@ public class TestParallelGCThreads {
   private static final String printFlagsFinalPattern = " *uint *" + flagName + " *:?= *(\\d+) *\\{product\\} *";
 
   public static void testDefaultValue()  throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
       "-XX:+UnlockExperimentalVMOptions", "-XX:+PrintFlagsFinal", "-version");
 
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
@@ -101,7 +101,7 @@ public class TestParallelGCThreads {
 
       // Make sure the VM does not allow ParallelGCThreads set to 0
       String[] flags = new String[] {"-XX:+Use" + gc + "GC", "-XX:ParallelGCThreads=0", "-XX:+PrintFlagsFinal", "-version"};
-      ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(flags);
+      ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flags);
       OutputAnalyzer output = new OutputAnalyzer(pb.start());
       output.shouldHaveExitValue(1);
 
@@ -124,7 +124,7 @@ public class TestParallelGCThreads {
   }
 
   public static long getParallelGCThreadCount(String flags[]) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(flags);
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flags);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
     String stdout = output.getStdout();

--- a/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
@@ -28,6 +28,7 @@ package gc.arguments;
  * @key gc
  * @summary Test defaults processing for -XX:+ParallelRefProcEnabled.
  * @library /test/lib
+ * @library /
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI gc.arguments.TestParallelRefProc
@@ -80,7 +81,7 @@ public class TestParallelRefProc {
         result.addAll(Arrays.asList(args));
         result.add("-XX:+PrintFlagsFinal");
         result.add("-version");
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(result.toArray(new String[0]));
+        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(result.toArray(new String[0]));
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 

--- a/test/hotspot/jtreg/gc/arguments/TestSelectDefaultGC.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSelectDefaultGC.java
@@ -29,6 +29,7 @@ package gc.arguments;
  * @bug 8068582
  * @key gc
  * @library /test/lib
+ * @library /
  * @requires vm.gc.Serial & vm.gc.G1
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -55,7 +56,7 @@ public class TestSelectDefaultGC {
         };
 
         // Start VM without specifying GC
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args);
+        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(args);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
 

--- a/test/hotspot/jtreg/gc/arguments/TestSmallInitialHeapWithLargePageAndNUMA.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSmallInitialHeapWithLargePageAndNUMA.java
@@ -30,6 +30,7 @@ package gc.arguments;
  * @requires vm.gc.Parallel
  * @summary Check large pages and NUMA are working together via the output message.
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  * @modules java.management/sun.management
  * @build TestSmallInitialHeapWithLargePageAndNUMA
@@ -67,7 +68,7 @@ public class TestSmallInitialHeapWithLargePageAndNUMA {
                        "-XX:+PrintFlagsFinal",
                        "-version"};
 
-    ProcessBuilder pb_enabled = ProcessTools.createJavaProcessBuilder(vmArgs);
+    ProcessBuilder pb_enabled = GCArguments.createJavaProcessBuilder(vmArgs);
     OutputAnalyzer analyzer = new OutputAnalyzer(pb_enabled.start());
 
     if (largePageOrNumaEnabled(analyzer)) {

--- a/test/hotspot/jtreg/gc/arguments/TestSurvivorRatioFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSurvivorRatioFlag.java
@@ -89,7 +89,7 @@ public class TestSurvivorRatioFlag {
                 Integer.toString(ratio)
         );
 
-        ProcessBuilder procBuilder = ProcessTools.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
         analyzer.shouldHaveExitValue(0);
     }

--- a/test/hotspot/jtreg/gc/arguments/TestTargetSurvivorRatioFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestTargetSurvivorRatioFlag.java
@@ -117,7 +117,7 @@ public class TestTargetSurvivorRatioFlag {
         vmOptions.add("-XX:TargetSurvivorRatio=" + ratio);
         vmOptions.add("-version");
 
-        ProcessBuilder procBuilder = ProcessTools.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
 
         analyzer.shouldHaveExitValue(1);
@@ -152,7 +152,7 @@ public class TestTargetSurvivorRatioFlag {
                 Integer.toString(ratio)
         );
 
-        ProcessBuilder procBuilder = ProcessTools.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
 
         analyzer.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/arguments/TestUnrecognizedVMOptionsHandling.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUnrecognizedVMOptionsHandling.java
@@ -29,6 +29,7 @@ package gc.arguments;
  * @bug 8017611
  * @summary Tests handling unrecognized VM options
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run main/othervm gc.arguments.TestUnrecognizedVMOptionsHandling
@@ -41,7 +42,7 @@ public class TestUnrecognizedVMOptionsHandling {
 
   public static void main(String args[]) throws Exception {
     // The first two JAVA processes are expected to fail, but with a correct VM option suggestion
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
       "-XX:+UseDynamicNumberOfGcThreads",
       "-version"
       );
@@ -51,7 +52,7 @@ public class TestUnrecognizedVMOptionsHandling {
       throw new RuntimeException("Not expected to get exit value 0");
     }
 
-    pb = ProcessTools.createJavaProcessBuilder(
+    pb = GCArguments.createJavaProcessBuilder(
       "-XX:MaxiumHeapSize=500m",
       "-version"
       );
@@ -62,7 +63,7 @@ public class TestUnrecognizedVMOptionsHandling {
     }
 
     // The last JAVA process should run successfully for the purpose of sanity check
-    pb = ProcessTools.createJavaProcessBuilder(
+    pb = GCArguments.createJavaProcessBuilder(
       "-XX:+UseDynamicNumberOfGCThreads",
       "-version"
       );

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
@@ -105,7 +105,7 @@ class TestUseCompressedOopsErgoTools {
     finalargs.add(classname);
     finalargs.addAll(Arrays.asList(arguments));
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs.toArray(new String[0]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(new String[0]));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
     return output;
@@ -169,7 +169,7 @@ class TestUseCompressedOopsErgoTools {
   }
 
   private static String expect(String[] flags, boolean hasWarning, boolean hasError, int errorcode) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(flags);
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flags);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(errorcode);
     return output.getStdout();

--- a/test/hotspot/jtreg/gc/arguments/TestUseNUMAInterleaving.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseNUMAInterleaving.java
@@ -30,6 +30,7 @@ package gc.arguments;
  * @bug 8059614
  * @key gc
  * @library /test/lib
+ * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run driver gc.arguments.TestUseNUMAInterleaving
@@ -45,7 +46,7 @@ public class TestUseNUMAInterleaving {
             "-XX:+PrintFlagsFinal",
             "-version"
         };
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, vmargs);
+        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(true, vmargs);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
         boolean isNUMAEnabled

--- a/test/hotspot/jtreg/gc/arguments/TestVerifyBeforeAndAfterGCFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestVerifyBeforeAndAfterGCFlags.java
@@ -34,6 +34,7 @@ package gc.arguments;
  * @modules java.base/jdk.internal.misc
  * @modules java.management
  * @library /test/lib
+ * @library /
  * @run driver gc.arguments.TestVerifyBeforeAndAfterGCFlags
  */
 
@@ -76,7 +77,6 @@ public class TestVerifyBeforeAndAfterGCFlags {
         if (opts != null && (opts.length > 0)) {
             Collections.addAll(vmOpts, opts);
         }
-
         Collections.addAll(vmOpts, new String[] {
                                        "-Xlog:gc+verify=debug",
                                        "-Xmx5m",
@@ -89,8 +89,8 @@ public class TestVerifyBeforeAndAfterGCFlags {
                                                       : "-XX:-VerifyAfterGC"),
                                        GarbageProducer.class.getName() });
         ProcessBuilder procBuilder =
-            ProcessTools.createJavaProcessBuilder(vmOpts.toArray(
-                                                   new String[vmOpts.size()]));
+            GCArguments.createJavaProcessBuilder(vmOpts.toArray(
+                                                     new String[vmOpts.size()]));
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
 
         analyzer.shouldHaveExitValue(0);


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

test/hotspot/jtreg/gc/arguments/TestDisableDefaultGC.java
Trivial resolve.

test/hotspot/jtreg/gc/arguments/TestMaxRAMFlags.java omitted.
Test came with https://bugs.openjdk.org/browse/JDK-8224764 which is not in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8217170](https://bugs.openjdk.org/browse/JDK-8217170): gc/arguments/TestUseCompressedOopsErgo.java timed out


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1159/head:pull/1159` \
`$ git checkout pull/1159`

Update a local copy of the PR: \
`$ git checkout pull/1159` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1159`

View PR using the GUI difftool: \
`$ git pr show -t 1159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1159.diff">https://git.openjdk.org/jdk11u-dev/pull/1159.diff</a>

</details>
