### PR TITLE
8288763: Pack200 extraction failure with invalid size

### DIFF
--- a/src/java.base/share/classes/com/sun/java/util/jar/pack/Utils.java
+++ b/src/java.base/share/classes/com/sun/java/util/jar/pack/Utils.java
@@ -221,7 +221,7 @@ class Utils {
         byte[] buffer = new byte[1 << 14];
         for (JarEntry je; (je = in.getNextJarEntry()) != null; ) {
             je.setCompressedSize(-1);
-				out.putNextEntry(je);
+            out.putNextEntry(je);
             for (int nr; 0 < (nr = in.read(buffer)); ) {
                 out.write(buffer, 0, nr);
             }

--- a/src/java.base/share/classes/com/sun/java/util/jar/pack/Utils.java
+++ b/src/java.base/share/classes/com/sun/java/util/jar/pack/Utils.java
@@ -220,7 +220,8 @@ class Utils {
         }
         byte[] buffer = new byte[1 << 14];
         for (JarEntry je; (je = in.getNextJarEntry()) != null; ) {
-            out.putNextEntry(je);
+            je.setCompressedSize(-1);
+				out.putNextEntry(je);
             for (int nr; 0 < (nr = in.read(buffer)); ) {
                 out.write(buffer, 0, nr);
             }
@@ -231,6 +232,7 @@ class Utils {
     static void copyJarFile(JarFile in, JarOutputStream out) throws IOException {
         byte[] buffer = new byte[1 << 14];
         for (JarEntry je : Collections.list(in.entries())) {
+            je.setCompressedSize(-1);
             out.putNextEntry(je);
             InputStream ein = in.getInputStream(je);
             for (int nr; 0 < (nr = ein.read(buffer)); ) {


### PR DESCRIPTION
While running some internal testing, a college has discovered a failure related to the Pack200 archive format on the zLinux platform. The problematic code was removed in the current repo by [JDK-8234596](https://bugs.openjdk.org/browse/JDK-8234596), however that change was large, and required a CSR. I feel that it would be too risky and cumbersome to backport those changes to jdk11 (and ultimately jdk8 as well), so I'd like to propose this change as a new change to jdk11 rather than via the usual backport process.

### Testing
These changes have been run against the failing test on zLinux and the Tier 1 tests completed successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288763](https://bugs.openjdk.org/browse/JDK-8288763): Pack200 extraction failure with invalid size


### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1163/head:pull/1163` \
`$ git checkout pull/1163`

Update a local copy of the PR: \
`$ git checkout pull/1163` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1163`

View PR using the GUI difftool: \
`$ git pr show -t 1163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1163.diff">https://git.openjdk.org/jdk11u-dev/pull/1163.diff</a>

</details>
