### PR TITLE
8164804: sun/security/ssl/SSLSocketImpl/CloseSocket.java makes not reliable time assumption

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSocketImpl/CloseSocket.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/CloseSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,26 +25,70 @@
  * @test
  * @bug 4674913
  * @summary Verify that EOFException are correctly handled during the handshake
+ * @library /javax/net/ssl/templates
  * @author Andreas Sterbenz
  * @run main/othervm CloseSocket
  */
 
-import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.ServerSocket;
-import java.net.Socket;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-public class CloseSocket {
 
-    private static ArrayList<TestCase> testCases = new ArrayList<>();
+public class CloseSocket extends SSLSocketTemplate {
 
-    static {
-        testCases.add(socket -> socket.startHandshake());
+/*
+ * SSLSocketImpl::startHandshake internally checks that the socket is not closed or
+ * broken and still connected, so this test needs the server to close the socket
+ * after those verifications are performed to reproduce the scenario. Using a
+ * CountDownLatch in the test before calling startHandshake does not guarantee that.
+ * Using a CountDownLatch after startHandshake does not work either since the client
+ * keeps waiting for a server response, which is blocked waiting for the latch.
+ *
+ * Therefore, we can only guarantee the socket is not yet closed when the handshake
+ * is requested by looking at the client thread stack
+ */
+    private volatile Thread clientThread = null;
+
+    @Override
+    protected void runClientApplication(SSLSocket socket) throws Exception {
+        clientThread = Thread.currentThread();
+        boolean failed = false;
+        for (TestCase testCase : getTestCases()) {
+            try {
+                testCase.test(socket);
+                System.out.println("ERROR: no exception");
+                failed = true;
+            } catch (IOException e) {
+                System.out.println("Failed as expected: " + e);
+            }
+        }
+        if (failed) {
+            throw new Exception("One or more tests failed");
+        }
+    }
+
+    @Override
+    protected void runServerApplication(SSLSocket socket) throws Exception {
+        System.out.println("Server accepted connection");
+        while (!isHandshakeStarted()) {
+            // wait for a short time before checking again if handshake started
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+
+        socket.close();
+        System.out.println("Server closed socket, done.");
+    }
+
+    private List<TestCase> getTestCases() {
+        List<TestCase> testCases = new ArrayList<>();
+
+        testCases.add(SSLSocket::startHandshake);
         testCases.add(socket -> {
             InputStream in = socket.getInputStream();
             in.read();
@@ -53,66 +97,22 @@ public class CloseSocket {
             OutputStream out = socket.getOutputStream();
             out.write(43);
         });
+
+        return testCases;
+    }
+
+    private boolean isHandshakeStarted() {
+        if (clientThread == null) {
+            return false;
+        } else {
+            StackTraceElement[] traces = clientThread.getStackTrace();
+            return Arrays.stream(traces).anyMatch(stackElement ->
+                    stackElement.getMethodName().equals("readHandshakeRecord"));
+        }
     }
 
     public static void main(String[] args) throws Exception {
-        try (Server server = new Server()) {
-            new Thread(server).start();
-
-            SocketFactory factory = SSLSocketFactory.getDefault();
-            try (SSLSocket socket = (SSLSocket) factory.createSocket("localhost",
-                    server.getPort())) {
-                socket.setSoTimeout(2000);
-                System.out.println("Client established TCP connection");
-                boolean failed = false;
-                for (TestCase testCase : testCases) {
-                    try {
-                        testCase.test(socket);
-                        System.out.println("ERROR: no exception");
-                        failed = true;
-                    } catch (IOException e) {
-                        System.out.println("Failed as expected: " + e);
-                    }
-                }
-                if (failed) {
-                    throw new Exception("One or more tests failed");
-                }
-            }
-        }
-    }
-
-    static class Server implements AutoCloseable, Runnable {
-
-        final ServerSocket serverSocket;
-
-        Server() throws IOException {
-            serverSocket = new ServerSocket(0);
-        }
-
-        public int getPort() {
-            return serverSocket.getLocalPort();
-        }
-
-        @Override
-        public void run() {
-            try (Socket s = serverSocket.accept()) {
-                System.out.println("Server accepted connection");
-                // wait a bit before closing the socket to give
-                // the client time to send its hello message
-                Thread.currentThread().sleep(100);
-                s.close();
-                System.out.println("Server closed socket, done.");
-            } catch (Exception e) {
-                throw new RuntimeException("Problem in test execution", e);
-            }
-        }
-
-        @Override
-        public void close() throws Exception {
-            if (!serverSocket.isClosed()) {
-                serverSocket.close();
-            }
-        }
+        new CloseSocket().run();
     }
 
     interface TestCase {


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8164804](https://bugs.openjdk.org/browse/JDK-8164804): sun/security/ssl/SSLSocketImpl/CloseSocket.java makes not reliable time assumption


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1165/head:pull/1165` \
`$ git checkout pull/1165`

Update a local copy of the PR: \
`$ git checkout pull/1165` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1165`

View PR using the GUI difftool: \
`$ git pr show -t 1165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1165.diff">https://git.openjdk.org/jdk11u-dev/pull/1165.diff</a>

</details>
