### PR TITLE
8266881: Enable debug log for SSLEngineExplorerMatchedSNI.java

### DIFF
--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public class SSLEngineExplorerMatchedSNI extends SSLEngineService {
     /*
      * Turn on SSL debugging?
      */
-    static boolean debug = false;
+    static boolean debug = true;
 
     /*
      * Define the server side of the test.


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266881](https://bugs.openjdk.org/browse/JDK-8266881): Enable debug log for SSLEngineExplorerMatchedSNI.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1166/head:pull/1166` \
`$ git checkout pull/1166`

Update a local copy of the PR: \
`$ git checkout pull/1166` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1166`

View PR using the GUI difftool: \
`$ git pr show -t 1166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1166.diff">https://git.openjdk.org/jdk11u-dev/pull/1166.diff</a>

</details>
