### PR TITLE
8281569: Create tests for Frame.setMinimumSize() method

### DIFF
--- a/test/jdk/java/awt/Frame/SetMinimumSizeTest/SetMinimumSizeTest1.java
+++ b/test/jdk/java/awt/Frame/SetMinimumSizeTest/SetMinimumSizeTest1.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @summary Verify that increase in Frame's minimumSize gets reflected in the subsequent getSize call
+ * @run main SetMinimumSizeTest1
+ */
+
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Robot;
+
+public class SetMinimumSizeTest1 {
+
+    private static Frame frame;
+    private static volatile Dimension dimension;
+    private static volatile Dimension actualDimension;
+
+    public static void createGUI() {
+        frame = new Frame();
+        frame.add(new Button("Button"));
+        frame.setSize(140, 140);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void doTest() throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> createGUI());
+
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.waitForIdle();
+
+            EventQueue.invokeAndWait(() -> {
+                dimension = frame.getSize();
+                dimension.width += 20;
+                dimension.height += 20;
+                frame.setMinimumSize(dimension);
+                frame.invalidate();
+                frame.validate();
+            });
+
+            robot.waitForIdle();
+
+            EventQueue.invokeAndWait(() -> {
+                actualDimension = frame.getSize();
+            });
+
+            if (!actualDimension.equals(dimension)) {
+                throw new RuntimeException("Test Failed\n"
+                    + "expected dimension:(" + dimension.width + "," + dimension.height +")\n"
+                    + "actual dimension:(" + actualDimension.width + "," + actualDimension.height + ")");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> frame.dispose());
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        doTest();
+    }
+}
+

--- a/test/jdk/java/awt/Frame/SetMinimumSizeTest/SetMinimumSizeTest2.java
+++ b/test/jdk/java/awt/Frame/SetMinimumSizeTest/SetMinimumSizeTest2.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @summary Verify frame resizes back to minimumSize on calling pack
+ * @run main SetMinimumSizeTest2
+ */
+
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Robot;
+
+public class SetMinimumSizeTest2 {
+
+    private static Frame frame;
+    private static volatile Dimension dimension;
+    private static volatile Dimension actualDimension;
+
+    public static void createGUI() {
+        frame = new Frame();
+        frame.add(new Button("Button"));
+        frame.setMinimumSize(new Dimension(140, 140));
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void doTest() throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> createGUI());
+
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.waitForIdle();
+
+            EventQueue.invokeAndWait(() -> {
+                dimension = frame.getSize();
+            });
+
+            EventQueue.invokeAndWait(() -> {
+                frame.setSize(dimension.width + 20, dimension.height + 20);
+                frame.invalidate();
+                frame.validate();
+            });
+
+            robot.waitForIdle();
+
+            EventQueue.invokeAndWait(() -> {
+                frame.pack();
+                frame.invalidate();
+                frame.validate();
+            });
+
+            robot.waitForIdle();
+
+            EventQueue.invokeAndWait(() -> {
+                actualDimension = frame.getSize();
+            });
+
+            if (!actualDimension.equals(dimension)) {
+                throw new RuntimeException("Test Failed\n"
+                    + "expected dimension:(" + dimension.width + "," + dimension.height +")\n"
+                    + "actual dimension:(" + actualDimension.width + "," + actualDimension.height + ")");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> frame.dispose());
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        doTest();
+    }
+}
+


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281569](https://bugs.openjdk.org/browse/JDK-8281569): Create tests for Frame.setMinimumSize() method


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1168/head:pull/1168` \
`$ git checkout pull/1168`

Update a local copy of the PR: \
`$ git checkout pull/1168` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1168`

View PR using the GUI difftool: \
`$ git pr show -t 1168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1168.diff">https://git.openjdk.org/jdk11u-dev/pull/1168.diff</a>

</details>
