### PR TITLE
8288928: Incorrect GPL header in pnglibconf.h (backport of JDK-8185041)

### DIFF
--- a/src/java.desktop/share/native/libsplashscreen/libpng/pnglibconf.h
+++ b/src/java.desktop/share/native/libsplashscreen/libpng/pnglibconf.h
@@ -1,11 +1,6 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * This file is available under and governed by the GNU General Public
- * License version 2 only, as published by the Free Software Foundation.
- * However, the following notice accompanied the original version of this
- * file and, per its terms, should not be removed:
- *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.  Oracle designates this
@@ -29,8 +24,9 @@
  * THIS FILE WAS MODIFIED BY ORACLE, INC.
  */
 
-/* pnglibconf.h - library build configuration */
-/* This file is available under and governed by the GNU General Public
+/* pnglibconf.h - library build configuration
+ *
+ * This file is available under and governed by the GNU General Public
  * License version 2 only, as published by the Free Software Foundation.
  * However, the following notice accompanied the original version of this
  * file and, per its terms, should not be removed:


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [70762d39](https://github.com/openjdk/jdk/commit/70762d397267f85ce81727ec0c89c9448967798e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 7 Oct 2019 and was reviewed by Phil Race.
Thanks!

Backport is clean, but I have to create a new JBS issue, the initial one is closed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288928](https://bugs.openjdk.org/browse/JDK-8288928): Incorrect GPL header in pnglibconf.h (backport of JDK-8185041)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1169/head:pull/1169` \
`$ git checkout pull/1169`

Update a local copy of the PR: \
`$ git checkout pull/1169` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1169`

View PR using the GUI difftool: \
`$ git pr show -t 1169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1169.diff">https://git.openjdk.org/jdk11u-dev/pull/1169.diff</a>

</details>
