### PR TITLE
8253829: Wrong length compared in SSPI bridge

### DIFF
--- a/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
+++ b/src/java.security.jgss/windows/native/libsspi_bridge/sspi.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -462,7 +462,7 @@ gss_compare_name(OM_uint32 *minor_status,
     }
 
     if (l1 < l2 && l1 != r2
-            || l2 < l1 && l2 != l1) {
+            || l2 < l1 && l2 != r1) {
         return GSS_S_COMPLETE; // different
     }
 


### PR DESCRIPTION
I'd like to backport the fix for an obvious error as it occurs in the production of one of our customer

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253829](https://bugs.openjdk.org/browse/JDK-8253829): Wrong length compared in SSPI bridge


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1170/head:pull/1170` \
`$ git checkout pull/1170`

Update a local copy of the PR: \
`$ git checkout pull/1170` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1170`

View PR using the GUI difftool: \
`$ git pr show -t 1170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1170.diff">https://git.openjdk.org/jdk11u-dev/pull/1170.diff</a>

</details>
