### PR TITLE
8210722: JAXP Tests: CatalogSupport2 and CatalogSupport3 generate incorrect messages upon failure

### DIFF
--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport.xml
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <!-- DTDs and external entities -->
-    <system systemId="http://openjdk.java.net/xml/catalog/dtd/system.dtd" uri="system.dtd"/>
+    <system systemId="http://openjdk_java_net/xml/catalog/dtd/system.dtd" uri="system.dtd"/>
     
     <!-- XMLSchema refers to XMLSchema.dtd -->
     <public publicId="-//W3C//DTD XMLSCHEMA 200102//EN" uri="XMLSchema.dtd"/>
@@ -35,8 +35,8 @@
     <system systemId="pathto/XSLInclude_header.xsl" uri="XSLInclude_header.xsl"/>
     <system systemId="pathto/XSLInclude_footer.xsl" uri="XSLInclude_footer.xsl"/>
     <!-- and DTDs -->
-    <system systemId="http://openjdk.java.net/xml/catalog/dtd/XSLDTD.dtd" uri="XSLDTD.dtd"/>
-    <system systemId="http://openjdk.java.net/xml/catalog/dtd/include.dtd" uri="include.dtd"/>
+    <system systemId="http://openjdk_java_net/xml/catalog/dtd/XSLDTD.dtd" uri="XSLDTD.dtd"/>
+    <system systemId="http://openjdk_java_net/xml/catalog/dtd/include.dtd" uri="include.dtd"/>
     
     <!-- XSLT document function -->
     <system systemId="pathto/DocFunc2.xml" uri="DocFuncCatalog.xml"/>

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport2.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,6 +81,7 @@ public class CatalogSupport2 extends CatalogSupportBase {
     public void setUpClass() throws Exception {
         setUp();
         setSystemProperty(SP_USE_CATALOG, "false");
+        setSystemProperty(SP_ACCESS_EXTERNAL_DTD, "file");
         timeoutRead = getSystemProperty(TTIMEOUTREAD);
         timeoutConnect = getSystemProperty(TIMEOUTCONNECT);
         setSystemProperty(TTIMEOUTREAD, "1000");
@@ -90,6 +91,7 @@ public class CatalogSupport2 extends CatalogSupportBase {
     @AfterClass
     public void tearDownClass() throws Exception {
         clearSystemProperty(SP_USE_CATALOG);
+        clearSystemProperty(SP_ACCESS_EXTERNAL_DTD);
         setSystemProperty(TIMEOUTCONNECT, "-1");
         setSystemProperty(TTIMEOUTREAD, "-1");
     }
@@ -97,7 +99,7 @@ public class CatalogSupport2 extends CatalogSupportBase {
     /*
        Verifies the Catalog support on SAXParser.
     */
-    @Test(dataProvider = "data_SAXC", expectedExceptions = IOException.class)
+    @Test(dataProvider = "data_SAXC", expectedExceptions = SAXParseException.class)
     public void testSAXC(boolean setUseCatalog, boolean useCatalog, String catalog, String
             xml, MyHandler handler, String expected) throws Exception {
         testSAX(setUseCatalog, useCatalog, catalog, xml, handler, expected);
@@ -106,7 +108,7 @@ public class CatalogSupport2 extends CatalogSupportBase {
     /*
        Verifies the Catalog support on XMLReader.
     */
-    @Test(dataProvider = "data_SAXC", expectedExceptions = IOException.class)
+    @Test(dataProvider = "data_SAXC", expectedExceptions = SAXParseException.class)
     public void testXMLReaderC(boolean setUseCatalog, boolean useCatalog, String catalog,
             String xml, MyHandler handler, String expected) throws Exception {
         testXMLReader(setUseCatalog, useCatalog, catalog, xml, handler, expected);
@@ -124,7 +126,7 @@ public class CatalogSupport2 extends CatalogSupportBase {
     /*
        Verifies the Catalog support on DOM parser.
     */
-    @Test(dataProvider = "data_DOMC", expectedExceptions = IOException.class)
+    @Test(dataProvider = "data_DOMC", expectedExceptions = SAXParseException.class)
     public void testDOMC(boolean setUseCatalog, boolean useCatalog, String catalog,
             String xml, MyHandler handler, String expected) throws Exception {
         testDOM(setUseCatalog, useCatalog, catalog, xml, handler, expected);
@@ -133,7 +135,7 @@ public class CatalogSupport2 extends CatalogSupportBase {
     /*
        Verifies the Catalog support on XMLStreamReader.
     */
-    @Test(dataProvider = "data_StAXC")
+    @Test(dataProvider = "data_StAXC", expectedExceptions = XMLStreamException.class)
     public void testStAXC(boolean setUseCatalog, boolean useCatalog, String catalog,
             String xml, XMLResolver resolver, String expected) throws Exception {
         testStAXNegative(setUseCatalog, useCatalog, catalog, xml, resolver, expected);

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport3.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package catalog;
 
+import static jaxp.library.JAXPTestUtilities.clearSystemProperty;
 import static jaxp.library.JAXPTestUtilities.getSystemProperty;
 import static jaxp.library.JAXPTestUtilities.setSystemProperty;
 
@@ -82,18 +83,20 @@ public class CatalogSupport3 extends CatalogSupportBase {
         timeoutConnect = getSystemProperty(TIMEOUTCONNECT);
         setSystemProperty(TTIMEOUTREAD, "1000");
         setSystemProperty(TIMEOUTCONNECT, "1000");
+        setSystemProperty(SP_ACCESS_EXTERNAL_DTD, "file");
     }
 
     @AfterClass
     public void tearDownClass() throws Exception {
         setSystemProperty(TIMEOUTCONNECT, "-1");
         setSystemProperty(TTIMEOUTREAD, "-1");
+        clearSystemProperty(SP_ACCESS_EXTERNAL_DTD);
     }
 
     /*
        Verifies the Catalog support on SAXParser.
     */
-    @Test(dataProvider = "data_SAXC", expectedExceptions = IOException.class)
+    @Test(dataProvider = "data_SAXC", expectedExceptions = SAXParseException.class)
     public void testSAXC(boolean setUseCatalog, boolean useCatalog, String catalog,
             String xml, MyHandler handler, String expected) throws Exception {
         testSAX(setUseCatalog, useCatalog, catalog, xml, handler, expected);
@@ -102,7 +105,7 @@ public class CatalogSupport3 extends CatalogSupportBase {
     /*
        Verifies the Catalog support on XMLReader.
     */
-    @Test(dataProvider = "data_SAXC", expectedExceptions = IOException.class)
+    @Test(dataProvider = "data_SAXC", expectedExceptions = SAXParseException.class)
     public void testXMLReaderC(boolean setUseCatalog, boolean useCatalog, String catalog,
             String xml, MyHandler handler, String expected) throws Exception {
         testXMLReader(setUseCatalog, useCatalog, catalog, xml, handler, expected);
@@ -120,7 +123,7 @@ public class CatalogSupport3 extends CatalogSupportBase {
     /*
        Verifies the Catalog support on DOM parser.
     */
-    @Test(dataProvider = "data_DOMC", expectedExceptions = IOException.class)
+    @Test(dataProvider = "data_DOMC", expectedExceptions = SAXParseException.class)
     public void testDOMC(boolean setUseCatalog, boolean useCatalog, String catalog,
             String xml, MyHandler handler, String expected) throws Exception {
         testDOM(setUseCatalog, useCatalog, catalog, xml, handler, expected);
@@ -129,7 +132,7 @@ public class CatalogSupport3 extends CatalogSupportBase {
     /*
        Verifies the Catalog support on XMLStreamReader.
     */
-    @Test(dataProvider = "data_StAXC")
+    @Test(dataProvider = "data_StAXC", expectedExceptions = XMLStreamException.class)
     public void testStAXC(boolean setUseCatalog, boolean useCatalog, String catalog,
             String xml, XMLResolver resolver, String expected) throws Exception {
         testStAXNegative(setUseCatalog, useCatalog, catalog, xml, resolver, expected);

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupportBase.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupportBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,6 +90,7 @@ import org.xml.sax.ext.DefaultHandler2;
 public class CatalogSupportBase {
     // the System Property for the USE_CATALOG feature
     final static String SP_USE_CATALOG = "javax.xml.useCatalog";
+    final static String SP_ACCESS_EXTERNAL_DTD = "javax.xml.accessExternalDTD";
 
     boolean debug = false;
 
@@ -232,7 +233,7 @@ public class CatalogSupportBase {
                 + ""
                 + "</xsl:stylesheet>";
         xsl_includeDTD = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                + "<!DOCTYPE HTMLlat1 SYSTEM \"http://openjdk.java.net/xml/catalog/dtd/XSLDTD.dtd\">"
+                + "<!DOCTYPE HTMLlat1 SYSTEM \"http://openjdk_java_net/xml/catalog/dtd/XSLDTD.dtd\">"
                 + "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">"
                 + "  <xsl:import href=\"pathto/XSLImport_html.xsl\"/>"
                 + "  <xsl:include href=\"pathto/XSLInclude_header.xsl\"/>"
@@ -262,7 +263,7 @@ public class CatalogSupportBase {
                 "</content>";
 
         xml_xslDTD = "<?xml version=\"1.0\"?>\n" +
-                "<!DOCTYPE content SYSTEM \"http://openjdk.java.net/xml/catalog/dtd/include.dtd\">" +
+                "<!DOCTYPE content SYSTEM \"http://openjdk_java_net/xml/catalog/dtd/include.dtd\">" +
                 "<content>\n" +
                 "    <header>This is the header</header>\n" +
                 "    Some content\n" +

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport_uri.xml
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogSupport_uri.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <!-- DTDs and external entities -->
-    <uri name="http://openjdk.java.net/xml/catalog/dtd/system.dtd" uri="system.dtd"/>
+    <uri name="http://openjdk_java_net/xml/catalog/dtd/system.dtd" uri="system.dtd"/>
     
     <!-- XMLSchema refers to XMLSchema.dtd -->
     <public publicId="-//W3C//DTD XMLSCHEMA 200102//EN" uri="XMLSchema.dtd"/>
@@ -34,8 +34,8 @@
     <uri name="pathto/XSLInclude_header.xsl" uri="XSLInclude_header.xsl"/>
     <uri name="pathto/XSLInclude_footer.xsl" uri="XSLInclude_footer.xsl"/>
     <!-- and DTDs -->
-    <uri name="http://openjdk.java.net/xml/catalog/dtd/XSLDTD.dtd" uri="XSLDTD.dtd"/>
-    <uri name="http://openjdk.java.net/xml/catalog/dtd/include.dtd" uri="include.dtd"/>
+    <uri name="http://openjdk_java_net/xml/catalog/dtd/XSLDTD.dtd" uri="XSLDTD.dtd"/>
+    <uri name="http://openjdk_java_net/xml/catalog/dtd/include.dtd" uri="include.dtd"/>
     
     <!-- XSLT document function -->
     <uri name="pathto/DocFunc2.xml" uri="DocFuncCatalog.xml"/>

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/CatalogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -654,7 +654,7 @@ public class CatalogTest extends CatalogSupportBase {
         };
     }
 
-    static String id = "http://openjdk.java.net/xml/catalog/dtd/system.dtd";
+    static String id = "http://openjdk_java_net/xml/catalog/dtd/system.dtd";
     /*
        DataProvider: used to verify how prefer settings affect the result of the
         Catalog's matching operation.

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/catalog.xml
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/catalog.xml
@@ -9,12 +9,12 @@
                   uri="file:///share/mirrors/w3c/xhtml1/xhtml1-strict.dtd"/>
 
     <public publicId="-//OPENJDK//XML CATALOG DTD//1.0" uri="public.dtd"/>
-    <system systemId="http://openjdk.java.net/xml/catalog/dtd/system.dtd" uri="system.dtd"/>
+    <system systemId="http://openjdk_java_net/xml/catalog/dtd/system.dtd" uri="system.dtd"/>
     
-    <rewriteSystem systemIdStartString="http://openjdk.java.net/" 
+    <rewriteSystem systemIdStartString="http://openjdk_java_net/" 
                    rewritePrefix="files" />
     
-    <rewriteSystem systemIdStartString="http://openjdk.java.net/xml/catalog/dtd/" 
+    <rewriteSystem systemIdStartString="http://openjdk_java_net/xml/catalog/dtd/" 
                    rewritePrefix="files" />
     
     <systemSuffix systemIdSuffix="systemsuffix.dtd" uri="systemsuffix.dtd"/>

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/catalog_uri.xml
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/catalog_uri.xml
@@ -3,11 +3,11 @@
   xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
 
     <!-- using uri entries -->
-    <uri name="http://openjdk.java.net/xml/catalog/dtd/system.dtd" uri="system.dtd"/>
-    <rewriteURI uriStartString="http://openjdk.java.net/" 
+    <uri name="http://openjdk_java_net/xml/catalog/dtd/system.dtd" uri="system.dtd"/>
+    <rewriteURI uriStartString="http://openjdk_java_net/" 
                    rewritePrefix="files" />
     
-    <rewriteURI uriStartString="http://openjdk.java.net/xml/catalog/dtd/" 
+    <rewriteURI uriStartString="http://openjdk_java_net/xml/catalog/dtd/" 
                    rewritePrefix="files" />
 
     <uriSuffix uriSuffix="systemsuffix.dtd" uri="systemsuffix.dtd"/>

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/pubOnly.xml
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/pubOnly.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" xml:base="http://local/base/dtd/">
 
-    <public publicId="http://openjdk.java.net/xml/catalog/dtd/system.dtd" uri="public.dtd"/>
+    <public publicId="http://openjdk_java_net/xml/catalog/dtd/system.dtd" uri="public.dtd"/>
 
 </catalog>

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/rewritesystem.xml
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/rewritesystem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE  catalogtest  PUBLIC  "-//OPENJDK//XML CATALOG DTD//REWRITE"  
-     "http://openjdk.java.net/xml/catalog/dtd/rewritesystem.dtd">
+     "http://openjdk_java_net/xml/catalog/dtd/rewritesystem.dtd">
      
 <catalogtest>Test &rewritesystem; entry</catalogtest>

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/rewritesystem1.xml
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/rewritesystem1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE  catalogtest  PUBLIC  "-//OPENJDK//XML CATALOG DTD//REWRITE"  
-     "http://openjdk.java.net/rewritesystem.dtd">
+     "http://openjdk_java_net/rewritesystem.dtd">
      
 <catalogtest>Test &rewritesystem; entry</catalogtest>

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/sysAndPub.xml
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/sysAndPub.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" xml:base="http://local/base/dtd/">
 
-    <system systemId="http://openjdk.java.net/xml/catalog/dtd/system.dtd" uri="system.dtd"/>
-    <public publicId="http://openjdk.java.net/xml/catalog/dtd/system.dtd" uri="public.dtd"/>
+    <system systemId="http://openjdk_java_net/xml/catalog/dtd/system.dtd" uri="system.dtd"/>
+    <public publicId="http://openjdk_java_net/xml/catalog/dtd/system.dtd" uri="public.dtd"/>
 
 </catalog>

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/sysOnly.xml
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/sysOnly.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" xml:base="http://local/base/dtd/">
 
-    <system systemId="http://openjdk.java.net/xml/catalog/dtd/system.dtd" uri="system.dtd"/>
+    <system systemId="http://openjdk_java_net/xml/catalog/dtd/system.dtd" uri="system.dtd"/>
 
 </catalog>

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/system.xml
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/system.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE  catalogtest  PUBLIC  "-//OPENJDK//XML CATALOG DTD SYSTEM//1.0"  
-     "http://openjdk.java.net/xml/catalog/dtd/system.dtd">
+     "http://openjdk_java_net/xml/catalog/dtd/system.dtd">
      
 <catalogtest>Test &system; entry</catalogtest>

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/systemsuffix.xml
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/systemsuffix.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE  catalogtest  PUBLIC  "-//OPENJDK//XML CATALOG DTD//REWRITE"  
-     "http://openjdk.java.net/xml/catalog/dtd/systemsuffix.dtd">
+     "http://openjdk_java_net/xml/catalog/dtd/systemsuffix.dtd">
      
 <catalogtest>Test &systemsuffix; entry</catalogtest>

--- a/test/jaxp/javax/xml/jaxp/unittest/catalog/val_test.xml
+++ b/test/jaxp/javax/xml/jaxp/unittest/catalog/val_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.1"?>
 <!DOCTYPE  catalogtest  PUBLIC  "-//OPENJDK//XML CATALOG DTD//1.0"  
-     "http://openjdk.java.net/xml/catalog/dtd/system.dtd">
+     "http://openjdk_java_net/xml/catalog/dtd/system.dtd">
 <test:root xmlns:test="test"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="test pathto/val_test.xsd"


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210722](https://bugs.openjdk.org/browse/JDK-8210722): JAXP Tests: CatalogSupport2 and CatalogSupport3 generate incorrect messages upon failure


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1171/head:pull/1171` \
`$ git checkout pull/1171`

Update a local copy of the PR: \
`$ git checkout pull/1171` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1171`

View PR using the GUI difftool: \
`$ git pr show -t 1171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1171.diff">https://git.openjdk.org/jdk11u-dev/pull/1171.diff</a>

</details>
