### PR TITLE
8273526: Extend the OSContainer API  pids controller with pids.current

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -247,6 +247,7 @@ class CgroupSubsystem: public CHeapObj<mtInternal> {
     virtual int cpu_period() = 0;
     virtual int cpu_shares() = 0;
     virtual jlong pids_max() = 0;
+    virtual jlong pids_current() = 0;
     virtual jlong memory_usage_in_bytes() = 0;
     virtual jlong memory_and_swap_limit_in_bytes() = 0;
     virtual jlong memory_soft_limit_in_bytes() = 0;

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -266,3 +266,18 @@ jlong CgroupV1Subsystem::pids_max() {
   char * pidsmax_str = pids_max_val();
   return limit_from_str(pidsmax_str);
 }
+
+/* pids_current
+ *
+ * The number of tasks currently in the cgroup (and its descendants) of the process
+ *
+ * return:
+ *    current number of tasks
+ *    OSCONTAINER_ERROR for not supported
+ */
+jlong CgroupV1Subsystem::pids_current() {
+  if (_pids == NULL) return OSCONTAINER_ERROR;
+  GET_CONTAINER_INFO(jlong, _pids, "/pids.current",
+                     "Current number of tasks is: " JLONG_FORMAT, JLONG_FORMAT, pids_current);
+  return pids_current;
+}

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -88,6 +88,7 @@ class CgroupV1Subsystem: public CgroupSubsystem {
     int cpu_shares();
 
     jlong pids_max();
+    jlong pids_current();
 
     const char * container_type() {
       return "cgroupv1";

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -248,3 +248,18 @@ jlong CgroupV2Subsystem::pids_max() {
   char * pidsmax_str = pids_max_val();
   return limit_from_str(pidsmax_str);
 }
+
+/* pids_current
+ *
+ * The number of tasks currently in the cgroup (and its descendants) of the process
+ *
+ * return:
+ *    current number of tasks
+ *    OSCONTAINER_ERROR for not supported
+ */
+jlong CgroupV2Subsystem::pids_current() {
+  GET_CONTAINER_INFO(jlong, _unified, "/pids.current",
+                     "Current number of tasks is: " JLONG_FORMAT, JLONG_FORMAT, pids_current);
+  return pids_current;
+}
+

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
@@ -80,6 +80,7 @@ class CgroupV2Subsystem: public CgroupSubsystem {
     char * cpu_cpuset_cpus();
     char * cpu_cpuset_memory_nodes();
     jlong pids_max();
+    jlong pids_current();
 
     const char * container_type() {
       return "cgroupv2";

--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -143,3 +143,8 @@ jlong OSContainer::pids_max() {
   assert(cgroup_subsystem != NULL, "cgroup subsystem not available");
   return cgroup_subsystem->pids_max();
 }
+
+jlong OSContainer::pids_current() {
+  assert(cgroup_subsystem != NULL, "cgroup subsystem not available");
+  return cgroup_subsystem->pids_current();
+}

--- a/src/hotspot/os/linux/osContainer_linux.hpp
+++ b/src/hotspot/os/linux/osContainer_linux.hpp
@@ -63,6 +63,7 @@ class OSContainer: AllStatic {
   static int cpu_shares();
 
   static jlong pids_max();
+  static jlong pids_current();
 };
 
 inline bool OSContainer::is_containerized() {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2554,6 +2554,16 @@ void os::Linux::print_container_info(outputStream* st) {
     st->print_cr("%s", j == OSCONTAINER_ERROR ? "not supported" : "unlimited");
   }
 
+  j = OSContainer::OSContainer::pids_current();
+  st->print("current number of tasks: ");
+  if (j > 0) {
+    st->print_cr(JLONG_FORMAT, j);
+  } else {
+    if (j == OSCONTAINER_ERROR) {
+      st->print_cr("not supported");
+    }
+  }
+
   st->cr();
 }
 

--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupMetrics.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat Inc.
+ * Copyright (c) 2020, 2021, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,6 +152,11 @@ public class CgroupMetrics implements Metrics {
     @Override
     public long getPidsMax() {
         return subsystem.getPidsMax();
+    }
+
+    @Override
+    public long getPidsCurrent() {
+        return subsystem.getPidsCurrent();
     }
 
     @Override

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
@@ -416,6 +416,10 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
         return CgroupSubsystem.limitFromString(pidsMaxStr);
     }
 
+    public long getPidsCurrent() {
+        return getLongValue(pids, "pids.current");
+    }
+
     /*****************************************************************
      * BlKIO Subsystem
      ****************************************************************/

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
@@ -312,6 +312,11 @@ public class CgroupV2Subsystem implements CgroupSubsystem {
     }
 
     @Override
+    public long getPidsCurrent() {
+        return getLongVal("pids.current");
+    }
+
+    @Override
     public long getBlkIOServiceCount() {
         return sumTokensIOStat(CgroupV2Subsystem::lineToRandWIOs);
     }

--- a/src/java.base/share/classes/jdk/internal/platform/Metrics.java
+++ b/src/java.base/share/classes/jdk/internal/platform/Metrics.java
@@ -365,6 +365,14 @@ public interface Metrics {
      */
     public long getPidsMax();
 
+    /**
+     * Returns the current number of tasks in the Isolation Group.
+     *
+     * @return The current number of tasks or -2 if not supported
+     *
+     */
+    public long getPidsCurrent();
+
     /*****************************************************************
      * BlKIO Subsystem
      ****************************************************************/

--- a/test/hotspot/jtreg/containers/docker/TestMisc.java
+++ b/test/hotspot/jtreg/containers/docker/TestMisc.java
@@ -116,7 +116,8 @@ public class TestMisc {
             "Memory Usage",
             "Maximum Memory Usage",
             "memory_max_usage_in_bytes",
-            "maximum number of tasks"
+            "maximum number of tasks",
+            "current number of tasks"
         };
 
         for (String s : expectedToContain) {

--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -46,6 +46,8 @@ import jdk.test.lib.Utils;
 public class TestPids {
     private static final String imageName = Common.imageName("pids");
 
+    static final String warning_kernel_no_pids_support = "WARNING: Your kernel does not support pids limit capabilities";
+
     public static void main(String[] args) throws Exception {
         if (!DockerTestUtils.canTestDocker()) {
             return;
@@ -83,7 +85,7 @@ public class TestPids {
         boolean lineMarkerFound = false;
 
         for (String line : lines) {
-            if (line.contains("WARNING: Your kernel does not support pids limit capabilities")) {
+            if (line.contains(warning_kernel_no_pids_support)) {
                 System.out.println("Docker pids limitation seems not to work, avoiding check");
                 return;
             }
@@ -93,6 +95,17 @@ public class TestPids {
                 String[] parts = line.split(":");
                 System.out.println("DEBUG: line = " + line);
                 System.out.println("DEBUG: parts.length = " + parts.length);
+                if (expectedValue.equals("any_integer")) {
+                    Asserts.assertEquals(parts.length, 2);
+                    String ivalue = parts[1].replaceAll("\\s","");
+                    try {
+                        int ai = Integer.parseInt(ivalue);
+                        System.out.println("Found " + lineMarker + " with value: " + ai + ". PASS.");
+                    } catch (NumberFormatException ex) {
+                        throw new RuntimeException("Could not convert " + ivalue + " to an integer, log line was " + line);
+                    }
+                    break;
+                }
 
                 Asserts.assertEquals(parts.length, 2);
                 String actual = parts[1].replaceAll("\\s","");
@@ -137,6 +150,8 @@ public class TestPids {
         } else {
             checkResult(lines, "Maximum number of tasks is: ", value);
         }
+        // current number of tasks value is hard to predict, so better expect no value
+        checkResult(lines, "Current number of tasks is: ", "any_integer");
     }
 
 }


### PR DESCRIPTION
backport of 8273526, os_linux.cpp and src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp changes had to manually adjusted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273526](https://bugs.openjdk.org/browse/JDK-8273526): Extend the OSContainer API  pids controller with pids.current


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1172/head:pull/1172` \
`$ git checkout pull/1172`

Update a local copy of the PR: \
`$ git checkout pull/1172` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1172`

View PR using the GUI difftool: \
`$ git pr show -t 1172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1172.diff">https://git.openjdk.org/jdk11u-dev/pull/1172.diff</a>

</details>
