### PR TITLE
8288754: GCC 12 fails to build zReferenceProcessor.cpp

### DIFF
--- a/src/hotspot/share/gc/z/zReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/z/zReferenceProcessor.cpp
@@ -93,7 +93,7 @@ const char* ZReferenceProcessor::reference_type_name(ReferenceType type) const {
 
   default:
     ShouldNotReachHere();
-    return NULL;
+    return "Unknown";
   }
 }
 


### PR DESCRIPTION
Clean backport to improve GCC 12 support.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288754](https://bugs.openjdk.org/browse/JDK-8288754): GCC 12 fails to build zReferenceProcessor.cpp


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1174/head:pull/1174` \
`$ git checkout pull/1174`

Update a local copy of the PR: \
`$ git checkout pull/1174` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1174`

View PR using the GUI difftool: \
`$ git pr show -t 1174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1174.diff">https://git.openjdk.org/jdk11u-dev/pull/1174.diff</a>

</details>
