### PR TITLE
8284882: SIGSEGV in Node::verify_edges due to compilation bailout

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2497,7 +2497,11 @@ void Compile::Code_Gen() {
   {
     TracePhase tp("matcher", &timers[_t_matcher]);
     matcher.match();
+    if (failing()) {
+      return;
+    }
   }
+
   // In debug mode can dump m._nodes.dump() for mapping of ideal to machine
   // nodes.  Mapping is only valid at the root of each matched subtree.
   NOT_PRODUCT( verify_graph_edges(); )


### PR DESCRIPTION
This is a standalone fix for 11, crafted according to the description in the bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284882](https://bugs.openjdk.org/browse/JDK-8284882): SIGSEGV in Node::verify_edges due to compilation bailout ⚠️ Issue is not open.


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1184/head:pull/1184` \
`$ git checkout pull/1184`

Update a local copy of the PR: \
`$ git checkout pull/1184` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1184`

View PR using the GUI difftool: \
`$ git pr show -t 1184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1184.diff">https://git.openjdk.org/jdk11u-dev/pull/1184.diff</a>

</details>
