### PR TITLE
8274506: TestPids.java and TestPidsLimit.java fail with podman run as root

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -40,11 +40,15 @@ import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerRunOptions;
 import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Container;
 import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 
 public class TestPids {
     private static final String imageName = Common.imageName("pids");
+    private static final boolean IS_PODMAN = Container.ENGINE_COMMAND.contains("podman");
+    private static final int UNLIMITED_PIDS_PODMAN = 0;
+    private static final int UNLIMITED_PIDS_DOCKER = -1;
 
     static final String warning_kernel_no_pids_support = "WARNING: Your kernel does not support pids limit capabilities";
 
@@ -139,7 +143,8 @@ public class TestPids {
 
         DockerRunOptions opts = commonOpts();
         if (value.equals("Unlimited")) {
-            opts.addDockerOpts("--pids-limit=-1");
+            int unlimited = IS_PODMAN ? UNLIMITED_PIDS_PODMAN : UNLIMITED_PIDS_DOCKER;
+            opts.addDockerOpts("--pids-limit=" + unlimited);
         } else {
             opts.addDockerOpts("--pids-limit="+value);
         }

--- a/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
+++ b/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
@@ -39,9 +39,13 @@ import jdk.test.lib.containers.docker.DockerRunOptions;
 import jdk.test.lib.containers.docker.DockerTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Container;
 
 public class TestPidsLimit {
     private static final String imageName = Common.imageName("pids");
+    private static final boolean IS_PODMAN = Container.ENGINE_COMMAND.contains("podman");
+    private static final int UNLIMITED_PIDS_PODMAN = 0;
+    private static final int UNLIMITED_PIDS_DOCKER = -1;
 
     public static void main(String[] args) throws Exception {
         if (!DockerTestUtils.canTestDocker()) {
@@ -107,7 +111,8 @@ public class TestPidsLimit {
         Common.logNewTestCase("testPidsLimit (limit: " + pidsLimit + ")");
         DockerRunOptions opts = Common.newOptsShowSettings(imageName);
         if (pidsLimit.equals("Unlimited")) {
-            opts.addDockerOpts("--pids-limit=-1");
+            int unlimited = IS_PODMAN ? UNLIMITED_PIDS_PODMAN : UNLIMITED_PIDS_DOCKER;
+            opts.addDockerOpts("--pids-limit=" + unlimited);
         } else {
             opts.addDockerOpts("--pids-limit="+pidsLimit);
         }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274506](https://bugs.openjdk.org/browse/JDK-8274506): TestPids.java and TestPidsLimit.java fail with podman run as root


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1186/head:pull/1186` \
`$ git checkout pull/1186`

Update a local copy of the PR: \
`$ git checkout pull/1186` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1186`

View PR using the GUI difftool: \
`$ git pr show -t 1186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1186.diff">https://git.openjdk.org/jdk11u-dev/pull/1186.diff</a>

</details>
