### PR TITLE
8287366: Improve test failure reporting in GHA

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -364,14 +364,102 @@ jobs:
           JTREG_KEYWORDS="!headful"
           JTREG="JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash"
 
-      - name: Check that all tests executed successfully
-        if: steps.run_tests.outcome != 'skipped'
-        run: >
-          if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
-            cat build/*/test-results/*/text/newfailures.txt ;
-            cat build/*/test-results/*/text/other_errors.txt ;
-            exit 1 ;
+      - name: Generate test failure summary
+        run: |
+          #
+          test_suite_name=$(cat build/run-test-prebuilt/test-support/test-last-ids.txt)
+          results_dir=build/run-test-prebuilt/test-results/$test_suite_name/text
+
+          failures=$(sed -e 's!\(.*\)\.java!\1!' -e '/^#/d' $results_dir/newfailures.txt || true)
+          errors=$(sed -e 's!\(.*\)\.java!\1!' -e '/^#/d' $results_dir/other_errors.txt || true)
+          failure_count=$(echo $failures | wc -w || true)
+          error_count=$(echo $errors | wc -w || true)
+
+          if [[ "$failures" = "" && "$errors" = "" ]]; then
+            # If we have nothing to report, exit this step now
+            exit 0
           fi
+
+          echo "::error:: Test run reported $failure_count test failure(s) and $error_count error(s). See summary for details."
+
+          echo "### :boom: Test failures summary" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "$failures" != "" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "These tests reported failure:" >> $GITHUB_STEP_SUMMARY
+            for test in $failures; do
+              anchor="$(echo "$test" | tr [A-Z/] [a-z_])"
+              echo "* [$test](#user-content-$anchor)"
+            done >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [[ "$errors" != "" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "These tests reported errors:"  >> $GITHUB_STEP_SUMMARY
+            for test in $errors; do
+              anchor="$(echo "$test" | tr [A-Z/] [a-z_])"
+              echo "* [$test](#user-content-$anchor)"
+            done >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Collect failed test output
+        run: |
+          #
+          # This is a separate step, since if the markdown from a step gets bigger than
+          # 1024 kB it is skipped, but then the summary above is still generated
+          test_suite_name=$(cat build/run-test-prebuilt/test-support/test-last-ids.txt)
+          results_dir=build/run-test-prebuilt/test-results/$test_suite_name/text
+          report_dir=build/run-test-prebuilt/test-support/$test_suite_name
+
+          failures=$(sed -e 's!\(.*\)\.java!\1!' -e '/^#/d' $results_dir/newfailures.txt || true)
+          errors=$(sed -e 's!\(.*\)\.java!\1!' -e '/^#/d' $results_dir/other_errors.txt || true)
+
+          if [[ "$failures" = "" && "$errors" = "" ]]; then
+            # If we have nothing to report, exit this step now
+            exit 0
+          fi
+
+          echo "### Test output for failed tests" >> $GITHUB_STEP_SUMMARY
+          for test in $failures $errors; do
+            anchor="$(echo "$test" | tr [A-Z/] [a-z_])"
+            base_path="$(echo "$test" | tr '#' '_')"
+            report_file="$report_dir/$base_path.jtr"
+            hs_err_files="$report_dir/$base_path/hs_err*.log"
+            echo "####  <a id="$anchor">$test"
+
+            echo "<details><summary>View test results</summary>"
+            echo ""
+            echo '```'
+            if [[ -f "$report_file" ]]; then
+              cat "$report_file"
+            else
+              echo "Error: Result file $report_file not found"
+            fi
+            echo '```'
+            echo "</details>"
+            echo ""
+
+            if [[ "$hs_err_files" != "" ]]; then
+              echo "<details><summary>View HotSpot error log</summary>"
+              echo ""
+              for hs_err in $hs_err_files; do
+                echo '```'
+                echo "$hs_err:"
+                echo ""
+                cat "$hs_err"
+                echo '```'
+              done
+
+              echo "</details>"
+              echo ""
+            fi
+
+          done >> $GITHUB_STEP_SUMMARY
+
+          echo ":arrow_right: To see the entire test log, click the job in the list to the left"  >> $GITHUB_STEP_SUMMARY
+
+          # This will abort the entire job in GHA, which is what we want
+          exit 1
 
       - name: Create suitable test log artifact name
         if: always()
@@ -834,14 +922,102 @@ jobs:
           JTREG_KEYWORDS="!headful"
           JTREG="JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash"
 
-      - name: Check that all tests executed successfully
-        if: steps.run_tests.outcome != 'skipped'
-        run: >
-          if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
-            cat build/*/test-results/*/text/newfailures.txt ;
-            cat build/*/test-results/*/text/other_errors.txt ;
-            exit 1 ;
+      - name: Generate test failure summary
+        run: |
+          #
+          test_suite_name=$(cat build/run-test-prebuilt/test-support/test-last-ids.txt)
+          results_dir=build/run-test-prebuilt/test-results/$test_suite_name/text
+
+          failures=$(sed -e 's!\(.*\)\.java!\1!' -e '/^#/d' $results_dir/newfailures.txt || true)
+          errors=$(sed -e 's!\(.*\)\.java!\1!' -e '/^#/d' $results_dir/other_errors.txt || true)
+          failure_count=$(echo $failures | wc -w || true)
+          error_count=$(echo $errors | wc -w || true)
+
+          if [[ "$failures" = "" && "$errors" = "" ]]; then
+            # If we have nothing to report, exit this step now
+            exit 0
           fi
+
+          echo "::error:: Test run reported $failure_count test failure(s) and $error_count error(s). See summary for details."
+
+          echo "### :boom: Test failures summary" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "$failures" != "" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "These tests reported failure:" >> $GITHUB_STEP_SUMMARY
+            for test in $failures; do
+              anchor="$(echo "$test" | tr [A-Z/] [a-z_])"
+              echo "* [$test](#user-content-$anchor)"
+            done >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [[ "$errors" != "" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "These tests reported errors:"  >> $GITHUB_STEP_SUMMARY
+            for test in $errors; do
+              anchor="$(echo "$test" | tr [A-Z/] [a-z_])"
+              echo "* [$test](#user-content-$anchor)"
+            done >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Collect failed test output
+        run: |
+          #
+          # This is a separate step, since if the markdown from a step gets bigger than
+          # 1024 kB it is skipped, but then the summary above is still generated
+          test_suite_name=$(cat build/run-test-prebuilt/test-support/test-last-ids.txt)
+          results_dir=build/run-test-prebuilt/test-results/$test_suite_name/text
+          report_dir=build/run-test-prebuilt/test-support/$test_suite_name
+
+          failures=$(sed -e 's!\(.*\)\.java!\1!' -e '/^#/d' $results_dir/newfailures.txt || true)
+          errors=$(sed -e 's!\(.*\)\.java!\1!' -e '/^#/d' $results_dir/other_errors.txt || true)
+
+          if [[ "$failures" = "" && "$errors" = "" ]]; then
+            # If we have nothing to report, exit this step now
+            exit 0
+          fi
+
+          echo "### Test output for failed tests" >> $GITHUB_STEP_SUMMARY
+          for test in $failures $errors; do
+            anchor="$(echo "$test" | tr [A-Z/] [a-z_])"
+            base_path="$(echo "$test" | tr '#' '_')"
+            report_file="$report_dir/$base_path.jtr"
+            hs_err_files="$report_dir/$base_path/hs_err*.log"
+            echo "####  <a id="$anchor">$test"
+
+            echo "<details><summary>View test results</summary>"
+            echo ""
+            echo '```'
+            if [[ -f "$report_file" ]]; then
+              cat "$report_file"
+            else
+              echo "Error: Result file $report_file not found"
+            fi
+            echo '```'
+            echo "</details>"
+            echo ""
+
+            if [[ "$hs_err_files" != "" ]]; then
+              echo "<details><summary>View HotSpot error log</summary>"
+              echo ""
+              for hs_err in $hs_err_files; do
+                echo '```'
+                echo "$hs_err:"
+                echo ""
+                cat "$hs_err"
+                echo '```'
+              done
+
+              echo "</details>"
+              echo ""
+            fi
+
+          done >> $GITHUB_STEP_SUMMARY
+
+          echo ":arrow_right: To see the entire test log, click the job in the list to the left"  >> $GITHUB_STEP_SUMMARY
+
+          # This will abort the entire job in GHA, which is what we want
+          exit 1
 
       - name: Create suitable test log artifact name
         if: always()
@@ -1560,14 +1736,102 @@ jobs:
           JTREG_KEYWORDS="!headful"
           JTREG="JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash"
 
-      - name: Check that all tests executed successfully
-        if: steps.run_tests.outcome != 'skipped'
-        run: >
-          if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
-            cat build/*/test-results/*/text/newfailures.txt ;
-            cat build/*/test-results/*/text/other_errors.txt ;
-            exit 1 ;
+      - name: Generate test failure summary
+        run: |
+          #
+          test_suite_name=$(cat build/run-test-prebuilt/test-support/test-last-ids.txt)
+          results_dir=build/run-test-prebuilt/test-results/$test_suite_name/text
+
+          failures=$(sed -e 's!\(.*\)\.java!\1!' -e '/^#/d' $results_dir/newfailures.txt || true)
+          errors=$(sed -e 's!\(.*\)\.java!\1!' -e '/^#/d' $results_dir/other_errors.txt || true)
+          failure_count=$(echo $failures | wc -w || true)
+          error_count=$(echo $errors | wc -w || true)
+
+          if [[ "$failures" = "" && "$errors" = "" ]]; then
+            # If we have nothing to report, exit this step now
+            exit 0
           fi
+
+          echo "::error:: Test run reported $failure_count test failure(s) and $error_count error(s). See summary for details."
+
+          echo "### :boom: Test failures summary" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "$failures" != "" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "These tests reported failure:" >> $GITHUB_STEP_SUMMARY
+            for test in $failures; do
+              anchor="$(echo "$test" | tr [A-Z/] [a-z_])"
+              echo "* [$test](#user-content-$anchor)"
+            done >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [[ "$errors" != "" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "These tests reported errors:"  >> $GITHUB_STEP_SUMMARY
+            for test in $errors; do
+              anchor="$(echo "$test" | tr [A-Z/] [a-z_])"
+              echo "* [$test](#user-content-$anchor)"
+            done >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Collect failed test output
+        run: |
+          #
+          # This is a separate step, since if the markdown from a step gets bigger than
+          # 1024 kB it is skipped, but then the summary above is still generated
+          test_suite_name=$(cat build/run-test-prebuilt/test-support/test-last-ids.txt)
+          results_dir=build/run-test-prebuilt/test-results/$test_suite_name/text
+          report_dir=build/run-test-prebuilt/test-support/$test_suite_name
+
+          failures=$(sed -e 's!\(.*\)\.java!\1!' -e '/^#/d' $results_dir/newfailures.txt || true)
+          errors=$(sed -e 's!\(.*\)\.java!\1!' -e '/^#/d' $results_dir/other_errors.txt || true)
+
+          if [[ "$failures" = "" && "$errors" = "" ]]; then
+            # If we have nothing to report, exit this step now
+            exit 0
+          fi
+
+          echo "### Test output for failed tests" >> $GITHUB_STEP_SUMMARY
+          for test in $failures $errors; do
+            anchor="$(echo "$test" | tr [A-Z/] [a-z_])"
+            base_path="$(echo "$test" | tr '#' '_')"
+            report_file="$report_dir/$base_path.jtr"
+            hs_err_files="$report_dir/$base_path/hs_err*.log"
+            echo "####  <a id="$anchor">$test"
+
+            echo "<details><summary>View test results</summary>"
+            echo ""
+            echo '```'
+            if [[ -f "$report_file" ]]; then
+              cat "$report_file"
+            else
+              echo "Error: Result file $report_file not found"
+            fi
+            echo '```'
+            echo "</details>"
+            echo ""
+
+            if [[ "$hs_err_files" != "" ]]; then
+              echo "<details><summary>View HotSpot error log</summary>"
+              echo ""
+              for hs_err in $hs_err_files; do
+                echo '```'
+                echo "$hs_err:"
+                echo ""
+                cat "$hs_err"
+                echo '```'
+              done
+
+              echo "</details>"
+              echo ""
+            fi
+
+          done >> $GITHUB_STEP_SUMMARY
+
+          echo ":arrow_right: To see the entire test log, click the job in the list to the left"  >> $GITHUB_STEP_SUMMARY
+
+          # This will abort the entire job in GHA, which is what we want
+          exit 1
 
       - name: Create suitable test log artifact name
         if: always()


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8287366](https://bugs.openjdk.org/browse/JDK-8287366), commit [e0e15def](https://github.com/openjdk/jdk/commit/e0e15def24c4c93c863ff459788bea23ef99d790) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

There are further improvements for GHA in head which I'd like to bring down and this is the first one that improves error reporting.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287366](https://bugs.openjdk.org/browse/JDK-8287366): Improve test failure reporting in GHA


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1187/head:pull/1187` \
`$ git checkout pull/1187`

Update a local copy of the PR: \
`$ git checkout pull/1187` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1187`

View PR using the GUI difftool: \
`$ git pr show -t 1187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1187.diff">https://git.openjdk.org/jdk11u-dev/pull/1187.diff</a>

</details>
