### PR TITLE
8288467: remove memory_operand assert for spilled instructions

### DIFF
--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -1693,8 +1693,13 @@ void PhaseChaitin::fixup_spills() {
             // instructions which have "stackSlotX" parameter instead of "memory".
             // For example, "MoveF2I_stack_reg". We always need a memory edge from
             // src to cisc, else we might schedule cisc before src, loading from a
-            // spill location before storing the spill.
-            assert(cisc->memory_operand() == NULL, "no memory operand, only stack");
+            // spill location before storing the spill. On some platforms, we land
+            // in this else case because mach->oper_input_base() > 1, i.e. we have
+            // multiple inputs. In some rare cases there are even multiple memory
+            // operands, before and after spilling.
+            // (e.g. spilling "addFPR24_reg_mem" to "addFPR24_mem_cisc")
+            // In either case, there is no space in the inputs for the memory edge
+            // so we add an additional precedence / memory edge.
             cisc->add_prec(src);
           }
           block->map_node(cisc, j);          // Insert into basic block


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle

I had to do a trivial resolve.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288467](https://bugs.openjdk.org/browse/JDK-8288467): remove memory_operand assert for spilled instructions


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [536e78f7](https://git.openjdk.org/jdk11u-dev/pull/1188/files/536e78f7c0171176e6aee49a13bd7411f86bfc37)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1188/head:pull/1188` \
`$ git checkout pull/1188`

Update a local copy of the PR: \
`$ git checkout pull/1188` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1188`

View PR using the GUI difftool: \
`$ git pr show -t 1188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1188.diff">https://git.openjdk.org/jdk11u-dev/pull/1188.diff</a>

</details>
