### PR TITLE
8287672: jtreg test com/sun/jndi/ldap/LdapPoolTimeoutTest.java fails intermittently in nightly run

### DIFF
--- a/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 
 import static jdk.test.lib.Utils.adjustTimeout;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.expectThrows;
 
 public class LdapPoolTimeoutTest {
@@ -121,7 +122,9 @@ public class LdapPoolTimeoutTest {
             String msg = e.getCause() == null ? e.getMessage() : e.getCause().getMessage();
             System.err.println("MSG RTE: " + msg);
             // assertCompletion may wrap a CommunicationException in an RTE
-            assertTrue(msg != null && msg.contains("Network is unreachable"));
+            assertNotNull(msg);
+            assertTrue(msg.contains("Network is unreachable")
+                        || msg.contains("No route to host"));
         } catch (NamingException ex) {
             String msg = ex.getCause() == null ? ex.getMessage() : ex.getCause().getMessage();
             System.err.println("MSG: " + msg);


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287672](https://bugs.openjdk.org/browse/JDK-8287672): jtreg test com/sun/jndi/ldap/LdapPoolTimeoutTest.java fails intermittently in nightly run


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1192/head:pull/1192` \
`$ git checkout pull/1192`

Update a local copy of the PR: \
`$ git checkout pull/1192` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1192`

View PR using the GUI difftool: \
`$ git pr show -t 1192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1192.diff">https://git.openjdk.org/jdk11u-dev/pull/1192.diff</a>

</details>
