### PR TITLE
8286177: C2: "failed: non-reduction loop contains reduction nodes" assert failure

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -104,8 +104,6 @@ void SuperWord::transform_loop(IdealLoopTree* lpt, bool do_optimization) {
 
   if (!cl->is_valid_counted_loop()) return; // skip malformed counted loop
 
-  assert(!lpt->has_reduction_nodes() || cl->is_reduction_loop(),
-         "non-reduction loop contains reduction nodes");
   bool post_loop_allowed = (PostLoopMultiversioning && Matcher::has_predicated_vectors() && cl->is_post_loop());
   if (post_loop_allowed) {
     if (cl->is_reduction_loop()) return; // no predication mapping
@@ -2298,6 +2296,11 @@ void SuperWord::output() {
     }
     return;
   }
+
+  // Check that the loop to be vectorized does not have inconsistent reduction
+  // information, which would likely lead to a miscompilation.
+  assert(!lpt()->has_reduction_nodes() || cl->is_reduction_loop(),
+         "non-reduction loop contains reduction nodes");
 
 #ifndef PRODUCT
   if (TraceLoopOpts) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestHoistedReductionNode.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestHoistedReductionNode.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8286177
+ * @summary Test that inconsistent reduction node-loop state does not trigger
+ *          assertion failures when the inconsistency does not lead to a
+ *          miscompilation.
+ * @run main/othervm -Xbatch compiler.loopopts.superword.TestHoistedReductionNode
+ */
+package compiler.loopopts.superword;
+
+public class TestHoistedReductionNode {
+
+    static boolean b = true;
+
+    static int test() {
+        int acc = 0;
+        int i = 0;
+        do {
+            int j = 0;
+            do {
+                if (b) {
+                    acc += j;
+                }
+                j++;
+            } while (j < 5);
+            i++;
+        } while (i < 100);
+        return acc;
+
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            test();
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286177](https://bugs.openjdk.org/browse/JDK-8286177): C2: "failed: non-reduction loop contains reduction nodes" assert failure


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1195/head:pull/1195` \
`$ git checkout pull/1195`

Update a local copy of the PR: \
`$ git checkout pull/1195` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1195`

View PR using the GUI difftool: \
`$ git pr show -t 1195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1195.diff">https://git.openjdk.org/jdk11u-dev/pull/1195.diff</a>

</details>
