### PR TITLE
8219074: [TESTBUG] runtime/containers/docker/TestCPUAwareness.java typo of printing parameters (period should be shares)

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -206,7 +206,7 @@ public class TestCPUAwareness {
         System.out.println("cpuset = " + cpuset);
         System.out.println("quota = " + quota);
         System.out.println("period = " + period);
-        System.out.println("shares = " + period);
+        System.out.println("shares = " + shares);
         System.out.println("useContainerCpuShares = " + useContainerCpuShares);
         System.out.println("usePreferContainerQuotaForCPUCount = " + usePreferContainerQuotaForCPUCount);
         System.out.println("expectedAPC = " + expectedAPC);


### PR DESCRIPTION
Clean backport. It's only the path to the test file that is different.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8219074](https://bugs.openjdk.org/browse/JDK-8219074): [TESTBUG] runtime/containers/docker/TestCPUAwareness.java typo of printing parameters (period should be shares)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1197/head:pull/1197` \
`$ git checkout pull/1197`

Update a local copy of the PR: \
`$ git checkout pull/1197` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1197`

View PR using the GUI difftool: \
`$ git pr show -t 1197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1197.diff">https://git.openjdk.org/jdk11u-dev/pull/1197.diff</a>

</details>
