### PR TITLE
8285380: Fix typos in security

### DIFF
--- a/src/java.security.jgss/macosx/native/libosxkrb5/nativeccache.c
+++ b/src/java.security.jgss/macosx/native/libosxkrb5/nativeccache.c
@@ -616,7 +616,7 @@ jobject BuildAddressList(JNIEnv *env, krb5_address **addresses) {
         if (address == NULL) {
             return (jobject) NULL;
         }
-        // Add the HostAddress to the arrray.
+        // Add the HostAddress to the array.
         (*env)->SetObjectArrayElement(env, address_list, index, address);
 
         if ((*env)->ExceptionCheck(env)) {

--- a/src/java.security.jgss/share/classes/javax/security/auth/kerberos/EncryptionKey.java
+++ b/src/java.security.jgss/share/classes/javax/security/auth/kerberos/EncryptionKey.java
@@ -141,7 +141,7 @@ public final class EncryptionKey implements SecretKey {
     /**
      * Destroys this key by clearing out the key material of this key.
      *
-     * @throws DestroyFailedException if some error occurs while destorying
+     * @throws DestroyFailedException if some error occurs while destroying
      * this key.
      */
     @Override

--- a/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KerberosKey.java
+++ b/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KerberosKey.java
@@ -244,7 +244,7 @@ public class KerberosKey implements SecretKey {
     /**
      * Destroys this key by clearing out the key material of this secret key.
      *
-     * @throws DestroyFailedException if some error occurs while destorying
+     * @throws DestroyFailedException if some error occurs while destroying
      * this key.
      */
     public void destroy() throws DestroyFailedException {

--- a/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KeyImpl.java
+++ b/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KeyImpl.java
@@ -75,7 +75,7 @@ class KeyImpl implements SecretKey, Destroyable, Serializable {
      * @param principal the principal from which to derive the salt
      * @param password the password that should be used to compute the
      * key.
-     * @param algorithm the name for the algorithm that this key wil be
+     * @param algorithm the name for the algorithm that this key will be
      * used for. This parameter may be null in which case "DES" will be
      * assumed.
      */

--- a/src/java.security.jgss/share/classes/org/ietf/jgss/GSSException.java
+++ b/src/java.security.jgss/share/classes/org/ietf/jgss/GSSException.java
@@ -249,7 +249,7 @@ public class GSSException extends Exception {
      * specific major string for it.
      *
      * @param majorCode the fatal error code causing this exception.
-     * @param majorString an expicit message to be included in this exception
+     * @param majorString an explicit message to be included in this exception
      */
     GSSException (int majorCode, String majorString) {
 

--- a/src/java.security.jgss/share/classes/sun/security/jgss/GSSHeader.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/GSSHeader.java
@@ -45,7 +45,7 @@ import sun.security.util.*;
 
 /*
  * The RFC states that implementations should explicitly follow the
- * encoding scheme descibed in this section rather than use ASN.1
+ * encoding scheme described in this section rather than use ASN.1
  * compilers. However, we should consider removing duplicate ASN.1
  * like code from here and depend on sun.security.util if possible.
  */
@@ -131,7 +131,7 @@ public class GSSHeader {
 
     /**
      * Used to obtain the length of the encoding of this GSSHeader.
-     * @return the lenght of the encoding of this GSSHeader instance.
+     * @return the length of the encoding of this GSSHeader instance.
      */
     public int getLength() {
         int lenField = mechOidBytes.length + mechTokenLength;

--- a/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
@@ -407,9 +407,9 @@ public final class ProviderList {
     }
 
     /**
-     * Helper routine to go through all properties contined in a
+     * Helper routine to go through all properties continued in a
      * provider and add its mechanisms to the list of supported
-     * mechanisms. If no default mechanism has been assinged so far,
+     * mechanisms. If no default mechanism has been assigned so far,
      * it sets the default MechanismFactory and Oid as well.
      * @param p the provider to query
      * @return true if there is at least one mechanism that this

--- a/src/java.security.jgss/share/classes/sun/security/jgss/TokenTracker.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/TokenTracker.java
@@ -108,7 +108,7 @@ public class TokenTracker {
      * The following represents the number line with positions of
      * initNumber, windowStart, expectedNumber marked on it. Regions in
      * between them show the different sequencing and replay state
-     * possibilites for tokens that fall in there.
+     * possibilities for tokens that fall in there.
      *
      *  (1)      windowStart
      *           initNumber               expectedNumber
@@ -277,7 +277,7 @@ public class TokenTracker {
 
         /*
          * At this point we know that the number will start a new interval
-         * which needs to be added to the list. We might have to recyle an
+         * which needs to be added to the list. We might have to recycle an
          * older entry in the list.
          */
 
@@ -353,7 +353,7 @@ public class TokenTracker {
 
     /**
      * An entry in the list that represents the sequence of received
-     * tokens. Each entry is actaully an interval of numbers, all of which
+     * tokens. Each entry is actually an interval of numbers, all of which
      * have been received.
      */
     class Entry {

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/CipherHelper.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/CipherHelper.java
@@ -987,7 +987,7 @@ class CipherHelper {
      * @param len the length of the encrypted data
      * @param dataOutBuf the output buffer where the application data
      * should be writte
-     * @param dataOffset the offser where the application data should
+     * @param dataOffset the offset where the application data should
      * be written.
      * @throws GSSException is an error occurs while decrypting the
      * data
@@ -1078,7 +1078,7 @@ class CipherHelper {
      * @param len the length of the ciphertext data
      * @param dataOutBuf the output buffer where the application data
      * should be writte
-     * @param dataOffset the offser where the application data should
+     * @param dataOffset the offset where the application data should
      * be written.
      * @throws GSSException is an error occurs while decrypting the
      * data

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5InitCredential.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5InitCredential.java
@@ -149,7 +149,7 @@ public class Krb5InitCredential
                 .kerberosTicketSetServerAlias(this, serverAlias);
         this.name = name;
         // A delegated cred does not have all fields set. So do not try to
-        // creat new Credentials out of the delegatedCred.
+        // create new Credentials out of the delegatedCred.
         this.krb5Credentials = delegatedCred;
     }
 

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5NameElement.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5NameElement.java
@@ -329,7 +329,7 @@ public class Krb5NameElement
      * @return the Oid for the format of the printed name
      */
     public Oid getStringNameType() {
-        // XXX For NT_EXPORT_NAME return a different name type. Infact,
+        // XXX For NT_EXPORT_NAME return a different name type. In fact,
         // don't even store NT_EXPORT_NAME in the cons.
         return (gssNameType);
     }

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/MessageToken.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/MessageToken.java
@@ -65,7 +65,7 @@ import java.security.MessageDigest;
  * </pre>
  * Where "s" indicates the size of the checksum.
  * <p>
- * As always, this is preceeded by a GSSHeader.
+ * As always, this is preceded by a GSSHeader.
  *
  * @author Mayank Upadhyay
  * @author Ram Marti
@@ -141,7 +141,7 @@ abstract class MessageToken extends Krb5Token {
 
     /**
      * Constructs a MessageToken from a byte array. If there are more bytes
-     * in the array than needed, the extra bytes are simply ignroed.
+     * in the array than needed, the extra bytes are simply ignored.
      *
      * @param tokenId the token id that should be contained in this token as
      * it is read.
@@ -536,7 +536,7 @@ abstract class MessageToken extends Krb5Token {
     }
 
     /**
-     * Obtains the conext key that is associated with this token.
+     * Obtains the context key that is associated with this token.
      * @return the context key
      */
     /*

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/SubjectComber.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/SubjectComber.java
@@ -181,7 +181,7 @@ class SubjectComber {
                                 } catch (DestroyFailedException dfe) {
                                     if (DEBUG) {
                                         System.out.println("Expired ticket not" +
-                                                " detroyed successfully. " + dfe);
+                                                " destroyed successfully. " + dfe);
                                     }
                                 }
                             }

--- a/src/java.security.jgss/share/classes/sun/security/jgss/spi/GSSContextSpi.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/spi/GSSContextSpi.java
@@ -62,7 +62,7 @@ import java.security.Provider;
  * On the other hands, tokens used for per-message calls are generated
  * entirely by the mechanism. It is possible that the mechanism chooses to
  * encase inner-level per-message tokens in a header similar to that used
- * for initial tokens, however, this is upto the mechanism to do. The token
+ * for initial tokens, however, this is up to the mechanism to do. The token
  * to/from the per-message calls are opaque to the GSS-Framework.
  * </strong>
  * <p>
@@ -81,7 +81,7 @@ import java.security.Provider;
  * the token directly form an InputStream but output it to some byte[] for
  * the application to process. Unfortunately the high level GSS bindings
  * do not contain overloaded forms of wrap() and unwrap() that do just
- * this, however we have accomodated those cases here with the expectation
+ * this, however we have accommodated those cases here with the expectation
  * that this will be rolled into the high level bindings sooner or later.
  *
  * @author Mayank Upadhyay
@@ -161,7 +161,7 @@ public interface GSSContextSpi {
      * <p>
      * All overloaded forms of GSSContext.initSecContext() can be handled
      * with this mechanism level initSecContext. Since the output token
-     * from this method is a fixed size, not exeedingly large, and a one
+     * from this method is a fixed size, not exceedingly large, and a one
      * time deal, an overloaded form that takes an OutputStream has not
      * been defined. The GSS-Framwork can write the returned byte[] to any
      * application provided OutputStream. Similarly, any application input
@@ -202,7 +202,7 @@ public interface GSSContextSpi {
      * <p>
      * All overloaded forms of GSSContext.acceptSecContext() can be handled
      * with this mechanism level acceptSecContext. Since the output token
-     * from this method is a fixed size, not exeedingly large, and a one
+     * from this method is a fixed size, not exceedingly large, and a one
      * time deal, an overloaded form that takes an OutputStream has not
      * been defined. The GSS-Framwork can write the returned byte[] to any
      * application provided OutputStream. Similarly, any application input

--- a/src/java.security.jgss/share/classes/sun/security/jgss/spi/MechanismFactory.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/spi/MechanismFactory.java
@@ -102,12 +102,12 @@ public interface MechanismFactory {
      * @param initLifetime indicates the lifetime (in seconds) that is
      * requested for this credential to be used at the context initiator's
      * end. This value should be ignored if the usage is
-     * ACCEPT_ONLY. Predefined contants are available in the
+     * ACCEPT_ONLY. Predefined constants are available in the
      * org.ietf.jgss.GSSCredential interface.
      * @param acceptLifetime indicates the lifetime (in seconds) that is
      * requested for this credential to be used at the context acceptor's
      * end. This value should be ignored if the usage is
-     * INITIATE_ONLY. Predefined contants are available in the
+     * INITIATE_ONLY. Predefined constants are available in the
      * org.ietf.jgss.GSSCredential interface.
      * @param usage One of the values GSSCredential.INIATE_ONLY,
      * GSSCredential.ACCEPT_ONLY, and GSSCredential.INITIATE_AND_ACCEPT.
@@ -169,7 +169,7 @@ public interface MechanismFactory {
      * mechanism's choice should be assumed to be the context initiator and
      * that default credentials should be applied.
      * @param lifetime the requested lifetime (in seconds) for the security
-     * context. Predefined contants are available in the
+     * context. Predefined constants are available in the
      * org.ietf.jgss.GSSContext interface.
      * @throws GSSException if any of the errors described in RFC 2743 in
      * the GSS_Init_Sec_Context call occur.
@@ -184,8 +184,8 @@ public interface MechanismFactory {
      *
      * @param myAcceptorCred a credential element for the context acceptor
      * obtained previously from this mechanism. The identity of the context
-     * acceptor cna be obtained from this credential. Passing a value of
-     * null here indicates that tha default entity of the mechanism's
+     * acceptor can be obtained from this credential. Passing a value of
+     * null here indicates that the default entity of the mechanism's
      * choice should be assumed to be the context acceptor and default
      * credentials should be applied.
      *

--- a/src/java.security.jgss/share/classes/sun/security/jgss/spnego/SpNegoContext.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/spnego/SpNegoContext.java
@@ -357,7 +357,7 @@ public class SpNegoContext implements GSSContextSpi {
                 // pull out mechanism
                 internal_mech = targToken.getSupportedMech();
                 if (internal_mech == null) {
-                    // return wth failure
+                    // return with failure
                     throw new GSSException(errorCode, -1,
                                 "supported mechanism from server is null");
                 }
@@ -695,7 +695,7 @@ public class SpNegoContext implements GSSContextSpi {
     }
 
     /**
-     * get ther DER encoded MechList
+     * get the DER encoded MechList
      */
     private byte[] getEncodedMechs(Oid[] mechSet)
         throws IOException, GSSException {
@@ -910,7 +910,7 @@ public class SpNegoContext implements GSSContextSpi {
     }
 
     /**
-     * This routine compares the recieved mechset to the mechset that
+     * This routine compares the received mechset to the mechset that
      * this server can support. It looks sequentially through the mechset
      * and the first one that matches what the server can support is
      * chosen as the negotiated mechanism. If one is found, negResult

--- a/src/java.security.jgss/share/classes/sun/security/krb5/Checksum.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Checksum.java
@@ -251,7 +251,7 @@ public class Checksum {
      * specification available at
      * <a href="http://www.ietf.org/rfc/rfc4120.txt">
      * http://www.ietf.org/rfc/rfc4120.txt</a>.
-     * @return byte array of enocded Checksum.
+     * @return byte array of encoded Checksum.
      * @exception Asn1Exception if an error occurs while decoding an
      * ASN1 encoded data.
      * @exception IOException if an I/O error occurs while reading

--- a/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
@@ -103,7 +103,7 @@ public class Config {
 
     private static boolean DEBUG = sun.security.krb5.internal.Krb5.DEBUG;
 
-    // these are used for hexdecimal calculation.
+    // these are used for hexadecimal calculation.
     private static final int BASE16_0 = 1;
     private static final int BASE16_1 = 16;
     private static final int BASE16_2 = 16 * 16;
@@ -273,7 +273,7 @@ public class Config {
     /**
      * Gets the boolean value for the specified keys. Returns TRUE if the
      * string value is "yes", or "true", FALSE if "no", or "false", or null
-     * if otherwise or not defined. The comparision is case-insensitive.
+     * if otherwise or not defined. The comparison is case-insensitive.
      *
      * @param keys the keys, see {@link #get(String...)}
      * @return the boolean value, or null if there is no value defined or the

--- a/src/java.security.jgss/share/classes/sun/security/krb5/EncryptionKey.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/EncryptionKey.java
@@ -112,7 +112,7 @@ public class EncryptionKey
 
         if (princ == null)
             throw new IllegalArgumentException(
-                "Cannot have null pricipal name to look in keytab.");
+                "Cannot have null principal name to look in keytab.");
 
         // KeyTab getInstance(keytab) will call KeyTab.getInstance()
         // if keytab is null

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/EncASRepPart.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/EncASRepPart.java
@@ -65,7 +65,7 @@ public class EncASRepPart extends EncKDCRepPart {
                 Krb5.KRB_ENC_AS_REP_PART
                 );
         //may need to use Krb5.KRB_ENC_TGS_REP_PART to mimic
-        //behavior of other implementaions, instead of above
+        //behavior of other implementations, instead of above
     }
 
     public EncASRepPart(byte[] data) throws Asn1Exception,

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ccache/MemoryCredentialsCache.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ccache/MemoryCredentialsCache.java
@@ -37,7 +37,7 @@ import java.io.File;
 
 //Windows supports the "API: cache" type, which is a shared memory cache.  This is
 //implemented by krbcc32.dll as part of the MIT Kerberos for Win32 distribution.
-//MemoryCredentialsCache will provide future functions to access shared memeory cache on
+//MemoryCredentialsCache will provide future functions to access shared memory cache on
 //Windows platform. Native code implementation may be necessary.
 /**
  * This class extends CredentialsCache. It is used for accessing data in shared memory

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/DkCrypto.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/DkCrypto.java
@@ -469,7 +469,7 @@ public abstract class DkCrypto {
      * must be expanded with n-fold() so it can be encrypted.  If the output
      * of E is shorter than k bits it is fed back into the encryption as
      * many times as necessary.  The construct is as follows (where |
-     * indicates concatentation):
+     * indicates concatenation):
      *
      * K1 = E(Key, n-fold(Constant), initial-cipher-state)
      * K2 = E(Key, K1, initial-cipher-state)

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ktab/KeyTab.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ktab/KeyTab.java
@@ -85,7 +85,7 @@ public class KeyTab implements KeyTabConstants {
     /**
      * Constructs a KeyTab object.
      *
-     * If there is any I/O error or format errot during the loading, the
+     * If there is any I/O error or format error during the loading, the
      * isValid flag is set to false, and all half-read entries are dismissed.
      * @param filename path name for the keytab file, must not be null
      */

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/util/KrbDataInputStream.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/util/KrbDataInputStream.java
@@ -36,7 +36,7 @@ import java.io.InputStream;
 import java.io.IOException;
 
 /**
- * This class implements a buffered input stream. It provides methods to read a chunck
+ * This class implements a buffered input stream. It provides methods to read a chunk
  * of data from underlying data stream.
  *
  * @author Yanni Zhang

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/util/KrbDataOutputStream.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/util/KrbDataOutputStream.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 /**
- * This class implements a buffered output stream. It provides methods to write a chunck of
+ * This class implements a buffered output stream. It provides methods to write a chunk of
  * bytes to underlying data stream.
  *
  * @author Yanni Zhang

--- a/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Kinit.java
+++ b/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Kinit.java
@@ -117,7 +117,7 @@ public class Kinit {
     /**
      * Constructs a new Kinit object.
      * @param args array of ticket request options.
-     * Avaiable options are: -f, -p, -c, principal, password.
+     * Available options are: -f, -p, -c, principal, password.
      * @exception IOException if an I/O error occurs.
      * @exception RealmException if the Realm could not be instantiated.
      * @exception KrbException if error occurs during Kerberos operation.

--- a/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Ktab.java
+++ b/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Ktab.java
@@ -447,7 +447,7 @@ public class Ktab {
                 + "    kvno. If \"all\" is specified, delete all keys. If \"old\" is specified,\n"
                 + "    delete all keys except those with the highest kvno. Default action\n"
                 + "    is \"all\". If <etype> is specified, only keys of this encryption type\n"
-                + "    are deleted. <etype> should be specified as the numberic value etype\n"
+                + "    are deleted. <etype> should be specified as the numeric value etype\n"
                 + "    defined in RFC 3961, section 8. A prompt to confirm the deletion is\n"
                 + "    displayed unless -f is specified.");
         System.out.println();

--- a/src/java.security.jgss/windows/native/libw2k_lsa_auth/NativeCreds.c
+++ b/src/java.security.jgss/windows/native/libw2k_lsa_auth/NativeCreds.c
@@ -1048,7 +1048,7 @@ jobject BuildTicketFlags(JNIEnv *env, PULONG flags) {
     jobject ticketFlags = NULL;
     jbyteArray ary;
     /*
-     * mdu: Convert the bytes to nework byte order before copying
+     * mdu: Convert the bytes to network byte order before copying
      * them to a Java byte array.
      */
     ULONG nlflags = htonl(*flags);

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Base.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Base.java
@@ -62,7 +62,7 @@ import javax.security.auth.callback.CallbackHandler;
 /**
  * Utility class for DIGEST-MD5 mechanism. Provides utility methods
  * and contains two inner classes which implement the SecurityCtx
- * interface. The inner classes provide the funtionality to allow
+ * interface. The inner classes provide the functionality to allow
  * for quality-of-protection (QOP) with integrity checking and
  * privacy.
  *
@@ -171,7 +171,7 @@ abstract class DigestMD5Base extends AbstractSaslImpl {
     protected DigestMD5Base(Map<String, ?> props, String className,
         int firstStep, String digestUri, CallbackHandler cbh)
         throws SaslException {
-        super(props, className); // sets QOP, STENGTH and BUFFER_SIZE
+        super(props, className); // sets QOP, STRENGTH and BUFFER_SIZE
 
         step = firstStep;
         this.digestUri = digestUri;
@@ -1277,7 +1277,7 @@ abstract class DigestMD5Base extends AbstractSaslImpl {
                     "specification used.", e);
             } catch (InvalidAlgorithmParameterException e) {
                 throw new SaslException("DIGEST-MD5: Invalid cipher " +
-                    "algorithem parameter used to create cipher instance", e);
+                    "algorithm parameter used to create cipher instance", e);
             } catch (NoSuchPaddingException e) {
                 throw new SaslException("DIGEST-MD5: Unsupported " +
                     "padding used for chosen cipher", e);

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Client.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Client.java
@@ -268,7 +268,7 @@ final class DigestMD5Client extends DigestMD5Base implements SaslClient {
     * directives not missing from the digest-challenge.
     *
     * @throws SaslException if a sasl is a the mechanism cannot
-    * correcly handle a callbacks or if a violation in the
+    * correctly handle a callbacks or if a violation in the
     * digest challenge format is detected.
     */
     private void processChallenge(byte[][] challengeVal, List<byte[]> realmChoices)
@@ -655,7 +655,7 @@ final class DigestMD5Client extends DigestMD5Base implements SaslClient {
      */
     private void validateResponseValue(byte[] fromServer) throws SaslException {
         if (fromServer == null) {
-            throw new SaslException("DIGEST-MD5: Authenication failed. " +
+            throw new SaslException("DIGEST-MD5: Authentication failed. " +
                 "Expecting 'rspauth' authentication success message");
         }
 

--- a/src/java.smartcardio/unix/native/libj2pcsc/MUSCLE/pcsclite.h
+++ b/src/java.smartcardio/unix/native/libj2pcsc/MUSCLE/pcsclite.h
@@ -58,7 +58,7 @@ typedef SCARDHANDLE *LPSCARDHANDLE;
 
 #define MAX_ATR_SIZE                  33      /**< Maximum ATR size */
 
-/* Set structure elements aligment on bytes
+/* Set structure elements alignment on bytes
  * http://gcc.gnu.org/onlinedocs/gcc/Structure_002dPacking-Pragmas.html */
 #ifdef __APPLE__
 #pragma pack(1)
@@ -292,7 +292,7 @@ extern const SCARD_IO_REQUEST g_rgSCardT0Pci, g_rgSCardT1Pci, g_rgSCardRawPci;
 /*
  * The message and buffer sizes must be multiples of 16.
  * The max message size must be at least large enough
- * to accomodate the transmit_struct
+ * to accommodate the transmit_struct
  */
 #define MAX_BUFFER_SIZE                  264      /**< Maximum Tx/Rx Buffer for short APDU */
 #define MAX_BUFFER_SIZE_EXTENDED      (4 + 3 + (1<<16) + 3 + 2)      /**< enhanced (64K + APDU + Lc + Le + SW) Tx/Rx Buffer */

--- a/src/java.xml.crypto/share/classes/javax/xml/crypto/dsig/keyinfo/X509Data.java
+++ b/src/java.xml.crypto/share/classes/javax/xml/crypto/dsig/keyinfo/X509Data.java
@@ -35,7 +35,7 @@ import java.util.List;
  * A representation of the XML <code>X509Data</code> element as defined in
  * the <a href="http://www.w3.org/TR/xmldsig-core/">
  * W3C Recommendation for XML-Signature Syntax and Processing</a>. An
- * <code>X509Data</code> object contains one or more identifers of keys
+ * <code>X509Data</code> object contains one or more identifiers of keys
  * or X.509 certificates (or certificates' identifiers or a revocation list).
  * The XML Schema Definition is defined as:
  *

--- a/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMManifest.java
+++ b/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMManifest.java
@@ -104,7 +104,7 @@ public final class DOMManifest extends DOMStructure implements Manifest {
             }
             refs.add(new DOMReference(refElem, context, provider));
             if (secVal && Policy.restrictNumReferences(refs.size())) {
-                String error = "A maxiumum of " + Policy.maxReferences()
+                String error = "A maximum of " + Policy.maxReferences()
                     + " references per Manifest are allowed when"
                     + " secure validation is enabled";
                 throw new MarshalException(error);

--- a/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMSignedInfo.java
+++ b/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMSignedInfo.java
@@ -102,7 +102,7 @@ public final class DOMSignedInfo extends DOMStructure implements SignedInfo {
      * @param cm the canonicalization method
      * @param sm the signature method
      * @param references the list of references. The list is copied.
-     * @param id an optional identifer that will allow this
+     * @param id an optional identifier that will allow this
      *    {@code SignedInfo} to be referenced by other signatures and
      *    objects
      * @throws NullPointerException if {@code cm}, {@code sm},
@@ -168,7 +168,7 @@ public final class DOMSignedInfo extends DOMStructure implements SignedInfo {
             }
             refList.add(new DOMReference(refElem, context, provider));
             if (secVal && Policy.restrictNumReferences(refList.size())) {
-                String error = "A maxiumum of " + Policy.maxReferences()
+                String error = "A maximum of " + Policy.maxReferences()
                     + " references per Manifest are allowed when"
                     + " secure validation is enabled";
                 throw new MarshalException(error);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -96,7 +96,7 @@ final class P11AEADCipher extends CipherSpi {
     // flag indicating whether an operation is initialized
     private boolean initialized = false;
 
-    // falg indicating encrypt or decrypt mode
+    // flag indicating encrypt or decrypt mode
     private boolean encrypt = true;
 
     // parameters

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -138,7 +138,7 @@ final class P11Cipher extends CipherSpi {
     // flag indicating whether an operation is initialized
     private boolean initialized;
 
-    // falg indicating encrypt or decrypt mode
+    // flag indicating encrypt or decrypt mode
     private boolean encrypt;
 
     // mode, one of MODE_* above (MODE_ECB for stream ciphers)

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -88,7 +88,7 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
     }
 
     // returns the PKCS11 key type of the specified algorithm
-    // no psuedo KeyTypes
+    // no pseudo KeyTypes
     static long getPKCS11KeyType(String algorithm) {
         long kt = getKeyType(algorithm);
         if (kt == -1 || kt > PCKK_ANY) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -292,7 +292,7 @@ public final class SunPKCS11 extends AuthProvider {
         File libraryFile = new File(library);
         // if the filename is a simple filename without path
         // (e.g. "libpkcs11.so"), it may refer to a library somewhere on the
-        // OS library search path. Omit the test for file existance as that
+        // OS library search path. Omit the test for file existence as that
         // only looks in the current directory.
         if (libraryFile.getName().equals(library) == false) {
             if (new File(library).isFile() == false) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Constants.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Constants.java
@@ -51,7 +51,7 @@ package sun.security.pkcs11.wrapper;
  * This interface holds constants of the PKCS#11 v3.00 standard.
  * This is mainly the content of the 'pkcs11t.h' header file.
  *
- * Mapping of primitiv data types to Java types:
+ * Mapping of primitive data types to Java types:
  * <pre>
  *   TRUE .......................................... true
  *   FALSE ......................................... false

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11RuntimeException.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11RuntimeException.java
@@ -73,7 +73,7 @@ public class PKCS11RuntimeException extends RuntimeException {
      * Constructor taking a string that describes the reason of the exception
      * in more detail.
      *
-     * @param message A descrption of the reason for this exception.
+     * @param message A description of the reason for this exception.
      * @preconditions
      * @postconditions
      */

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/j2secmod.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/j2secmod.h
@@ -88,7 +88,7 @@ struct PK11SlotInfoStr {
     void *functionList;
     SECMODModule *module; /* our parent module */
     /* Boolean to indicate the current state of this slot */
-    PRBool needTest;           /* Has this slot been tested for Export complience */
+    PRBool needTest;           /* Has this slot been tested for Export compliance */
     PRBool isPerm;             /* is this slot a permanment device */
     PRBool isHW;               /* is this slot a hardware device */
     PRBool isInternal;         /* is this slot one of our internal PKCS #11 devices */
@@ -110,9 +110,9 @@ struct PK11SlotInfoStr {
     void *sessionLock; /* lock for this session */
     /* our ID */
     CK_SLOT_ID slotID;
-    /* persistant flags saved from startup to startup */
+    /* persistent flags saved from startup to startup */
     unsigned long defaultFlags;
-    /* keep track of who is using us so we don't accidently get freed while
+    /* keep track of who is using us so we don't accidentally get freed while
      * still in use */
     PRInt32 refCount; /* to be in/decremented by atomic calls ONLY! */
     void *freeListLock;

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
@@ -1553,10 +1553,10 @@ CK_VOID_PTR jMechParamToCKMechParamPtrSlow(JNIEnv *env, jobject jParam,
         case CKM_SKIPJACK_PRIVATE_WRAP: // CK_SKIPJACK_PRIVATE_WRAP_PARAMS
         case CKM_SKIPJACK_RELAYX: // CK_SKIPJACK_RELAYX_PARAMS
         case CKM_KEY_WRAP_SET_OAEP: // CK_KEY_WRAP_SET_OAEP_PARAMS
-            throwPKCS11RuntimeException(env, "No parameter support for this mchanism");
+            throwPKCS11RuntimeException(env, "No parameter support for this mechanism");
             break;
         default:
-            /* if everything faild up to here */
+            /* if everything failed up to here */
             /* try if the parameter is a primitive Java type */
             ckpParamPtr = jObjectToPrimitiveCKObjectPtr(env, jParam, ckpLength);
             /* *ckpParamPtr = jObjectToCKVoidPtr(jParam); */
@@ -1905,7 +1905,7 @@ jRsaPkcsPssParamToCKRsaPkcsPssParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pL
  * @param env - used to call JNI funktions to get the Java classes and objects
  * @param jParam - the Java CK_ECDH1_DERIVE_PARAMS object to convert
  * @param pLength - length of the allocated memory of the returned pointer
- * @retur pointer to nthe new CK_ECDH1_DERIVE_PARAMS structure
+ * @return pointer to nthe new CK_ECDH1_DERIVE_PARAMS structure
  */
 CK_ECDH1_DERIVE_PARAMS_PTR
 jEcdh1DeriveParamToCKEcdh1DeriveParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pLength)

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
@@ -210,7 +210,7 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1Initialize
 (JNIEnv *env, jobject obj, jobject jInitArgs)
 {
     /*
-     * Initalize Cryptoki
+     * Initialize Cryptoki
      */
     CK_C_INITIALIZE_ARGS_PTR ckpInitArgs;
     CK_RV rv;

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_keymgmt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_keymgmt.c
@@ -819,7 +819,7 @@ void copyBackTLSPrfParams(JNIEnv *env, CK_MECHANISM_PTR ckpMechanism, jobject jM
     jMechanismType = (*env)->GetLongField(env, jMechanism, fieldID);
     ckMechanismType = jLongToCKULong(jMechanismType);
     if (ckMechanismType != ckpMechanism->mechanism) {
-        /* we do not have maching types, this should not occur */
+        /* we do not have matching types, this should not occur */
         return;
     }
 
@@ -967,7 +967,7 @@ static void copyBackClientVersion(JNIEnv *env, CK_MECHANISM_PTR ckpMechanism, jo
     jMechanismType = (*env)->GetLongField(env, jMechanism, fieldID);
     ckMechanismType = jLongToCKULong(jMechanismType);
     if (ckMechanismType != ckpMechanism->mechanism) {
-        /* we do not have maching types, this should not occur */
+        /* we do not have matching types, this should not occur */
         return;
     }
 
@@ -1065,7 +1065,7 @@ static void copyBackKeyMatParams(JNIEnv *env, CK_MECHANISM_PTR ckpMechanism,
     jMechanismType = (*env)->GetLongField(env, jMechanism, fieldID);
     ckMechanismType = jLongToCKULong(jMechanismType);
     if (ckMechanismType != ckpMechanism->mechanism) {
-        /* we do not have maching types, this should not occur */
+        /* we do not have matching types, this should not occur */
         return;
     }
 

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sessmgmt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sessmgmt.c
@@ -543,7 +543,7 @@ NotifyEncapsulation * removeFirstNotifyEntry(JNIEnv *env) {
  * back to a NotifyEncapsulation structure and retrieves the Notify object and
  * the application data from it.
  *
- * @param hSession The session, this callback is comming from.
+ * @param hSession The session, this callback is coming from.
  * @param event The type of event that occurred.
  * @param pApplication The application data as passed in upon OpenSession. In
                        this wrapper we always pass in a NotifyEncapsulation

--- a/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
@@ -50,7 +50,7 @@
  * 18.05.2001
  *
  * This module contains the native functions of the Java to PKCS#11 interface
- * which are platform dependent. This includes loading a dynamic link libary,
+ * which are platform dependent. This includes loading a dynamic link library,
  * retrieving the function list and unloading the dynamic link library.
  *
  * @author Karl Scheibelhofer <Karl.Scheibelhofer@iaik.at>

--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
@@ -50,7 +50,7 @@
  * 18.05.2001
  *
  * This module contains the native functions of the Java to PKCS#11 interface
- * which are platform dependent. This includes loading a dynamic link libary,
+ * which are platform dependent. This includes loading a dynamic link library,
  * retrieving the function list and unloading the dynamic link library.
  *
  * @author Karl Scheibelhofer <Karl.Scheibelhofer@iaik.at>

--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.h
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.h
@@ -50,7 +50,7 @@
  */
 
 /*
- * platoform.h
+ * platform.h
  * 10.12.2001
  *
  * declaration of all platform dependent functions used by pkcs11wrapper.c

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECKeyFactory.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECKeyFactory.java
@@ -73,7 +73,7 @@ public final class ECKeyFactory extends KeyFactorySpi {
     }
 
     /**
-     * Static method to convert Key into a useable instance of
+     * Static method to convert Key into a usable instance of
      * ECPublicKey or ECPrivateKey. Check the key and convert it
      * to a Sun key if necessary. If the key is not an EC key
      * or cannot be used, throw an InvalidKeyException.

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/module/Krb5LoginModule.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/module/Krb5LoginModule.java
@@ -773,7 +773,7 @@ public class Krb5LoginModule implements LoginModule {
                     }
                 }
 
-                // we should hava a non-null cred
+                // we should have a non-null cred
                 if (isInitiator && (cred == null)) {
                     throw new LoginException
                         ("TGT Can not be obtained from the KDC ");

--- a/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Server.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/GssKrb5Server.java
@@ -133,7 +133,7 @@ final class GssKrb5Server extends GssKrb5Base implements SaslServer {
      *
      * The client sends response data to which the server must
      * process using GSS_accept_sec_context.
-     * As per RFC 2222, the GSS authenication completes (GSS_S_COMPLETE)
+     * As per RFC 2222, the GSS authentication completes (GSS_S_COMPLETE)
      * we do an extra hand shake to determine the negotiated security protection
      * and buffer sizes.
      *


### PR DESCRIPTION
I backport this to simplify follow-up backports.

Applies clean except for the chunk in src/jdk.security.auth/share/classes/com/sun/security/auth/module/JndiLoginModule.java
The comments corrected there were only added in "8263105: security-libs doclint cleanup" which is not in 11. 
I thought about grabbing the whole comment, but that change has a CSR, so I don't want to take parts of it back to 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285380](https://bugs.openjdk.org/browse/JDK-8285380): Fix typos in security


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1199/head:pull/1199` \
`$ git checkout pull/1199`

Update a local copy of the PR: \
`$ git checkout pull/1199` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1199`

View PR using the GUI difftool: \
`$ git pr show -t 1199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1199.diff">https://git.openjdk.org/jdk11u-dev/pull/1199.diff</a>

</details>
