### PR TITLE
8284944: assert(cnt++ < 40) failed: infinite cycle in loop optimization

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2181,10 +2181,8 @@ void Compile::inline_incrementally(PhaseIterGVN& igvn) {
 
 bool Compile::optimize_loops(int& loop_opts_cnt, PhaseIterGVN& igvn, LoopOptsMode mode) {
   if(loop_opts_cnt > 0) {
-    debug_only( int cnt = 0; );
-    while(major_progress() && (loop_opts_cnt > 0)) {
+    while (major_progress() && (loop_opts_cnt > 0)) {
       TracePhase tp("idealLoop", &timers[_t_idealLoop]);
-      assert( cnt++ < 40, "infinite cycle in loop optimization" );
       PhaseIdealLoop ideal_loop(igvn, mode);
       loop_opts_cnt--;
       if (failing())  return false;

--- a/test/hotspot/jtreg/compiler/loopopts/TestMaxLoopOptsCountReached.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestMaxLoopOptsCountReached.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8284944
+ * @requires vm.compiler2.enabled
+ * @summary triggers the loop optimization phase `LoopOptsCount` many times
+ * @run main/othervm -Xcomp -XX:-PartialPeelLoop -XX:CompileCommand=compileonly,TestMaxLoopOptsCountReached::test TestMaxLoopOptsCountReached
+ */
+
+import java.lang.System.Logger.Level;
+
+public class TestMaxLoopOptsCountReached {
+
+    static Long a = Long.valueOf(42);
+
+    class A {
+
+        static String e(long f, boolean b, String g, Level h, String s,
+                        Object... i) {
+            return "message" + s + new String() + g;
+        }
+    }
+
+    public static void main(String[] args) {
+        test(null, "", null, null);
+        test(null, "", null, null);
+    }
+
+    static void test(Integer o, String g, String name, Object obj) {
+        for (Level q : Level.values())
+            for (Level r : Level.values())
+                A.e(a.longValue(), q != Level.OFF, g, null, null);
+        for (Level q : Level.values())
+            for (Level r : Level.values())
+                A.e(a.longValue(), q != Level.OFF, g, null, null);
+        for (Level q : Level.values()) {
+            for (Level r : Level.values()) {
+                String msg = q + "message";
+                String val =
+                        (q != Level.OFF || name != msg)
+                                ? A.e(a.longValue(), q != Level.OFF, g, null, null, "foo")
+                                : null;
+            }
+            for (Level r : Level.values()) {
+                String msg = q + "message";
+                String val =
+                        (q != Level.OFF || name != msg)
+                                ? A.e(a.longValue(), q != Level.OFF, g, null, null, "foo")
+                                : null;
+            }
+        }
+        for (Level q : Level.values()) {
+            for (Level r : Level.values()) {
+                String msg = q + "message";
+                String val =
+                        (q != Level.OFF || name != msg)
+                                ? A.e(a.longValue(), q != Level.OFF, g, null, null, "foo")
+                                : null;
+            }
+            for (Level r : Level.values()) {
+                String msg = q + "message";
+                String val =
+                        (q != Level.OFF || name != msg)
+                                ? A.e(a.longValue(), q != Level.OFF, g, null, null, "foo")
+                                : null;
+            }
+        }
+        for (Level q : Level.values()) {
+            for (Level r : Level.values()) {
+                String msg = q + "message";
+                String val =
+                        (q != Level.OFF || name != msg)
+                                ? A.e(a.longValue(), q != Level.OFF, g, null, null, "foo")
+                                : null;
+            }
+            for (Level r : Level.values())
+                ;
+        }
+        for (Level q : Level.values()) {
+            for (Level r : Level.values())
+                ;
+            for (Level r : Level.values())
+                ;
+        }
+        for (Level q : Level.values()) {
+            for (Level r : Level.values()) {
+                String msg = q + "message";
+                String val =
+                        (q != Level.OFF || name != msg)
+                                ? A.e(a.longValue(), q != Level.OFF, g, null, null, "foo")
+                                : null;
+            }
+            for (Level r : Level.values())
+                ;
+        }
+        for (Level q : Level.values()) {
+            for (Level r : Level.values())
+                ;
+            for (Level r : Level.values())
+                ;
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestMaxLoopOptsCountReached.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestMaxLoopOptsCountReached.java
@@ -31,17 +31,18 @@
 
 import java.lang.System.Logger.Level;
 
+class A {
+
+   static String e(long f, boolean b, String g, Level h, String s,
+                   Object... i) {
+       return "message" + s + new String() + g;
+   }
+}
+
 public class TestMaxLoopOptsCountReached {
 
     static Long a = Long.valueOf(42);
 
-    class A {
-
-        static String e(long f, boolean b, String g, Level h, String s,
-                        Object... i) {
-            return "message" + s + new String() + g;
-        }
-    }
 
     public static void main(String[] args) {
         test(null, "", null, null);


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.
I had to resolve compile.cpp because of a space difference in the context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284944](https://bugs.openjdk.org/browse/JDK-8284944): assert(cnt++ < 40) failed: infinite cycle in loop optimization


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [7422f92a](https://git.openjdk.org/jdk11u-dev/pull/1200/files/7422f92a4769138070c47a49cf2cf1136521b1a7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1200/head:pull/1200` \
`$ git checkout pull/1200`

Update a local copy of the PR: \
`$ git checkout pull/1200` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1200`

View PR using the GUI difftool: \
`$ git pr show -t 1200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1200.diff">https://git.openjdk.org/jdk11u-dev/pull/1200.diff</a>

</details>
