### PR TITLE
8255381: com/sun/jdi/EATests.java should not suspend graal threads

### DIFF
--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -838,6 +838,12 @@ abstract public class TestScaffold extends TargetAdapter {
 
     public BreakpointEvent resumeTo(String clsName, String methodName,
                                          String methodSignature) {
+        return resumeTo(clsName, methodName, methodSignature, false /* suspendThread */);
+    }
+
+    public BreakpointEvent resumeTo(String clsName, String methodName,
+                                    String methodSignature,
+                                    boolean suspendThread) {
         ReferenceType rt = findReferenceType(clsName);
         if (rt == null) {
             rt = resumeToPrepareOf(clsName).referenceType();
@@ -849,7 +855,7 @@ abstract public class TestScaffold extends TargetAdapter {
                     + clsName + "." + methodName + ":" + methodSignature);
         }
 
-        return resumeTo(method.location());
+        return resumeTo(method.location(), suspendThread);
     }
 
     public BreakpointEvent resumeTo(String clsName, int lineNumber) throws AbsentInformationException {


### PR DESCRIPTION
This is the backport of a small enhancement of the test library. The `TestScaffold` used in jdi tests is changed adding a new version of the overloaded method `resumeTo()` which takes an additional parameter `suspendThread`.

This part applies well.
Other parts of the original commit 09e8675f568571d959d55b096c2cd3b033204e62 are not applicable (tested feature not in 11u).

Testing: jtreg:test/jdk:jdk_jdi

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255381](https://bugs.openjdk.org/browse/JDK-8255381): com/sun/jdi/EATests.java should not suspend graal threads


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1202/head:pull/1202` \
`$ git checkout pull/1202`

Update a local copy of the PR: \
`$ git checkout pull/1202` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1202`

View PR using the GUI difftool: \
`$ git pr show -t 1202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1202.diff">https://git.openjdk.org/jdk11u-dev/pull/1202.diff</a>

</details>
