### PR TITLE
8289856: [PPC64] SIGSEGV in C2Compiler::init_c2_runtime() after JDK-8289060

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
-// Copyright (c) 2012, 2020 SAP SE. All rights reserved.
+// Copyright (c) 2012, 2022 SAP SE. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -257,70 +257,70 @@ register %{
 // ----------------------------
 // Vector-Scalar Registers
 // ----------------------------
-  reg_def VSR0 ( SOC, SOC, Op_VecX, 0, NULL);
-  reg_def VSR1 ( SOC, SOC, Op_VecX, 1, NULL);
-  reg_def VSR2 ( SOC, SOC, Op_VecX, 2, NULL);
-  reg_def VSR3 ( SOC, SOC, Op_VecX, 3, NULL);
-  reg_def VSR4 ( SOC, SOC, Op_VecX, 4, NULL);
-  reg_def VSR5 ( SOC, SOC, Op_VecX, 5, NULL);
-  reg_def VSR6 ( SOC, SOC, Op_VecX, 6, NULL);
-  reg_def VSR7 ( SOC, SOC, Op_VecX, 7, NULL);
-  reg_def VSR8 ( SOC, SOC, Op_VecX, 8, NULL);
-  reg_def VSR9 ( SOC, SOC, Op_VecX, 9, NULL);
-  reg_def VSR10 ( SOC, SOC, Op_VecX, 10, NULL);
-  reg_def VSR11 ( SOC, SOC, Op_VecX, 11, NULL);
-  reg_def VSR12 ( SOC, SOC, Op_VecX, 12, NULL);
-  reg_def VSR13 ( SOC, SOC, Op_VecX, 13, NULL);
-  reg_def VSR14 ( SOC, SOC, Op_VecX, 14, NULL);
-  reg_def VSR15 ( SOC, SOC, Op_VecX, 15, NULL);
-  reg_def VSR16 ( SOC, SOC, Op_VecX, 16, NULL);
-  reg_def VSR17 ( SOC, SOC, Op_VecX, 17, NULL);
-  reg_def VSR18 ( SOC, SOC, Op_VecX, 18, NULL);
-  reg_def VSR19 ( SOC, SOC, Op_VecX, 19, NULL);
-  reg_def VSR20 ( SOC, SOC, Op_VecX, 20, NULL);
-  reg_def VSR21 ( SOC, SOC, Op_VecX, 21, NULL);
-  reg_def VSR22 ( SOC, SOC, Op_VecX, 22, NULL);
-  reg_def VSR23 ( SOC, SOC, Op_VecX, 23, NULL);
-  reg_def VSR24 ( SOC, SOC, Op_VecX, 24, NULL);
-  reg_def VSR25 ( SOC, SOC, Op_VecX, 25, NULL);
-  reg_def VSR26 ( SOC, SOC, Op_VecX, 26, NULL);
-  reg_def VSR27 ( SOC, SOC, Op_VecX, 27, NULL);
-  reg_def VSR28 ( SOC, SOC, Op_VecX, 28, NULL);
-  reg_def VSR29 ( SOC, SOC, Op_VecX, 29, NULL);
-  reg_def VSR30 ( SOC, SOC, Op_VecX, 30, NULL);
-  reg_def VSR31 ( SOC, SOC, Op_VecX, 31, NULL);
-  reg_def VSR32 ( SOC, SOC, Op_VecX, 32, NULL);
-  reg_def VSR33 ( SOC, SOC, Op_VecX, 33, NULL);
-  reg_def VSR34 ( SOC, SOC, Op_VecX, 34, NULL);
-  reg_def VSR35 ( SOC, SOC, Op_VecX, 35, NULL);
-  reg_def VSR36 ( SOC, SOC, Op_VecX, 36, NULL);
-  reg_def VSR37 ( SOC, SOC, Op_VecX, 37, NULL);
-  reg_def VSR38 ( SOC, SOC, Op_VecX, 38, NULL);
-  reg_def VSR39 ( SOC, SOC, Op_VecX, 39, NULL);
-  reg_def VSR40 ( SOC, SOC, Op_VecX, 40, NULL);
-  reg_def VSR41 ( SOC, SOC, Op_VecX, 41, NULL);
-  reg_def VSR42 ( SOC, SOC, Op_VecX, 42, NULL);
-  reg_def VSR43 ( SOC, SOC, Op_VecX, 43, NULL);
-  reg_def VSR44 ( SOC, SOC, Op_VecX, 44, NULL);
-  reg_def VSR45 ( SOC, SOC, Op_VecX, 45, NULL);
-  reg_def VSR46 ( SOC, SOC, Op_VecX, 46, NULL);
-  reg_def VSR47 ( SOC, SOC, Op_VecX, 47, NULL);
-  reg_def VSR48 ( SOC, SOC, Op_VecX, 48, NULL);
-  reg_def VSR49 ( SOC, SOC, Op_VecX, 49, NULL);
-  reg_def VSR50 ( SOC, SOC, Op_VecX, 50, NULL);
-  reg_def VSR51 ( SOC, SOC, Op_VecX, 51, NULL);
-  reg_def VSR52 ( SOC, SOC, Op_VecX, 52, NULL);
-  reg_def VSR53 ( SOC, SOC, Op_VecX, 53, NULL);
-  reg_def VSR54 ( SOC, SOC, Op_VecX, 54, NULL);
-  reg_def VSR55 ( SOC, SOC, Op_VecX, 55, NULL);
-  reg_def VSR56 ( SOC, SOC, Op_VecX, 56, NULL);
-  reg_def VSR57 ( SOC, SOC, Op_VecX, 57, NULL);
-  reg_def VSR58 ( SOC, SOC, Op_VecX, 58, NULL);
-  reg_def VSR59 ( SOC, SOC, Op_VecX, 59, NULL);
-  reg_def VSR60 ( SOC, SOC, Op_VecX, 60, NULL);
-  reg_def VSR61 ( SOC, SOC, Op_VecX, 61, NULL);
-  reg_def VSR62 ( SOC, SOC, Op_VecX, 62, NULL);
-  reg_def VSR63 ( SOC, SOC, Op_VecX, 63, NULL);
+  reg_def VSR0 ( SOC, SOC, Op_VecX, 0, VMRegImpl::Bad());
+  reg_def VSR1 ( SOC, SOC, Op_VecX, 1, VMRegImpl::Bad());
+  reg_def VSR2 ( SOC, SOC, Op_VecX, 2, VMRegImpl::Bad());
+  reg_def VSR3 ( SOC, SOC, Op_VecX, 3, VMRegImpl::Bad());
+  reg_def VSR4 ( SOC, SOC, Op_VecX, 4, VMRegImpl::Bad());
+  reg_def VSR5 ( SOC, SOC, Op_VecX, 5, VMRegImpl::Bad());
+  reg_def VSR6 ( SOC, SOC, Op_VecX, 6, VMRegImpl::Bad());
+  reg_def VSR7 ( SOC, SOC, Op_VecX, 7, VMRegImpl::Bad());
+  reg_def VSR8 ( SOC, SOC, Op_VecX, 8, VMRegImpl::Bad());
+  reg_def VSR9 ( SOC, SOC, Op_VecX, 9, VMRegImpl::Bad());
+  reg_def VSR10 ( SOC, SOC, Op_VecX, 10, VMRegImpl::Bad());
+  reg_def VSR11 ( SOC, SOC, Op_VecX, 11, VMRegImpl::Bad());
+  reg_def VSR12 ( SOC, SOC, Op_VecX, 12, VMRegImpl::Bad());
+  reg_def VSR13 ( SOC, SOC, Op_VecX, 13, VMRegImpl::Bad());
+  reg_def VSR14 ( SOC, SOC, Op_VecX, 14, VMRegImpl::Bad());
+  reg_def VSR15 ( SOC, SOC, Op_VecX, 15, VMRegImpl::Bad());
+  reg_def VSR16 ( SOC, SOC, Op_VecX, 16, VMRegImpl::Bad());
+  reg_def VSR17 ( SOC, SOC, Op_VecX, 17, VMRegImpl::Bad());
+  reg_def VSR18 ( SOC, SOC, Op_VecX, 18, VMRegImpl::Bad());
+  reg_def VSR19 ( SOC, SOC, Op_VecX, 19, VMRegImpl::Bad());
+  reg_def VSR20 ( SOC, SOC, Op_VecX, 20, VMRegImpl::Bad());
+  reg_def VSR21 ( SOC, SOC, Op_VecX, 21, VMRegImpl::Bad());
+  reg_def VSR22 ( SOC, SOC, Op_VecX, 22, VMRegImpl::Bad());
+  reg_def VSR23 ( SOC, SOC, Op_VecX, 23, VMRegImpl::Bad());
+  reg_def VSR24 ( SOC, SOC, Op_VecX, 24, VMRegImpl::Bad());
+  reg_def VSR25 ( SOC, SOC, Op_VecX, 25, VMRegImpl::Bad());
+  reg_def VSR26 ( SOC, SOC, Op_VecX, 26, VMRegImpl::Bad());
+  reg_def VSR27 ( SOC, SOC, Op_VecX, 27, VMRegImpl::Bad());
+  reg_def VSR28 ( SOC, SOC, Op_VecX, 28, VMRegImpl::Bad());
+  reg_def VSR29 ( SOC, SOC, Op_VecX, 29, VMRegImpl::Bad());
+  reg_def VSR30 ( SOC, SOC, Op_VecX, 30, VMRegImpl::Bad());
+  reg_def VSR31 ( SOC, SOC, Op_VecX, 31, VMRegImpl::Bad());
+  reg_def VSR32 ( SOC, SOC, Op_VecX, 32, VMRegImpl::Bad());
+  reg_def VSR33 ( SOC, SOC, Op_VecX, 33, VMRegImpl::Bad());
+  reg_def VSR34 ( SOC, SOC, Op_VecX, 34, VMRegImpl::Bad());
+  reg_def VSR35 ( SOC, SOC, Op_VecX, 35, VMRegImpl::Bad());
+  reg_def VSR36 ( SOC, SOC, Op_VecX, 36, VMRegImpl::Bad());
+  reg_def VSR37 ( SOC, SOC, Op_VecX, 37, VMRegImpl::Bad());
+  reg_def VSR38 ( SOC, SOC, Op_VecX, 38, VMRegImpl::Bad());
+  reg_def VSR39 ( SOC, SOC, Op_VecX, 39, VMRegImpl::Bad());
+  reg_def VSR40 ( SOC, SOC, Op_VecX, 40, VMRegImpl::Bad());
+  reg_def VSR41 ( SOC, SOC, Op_VecX, 41, VMRegImpl::Bad());
+  reg_def VSR42 ( SOC, SOC, Op_VecX, 42, VMRegImpl::Bad());
+  reg_def VSR43 ( SOC, SOC, Op_VecX, 43, VMRegImpl::Bad());
+  reg_def VSR44 ( SOC, SOC, Op_VecX, 44, VMRegImpl::Bad());
+  reg_def VSR45 ( SOC, SOC, Op_VecX, 45, VMRegImpl::Bad());
+  reg_def VSR46 ( SOC, SOC, Op_VecX, 46, VMRegImpl::Bad());
+  reg_def VSR47 ( SOC, SOC, Op_VecX, 47, VMRegImpl::Bad());
+  reg_def VSR48 ( SOC, SOC, Op_VecX, 48, VMRegImpl::Bad());
+  reg_def VSR49 ( SOC, SOC, Op_VecX, 49, VMRegImpl::Bad());
+  reg_def VSR50 ( SOC, SOC, Op_VecX, 50, VMRegImpl::Bad());
+  reg_def VSR51 ( SOC, SOC, Op_VecX, 51, VMRegImpl::Bad());
+  reg_def VSR52 ( SOC, SOC, Op_VecX, 52, VMRegImpl::Bad());
+  reg_def VSR53 ( SOC, SOC, Op_VecX, 53, VMRegImpl::Bad());
+  reg_def VSR54 ( SOC, SOC, Op_VecX, 54, VMRegImpl::Bad());
+  reg_def VSR55 ( SOC, SOC, Op_VecX, 55, VMRegImpl::Bad());
+  reg_def VSR56 ( SOC, SOC, Op_VecX, 56, VMRegImpl::Bad());
+  reg_def VSR57 ( SOC, SOC, Op_VecX, 57, VMRegImpl::Bad());
+  reg_def VSR58 ( SOC, SOC, Op_VecX, 58, VMRegImpl::Bad());
+  reg_def VSR59 ( SOC, SOC, Op_VecX, 59, VMRegImpl::Bad());
+  reg_def VSR60 ( SOC, SOC, Op_VecX, 60, VMRegImpl::Bad());
+  reg_def VSR61 ( SOC, SOC, Op_VecX, 61, VMRegImpl::Bad());
+  reg_def VSR62 ( SOC, SOC, Op_VecX, 62, VMRegImpl::Bad());
+  reg_def VSR63 ( SOC, SOC, Op_VecX, 63, VMRegImpl::Bad());
 
 // ----------------------------
 // Specify priority of register selection within phases of register


### PR DESCRIPTION
Clean backport of JDK-8289856 (except Copyright year update). Avoids undefined behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289856](https://bugs.openjdk.org/browse/JDK-8289856): [PPC64] SIGSEGV in C2Compiler::init_c2_runtime() after JDK-8289060


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1205/head:pull/1205` \
`$ git checkout pull/1205`

Update a local copy of the PR: \
`$ git checkout pull/1205` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1205`

View PR using the GUI difftool: \
`$ git pr show -t 1205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1205.diff">https://git.openjdk.org/jdk11u-dev/pull/1205.diff</a>

</details>
