### PR TITLE
8203277: preflow visitor used during lambda attribution shouldn't visit class definitions inside the lambda body

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2714,6 +2714,15 @@ public class Attr extends JCTree.Visitor {
                     }
                     super.scan(tree);
                 }
+
+                @Override
+                public void visitClassDef(JCClassDecl that) {
+                    // or class declaration trees!
+                }
+
+                public void visitLambda(JCLambda that) {
+                    // or lambda expressions!
+                }
             }.scan(tree);
         }
 

--- a/test/langtools/tools/javac/T8203277/PreflowShouldVisitLambdaOrDiamondInsideLambdaTest.java
+++ b/test/langtools/tools/javac/T8203277/PreflowShouldVisitLambdaOrDiamondInsideLambdaTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8203277
+ * @summary preflow visitor used during lambda attribution shouldn't visit class definitions inside the lambda body
+ * @compile PreflowShouldVisitLambdaOrDiamondInsideLambdaTest.java
+ */
+
+import java.util.List;
+import java.util.function.Function;
+
+class PreflowShouldVisitLambdaOrDiamondInsideLambdaTest {
+    void build() {
+        List<Function<String, Double>> list1 = transform(null,
+                builder -> new Function<>() {
+                    public Double apply(String params) { return null; }
+                });
+
+        List<Function<String, Double>> list2 = transform(null,
+                builder -> arg -> null);
+    }
+
+    static <Argument, Result> List<Result> transform(List<Argument> fromList,
+            Function<? super Argument,? extends Result> function) { return null; }
+}


### PR DESCRIPTION
Hi all,

JDK-8203277 [1] fixes the issue about `AssertionError: isSubtype UNKNOWN` in JDK12. The users reported the similar issue JDK-8246111 [2] in JDK11. So it is good to backport JDK-8203277 to JDK11 to solve the problem.

The code doesn't appy cleanly, because the file `test/langtools/tools/javac/api/TestGetScopeResult.java` doesn't exist in JDK11. This patch removes the file `TestGetScopeResult.java` from the original patch.

Thanks for taking the time to review.

[1] https://bugs.openjdk.org/browse/JDK-8203277
[2] https://bugs.openjdk.org/browse/JDK-8246111

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8203277](https://bugs.openjdk.org/browse/JDK-8203277): preflow visitor used during lambda attribution shouldn't visit class definitions inside the lambda body


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1207/head:pull/1207` \
`$ git checkout pull/1207`

Update a local copy of the PR: \
`$ git checkout pull/1207` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1207`

View PR using the GUI difftool: \
`$ git pr show -t 1207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1207.diff">https://git.openjdk.org/jdk11u-dev/pull/1207.diff</a>

</details>
