### PR TITLE
8193462: Fix Filer handling of package-info initial elements

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
@@ -379,6 +379,7 @@ public class Enter extends JCTree.Visitor {
             c.completer = Completer.NULL_COMPLETER;
                 c.members_field = WriteableScope.create(c);
                 tree.packge.package_info = c;
+                tree.packge.sourcefile = tree.sourcefile;
             }
             classEnter(tree.defs, topEnv);
             if (addEnv) {


### PR DESCRIPTION
Hi all,

In order to backport JDK-8255729 [1] cleanly to jdk11, I need to backport this patch [2] firstly.

The code applies cleanly.

[1] https://bugs.openjdk.org/browse/JDK-8255729
[2] https://bugs.openjdk.org/browse/JDK-8193462

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8193462](https://bugs.openjdk.org/browse/JDK-8193462): Fix Filer handling of package-info initial elements


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1208/head:pull/1208` \
`$ git checkout pull/1208`

Update a local copy of the PR: \
`$ git checkout pull/1208` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1208`

View PR using the GUI difftool: \
`$ git pr show -t 1208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1208.diff">https://git.openjdk.org/jdk11u-dev/pull/1208.diff</a>

</details>
