### PR TITLE
8236490: Compiler bug relating to @NonNull annotation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotationPosition.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotationPosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,6 +153,10 @@ public class TypeAnnotationPosition {
     // use that value to determine the exception table index.
     // When read from class file, this holds
     private int exception_index = Integer.MIN_VALUE;
+
+    // The exception start position.
+    // Corresponding to the start_pc in the exception table.
+    private int exceptionStartPos = Integer.MIN_VALUE;
 
     // If this type annotation is within a lambda expression,
     // store a pointer to the lambda expression tree in order
@@ -322,20 +326,22 @@ public class TypeAnnotationPosition {
     public int getCatchType() {
         Assert.check(hasCatchType(),
                      "exception_index does not contain valid catch info");
-        return ((-this.exception_index) - 1) & 0xff ;
+        return (-this.exception_index) - 1;
     }
 
     public int getStartPos() {
-        Assert.check(hasCatchType(),
-                     "exception_index does not contain valid catch info");
-        return ((-this.exception_index) - 1) >> 8 ;
+        Assert.check(exceptionStartPos >= 0,
+                     "exceptionStartPos does not contain valid start position");
+        return this.exceptionStartPos;
     }
 
     public void setCatchInfo(final int catchType, final int startPos) {
         Assert.check(!hasExceptionIndex(),
                      "exception_index is already set");
         Assert.check(catchType >= 0, "Expected a valid catch type");
-        this.exception_index = -((catchType | startPos << 8) + 1);
+        Assert.check(startPos >= 0, "Expected a valid start position");
+        this.exception_index = -(catchType + 1);
+        this.exceptionStartPos = startPos;
     }
 
     /**

--- a/test/langtools/tools/javac/annotations/typeAnnotations/8236490/T8236490.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/8236490/T8236490.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8236490
+ * @summary If the exception class index in constant pool exceeds 256,
+ *          the type annotations in conresponding catch expression should be compiled successfully.
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.api
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main T8236490
+ */
+
+import toolbox.ToolBox;
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.TestRunner;
+
+public class T8236490 extends TestRunner {
+    ToolBox tb;
+
+    public T8236490() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String[] args) throws Exception {
+        new T8236490().runTests();
+    }
+
+    @Test
+    public void testTypeAnnotationInCatchExpression() throws Exception {
+        // Generate a class which contains more than 256 constant pool entries
+        // and the exception class index in constant pool exceeds 256.
+        // The code is shown as below:
+        // import java.lang.annotation.ElementType;
+        // import java.lang.annotation.Target;
+        // public class Test8236490 {
+        //     private class Test0 {}
+        //     ... many classes ...
+        //     private class Test299 {}
+        //     @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+        //     private @interface AnnotationTest {}
+        //     public void test() {
+        //         Test0 test0 = new Test0();
+        //         ... many variables ...
+        //         Test299 test299 = new Test299();
+        //         try {
+        //             System.out.println("Hello");
+        //         } catch (@AnnotationTest Exception e) {}
+        //     }
+        // }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("""
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Target;
+                public class Test8236490 {
+                """);
+        for (int i = 0; i < 300; i++) {
+            stringBuilder.append("    private class Test" + i + " {}\n");
+        }
+        stringBuilder.append("""
+                    @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+                    private @interface AnnotationTest {}
+                    public void test() {
+                """);
+        for (int i = 0; i < 300; i++) {
+            stringBuilder.append("        Test" + i + " test" + i + " = new Test" + i + "();\n");
+        }
+        stringBuilder.append("""
+                        try {
+                            System.out.println("Hello");
+                        } catch (@AnnotationTest Exception e) {}
+                    }
+                }
+                """);
+
+        new JavacTask(tb)
+                .sources(stringBuilder.toString())
+                .outdir(".")
+                .run();
+    }
+}

--- a/test/langtools/tools/javac/annotations/typeAnnotations/8236490/T8236490.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/8236490/T8236490.java
@@ -73,29 +73,26 @@ public class T8236490 extends TestRunner {
         //     }
         // }
         StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append("""
-                import java.lang.annotation.ElementType;
-                import java.lang.annotation.Target;
-                public class Test8236490 {
-                """);
+        stringBuilder.append(
+                "import java.lang.annotation.ElementType;\n" +
+                "import java.lang.annotation.Target;\n" +
+                "public class Test8236490 {");
         for (int i = 0; i < 300; i++) {
             stringBuilder.append("    private class Test" + i + " {}\n");
         }
-        stringBuilder.append("""
-                    @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-                    private @interface AnnotationTest {}
-                    public void test() {
-                """);
+        stringBuilder.append(
+                "    @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})" +
+                "    private @interface AnnotationTest {}" +
+                "    public void test() {");
         for (int i = 0; i < 300; i++) {
             stringBuilder.append("        Test" + i + " test" + i + " = new Test" + i + "();\n");
         }
-        stringBuilder.append("""
-                        try {
-                            System.out.println("Hello");
-                        } catch (@AnnotationTest Exception e) {}
-                    }
-                }
-                """);
+        stringBuilder.append(
+                "        try {" +
+                "            System.out.println(\"Hello\");" +
+                "        } catch (@AnnotationTest Exception e) {}" +
+                "    }" +
+                "}");
 
         new JavacTask(tb)
                 .sources(stringBuilder.toString())


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [23edb6f6](https://github.com/openjdk/jdk/commit/23edb6f6b22e157e143e7449d6a4ad3f28cceb21) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The patch has run well for a long time so that I think it has low risk to backport now.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8236490](https://bugs.openjdk.org/browse/JDK-8236490): Compiler bug relating to @NonNull annotation


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1209/head:pull/1209` \
`$ git checkout pull/1209`

Update a local copy of the PR: \
`$ git checkout pull/1209` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1209`

View PR using the GUI difftool: \
`$ git pr show -t 1209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1209.diff">https://git.openjdk.org/jdk11u-dev/pull/1209.diff</a>

</details>
