### PR TITLE
8249623: test @ignore-d due to 7013634 should be returned back to execution

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -197,9 +197,9 @@ vmTestbase/metaspace/gc/firstGC_default/TestDescription.java 8208250 generic-all
 
 vmTestbase/nsk/jvmti/ClearBreakpoint/clrbrk001/TestDescription.java 8016181 generic-all
 vmTestbase/nsk/jvmti/FieldModification/fieldmod001/TestDescription.java 8016181 generic-all
-vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java 7013634 generic-all
+vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java 8253916 linux-all
 vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java 6606767 generic-all
-vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004/TestDescription.java 7013634,6606767 generic-all
+vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004/TestDescription.java 6606767 generic-all
 vmTestbase/nsk/jvmti/ThreadStart/threadstart001/TestDescription.java 8016181 generic-all
 vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t002/TestDescription.java 8204506,8203350 generic-all
 vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t001/hs204t001.java 6813266 generic-all

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import nsk.share.Consts;
 import nsk.share.test.Stresser;
+import jtreg.SkippedException;
 
 public class resexhausted001 {
     static {
@@ -56,15 +57,15 @@ public class resexhausted001 {
             }
 
             System.out.println("Can't reproduce OOME due to a limit on iterations/execution time. Test was useless.");
-            return Consts.TEST_PASSED;
+            throw new SkippedException("Test did not get an OutOfMemory error");
 
         } catch (OutOfMemoryError e) {
             count = threadCount.get();
+        } finally {
             threadsDone = true;
             synchronized (hanger) {
                 hanger.notifyAll();
             }
-        } finally {
             stress.finish();
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java
@@ -38,11 +38,10 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @ignore 7013634
- * @run main/othervm/native
+ * @run main/othervm/native/timeout=240
  *      -agentlib:resexhausted=-waittime=5
  *      -XX:-UseGCOverheadLimit
  *      nsk.jvmti.ResourceExhausted.resexhausted001
- *      -stressTime 1200
+ *      -stressTime 220
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package nsk.jvmti.ResourceExhausted;
 import java.io.PrintStream;
 import nsk.share.Consts;
 import nsk.share.test.Stresser;
+import jtreg.SkippedException;
 
 public class resexhausted002 {
     static final long MAX_ITERATIONS = Long.MAX_VALUE;
@@ -55,7 +56,7 @@ public class resexhausted002 {
             }
 
             System.out.println("Can't reproduce OOME due to a limit on iterations/execution time. Test was useless.");
-            return Consts.TEST_PASSED;
+            throw new SkippedException("Test did not get an OutOfMemory error");
 
         } catch (OutOfMemoryError e) {
         } finally {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.PrintStream;
 import java.security.ProtectionDomain;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import nsk.share.Consts;
 import nsk.share.test.Stresser;
@@ -77,12 +79,20 @@ public class resexhausted003 {
 
 
     public static int run(String args[], PrintStream out) {
-        if ( args == null || args.length < 1 ) {
-            System.err.println("TEST BUG: Classes directory should be the first argument. Check .cfg file.");
+        String testclasspath = System.getProperty("test.class.path");
+        String [] testpaths = testclasspath.split(System.getProperty("path.separator"));
+        String classesDir = "";
+
+        Pattern pattern = Pattern.compile("^(.*)classes(.*)vmTestbase(.*)$");
+        for (int i = 0 ; i < testpaths.length; i++) {
+            if (pattern.matcher(testpaths[i]).matches()) {
+                classesDir = testpaths[i];
+            }
+        }
+        if (classesDir.equals("")) {
+            System.err.println("TEST BUG: Classes directory not found in test,class.path.");
             return Consts.TEST_FAILED;
         }
-
-        String classesDir = args[0];
         Stresser stress = new Stresser(args);
 
         String className = Helper.class.getName();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TEST.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,5 @@
  *      -XX:MaxMetaspaceSize=9m
  *      -XX:-UseGCOverheadLimit
  *      nsk.jvmti.ResourceExhausted.resexhausted003
- *      ../../classes/0/vmTestbase
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,14 +39,12 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @ignore 7013634 6606767
  * @run main/othervm/native
  *      -agentlib:resexhausted=-waittime=5
  *      -Xms16m
  *      -Xmx16m
- *      -XX:MaxMetaspaceSize=8m
+ *      -XX:MaxMetaspaceSize=9m
  *      -XX:-UseGCOverheadLimit
  *      nsk.jvmti.ResourceExhausted.resexhausted004
- *      ./bin/classes
  */
 


### PR DESCRIPTION
This is a backport of [JDK-8249623](https://bugs.openjdk.org/browse/JDK-8249623) to prepare for backporting
[JDK-8253916](https://bugs.openjdk.org/browse/JDK-8253916). I had to resolve resexhausted001\TestDescription.java
and the problemlist entries a little bit.

The entries for JDK-7013634 had originally been removed by two test cleanup commits,
e.g. (https://github.com/openjdk/jdk12/commit/996ecff62491ed308a30c057e94e3ba11326a930) and
(https://github.com/openjdk/jdk12/commit/6a4f482ff54735bbce6e1758b032e25878dae63c) after JDK-7013634
had been closed as not reproducible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8249623](https://bugs.openjdk.org/browse/JDK-8249623): test @ignore-d due to 7013634 should be returned back to execution


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1212/head:pull/1212` \
`$ git checkout pull/1212`

Update a local copy of the PR: \
`$ git checkout pull/1212` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1212`

View PR using the GUI difftool: \
`$ git pr show -t 1212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1212.diff">https://git.openjdk.org/jdk11u-dev/pull/1212.diff</a>

</details>
