### PR TITLE
6606767: resexhausted00[34] fail assert(!thread->owns_locks(), "must release all locks when leaving VM")

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -198,8 +198,7 @@ vmTestbase/metaspace/gc/firstGC_default/TestDescription.java 8208250 generic-all
 vmTestbase/nsk/jvmti/ClearBreakpoint/clrbrk001/TestDescription.java 8016181 generic-all
 vmTestbase/nsk/jvmti/FieldModification/fieldmod001/TestDescription.java 8016181 generic-all
 vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java 8253916 linux-all
-vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java 6606767 generic-all
-vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004/TestDescription.java 6606767 generic-all
+vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004/TestDescription.java 8253916 linux-all
 vmTestbase/nsk/jvmti/ThreadStart/threadstart001/TestDescription.java 8016181 generic-all
 vmTestbase/nsk/jvmti/scenarios/hotswap/HS102/hs102t002/TestDescription.java 8204506,8203350 generic-all
 vmTestbase/nsk/jvmti/scenarios/hotswap/HS204/hs204t001/hs204t001.java 6813266 generic-all

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.util.regex.Matcher;
 
 import nsk.share.Consts;
 import nsk.share.test.Stresser;
+import jtreg.SkippedException;
 
 public class resexhausted003 {
 
@@ -115,7 +116,7 @@ public class resexhausted003 {
             }
 
             System.out.println("Can't reproduce OOME due to a limit on iterations/execution time. Test was useless.");
-            return Consts.TEST_PASSED;
+            throw new SkippedException("Test did not get an OutOfMemory error");
 
         } catch (OutOfMemoryError e) {
             // that is what we are waiting for

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004.java
@@ -26,6 +26,7 @@ import java.io.*;
 import java.util.Random;
 
 import nsk.share.Consts;
+import jtreg.SkippedException;
 
 public class resexhausted004 {
     public static int run(String args[], PrintStream out) {
@@ -34,23 +35,24 @@ public class resexhausted004 {
         int r;
 
         for ( int i = 4 + selector.nextInt() & 3; i > 0; i-- ) {
-            switch ( selector.nextInt() % 3 ) {
+            try {
+                switch (selector.nextInt() % 3) {
                 case 0:
                     r = resexhausted001.run(args, out);
-                    if ( r != Consts.TEST_PASSED )
-                        return r;
                     break;
                 case 1:
                     r = resexhausted002.run(args, out);
-                    if ( r != Consts.TEST_PASSED )
-                        return r;
                     break;
                 default:
                     r = resexhausted003.run(args, out);
-                    if ( r != Consts.TEST_PASSED )
-                        return r;
                     break;
-           }
+                }
+                if (r != Consts.TEST_PASSED) {
+                    return r;
+                }
+            } catch (SkippedException ex) {
+                // it's ok
+            }
        }
 
        return Consts.TEST_PASSED;


### PR DESCRIPTION
Backport of JDK-6606767, nearly clean. Only a copyright header resolve and trivial test list resolving was necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6606767](https://bugs.openjdk.org/browse/JDK-6606767): resexhausted00[34] fail assert(!thread->owns_locks(), "must release all locks when leaving VM")


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1213/head:pull/1213` \
`$ git checkout pull/1213`

Update a local copy of the PR: \
`$ git checkout pull/1213` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1213`

View PR using the GUI difftool: \
`$ git pr show -t 1213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1213.diff">https://git.openjdk.org/jdk11u-dev/pull/1213.diff</a>

</details>
