### PR TITLE
8257623: vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java shouldn't use timeout

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java
@@ -39,7 +39,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @run main/othervm/native/manual/timeout=240
+ * @run main/othervm/native/manual
  *      -agentlib:resexhausted=-waittime=5
  *      -XX:-UseGCOverheadLimit
  *      nsk.jvmti.ResourceExhausted.resexhausted001


### PR DESCRIPTION
Backport of [JDK-8257623](https://bugs.openjdk.java.net/browse/JDK-8257623). Does not apply cleanly but only did a trivial resolve. Will mark as clean, once dependent PRs are integrated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8257623](https://bugs.openjdk.org/browse/JDK-8257623): vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001/TestDescription.java shouldn't use timeout


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1215/head:pull/1215` \
`$ git checkout pull/1215`

Update a local copy of the PR: \
`$ git checkout pull/1215` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1215`

View PR using the GUI difftool: \
`$ git pr show -t 1215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1215.diff">https://git.openjdk.org/jdk11u-dev/pull/1215.diff</a>

</details>
