### PR TITLE
8262085: Hovering Metal HTML Tooltips in different windows cause IllegalArgExc on Linux

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalToolTipUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalToolTipUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,6 @@ import sun.swing.SwingUtilities2;
 import java.awt.*;
 import java.awt.event.*;
 import javax.swing.*;
-import javax.swing.BorderFactory;
-import javax.swing.border.Border;
 import javax.swing.plaf.*;
 import javax.swing.plaf.basic.BasicToolTipUI;
 import javax.swing.plaf.basic.BasicHTML;
@@ -120,6 +118,11 @@ public class MetalToolTipUI extends BasicToolTipUI {
             insets.top,
             size.width - (insets.left + insets.right) - 6 - accelSpacing,
             size.height - (insets.top + insets.bottom));
+
+        if (paintTextR.width <= 0 || paintTextR.height <= 0) {
+            return;
+        }
+
         View v = (View) c.getClientProperty(BasicHTML.propertyKey);
         if (v != null) {
             v.paint(g, paintTextR);

--- a/test/jdk/javax/swing/JToolTip/FastTooltipSwitchIAE.java
+++ b/test/jdk/javax/swing/JToolTip/FastTooltipSwitchIAE.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 8262085
+ * @summary Tests tooltip for not throwing IllegalArgumentException on fast switching between frames.
+ * @run main FastTooltipSwitchIAE
+ */
+
+import javax.swing.JToolTip;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+public class FastTooltipSwitchIAE {
+    static Dimension oneByOneSize = new Dimension(1, 1);
+
+    public static void main(String[] args) {
+        for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
+            try {
+                SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+                SwingUtilities.invokeAndWait(FastTooltipSwitchIAE::doTest);
+                System.out.println("Test passed for LookAndFeel " + laf.getClassName());
+            } catch (Exception e) {
+                throw new RuntimeException("Test failed for " + laf.getClassName(), e);
+            }
+        }
+    }
+
+    private static void setLookAndFeel(final UIManager.LookAndFeelInfo laf) {
+        try {
+            System.out.println("LookAndFeel: " + laf.getClassName());
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.err.println("Unsupported L&F: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void doTest() {
+        JToolTip toolTip = new JToolTip();
+        toolTip.setTipText("<html><h1>Hello world</h1></html>");
+        toolTip.setMinimumSize(oneByOneSize);
+        toolTip.setMaximumSize(oneByOneSize);
+        toolTip.setPreferredSize(oneByOneSize);
+        toolTip.setBounds(100, 100, 1, 1);
+
+        BufferedImage img = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = img.createGraphics();
+
+        toolTip.paint(g2d);
+
+        g2d.dispose();
+    }
+}


### PR DESCRIPTION
Backport JDK-8262085

Clean backport except Copyright year

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8262085](https://bugs.openjdk.org/browse/JDK-8262085): Hovering Metal HTML Tooltips in different windows cause IllegalArgExc on Linux


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1217/head:pull/1217` \
`$ git checkout pull/1217`

Update a local copy of the PR: \
`$ git checkout pull/1217` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1217`

View PR using the GUI difftool: \
`$ git pr show -t 1217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1217.diff">https://git.openjdk.org/jdk11u-dev/pull/1217.diff</a>

</details>
