### PR TITLE
8255729: com.sun.tools.javac.processing.JavacFiler.FilerOutputStream  is inefficient

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacFiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacFiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -275,6 +275,13 @@ public class JavacFiler implements Filer, Closeable {
             this.fileObject = fileObject;
         }
 
+        @Override
+        public void write(byte b[], int off, int len) throws IOException {
+            Objects.checkFromIndexSize(off, len, b.length);
+            out.write(b, off, len);
+        }
+
+        @Override
         public synchronized void close() throws IOException {
             if (!closed) {
                 closed = true;
@@ -312,6 +319,7 @@ public class JavacFiler implements Filer, Closeable {
             this.fileObject = fileObject;
         }
 
+        @Override
         public synchronized void close() throws IOException {
             if (!closed) {
                 closed = true;


### PR DESCRIPTION
Hi all,

Request to backport [JDK-8255729](https://bugs.openjdk.org/browse/JDK-8255729) to jdk11. The code doesn't apply cleanly. Because the [JDK-8236435](https://bugs.openjdk.org/browse/JDK-8236435) whcih fixed typos changed the file `JavacFiler.java` as well. I try to backport JDK-8236435 to let this patch clean but the JDK-8236435 has many conflicts so that it is not easy to backport. So I decide not to backport JDK-8236435. I have backported [JDK-8193462](https://bugs.openjdk.org/browse/JDK-8193462) to jdk11 in order to make this patch clean but unfortunately the clean backport is blocked by JDK-8236435.

Thanks for taking the time to review.

Best Regrads,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255729](https://bugs.openjdk.org/browse/JDK-8255729): com.sun.tools.javac.processing.JavacFiler.FilerOutputStream  is inefficient


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1218/head:pull/1218` \
`$ git checkout pull/1218`

Update a local copy of the PR: \
`$ git checkout pull/1218` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1218`

View PR using the GUI difftool: \
`$ git pr show -t 1218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1218.diff">https://git.openjdk.org/jdk11u-dev/pull/1218.diff</a>

</details>
