### PR TITLE
8290198: Shenandoah: a few Shenandoah tests failure after JDK-8214799 11u backport

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/jni/CriticalNativeArgs.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/CriticalNativeArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2018, 2022, Red Hat, Inc. and/or its affiliates.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
@@ -37,20 +37,14 @@ package gc.shenandoah.jni;
  * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+UnlockExperimentalVMOptions -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeArgs
  */
 public class CriticalNativeArgs {
-    static {
-        System.loadLibrary("CriticalNative");
-    }
-
-    static native boolean isNull(int[] a);
-
     public static void main(String[] args) {
         int[] arr = new int[2];
 
-        if (isNull(arr)) {
+        if (CriticalNative.isNull(arr)) {
             throw new RuntimeException("Should not be null");
         }
 
-        if (!isNull(null)) {
+        if (!CriticalNative.isNull(null)) {
             throw new RuntimeException("Should be null");
         }
     }

--- a/test/hotspot/jtreg/gc/shenandoah/jni/CriticalNativeStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/CriticalNativeStress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2018, 2022, Red Hat, Inc. and/or its affiliates.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
@@ -26,11 +26,11 @@ package gc.shenandoah.jni;
 import java.util.Random;
 import jdk.test.lib.Utils;
 
-import gc.shenandoah.jni.CriticalNative;
-
 /* @test
  * @key randomness
- * @library /test/lib
+ * @library /
+ *          /test/lib
+ *
  * @requires (os.arch =="x86_64" | os.arch == "amd64" | os.arch=="x86" | os.arch=="i386") & !vm.graal.enabled & vm.gc.Shenandoah
  *
  * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive    -XX:+ShenandoahDegeneratedGC -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeStress
@@ -43,17 +43,8 @@ import gc.shenandoah.jni.CriticalNative;
  * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive -Xcomp -Xmx512M -XX:+CriticalJNINatives gc.shenandoah.jni.CriticalNativeStress
  */
 public class CriticalNativeStress {
-    static {
-        System.loadLibrary("CriticalNative");
-    }
-
     static final int CYCLES = 50;
     static final int THREAD_PER_CASE = 1;
-
-    static native long sum1(long[] a);
-
-    // More than 6 parameters
-    static native long sum2(long a1, int[] a2, int[] a3, long[] a4, int[] a5);
 
     static long sum(long[] a) {
         long sum = 0;
@@ -93,7 +84,7 @@ public class CriticalNativeStress {
             create_garbage(index);
         }
 
-        long native_sum = sum1(arr);
+        long native_sum = CriticalNative.sum1(arr);
         long java_sum = sum(arr);
         if (native_sum != java_sum) {
             StringBuffer sb = new StringBuffer("Sums do not match: native = ")
@@ -135,7 +126,7 @@ public class CriticalNativeStress {
             create_garbage(index);
         }
 
-        long native_sum = sum2(a1, a2, a3, a4, a5);
+        long native_sum = CriticalNative.sum2(a1, a2, a3, a4, a5);
         long java_sum = a1 + sum(a2) + sum(a3) + sum(a4) + sum(a5);
         if (native_sum != java_sum) {
             StringBuffer sb = new StringBuffer("Sums do not match: native = ")

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasherWithShenandoah.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2016, 2022, Red Hat, Inc. All rights reserved.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
@@ -29,6 +29,7 @@ import java.io.IOException;
  * @test TestGCBasherWithShenandoah
  * @key gc
  * @key stress
+ * @library /
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @requires vm.flavor == "server" & !vm.emulatedClient & !vm.graal.enabled
  * @summary Stress the Shenandoah GC by trying to make old objects more likely to be garbage than young objects.

--- a/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestGCLockerWithShenandoah.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package gc.stress.gclocker;
 /*
  * @test TestGCLockerWithShenandoah
  * @key gc
+ * @library /
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @summary Stress Shenandoah's JNI handling by calling GetPrimitiveArrayCritical while concurrently filling up old gen.
  *
@@ -43,6 +44,7 @@ package gc.stress.gclocker;
 /*
  * @test TestGCLockerWithShenandoah
  * @key gc
+ * @library /
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @summary Stress Shenandoah's JNI handling by calling GetPrimitiveArrayCritical while concurrently filling up old gen.
  *

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOldWithShenandoah.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -77,6 +77,7 @@ package gc.stress.gcold;
  * @test TestGCOldWithShenandoah
  * @key gc
  * @key stress
+ * @library / /test/lib
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @summary Stress the GC by trying to make old objects more likely to be garbage than young objects.
  *
@@ -94,6 +95,7 @@ package gc.stress.gcold;
  * @test TestGCOldWithShenandoah
  * @key gc
  * @key stress
+ * @library / /test/lib
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @summary Stress the GC by trying to make old objects more likely to be garbage than young objects.
  *
@@ -128,6 +130,7 @@ package gc.stress.gcold;
  * @test TestGCOldWithShenandoah
  * @key gc
  * @key stress
+ * @library / /test/lib
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @summary Stress the GC by trying to make old objects more likely to be garbage than young objects.
  *

--- a/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithShenandoah.java
+++ b/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGCWithShenandoah.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2017, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package gc.stress.systemgc;
  * @test TestSystemGCWithShenandoah
  * @key gc
  * @key stress
+ * @library /
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @summary Stress the Shenandoah GC full GC by allocating objects of different lifetimes concurrently with System.gc().
  *


### PR DESCRIPTION
Please review this patch that fixes Shenandoah test failures after JDK-8214799 11u backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290198](https://bugs.openjdk.org/browse/JDK-8290198): Shenandoah: a few Shenandoah tests failure after  JDK-8214799 11u backport


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1220/head:pull/1220` \
`$ git checkout pull/1220`

Update a local copy of the PR: \
`$ git checkout pull/1220` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1220`

View PR using the GUI difftool: \
`$ git pr show -t 1220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1220.diff">https://git.openjdk.org/jdk11u-dev/pull/1220.diff</a>

</details>
