### PR TITLE
8238203: Return value of GetUserDefaultUILanguage() should be handled as LANGID

### DIFF
--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -666,7 +666,8 @@ GetJavaProperties(JNIEnv* env)
          */
         LCID userDefaultLCID = GetUserDefaultLCID();
         LCID systemDefaultLCID = GetSystemDefaultLCID();
-        LCID userDefaultUILang = GetUserDefaultUILanguage();
+        LANGID userDefaultUILang = GetUserDefaultUILanguage();
+        LCID userDefaultUILCID = MAKELCID(userDefaultUILang, SORTIDFROMLCID(userDefaultLCID));
 
         {
             char * display_encoding;
@@ -680,8 +681,8 @@ GetJavaProperties(JNIEnv* env)
             // for the UI Language, if the "language" portion of those
             // two locales are the same.
             if (PRIMARYLANGID(LANGIDFROMLCID(userDefaultLCID)) ==
-                PRIMARYLANGID(LANGIDFROMLCID(userDefaultUILang))) {
-                userDefaultUILang = userDefaultLCID;
+                PRIMARYLANGID(userDefaultUILang)) {
+                userDefaultUILCID = userDefaultLCID;
             }
 
             SetupI18nProps(userDefaultUILang,
@@ -696,7 +697,7 @@ GetJavaProperties(JNIEnv* env)
                            &sprops.format_country,
                            &sprops.format_variant,
                            &sprops.encoding);
-            SetupI18nProps(userDefaultUILang,
+            SetupI18nProps(userDefaultUILCID,
                            &sprops.display_language,
                            &sprops.display_script,
                            &sprops.display_country,


### PR DESCRIPTION
Backport of JDK-8238203.

Along with JDK-8266774, prerequisite for a backport of JDK-8272352 to allow java to correctly parse Chinese characters in file paths and string arguments passed to java.exe.

Applies cleanly except for year change in copyright header.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8238203](https://bugs.openjdk.org/browse/JDK-8238203): Return value of GetUserDefaultUILanguage() should be handled as LANGID


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1225/head:pull/1225` \
`$ git checkout pull/1225`

Update a local copy of the PR: \
`$ git checkout pull/1225` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1225`

View PR using the GUI difftool: \
`$ git pr show -t 1225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1225.diff">https://git.openjdk.org/jdk11u-dev/pull/1225.diff</a>

</details>
