### PR TITLE
8264208: Console charset API

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import jdk.internal.misc.JavaIOAccess;
 import jdk.internal.misc.SharedSecrets;
 import sun.nio.cs.StreamDecoder;
 import sun.nio.cs.StreamEncoder;
+import sun.security.action.GetPropertyAction;
 
 /**
  * Methods to access the character-based console device, if any, associated
@@ -390,13 +391,31 @@ public final class Console implements Flushable
         pw.flush();
     }
 
+
+    /**
+     * Returns the {@link java.nio.charset.Charset Charset} object used for
+     * the {@code Console}.
+     * <p>
+     * The returned charset corresponds to the input and output source
+     * (e.g., keyboard and/or display) specified by the host environment or user.
+     * It may not necessarily be the same as the default charset returned from
+     * {@link java.nio.charset.Charset#defaultCharset() Charset.defaultCharset()}.
+     *
+     * @return a {@link java.nio.charset.Charset Charset} object used for the
+     *          {@code Console}
+     * @since 17
+     */
+    public Charset charset() {
+        assert CHARSET != null : "charset() should not return null";
+        return CHARSET;
+    }
+
     private Object readLock;
     private Object writeLock;
     private Reader reader;
     private Writer out;
     private PrintWriter pw;
     private Formatter formatter;
-    private Charset cs;
     private char[] rcb;
     private boolean restoreEcho;
     private boolean shutdownHookInstalled;
@@ -551,8 +570,21 @@ public final class Console implements Flushable
         }
     }
 
-    // Set up JavaIOAccess in SharedSecrets
+    private static final Charset CHARSET;
     static {
+        String csname = encoding();
+        Charset cs = null;
+        if (csname == null) {
+            csname = GetPropertyAction.privilegedGetProperty("sun.stdout.encoding");
+        }
+        if (csname != null) {
+            try {
+                cs = Charset.forName(csname);
+            } catch (Exception ignored) { }
+        }
+        CHARSET = cs == null ? Charset.defaultCharset() : cs;
+
+        // Set up JavaIOAccess in SharedSecrets
         SharedSecrets.setJavaIOAccess(new JavaIOAccess() {
             public Console console() {
                 if (istty()) {
@@ -564,9 +596,7 @@ public final class Console implements Flushable
             }
 
             public Charset charset() {
-                // This method is called in sun.security.util.Password,
-                // cons already exists when this method is called
-                return cons.cs;
+                return CHARSET;
             }
         });
     }
@@ -575,24 +605,16 @@ public final class Console implements Flushable
     private Console() {
         readLock = new Object();
         writeLock = new Object();
-        String csname = encoding();
-        if (csname != null) {
-            try {
-                cs = Charset.forName(csname);
-            } catch (Exception x) {}
-        }
-        if (cs == null)
-            cs = Charset.defaultCharset();
         out = StreamEncoder.forOutputStreamWriter(
                   new FileOutputStream(FileDescriptor.out),
                   writeLock,
-                  cs);
+                  CHARSET);
         pw = new PrintWriter(out, true) { public void close() {} };
         formatter = new Formatter(out);
         reader = new LineReader(StreamDecoder.forInputStreamReader(
                      new FileInputStream(FileDescriptor.in),
                      readLock,
-                     cs));
+                     CHARSET));
         rcb = new char[1024];
     }
 }

--- a/src/java.base/share/classes/java/io/InputStreamReader.java
+++ b/src/java.base/share/classes/java/io/InputStreamReader.java
@@ -35,7 +35,7 @@ import sun.nio.cs.StreamDecoder;
  * reads bytes and decodes them into characters using a specified {@link
  * java.nio.charset.Charset charset}.  The charset that it uses
  * may be specified by name or may be given explicitly, or the platform's
- * default charset may be accepted.
+ * {@link Charset#defaultCharset() default charset} may be accepted.
  *
  * <p> Each invocation of one of an InputStreamReader's read() methods may
  * cause one or more bytes to be read from the underlying byte-input stream.
@@ -48,7 +48,7 @@ import sun.nio.cs.StreamDecoder;
  *
  * <pre>
  * BufferedReader in
- *   = new BufferedReader(new InputStreamReader(System.in));
+ *   = new BufferedReader(new InputStreamReader(anInputStream));
  * </pre>
  *
  * @see BufferedReader
@@ -64,9 +64,12 @@ public class InputStreamReader extends Reader {
     private final StreamDecoder sd;
 
     /**
-     * Creates an InputStreamReader that uses the default charset.
+     * Creates an InputStreamReader that uses the
+     * {@link Charset#defaultCharset() default charset}.
      *
      * @param  in   An InputStream
+     *
+     * @see Charset#defaultCharset()
      */
     public InputStreamReader(InputStream in) {
         super(in);

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -110,7 +110,13 @@ public final class System {
      * The "standard" input stream. This stream is already
      * open and ready to supply input data. Typically this stream
      * corresponds to keyboard input or another input source specified by
-     * the host environment or user.
+     * the host environment or user. In case this stream is wrapped
+     * in a {@link java.io.InputStreamReader}, {@link Console#charset()}
+     * should be used for the charset, or consider using
+     * {@link Console#reader()}.
+     *
+     * @see Console#charset()
+     * @see Console#reader()
      */
     public static final InputStream in = null;
 
@@ -118,7 +124,10 @@ public final class System {
      * The "standard" output stream. This stream is already
      * open and ready to accept output data. Typically this stream
      * corresponds to display output or another output destination
-     * specified by the host environment or user.
+     * specified by the host environment or user. The encoding used
+     * in the conversion from characters to bytes is equivalent to
+     * {@link Console#charset()} if the {@code Console} exists,
+     * {@link Charset#defaultCharset()} otherwise.
      * <p>
      * For simple stand-alone Java applications, a typical way to write
      * a line of output data is:
@@ -138,6 +147,8 @@ public final class System {
      * @see     java.io.PrintStream#println(long)
      * @see     java.io.PrintStream#println(java.lang.Object)
      * @see     java.io.PrintStream#println(java.lang.String)
+     * @see     Console#charset()
+     * @see     Charset#defaultCharset()
      */
     public static final PrintStream out = null;
 
@@ -152,6 +163,12 @@ public final class System {
      * of a user even if the principal output stream, the value of the
      * variable {@code out}, has been redirected to a file or other
      * destination that is typically not continuously monitored.
+     * The encoding used in the conversion from characters to bytes is
+     * equivalent to {@link Console#charset()} if the {@code Console}
+     * exists, {@link Charset#defaultCharset()} otherwise.
+     *
+     * @see     Console#charset()
+     * @see     Charset#defaultCharset()
      */
     public static final PrintStream err = null;
 
@@ -1971,6 +1988,9 @@ public final class System {
         FileOutputStream fdOut = new FileOutputStream(FileDescriptor.out);
         FileOutputStream fdErr = new FileOutputStream(FileDescriptor.err);
         setIn0(new BufferedInputStream(fdIn));
+        // sun.stdout/err.encoding are set when the VM is associated with the terminal,
+        // thus they are equivalent to Console.charset(), otherwise the encoding
+        // defaults to Charset.defaultCharset()
         setOut0(newPrintStream(fdOut, props.getProperty("sun.stdout.encoding")));
         setErr0(newPrintStream(fdErr, props.getProperty("sun.stderr.encoding")));
 

--- a/src/java.base/share/classes/jdk/internal/misc/JavaIOAccess.java
+++ b/src/java.base/share/classes/jdk/internal/misc/JavaIOAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,6 @@ import java.io.Console;
 import java.nio.charset.Charset;
 
 public interface JavaIOAccess {
-    public Console console();
-    public Charset charset();
+    Console console();
+    Charset charset();
 }

--- a/src/java.base/share/classes/sun/security/util/Password.java
+++ b/src/java.base/share/classes/sun/security/util/Password.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import java.io.*;
 import java.nio.*;
 import java.nio.charset.*;
 import java.util.Arrays;
-import jdk.internal.misc.SharedSecrets;
 
 /**
  * A utility class for reading passwords
@@ -140,7 +139,7 @@ public class Password {
     private static byte[] convertToBytes(char[] pass) {
         if (enc == null) {
             synchronized (Password.class) {
-                enc = SharedSecrets.getJavaIOAccess()
+                enc = System.console()
                         .charset()
                         .newEncoder()
                         .onMalformedInput(CodingErrorAction.REPLACE)

--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -545,6 +545,12 @@ GetJavaProperties(JNIEnv *env)
 #else
     sprops.sun_jnu_encoding = sprops.encoding;
 #endif
+    if (isatty(STDOUT_FILENO) == 1) {
+        sprops.sun_stdout_encoding = sprops.encoding;
+    }
+    if (isatty(STDERR_FILENO) == 1) {
+        sprops.sun_stderr_encoding = sprops.encoding;
+    }
 
 #ifdef _ALLBSD_SOURCE
 #if BYTE_ORDER == _LITTLE_ENDIAN

--- a/src/java.base/windows/native/libjava/Console_md.c
+++ b/src/java.base/windows/native/libjava/Console_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,8 @@ Java_java_io_Console_encoding(JNIEnv *env, jclass cls)
     int cp = GetConsoleCP();
     if (cp >= 874 && cp <= 950)
         sprintf(buf, "ms%d", cp);
+    else if (cp == 65001)
+        sprintf(buf, "UTF-8");
     else
         sprintf(buf, "cp%d", cp);
     return JNU_NewStringPlatform(env, buf);

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,7 @@ getEncodingInternal(LCID lcid)
 
     switch (codepage) {
     case 0:
+    case 65001:
         strcpy(ret, "UTF-8");
         break;
     case 874:     /*  9:Thai     */

--- a/test/jdk/java/io/Console/CharsetTest.java
+++ b/test/jdk/java/io/Console/CharsetTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.Console;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+/**
+ * @test
+ * @bug 8264208
+ * @summary Tests Console.charset() method. "expect" command in Windows/Cygwin
+ *          does not work as expected. Ignoring tests on Windows.
+ * @requires (os.family == "linux") | (os.family == "mac")
+ * @library /test/lib
+ * @run main CharsetTest en_US.ISO8859-1 ISO-8859-1
+ * @run main CharsetTest en_US.US-ASCII US-ASCII
+ * @run main CharsetTest en_US.UTF-8 UTF-8
+ * @run main CharsetTest en_US.FOO ignored
+ */
+public class CharsetTest {
+    public static void main(String... args) throws Throwable {
+        if (args.length == 0) {
+            // no arg means child java process being tested.
+            Console con = System.console();
+            System.out.println(con.charset());
+            return;
+        } else {
+            // check "expect" command availability
+            var expect = Paths.get("/usr/bin/expect");
+            if (!Files.exists(expect) || !Files.isExecutable(expect)) {
+                System.out.println("'expect' command not found. Test ignored.");
+                return;
+            }
+
+            // invoking "expect" command
+            var testSrc = System.getProperty("test.src", ".");
+            var testClasses = System.getProperty("test.classes", ".");
+            var jdkDir = System.getProperty("test.jdk");
+            OutputAnalyzer output = ProcessTools.executeProcess(
+                    "expect",
+                    "-n",
+                    testSrc + "/script.exp",
+                    jdkDir + "/bin/java",
+                    args[0],
+                    args[1],
+                    testClasses);
+            output.reportDiagnosticSummary();
+            var eval = output.getExitValue();
+            if (eval != 0) {
+                throw new RuntimeException("Test failed. Exit value from 'expect' command: " + eval);
+            }
+        }
+    }
+}

--- a/test/jdk/java/io/Console/script.exp
+++ b/test/jdk/java/io/Console/script.exp
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+set java [lrange $argv 0 0]
+set locale [lrange $argv 1 1]
+set expected [lrange $argv 2 2]
+set args [lrange $argv 3 end]
+regexp {([a-zA-Z_]*).([a-zA-Z0-9\-]*)} $locale dummy lang_region encoding
+
+eval spawn $java -Dsun.stdout.encoding=$encoding -classpath $args CharsetTest
+if {$encoding == "FOO"} then \
+    {expect "UTF-8"} \
+else \
+    {expect $expected}
+
+eval spawn env LANG=$locale LC_ALL=$locale $java -classpath $args CharsetTest
+if {$encoding == "FOO"} then \
+    {expect "US-ASCII"} \
+else \
+    {expect $expected}
+
+expect eof


### PR DESCRIPTION
Backport of JDK-8264208.

Along with JDK-8238203 and JDK-8266774, prerequisite for a clean backport of JDK-8272352 to allow java to correctly parse Chinese characters in file paths and string arguments passed to java.exe.

Applies cleanly except for year changes in copyright headers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #1225 must be integrated first

### Issue
 * [JDK-8264208](https://bugs.openjdk.org/browse/JDK-8264208): Console charset API


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1226/head:pull/1226` \
`$ git checkout pull/1226`

Update a local copy of the PR: \
`$ git checkout pull/1226` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1226`

View PR using the GUI difftool: \
`$ git pr show -t 1226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1226.diff">https://git.openjdk.org/jdk11u-dev/pull/1226.diff</a>

</details>
