### PR TITLE
8218128: vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003 and 004 use wrong path to test classes

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.PrintStream;
 import java.security.ProtectionDomain;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import nsk.share.Consts;
 import nsk.share.test.Stresser;
@@ -77,12 +79,20 @@ public class resexhausted003 {
 
 
     public static int run(String args[], PrintStream out) {
-        if ( args == null || args.length < 1 ) {
-            System.err.println("TEST BUG: Classes directory should be the first argument. Check .cfg file.");
+        String testclasspath = System.getProperty("test.class.path");
+        String [] testpaths = testclasspath.split(System.getProperty("path.separator"));
+        String classesDir = "";
+
+        Pattern pattern = Pattern.compile("^(.*)classes(.*)vmTestbase(.*)$");
+        for (int i = 0 ; i < testpaths.length; i++) {
+            if (pattern.matcher(testpaths[i]).matches()) {
+                classesDir = testpaths[i];
+            }
+        }
+        if (classesDir.equals("")) {
+            System.err.println("TEST BUG: Classes directory not found in test,class.path.");
             return Consts.TEST_FAILED;
         }
-
-        String classesDir = args[0];
         Stresser stress = new Stresser(args);
 
         String className = Helper.class.getName();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TEST.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,5 @@
  *      -XX:MaxMetaspaceSize=9m
  *      -XX:-UseGCOverheadLimit
  *      nsk.jvmti.ResourceExhausted.resexhausted003
- *      ../../classes/0/vmTestbase
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted004/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,14 +39,12 @@
  * @library /vmTestbase
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
- * @ignore 7013634 6606767
  * @run main/othervm/native
  *      -agentlib:resexhausted=-waittime=5
  *      -Xms16m
  *      -Xmx16m
- *      -XX:MaxMetaspaceSize=8m
+ *      -XX:MaxMetaspaceSize=9m
  *      -XX:-UseGCOverheadLimit
  *      nsk.jvmti.ResourceExhausted.resexhausted004
- *      ./bin/classes
  */
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8218128](https://bugs.openjdk.org/browse/JDK-8218128), commit [c986cef7](https://github.com/openjdk/jdk/commit/c986cef7ba8c059b321bd2faaed8a8c850202d6f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

It is a prerequisite for backporting [JDK-6606767](https://bugs.openjdk.org/browse/JDK-6606767).

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8218128](https://bugs.openjdk.org/browse/JDK-8218128): vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003 and 004 use wrong path to test classes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1229/head:pull/1229` \
`$ git checkout pull/1229`

Update a local copy of the PR: \
`$ git checkout pull/1229` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1229`

View PR using the GUI difftool: \
`$ git pr show -t 1229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1229.diff">https://git.openjdk.org/jdk11u-dev/pull/1229.diff</a>

</details>
