### PR TITLE
8208471: nsk/jdb/unwatch/unwatch002/unwatch002.java fails with "Prompt is not received during 300200 milliseconds"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java
@@ -91,6 +91,7 @@ public class unwatch002 extends JdbTest {
     static final String DEBUGGEE_CLASS2    = DEBUGGEE_CLASS + "$CheckedFields";
     static final String FIRST_BREAK        = DEBUGGEE_CLASS + ".main";
     static final String LAST_BREAK         = DEBUGGEE_CLASS + ".breakHere";
+    static final String expectedPrompt     = "main[1]";
 
     static String[] checkedFields  = { "FS1" };
     static String[] checkedFields2 = { "FT1", "FV1" };
@@ -113,7 +114,7 @@ public class unwatch002 extends JdbTest {
 
 //        jdb.contToExit((checkedFields.length *2)  + (checkedFields2.length *2) + 2);
         for (int i = 0; i < (checkedFields.length *2 + checkedFields2.length*2 + 2); i++) {
-            reply = jdb.receiveReplyFor(JdbCommand.cont);
+            reply = jdb.receiveReplyForWithMessageWait(JdbCommand.cont, expectedPrompt);
         }
 
         unwatchFields (DEBUGGEE_CLASS, checkedFields);


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8208471](https://bugs.openjdk.org/browse/JDK-8208471): nsk/jdb/unwatch/unwatch002/unwatch002.java fails with "Prompt is not received during 300200 milliseconds"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1235/head:pull/1235` \
`$ git checkout pull/1235`

Update a local copy of the PR: \
`$ git checkout pull/1235` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1235`

View PR using the GUI difftool: \
`$ git pr show -t 1235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1235.diff">https://git.openjdk.org/jdk11u-dev/pull/1235.diff</a>

</details>
