### PR TITLE
8265531: doc/building.md should mention homebrew install freetype

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -384,6 +384,7 @@ CC: Sun C++ 5.13 SunOS_i386 151846-10 2015/10/30</code></pre>
 <li>To install on an apt-based Linux, try running <code>sudo apt-get install libfreetype6-dev</code>.</li>
 <li>To install on an rpm-based Linux, try running <code>sudo yum install freetype-devel</code>.</li>
 <li>To install on Alpine Linux, try running <code>sudo apk add freetype-dev</code>.</li>
+<li>To install on macOS, try running <code>brew install freetype</code>.</li>
 <li>To install on Solaris, try running <code>pkg install system/library/freetype-2</code>.</li>
 </ul>
 <p>Use <code>--with-freetype-include=&lt;path&gt;</code> and <code>--with-freetype-lib=&lt;path&gt;</code> if <code>configure</code> does not automatically locate the platform FreeType files.</p>

--- a/doc/building.md
+++ b/doc/building.md
@@ -473,6 +473,7 @@ rather than bundling the JDK's own copy.
   * To install on an rpm-based Linux, try running `sudo yum install
     freetype-devel`.
   * To install on Alpine Linux, try running `sudo apk add freetype-dev`.
+  * To install on macOS, try running `brew install freetype`.
   * To install on Solaris, try running `pkg install system/library/freetype-2`.
 
 Use `--with-freetype-include=<path>` and `--with-freetype-lib=<path>`


### PR DESCRIPTION
simple backport of https://bugs.openjdk.org/browse/JDK-8265531 - no risk

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8265531](https://bugs.openjdk.org/browse/JDK-8265531): doc/building.md should mention homebrew install freetype


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1236/head:pull/1236` \
`$ git checkout pull/1236`

Update a local copy of the PR: \
`$ git checkout pull/1236` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1236`

View PR using the GUI difftool: \
`$ git pr show -t 1236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1236.diff">https://git.openjdk.org/jdk11u-dev/pull/1236.diff</a>

</details>
