### PR TITLE
8271010: vmTestbase/gc/lock/malloc/malloclock04/TestDescription.java crashes intermittently

### DIFF
--- a/src/hotspot/share/runtime/compilationPolicy.cpp
+++ b/src/hotspot/share/runtime/compilationPolicy.cpp
@@ -328,8 +328,6 @@ void NonTieredCompPolicy::reset_counter_for_invocation_event(const methodHandle&
   assert(mcs != NULL, "MethodCounters cannot be NULL for profiling");
   mcs->invocation_counter()->set_carry();
   mcs->backedge_counter()->set_carry();
-
-  assert(!m->was_never_executed(), "don't reset to 0 -- could be mistaken for never-executed");
 }
 
 void NonTieredCompPolicy::reset_counter_for_back_branch_event(const methodHandle& m) {


### PR DESCRIPTION
…crashes intermittently

I crafted this simple change for 11 by the description in the bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271010](https://bugs.openjdk.org/browse/JDK-8271010): vmTestbase/gc/lock/malloc/malloclock04/TestDescription.java crashes intermittently ⚠️ Issue is not open.


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1237/head:pull/1237` \
`$ git checkout pull/1237`

Update a local copy of the PR: \
`$ git checkout pull/1237` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1237`

View PR using the GUI difftool: \
`$ git pr show -t 1237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1237.diff">https://git.openjdk.org/jdk11u-dev/pull/1237.diff</a>

</details>
