### PR TITLE
8288360: CI: ciInstanceKlass::implementor() is not consistent for well-known classes

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -601,8 +601,10 @@ bool ciInstanceKlass::is_leaf_type() {
 ciInstanceKlass* ciInstanceKlass::implementor() {
   ciInstanceKlass* impl = _implementor;
   if (impl == NULL) {
-    // Go into the VM to fetch the implementor.
-    {
+    if (is_shared()) {
+      impl = this; // assume a well-known interface never has a unique implementor
+    } else {
+      // Go into the VM to fetch the implementor.
       VM_ENTRY_MARK;
       MutexLocker ml(Compile_lock);
       Klass* k = get_instanceKlass()->implementor();
@@ -616,9 +618,7 @@ ciInstanceKlass* ciInstanceKlass::implementor() {
       }
     }
     // Memoize this result.
-    if (!is_shared()) {
-      _implementor = impl;
-    }
+    _implementor = impl;
   }
   return impl;
 }


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288360](https://bugs.openjdk.org/browse/JDK-8288360): CI: ciInstanceKlass::implementor() is not consistent for well-known classes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1238/head:pull/1238` \
`$ git checkout pull/1238`

Update a local copy of the PR: \
`$ git checkout pull/1238` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1238`

View PR using the GUI difftool: \
`$ git pr show -t 1238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1238.diff">https://git.openjdk.org/jdk11u-dev/pull/1238.diff</a>

</details>
