### PR TITLE
8266254: Update to use jtreg 6

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -916,10 +916,9 @@ var getJibProfilesDependencies = function (input, common) {
         jtreg: {
             server: "jpg",
             product: "jtreg",
-            version: "5.1",
-            build_number: "b01",
-            checksum_file: "MD5_VALUES",
-            file: "bundles/jtreg_bin-5.1.zip",
+            version: "6",
+            build_number: "1",
+            file: "bundles/jtreg-6+1.zip",
             environment_name: "JT_HOME",
             environment_path: input.get("jtreg", "install_path") + "/jtreg/bin"
         },

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -75,7 +75,7 @@ requires.properties= \
     docker.support
 
 # Minimum jtreg version
-requiredVersion=5.1 b1
+requiredVersion=6+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../../ notation to reach them

--- a/test/jaxp/TEST.ROOT
+++ b/test/jaxp/TEST.ROOT
@@ -23,7 +23,7 @@ modules=java.xml
 groups=TEST.groups
 
 # Minimum jtreg version
-requiredVersion=5.1 b1
+requiredVersion=6+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../ notation to reach them

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -59,7 +59,7 @@ requires.properties= \
     release.implementor
 
 # Minimum jtreg version
-requiredVersion=5.1 b1
+requiredVersion=6+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../ notation to reach them

--- a/test/jdk/java/lang/ModuleTests/addXXX/test/module-info.java
+++ b/test/jdk/java/lang/ModuleTests/addXXX/test/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,10 +21,10 @@
  * questions.
  */
 module test {
-    exports test to testng;
+    exports test to org.testng;
 
     requires m2;
     requires m3;
     requires m4;
-    requires testng;
+    requires org.testng;
 }

--- a/test/jdk/java/lang/invoke/MethodHandles/privateLookupIn/test/module-info.java
+++ b/test/jdk/java/lang/invoke/MethodHandles/privateLookupIn/test/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,6 @@
  */
 
 module test {
-   requires testng;
-   exports p to testng;   // TestNG invokes the public methods
+   requires org.testng;
+   exports p to org.testng;   // TestNG invokes the public methods
 }

--- a/test/jdk/java/lang/invoke/modules/m1/module-info.java
+++ b/test/jdk/java/lang/invoke/modules/m1/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,6 @@
  */
 module m1 {
     requires m2;
-    requires testng;
+    requires org.testng;
     exports p1;
 }

--- a/test/jdk/java/util/ServiceLoader/security/test/module-info.java
+++ b/test/jdk/java/util/ServiceLoader/security/test/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,6 @@ module test {
     provides S4 with P4;
     provides S5 with P5;
     provides S6 with P6;
-    requires testng;
-    exports p to testng;
+    requires org.testng;
+    exports p to org.testng;
 }

--- a/test/langtools/TEST.ROOT
+++ b/test/langtools/TEST.ROOT
@@ -15,7 +15,7 @@ keys=intermittent randomness
 groups=TEST.groups
 
 # Minimum jtreg version
-requiredVersion=5.1 b1
+requiredVersion=6+1
 
 # Use new module options
 useNewOptions=true


### PR DESCRIPTION
Backport required in order to bump to jtreg 6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8266254](https://bugs.openjdk.org/browse/JDK-8266254): Update to use jtreg 6
 * [JDK-8265020](https://bugs.openjdk.org/browse/JDK-8265020): tests must be updated for new TestNG module name


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1241/head:pull/1241` \
`$ git checkout pull/1241`

Update a local copy of the PR: \
`$ git checkout pull/1241` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1241`

View PR using the GUI difftool: \
`$ git pr show -t 1241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1241.diff">https://git.openjdk.org/jdk11u-dev/pull/1241.diff</a>

</details>
