### PR TITLE
8285728: Alpine Linux build fails with busybox tar

### DIFF
--- a/make/autoconf/basics.m4
+++ b/make/autoconf/basics.m4
@@ -1127,6 +1127,8 @@ AC_DEFUN([BASIC_CHECK_TAR],
     TAR_TYPE="bsd"
   elif test "x$($TAR -v | $GREP "bsdtar")" != "x"; then
     TAR_TYPE="bsd"
+  elif test "x$($TAR --version | $GREP "busybox")" != "x"; then
+    TAR_TYPE="busybox"
   elif test "x$OPENJDK_BUILD_OS" = "xsolaris"; then
     TAR_TYPE="solaris"
   fi
@@ -1142,6 +1144,9 @@ AC_DEFUN([BASIC_CHECK_TAR],
       # When using gnu tar for Solaris targets, need to use compatibility mode
       TAR_CREATE_EXTRA_PARAM="--format=ustar"
     fi
+  elif test "x$TAR_TYPE" = "xbusybox"; then
+    TAR_INCLUDE_PARAM="T"
+    TAR_SUPPORTS_TRANSFORM="false"
   else
     TAR_INCLUDE_PARAM="I"
     TAR_SUPPORTS_TRANSFORM="false"


### PR DESCRIPTION
Backport to jdk11u-dev of 8285728; mostly similar to jdk17 version but does not apply cleanly because of diffs in the stride .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285728](https://bugs.openjdk.org/browse/JDK-8285728): Alpine Linux build fails with busybox tar


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1242/head:pull/1242` \
`$ git checkout pull/1242`

Update a local copy of the PR: \
`$ git checkout pull/1242` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1242`

View PR using the GUI difftool: \
`$ git pr show -t 1242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1242.diff">https://git.openjdk.org/jdk11u-dev/pull/1242.diff</a>

</details>
