### PR TITLE
8266250: WebSocketTest and WebSocketProxyTest call assertEquals(List<byte[]>, List<byte[]>)

### DIFF
--- a/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,9 @@ import java.net.http.WebSocketHandshakeException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -432,6 +434,35 @@ public class WebSocketTest {
         };
     }
 
+    record bytes(byte[] bytes) {
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o instanceof bytes other) {
+                return Arrays.equals(bytes(), other.bytes());
+            }
+            return false;
+        }
+        @Override
+        public int hashCode() { return Arrays.hashCode(bytes()); }
+        public String toString() {
+            return "0x" + HexFormat.of()
+                    .withUpperCase()
+                    .formatHex(bytes());
+        }
+    }
+
+    static List<bytes> ofBytes(List<byte[]> bytes) {
+        return bytes.stream().map(bytes::new).toList();
+    }
+
+    static String diagnose(List<byte[]> a, List<byte[]> b) {
+        var actual = ofBytes(a);
+        var expected = ofBytes(b);
+        var message = actual.equals(expected) ? "match" : "differ";
+        return "%s and %s %s".formatted(actual, expected, message);
+    }
+
     @Test(dataProvider = "servers")
     public void simpleAggregatingBinaryMessages
             (Function<int[],DummyWebSocketServer> serverSupplier)
@@ -525,7 +556,7 @@ public class WebSocketTest {
                     .join();
             try {
                 List<byte[]> a = actual.join();
-                assertEquals(a, expected);
+                assertEquals(ofBytes(a), ofBytes(expected), diagnose(a, expected));
             } finally {
                 webSocket.abort();
             }


### PR DESCRIPTION
Backport required to bump JDK11u to jtreg 6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266250](https://bugs.openjdk.org/browse/JDK-8266250): WebSocketTest and WebSocketProxyTest call assertEquals(List<byte[]>, List<byte[]>)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1253/head:pull/1253` \
`$ git checkout pull/1253`

Update a local copy of the PR: \
`$ git checkout pull/1253` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1253`

View PR using the GUI difftool: \
`$ git pr show -t 1253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1253.diff">https://git.openjdk.org/jdk11u-dev/pull/1253.diff</a>

</details>
