### PR TITLE
8266460: java.io tests fail on null stream with upgraded jtreg/TestNG

### DIFF
--- a/test/jdk/java/io/InputStream/NullInputStream.java
+++ b/test/jdk/java/io/InputStream/NullInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,14 @@
  * questions.
  */
 
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.io.IOException;
-import org.testng.annotations.AfterGroups;
-import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
 import static org.testng.Assert.*;
 
 /*
@@ -39,13 +41,9 @@ public class NullInputStream {
     private static InputStream openStream;
     private static InputStream closedStream;
 
-    @BeforeGroups(groups="open")
-    public static void openStream() {
+    @BeforeClass
+    public static void setup() {
         openStream = InputStream.nullInputStream();
-    }
-
-    @BeforeGroups(groups="closed")
-    public static void openAndCloseStream() {
         closedStream = InputStream.nullInputStream();
         try {
            closedStream.close();
@@ -54,7 +52,7 @@ public class NullInputStream {
         }
     }
 
-    @AfterGroups(groups="open")
+    @AfterClass
     public static void closeStream() {
         try {
             openStream.close();
@@ -63,12 +61,12 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testOpen() {
         assertNotNull(openStream, "InputStream.nullInputStream() returned null");
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testAvailable() {
         try {
             assertEquals(0, openStream.available(), "available() != 0");
@@ -77,7 +75,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testRead() {
         try {
             assertEquals(-1, openStream.read(), "read() != -1");
@@ -86,7 +84,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testReadBII() {
         try {
             assertEquals(-1, openStream.read(new byte[1], 0, 1),
@@ -96,7 +94,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testReadAllBytes() {
         try {
             assertEquals(0, openStream.readAllBytes().length,
@@ -106,7 +104,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testReadNBytes() {
         try {
             assertEquals(0, openStream.readNBytes(new byte[1], 0, 1),
@@ -116,7 +114,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testReadNBytesWithLength() {
         try {
             assertEquals(0, openStream.readNBytes(-1).length,
@@ -136,7 +134,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testSkip() {
         try {
             assertEquals(0, openStream.skip(1), "skip() != 0");
@@ -145,7 +143,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testTransferTo() {
         try {
             assertEquals(0, openStream.transferTo(new ByteArrayOutputStream(7)),
@@ -155,7 +153,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "closed")
+    @Test
     public static void testAvailableClosed() {
         try {
             closedStream.available();
@@ -164,7 +162,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "closed")
+    @Test
     public static void testReadClosed() {
         try {
             closedStream.read();
@@ -173,7 +171,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "closed")
+    @Test
     public static void testReadBIIClosed() {
         try {
             closedStream.read(new byte[1], 0, 1);
@@ -182,7 +180,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "closed")
+    @Test
     public static void testReadAllBytesClosed() {
         try {
             closedStream.readAllBytes();
@@ -191,7 +189,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "closed")
+    @Test
     public static void testReadNBytesClosed() {
         try {
             closedStream.readNBytes(new byte[1], 0, 1);
@@ -200,7 +198,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "closed")
+    @Test
     public static void testReadNBytesWithLengthClosed() {
         try {
             closedStream.readNBytes(1);
@@ -209,7 +207,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "closed")
+    @Test
     public static void testSkipClosed() {
         try {
             closedStream.skip(1);
@@ -218,7 +216,7 @@ public class NullInputStream {
         }
     }
 
-    @Test(groups = "closed")
+    @Test
     public static void testTransferToClosed() {
         try {
             closedStream.transferTo(new ByteArrayOutputStream(7));

--- a/test/jdk/java/io/OutputStream/NullOutputStream.java
+++ b/test/jdk/java/io/OutputStream/NullOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,15 @@
  * questions.
  */
 
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
 import java.io.IOException;
 import java.io.OutputStream;
-import org.testng.annotations.AfterGroups;
-import org.testng.annotations.BeforeGroups;
-import org.testng.annotations.Test;
-import static org.testng.Assert.*;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
 
 /*
  * @test
@@ -38,13 +41,9 @@ public class NullOutputStream {
     private static OutputStream openStream;
     private static OutputStream closedStream;
 
-    @BeforeGroups(groups="open")
-    public static void openStream() {
+    @BeforeClass
+    public static void setup() {
         openStream = OutputStream.nullOutputStream();
-    }
-
-    @BeforeGroups(groups="closed")
-    public static void openAndCloseStream() {
         closedStream = OutputStream.nullOutputStream();
         try {
            closedStream.close();
@@ -53,7 +52,7 @@ public class NullOutputStream {
         }
     }
 
-    @AfterGroups(groups="open")
+    @AfterClass
     public static void closeStream() {
         try {
             openStream.close();
@@ -62,13 +61,13 @@ public class NullOutputStream {
         }
     }
 
-    @Test(groups="open")
+    @Test
     public static void testOpen() {
         assertNotNull(openStream,
             "OutputStream.nullOutputStream() returned null");
     }
 
-    @Test(groups="open")
+    @Test
     public static void testWrite() {
         try {
             openStream.write(62832);
@@ -77,7 +76,7 @@ public class NullOutputStream {
         }
     }
 
-    @Test(groups="open")
+    @Test
     public static void testWriteBII() {
         try {
             openStream.write(new byte[] {(byte)6}, 0, 1);
@@ -86,7 +85,7 @@ public class NullOutputStream {
         }
     }
 
-    @Test(groups="closed")
+    @Test
     public static void testWriteClosed() {
         try {
             closedStream.write(62832);
@@ -95,7 +94,7 @@ public class NullOutputStream {
         }
     }
 
-    @Test(groups="closed")
+    @Test
     public static void testWriteBIIClosed() {
         try {
             closedStream.write(new byte[] {(byte)6}, 0, 1);

--- a/test/jdk/java/io/Reader/NullReader.java
+++ b/test/jdk/java/io/Reader/NullReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,7 @@ import java.io.StringWriter;
 import java.nio.CharBuffer;
 import java.nio.ReadOnlyBufferException;
 
-import org.testng.annotations.AfterGroups;
-import org.testng.annotations.BeforeGroups;
-import org.testng.annotations.Test;
+import org.testng.annotations.*;
 
 import static org.testng.Assert.*;
 
@@ -43,107 +41,103 @@ public class NullReader {
     private static Reader openReader;
     private static Reader closedReader;
 
-    @BeforeGroups(groups = "open")
-    public static void openStream() {
+    @BeforeClass
+    public static void setup() throws IOException {
         openReader = Reader.nullReader();
-    }
-
-    @BeforeGroups(groups = "closed")
-    public static void openAndCloseStream() throws IOException {
         closedReader = Reader.nullReader();
         closedReader.close();
     }
 
-    @AfterGroups(groups = "open")
+    @AfterClass
     public static void closeStream() throws IOException {
         openReader.close();
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testOpen() {
         assertNotNull(openReader, "Reader.nullReader() returned null");
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testRead() throws IOException {
         assertEquals(-1, openReader.read(), "read() != -1");
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testReadBII() throws IOException {
         assertEquals(-1, openReader.read(new char[1], 0, 1),
                 "read(char[],int,int) != -1");
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testReadBIILenZero() throws IOException {
         assertEquals(0, openReader.read(new char[1], 0, 0),
                 "read(char[],int,int) != 0");
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testReadCharBuffer() throws IOException {
         CharBuffer charBuffer = CharBuffer.allocate(1);
         assertEquals(-1, openReader.read(charBuffer),
                 "read(CharBuffer) != -1");
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testReadCharBufferZeroRemaining() throws IOException {
         CharBuffer charBuffer = CharBuffer.allocate(0);
         assertEquals(0, openReader.read(charBuffer),
                 "read(CharBuffer) != 0");
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testReady() throws IOException {
         assertFalse(openReader.ready());
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testSkip() throws IOException {
         assertEquals(0, openReader.skip(1), "skip() != 0");
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testTransferTo() throws IOException {
         assertEquals(0, openReader.transferTo(new StringWriter(7)),
                 "transferTo() != 0");
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testReadClosed() throws IOException {
         closedReader.read();
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testReadBIIClosed() throws IOException {
         closedReader.read(new char[1], 0, 1);
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testReadCharBufferClosed() throws IOException {
         CharBuffer charBuffer = CharBuffer.allocate(0);
         closedReader.read(charBuffer);
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testReadCharBufferZeroRemainingClosed() throws IOException {
         CharBuffer charBuffer = CharBuffer.allocate(0);
         closedReader.read(charBuffer);
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testReadyClosed() throws IOException {
         closedReader.ready();
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testSkipClosed() throws IOException {
         closedReader.skip(1);
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testTransferToClosed() throws IOException {
         closedReader.transferTo(new StringWriter(7));
     }

--- a/test/jdk/java/io/Writer/NullWriter.java
+++ b/test/jdk/java/io/Writer/NullWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,14 +21,15 @@
  * questions.
  */
 
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
 import java.io.IOException;
 import java.io.Writer;
 
-import org.testng.annotations.AfterGroups;
-import org.testng.annotations.BeforeGroups;
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
 
 /*
  * @test
@@ -40,127 +41,123 @@ public class NullWriter {
     private static Writer openWriter;
     private static Writer closedWriter;
 
-    @BeforeGroups(groups = "open")
-    public static void openStream() {
+    @BeforeClass
+    public static void setup() throws IOException {
         openWriter = Writer.nullWriter();
-    }
-
-    @BeforeGroups(groups = "closed")
-    public static void openAndCloseStream() throws IOException {
         closedWriter = Writer.nullWriter();
         closedWriter.close();
     }
 
-    @AfterGroups(groups = "open")
+    @AfterClass
     public static void closeStream() throws IOException {
         openWriter.close();
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testOpen() {
         assertNotNull(openWriter, "Writer.nullWriter() returned null");
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testAppendChar() throws IOException {
         assertSame(openWriter, openWriter.append('x'));
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testAppendCharSequence() throws IOException {
         CharSequence cs = "abc";
         assertSame(openWriter, openWriter.append(cs));
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testAppendCharSequenceNull() throws IOException {
         assertSame(openWriter, openWriter.append(null));
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testAppendCharSequenceII() throws IOException {
         CharSequence cs = "abc";
         assertSame(openWriter, openWriter.append(cs, 0, 1));
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testAppendCharSequenceIINull() throws IOException {
         assertSame(openWriter, openWriter.append(null, 2, 1));
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testFlush() throws IOException {
         openWriter.flush();
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testWrite() throws IOException {
         openWriter.write(62832);
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testWriteString() throws IOException {
         openWriter.write("");
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testWriteStringII() throws IOException {
         openWriter.write("", 0, 0);
     }
 
-    @Test(groups = "open")
+    @Test
     public static void testWriteBII() throws IOException, Exception {
         openWriter.write(new char[]{(char) 6}, 0, 1);
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testAppendCharClosed() throws IOException {
         closedWriter.append('x');
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testAppendCharSequenceClosed() throws IOException {
         CharSequence cs = "abc";
         closedWriter.append(cs);
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testAppendCharSequenceNullClosed() throws IOException {
         closedWriter.append(null);
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testAppendCharSequenceIIClosed() throws IOException {
         CharSequence cs = "abc";
         closedWriter.append(cs, 0, 1);
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testAppendCharSequenceIINullClosed() throws IOException {
         closedWriter.append(null, 2, 1);
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testFlushClosed() throws IOException {
         closedWriter.flush();
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testWriteClosed() throws IOException {
         closedWriter.write(62832);
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testWriteStringClosed() throws IOException {
         closedWriter.write("");
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testWriteStringIIClosed() throws IOException {
         closedWriter.write("", 0, 0);
     }
 
-    @Test(groups = "closed", expectedExceptions = IOException.class)
+    @Test(expectedExceptions = IOException.class)
     public static void testWriteBIIClosed() throws IOException {
         closedWriter.write(new char[]{(char) 6}, 0, 1);
     }


### PR DESCRIPTION
Backport required to bump JDK11u to jtreg 6

`test/jdk/java/io/InputStream/NullInputStream.java`
- no `import java.io.EOFException;` in jdk11u which prevented the patch from applying cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266460](https://bugs.openjdk.org/browse/JDK-8266460): java.io tests fail on null stream with upgraded jtreg/TestNG


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1254/head:pull/1254` \
`$ git checkout pull/1254`

Update a local copy of the PR: \
`$ git checkout pull/1254` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1254`

View PR using the GUI difftool: \
`$ git pr show -t 1254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1254.diff">https://git.openjdk.org/jdk11u-dev/pull/1254.diff</a>

</details>
