### PR TITLE
8290813 jdk/nashorn/api/scripting/test/ScriptObjectMirrorTest.java fails: assertEquals is ambiguous

### DIFF
--- a/test/nashorn/src/jdk/nashorn/api/scripting/test/ScriptObjectMirrorTest.java
+++ b/test/nashorn/src/jdk/nashorn/api/scripting/test/ScriptObjectMirrorTest.java
@@ -282,7 +282,7 @@ public class ScriptObjectMirrorTest {
 
         ScriptObjectMirror obj = (ScriptObjectMirror)e.eval(
             "({ valueOf: function() { return 42 } })");
-        assertEquals(42.0, obj.to(Double.class));
+        assertEquals(new Double(42.0), obj.to(Double.class));
 
         obj = (ScriptObjectMirror)e.eval(
             "({ toString: function() { return 'foo' } })");

--- a/test/nashorn/src/jdk/nashorn/api/scripting/test/ScriptObjectMirrorTest.java
+++ b/test/nashorn/src/jdk/nashorn/api/scripting/test/ScriptObjectMirrorTest.java
@@ -282,7 +282,7 @@ public class ScriptObjectMirrorTest {
 
         ScriptObjectMirror obj = (ScriptObjectMirror)e.eval(
             "({ valueOf: function() { return 42 } })");
-        assertEquals(new Double(42.0), obj.to(Double.class));
+        assertEquals(Double.valueOf(42.0), obj.to(Double.class));
 
         obj = (ScriptObjectMirror)e.eval(
             "({ toString: function() { return 'foo' } })");


### PR DESCRIPTION
Required as part of the jtreg 6 update - Tested locally and passes on my machine

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290813](https://bugs.openjdk.org/browse/JDK-8290813): jdk/nashorn/api/scripting/test/ScriptObjectMirrorTest.java fails: assertEquals is ambiguous


### Reviewers
 * [Attila Szegedi](https://openjdk.org/census#attila) (@szegedi - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1255/head:pull/1255` \
`$ git checkout pull/1255`

Update a local copy of the PR: \
`$ git checkout pull/1255` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1255`

View PR using the GUI difftool: \
`$ git pr show -t 1255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1255.diff">https://git.openjdk.org/jdk11u-dev/pull/1255.diff</a>

</details>
