### PR TITLE
8235870: C2 crashes in IdealLoopTree::est_loop_flow_merge_sz()

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2532,13 +2532,14 @@ uint IdealLoopTree::est_loop_flow_merge_sz() const {
 
     for (uint k = 0; k < outcnt; k++) {
       Node* out = node->raw_out(k);
-
+      if (out == NULL) continue;
       if (out->is_CFG()) {
         if (!is_member(_phase->get_loop(out))) {
           ctrl_edge_out_cnt++;
         }
-      } else {
+      } else if (_phase->has_ctrl(out)) {
         Node* ctrl = _phase->get_ctrl(out);
+        assert(ctrl != NULL, "must be");
         assert(ctrl->is_CFG(), "must be");
         if (!is_member(_phase->get_loop(ctrl))) {
           data_edge_out_cnt++;


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8235870](https://bugs.openjdk.org/browse/JDK-8235870): C2 crashes in IdealLoopTree::est_loop_flow_merge_sz()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1256/head:pull/1256` \
`$ git checkout pull/1256`

Update a local copy of the PR: \
`$ git checkout pull/1256` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1256`

View PR using the GUI difftool: \
`$ git pr show -t 1256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1256.diff">https://git.openjdk.org/jdk11u-dev/pull/1256.diff</a>

</details>
