### PR TITLE
8255724: [XRender] the BlitRotateClippedArea test fails on Linux in the XR pipeline

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -216,7 +216,6 @@ java/awt/image/DrawImage/IncorrectClipXorModeSW2Surface.java 8196025 windows-all
 java/awt/image/DrawImage/IncorrectClipXorModeSurface2Surface.java 8196025 windows-all
 java/awt/image/DrawImage/IncorrectSourceOffset.java 8196086 windows-all
 java/awt/image/DrawImage/IncorrectUnmanagedImageRotatedClip.java 8196087 windows-all
-java/awt/image/DrawImage/BlitRotateClippedArea.java 8255724 linux-all
 java/awt/image/MultiResolutionImage/MultiResolutionDrawImageWithTransformTest.java 8198390 generic-all
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8169187 macosx-all
 java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all

--- a/test/jdk/java/awt/image/DrawImage/BlitRotateClippedArea.java
+++ b/test/jdk/java/awt/image/DrawImage/BlitRotateClippedArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import static java.awt.Transparency.TRANSLUCENT;
 
 /**
  * @test
- * @bug 8255722
+ * @bug 8255722 8255724
  * @key headful
  */
 public class BlitRotateClippedArea {
@@ -103,10 +103,15 @@ public class BlitRotateClippedArea {
             throws IOException {
         for (int x = 0; x < gold.getWidth(); ++x) {
             for (int y = 0; y < gold.getHeight(); ++y) {
-                if (gold.getRGB(x, y) != img.getRGB(x, y)) {
-                    ImageIO.write(gold, "png", new File("gold.png"));
-                    ImageIO.write(img, "png", new File("snapshot.png"));
-                    throw new RuntimeException("Test failed.");
+                Color goldColor = new Color(gold.getRGB(x, y));
+                Color actualColor = new Color(img.getRGB(x, y));
+                if ((Math.abs(goldColor.getRed() - actualColor.getRed()) > 1) ||
+                    (Math.abs(goldColor.getGreen() - actualColor.getGreen()) > 1) ||
+                    (Math.abs(goldColor.getBlue() - actualColor.getBlue()) > 1)) {
+                     ImageIO.write(gold, "png", new File("gold.png"));
+                     ImageIO.write(img, "png", new File("snapshot.png"));
+                     throw new RuntimeException("Test failed for pixel :"
+                        + x + "/" + y);
                 }
             }
         }


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

Clean except for ProblemList, will mark as /clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255724](https://bugs.openjdk.org/browse/JDK-8255724): [XRender] the BlitRotateClippedArea test fails on Linux in the XR pipeline


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1258/head:pull/1258` \
`$ git checkout pull/1258`

Update a local copy of the PR: \
`$ git checkout pull/1258` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1258`

View PR using the GUI difftool: \
`$ git pr show -t 1258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1258.diff">https://git.openjdk.org/jdk11u-dev/pull/1258.diff</a>

</details>
