### PR TITLE
8017175: [TESTBUG] javax/swing/JPopupMenu/4634626/bug4634626.java sometimes failed on mac

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -756,7 +756,6 @@ javax/swing/JTabbedPane/TabProb.java 8236635 linux-all
 javax/swing/JTree/8003830/bug8003830.java 8199057 generic-all
 javax/swing/text/GlyphPainter2/6427244/bug6427244.java 8208566 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
-javax/swing/JPopupMenu/4634626/bug4634626.java 8017175 macosx-all
 javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
 javax/swing/plaf/synth/7158712/bug7158712.java 8238720 windows-all
 javax/swing/plaf/basic/BasicComboPopup/JComboBoxPopupLocation/JComboBoxPopupLocation.java 8238720 windows-all

--- a/test/jdk/javax/swing/JPopupMenu/4634626/bug4634626.java
+++ b/test/jdk/javax/swing/JPopupMenu/4634626/bug4634626.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,24 +31,35 @@
  * @run main bug4634626
  */
 
-import javax.swing.*;
-import java.awt.event.*;
-import java.awt.*;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class bug4634626  {
 
-    public boolean passed = true;
-    public boolean done = false;
+    public volatile boolean passed = true;
+    public volatile boolean done = false;
 
-    public static JFrame mainFrame = new JFrame("Bug4634626");
-    public JRootPane rootPane = mainFrame.getRootPane();
-    public JPanel contentPane = new JPanel();
-    public JButton nopButton = new JButton("No popup button");
-    public JTextArea someText = new JTextArea("Some text here", 20, 10);
-    public JButton popButton = new JButton("Button with the popup");
+    public static JFrame mainFrame;
+    public JPanel contentPane;
+    public JButton nopButton;
+    public JTextArea someText;
+    public JButton popButton;
 
-    public JPopupMenu btnPopup = new JPopupMenu();
-    public JPopupMenu commonPopup = new JPopupMenu();
+    public JPopupMenu btnPopup;
+    public JPopupMenu commonPopup;
     static public Error toBeThrown = null;
     static int popTrig = MouseEvent.BUTTON3_MASK;
     static boolean popt = false;
@@ -61,10 +72,11 @@ public class bug4634626  {
                e.isPopupTrigger() &&
                ((JComponent)e.getComponent()).getComponentPopupMenu() != null) {
                 toBeThrown =
-                  new Error("The event got thru the component with popup: "
+                  new Error("The event got through the component with popup: "
                   + e);
             }
         }
+
         public void mouseReleased(MouseEvent e) {
             if(e.isPopupTrigger()) popt = true;
             if(e.getComponent() != null &&
@@ -72,7 +84,7 @@ public class bug4634626  {
                e.isPopupTrigger() &&
                ((JComponent)e.getComponent()).getComponentPopupMenu() != null) {
                 toBeThrown =
-                  new Error("The event got thru the component with popup: "
+                  new Error("The event got through the component with popup: "
                   + e);
             }
             if(toBeThrown != null) {
@@ -93,49 +105,57 @@ public class bug4634626  {
         }
     }
 
-    public void init() {
+    public void init() throws Exception {
+        SwingUtilities.invokeLater(() -> {
+            mainFrame = new JFrame("Bug4634626");
+            contentPane = new JPanel();
+            nopButton = new JButton("No popup button");
+            someText = new JTextArea("Some text here", 20, 10);
+            popButton = new JButton("Button with the popup");
 
-        try {
-            popButton.setComponentPopupMenu(null);
-            popButton.setComponentPopupMenu(null);
+            btnPopup = new JPopupMenu();
+            commonPopup = new JPopupMenu();
+
+            try {
+                popButton.setComponentPopupMenu(null);
+                popButton.setComponentPopupMenu(null);
+                popButton.setComponentPopupMenu(btnPopup);
+                popButton.setComponentPopupMenu(null);
+            } catch (Exception ex) {
+                System.err.println("Unexpected exception was thrown by " +
+                        "setComponentPopupMenu() method: " + ex);
+            }
+            btnPopup.add("Button 1");
+            btnPopup.add("Button 2");
+            btnPopup.add("Button 3");
             popButton.setComponentPopupMenu(btnPopup);
-            popButton.setComponentPopupMenu(null);
-        } catch(Exception ex) {
-            System.err.println("Unexpected exception was thrown by " +
-                               "setComponentPopupMenu() method: " + ex);
-        }
-        btnPopup.add("Button 1");
-        btnPopup.add("Button 2");
-        btnPopup.add("Button 3");
-        popButton.setComponentPopupMenu(btnPopup);
-        popButton.addMouseListener(mouser);
-        commonPopup.add("One");
-        commonPopup.add("Two");
-        commonPopup.add("Three");
+            popButton.addMouseListener(mouser);
+            commonPopup.add("One");
+            commonPopup.add("Two");
+            commonPopup.add("Three");
 
-        contentPane.setLayout(new BorderLayout());
-        contentPane.setComponentPopupMenu(commonPopup);
-        contentPane.addMouseListener(mouser);
-        contentPane.add(nopButton, BorderLayout.NORTH);
-        nopButton.addMouseListener(mouser);
-        contentPane.add(popButton, BorderLayout.SOUTH);
-        someText.addMouseListener(mouser);
-        contentPane.add(someText, BorderLayout.CENTER);
-        mainFrame.setContentPane(contentPane);
+            contentPane.setLayout(new BorderLayout());
+            contentPane.setComponentPopupMenu(commonPopup);
+            contentPane.addMouseListener(mouser);
+            contentPane.add(nopButton, BorderLayout.NORTH);
+            nopButton.addMouseListener(mouser);
+            contentPane.add(popButton, BorderLayout.SOUTH);
+            someText.addMouseListener(mouser);
+            contentPane.add(someText, BorderLayout.CENTER);
+            mainFrame.setContentPane(contentPane);
 
-        mainFrame.pack();
-        mainFrame.setLocation(50, 50);
-
-        mainFrame.addWindowListener(new TestStateListener());
-        mainFrame.setLocationRelativeTo(null);
-        mainFrame.setVisible(true);
+            mainFrame.pack();
+            mainFrame.setLocation(50, 50);
+            mainFrame.addWindowListener(new TestStateListener());
+            mainFrame.setLocationRelativeTo(null);
+            mainFrame.setVisible(true);
+        });
 
         while(!done) Thread.yield();
 
         if(!passed) {
             throw new RuntimeException("Test failed");
         }
-
     }
 
     public class TestStateListener extends WindowAdapter {
@@ -165,31 +185,52 @@ public class bug4634626  {
             // Determine working popup trigger event
             clickMouseOn(robo, nopButton, popTrig);
             robo.waitForIdle();
-            robo.delay(500);
+            robo.delay(1000);
             if(!popt) popTrig = MouseEvent.BUTTON2_MASK;
 
             // Inheritance is OFF by default. Popup should not appear.
             clickMouseOn(robo, someText, popTrig);
 
             // Set inheritance ON watch for popup.
-            someText.setInheritsPopupMenu(true);
+            try {
+                SwingUtilities.invokeAndWait(() -> someText.setInheritsPopupMenu(true));
+            } catch (Exception ex) {
+                throw new RuntimeException("Can not assign popup to button", ex);
+            }
             clickMouseOn(robo, someText, popTrig);
             robo.waitForIdle();
-            robo.delay(500);
-            if(!commonPopup.isVisible()) {
+            robo.delay(1000);
+            AtomicBoolean popupVisible = new AtomicBoolean(false);
+            try {
+                SwingUtilities.invokeAndWait(() ->
+                        popupVisible.set(commonPopup.isVisible()));
+            } catch (Exception ex) {
+                throw new RuntimeException("Can not get commonPopup status");
+            }
+            if(!popupVisible.get()) {
                 toBeThrown = new Error("Popup should be visible");
                 passed = false;
             }
             // Dispose popup.
             robo.type(KeyEvent.VK_ESCAPE);
             robo.waitForIdle();
-            someText.setInheritsPopupMenu(false);
+            try {
+                SwingUtilities.invokeAndWait(() -> someText.setInheritsPopupMenu(false));
+            } catch (Exception ex) {
+                throw new RuntimeException("Can not unassign popup on button", ex);
+            }
 
             // Button with popup assigned. Wathch for popup.
             clickMouseOn(robo, popButton, popTrig);
             robo.waitForIdle();
-            robo.delay(500);
-            if(!btnPopup.isVisible()) {
+            robo.delay(1000);
+            try {
+                SwingUtilities.invokeAndWait(() ->
+                    popupVisible.set(btnPopup.isVisible()));
+            } catch (Exception ex) {
+                throw new RuntimeException("Can not get btnPopup status");
+            }
+            if(!popupVisible.get()) {
                 toBeThrown = new Error("Popup should be visible");
                 passed = false;
             }
@@ -200,13 +241,12 @@ public class bug4634626  {
         }
     }
 
-
-
     public void destroy() {
         if(!passed) {
             throw(toBeThrown);
         }
     }
+
     private void clickMouseOn(ExtendedRobot robot, Component c, int button) {
         java.awt.Point p = c.getLocationOnScreen();
         java.awt.Dimension size = c.getSize();


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

I resolved the ProblemList and a chunk in the test. Trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8017175](https://bugs.openjdk.org/browse/JDK-8017175): [TESTBUG] javax/swing/JPopupMenu/4634626/bug4634626.java sometimes failed on mac


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1259/head:pull/1259` \
`$ git checkout pull/1259`

Update a local copy of the PR: \
`$ git checkout pull/1259` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1259`

View PR using the GUI difftool: \
`$ git pr show -t 1259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1259.diff">https://git.openjdk.org/jdk11u-dev/pull/1259.diff</a>

</details>
