### PR TITLE
8290886 [11u]: Backport of JDK-8266250 introduced test failures

### DIFF
--- a/test/jdk/java/net/httpclient/websocket/WebSocketProxyTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketProxyTest.java
@@ -68,7 +68,6 @@ import javax.net.ssl.SSLContext;
 
 import static java.net.http.HttpClient.newBuilder;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.FileAssert.fail;
 
@@ -155,6 +154,9 @@ public class WebSocketProxyTest {
         public Bytes(byte[] bytes) {
             this.bytes = bytes;
         }
+        public byte[] getBytes() {
+            return bytes;
+        }
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
@@ -166,13 +168,8 @@ public class WebSocketProxyTest {
             }
             return false;
         }
-        public byte[] getBytes() {
-            return bytes;
-        }
         @Override
-        public int hashCode() {
-            return Arrays.hashCode(bytes);
-        }
+        public int hashCode() { return Arrays.hashCode(bytes); }
         public String toString() {
             StringBuilder builder = new StringBuilder("0x");
             for (byte aByte : bytes) {
@@ -183,10 +180,7 @@ public class WebSocketProxyTest {
     }
 
     static List<Bytes> ofBytes(List<byte[]> bytes) {
-        return bytes
-            .stream()
-            .map(byteArray -> new Bytes(byteArray))
-            .collect(Collectors.toList());
+        return bytes.stream().map(WebSocketProxyTest.Bytes::new).collect(Collectors.toList());
     }
 
     static String diagnose(List<byte[]> a, List<byte[]> b) {

--- a/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
@@ -43,7 +43,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -58,6 +57,7 @@ import static java.net.http.HttpClient.Builder.NO_PROXY;
 import static java.net.http.HttpClient.newBuilder;
 import static java.net.http.WebSocket.NORMAL_CLOSURE;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.fail;
@@ -434,33 +434,50 @@ public class WebSocketTest {
         };
     }
 
-    record bytes(byte[] bytes) {
+    private static class Bytes {
+        private final byte[] bytes;
+        public Bytes(byte[] bytes) {
+            this.bytes = bytes;
+        }
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o instanceof bytes other) {
-                return Arrays.equals(bytes(), other.bytes());
+            if (o instanceof byte[]) {
+                return Arrays.equals(bytes, (byte[]) o);
+            }
+            if (o instanceof Bytes) {
+                return Arrays.equals(bytes, ((Bytes) o).getBytes());
             }
             return false;
         }
+        public byte[] getBytes() {
+            return bytes;
+        }
         @Override
-        public int hashCode() { return Arrays.hashCode(bytes()); }
+        public int hashCode() {
+            return Arrays.hashCode(bytes);
+        }
         public String toString() {
-            return "0x" + HexFormat.of()
-                    .withUpperCase()
-                    .formatHex(bytes());
+            StringBuilder builder = new StringBuilder("0x");
+            for (byte aByte : bytes) {
+                builder.append(String.format("%X", aByte).toUpperCase());
+            }
+            return builder.toString();
         }
     }
 
-    static List<bytes> ofBytes(List<byte[]> bytes) {
-        return bytes.stream().map(bytes::new).toList();
+    static List<Bytes> ofBytes(List<byte[]> bytes) {
+        return bytes
+            .stream()
+            .map(byteArray -> new Bytes(byteArray))
+            .collect(Collectors.toList());
     }
 
     static String diagnose(List<byte[]> a, List<byte[]> b) {
         var actual = ofBytes(a);
         var expected = ofBytes(b);
         var message = actual.equals(expected) ? "match" : "differ";
-        return "%s and %s %s".formatted(actual, expected, message);
+        return String.format("%s and %s %s", actual, expected, message);
     }
 
     @Test(dataProvider = "servers")

--- a/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
+++ b/test/jdk/java/net/httpclient/websocket/WebSocketTest.java
@@ -57,7 +57,6 @@ import static java.net.http.HttpClient.Builder.NO_PROXY;
 import static java.net.http.HttpClient.newBuilder;
 import static java.net.http.WebSocket.NORMAL_CLOSURE;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.fail;
@@ -439,6 +438,9 @@ public class WebSocketTest {
         public Bytes(byte[] bytes) {
             this.bytes = bytes;
         }
+        public byte[] getBytes() {
+            return bytes;
+        }
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
@@ -450,13 +452,8 @@ public class WebSocketTest {
             }
             return false;
         }
-        public byte[] getBytes() {
-            return bytes;
-        }
         @Override
-        public int hashCode() {
-            return Arrays.hashCode(bytes);
-        }
+        public int hashCode() { return Arrays.hashCode(bytes); }
         public String toString() {
             StringBuilder builder = new StringBuilder("0x");
             for (byte aByte : bytes) {
@@ -467,10 +464,7 @@ public class WebSocketTest {
     }
 
     static List<Bytes> ofBytes(List<byte[]> bytes) {
-        return bytes
-            .stream()
-            .map(byteArray -> new Bytes(byteArray))
-            .collect(Collectors.toList());
+        return bytes.stream().map(WebSocketTest.Bytes::new).collect(Collectors.toList());
     }
 
     static String diagnose(List<byte[]> a, List<byte[]> b) {


### PR DESCRIPTION
Tested locally and confirmed that both tests now pass again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290886](https://bugs.openjdk.org/browse/JDK-8290886): [11u]: Backport of JDK-8266250 introduced test failures


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1265/head:pull/1265` \
`$ git checkout pull/1265`

Update a local copy of the PR: \
`$ git checkout pull/1265` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1265`

View PR using the GUI difftool: \
`$ git pr show -t 1265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1265.diff">https://git.openjdk.org/jdk11u-dev/pull/1265.diff</a>

</details>
