### PR TITLE
8239379: ProblemList serviceability/sa/sadebugd/DebugdConnectTest.java on OSX

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -137,7 +137,7 @@ serviceability/sa/ClhsdbWhere.java 8193639 solaris-all
 serviceability/sa/DeadlockDetectionTest.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64
 serviceability/sa/JhsdbThreadInfoTest.java 8193639 solaris-all
 serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java 8193639 solaris-all
-serviceability/sa/sadebugd/SADebugDTest.java 8163805 generic-all
+serviceability/sa/sadebugd/DebugdConnectTest.java 8239062,8270326 macosx-x64,macosx-aarch64
 serviceability/sa/TestClassDump.java 8193639 solaris-all
 serviceability/sa/TestClhsdbJstackLock.java 8193639 solaris-all
 serviceability/sa/TestCpoolForInvokeDynamic.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64


### PR DESCRIPTION
This is a preparation backport for the backport of [JDK-8238268](https://bugs.openjdk.org/browse/JDK-8238268).

It backports [JDK-8239379](https://bugs.openjdk.org/browse/JDK-8239379) and
 [JDK-8271512](https://bugs.openjdk.org/browse/JDK-8271512) which exclude
test serviceability/sa/sadebugd/DebugdConnectTest.java on both Mac OS architectures.
This test will generally be enabled via [JDK-8238268](https://bugs.openjdk.org/browse/JDK-8238268).

While editing the test list, I also figured out that the backport of
[JDK-8163805](https://bugs.openjdk.org/browse/JDK-8163805) was incomplete in that it
did not remove the exclusion of serviceability/sa/sadebugd/SADebugDTest.java which
I'm correcting in this patch as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8239379](https://bugs.openjdk.org/browse/JDK-8239379): ProblemList serviceability/sa/sadebugd/DebugdConnectTest.java on OSX
 * [JDK-8271512](https://bugs.openjdk.org/browse/JDK-8271512): ProblemList serviceability/sa/sadebugd/DebugdConnectTest.java due to 8270326


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1268/head:pull/1268` \
`$ git checkout pull/1268`

Update a local copy of the PR: \
`$ git checkout pull/1268` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1268`

View PR using the GUI difftool: \
`$ git pr show -t 1268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1268.diff">https://git.openjdk.org/jdk11u-dev/pull/1268.diff</a>

</details>
