### PR TITLE
8210960: Allow --with-boot-jdk-jvmargs to work during configure

### DIFF
--- a/make/autoconf/basics.m4
+++ b/make/autoconf/basics.m4
@@ -168,7 +168,7 @@ AC_DEFUN([ADD_JVM_ARG_IF_OK],
 [
   $ECHO "Check if jvm arg is ok: $1" >&AS_MESSAGE_LOG_FD
   $ECHO "Command: $3 $1 -version" >&AS_MESSAGE_LOG_FD
-  OUTPUT=`$3 $1 -version 2>&1`
+  OUTPUT=`$3 $1 $USER_BOOT_JDK_OPTIONS -version 2>&1`
   FOUND_WARN=`$ECHO "$OUTPUT" | $GREP -i warn`
   FOUND_VERSION=`$ECHO $OUTPUT | $GREP " version \""`
   if test "x$FOUND_VERSION" != x && test "x$FOUND_WARN" = x; then


### PR DESCRIPTION
clean backport - makes https://bugs.openjdk.org/browse/JDK-8239708 apply more cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210960](https://bugs.openjdk.org/browse/JDK-8210960): Allow --with-boot-jdk-jvmargs to work during configure


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1271/head:pull/1271` \
`$ git checkout pull/1271`

Update a local copy of the PR: \
`$ git checkout pull/1271` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1271`

View PR using the GUI difftool: \
`$ git pr show -t 1271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1271.diff">https://git.openjdk.org/jdk11u-dev/pull/1271.diff</a>

</details>
