### PR TITLE
8291570: [TESTBUG] Part of JDK-8250984 absent from 11u

### DIFF
--- a/test/hotspot/jtreg/containers/cgroup/PlainRead.java
+++ b/test/hotspot/jtreg/containers/cgroup/PlainRead.java
@@ -47,7 +47,7 @@ public class PlainRead {
        oa.shouldNotMatch("^.*" + what + " *" + value + ".*$");
     }
 
-    static final String good_value = "(\\d+|-1|Unlimited)";
+    static final String good_value = "(\\d+|-1|-2|Unlimited)";
     static final String bad_value = "(failed)";
 
     static final String[] variables = {"Memory Limit is:", "CPU Quota is:", "CPU Period is:", "active_processor_count:"};


### PR DESCRIPTION
So, the story goes:

* [JDK-8250984](https://bugs.openjdk.org/browse/JDK-8250984) was backported in 11.0.10
* [JDK-8231111](https://bugs.openjdk.org/browse/JDK-8231111) was backported in 11.0.16
* In later JDKs, these changes occur in the opposite order. So, when 8250984 was backported, changes related to 8231111 were stripped from it.
* Now 8231111 has been backported, the testcase needs to be updated to recognise `OSCONTAINER_ERROR` (which is `-2`) as a valid return value from the CGroups v2 code.

Without this fix, we're seeing the testcase failing on newer systems. This change syncs the testcase with trunk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291570](https://bugs.openjdk.org/browse/JDK-8291570): [TESTBUG] Part of JDK-8250984 absent from 11u


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1289/head:pull/1289` \
`$ git checkout pull/1289`

Update a local copy of the PR: \
`$ git checkout pull/1289` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1289`

View PR using the GUI difftool: \
`$ git pr show -t 1289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1289.diff">https://git.openjdk.org/jdk11u-dev/pull/1289.diff</a>

</details>
