### PR TITLE
8267880: Upgrade the default PKCS12 MAC algorithm

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -101,10 +101,10 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
             = "PBEWithHmacSHA256AndAES_256";
     private static final String DEFAULT_KEY_PBE_ALGORITHM
             = "PBEWithHmacSHA256AndAES_256";
-    private static final String DEFAULT_MAC_ALGORITHM = "HmacPBESHA1";
+    private static final String DEFAULT_MAC_ALGORITHM = "HmacPBESHA256";
     private static final int DEFAULT_CERT_PBE_ITERATION_COUNT = 10000;
     private static final int DEFAULT_KEY_PBE_ITERATION_COUNT = 10000;
-    private static final int DEFAULT_MAC_ITERATION_COUNT = 100000;
+    private static final int DEFAULT_MAC_ITERATION_COUNT = 10000;
 
     // Legacy settings. Used when "keystore.pkcs12.legacy" is set.
     private static final String LEGACY_CERT_PBE_ALGORITHM

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1211,12 +1211,12 @@ jceks.key.serialFilter = java.base/java.lang.Enum;java.base/java.security.KeyRep
 # The algorithm used to calculate the optional MacData at the end of a PKCS12
 # file. This can be any HmacPBE algorithm defined in the Mac section of the
 # Java Security Standard Algorithm Names Specification. When set to "NONE",
-# no Mac is generated. The default value is "HmacPBESHA1".
-#keystore.pkcs12.macAlgorithm = HmacPBESHA1
+# no Mac is generated. The default value is "HmacPBESHA256".
+#keystore.pkcs12.macAlgorithm = HmacPBESHA256
 
 # The iteration count used by the MacData algorithm. This value must be a
-# positive integer. The default value is 100000.
-#keystore.pkcs12.macIterationCount = 100000
+# positive integer. The default value is 10000.
+#keystore.pkcs12.macIterationCount = 10000
 
 #
 # Enhanced exception message information

--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -169,8 +169,8 @@ public class KeytoolOpensslInteropTest {
         keytool("-importkeystore -srckeystore ks -srcstorepass changeit "
                 + "-destkeystore ksnormal -deststorepass changeit");
         data = Files.readAllBytes(Path.of("ksnormal"));
-        checkInt(data, "22", 100000); // Mac ic
-        checkAlg(data, "2000", SHA_1); // Mac alg
+        checkInt(data, "22", 10000); // Mac ic
+        checkAlg(data, "2000", SHA_256); // Mac alg
         checkAlg(data, "110c010c01000", PBES2); // key alg
         checkInt(data, "110c010c01001011", 10000); // key ic
         checkAlg(data, "110c110110", PBES2); // cert alg
@@ -195,8 +195,8 @@ public class KeytoolOpensslInteropTest {
                 + "-J-Dkeystore.pkcs12.certProtectionAlgorithm=NONE "
                 + "-J-Dkeystore.pkcs12.macAlgorithm=NONE");
         data = Files.readAllBytes(Path.of("ksnormal"));
-        checkInt(data, "22", 100000); // Mac ic
-        checkAlg(data, "2000", SHA_1); // Mac alg
+        checkInt(data, "22", 10000); // Mac ic
+        checkAlg(data, "2000", SHA_256); // Mac alg
         checkAlg(data, "110c010c01000", PBES2); // key alg
         checkInt(data, "110c010c01001011", 10000); // key ic
         checkAlg(data, "110c010c11000", PBES2); // new key alg
@@ -240,7 +240,7 @@ public class KeytoolOpensslInteropTest {
                 + "-J-Dkeystore.pkcs12.keyPbeIterationCount=7777");
         data = Files.readAllBytes(Path.of("ksnewic"));
         checkInt(data, "22", 5555); // Mac ic
-        checkAlg(data, "2000", SHA_1); // Mac alg
+        checkAlg(data, "2000", SHA_256); // Mac alg
         checkAlg(data, "110c010c01000", PBES2); // key alg
         checkInt(data, "110c010c01001011", 7777); // key ic
         checkAlg(data, "110c110110", PBES2); // cert alg
@@ -257,7 +257,7 @@ public class KeytoolOpensslInteropTest {
                 + "-J-Dkeystore.pkcs12.keyProtectionAlgorithm=PBEWithSHA1AndRC4_128");
         data = Files.readAllBytes(Path.of("ksnewic"));
         checkInt(data, "22", 5555); // Mac ic
-        checkAlg(data, "2000", SHA_1); // Mac alg
+        checkAlg(data, "2000", SHA_256); // Mac alg
         checkAlg(data, "110c010c01000", PBES2); // key alg
         checkInt(data, "110c010c01001011", 7777); // key ic
         checkAlg(data, "110c010c11000", PBEWithSHA1AndRC4_128); // new key alg
@@ -273,8 +273,8 @@ public class KeytoolOpensslInteropTest {
             ks.store(fos, "changeit".toCharArray());
         }
         data = Files.readAllBytes(Path.of("ksnormaldup"));
-        checkInt(data, "22", 100000); // Mac ic
-        checkAlg(data, "2000", SHA_1); // Mac alg
+        checkInt(data, "22", 10000); // Mac ic
+        checkAlg(data, "2000", SHA_256); // Mac alg
         checkAlg(data, "110c010c01000", PBES2); // key alg
         checkInt(data, "110c010c01001011", 10000); // key ic
         checkAlg(data, "110c010c11000", PBES2); // new key alg
@@ -303,7 +303,7 @@ public class KeytoolOpensslInteropTest {
         }
         data = Files.readAllBytes(Path.of("ksnewicdup"));
         checkInt(data, "22", 5555); // Mac ic
-        checkAlg(data, "2000", SHA_1); // Mac alg
+        checkAlg(data, "2000", SHA_256); // Mac alg
         checkAlg(data, "110c010c01000", PBES2); // key alg
         checkInt(data, "110c010c01001011", 7777); // key ic
         checkAlg(data, "110c010c11000", PBEWithSHA1AndRC4_128); // new key alg

--- a/test/jdk/sun/security/pkcs12/ParamsPreferences.java
+++ b/test/jdk/sun/security/pkcs12/ParamsPreferences.java
@@ -57,7 +57,7 @@ public class ParamsPreferences {
                 Map.of(),
                 PBES2, HmacSHA256, AES_256$CBC$NoPadding, 10000,
                 PBES2, HmacSHA256, AES_256$CBC$NoPadding, 10000,
-                SHA_1, 100000);
+                SHA_256, 10000);
 
         // legacy settings
         test(c++,
@@ -107,7 +107,7 @@ public class ParamsPreferences {
                         "keystore.pkcs12.macAlgorithm", "NONE"),
                 PBEWithSHA1AndDESede, 10000,
                 PBES2, HmacSHA256, AES_256$CBC$NoPadding, 10000,
-                SHA_256, 100000);
+                SHA_256, 10000);
 
         // back to with storepass by using "" to force hardcoded default
         test(c++,
@@ -119,7 +119,7 @@ public class ParamsPreferences {
                         "keystore.pkcs12.macAlgorithm", "NONE"),
                 PBES2, HmacSHA256, AES_256$CBC$NoPadding, 10000,
                 PBES2, HmacSHA256, AES_256$CBC$NoPadding, 10000,
-                SHA_1, 100000);
+                SHA_256, 10000);
 
         // change everything with system property
         test(c++,
@@ -173,21 +173,21 @@ public class ParamsPreferences {
                 Map.of("keystore.PKCS12.keyProtectionAlgorithm", "PBEWithSHA1AndRC2_128"),
                 PBES2, HmacSHA256, AES_256$CBC$NoPadding, 10000,
                 PBEWithSHA1AndRC2_128, 10000,
-                SHA_1, 100000);
+                SHA_256, 10000);
         test(c++,
                 Map.of(),
                 Map.of("keystore.PKCS12.keyProtectionAlgorithm", "PBEWithSHA1AndRC2_128",
                         "keystore.pkcs12.keyProtectionAlgorithm", "PBEWithSHA1AndRC2_40"),
                 PBES2, HmacSHA256, AES_256$CBC$NoPadding, 10000,
                 PBEWithSHA1AndRC2_40, 10000,
-                SHA_1, 100000);
+                SHA_256, 10000);
         test(c++,
                 Map.of("keystore.PKCS12.keyProtectionAlgorithm", "PBEWithSHA1AndRC4_128"),
                 Map.of("keystore.PKCS12.keyProtectionAlgorithm", "PBEWithSHA1AndRC2_128",
                         "keystore.pkcs12.keyProtectionAlgorithm", "PBEWithSHA1AndRC2_40"),
                 PBES2, HmacSHA256, AES_256$CBC$NoPadding, 10000,
                 PBEWithSHA1AndRC4_128, 10000,
-                SHA_1, 100000);
+                SHA_256, 10000);
         test(c++,
                 Map.of("keystore.PKCS12.keyProtectionAlgorithm", "PBEWithSHA1AndRC4_128",
                         "keystore.pkcs12.keyProtectionAlgorithm", "PBEWithSHA1AndRC4_40"),
@@ -195,7 +195,7 @@ public class ParamsPreferences {
                         "keystore.pkcs12.keyProtectionAlgorithm", "PBEWithSHA1AndRC2_40"),
                 PBES2, HmacSHA256, AES_256$CBC$NoPadding, 10000,
                 PBEWithSHA1AndRC4_40, 10000,
-                SHA_1, 100000);
+                SHA_256, 10000);
 
         // 8266293
         test(c++,
@@ -204,7 +204,7 @@ public class ParamsPreferences {
                 Map.of(),
                 PBEWithMD5AndDES, 10000,
                 PBEWithMD5AndDES, 10000,
-                SHA_1, 100000);
+                SHA_256, 10000);
     }
 
     /**


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

In 11.0.12, "JDK-8153005 Upgrade the default PKCS12 encryption/MAC algorithms" was pushed.
Some parts of it were reverted right away in "JDK-8267599 Revert the change to the default PKCS12 macAlgorithm and macIterationCount props for 11u/8u/7u".
This change now again enables 8153005. It is basically the reverse patch of 8267599,
where ParamsTest.java has been renamed to KeytoolOpensslInteropTest.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8267880](https://bugs.openjdk.org/browse/JDK-8267880): Upgrade the default PKCS12 MAC algorithm ⚠️ Issue is not open.


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1296/head:pull/1296` \
`$ git checkout pull/1296`

Update a local copy of the PR: \
`$ git checkout pull/1296` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1296`

View PR using the GUI difftool: \
`$ git pr show -t 1296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1296.diff">https://git.openjdk.org/jdk11u-dev/pull/1296.diff</a>

</details>
