### PR TITLE
8287917: System.loadLibrary does not work on Big Sur if JDK is built with macOS SDK 10.15 and earlier

### DIFF
--- a/src/java.base/macosx/classes/java/lang/ClassLoaderHelper.java
+++ b/src/java.base/macosx/classes/java/lang/ClassLoaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,8 @@ class ClassLoaderHelper {
         try {
             major = Integer.parseInt(i < 0 ? osVersion : osVersion.substring(0, i));
         } catch (NumberFormatException e) {}
-        hasDynamicLoaderCache = major >= 11;
+        // SDK 10.15 and earlier always reports 10.16 instead of 11.x.x
+        hasDynamicLoaderCache = major >= 11 || osVersion.equals("10.16");
     }
 
     private ClassLoaderHelper() {}

--- a/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
+++ b/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ import java.nio.file.Paths;
 
 public class LibraryFromCache {
     public static void main(String[] args) throws IOException {
+        System.out.println("os.version = " + System.getProperty("os.version"));
+
         String libname = args[0];
         if (!systemHasLibrary(libname)) {
             System.out.println("Test skipped. Library " + libname + " not found");


### PR DESCRIPTION
This pull request contains a backport of commit [fe807217](https://github.com/openjdk/jdk/commit/fe807217a79753f84c00432e7451c17baa6645c5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Yoshiki Sato on 15 Jun 2022 and was reviewed by Mandy Chung.

I wish to backport it for Oracle parity.

It does not apply cleanly due to a renamed file in jdk master subsequent to 11u:

    src/java.base/macosx/classes/{java/lang => jdk/internal/loader}/ClassLoaderHelper.java

Manual testing results forthcoming; I'll add them as a comment on this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287917](https://bugs.openjdk.org/browse/JDK-8287917): System.loadLibrary does not work on Big Sur if JDK is built with macOS SDK 10.15 and earlier


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1298/head:pull/1298` \
`$ git checkout pull/1298`

Update a local copy of the PR: \
`$ git checkout pull/1298` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1298`

View PR using the GUI difftool: \
`$ git pr show -t 1298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1298.diff">https://git.openjdk.org/jdk11u-dev/pull/1298.diff</a>

</details>
