### PR TITLE
8218413: make reconfigure ignores configure-time AUTOCONF environment variable

### DIFF
--- a/make/Init.gmk
+++ b/make/Init.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -272,7 +272,7 @@ else # HAS_SPEC=true
         else
 	  $(ECHO) "Re-running configure using default settings"
         endif
-	( cd $(OUTPUTDIR) && PATH="$(ORIGINAL_PATH)" \
+	( cd $(OUTPUTDIR) && PATH="$(ORIGINAL_PATH)" AUTOCONF="$(AUTOCONF)" \
 	    CUSTOM_ROOT="$(CUSTOM_ROOT)" \
 	    CUSTOM_CONFIG_DIR="$(CUSTOM_CONFIG_DIR)" \
 	    $(BASH) $(TOPDIR)/configure $(CONFIGURE_COMMAND_LINE) )

--- a/make/autoconf/basics.m4
+++ b/make/autoconf/basics.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -402,6 +402,8 @@ AC_DEFUN_ONCE([BASIC_INIT],
 [
   # Save the original command line. This is passed to us by the wrapper configure script.
   AC_SUBST(CONFIGURE_COMMAND_LINE)
+  # AUTOCONF might be set in the environment by the user. Preserve for "make reconfigure".
+  AC_SUBST(AUTOCONF)
   # Save the path variable before it gets changed
   ORIGINAL_PATH="$PATH"
   AC_SUBST(ORIGINAL_PATH)

--- a/make/autoconf/spec.gmk.in
+++ b/make/autoconf/spec.gmk.in
@@ -36,6 +36,9 @@ CONFIGURE_COMMAND_LINE:=@CONFIGURE_COMMAND_LINE@
 # A self-referential reference to this file.
 SPEC:=@SPEC@
 
+# Path to autoconf if overriden by the user, to be used by "make reconfigure"
+AUTOCONF := @AUTOCONF@
+
 # SPACE and COMMA are defined in MakeBase.gmk, but they are also used in
 # some definitions here, and are needed if MakeBase.gmk is not included before
 # this file.


### PR DESCRIPTION
Backport applies cleanly and is a prerequisite of https://github.com/openjdk/jdk11u-dev/pull/1277

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8218413](https://bugs.openjdk.org/browse/JDK-8218413): make reconfigure ignores configure-time AUTOCONF environment variable


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1300/head:pull/1300` \
`$ git checkout pull/1300`

Update a local copy of the PR: \
`$ git checkout pull/1300` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1300`

View PR using the GUI difftool: \
`$ git pr show -t 1300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1300.diff">https://git.openjdk.org/jdk11u-dev/pull/1300.diff</a>

</details>
