### PR TITLE
8291794: [11u] Corrections after backport of JDK-8212028

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -33,43 +33,6 @@ include FindTests.gmk
 .NOTPARALLEL:
 
 ################################################################################
-# Setup global test running parameters
-################################################################################
-
-# Each factor variable comes in 3 variants. The first one is reserved for users
-# to use on command line. The other two are for predifined configurations in JDL
-# and for machine specific configurations respectively.
-TEST_JOBS_FACTOR ?= 1
-TEST_JOBS_FACTOR_JDL ?= 1
-TEST_JOBS_FACTOR_MACHINE ?= 1
-
-ifeq ($(TEST_JOBS), 0)
-  CORES_DIVIDER := 2
-  ifeq ($(OPENJDK_TARGET_CPU_ARCH), sparc)
-    # For smaller SPARC machines we see reasonable scaling of throughput up to
-    # cpus/4 without affecting test reliability. On the bigger machines, cpus/4
-    # causes intermittent timeouts.
-    ifeq ($(shell $(EXPR) $(NUM_CORES) \> 16), 1)
-      CORES_DIVIDER := 5
-    else
-      CORES_DIVIDER := 4
-    endif
-  endif
-  MEMORY_DIVIDER := 2048
-  TEST_JOBS := $(shell $(AWK) \
-    'BEGIN { \
-      c = $(NUM_CORES) / $(CORES_DIVIDER); \
-      m = $(MEMORY_SIZE) / $(MEMORY_DIVIDER); \
-      if (c > m) c = m; \
-      c = c * $(TEST_JOBS_FACTOR); \
-      c = c * $(TEST_JOBS_FACTOR_JDL); \
-      c = c * $(TEST_JOBS_FACTOR_MACHINE); \
-      if (c < 1) c = 1; \
-      printf "%.0f", c; \
-    }')
-endif
-
-################################################################################
 # Parse global control variables
 ################################################################################
 
@@ -241,11 +204,23 @@ TEST_JOBS_FACTOR_JDL ?= 1
 TEST_JOBS_FACTOR_MACHINE ?= 1
 
 ifeq ($(TEST_JOBS), 0)
-  # Concurrency based on min(cores / 2, 12) * TEST_JOBS_FACTOR
+  CORES_DIVIDER := 2
+  ifeq ($(OPENJDK_TARGET_CPU_ARCH), sparc)
+    # For smaller SPARC machines we see reasonable scaling of throughput up to
+    # cpus/4 without affecting test reliability. On the bigger machines, cpus/4
+    # causes intermittent timeouts.
+    ifeq ($(shell $(EXPR) $(NUM_CORES) \> 16), 1)
+      CORES_DIVIDER := 5
+    else
+      CORES_DIVIDER := 4
+    endif
+  endif
+  MEMORY_DIVIDER := 2048
   TEST_JOBS := $(shell $(AWK) \
     'BEGIN { \
-      c = $(NUM_CORES) / 2; \
-      if (c > 12) c = 12; \
+      c = $(NUM_CORES) / $(CORES_DIVIDER); \
+      m = $(MEMORY_SIZE) / $(MEMORY_DIVIDER); \
+      if (c > m) c = m; \
       c = c * $(TEST_JOBS_FACTOR); \
       c = c * $(TEST_JOBS_FACTOR_JDL); \
       c = c * $(TEST_JOBS_FACTOR_MACHINE); \

--- a/test/hotspot/jtreg/compiler/jsr292/ContinuousCallSiteTargetChange.java
+++ b/test/hotspot/jtreg/compiler/jsr292/ContinuousCallSiteTargetChange.java
@@ -28,7 +28,7 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run driver/timeout=300 compiler.jsr292.ContinuousCallSiteTargetChange
+ * @run driver compiler.jsr292.ContinuousCallSiteTargetChange
  */
 
 package compiler.jsr292;


### PR DESCRIPTION
This change allows me to merge https://github.com/openjdk/jdk/commit/753c58b7f556fedd7828da487a34b8b228785ff9 cleanly

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291794](https://bugs.openjdk.org/browse/JDK-8291794): [11u] Corrections after backport of JDK-8212028


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1302/head:pull/1302` \
`$ git checkout pull/1302`

Update a local copy of the PR: \
`$ git checkout pull/1302` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1302`

View PR using the GUI difftool: \
`$ git pr show -t 1302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1302.diff">https://git.openjdk.org/jdk11u-dev/pull/1302.diff</a>

</details>
