### PR TITLE
8214003: Limit default test jobs based on memory size

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -252,9 +252,12 @@ ifeq ($(TEST_JOBS), 0)
       CORES_DIVIDER := 4
     endif
   endif
+  MEMORY_DIVIDER := 2048
   TEST_JOBS := $(shell $(AWK) \
     'BEGIN { \
       c = $(NUM_CORES) / $(CORES_DIVIDER); \
+      m = $(MEMORY_SIZE) / $(MEMORY_DIVIDER); \
+      if (c > m) c = m; \
       c = c * $(TEST_JOBS_FACTOR); \
       c = c * $(TEST_JOBS_FACTOR_JDL); \
       c = c * $(TEST_JOBS_FACTOR_MACHINE); \


### PR DESCRIPTION
This patch was partially backported in https://github.com/openjdk/jdk11u-dev/commit/abcacaefe01e427c7a643b578479e3aedd0b6949. This PR adds the remaining patch to `make/RunTests.gmk`.

This backport is a prerequisite to backporting https://github.com/openjdk/jdk/commit/753c58b7f556fedd7828da487a34b8b228785ff9

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #1302 must be integrated first

### Issue
 * [JDK-8214003](https://bugs.openjdk.org/browse/JDK-8214003): Limit default test jobs based on memory size


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1307/head:pull/1307` \
`$ git checkout pull/1307`

Update a local copy of the PR: \
`$ git checkout pull/1307` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1307`

View PR using the GUI difftool: \
`$ git pr show -t 1307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1307.diff">https://git.openjdk.org/jdk11u-dev/pull/1307.diff</a>

</details>
