### PR TITLE
Backport 6217349ee65fa4f564b0679774877716594981d3

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -517,9 +517,9 @@ $(foreach m, $(ALL_MODULES), \
   ) \
 )
 
-ifeq ($(ENABLE_FULL_DOCS), true)
+ifneq ($(PANDOC), )
   # For all markdown files in $module/share/specs directories, convert them to
-  # html.
+  # html, if we have pandoc (otherwise we'll just skip this).
 
   GLOBAL_SPECS_DEFAULT_CSS_FILE := $(DOCS_OUTPUTDIR)/resources/jdk-default.css
 


### PR DESCRIPTION
backport applies cleanly - prerequisite to https://github.com/openjdk/jdk/commit/9f1d035d8d862fc0e827c1df7e34f4b4c062c6a1 and https://github.com/openjdk/jdk/commit/4f45b5f9739e5a5e7d1c4f80da9c42e0d77dd0bf 