### PR TITLE
8215635: Pandoc check in Docs.gmk does not work on Windows

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -517,7 +517,7 @@ $(foreach m, $(ALL_MODULES), \
   ) \
 )
 
-ifneq ($(PANDOC), )
+ifeq ($(ENABLE_PANDOC), true)
   # For all markdown files in $module/share/specs directories, convert them to
   # html, if we have pandoc (otherwise we'll just skip this).
 

--- a/make/autoconf/basics.m4
+++ b/make/autoconf/basics.m4
@@ -611,7 +611,14 @@ AC_DEFUN_ONCE([BASIC_SETUP_FUNDAMENTAL_TOOLS],
   BASIC_PATH_PROGS(DF, df)
   BASIC_PATH_PROGS(CPIO, [cpio bsdcpio])
   BASIC_PATH_PROGS(NICE, nice)
+
   BASIC_PATH_PROGS(PANDOC, pandoc)
+  if test -n "$PANDOC"; then
+    ENABLE_PANDOC="true"
+  else
+    ENABLE_PANDOC="false"
+  fi
+  AC_SUBST(ENABLE_PANDOC)
 ])
 
 ###############################################################################

--- a/make/autoconf/spec.gmk.in
+++ b/make/autoconf/spec.gmk.in
@@ -781,6 +781,7 @@ MSVCR_DLL:=@MSVCR_DLL@
 MSVCP_DLL:=@MSVCP_DLL@
 UCRT_DLL_DIR:=@UCRT_DLL_DIR@
 STLPORT_LIB:=@STLPORT_LIB@
+ENABLE_PANDOC:=@ENABLE_PANDOC@
 
 ####################################################
 #

--- a/make/launcher/LauncherCommon.gmk
+++ b/make/launcher/LauncherCommon.gmk
@@ -234,7 +234,7 @@ ifeq ($(OPENJDK_TARGET_OS_TYPE), unix)
 
   ifneq ($(MAN_FILES_MD), )
     # If we got markdown files, ignore the troff files
-    ifeq ($(PANDOC), )
+    ifeq ($(ENABLE_PANDOC), false)
       $(info Warning: pandoc not found. Not generating man pages)
     else
       # Create dynamic man pages from markdown using pandoc. We need


### PR DESCRIPTION
patch applies cleanly - prerequisite to https://github.com/openjdk/jdk/commit/4f45b5f9739e5a5e7d1c4f80da9c42e0d77dd0bf

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #1312 must be integrated first

### Issue
 * [JDK-8215635](https://bugs.openjdk.org/browse/JDK-8215635): Pandoc check in Docs.gmk does not work on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1313/head:pull/1313` \
`$ git checkout pull/1313`

Update a local copy of the PR: \
`$ git checkout pull/1313` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1313`

View PR using the GUI difftool: \
`$ git pr show -t 1313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1313.diff">https://git.openjdk.org/jdk11u-dev/pull/1313.diff</a>

</details>
