### PR TITLE
8215131: Pandoc 2.3/build documentation fixes

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -1,19 +1,24 @@
 <!DOCTYPE html>
-<html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
 <head>
-  <meta charset="utf-8">
-  <meta name="generator" content="pandoc">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title>Building the JDK</title>
-  <style type="text/css">code{white-space: pre;}</style>
-  <link rel="stylesheet" href="../make/data/docs-resources/resources/jdk-default.css">
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
+  </style>
+  <link rel="stylesheet" href="../make/data/docs-resources/resources/jdk-default.css" />
   <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
   <![endif]-->
   <style type="text/css">pre, code, tt { color: #1d6ae5; }</style>
 </head>
 <body>
-<header>
+<header id="title-block-header">
 <h1 class="title">Building the JDK</h1>
 </header>
 <nav id="TOC">
@@ -644,11 +649,13 @@ x86_64-linux-gnu-to-ppc64le-linux-gnu</code></pre>
 <p>Note that alsa is needed even if you only want to build a headless JDK.</p>
 <ul>
 <li><p>Go to <a href="https://www.debian.org/distrib/packages">Debian Package Search</a> and search for the <code>libasound2</code> and <code>libasound2-dev</code> packages for your <em>target</em> system. Download them to /tmp.</p></li>
-<li><p>Install the libraries into the cross-compilation toolchain. For instance:</p>
+<li>Install the libraries into the cross-compilation toolchain. For instance:</li>
+</ul>
 <pre><code>cd /tools/gcc-linaro-arm-linux-gnueabihf-raspbian-2012.09-20120921_linux/arm-linux-gnueabihf/libc
 dpkg-deb -x /tmp/libasound2_1.0.25-4_armhf.deb .
-dpkg-deb -x /tmp/libasound2-dev_1.0.25-4_armhf.deb .</code></pre></li>
-<li><p>If alsa is not properly detected by <code>configure</code>, you can point it out by <code>--with-alsa</code>.</p></li>
+dpkg-deb -x /tmp/libasound2-dev_1.0.25-4_armhf.deb .</code></pre>
+<ul>
+<li>If alsa is not properly detected by <code>configure</code>, you can point it out by <code>--with-alsa</code>.</li>
 </ul>
 <h4 id="x11-1">X11</h4>
 <p>You will need X11 libraries suitable for your <em>target</em> system. For most cases, using Debian's pre-built libraries work fine.</p>
@@ -693,9 +700,12 @@ cp: cannot stat `arm-linux-gnueabihf/libXt.so&#39;: No such file or directory</c
 <p>Fortunately, you can create sysroots for foreign architectures with tools provided by your OS. On Debian/Ubuntu systems, one could use <code>qemu-deboostrap</code> to create the <em>target</em> system chroot, which would have the native libraries and headers specific to that <em>target</em> system. After that, we can use the cross-compiler on the <em>build</em> system, pointing into chroot to get the build dependencies right. This allows building for foreign architectures with native compilation speed.</p>
 <p>For example, cross-compiling to AArch64 from x86_64 could be done like this:</p>
 <ul>
-<li><p>Install cross-compiler on the <em>build</em> system:</p>
-<pre><code>apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu</code></pre></li>
-<li><p>Create chroot on the <em>build</em> system, configuring it for <em>target</em> system:</p>
+<li>Install cross-compiler on the <em>build</em> system:</li>
+</ul>
+<pre><code>apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu</code></pre>
+<ul>
+<li>Create chroot on the <em>build</em> system, configuring it for <em>target</em> system:</li>
+</ul>
 <pre><code>sudo qemu-debootstrap \
   --arch=arm64 \
   --verbose \
@@ -703,16 +713,19 @@ cp: cannot stat `arm-linux-gnueabihf/libXt.so&#39;: No such file or directory</c
   --resolve-deps \
   buster \
   ~/sysroot-arm64 \
-  http://httpredir.debian.org/debian/</code></pre></li>
-<li><p>Make sure the symlinks inside the newly created chroot point to proper locations:</p>
-<pre><code>sudo chroot ~/sysroot-arm64 symlinks -cr .</code></pre></li>
-<li><p>Configure and build with newly created chroot as sysroot/toolchain-path:</p>
+  http://httpredir.debian.org/debian/</code></pre>
+<ul>
+<li>Make sure the symlinks inside the newly created chroot point to proper locations:</li>
+</ul>
+<pre><code>sudo chroot ~/sysroot-arm64 symlinks -cr .</code></pre>
+<ul>
+<li>Configure and build with newly created chroot as sysroot/toolchain-path:</li>
+</ul>
 <pre><code>sh ./configure \
   --openjdk-target=aarch64-linux-gnu \
   --with-sysroot=~/sysroot-arm64
 make images
-ls build/linux-aarch64-normal-server-release/</code></pre></li>
-</ul>
+ls build/linux-aarch64-normal-server-release/</code></pre>
 <p>The build does not create new files in that chroot, so it can be reused for multiple builds without additional cleanup.</p>
 <p>The build system should automatically detect the toolchain paths and dependencies, but sometimes it might require a little nudge with:</p>
 <ul>

--- a/doc/building.md
+++ b/doc/building.md
@@ -928,7 +928,7 @@ targets are given, a native toolchain for the current platform will be
 created. Currently, at least the following targets are known to work:
 
  Supported devkit targets
- ------------------------
+ -------------------------
  x86_64-linux-gnu
  aarch64-linux-gnu
  arm-linux-gnueabihf

--- a/make/common/ProcessMarkdown.gmk
+++ b/make/common/ProcessMarkdown.gmk
@@ -80,7 +80,7 @@ define ProcessMarkdown
 	$$(call LogInfo, Converting $2 to $$($1_FORMAT))
 	$$(call MakeDir, $$(SUPPORT_OUTPUTDIR)/markdown $$(dir $$($1_$2_PANDOC_OUTPUT)))
 	$$(call ExecuteWithLog, $$(SUPPORT_OUTPUTDIR)/markdown/$$($1_$2_MARKER), \
-	    $$(PANDOC) $$($1_OPTIONS) -f markdown -t $$($1_FORMAT) --standalone \
+	    $$(PANDOC) $$($1_OPTIONS) -f markdown-smart -t $$($1_FORMAT) --standalone \
 	    $$($1_$2_CSS_OPTION) $$($1_$2_OPTIONS) '$$($1_$2_PANDOC_INPUT)' \
 	    -o '$$($1_$2_PANDOC_OUTPUT)')
         ifneq ($$(findstring $$(LOG_LEVEL), debug trace),)


### PR DESCRIPTION
changes apply cleanly except for the cross-compile markdown table which was updated in https://github.com/openjdk/jdk11u-dev/commit/90ac8aea0372a6f26592015ca42b98b109ac89f7

Prerequisite to backporting https://github.com/openjdk/jdk/commit/4f45b5f9739e5a5e7d1c4f80da9c42e0d77dd0bf

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #1313 must be integrated first

### Issue
 * [JDK-8215131](https://bugs.openjdk.org/browse/JDK-8215131): Pandoc 2.3/build documentation fixes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1314/head:pull/1314` \
`$ git checkout pull/1314`

Update a local copy of the PR: \
`$ git checkout pull/1314` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1314`

View PR using the GUI difftool: \
`$ git pr show -t 1314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1314.diff">https://git.openjdk.org/jdk11u-dev/pull/1314.diff</a>

</details>
