### PR TITLE
8214078: (fs) SecureDirectoryStream not supported on arm32

### DIFF
--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -152,10 +152,9 @@ static futimesat_func* my_futimesat_func = NULL;
 static fdopendir_func* my_fdopendir_func = NULL;
 
 /**
- * fstatat missing from glibc on Linux. Temporary workaround
- * for x86/x64.
+ * fstatat missing from glibc on Linux.
  */
-#if defined(__linux__) && defined(__i386)
+#if defined(__linux__) && (defined(__i386) || defined(__arm__))
 #define FSTATAT64_SYSCALL_AVAILABLE
 static int fstatat64_wrapper(int dfd, const char *path,
                              struct stat64 *statbuf, int flag)


### PR DESCRIPTION
Clean backport. Passes test on our arm32 machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8214078](https://bugs.openjdk.org/browse/JDK-8214078): (fs) SecureDirectoryStream not supported on arm32


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1322/head:pull/1322` \
`$ git checkout pull/1322`

Update a local copy of the PR: \
`$ git checkout pull/1322` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1322`

View PR using the GUI difftool: \
`$ git pr show -t 1322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1322.diff">https://git.openjdk.org/jdk11u-dev/pull/1322.diff</a>

</details>
