### PR TITLE
8289569: [test] java/lang/ProcessBuilder/Basic.java fails on Alpine/musl

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -31,6 +31,7 @@
  * @key intermittent
  * @summary Basic tests for Process and Environment Variable code
  * @modules java.base/java.lang:open
+ * @requires !vm.musl
  * @library /test/lib
  * @run main/othervm/timeout=300 Basic
  * @run main/othervm/timeout=300 -Djdk.lang.Process.launchMechanism=fork Basic
@@ -40,7 +41,7 @@
 /*
  * @test
  * @modules java.base/java.lang:open
- * @requires (os.family == "linux")
+ * @requires (os.family == "linux" & !vm.musl)
  * @library /test/lib
  * @run main/othervm/timeout=300 -Djdk.lang.Process.launchMechanism=posix_spawn Basic
  */


### PR DESCRIPTION
Not a clean backport since surrounding lines are different, but changes are simple enough. This change passes ProcessBuilder/Basic.java jtreg test on our Alpine systems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289569](https://bugs.openjdk.org/browse/JDK-8289569): [test] java/lang/ProcessBuilder/Basic.java fails on Alpine/musl


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1324/head:pull/1324` \
`$ git checkout pull/1324`

Update a local copy of the PR: \
`$ git checkout pull/1324` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1324`

View PR using the GUI difftool: \
`$ git pr show -t 1324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1324.diff">https://git.openjdk.org/jdk11u-dev/pull/1324.diff</a>

</details>
