### PR TITLE
8239265: JFR: Test cleanup of jdk.jfr.api.consumer package

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/TestFieldAccess.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestFieldAccess.java
@@ -45,6 +45,8 @@ import jdk.test.lib.jfr.Events;
 public class TestFieldAccess {
 
     private static class MyEvent extends Event {
+        byte byteField = 42;
+        char charField = 'X';
         String stringField = "Hello";
         int intField = 4711;
         long longField = 4712L;
@@ -72,6 +74,12 @@ public class TestFieldAccess {
     }
 
     private static void testGetField(RecordedEvent event, MyEvent myEvent) {
+        char charField = event.getValue("charField");
+        Asserts.assertEquals(charField, myEvent.charField);
+
+        byte byteField = event.getValue("byteField");
+        Asserts.assertEquals(byteField, myEvent.byteField);
+
         String stringField = event.getValue("stringField");
         Asserts.assertEquals(stringField, myEvent.stringField);
 
@@ -103,7 +111,6 @@ public class TestFieldAccess {
         String className = event.getValue("classField.name");
         Asserts.assertEquals(classField.getName(), className.replace("/", "."));
 
-
         try {
             event.getValue("doesnotexist");
         } catch (IllegalArgumentException iae) {
@@ -125,6 +132,8 @@ public class TestFieldAccess {
 
     private static void testHasField(RecordedEvent event) {
         System.out.println(event);
+        Asserts.assertTrue(event.hasField("charField"));
+        Asserts.assertTrue(event.hasField("byteField"));
         Asserts.assertTrue(event.hasField("stringField"));
         Asserts.assertTrue(event.hasField("intField"));
         Asserts.assertTrue(event.hasField("longField"));

--- a/test/jdk/jdk/jfr/api/consumer/TestGetStackTrace.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestGetStackTrace.java
@@ -31,7 +31,6 @@ import static jdk.test.lib.Asserts.assertNull;
 import static jdk.test.lib.Asserts.assertTrue;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
@@ -53,27 +52,26 @@ import jdk.test.lib.jfr.SimpleEvent;
 public class TestGetStackTrace {
 
     public static void main(String[] args) throws Throwable {
-        testStackTrace(r -> r.enable(SimpleEvent.class), TestGetStackTrace::assertNoStackTrace);
-        testStackTrace(r -> r.enable(SimpleEvent.class).withoutStackTrace(), TestGetStackTrace::assertStackTrace);
+        testWithoutStackTrace(recordEvent("stackTrace", "false"));
+        testWithStackTrace(recordEvent("stackTrace", "true"));
     }
 
-    private static void testStackTrace(Consumer<Recording> recordingConfigurer, Consumer<RecordedEvent> asserter) throws Throwable {
-        Recording r = new Recording();
-        recordingConfigurer.accept(r);
-        r.start();
-        SimpleEvent event = new SimpleEvent();
-        event.commit();
-        r.stop();
-        List<RecordedEvent> events = Events.fromRecording(r);
-        r.close();
-        Events.hasEvents(events);
+    private static RecordedEvent recordEvent(String key, String value) throws Throwable {
+        try (Recording r = new Recording()) {
+            r.enable(SimpleEvent.class).with(key, value);
+            r.start();
+            SimpleEvent event = new SimpleEvent();
+            event.commit();
+            r.stop();
+            return Events.fromRecording(r).get(0);
+        }
     }
 
-    private static void assertNoStackTrace(RecordedEvent re) {
+    private static void testWithoutStackTrace(RecordedEvent re) {
         assertNull(re.getStackTrace());
     }
 
-    private static void assertStackTrace(RecordedEvent re) {
+    private static void testWithStackTrace(RecordedEvent re) {
         assertNotNull(re.getStackTrace());
         RecordedStackTrace strace = re.getStackTrace();
         assertEquals(strace.isTruncated(), false);

--- a/test/jdk/jdk/jfr/api/consumer/TestHiddenMethod.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestHiddenMethod.java
@@ -56,42 +56,43 @@ import jdk.test.lib.jfr.Events;
 public final class TestHiddenMethod {
 
     public static void main(String[] args) throws Throwable {
-        Recording recording = new Recording();
-        recording.enable(MyEvent.class).withThreshold(Duration.ofMillis(0));
-        recording.start();
+        try (Recording recording = new Recording()) {
+            recording.enable(MyEvent.class).withThreshold(Duration.ofMillis(0));
+            recording.start();
 
-        // Commit event with hidden methods
-        ScriptEngineManager manager = new ScriptEngineManager();
-        ScriptEngine engine = manager.getEngineByName("nashorn");
-        engine.eval(
-                "function emit() {"
-                + "  print('About to emit event from Javascript');"
-                + "  var TestEvent = Java.type(\"jdk.jfr.api.consumer.TestHiddenMethod$MyEvent\");"
-                + "  var event = new TestEvent;"
-                + "  event.begin();"
-                + "  event.end();"
-                + "  event.commit();"
-                + "  print('Event emitted from Javascript!');"
-                + "}"
-                + "emit();");
+            // Commit event with hidden methods
+            ScriptEngineManager manager = new ScriptEngineManager();
+            ScriptEngine engine = manager.getEngineByName("nashorn");
+            engine.eval(
+                    "function emit() {"
+                    + "  print('About to emit event from Javascript');"
+                    + "  var TestEvent = Java.type(\"jdk.jfr.api.consumer.TestHiddenMethod$MyEvent\");"
+                    + "  var event = new TestEvent;"
+                    + "  event.begin();"
+                    + "  event.end();"
+                    + "  event.commit();"
+                    + "  print('Event emitted from Javascript!');"
+                    + "}"
+                    + "emit();");
 
-        // Commit event with visible method
-        MyEvent visible = new MyEvent();
-        visible.begin();
-        visible.end();
-        visible.commit();
-        recording.stop();
+            // Commit event with visible method
+            MyEvent visible = new MyEvent();
+            visible.begin();
+            visible.end();
+            visible.commit();
+            recording.stop();
 
-        List<RecordedEvent> events = Events.fromRecording(recording);
-        assertEquals(2, events.size(), "Expected two events");
-        RecordedEvent hiddenEvent = events.get(0);
-        RecordedEvent visibleEvent = events.get(1);
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            assertEquals(2, events.size(), "Expected two events");
+            RecordedEvent hiddenEvent = events.get(0);
+            RecordedEvent visibleEvent = events.get(1);
 
-        System.out.println("hiddenEvent:" + hiddenEvent);
-        System.out.println("visibleEvent:" + visibleEvent);
+            System.out.println("hiddenEvent:" + hiddenEvent);
+            System.out.println("visibleEvent:" + visibleEvent);
 
-        assertTrue(hasHiddenStackFrame(hiddenEvent), "No hidden frame in hidden event: " + hiddenEvent);
-        assertFalse(hasHiddenStackFrame(visibleEvent), "Hidden frame in visible event: " + visibleEvent);
+            assertTrue(hasHiddenStackFrame(hiddenEvent), "No hidden frame in hidden event: " + hiddenEvent);
+            assertFalse(hasHiddenStackFrame(visibleEvent), "Hidden frame in visible event: " + visibleEvent);
+        }
     }
 
     private static boolean hasHiddenStackFrame(RecordedEvent event) throws Throwable {
@@ -108,5 +109,4 @@ public final class TestHiddenMethod {
 
     public static class MyEvent extends Event {
     }
-
 }

--- a/test/jdk/jdk/jfr/api/consumer/TestMethodGetModifiers.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestMethodGetModifiers.java
@@ -41,6 +41,7 @@ import jdk.test.lib.jfr.SimpleEvent;
 
 /**
  * @test
+ * @summary Verifies that a recorded method has the correct modifier
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
@@ -49,33 +50,32 @@ import jdk.test.lib.jfr.SimpleEvent;
 public final class TestMethodGetModifiers {
 
     public static void main(String[] args) throws Throwable {
-        Recording recording = new Recording();
-        recording.start();
+        try (Recording recording = new Recording()) {
+            recording.start();
 
-        SimpleEvent ev = new SimpleEvent();
-        ev.commit();
-        recording.stop();
+            SimpleEvent ev = new SimpleEvent();
+            ev.commit();
+            recording.stop();
 
-        List<RecordedEvent> recordedEvents = Events.fromRecording(recording);
-        Events.hasEvents(recordedEvents);
-        RecordedEvent recordedEvent = recordedEvents.get(0);
+            List<RecordedEvent> recordedEvents = Events.fromRecording(recording);
+            Events.hasEvents(recordedEvents);
+            RecordedEvent recordedEvent = recordedEvents.get(0);
 
-        System.out.println("recorded event:" + recordedEvent);
+            System.out.println(recordedEvent);
 
-        RecordedStackTrace stacktrace = recordedEvent.getStackTrace();
-        List<RecordedFrame> frames = stacktrace.getFrames();
-        for (RecordedFrame frame : frames) {
-            RecordedMethod method = frame.getMethod();
-            if (method.getName().equals("main")) {
-                System.out.println("'main' method: " + method);
-                int modifiers = TestMethodGetModifiers.class.getDeclaredMethod("main", (Class<?>)String[].class).getModifiers();
-                System.out.println("modifiers: " + modifiers);
-                Asserts.assertEquals(method.getModifiers(), modifiers, "Incorrect method modifier reported");
-                RecordedClass type = method.getType();
-                assertNotNull(type, "Recorded class can not be null");
+            RecordedStackTrace stacktrace = recordedEvent.getStackTrace();
+            List<RecordedFrame> frames = stacktrace.getFrames();
+            for (RecordedFrame frame : frames) {
+                RecordedMethod method = frame.getMethod();
+                if (method.getName().equals("main")) {
+                    System.out.println("'main' method: " + method);
+                    int modifiers = TestMethodGetModifiers.class.getDeclaredMethod("main", (Class<?>)String[].class).getModifiers();
+                    System.out.println("modifiers: " + modifiers);
+                    Asserts.assertEquals(method.getModifiers(), modifiers, "Incorrect method modifier reported");
+                    RecordedClass type = method.getType();
+                    assertNotNull(type, "Recorded class can not be null");
+                }
             }
-
         }
     }
-
 }

--- a/test/jdk/jdk/jfr/api/consumer/TestReadTwice.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestReadTwice.java
@@ -37,7 +37,6 @@ import jdk.jfr.consumer.RecordingFile;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.Utils;
 
-
 /**
  * @test
  * @summary Reads the recorded file two times and verifies that both reads are the same
@@ -52,34 +51,34 @@ public class TestReadTwice {
     }
 
     public static void main(String[] args) throws Throwable {
-        Recording r = new Recording();
-        r.enable(MyEvent.class).withoutStackTrace();
-        r.start();
+        try (Recording r = new Recording()) {
+            r.enable(MyEvent.class).withoutStackTrace();
+            r.start();
 
-        // Commit a single event to the recording
-        MyEvent event = new MyEvent();
-        event.commit();
+            // Commit a single event to the recording
+            MyEvent event = new MyEvent();
+            event.commit();
 
-        r.stop();
+            r.stop();
 
-        // Dump the recording to a file
-        Path path = Utils.createTempFile("read-twice", ".jfr");
-        System.out.println("Dumping to " + path);
-        r.dump(path);
-        r.close();
+            // Dump the recording to a file
+            Path path = Utils.createTempFile("read-twice", ".jfr");
+            System.out.println("Dumping to " + path);
+            r.dump(path);
 
-        // Read all events from the file in one go
-        List<RecordedEvent> events = RecordingFile.readAllEvents(path);
+            // Read all events from the file in one go
+            List<RecordedEvent> events = RecordingFile.readAllEvents(path);
 
-        // Read again the same events one by one
-        RecordingFile rfile = new RecordingFile(path);
-        List<RecordedEvent> events2 = new LinkedList<>();
-        while (rfile.hasMoreEvents()) {
-            events2.add(rfile.readEvent());
+            // Read again the same events one by one
+            try (RecordingFile rfile = new RecordingFile(path)) {
+                List<RecordedEvent> events2 = new LinkedList<>();
+                while (rfile.hasMoreEvents()) {
+                    events2.add(rfile.readEvent());
+                }
+
+                // Compare sizes
+                Asserts.assertEquals(events.size(), events2.size());
+            }
         }
-
-        // Compare sizes
-        Asserts.assertEquals(events.size(), events2.size());
-        rfile.close();
     }
 }

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedEvent.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedEvent.java
@@ -51,7 +51,6 @@ public class TestRecordedEvent {
     }
 
     static class TestEvent extends Event {
-
         @Description("MyField")
         Class<?> clzField = String.class;
         int intField;
@@ -60,51 +59,50 @@ public class TestRecordedEvent {
     }
 
     public static void main(String[] args) throws Throwable {
-        Recording r = new Recording();
-        r.start();
-        TestEvent t = new TestEvent();
-        t.commit();
-        r.stop();
-        List<RecordedEvent> events = Events.fromRecording(r);
-        Events.hasEvents(events);
+        try (Recording r = new Recording()) {
+            r.start();
+            TestEvent t = new TestEvent();
+            t.commit();
+            r.stop();
 
-        Asserts.assertEquals(events.size(), 1);
+            List<RecordedEvent> events = Events.fromRecording(r);
+            Events.hasEvents(events);
+            Asserts.assertEquals(events.size(), 1);
+            RecordedEvent event = events.get(0);
 
-        RecordedEvent event = events.get(0);
+            List<ValueDescriptor> descriptors = event.getFields();
 
-        List<ValueDescriptor> descriptors = event.getFields();
+            System.out.println("Descriptors");
+            for (ValueDescriptor descriptor : descriptors) {
+                System.out.println(descriptor.getName());
+                System.out.println(descriptor.getTypeName());
+            }
+            System.out.println("Descriptors end");
 
-        System.out.println("Descriptors");
-        for (ValueDescriptor descriptor : descriptors) {
-            System.out.println(descriptor.getName());
-            System.out.println(descriptor.getTypeName());
+            Object recordedClass = event.getValue("clzField");
+            Asserts.assertTrue(recordedClass instanceof RecordedClass, "Expected Recorded Class got " + recordedClass);
+
+            Object recordedInt = event.getValue("intField");
+            Asserts.assertTrue(recordedInt instanceof Integer);
+
+            Object recordedString = event.getValue("stringField");
+            System.out.println("recordedString class: " + recordedString.getClass());
+            Asserts.assertTrue(recordedString instanceof String);
+
+            Object myClass = event.getValue("myClass");
+            Asserts.assertTrue(myClass instanceof RecordedClass, "Expected Recorded Class got " + recordedClass);
+
+            RecordedClass myRecClass = (RecordedClass) myClass;
+            Asserts.assertEquals(MyClass.class.getName(), myRecClass.getName(), "Got " + myRecClass.getName());
+
+            Object recordedClassLoader = myRecClass.getValue("classLoader");
+            Asserts.assertTrue(recordedClassLoader instanceof RecordedClassLoader, "Expected Recorded ClassLoader got " + recordedClassLoader);
+
+            RecordedClassLoader myRecClassLoader = (RecordedClassLoader) recordedClassLoader;
+            ClassLoader cl = MyClass.class.getClassLoader();
+            Asserts.assertEquals(cl.getClass().getName(), myRecClassLoader.getType().getName(), "Expected Recorded ClassLoader type to equal loader type");
+
+            Asserts.assertNotNull(myRecClass.getModifiers());
         }
-        System.out.println("Descriptors end");
-
-        Object recordedClass = event.getValue("clzField");
-        Asserts.assertTrue(recordedClass instanceof RecordedClass, "Expected Recorded Class got " + recordedClass);
-
-        Object recordedInt = event.getValue("intField");
-        Asserts.assertTrue(recordedInt instanceof Integer);
-
-        Object recordedString = event.getValue("stringField");
-        System.out.println("recordedString class: " + recordedString.getClass());
-        Asserts.assertTrue(recordedString instanceof String);
-
-        Object myClass = event.getValue("myClass");
-        Asserts.assertTrue(myClass instanceof RecordedClass, "Expected Recorded Class got " + recordedClass);
-
-        RecordedClass myRecClass = (RecordedClass) myClass;
-        Asserts.assertEquals(MyClass.class.getName(), myRecClass.getName(), "Got " + myRecClass.getName());
-
-        Object recordedClassLoader = myRecClass.getValue("classLoader");
-        Asserts.assertTrue(recordedClassLoader instanceof RecordedClassLoader, "Expected Recorded ClassLoader got " + recordedClassLoader);
-
-        RecordedClassLoader myRecClassLoader = (RecordedClassLoader)recordedClassLoader;
-        ClassLoader cl = MyClass.class.getClassLoader();
-        Asserts.assertEquals(cl.getClass().getName(), myRecClassLoader.getType().getName(), "Expected Recorded ClassLoader type to equal loader type");
-
-        Asserts.assertNotNull(myRecClass.getModifiers());
     }
-
 }

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedEventGetThread.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedEventGetThread.java
@@ -49,24 +49,24 @@ public class TestRecordedEventGetThread {
     public static void main(String[] args) throws Throwable {
         Thread currentThread = Thread.currentThread();
         currentThread.setName(MY_THREAD_NAME);
-        long expectedThreadId = currentThread.getId();
 
-        Recording r = new Recording();
-        r.start();
-        SimpleEvent t = new SimpleEvent();
-        t.commit();
-        r.stop();
-        List<RecordedEvent> events = Events.fromRecording(r);
-        r.close();
-        Events.hasEvents(events);
-        RecordedEvent event = events.get(0);
-        RecordedThread recordedThread = event.getThread();
+        try (Recording r = new Recording()) {
+            r.start();
+            SimpleEvent t = new SimpleEvent();
+            t.commit();
+            r.stop();
 
-        Asserts.assertNotNull(recordedThread);
-        Asserts.assertEquals(recordedThread.getJavaName(), MY_THREAD_NAME);
-        Asserts.assertEquals(recordedThread.getJavaThreadId(), expectedThreadId);
-        Asserts.assertNotNull(recordedThread.getOSThreadId());
-        Asserts.assertNotNull(recordedThread.getId());
-        Asserts.assertEquals(recordedThread.getOSName(), MY_THREAD_NAME);
+            List<RecordedEvent> events = Events.fromRecording(r);
+            Events.hasEvents(events);
+            RecordedEvent event = events.get(0);
+            RecordedThread recordedThread = event.getThread();
+            Asserts.assertNotNull(recordedThread);
+
+            Asserts.assertEquals(recordedThread.getJavaName(), MY_THREAD_NAME);
+            Asserts.assertEquals(recordedThread.getJavaThreadId(), currentThread.getId());
+            Asserts.assertNotNull(recordedThread.getOSThreadId());
+            Asserts.assertNotNull(recordedThread.getId());
+            Asserts.assertEquals(recordedThread.getOSName(), MY_THREAD_NAME);
+        }
     }
 }

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedEventGetThreadOther.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedEventGetThreadOther.java
@@ -47,25 +47,28 @@ import jdk.test.lib.Utils;
 public class TestRecordedEventGetThreadOther {
 
     private static final String MY_THREAD_NAME = "MY_THREAD_NAME";
-    private static long expectedThreadId;
-    private static Path dumpFilePath;
 
     static class TestEvent extends Event {
     }
 
     static class PostingThread extends Thread {
-
-        PostingThread() {
-            setName(MY_THREAD_NAME);
-            expectedThreadId = getId();
+        private final Path dumpFilePath;
+        PostingThread(Path dumpFilePath) {
+            this.dumpFilePath = dumpFilePath;
         }
 
         @Override
         public void run() {
             try {
                 System.out.println("Starting thread...");
-                dumpFilePath = postEventAndDumpToFile();
-                System.out.println("events dumped to the file " + dumpFilePath);
+                try (Recording r = new Recording()) {
+                    r.start();
+                    TestEvent t = new TestEvent();
+                    t.commit();
+                    r.stop();
+                    r.dump(dumpFilePath);
+                    System.out.println("events dumped to the file " + dumpFilePath);
+                }
             } catch (Throwable t) {
                 t.printStackTrace();
                 Asserts.fail();
@@ -73,13 +76,13 @@ public class TestRecordedEventGetThreadOther {
         }
     }
 
-    public static void main(String[] args) throws Throwable {
-        Thread.currentThread().setName("MyMainThread");
+    public static void main(String[] args) throws Exception  {
+        Path dumpFilePath = Utils.createTempFile("event-thread", ".jfr");
 
-        PostingThread thread = new PostingThread();
+        PostingThread thread = new PostingThread(dumpFilePath);
+        thread.setName(MY_THREAD_NAME);
         thread.start();
         thread.join();
-        System.out.println("testing dump in file " + dumpFilePath);
 
         List<RecordedEvent> events = RecordingFile.readAllEvents(dumpFilePath);
         Asserts.assertEquals(events.size(), 1);
@@ -89,21 +92,8 @@ public class TestRecordedEventGetThreadOther {
 
         Asserts.assertNotNull(recordedThread);
         Asserts.assertEquals(recordedThread.getJavaName(), MY_THREAD_NAME);
-        Asserts.assertEquals(recordedThread.getJavaThreadId(), expectedThreadId);
+        Asserts.assertEquals(recordedThread.getJavaThreadId(), thread.getId());
         Asserts.assertNotNull(recordedThread.getId());
         Asserts.assertEquals(recordedThread.getOSName(), MY_THREAD_NAME);
-    }
-
-    private static Path postEventAndDumpToFile() throws Throwable {
-        Recording r = new Recording();
-        r.start();
-        TestEvent t = new TestEvent();
-        t.commit();
-        r.stop();
-        Path path = Utils.createTempFile("event-thread", ".jfr");
-        System.out.println("Created path: " + path);
-        r.dump(path);
-        r.close();
-        return path;
     }
 }

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedFrame.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedFrame.java
@@ -26,6 +26,7 @@ package jdk.jfr.api.consumer;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
@@ -49,74 +50,59 @@ import jdk.test.lib.jfr.SimpleEvent;
 public final class TestRecordedFrame {
 
     public static void main(String[] args) throws IOException {
-        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-        doTest(getLineNumber("main", stackTrace) + 1);
+        System.out.println(); // Makes BCI for method larger than 0
+        test(); // Records the line number and BCI for the main method/frame
+    }
+
+    static void test() throws IOException {
+        try (Recording recording = new Recording()) {
+            recording.start();
+
+            SimpleEvent ev = new SimpleEvent();
+            ev.commit();
+            recording.stop();
+
+            List<RecordedEvent> recordedEvents = Events.fromRecording(recording);
+            Events.hasEvents(recordedEvents);
+            RecordedEvent recordedEvent = recordedEvents.get(0);
+
+            RecordedStackTrace stacktrace = recordedEvent.getStackTrace();
+            List<RecordedFrame> frames = stacktrace.getFrames();
+            for (RecordedFrame frame : frames) {
+                // All frames are java frames
+                Asserts.assertTrue(frame.isJavaFrame());
+                // Verify the main() method frame
+                RecordedMethod method = frame.getMethod();
+                if (method.getName().equals("main")) {
+                    // Frame type
+                    String type = frame.getType();
+                    System.out.println("type: " + type);
+                    Set<String> types = Set.of("Interpreted", "JIT compiled", "Inlined");
+                    Asserts.assertTrue(types.contains(type));
+                    // Line number
+                    Asserts.assertEquals(getLineNumber("main"), frame.getLineNumber());
+                    // Interpreted
+                    boolean isInterpreted = "Interpreted".equals(type);
+                    boolean expectedInterpreted = "true".equals(System.getProperty("interpreted"));
+                    Asserts.assertEquals(isInterpreted, expectedInterpreted);
+                    // BCI
+                    int bci = frame.getBytecodeIndex();
+                    System.out.println("bci: " + bci);
+                    Asserts.assertGreaterThan(bci, 0);
+                }
+            }
+        }
     }
 
     /**
-     * Returns line number of the passed method for the passed stacktrace
+     * Returns line number of a method on the stack
      */
-    private static int getLineNumber(String methodName, StackTraceElement[] stackTrace) {
-        for (StackTraceElement ste : stackTrace) {
+    private static int getLineNumber(String methodName) {
+        for (StackTraceElement ste : Thread.currentThread().getStackTrace()) {
             if (methodName.equals(ste.getMethodName())) {
                 return ste.getLineNumber();
             }
         }
         throw new RuntimeException("Unexpected error: could not analyze stacktrace");
     }
-
-    public static void doTest(int lineNumber) throws IOException {
-
-        System.out.println("Enetring method");
-
-        Recording recording = new Recording();
-        recording.start();
-
-        SimpleEvent ev = new SimpleEvent();
-        commitEvent(ev);
-        recording.stop();
-
-        List<RecordedEvent> recordedEvents = Events.fromRecording(recording);
-        Events.hasEvents(recordedEvents);
-        RecordedEvent recordedEvent = recordedEvents.get(0);
-
-        RecordedStackTrace stacktrace = recordedEvent.getStackTrace();
-        List<RecordedFrame> frames = stacktrace.getFrames();
-        for (RecordedFrame frame : frames) {
-
-            // All frames are java frames
-            Asserts.assertTrue(frame.isJavaFrame());
-            // Verify the main() method frame
-            RecordedMethod method = frame.getMethod();
-            if (method.getName().equals("main")) {
-
-                // Frame type
-                String type = frame.getType();
-                System.out.println("type: " + type);
-                Asserts.assertTrue(
-                        type.equals("Interpreted")
-                        || type.equals("JIT compiled")
-                        || type.equals("Inlined"));
-
-                Asserts.assertEquals(lineNumber, frame.getLineNumber());
-
-                boolean isInterpreted = "Interpreted".equals(type);
-                boolean expectedInterpreted = "true".equals(System.getProperty("interpreted"));
-                Asserts.assertEquals(isInterpreted, expectedInterpreted);
-
-                int bci = frame.getBytecodeIndex();
-
-                System.out.println("bci: " + bci);
-                Asserts.assertTrue(bci > 0);
-            }
-
-        }
-
-    }
-
-    private static void commitEvent(SimpleEvent ev) {
-        System.out.println("commit");
-        ev.commit();
-    }
-
 }

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedFullStackTrace.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedFullStackTrace.java
@@ -79,16 +79,16 @@ public class TestRecordedFullStackTrace {
     private static void assertStackTraces(RecurseThread[] threads) throws Throwable {
         Path path = null;
         do {
-            Recording recording = new Recording();
-            recording.enable(EVENT_NAME).withPeriod(Duration.ofMillis(50));
-            recording.start();
-            Thread.sleep(500);
-            recording.stop();
-            // Dump the recording to a file
-            path = Utils.createTempFile("execution-stack-trace", ".jfr");
-            System.out.println("Dumping to " + path);
-            recording.dump(path);
-            recording.close();
+            try (Recording recording = new Recording()) {
+                recording.enable(EVENT_NAME).withPeriod(Duration.ofMillis(1));
+                recording.start();
+                Thread.sleep(50);
+                recording.stop();
+                // Dump the recording to a file
+                path = Utils.createTempFile("execution-stack-trace", ".jfr");
+                System.out.println("Dumping to " + path);
+                recording.dump(path);
+            }
         } while (!hasValidStackTraces(path, threads));
     }
 
@@ -103,8 +103,7 @@ public class TestRecordedFullStackTrace {
             for (int threadIndex = 0; threadIndex < threads.length; ++threadIndex) {
                 RecurseThread currThread = threads[threadIndex];
                 if (threadId == currThread.getId()) {
-                    System.out.println("ThreadName=" + currThread.getName() + ", depth=" + currThread.totalDepth);
-                    Asserts.assertEquals(threadName, currThread.getName(), "Wrong thread name");
+                    Asserts.assertEquals(threadName, currThread.getName(), "Wrong thread name, deptth=" + currThread.totalDepth);
                     if ("recurseEnd".equals(getTopMethodName(event))) {
                         isEventFound[threadIndex] = true;
                         checkEvent(event, currThread.totalDepth);
@@ -147,8 +146,7 @@ public class TestRecordedFullStackTrace {
             for (int i = 0; i < frames.size(); ++i) {
                 String name = frames.get(i).getMethod().getName();
                 String expectedName = expectedMethods.get(i);
-                System.out.printf("method[%d]=%s, expected=%s%n", i, name, expectedName);
-                Asserts.assertEquals(name, expectedName, "Wrong method name");
+                Asserts.assertEquals(name, expectedName, "Wrong method name at index " + i);
             }
 
             boolean isTruncated = stacktrace.isTruncated();

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedInstantEventTimestamp.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedInstantEventTimestamp.java
@@ -44,17 +44,16 @@ import jdk.test.lib.jfr.SimpleEvent;
 public class TestRecordedInstantEventTimestamp {
 
     public static void main(String[] args) throws Throwable {
-        Recording r = new Recording();
-        r.start();
-        SimpleEvent s = new SimpleEvent();
-        s.commit();
-        r.stop();
+        try (Recording r = new Recording()) {
+            r.start();
+            SimpleEvent s = new SimpleEvent();
+            s.commit();
+            r.stop();
 
-        List<RecordedEvent> events = Events.fromRecording(r);
-        Events.hasEvents(events);
-        RecordedEvent event = events.get(0);
-        Asserts.assertEquals(event.getStartTime(), event.getEndTime());
-
-        r.close();
+            List<RecordedEvent> events = Events.fromRecording(r);
+            Events.hasEvents(events);
+            RecordedEvent event = events.get(0);
+            Asserts.assertEquals(event.getStartTime(), event.getEndTime());
+        }
     }
 }

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedMethodDescriptor.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedMethodDescriptor.java
@@ -34,14 +34,15 @@ import java.util.List;
 import jdk.jfr.Event;
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
-import jdk.jfr.consumer.RecordedMethod;
 import jdk.jfr.consumer.RecordedFrame;
+import jdk.jfr.consumer.RecordedMethod;
 import jdk.jfr.consumer.RecordedStackTrace;
 import jdk.test.lib.jfr.Events;
 
 
 /**
  * @test
+ * @summary Verifies that the method descriptor is correct
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
@@ -49,49 +50,42 @@ import jdk.test.lib.jfr.Events;
  */
 public final class TestRecordedMethodDescriptor {
 
-    private static boolean isMainMethodDescriptorRecorded;
-    private static final String MAIN_METHOD_DESCRIPTOR = "([Ljava/lang/String;)V";
-    private static final String MAIN_METHOD_NAME = "main";
-
-    public static void main(String[] args) throws Throwable {
-        Recording recording = new Recording();
-        recording.enable(MyEvent.class).withStackTrace();
-        recording.start();
-
-        MyEvent event = new MyEvent();
-        event.begin();
-        event.end();
-        event.commit();
-        recording.stop();
-
-        List<RecordedEvent> recordedEvents = Events.fromRecording(recording);
-        assertEquals(1, recordedEvents.size(), "Expected one event");
-        RecordedEvent recordedEvent = recordedEvents.get(0);
-
-        RecordedStackTrace stacktrace = recordedEvent.getStackTrace();
-        List<RecordedFrame> frames = stacktrace.getFrames();
-        assertFalse(frames.isEmpty(), "Stacktrace frames was empty");
-        for (RecordedFrame frame : frames) {
-            analyzeRecordedMethodDescriptor(frame.getMethod());
-        }
-
-        assertTrue(isMainMethodDescriptorRecorded, "main() method descriptor has never been recorded");
-    }
-
-    private static void analyzeRecordedMethodDescriptor(RecordedMethod method) {
-
-        String descr = method.getDescriptor();
-        assertNotNull(descr, "Method descriptor is null");
-        String name = method.getName();
-        assertNotNull(name, "Method name is null");
-
-        if (name.equals(MAIN_METHOD_NAME) && descr.equals(MAIN_METHOD_DESCRIPTOR)) {
-            assertFalse(isMainMethodDescriptorRecorded, "main() method descriptor already recorded");
-            isMainMethodDescriptorRecorded = true;
-        }
-    }
-
     public static class MyEvent extends Event {
     }
 
+    private static final String MAIN_METHOD_DESCRIPTOR = "([Ljava/lang/String;)V";
+    private static final String MAIN_METHOD_NAME = "main";
+
+    public static void main(String[] args) throws Exception  {
+        try (Recording recording = new Recording()) {
+            recording.enable(MyEvent.class);
+            recording.start();
+
+            MyEvent event = new MyEvent();
+            event.commit();
+            recording.stop();
+
+            List<RecordedEvent> recordedEvents = Events.fromRecording(recording);
+            assertEquals(1, recordedEvents.size(), "Expected one event");
+            RecordedEvent recordedEvent = recordedEvents.get(0);
+
+            RecordedStackTrace stacktrace = recordedEvent.getStackTrace();
+            List<RecordedFrame> frames = stacktrace.getFrames();
+            assertFalse(frames.isEmpty(), "Stacktrace frames was empty");
+
+            boolean foundMainMethod = false;
+            for (RecordedFrame frame : frames) {
+                RecordedMethod method = frame.getMethod();
+                String descr = method.getDescriptor();
+                assertNotNull(descr, "Method descriptor is null");
+                String name = method.getName();
+                assertNotNull(name, "Method name is null");
+                if (name.equals(MAIN_METHOD_NAME) && descr.equals(MAIN_METHOD_DESCRIPTOR)) {
+                    assertFalse(foundMainMethod, "main() method descriptor already recorded");
+                    foundMainMethod = true;
+                }
+            }
+            assertTrue(foundMainMethod, "main() method descriptor has never been recorded");
+        }
+    }
 }

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordedObject.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordedObject.java
@@ -377,14 +377,15 @@ public class TestRecordedObject {
     }
 
     private static RecordedObject makeRecordedObject() throws IOException {
-        Recording r = new Recording();
-        r.start();
-        EventWithValues t = new EventWithValues();
-        t.commit();
-        r.stop();
-        List<RecordedEvent> events = Events.fromRecording(r);
-        Events.hasEvents(events);
-        return events.get(0);
+        try (Recording r = new Recording()) {
+            r.start();
+            EventWithValues t = new EventWithValues();
+            t.commit();
+            r.stop();
+            List<RecordedEvent> events = Events.fromRecording(r);
+            Events.hasEvents(events);
+            return events.get(0);
+        }
     }
 
     private static Set<String> createAll() {

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordingFile.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordingFile.java
@@ -74,24 +74,23 @@ public class TestRecordingFile {
     private final static long METADATA_OFFSET = 24;
 
     public static void main(String[] args) throws Throwable {
+        Path valid = Utils.createTempFile("three-event-recording", ".jfr");
 
         // create some recording data
-        Recording r = new Recording();
-        r.enable(TestEvent1.class).withoutStackTrace();
-        r.enable(TestEvent2.class).withoutStackTrace();
-        r.enable(TestEvent3.class).withoutStackTrace();
-        r.start();
-        TestEvent1 t1 = new TestEvent1();
-        t1.commit();
-        TestEvent2 t2 = new TestEvent2();
-        t2.commit();
-        TestEvent3 t3 = new TestEvent3();
-        t3.commit();
-        r.stop();
-        Path valid = Utils.createTempFile("three-event-recording", ".jfr");
-        r.dump(valid);
-        r.close();
-
+        try (Recording r = new Recording()) {
+            r.enable(TestEvent1.class).withoutStackTrace();
+            r.enable(TestEvent2.class).withoutStackTrace();
+            r.enable(TestEvent3.class).withoutStackTrace();
+            r.start();
+            TestEvent1 t1 = new TestEvent1();
+            t1.commit();
+            TestEvent2 t2 = new TestEvent2();
+            t2.commit();
+            TestEvent3 t3 = new TestEvent3();
+            t3.commit();
+            r.stop();
+            r.dump(valid);
+        }
         Path brokenWithZeros = createBrokenWIthZeros(valid);
         Path brokenMetadata = createBrokenMetadata(valid);
         // prepare event sets

--- a/test/jdk/jdk/jfr/api/consumer/TestRecordingFileReadEventEof.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestRecordingFileReadEventEof.java
@@ -44,19 +44,19 @@ import jdk.test.lib.jfr.SimpleEvent;
 public class TestRecordingFileReadEventEof {
 
     public static void main(String[] args) throws Throwable {
-        Recording r = new Recording();
-        r.start();
-        SimpleEvent t = new SimpleEvent();
-        t.commit();
-        r.stop();
-        RecordingFile file = Events.copyTo(r);
-        r.close();
-        file.readEvent();
-        try {
+        try (Recording r = new Recording()) {
+            r.start();
+            SimpleEvent t = new SimpleEvent();
+            t.commit();
+            r.stop();
+            RecordingFile file = Events.copyTo(r);
             file.readEvent();
-            Asserts.fail("Expected EOFException not thrown");
-        } catch (EOFException x) {
-            // OK, as expected
+            try {
+                file.readEvent();
+                Asserts.fail("Expected EOFException not thrown");
+            } catch (EOFException x) {
+                // OK, as expected
+            }
         }
     }
 }

--- a/test/jdk/jdk/jfr/api/consumer/TestSingleRecordedEvent.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestSingleRecordedEvent.java
@@ -49,21 +49,19 @@ public class TestSingleRecordedEvent {
     }
 
     public static void main(String[] args) throws Throwable {
-        Recording r = new Recording();
-        r.start();
-        // Commit a single event to the recording
-        MyEvent event = new MyEvent();
-        event.commit();
-        r.stop();
-        List<RecordedEvent> events = Events.fromRecording(r);
-        Events.hasEvents(events);
+        try (Recording r = new Recording()) {
+            r.start();
+            // Commit a single event to the recording
+            MyEvent event = new MyEvent();
+            event.commit();
+            r.stop();
+            List<RecordedEvent> events = Events.fromRecording(r);
+            Events.hasEvents(events);
 
-        // Should be 1 event only
-        Asserts.assertEquals(events.size(), 1);
-
-        RecordedEvent recordedEvent = events.get(0);
-
-        // Event description should be the same
-        Asserts.assertEquals(recordedEvent.getEventType().getDescription(), "MyDescription");
+            // Should be 1 event only
+            Asserts.assertEquals(events.size(), 1);
+            RecordedEvent recordedEvent = events.get(0);
+            Asserts.assertEquals(recordedEvent.getEventType().getDescription(), "MyDescription");
+        }
     }
 }

--- a/test/jdk/jdk/jfr/api/consumer/TestValueDescriptorRecorded.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestValueDescriptorRecorded.java
@@ -48,31 +48,30 @@ import jdk.test.lib.jfr.Events;
 public class TestValueDescriptorRecorded {
 
     private static class MyEvent extends Event {
-
         @Label("myLabel")
         @Description("myDescription")
         int myValue;
     }
 
     public static void main(String[] args) throws Throwable {
-        Recording r = new Recording();
-        r.enable(MyEvent.class).withoutStackTrace();
-        r.start();
-        MyEvent event = new MyEvent();
-        event.commit();
-        r.stop();
+        try (Recording r = new Recording()) {
+            r.enable(MyEvent.class).withoutStackTrace();
+            r.start();
+            MyEvent event = new MyEvent();
+            event.commit();
+            r.stop();
 
-        List<RecordedEvent> events = Events.fromRecording(r);
-        Events.hasEvents(events);
-        RecordedEvent recordedEvent = events.get(0);
-
-        for (ValueDescriptor desc : recordedEvent.getFields()) {
-            if ("myValue".equals(desc.getName())) {
-                Asserts.assertEquals(desc.getLabel(), "myLabel");
-                Asserts.assertEquals(desc.getDescription(), "myDescription");
-                Asserts.assertEquals(desc.getTypeName(), int.class.getName());
-                Asserts.assertFalse(desc.isArray());
-                Asserts.assertNull(desc.getContentType());
+            List<RecordedEvent> events = Events.fromRecording(r);
+            Events.hasEvents(events);
+            RecordedEvent recordedEvent = events.get(0);
+            for (ValueDescriptor desc : recordedEvent.getFields()) {
+                if ("myValue".equals(desc.getName())) {
+                    Asserts.assertEquals(desc.getLabel(), "myLabel");
+                    Asserts.assertEquals(desc.getDescription(), "myDescription");
+                    Asserts.assertEquals(desc.getTypeName(), int.class.getName());
+                    Asserts.assertFalse(desc.isArray());
+                    Asserts.assertNull(desc.getContentType());
+                }
             }
         }
     }


### PR DESCRIPTION
clean backport. Primary motivation for this backport is that this patch is a dependency of [8242188](https://bugs.openjdk.org/browse/JDK-8242188), which fixes a JFR test bug. Opening a separate PR for that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8239265](https://bugs.openjdk.org/browse/JDK-8239265): JFR: Test cleanup of jdk.jfr.api.consumer package


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1326/head:pull/1326` \
`$ git checkout pull/1326`

Update a local copy of the PR: \
`$ git checkout pull/1326` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1326`

View PR using the GUI difftool: \
`$ git pr show -t 1326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1326.diff">https://git.openjdk.org/jdk11u-dev/pull/1326.diff</a>

</details>
