### PR TITLE
8230708: Hotspot fails to build on linux-sparc with gcc-9

### DIFF
--- a/src/hotspot/cpu/sparc/nativeInst_sparc.hpp
+++ b/src/hotspot/cpu/sparc/nativeInst_sparc.hpp
@@ -313,7 +313,7 @@ inline NativeInstruction* nativeInstruction_at(address address) {
 // (used to manipulate inline caches, primitive & dll calls, etc.)
 inline NativeCall* nativeCall_at(address instr);
 inline NativeCall* nativeCall_overwriting_at(address instr,
-                                             address destination);
+                                             address destination = NULL);
 inline NativeCall* nativeCall_before(address return_address);
 class NativeCall: public NativeInstruction {
  public:
@@ -342,7 +342,7 @@ class NativeCall: public NativeInstruction {
 
   // Creation
   friend inline NativeCall* nativeCall_at(address instr);
-  friend NativeCall* nativeCall_overwriting_at(address instr, address destination = NULL) {
+  friend NativeCall* nativeCall_overwriting_at(address instr, address destination) {
     // insert a "blank" call:
     NativeCall* call = (NativeCall*)instr;
     call->set_long_at(0 * BytesPerInstWord, call_instruction(destination, instr));
@@ -411,7 +411,7 @@ class NativeCallReg: public NativeInstruction {
 //      == sethi %hi54(addr), O7 ;  jumpl O7, %lo10(addr), O7 ;  <delay>
 // That is, it is essentially the same as a NativeJump.
 class NativeFarCall;
-inline NativeFarCall* nativeFarCall_overwriting_at(address instr, address destination);
+inline NativeFarCall* nativeFarCall_overwriting_at(address instr, address destination = NULL);
 inline NativeFarCall* nativeFarCall_at(address instr);
 class NativeFarCall: public NativeInstruction {
  public:
@@ -450,7 +450,7 @@ class NativeFarCall: public NativeInstruction {
     return call;
   }
 
-  friend inline NativeFarCall* nativeFarCall_overwriting_at(address instr, address destination = NULL) {
+  friend inline NativeFarCall* nativeFarCall_overwriting_at(address instr, address destination) {
     Unimplemented();
     NativeFarCall* call = (NativeFarCall*)instr;
     return call;


### PR DESCRIPTION
Backport of bug 8230708. Tested and worked for me and one other user of sparc/linux.

I signed the OCA: it is under review, will update when it goes through.

This should be fairly low risk: it only touches sparc-specific code.

I appreciate your time :^)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8230708](https://bugs.openjdk.org/browse/JDK-8230708): Hotspot fails to build on linux-sparc with gcc-9


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1330/head:pull/1330` \
`$ git checkout pull/1330`

Update a local copy of the PR: \
`$ git checkout pull/1330` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1330`

View PR using the GUI difftool: \
`$ git pr show -t 1330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1330.diff">https://git.openjdk.org/jdk11u-dev/pull/1330.diff</a>

</details>
