### PR TITLE
8275008: gtest build failure due to stringop-overflow warning with gcc11

### DIFF
--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2021/, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2021/, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ $(eval $(call SetupNativeCompilation, BUILD_GTEST_LIBJVM, \
     CFLAGS_windows := -EHsc, \
     CFLAGS_solaris := -DGTEST_HAS_EXCEPTIONS=0 -library=stlport4 +d, \
     CFLAGS_macosx := -DGTEST_OS_MAC=1, \
-    DISABLED_WARNINGS_gcc := undef, \
+    DISABLED_WARNINGS_gcc := undef stringop-overflow, \
     DISABLED_WARNINGS_clang := undef switch format-nonliteral \
         tautological-undefined-compare $(BUILD_LIBJVM_DISABLED_WARNINGS_clang), \
     DISABLED_WARNINGS_solstudio := identexpected, \


### PR DESCRIPTION
Backport of c55dd365e3463670697b09de0ff70877203e5a69, which did not apply cleanly due to changes in tip that reworked the make file.

Corretto is requiring this when building as a RPM on a hardened base OS with GCC 11.3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275008](https://bugs.openjdk.org/browse/JDK-8275008): gtest build failure due to stringop-overflow warning with gcc11


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to [767195be](https://git.openjdk.org/jdk11u-dev/pull/1333/files/767195befd4b610a7bed399457265d8c1eddaf70)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1333/head:pull/1333` \
`$ git checkout pull/1333`

Update a local copy of the PR: \
`$ git checkout pull/1333` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1333`

View PR using the GUI difftool: \
`$ git pr show -t 1333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1333.diff">https://git.openjdk.org/jdk11u-dev/pull/1333.diff</a>

</details>
