### PR TITLE
8282947: JFR: Dump on shutdown live-locks in some conditions

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunksChannel.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunksChannel.java
@@ -96,10 +96,13 @@ final class ChunksChannel implements ReadableByteChannel {
                 assert current != null;
 
                 long rem = current.getSize();
-
                 while (rem > 0) {
                     long n = Math.min(rem, 1024 * 1024);
                     long w = out.transferFrom(channel, pos, n);
+                    // Prevent endless loop
+                    if (w == 0) {
+                        return out.size();
+                    }
                     pos += w;
                     rem -= w;
                 }
@@ -111,7 +114,7 @@ final class ChunksChannel implements ReadableByteChannel {
                 current = null;
             }
             if (!nextChannel()) {
-                return pos;
+                return out.size();
             }
         }
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
@@ -691,8 +691,12 @@ public final class PlatformRecording implements AutoCloseable {
         synchronized (recorder) {
                 userPath.doPriviligedIO(() -> {
                     try (ChunksChannel cc = new ChunksChannel(chunks); FileChannel fc = FileChannel.open(userPath.getReal(), StandardOpenOption.WRITE, StandardOpenOption.APPEND)) {
-                        cc.transferTo(fc);
-                        fc.force(true);
+                        long bytes = cc.transferTo(fc);
+                        Logger.log(LogTag.JFR, LogLevel.INFO, "Transferred " + bytes + " bytes from the disk repository");
+                        // No need to force if no data was transferred, which avoids IOException when device is /dev/null
+                        if (bytes != 0) {
+                            fc.force(true);
+                        }
                     }
                     return null;
                 });

--- a/test/jdk/jdk/jfr/api/recording/dump/TestDumpDevNull.java
+++ b/test/jdk/jdk/jfr/api/recording/dump/TestDumpDevNull.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.api.recording.dump;
+
+import java.nio.file.Path;
+
+import jdk.jfr.Recording;
+
+/**
+ * @test
+ * @summary Tests that it's possible to dump to /dev/null without a livelock
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm -Xlog:jfr jdk.jfr.api.recording.dump.TestDumpDevNull
+ */
+public class TestDumpDevNull {
+
+    public static void main(String[] args) throws Exception {
+        try (Recording r1 = new Recording()) {
+            r1.setDestination(Path.of("/dev/null"));
+            r1.start();
+            // Force a chunk rotation which ensures that jdk.jfr.internal.ChunkChannel
+            // invokes FileChannel::transferFrom(ReadableByteChannel, position, count) twice.
+            // FileChannel will return 0 the second time because position exceeds
+            // FileChannel::size(), which is always 0 for /dev/null
+            // Without proper handling of return value 0, the ChunkChannel will spin indefinitely.
+            try (Recording r2 = new Recording()) {
+                r2.start();
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282947](https://bugs.openjdk.org/browse/JDK-8282947): JFR: Dump on shutdown live-locks in some conditions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1334/head:pull/1334` \
`$ git checkout pull/1334`

Update a local copy of the PR: \
`$ git checkout pull/1334` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1334`

View PR using the GUI difftool: \
`$ git pr show -t 1334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1334.diff">https://git.openjdk.org/jdk11u-dev/pull/1334.diff</a>

</details>
