### PR TITLE
8291713: assert(!phase->exceeding_node_budget()) failed: sanity after JDK-8223389

### DIFF
--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1392,7 +1392,6 @@ SHENANDOAHGC_ONLY(private:)
 
   uint require_nodes(uint require, uint minreq = REQUIRE_MIN) {
     precond(require > 0);
-    _nodes_required += MAX2(100u, require); // Keep requests at minimum 100.
     _nodes_required += MAX2(require, minreq);
     return _nodes_required;
   }

--- a/test/hotspot/jtreg/compiler/loopopts/TestBadNodeBudgetAfterBackport.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestBadNodeBudgetAfterBackport.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8291713
+ * @summary assert(!phase->exceeding_node_budget()) failed: sanity after JDK-8223389
+ * @run main/othervm -Xbatch -XX:-TieredCompilation TestBadNodeBudgetAfterBackport
+ */
+
+public class TestBadNodeBudgetAfterBackport {
+
+    public static long instanceCount=7400137408519306837L;
+    public static int iFld=-5840;
+
+    public static int iMeth(long l) {
+
+        float f1=42.67F;
+        double d2=2.45690;
+        int i14=-47, i16=5;
+
+        for (i14 = 8; 168 > i14; ++i14) {
+            TestBadNodeBudgetAfterBackport.iFld = (int)f1;
+            i16 = 1;
+            while (++i16 < 10) {
+                int i17=7;
+                f1 *= 4350;
+                try {
+                    TestBadNodeBudgetAfterBackport.iFld = (TestBadNodeBudgetAfterBackport.iFld / i17);
+                } catch (ArithmeticException a_e) {}
+                d2 = TestBadNodeBudgetAfterBackport.iFld;
+            }
+        }
+        return (int)Double.doubleToLongBits(d2);
+    }
+
+    public static void main(String[] strArr) {
+        TestBadNodeBudgetAfterBackport _instance = new TestBadNodeBudgetAfterBackport();
+        for (int i = 0; i < 10; i++ ) {
+            _instance.iMeth(TestBadNodeBudgetAfterBackport.instanceCount);
+        }
+    }
+}


### PR DESCRIPTION
This fixes an issue with the backport of
https://bugs.openjdk.org/browse/JDK-8223363:

https://github.com/openjdk/jdk11u/commit/5f40afc10909061b5b4e17ec59856611e160e474

where a line that should have been removed wasn't.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291713](https://bugs.openjdk.org/browse/JDK-8291713): assert(!phase->exceeding_node_budget()) failed: sanity after JDK-8223389


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - no project role)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1335/head:pull/1335` \
`$ git checkout pull/1335`

Update a local copy of the PR: \
`$ git checkout pull/1335` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1335`

View PR using the GUI difftool: \
`$ git pr show -t 1335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1335.diff">https://git.openjdk.org/jdk11u-dev/pull/1335.diff</a>

</details>
