### PR TITLE
8292852: [11u] TestMemoryWithCgroupV1 fails after JDK-8292768

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
@@ -35,7 +35,7 @@ import jdk.internal.platform.Metrics;
  * @modules java.base/jdk.internal.platform
  * @library /test/lib
  * @build sun.hotspot.WhiteBox PrintContainerInfo CheckOperatingSystemMXBean
- * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller -jar whitebox.jar sun.hotspot.WhiteBox
  * @run main TestMemoryWithCgroupV1
  */
 public class TestMemoryWithCgroupV1 {


### PR DESCRIPTION
8292852: [11u] TestMemoryWithCgroupV1 fails after JDK-8292768

Changed the startup command

This test case succeeded on my machine

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292852](https://bugs.openjdk.org/browse/JDK-8292852): [11u] TestMemoryWithCgroupV1  fails after JDK-8292768


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1337/head:pull/1337` \
`$ git checkout pull/1337`

Update a local copy of the PR: \
`$ git checkout pull/1337` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1337`

View PR using the GUI difftool: \
`$ git pr show -t 1337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1337.diff">https://git.openjdk.org/jdk11u-dev/pull/1337.diff</a>

</details>
