### PR TITLE
8238586: [TESTBUG] vmTestbase/jit/tiered/Test.java failed when TieredCompilation is disabled

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/jit/tiered/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/tiered/Test.java
@@ -46,7 +46,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 public class Test {
-    private static String UNSUPPORTED_OPTION_MESSAGE = "-XX:TieredCompilation not supported in this VM";
+    private static String UNSUPPORTED_OPTION_MESSAGE = "-XX:+TieredCompilation not supported in this VM";
     private static String REGEXP = "^[0-9.]+: \\[compile level=\\d";
     public static void main(String[] args) throws Exception {
         {
@@ -56,7 +56,7 @@ public class Test {
                     "-XX:+PrintTieredEvents",
                     "-version");
             var output = new OutputAnalyzer(pb.start());
-            if (output.getStdout().contains(UNSUPPORTED_OPTION_MESSAGE)) {
+            if (output.getStderr().contains(UNSUPPORTED_OPTION_MESSAGE)) {
                 throw new SkippedException(UNSUPPORTED_OPTION_MESSAGE);
             }
             output.shouldHaveExitValue(0)


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle. Low risk, only a test change. Clean backport. The changed test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8238586](https://bugs.openjdk.org/browse/JDK-8238586): [TESTBUG] vmTestbase/jit/tiered/Test.java failed when TieredCompilation is disabled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1338/head:pull/1338` \
`$ git checkout pull/1338`

Update a local copy of the PR: \
`$ git checkout pull/1338` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1338`

View PR using the GUI difftool: \
`$ git pr show -t 1338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1338.diff">https://git.openjdk.org/jdk11u-dev/pull/1338.diff</a>

</details>
