### PR TITLE
8279385: [test]  Adjust sun/security/pkcs12/KeytoolOpensslInteropTest.java after 8278344

### DIFF
--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -168,11 +168,13 @@ public class KeytoolOpensslInteropTest {
         // Current default pkcs12 setting
         keytool("-importkeystore -srckeystore ks -srcstorepass changeit "
                 + "-destkeystore ksnormal -deststorepass changeit");
+
         data = Files.readAllBytes(Path.of("ksnormal"));
         checkInt(data, "22", 10000); // Mac ic
         checkAlg(data, "2000", SHA_256); // Mac alg
         checkAlg(data, "110c010c01000", PBES2); // key alg
         checkInt(data, "110c010c01001011", 10000); // key ic
+        checkAlg(data, "110c10", ENCRYPTED_DATA_OID);
         checkAlg(data, "110c110110", PBES2); // cert alg
         check("ksnormal", "a", "changeit", "changeit", true, true, true);
         check("ksnormal", "a", null, "changeit", true, false, true);
@@ -180,7 +182,7 @@ public class KeytoolOpensslInteropTest {
 
         // Import it into a new keystore with legacy algorithms
         keytool("-importkeystore -srckeystore ksnormal -srcstorepass changeit "
-               + "-destkeystore kslegacyimp -deststorepass changeit "
+                + "-destkeystore kslegacyimp -deststorepass changeit "
                 + "-J-Dkeystore.pkcs12.legacy");
         data = Files.readAllBytes(Path.of("kslegacyimp"));
         checkInt(data, "22", 100000); // Mac ic
@@ -456,7 +458,7 @@ public class KeytoolOpensslInteropTest {
                 "pkcs12", "-in", "ksnormal", "-passin", "pass:changeit",
                 "-info", "-nokeys", "-nocerts");
         output1.shouldHaveExitValue(0)
-            .shouldContain("MAC: sha1, Iteration 100000")
+            .shouldContain("MAC:").shouldContain("sha256").shouldContain("Iteration 10000")
             .shouldContain("Shrouded Keybag: PBES2, PBKDF2, AES-256-CBC,"
                     + " Iteration 10000, PRF hmacWithSHA256")
             .shouldContain("PKCS7 Encrypted data: PBES2, PBKDF2, AES-256-CBC,"
@@ -499,7 +501,7 @@ public class KeytoolOpensslInteropTest {
                 "ksnewic", "-passin", "pass:changeit", "-info", "-nokeys",
                 "-nocerts");
         output1.shouldHaveExitValue(0)
-            .shouldContain("MAC: sha1, Iteration 5555")
+            .shouldContain("MAC:").shouldContain("sha256").shouldContain("Iteration 5555")
             .shouldContain("Shrouded Keybag: PBES2, PBKDF2, AES-256-CBC,"
                     + " Iteration 7777, PRF hmacWithSHA256")
             .shouldContain("Shrouded Keybag: pbeWithSHA1And128BitRC4,"

--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -458,7 +458,7 @@ public class KeytoolOpensslInteropTest {
                 "pkcs12", "-in", "ksnormal", "-passin", "pass:changeit",
                 "-info", "-nokeys", "-nocerts");
         output1.shouldHaveExitValue(0)
-            .shouldContain("MAC:").shouldContain("sha256").shouldContain("Iteration 10000")
+            .shouldMatch("MAC:.*sha256.*Iteration 10000")
             .shouldContain("Shrouded Keybag: PBES2, PBKDF2, AES-256-CBC,"
                     + " Iteration 10000, PRF hmacWithSHA256")
             .shouldContain("PKCS7 Encrypted data: PBES2, PBKDF2, AES-256-CBC,"
@@ -501,7 +501,7 @@ public class KeytoolOpensslInteropTest {
                 "ksnewic", "-passin", "pass:changeit", "-info", "-nokeys",
                 "-nocerts");
         output1.shouldHaveExitValue(0)
-            .shouldContain("MAC:").shouldContain("sha256").shouldContain("Iteration 5555")
+            .shouldMatch("MAC:.*sha256.*Iteration 5555")
             .shouldContain("Shrouded Keybag: PBES2, PBKDF2, AES-256-CBC,"
                     + " Iteration 7777, PRF hmacWithSHA256")
             .shouldContain("Shrouded Keybag: pbeWithSHA1And128BitRC4,"


### PR DESCRIPTION
Follow up after [JDK-8278344](https://bugs.openjdk.org/browse/JDK-8278344).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279385](https://bugs.openjdk.org/browse/JDK-8279385): [test]  Adjust sun/security/pkcs12/KeytoolOpensslInteropTest.java after 8278344


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1344/head:pull/1344` \
`$ git checkout pull/1344`

Update a local copy of the PR: \
`$ git checkout pull/1344` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1344`

View PR using the GUI difftool: \
`$ git pr show -t 1344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1344.diff">https://git.openjdk.org/jdk11u-dev/pull/1344.diff</a>

</details>
