### PR TITLE
8287741: Fix of JDK-8287107 (unused cgv1 freezer controller) was incomplete

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -260,7 +260,13 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
       }
     }
     if (is_cgroupsV2) {
+      // On some systems we have mixed cgroups v1 and cgroups v2 controllers (e.g. freezer on cg1 and
+      // all relevant controllers on cg2). Only set the cgroup path when we see a hierarchy id of 0.
+      if (hierarchy_id != 0) {
+        continue;
+      }
       for (int i = 0; i < CG_INFO_LENGTH; i++) {
+        assert(cg_infos[i]._cgroup_path == NULL, "cgroup path must only be set once");
         cg_infos[i]._cgroup_path = os::strdup(cgroup_path);
       }
     }


### PR DESCRIPTION
Follow-up backport (for hotspot) to https://bugs.openjdk.org/browse/JDK-8287107 applies clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287741](https://bugs.openjdk.org/browse/JDK-8287741): Fix of JDK-8287107 (unused cgv1 freezer controller) was incomplete


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1345/head:pull/1345` \
`$ git checkout pull/1345`

Update a local copy of the PR: \
`$ git checkout pull/1345` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1345`

View PR using the GUI difftool: \
`$ git pr show -t 1345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1345.diff">https://git.openjdk.org/jdk11u-dev/pull/1345.diff</a>

</details>
