### PR TITLE
8274563: jfr/event/oldobject/TestClassLoaderLeak.java fails when GC cycles are not happening

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -42,10 +42,9 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc == "null"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
- * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestClassLoaderLeak
+ * @run main/othervm -XX:TLABSize=2k -Xmx128m jdk.jfr.event.oldobject.TestClassLoaderLeak
  */
 public class TestClassLoaderLeak {
 


### PR DESCRIPTION
Backport for JDK-8274563

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274563](https://bugs.openjdk.org/browse/JDK-8274563): jfr/event/oldobject/TestClassLoaderLeak.java fails when GC cycles are not happening


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1350/head:pull/1350` \
`$ git checkout pull/1350`

Update a local copy of the PR: \
`$ git checkout pull/1350` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1350`

View PR using the GUI difftool: \
`$ git pr show -t 1350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1350.diff">https://git.openjdk.org/jdk11u-dev/pull/1350.diff</a>

</details>
