### PR TITLE
8293202: Document how to edit doc/testing, doc/building

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -108,6 +108,7 @@
 <li><a href="#developing-the-build-system-itself">Developing the Build System Itself</a></li>
 </ul></li>
 <li><a href="#contributing-to-the-jdk">Contributing to the JDK</a></li>
+<li><a href="#editing-this-document">Editing this document</a></li>
 </ul>
 </nav>
 <h2 id="tldr-instructions-for-the-impatient">TL;DR (Instructions for the Impatient)</h2>
@@ -1068,5 +1069,7 @@ test-support/</code></pre>
 <p>First of all: Thank you! We gladly welcome your contribution. However, please bear in mind that the JDK is a massive project, and we must ask you to follow our rules and guidelines to be able to accept your contribution.</p>
 <p>The official place to start is the <a href="http://openjdk.java.net/contribute/">'How to contribute' page</a>. There is also an official (but somewhat outdated and skimpy on details) <a href="http://openjdk.java.net/guide/">Developer's Guide</a>.</p>
 <p>If this seems overwhelming to you, the Adoption Group is there to help you! A good place to start is their <a href="https://wiki.openjdk.java.net/display/Adoption/New+Contributor">'New Contributor' page</a>, or start reading the comprehensive <a href="https://adoptopenjdk.gitbooks.io/adoptopenjdk-getting-started-kit/en/">Getting Started Kit</a>. The Adoption Group will also happily answer any questions you have about contributing. Contact them by <a href="http://mail.openjdk.java.net/mailman/listinfo/adoption-discuss">mail</a> or <a href="http://openjdk.java.net/irc/">IRC</a>.</p>
+<h2 id="editing-this-document">Editing this document</h2>
+<p>If you want to contribute changes to this document, edit <code>doc/building.md</code> and then run <code>make update-build-docs</code> to generate the same changes in <code>doc/building.html</code>.</p>
 </body>
 </html>

--- a/doc/building.md
+++ b/doc/building.md
@@ -1863,6 +1863,12 @@ contributing. Contact them by [mail](
 http://mail.openjdk.java.net/mailman/listinfo/adoption-discuss) or [IRC](
 http://openjdk.java.net/irc/).
 
+## Editing this document
+
+If you want to contribute changes to this document, edit `doc/building.md` and 
+then run `make update-build-docs` to generate the same changes in 
+`doc/building.html`.
+
 ---
 # Override styles from the base CSS file that are not ideal for this document.
 header-includes:

--- a/doc/testing.html
+++ b/doc/testing.html
@@ -41,6 +41,7 @@
 <li><a href="#docker-tests">Docker Tests</a></li>
 <li><a href="#client-ui-tests">Client UI Tests</a></li>
 </ul></li>
+<li><a href="#editing-this-document">Editing this document</a></li>
 </ul>
 </nav>
 <h2 id="using-the-run-test-framework">Using the run-test framework</h2>
@@ -185,5 +186,7 @@ TEST FAILURE</code></pre>
 <h4 id="windows">Windows</h4>
 <p>Type <code>gpedit</code> in the Search and then click Edit group policy; navigate to User Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; File Explorer; in the right-side pane look for “Turn off Windows key hotkeys” and double click on it; enable or disable hotkeys.</p>
 <p>Note: restart is required to make the settings take effect.</p>
+<h2 id="editing-this-document">Editing this document</h2>
+<p>If you want to contribute changes to this document, edit <code>doc/testing.md</code> and then run <code>make update-build-docs</code> to generate the same changes in <code>doc/testing.html</code>.</p>
 </body>
 </html>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -391,6 +391,12 @@ enable or disable hotkeys.
 
 Note: restart is required to make the settings take effect.
 
+## Editing this document
+
+If you want to contribute changes to this document, edit `doc/testing.md` and 
+then run `make update-build-docs` to generate the same changes in 
+`doc/testing.html`.
+
 ---
 # Override some definitions in the global css file that are not optimal for
 # this document.


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7c2f2994](https://github.com/openjdk/jdk/commit/7c2f2994da1577152870eaf2ea71dfba470c29ef) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ludvig Janiuk on 1 Sep 2022 and was reviewed by Erik Joelsson.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293202](https://bugs.openjdk.org/browse/JDK-8293202): Document how to edit doc/testing, doc/building


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1353/head:pull/1353` \
`$ git checkout pull/1353`

Update a local copy of the PR: \
`$ git checkout pull/1353` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1353`

View PR using the GUI difftool: \
`$ git pr show -t 1353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1353.diff">https://git.openjdk.org/jdk11u-dev/pull/1353.diff</a>

</details>
