### PR TITLE
8292541: [Metrics] Reported memory limit may exceed physical machine memory

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupMetrics.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupMetrics.java
@@ -121,7 +121,13 @@ public class CgroupMetrics implements Metrics {
 
     @Override
     public long getMemoryLimit() {
-        return subsystem.getMemoryLimit();
+        long subsMem = subsystem.getMemoryLimit();
+        // Catch the cgroup memory limit exceeding host physical memory.
+        // Treat this as unlimited.
+        if (subsMem >= getTotalMemorySize0()) {
+            return CgroupSubsystem.LONG_RETVAL_UNLIMITED;
+        }
+        return subsMem;
     }
 
     @Override
@@ -178,5 +184,6 @@ public class CgroupMetrics implements Metrics {
     }
 
     private static native boolean isUseContainerSupport();
+    private static native long getTotalMemorySize0();
 
 }

--- a/src/java.base/linux/native/libjava/CgroupMetrics.c
+++ b/src/java.base/linux/native/libjava/CgroupMetrics.c
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+#include <unistd.h>
 
 #include "jni.h"
 #include "jvm.h"
@@ -32,4 +33,11 @@ JNIEXPORT jboolean JNICALL
 Java_jdk_internal_platform_CgroupMetrics_isUseContainerSupport(JNIEnv *env, jclass ignored)
 {
     return JVM_IsUseContainerSupport();
+}
+
+JNIEXPORT jlong JNICALL
+Java_jdk_internal_platform_CgroupMetrics_getTotalMemorySize0
+  (JNIEnv *env, jclass ignored)
+{
+    return sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE);
 }

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -47,6 +47,13 @@ import static jdk.test.lib.Asserts.assertNotNull;
 public class TestMemoryAwareness {
     private static final String imageName = Common.imageName("memory");
 
+    private static String getHostMaxMemory() throws Exception {
+        DockerRunOptions opts = Common.newOpts(imageName);
+        String goodMem = Common.run(opts).firstMatch("total physical memory: (\\d+)", 1);
+        assertNotNull(goodMem, "no match for 'total physical memory' in trace output");
+        return goodMem;
+    }
+
     public static void main(String[] args) throws Exception {
         if (!DockerTestUtils.canTestDocker()) {
             return;
@@ -79,7 +86,10 @@ public class TestMemoryAwareness {
                 "1G", Integer.toString(((int) Math.pow(2, 20)) * 1024),
                 "1500M", Integer.toString(((int) Math.pow(2, 20)) * (1500 - 1024))
             );
-            testContainerMemExceedsPhysical();
+            final String hostMaxMem = getHostMaxMemory();
+            testOperatingSystemMXBeanIgnoresMemLimitExceedingPhysicalMemory(hostMaxMem);
+            testMetricsIgnoresMemLimitExceedingPhysicalMemory(hostMaxMem);
+            testContainerMemExceedsPhysical(hostMaxMem);
         } finally {
             if (!DockerTestUtils.RETAIN_IMAGE_AFTER_TEST) {
                 DockerTestUtils.removeDockerImage(imageName);
@@ -102,24 +112,16 @@ public class TestMemoryAwareness {
 
     // JDK-8292083
     // Ensure that Java ignores container memory limit values above the host's physical memory.
-    private static void testContainerMemExceedsPhysical()
+    private static void testContainerMemExceedsPhysical(final String hostMaxMem)
             throws Exception {
-
         Common.logNewTestCase("container memory limit exceeds physical memory");
-
-        DockerRunOptions opts = Common.newOpts(imageName);
-
-        // first run: establish physical memory in test environment and derive
-        // a bad value one power of ten larger
-        String goodMem = Common.run(opts).firstMatch("total physical memory: (\\d+)", 1);
-        assertNotNull(goodMem, "no match for 'total physical memory' in trace output");
-        String badMem = goodMem + "0";
-
-        // second run: set a container memory limit to the bad value
-        opts = Common.newOpts(imageName)
+        String badMem = hostMaxMem + "0";
+        // set a container memory limit to the bad value
+        DockerRunOptions opts = Common.newOpts(imageName)
             .addDockerOpts("--memory", badMem);
+
         Common.run(opts)
-            .shouldMatch("container memory limit (ignored: " + badMem + "|unlimited: -1), using host value " + goodMem);
+            .shouldMatch("container memory limit (ignored: " + badMem + "|unlimited: -1), using host value " + hostMaxMem);
     }
 
 
@@ -197,4 +199,23 @@ public class TestMemoryAwareness {
         }
     }
 
+
+    // JDK-8292541: Ensure OperatingSystemMXBean ignores container memory limits above the host's physical memory.
+    private static void testOperatingSystemMXBeanIgnoresMemLimitExceedingPhysicalMemory(final String hostMaxMem)
+            throws Exception {
+        String badMem = hostMaxMem + "0";
+        testOperatingSystemMXBeanAwareness(badMem, hostMaxMem, badMem, hostMaxMem);
+    }
+
+    // JDK-8292541: Ensure Metrics ignores container memory limits above the host's physical memory.
+    private static void testMetricsIgnoresMemLimitExceedingPhysicalMemory(final String hostMaxMem)
+            throws Exception {
+        Common.logNewTestCase("Metrics ignore container memory limit exceeding physical memory");
+        String badMem = hostMaxMem + "0";
+        DockerRunOptions opts = Common.newOpts(imageName)
+            .addJavaOpts("-XshowSettings:system")
+            .addDockerOpts("--memory", badMem);
+
+        DockerTestUtils.dockerRunJava(opts).shouldMatch("Memory Limit: Unlimited");
+    }
 }


### PR DESCRIPTION
Hi 

This pull request contains a backport of commit [9a0d1e7c](https://github.com/openjdk/jdk/commit/9a0d1e7ce86368cdcade713a9e220604f7d77ecf) from the [openjdk/jdk](https://git.openjdk.org/jdk) for jdk17u-dev. This patch for the Metrics system is a counterpart to 8292083 (which addressed the underlying issue in hotspot) which is already merged in jdk11u-dev. We would like it in 11u-dev for 11 users as we have seen this issue in the wild.

The commit being backported was authored by Jonathan Dowland on 26 Aug 2022 and was reviewed by Thomas Stuefe and Severin Gehwolf.

Patch applies clean to 11u-dev. The new tests it add fail in jdk11u-dev prior to this patch and pass after, as expected.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292541](https://bugs.openjdk.org/browse/JDK-8292541): [Metrics] Reported memory limit may exceed physical machine memory


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1355/head:pull/1355` \
`$ git checkout pull/1355`

Update a local copy of the PR: \
`$ git checkout pull/1355` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1355`

View PR using the GUI difftool: \
`$ git pr show -t 1355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1355.diff">https://git.openjdk.org/jdk11u-dev/pull/1355.diff</a>

</details>
