### PR TITLE
8269029: compiler/codegen/TestCharVect2.java fails for client VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/codegen/TestCharVect2.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestCharVect2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,14 @@
  * @summary incorrect results of char vectors right shift operaiton
  *
  * @run main/othervm/timeout=400 -Xbatch -Xmx128m compiler.codegen.TestCharVect2
+ */
+
+/**
+ * @test
+ * @bug 8001183
+ * @summary incorrect results of char vectors right shift operation
+ * @requires vm.compiler2.enabled | vm.graal.enabled
+ *
  * @run main/othervm/timeout=400 -Xbatch -Xmx128m -XX:MaxVectorSize=8 compiler.codegen.TestCharVect2
  * @run main/othervm/timeout=400 -Xbatch -Xmx128m -XX:MaxVectorSize=16 compiler.codegen.TestCharVect2
  * @run main/othervm/timeout=400 -Xbatch -Xmx128m -XX:MaxVectorSize=32 compiler.codegen.TestCharVect2


### PR DESCRIPTION
Simple resolve, original change has an additional arg in the context lines.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269029](https://bugs.openjdk.org/browse/JDK-8269029): compiler/codegen/TestCharVect2.java fails for client VMs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1357/head:pull/1357` \
`$ git checkout pull/1357`

Update a local copy of the PR: \
`$ git checkout pull/1357` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1357`

View PR using the GUI difftool: \
`$ git pr show -t 1357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1357.diff">https://git.openjdk.org/jdk11u-dev/pull/1357.diff</a>

</details>
