### PR TITLE
8290207: Missing notice in dom.md

### DIFF
--- a/src/java.xml/share/legal/dom.md
+++ b/src/java.xml/share/legal/dom.md
@@ -1,5 +1,20 @@
 ## DOM Level 3 Core Specification v1.0
 
+### W3C Software Notice
+<pre>
+Copyright © 2004 World Wide Web Consortium, (Massachusetts Institute of Technology,
+European Research Consortium for Informatics and Mathematics, Keio University).
+All Rights Reserved.
+
+The DOM bindings are published under the W3C Software Copyright Notice and License.
+The software license requires "Notice of any changes or modifications to the W3C
+files, including the date changes were made." Consequently, modified versions of
+the DOM bindings must document that they do not conform to the W3C standard; in the
+case of the IDL definitions, the pragma prefix can no longer be 'w3c.org'; in the
+case of the Java language binding, the package names can no longer be in the
+'org.w3c' package.
+</pre>
+
 ### W3C License
 <pre>
 


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290207](https://bugs.openjdk.org/browse/JDK-8290207): Missing notice in dom.md


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1358/head:pull/1358` \
`$ git checkout pull/1358`

Update a local copy of the PR: \
`$ git checkout pull/1358` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1358`

View PR using the GUI difftool: \
`$ git pr show -t 1358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1358.diff">https://git.openjdk.org/jdk11u-dev/pull/1358.diff</a>

</details>
