### PR TITLE
8279066: entries.remove(entry) is useless in PKCS12KeyStore

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -2220,11 +2220,6 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
                 /* Update existing KeyEntry in entries table */
                 if (chain.size() > 0) {
                     entry.chain = chain.toArray(new Certificate[chain.size()]);
-                } else {
-                    // Remove private key entries where there is no associated
-                    // certs. Most likely the keystore is loaded with a null
-                    // password.
-                    entries.remove(entry);
                 }
             }
         }


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279066](https://bugs.openjdk.org/browse/JDK-8279066): entries.remove(entry) is useless in PKCS12KeyStore


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1359/head:pull/1359` \
`$ git checkout pull/1359`

Update a local copy of the PR: \
`$ git checkout pull/1359` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1359`

View PR using the GUI difftool: \
`$ git pr show -t 1359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1359.diff">https://git.openjdk.org/jdk11u-dev/pull/1359.diff</a>

</details>
