### PR TITLE
8193942: Regression automated test '/open/test/jdk/javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java' fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -710,7 +710,6 @@ javax/swing/JComponent/4337267/bug4337267.java 8146451 windows-all
 javax/swing/JFileChooser/4524490/bug4524490.java 8042380 generic-all
 javax/swing/JFileChooser/8002077/bug8002077.java 8196094 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8058231 generic-all
-javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8193942 generic-all
 javax/swing/JList/6462008/bug6462008.java 7156347 generic-all
 javax/swing/JPopupMenu/6580930/bug6580930.java 7124313 macosx-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all

--- a/test/jdk/javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java
+++ b/test/jdk/javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java
@@ -44,7 +44,7 @@ public class ScaledFrameBackgroundTest {
     public static void main(String[] args) throws Exception {
         try {
             Robot robot = new Robot();
-            robot.setAutoDelay(50);
+            robot.setAutoDelay(100);
 
             SwingUtilities.invokeAndWait(() -> {
                 frame = new JFrame();
@@ -54,10 +54,11 @@ public class ScaledFrameBackgroundTest {
                 panel.setBackground(BACKGROUND);
                 frame.getContentPane().add(panel);
                 frame.setVisible(true);
+                frame.setLocationRelativeTo(null);
             });
 
             robot.waitForIdle();
-            Thread.sleep(200);
+            robot.delay(1000);
 
             Rectangle[] rects = new Rectangle[1];
             SwingUtilities.invokeAndWait(() -> {
@@ -81,7 +82,7 @@ public class ScaledFrameBackgroundTest {
             color = robot.getPixelColor(x, y);
 
             if (!BACKGROUND.equals(color)) {
-                throw new RuntimeException("Wrong backgound color!");
+                throw new RuntimeException("Wrong backgound color!!");
             }
         } finally {
             if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

Resolved ProblemList, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8193942](https://bugs.openjdk.org/browse/JDK-8193942): Regression automated test '/open/test/jdk/javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java' fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1361/head:pull/1361` \
`$ git checkout pull/1361`

Update a local copy of the PR: \
`$ git checkout pull/1361` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1361`

View PR using the GUI difftool: \
`$ git pr show -t 1361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1361.diff">https://git.openjdk.org/jdk11u-dev/pull/1361.diff</a>

</details>
