### PR TITLE
8282306: os::is_first_C_frame(frame*) crashes on invalid link access

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -149,10 +149,12 @@ inline bool frame::is_younger(intptr_t* id) const { assert(this->id() != NULL &&
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != NULL && id != NULL, "NULL frame id");
                                                     return this->id() > id ; }
 
-
-
 inline intptr_t* frame::link() const              { return (intptr_t*) *(intptr_t **)addr_at(link_offset); }
 
+inline intptr_t* frame::link_or_null() const {
+  intptr_t** ptr = (intptr_t **)addr_at(link_offset);
+  return os::is_readable_pointer(ptr) ? *ptr : NULL;
+}
 
 inline intptr_t* frame::unextended_sp() const     { return _unextended_sp; }
 

--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -132,8 +132,12 @@ inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != NULL &&
                                                     return this->id() > id ; }
 
 
-
 inline intptr_t* frame::link() const              { return (intptr_t*) *(intptr_t **)addr_at(link_offset); }
+
+inline intptr_t* frame::link_or_null() const {
+  intptr_t** ptr = (intptr_t **)addr_at(link_offset);
+  return os::is_readable_pointer(ptr) ? *ptr : NULL;
+}
 
 inline intptr_t* frame::unextended_sp() const     { return _unextended_sp; }
 

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -117,6 +117,10 @@ inline intptr_t* frame::link() const {
   return (intptr_t*)callers_abi()->callers_sp;
 }
 
+inline intptr_t* frame::link_or_null() const {
+  return link();
+}
+
 inline intptr_t* frame::real_fp() const {
   return fp();
 }

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -163,6 +163,10 @@ inline intptr_t* frame::link() const {
   return (intptr_t*) callers_abi()->callers_sp;
 }
 
+inline intptr_t* frame::link_or_null() const {
+  return link();
+}
+
 inline intptr_t** frame::interpreter_frame_locals_addr() const {
   return (intptr_t**) &(ijava_state()->locals);
 }

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -142,9 +142,12 @@ inline bool frame::is_younger(intptr_t* id) const { assert(this->id() != NULL &&
 inline bool frame::is_older(intptr_t* id) const   { assert(this->id() != NULL && id != NULL, "NULL frame id");
                                                     return this->id() > id ; }
 
-
-
 inline intptr_t* frame::link() const              { return (intptr_t*) *(intptr_t **)addr_at(link_offset); }
+
+inline intptr_t* frame::link_or_null() const {
+  intptr_t** ptr = (intptr_t **)addr_at(link_offset);
+  return os::is_readable_pointer(ptr) ? *ptr : NULL;
+}
 
 inline intptr_t* frame::unextended_sp() const     { return _unextended_sp; }
 

--- a/src/hotspot/cpu/zero/frame_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/frame_zero.inline.hpp
@@ -82,6 +82,11 @@ inline intptr_t* frame::link() const {
   return NULL;
 }
 
+inline intptr_t* frame::link_or_null() const {
+  ShouldNotCallThis();
+  return NULL;
+}
+
 #ifdef CC_INTERP
 inline interpreterState frame::get_interpreterState() const {
   return zero_interpreterframe()->interpreter_state();

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -193,7 +193,11 @@ class frame {
 
  public:
   // Link (i.e., the pointer to the previous frame)
+  // might crash if the frame has no parent
   intptr_t* link() const;
+
+  // Link (i.e., the pointer to the previous frame) or null if the link cannot be accessed
+  intptr_t* link_or_null() const;
 
   // Return address
   address  sender_pc() const;

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1214,41 +1214,34 @@ void os::print_location(outputStream* st, intptr_t x, bool verbose) {
   st->print_cr(INTPTR_FORMAT " is an unknown value", p2i(addr));
 }
 
+bool is_pointer_bad(intptr_t* ptr) {
+  return !is_aligned(ptr, sizeof(uintptr_t)) || !os::is_readable_pointer(ptr);
+}
+
 // Looks like all platforms can use the same function to check if C
 // stack is walkable beyond current frame. The check for fp() is not
 // necessary on Sparc, but it's harmless.
+// Returns true if this is not the case, i.e. the frame is possibly
+// the first C frame on the stack.
 bool os::is_first_C_frame(frame* fr) {
   // Load up sp, fp, sender sp and sender fp, check for reasonable values.
   // Check usp first, because if that's bad the other accessors may fault
   // on some architectures.  Ditto ufp second, etc.
-  uintptr_t fp_align_mask = (uintptr_t)(sizeof(address)-1);
-  // sp on amd can be 32 bit aligned.
-  uintptr_t sp_align_mask = (uintptr_t)(sizeof(int)-1);
 
-  uintptr_t usp    = (uintptr_t)fr->sp();
-  if ((usp & sp_align_mask) != 0) return true;
+  if (is_pointer_bad(fr->sp())) return true;
 
   uintptr_t ufp    = (uintptr_t)fr->fp();
-  if ((ufp & fp_align_mask) != 0) return true;
+  if (is_pointer_bad(fr->fp())) return true;
 
   uintptr_t old_sp = (uintptr_t)fr->sender_sp();
-  if ((old_sp & sp_align_mask) != 0) return true;
-  if (old_sp == 0 || old_sp == (uintptr_t)-1) return true;
+  if ((uintptr_t)fr->sender_sp() == (uintptr_t)-1 || is_pointer_bad(fr->sender_sp())) return true;
 
-  uintptr_t old_fp = (uintptr_t)fr->link();
-  if ((old_fp & fp_align_mask) != 0) return true;
-  if (old_fp == 0 || old_fp == (uintptr_t)-1 || old_fp == ufp) return true;
-
-  // stack grows downwards; if old_fp is below current fp or if the stack
-  // frame is too large, either the stack is corrupted or fp is not saved
-  // on stack (i.e. on x86, ebp may be used as general register). The stack
-  // is not walkable beyond current frame.
-  if (old_fp < ufp) return true;
-  if (old_fp - ufp > 64 * K) return true;
+  uintptr_t old_fp = (uintptr_t)fr->link_or_null();
+  if (old_fp == 0 || old_fp == (uintptr_t)-1 || old_fp == ufp ||
+    is_pointer_bad(fr->link_or_null())) return true;
 
   return false;
 }
-
 
 // Set up the boot classpath.
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1240,6 +1240,13 @@ bool os::is_first_C_frame(frame* fr) {
   if (old_fp == 0 || old_fp == (uintptr_t)-1 || old_fp == ufp ||
     is_pointer_bad(fr->link_or_null())) return true;
 
+  // stack grows downwards; if old_fp is below current fp or if the stack
+  // frame is too large, either the stack is corrupted or fp is not saved
+  // on stack (i.e. on x86, ebp may be used as general register). The stack
+  // is not walkable beyond current frame.
+  if (old_fp < ufp) return true;
+  if (old_fp - ufp > 64 * K) return true;
+
   return false;
 }
 

--- a/src/hotspot/share/runtime/safefetch.inline.hpp
+++ b/src/hotspot/share/runtime/safefetch.inline.hpp
@@ -52,10 +52,20 @@ inline intptr_t SafeFetchN(intptr_t* adr, intptr_t errValue) {
 
 // returns true if SafeFetch32 and SafeFetchN can be used safely (stubroutines are already generated)
 inline bool CanUseSafeFetch32() {
+#if defined (__APPLE__) && defined(AARCH64)
+  if (Thread::current_or_null_safe() == NULL) { // workaround for JDK-8282475
+    return false;
+  }
+#endif // __APPLE__ && AARCH64
   return StubRoutines::SafeFetch32_stub() ? true : false;
 }
 
 inline bool CanUseSafeFetchN() {
+#if defined (__APPLE__) && defined(AARCH64)
+  if (Thread::current_or_null_safe() == NULL) {
+    return false;
+  }
+#endif // __APPLE__ && AARCH64
   return StubRoutines::SafeFetchN_stub() ? true : false;
 }
 

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -372,9 +372,9 @@ void Thread::call_run() {
   // At this point, Thread object should be fully initialized and
   // Thread::current() should be set.
 
-  register_thread_stack_with_NMT();
-
   MACOS_AARCH64_ONLY(this->init_wx());
+
+  register_thread_stack_with_NMT();
 
   JFR_ONLY(Jfr::on_thread_start(this);)
 

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -26,6 +26,7 @@
 #include "runtime/os.hpp"
 #include "utilities/ostream.hpp"
 #include "unittest.hpp"
+#include "runtime/frame.inline.hpp"
 
 static size_t small_page_size() {
   return os::vm_page_size();
@@ -343,4 +344,14 @@ TEST_VM(os, jio_vsnprintf) {
 
 TEST_VM(os, jio_snprintf) {
   test_snprintf(jio_snprintf, false);
+}
+
+TEST_VM(os, is_first_C_frame) {
+#ifndef _WIN32
+  frame invalid_frame;
+  EXPECT_TRUE(os::is_first_C_frame(&invalid_frame)); // the frame has zeroes for all values
+
+  frame cur_frame = os::current_frame(); // this frame has to have a sender
+  EXPECT_FALSE(os::is_first_C_frame(&cur_frame));
+#endif // _WIN32
 }


### PR DESCRIPTION
Hardening os::is_first_C_frame(frame*) against accesses on invalid links.

Applies relatively clean (only a comment changed which hindered it from applying directly).

Tested via nightly SAP builds and on my own linux machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282306](https://bugs.openjdk.org/browse/JDK-8282306): os::is_first_C_frame(frame*) crashes on invalid link access


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1373/head:pull/1373` \
`$ git checkout pull/1373`

Update a local copy of the PR: \
`$ git checkout pull/1373` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1373`

View PR using the GUI difftool: \
`$ git pr show -t 1373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1373.diff">https://git.openjdk.org/jdk11u-dev/pull/1373.diff</a>

</details>
