### PR TITLE
8284732: FFI_GO_CLOSURES macro not defined but required for zero build on Mac OS X

### DIFF
--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -30,6 +30,10 @@
 #define SUPPORTS_NATIVE_CX8
 #endif
 
+#ifndef FFI_GO_CLOSURES
+#define FFI_GO_CLOSURES 0
+#endif
+
 #include <ffi.h>
 
 // Indicates whether the C calling conventions require that


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284732](https://bugs.openjdk.org/browse/JDK-8284732): FFI_GO_CLOSURES macro not defined but required for zero build on Mac OS X


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1374/head:pull/1374` \
`$ git checkout pull/1374`

Update a local copy of the PR: \
`$ git checkout pull/1374` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1374`

View PR using the GUI difftool: \
`$ git pr show -t 1374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1374.diff">https://git.openjdk.org/jdk11u-dev/pull/1374.diff</a>

</details>
