### PR TITLE
8284752: Zero does not build on Mac OS X due to missing os::current_thread_enable_wx implementation

### DIFF
--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
@@ -466,3 +466,9 @@ int os::extra_bang_size_in_bytes() {
   // Zero does not require an additional stack bang.
   return 0;
 }
+
+#if defined(AARCH64) && defined(__APPLE__)
+void os::current_thread_enable_wx(WXMode mode) {
+  pthread_jit_write_protect_np(mode == WXExec);
+}
+#endif


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284752](https://bugs.openjdk.org/browse/JDK-8284752): Zero does not build on Mac OS X due to missing os::current_thread_enable_wx implementation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1375/head:pull/1375` \
`$ git checkout pull/1375`

Update a local copy of the PR: \
`$ git checkout pull/1375` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1375`

View PR using the GUI difftool: \
`$ git pr show -t 1375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1375.diff">https://git.openjdk.org/jdk11u-dev/pull/1375.diff</a>

</details>
