### PR TITLE
8285836: sun/net/www/http/KeepAliveCache/KeepAliveProperty.java failed with "RuntimeException: Failed in server"

### DIFF
--- a/test/jdk/sun/net/www/http/KeepAliveCache/KeepAliveProperty.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/KeepAliveProperty.java
@@ -40,6 +40,7 @@ import static java.net.Proxy.NO_PROXY;
 public class KeepAliveProperty {
 
     static volatile boolean pass = false;
+    static Logger logger = Logger.getLogger("sun.net.www.protocol.http.HttpURLConnection");
 
     static class Server extends Thread {
         final ServerSocket server;
@@ -138,7 +139,6 @@ public class KeepAliveProperty {
 
     public static void main(String args[]) throws Exception {
         // exercise the logging code
-        Logger logger = Logger.getLogger("sun.net.www.protocol.http.HttpURLConnection");
         logger.setLevel(Level.FINEST);
         ConsoleHandler h = new ConsoleHandler();
         h.setLevel(Level.FINEST);
@@ -171,6 +171,7 @@ public class KeepAliveProperty {
             if (!expectClose)
                 throw e;
         }
+        s.join();
 
         if (!pass)
             throw new RuntimeException("Failed in server");


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285836](https://bugs.openjdk.org/browse/JDK-8285836): sun/net/www/http/KeepAliveCache/KeepAliveProperty.java failed with "RuntimeException: Failed in server"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1377/head:pull/1377` \
`$ git checkout pull/1377`

Update a local copy of the PR: \
`$ git checkout pull/1377` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1377`

View PR using the GUI difftool: \
`$ git pr show -t 1377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1377.diff">https://git.openjdk.org/jdk11u-dev/pull/1377.diff</a>

</details>
