### PR TITLE
8284977: MetricsTesterCgroupV2.getLongValueEntryFromFile fails when named value doesn't exist

### DIFF
--- a/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
+++ b/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV2.java
@@ -121,6 +121,11 @@ public class MetricsTesterCgroupV2 implements CgroupMetricsTester {
         Path filePath = Paths.get(UNIFIED.getPath(), file);
         try {
             String strVal = Files.lines(filePath).filter(l -> l.startsWith(metric)).collect(Collectors.joining());
+            if (strVal.isEmpty()) {
+                // sometimes the match for the metric does not exist, e.g. cpu.stat's nr_periods iff the controller
+                // is not enabled
+                return UNLIMITED;
+            }
             String[] keyValues = strVal.split("\\s+");
             String value = keyValues[1];
             return convertStringToLong(value);


### PR DESCRIPTION
I'd like to backport this to jdk11u-dev. It fixes a test failure caused due to expected cgroups virtual files (nr_quota etc) not existing in some circumstances/some systems. The patch cherry picks clean, touches one test library file, which is exercised by running ./test/jdk/jdk/internal/platform/cgroup/TestCgroupMetrics.java, which fails in current 11u-dev and passes after this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284977](https://bugs.openjdk.org/browse/JDK-8284977): MetricsTesterCgroupV2.getLongValueEntryFromFile fails when named value doesn't exist


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1379/head:pull/1379` \
`$ git checkout pull/1379`

Update a local copy of the PR: \
`$ git checkout pull/1379` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1379`

View PR using the GUI difftool: \
`$ git pr show -t 1379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1379.diff">https://git.openjdk.org/jdk11u-dev/pull/1379.diff</a>

</details>
