### PR TITLE
8290781: Segfault at PhaseIdealLoop::clone_loop_handle_data_uses

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1868,11 +1868,18 @@ static void clone_outer_loop_helper(Node* n, const IdealLoopTree *loop, const Id
       Node* c = phase->get_ctrl(u);
       IdealLoopTree* u_loop = phase->get_loop(c);
       assert(!loop->is_member(u_loop), "can be in outer loop or out of both loops only");
-      if (outer_loop->is_member(u_loop) ||
-          // nodes pinned with control in the outer loop but not referenced from the safepoint must be moved out of
-          // the outer loop too
-          (u->in(0) != NULL && outer_loop->is_member(phase->get_loop(u->in(0))))) {
+      if (outer_loop->is_member(u_loop)) {
         wq.push(u);
+      } else {
+        // nodes pinned with control in the outer loop but not referenced from the safepoint must be moved out of
+        // the outer loop too
+        Node* u_c = u->in(0);
+        if (u_c != NULL) {
+          IdealLoopTree* u_c_loop = phase->get_loop(u_c);
+          if (outer_loop->is_member(u_c_loop) && !loop->is_member(u_c_loop)) {
+            wq.push(u);
+          }
+        }
       }
     }
   }

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestLSMBadControlOverride.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestLSMBadControlOverride.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8290781
+ * @summary Segfault at PhaseIdealLoop::clone_loop_handle_data_uses
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:-TieredCompilation TestLSMBadControlOverride
+ */
+
+public class TestLSMBadControlOverride {
+    private static volatile int barrier;
+
+    public static void main(String[] args) {
+        int[] array = new int[100];
+        int[] small = new int[10];
+        for (int i = 0; i < 20_000; i++) {
+            test(array, array, true, true);
+            test(array, array, true, false);
+            test(array, array, false, false);
+            try {
+                test(small, array,true, true);
+            } catch (ArrayIndexOutOfBoundsException aieoobe) {
+
+            }
+        }
+    }
+
+    private static int test(int[] array, int[] array2, boolean flag1, boolean flag2) {
+        int i;
+        int v = 0;
+        int v1 = 0;
+        for (i = 0; i < 100; i++) {
+            v1 = array[i];
+        }
+        v += v1;
+        if (flag1) {
+            if (flag2) {
+                barrier = 42;
+            }
+        }
+        for (int j = 0; j < 100; j++) {
+            array[j] = j;
+            v += array[i-1];
+        }
+        return v;
+    }
+}


### PR DESCRIPTION
Backport of JDK-8290781 for 11u.

Fixes a crash during C2 compilation. The fix is low risk and applies cleanly. Already tested and backported to JDK 19u, Oracle JDK 11u and 17u. 

Tested by 
- running jtreg tier1, tier2, jck runtime on linux x64, x86, aarch64
- manually ran test from the JBS description with specified parameters.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290781](https://bugs.openjdk.org/browse/JDK-8290781): Segfault at PhaseIdealLoop::clone_loop_handle_data_uses


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1382/head:pull/1382` \
`$ git checkout pull/1382`

Update a local copy of the PR: \
`$ git checkout pull/1382` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1382`

View PR using the GUI difftool: \
`$ git pr show -t 1382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1382.diff">https://git.openjdk.org/jdk11u-dev/pull/1382.diff</a>

</details>
