### PR TITLE
8282276: Problem list failing two Robot Screen Capture tests

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -757,6 +757,7 @@ javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
 javax/swing/plaf/synth/7158712/bug7158712.java 8238720 windows-all
 javax/swing/plaf/basic/BasicComboPopup/JComboBoxPopupLocation/JComboBoxPopupLocation.java 8238720 windows-all
 javax/swing/plaf/basic/BasicComboPopup/7072653/bug7072653.java 8238720 windows-all
+java/awt/Robot/HiDPIScreenCapture/HiDPIRobotScreenCaptureTest.java 8282270 windows-all
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 


### PR DESCRIPTION
Backport https://github.com/openjdk/jdk/commit/2557ef8a02fe19784bd5e605b11d6bd574cde2c2. 

The backport is not clean as one of the test in original problem list `java/awt/Robot/HiDPIScreenCapture/ScreenCaptureGtkTest.java` is not in [jdk11u-dev](https://github.com/openjdk/jdk11u-dev). I removed `ScreenCaptureGtkTest.java` from this commit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282276](https://bugs.openjdk.org/browse/JDK-8282276): Problem list failing two Robot Screen Capture tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1385/head:pull/1385` \
`$ git checkout pull/1385`

Update a local copy of the PR: \
`$ git checkout pull/1385` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1385`

View PR using the GUI difftool: \
`$ git pr show -t 1385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1385.diff">https://git.openjdk.org/jdk11u-dev/pull/1385.diff</a>

</details>
