### PR TITLE
8290711: assert(false) failed: infinite loop in PhaseIterGVN::optimize

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1845,6 +1845,10 @@ void PhaseCCP::analyze() {
   // This loop is the meat of CCP.
   while( worklist.size() ) {
     Node *n = worklist.pop();
+    if (n->is_SafePoint()) {
+      // Keep track of SafePoint nodes for PhaseCCP::transform()
+      _safepoints.push(n);
+    }
     const Type *t = n->Value(this);
     if (t != type(n)) {
       assert(ccp_type_widens(t, type(n)), "ccp type must widen");
@@ -1961,6 +1965,23 @@ Node *PhaseCCP::transform( Node *n ) {
   GrowableArray <Node *> trstack(C->live_nodes() >> 1);
 
   trstack.push(new_node);           // Process children of cloned node
+
+  // This CCP pass may prove that no exit test for a loop ever succeeds (i.e. the loop is infinite). In that case,
+  // the logic below doesn't follow any path from Root to the loop body: there's at least one such path but it's proven
+  // never taken (its type is TOP). As a consequence the node on the exit path that's input to Root (let's call it n) is
+  // replaced by the top node and the inputs of that node n are not enqueued for further processing. If CCP only works
+  // through the graph from Root, this causes the loop body to never be processed here even when it's not dead (that
+  // is reachable from Root following its uses). To prevent that issue, transform() starts walking the graph from Root
+  // and all safepoints.
+  for (uint i = 0; i < _safepoints.size(); ++i) {
+    Node* nn = _safepoints.at(i);
+    Node* new_node = _nodes[nn->_idx];
+    assert(new_node == NULL, "");
+    new_node = transform_once(nn);
+    _nodes.map(nn->_idx, new_node);
+    trstack.push(new_node);
+  }
+
   while ( trstack.is_nonempty() ) {
     Node *clone = trstack.pop();
     uint cnt = clone->req();

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -582,6 +582,7 @@ protected:
 // Phase for performing global Conditional Constant Propagation.
 // Should be replaced with combined CCP & GVN someday.
 class PhaseCCP : public PhaseIterGVN {
+  Unique_Node_List _safepoints;
   // Non-recursive.  Use analysis to transform single Node.
   virtual Node *transform_once( Node *n );
 

--- a/test/hotspot/jtreg/compiler/ccp/TestInfiniteIGVNAfterCCP.java
+++ b/test/hotspot/jtreg/compiler/ccp/TestInfiniteIGVNAfterCCP.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8290711
+ * @summary assert(false) failed: infinite loop in PhaseIterGVN::optimize
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:-TieredCompilation TestInfiniteIGVNAfterCCP
+ */
+
+
+import java.util.function.BooleanSupplier;
+
+public class TestInfiniteIGVNAfterCCP {
+    private static int inc;
+    private static volatile boolean barrier;
+
+    static class A {
+        int field1;
+        int field2;
+    }
+
+    public static void main(String[] args) {
+        A a = new A();
+        for (int i = 0; i < 20_000; i++) {
+            test(false, a, false);
+            inc = 0;
+            testHelper(true, () -> inc < 10, a, 4, true);
+            inc = 0;
+            testHelper(true, () -> inc < 10, a, 4, false);
+            testHelper(false, () -> inc < 10, a, 42, false);
+        }
+    }
+
+    private static void test(boolean flag2, A a, boolean flag1) {
+        int i = 2;
+        for (; i < 4; i *= 2);
+        testHelper(flag2, () -> true, a, i, flag1);
+    }
+
+    private static void testHelper(boolean flag2, BooleanSupplier f, A a, int i, boolean flag1) {
+        if (i == 4) {
+            if (a == null) {
+
+            }
+        } else {
+            a = null;
+        }
+        if (flag2) {
+            while (true) {
+                synchronized (new Object()) {
+
+                }
+                if (!f.getAsBoolean()) {
+                    break;
+                }
+                if (flag1) {
+                    if (a == null) {
+
+                    }
+                }
+                barrier = true;
+                inc++;
+                if (inc % 2 == 0) {
+                    a.field1++;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backport for https://bugs.openjdk.org/browse/JDK-8290711 assert(false) failed: infinite loop in PhaseIterGVN::optimize

Backport this for parity with 17.0.6-oracle, fixes vm crash
Backport not clean, however the resolve is trivial.

How it was tested: 
* was able to reproduce test failure. Test fails on fastdebug build without the fix, passes with the fix. 
* jtreg tier1, tier 2, jck runtime is fine

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290711](https://bugs.openjdk.org/browse/JDK-8290711): assert(false) failed: infinite loop in PhaseIterGVN::optimize


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1387/head:pull/1387` \
`$ git checkout pull/1387`

Update a local copy of the PR: \
`$ git checkout pull/1387` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1387`

View PR using the GUI difftool: \
`$ git pr show -t 1387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1387.diff">https://git.openjdk.org/jdk11u-dev/pull/1387.diff</a>

</details>
