### PR TITLE
8233565: [TESTBUG] NullModalityDialogTest.java fails on MacOS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -482,7 +482,6 @@ java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsDocModalTest.java 816
 java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 7099223 linux-all,solaris-all,windows-all
 java/awt/Window/WindowResizing/DoubleClickTitleBarTest.java 8233557 macosx-all
 java/awt/Window/WindowOwnedByEmbeddedFrameTest/WindowOwnedByEmbeddedFrameTest.java 8233558 macosx-all
-java/awt/Modal/NullModalityDialogTest/NullModalityDialogTest.java 8233565 macosx-all
 java/awt/keyboard/AllKeyCode/AllKeyCode.java 8242930 macosx-all
 java/awt/FullScreen/8013581/bug8013581.java 8169471 macosx-all
 java/awt/event/MouseEvent/RobotLWTest/RobotLWTest.java 8233568 macosx-all

--- a/test/jdk/java/awt/Modal/NullModalityDialogTest/NullModalityDialogTest.java
+++ b/test/jdk/java/awt/Modal/NullModalityDialogTest/NullModalityDialogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,8 @@ public class NullModalityDialogTest {
     NullModalityDialogTest() throws Exception {
 
         robot = new ExtendedRobot();
-        EventQueue.invokeLater(this::createGUI);
+        robot.setAutoDelay(100);
+        EventQueue.invokeAndWait(this::createGUI);
     }
 
     private void createGUI() {
@@ -133,7 +134,9 @@ public class NullModalityDialogTest {
 
         dialog.openGained.reset();
 
-        robot.type(KeyEvent.VK_TAB);
+        robot.keyPress(KeyEvent.VK_TAB);
+        robot.keyRelease(KeyEvent.VK_TAB);
+        robot.waitForIdle();
 
         dialog.openGained.waitForFlagTriggered();
         assertTrue(dialog.openGained.flag(),


### PR DESCRIPTION
Not a clean backport:
* conflict in copyright year
* removing the test from ProblemList.txt is not clean because surrounding lines are different

Passes NullModalityDialogTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233565](https://bugs.openjdk.org/browse/JDK-8233565): [TESTBUG] NullModalityDialogTest.java fails on MacOS


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1392/head:pull/1392` \
`$ git checkout pull/1392`

Update a local copy of the PR: \
`$ git checkout pull/1392` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1392`

View PR using the GUI difftool: \
`$ git pr show -t 1392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1392.diff">https://git.openjdk.org/jdk11u-dev/pull/1392.diff</a>

</details>
