### PR TITLE
8215571: jdb does not include jdk.* in the default class filter

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Env.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/Env.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ class Env {
 
     static private List<String> excludes() {
         if (excludes == null) {
-            setExcludes("java.*, javax.*, sun.*, com.sun.*");
+            setExcludes("java.*, javax.*, sun.*, com.sun.*, jdk.*");
         }
         return excludes;
     }


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8215571](https://bugs.openjdk.org/browse/JDK-8215571): jdb does not include jdk.* in the default class filter


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1393/head:pull/1393` \
`$ git checkout pull/1393`

Update a local copy of the PR: \
`$ git checkout pull/1393` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1393`

View PR using the GUI difftool: \
`$ git pr show -t 1393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1393.diff">https://git.openjdk.org/jdk11u-dev/pull/1393.diff</a>

</details>
