### PR TITLE
8243568: serviceability/logging/TestLogRotation.java uses 'test.java.opts' and not 'test.vm.opts'

### DIFF
--- a/test/hotspot/jtreg/serviceability/logging/TestLogRotation.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestLogRotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm/timeout=600 TestLogRotation
+ * @run driver/timeout=600 TestLogRotation
  *
  */
 import jdk.test.lib.process.ProcessTools;
@@ -78,16 +78,10 @@ public class TestLogRotation {
             "-Xlog:gc=debug:" + logFileName + "::filesize=" + logFileSizeK + "k,filecount=" + numberOfFiles,
             "-XX:-DisableExplicitGC", // to ensure that System.gc() works
             "-Xmx128M"};
-        // System.getProperty("test.java.opts") is '' if no options is set
-        // need to skip such empty
-        String[] externalVMopts = System.getProperty("test.java.opts").length() == 0
-                ? new String[0]
-                : System.getProperty("test.java.opts").split(" ");
-        args.addAll(Arrays.asList(externalVMopts));
         args.addAll(Arrays.asList(logOpts));
         args.add(GCLoggingGenerator.class.getName());
         args.add(String.valueOf(numberOfFiles * logFileSizeK * 1024));
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args.toArray(new String[0]));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, args.toArray(String[]::new));
         pb.redirectErrorStream(true);
         pb.redirectOutput(new File(GCLoggingGenerator.class.getName() + ".log"));
         Process process = pb.start();


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8243568](https://bugs.openjdk.org/browse/JDK-8243568): serviceability/logging/TestLogRotation.java uses 'test.java.opts' and not 'test.vm.opts'


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1394/head:pull/1394` \
`$ git checkout pull/1394`

Update a local copy of the PR: \
`$ git checkout pull/1394` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1394`

View PR using the GUI difftool: \
`$ git pr show -t 1394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1394.diff">https://git.openjdk.org/jdk11u-dev/pull/1394.diff</a>

</details>
