### PR TITLE
8243565: some gc tests use 'test.java.opts' and not 'test.vm.opts'

### DIFF
--- a/test/hotspot/jtreg/gc/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAt.java
@@ -29,7 +29,7 @@ package gc;
  * @requires vm.gc != "Z" & os.family != "aix"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run main gc.TestAllocateHeapAt
+ * @run driver gc.TestAllocateHeapAt
  */
 
 import jdk.test.lib.JDKToolFinder;
@@ -40,28 +40,15 @@ import java.util.Collections;
 
 public class TestAllocateHeapAt {
   public static void main(String args[]) throws Exception {
-    ArrayList<String> vmOpts = new ArrayList<>();
-
-    String testVmOptsStr = System.getProperty("test.java.opts");
-    if (!testVmOptsStr.isEmpty()) {
-      String[] testVmOpts = testVmOptsStr.split(" ");
-      Collections.addAll(vmOpts, testVmOpts);
-    }
     String test_dir = System.getProperty("test.dir", ".");
-    Collections.addAll(vmOpts, new String[] {"-XX:AllocateHeapAt=" + test_dir,
-                                             "-Xlog:gc+heap=info",
-                                             "-Xmx32m",
-                                             "-Xms32m",
-                                             "-version"});
+    String[] flags = {
+        "-XX:AllocateHeapAt=" + test_dir,
+        "-Xlog:gc+heap=info",
+        "-Xmx32m",
+        "-Xms32m",
+        "-version"};
 
-    System.out.print("Testing:\n" + JDKToolFinder.getJDKTool("java"));
-    for (int i = 0; i < vmOpts.size(); i += 1) {
-      System.out.print(" " + vmOpts.get(i));
-    }
-    System.out.println();
-
-    ProcessBuilder pb =
-      ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, flags);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAtError.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAtError.java
@@ -29,26 +29,16 @@ package gc;
  * @requires vm.gc != "Z" & os.family != "aix"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run main gc.TestAllocateHeapAtError
+ * @run driver gc.TestAllocateHeapAtError
  */
 
 import java.io.File;
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.UUID;
 
 public class TestAllocateHeapAtError {
   public static void main(String args[]) throws Exception {
-    ArrayList<String> vmOpts = new ArrayList<>();
-
-    String testVmOptsStr = System.getProperty("test.java.opts");
-    if (!testVmOptsStr.isEmpty()) {
-      String[] testVmOpts = testVmOptsStr.split(" ");
-      Collections.addAll(vmOpts, testVmOpts);
-    }
     String test_dir = System.getProperty("test.dir", ".");
 
     File f = null;
@@ -56,20 +46,14 @@ public class TestAllocateHeapAtError {
       f = new File(test_dir, UUID.randomUUID().toString());
     } while(f.exists());
 
-    Collections.addAll(vmOpts, new String[] {"-XX:AllocateHeapAt=" + f.getName(),
-                                             "-Xlog:gc+heap=info",
-                                             "-Xmx32m",
-                                             "-Xms32m",
-                                             "-version"});
+    String[] flags = {
+        "-XX:AllocateHeapAt=" + f.getName(),
+        "-Xlog:gc+heap=info",
+        "-Xmx32m",
+        "-Xms32m",
+        "-version"};
 
-    System.out.print("Testing:\n" + JDKToolFinder.getJDKTool("java"));
-    for (int i = 0; i < vmOpts.size(); i += 1) {
-      System.out.print(" " + vmOpts.get(i));
-    }
-    System.out.println();
-
-    ProcessBuilder pb =
-      ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, flags);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
@@ -29,7 +29,7 @@ package gc;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @requires vm.bits == "64" & vm.gc != "Z" & os.family != "aix"
- * @run main/timeout=360 gc.TestAllocateHeapAtMultiple
+ * @run driver/timeout=360 gc.TestAllocateHeapAtMultiple
  */
 
 import jdk.test.lib.JDKToolFinder;
@@ -40,48 +40,30 @@ import java.util.Collections;
 
 public class TestAllocateHeapAtMultiple {
   public static void main(String args[]) throws Exception {
-    ArrayList<String> vmOpts = new ArrayList<>();
-    String[] testVmOpts = null;
+    ArrayList<String> flags = new ArrayList<>();
 
     String test_dir = System.getProperty("test.dir", ".");
 
-    String testVmOptsStr = System.getProperty("test.java.opts");
-    if (!testVmOptsStr.isEmpty()) {
-      testVmOpts = testVmOptsStr.split(" ");
-    }
-
-    // Extra options for each of the sub-tests
-    String[] extraOptsList = new String[] {
-      "-Xmx32m -Xms32m -XX:+UseCompressedOops",     // 1. With compressedoops enabled.
-      "-Xmx32m -Xms32m -XX:-UseCompressedOops",     // 2. With compressedoops disabled.
-      "-Xmx32m -Xms32m -XX:HeapBaseMinAddress=3g",  // 3. With user specified HeapBaseMinAddress.
-      "-Xmx32m -Xms32m -XX:+UseLargePages",         // 4. Set UseLargePages.
-      "-Xmx32m -Xms32m -XX:+UseNUMA"                // 5. Set UseNUMA.
+    // Extra flags for each of the sub-tests
+    String[][] extraFlagsList = new String[][] {
+      {"-Xmx32m", "-Xms32m", "-XX:+UseCompressedOops"},     // 1. With compressedoops enabled.
+      {"-Xmx32m", "-Xms32m", "-XX:-UseCompressedOops"},     // 2. With compressedoops disabled.
+      {"-Xmx32m", "-Xms32m", "-XX:HeapBaseMinAddress=3g"},  // 3. With user specified HeapBaseMinAddress.
+      {"-Xmx32m", "-Xms32m", "-XX:+UseLargePages"},         // 4. Set UseLargePages.
+      {"-Xmx32m", "-Xms32m", "-XX:+UseNUMA"}                // 5. Set UseNUMA.
     };
 
-    for(String extraOpts : extraOptsList) {
-      vmOpts.clear();
-      if(testVmOpts != null) {
-        Collections.addAll(vmOpts, testVmOpts);
-      }
-      // Add extra options specific to the sub-test.
-      String[] extraOptsArray = extraOpts.split(" ");
-      if(extraOptsArray != null) {
-        Collections.addAll(vmOpts, extraOptsArray);
-      }
-      // Add common options
-      Collections.addAll(vmOpts, new String[] {"-XX:AllocateHeapAt=" + test_dir,
-                                               "-Xlog:gc+heap=info",
-                                               "-version"});
-
-      System.out.print("Testing:\n" + JDKToolFinder.getJDKTool("java"));
-      for (int i = 0; i < vmOpts.size(); i += 1) {
-        System.out.print(" " + vmOpts.get(i));
-      }
-      System.out.println();
+    for (String[] extraFlags : extraFlagsList) {
+      flags.clear();
+      // Add extra flags specific to the sub-test.
+      Collections.addAll(flags, extraFlags);
+      // Add common flags
+      Collections.addAll(flags, new String[] {"-XX:AllocateHeapAt=" + test_dir,
+                                              "-Xlog:gc+heap=info",
+                                              "-version"});
 
       ProcessBuilder pb =
-        ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+          ProcessTools.createJavaProcessBuilder(true, flags.toArray(String[]::new));
       OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
       System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/TestVerifyDuringStartup.java
+++ b/test/hotspot/jtreg/gc/TestVerifyDuringStartup.java
@@ -30,38 +30,22 @@ package gc;
  * @requires vm.gc != "Z"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run main gc.TestVerifyDuringStartup
+ * @run driver gc.TestVerifyDuringStartup
  */
 
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
-import java.util.ArrayList;
-import java.util.Collections;
 
 public class TestVerifyDuringStartup {
   public static void main(String args[]) throws Exception {
-    ArrayList<String> vmOpts = new ArrayList<>();
+    String[] flags = {
+        "-XX:-UseTLAB",
+        "-XX:+UnlockDiagnosticVMOptions",
+        "-XX:+VerifyDuringStartup",
+        "-Xlog:gc+verify=debug",
+        "-version"};
 
-    String testVmOptsStr = System.getProperty("test.java.opts");
-    if (!testVmOptsStr.isEmpty()) {
-      String[] testVmOpts = testVmOptsStr.split(" ");
-      Collections.addAll(vmOpts, testVmOpts);
-    }
-    Collections.addAll(vmOpts, new String[] {"-XX:-UseTLAB",
-                                             "-XX:+UnlockDiagnosticVMOptions",
-                                             "-XX:+VerifyDuringStartup",
-                                             "-Xlog:gc+verify=debug",
-                                             "-version"});
-
-    System.out.print("Testing:\n" + JDKToolFinder.getJDKTool("java"));
-    for (int i = 0; i < vmOpts.size(); i += 1) {
-      System.out.print(" " + vmOpts.get(i));
-    }
-    System.out.println();
-
-    ProcessBuilder pb =
-      ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, flags);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
@@ -152,10 +152,9 @@ class TestMaxHeapSizeTools {
    * @param vmargs Arguments to the VM to run
    * @param classname Name of the class to run
    * @param arguments Arguments to the class
-   * @param useTestDotJavaDotOpts Use test.java.opts as part of the VM argument string
    * @return The OutputAnalyzer with the results for the invocation.
    */
-  public static OutputAnalyzer runWhiteBoxTest(String[] vmargs, String classname, String[] arguments, boolean useTestDotJavaDotOpts) throws Exception {
+  public static OutputAnalyzer runWhiteBoxTest(String[] vmargs, String classname, String[] arguments) throws Exception {
     ArrayList<String> finalargs = new ArrayList<String>();
 
     String[] whiteboxOpts = new String[] {
@@ -164,22 +163,12 @@ class TestMaxHeapSizeTools {
       "-cp", System.getProperty("java.class.path"),
     };
 
-    if (useTestDotJavaDotOpts) {
-      // System.getProperty("test.java.opts") is '' if no options is set,
-      // we need to skip such a result
-      String[] externalVMOpts = new String[0];
-      if (System.getProperty("test.java.opts") != null && System.getProperty("test.java.opts").length() != 0) {
-        externalVMOpts = System.getProperty("test.java.opts").split(" ");
-      }
-      finalargs.addAll(Arrays.asList(externalVMOpts));
-    }
-
     finalargs.addAll(Arrays.asList(vmargs));
     finalargs.addAll(Arrays.asList(whiteboxOpts));
     finalargs.add(classname);
     finalargs.addAll(Arrays.asList(arguments));
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(new String[0]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(String[]::new));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
 
@@ -187,7 +176,7 @@ class TestMaxHeapSizeTools {
   }
 
   private static void getMinInitialMaxHeap(String[] args, MinInitialMaxValues val) throws Exception {
-    OutputAnalyzer output = runWhiteBoxTest(args, ErgoArgsPrinter.class.getName(), new String[] {}, false);
+    OutputAnalyzer output = runWhiteBoxTest(args, ErgoArgsPrinter.class.getName(), new String[] {});
 
     // the output we watch for has the following format:
     //

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgo.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgo.java
@@ -35,8 +35,8 @@ package gc.arguments;
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseSerialGC
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run driver gc.arguments.TestUseCompressedOopsErgo -XX:+UseSerialGC
  */
 
 /*
@@ -51,9 +51,9 @@ package gc.arguments;
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC -XX:-UseParallelOldGC
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run driver gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC
+ * @run driver gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC -XX:-UseParallelOldGC
  */
 
 /*
@@ -68,8 +68,8 @@ package gc.arguments;
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseG1GC
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run driver gc.arguments.TestUseCompressedOopsErgo -XX:+UseG1GC
  */
 
 /*
@@ -84,8 +84,8 @@ package gc.arguments;
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseConcMarkSweepGC
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run driver gc.arguments.TestUseCompressedOopsErgo -XX:+UseConcMarkSweepGC
  */
 
 /*
@@ -100,8 +100,8 @@ package gc.arguments;
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run driver gc.arguments.TestUseCompressedOopsErgo -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC
  */
 
 public class TestUseCompressedOopsErgo {

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
@@ -56,7 +56,7 @@ class TestUseCompressedOopsErgoTools {
 
 
   public static long getMaxHeapForCompressedOops(String[] vmargs) throws Exception {
-    OutputAnalyzer output = runWhiteBoxTest(vmargs, DetermineMaxHeapForCompressedOops.class.getName(), new String[] {}, false);
+    OutputAnalyzer output = runWhiteBoxTest(vmargs, DetermineMaxHeapForCompressedOops.class.getName(), new String[] {});
     return Long.parseLong(output.getStdout());
   }
 
@@ -78,10 +78,9 @@ class TestUseCompressedOopsErgoTools {
    * @param vmargs Arguments to the VM to run
    * @param classname Name of the class to run
    * @param arguments Arguments to the class
-   * @param useTestDotJavaDotOpts Use test.java.opts as part of the VM argument string
    * @return The OutputAnalyzer with the results for the invocation.
    */
-  public static OutputAnalyzer runWhiteBoxTest(String[] vmargs, String classname, String[] arguments, boolean useTestDotJavaDotOpts) throws Exception {
+  public static OutputAnalyzer runWhiteBoxTest(String[] vmargs, String classname, String[] arguments) throws Exception {
     ArrayList<String> finalargs = new ArrayList<String>();
 
     String[] whiteboxOpts = new String[] {
@@ -90,22 +89,12 @@ class TestUseCompressedOopsErgoTools {
       "-cp", System.getProperty("java.class.path"),
     };
 
-    if (useTestDotJavaDotOpts) {
-      // System.getProperty("test.java.opts") is '' if no options is set,
-      // we need to skip such a result
-      String[] externalVMOpts = new String[0];
-      if (System.getProperty("test.java.opts") != null && System.getProperty("test.java.opts").length() != 0) {
-        externalVMOpts = System.getProperty("test.java.opts").split(" ");
-      }
-      finalargs.addAll(Arrays.asList(externalVMOpts));
-    }
-
     finalargs.addAll(Arrays.asList(vmargs));
     finalargs.addAll(Arrays.asList(whiteboxOpts));
     finalargs.add(classname);
     finalargs.addAll(Arrays.asList(arguments));
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(new String[0]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(String[]::new));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
     return output;
@@ -115,7 +104,7 @@ class TestUseCompressedOopsErgoTools {
     ArrayList<String> result = new ArrayList<String>();
     result.addAll(Arrays.asList(part1));
     result.add(part2);
-    return result.toArray(new String[0]);
+    return result.toArray(String[]::new);
   }
 
   public static void checkCompressedOopsErgo(String[] gcflags) throws Exception {

--- a/test/hotspot/jtreg/gc/g1/TestHumongousCodeCacheRoots.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousCodeCacheRoots.java
@@ -33,10 +33,10 @@ package gc.g1;
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                              sun.hotspot.WhiteBox$WhiteBoxPermission
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @summary Humongous objects may have references from the code cache
- * @run main gc.g1.TestHumongousCodeCacheRoots
-*/
+ * @run driver gc.g1.TestHumongousCodeCacheRoots
+ */
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
@@ -92,10 +92,9 @@ public class TestHumongousCodeCacheRoots {
    * @param vmargs Arguments to the VM to run
    * @param classname Name of the class to run
    * @param arguments Arguments to the class
-   * @param useTestDotJavaDotOpts Use test.java.opts as part of the VM argument string
    * @return The OutputAnalyzer with the results for the invocation.
    */
-  public static OutputAnalyzer runWhiteBoxTest(String[] vmargs, String classname, String[] arguments, boolean useTestDotJavaDotOpts) throws Exception {
+  public static OutputAnalyzer runWhiteBoxTest(String[] vmargs, String classname, String[] arguments) throws Exception {
     ArrayList<String> finalargs = new ArrayList<String>();
 
     String[] whiteboxOpts = new String[] {
@@ -104,22 +103,12 @@ public class TestHumongousCodeCacheRoots {
       "-cp", System.getProperty("java.class.path"),
     };
 
-    if (useTestDotJavaDotOpts) {
-      // System.getProperty("test.java.opts") is '' if no options is set,
-      // we need to skip such a result
-      String[] externalVMOpts = new String[0];
-      if (System.getProperty("test.java.opts") != null && System.getProperty("test.java.opts").length() != 0) {
-        externalVMOpts = System.getProperty("test.java.opts").split(" ");
-      }
-      finalargs.addAll(Arrays.asList(externalVMOpts));
-    }
-
     finalargs.addAll(Arrays.asList(vmargs));
     finalargs.addAll(Arrays.asList(whiteboxOpts));
     finalargs.add(classname);
     finalargs.addAll(Arrays.asList(arguments));
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs.toArray(new String[0]));
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs.toArray(String[]::new));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
     return output;
@@ -133,8 +122,7 @@ public class TestHumongousCodeCacheRoots {
       "-XX:+G1VerifyHeapRegionCodeRoots", "-XX:+VerifyAfterGC", // make sure that verification is run
     };
 
-    runWhiteBoxTest(baseArguments, TestHumongousCodeCacheRootsHelper.class.getName(),
-      new String[] {}, false);
+    runWhiteBoxTest(baseArguments, TestHumongousCodeCacheRootsHelper.class.getName(), new String[] { });
   }
 }
 


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.
TestUseCompressedOopsErgo.java has two additional test cases I had to resolve.
nvdimm tests are not in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8243565](https://bugs.openjdk.org/browse/JDK-8243565): some gc tests use 'test.java.opts' and not 'test.vm.opts'


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1395/head:pull/1395` \
`$ git checkout pull/1395`

Update a local copy of the PR: \
`$ git checkout pull/1395` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1395`

View PR using the GUI difftool: \
`$ git pr show -t 1395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1395.diff">https://git.openjdk.org/jdk11u-dev/pull/1395.diff</a>

</details>
