### PR TITLE
8244010: Simplify usages of ProcessTools.createJavaProcessBuilder in our tests

### DIFF
--- a/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
@@ -141,7 +141,7 @@ public abstract class CiReplayBase {
                         RUN_SHELL_NO_LIMIT, options.toArray(new String[0])));
             } else {
                 crashOut = ProcessTools.executeProcess(ProcessTools.createJavaProcessBuilder(true,
-                        options.toArray(new String[0])));
+                        options));
             }
             crashOutputString = crashOut.getOutput();
             Asserts.assertNotEquals(crashOut.getExitValue(), 0, "Crash JVM exits gracefully");

--- a/test/hotspot/jtreg/compiler/graalunit/common/GraalUnitTestLauncher.java
+++ b/test/hotspot/jtreg/compiler/graalunit/common/GraalUnitTestLauncher.java
@@ -264,7 +264,7 @@ public class GraalUnitTestLauncher {
         javaFlags.add("@"+GENERATED_TESTCLASSES_FILENAME);
 
         ProcessBuilder javaPB = ProcessTools.createJavaProcessBuilder(true,
-                javaFlags.toArray(new String[javaFlags.size()]));
+                javaFlags);
         System.out.println("INFO: run command: " + String.join(" ", javaPB.command()));
 
         OutputAnalyzer outputAnalyzer = new OutputAnalyzer(javaPB.start());

--- a/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bmi/BMITestRunner.java
@@ -146,8 +146,7 @@ public class BMITestRunner {
                 new Integer(iterations).toString()
             });
 
-        OutputAnalyzer outputAnalyzer = ProcessTools.
-            executeTestJvm(vmOpts.toArray(new String[vmOpts.size()]));
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm(vmOpts);
 
         outputAnalyzer.shouldHaveExitValue(0);
 

--- a/test/hotspot/jtreg/compiler/jsr292/ContinuousCallSiteTargetChange.java
+++ b/test/hotspot/jtreg/compiler/jsr292/ContinuousCallSiteTargetChange.java
@@ -61,8 +61,7 @@ public class ContinuousCallSiteTargetChange {
         argsList.add(test.getName());
         argsList.add(Integer.toString(ITERATIONS));
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-                argsList.toArray(new String[argsList.size()]));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(argsList);
 
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
 

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/GetFlagValueTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/GetFlagValueTest.java
@@ -64,8 +64,11 @@ public class GetFlagValueTest {
         ProcessBuilder pb;
         OutputAnalyzer out;
 
-        String[] arguments = {"-XX:+UnlockExperimentalVMOptions", "-XX:+EnableJVMCI", "-XX:+PrintFlagsFinal", "-version"};
-        pb = ProcessTools.createJavaProcessBuilder(arguments);
+        pb = ProcessTools.createJavaProcessBuilder(
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCI",
+            "-XX:+PrintFlagsFinal",
+            "-version");
         out = new OutputAnalyzer(pb.start());
 
         out.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/compiler/linkage/TestLinkageErrorInGenerateOopMap.java
+++ b/test/hotspot/jtreg/compiler/linkage/TestLinkageErrorInGenerateOopMap.java
@@ -42,12 +42,15 @@ public class TestLinkageErrorInGenerateOopMap {
     public static void main(String args[]) throws Exception {
         if (args.length == 0) {
             // Spawn new VM instance to execute test
-            String[] flags = {"-noverify", "-XX:-TieredCompilation",
-                              "-XX:CompileCommand=dontinline,compiler/linkage/OSRWithBadOperandStack.m*",
-                              "-XX:-CreateCoredumpOnCrash",
-                              "-Xmx64m",
-                              "compiler.linkage.TestLinkageErrorInGenerateOopMap", "run"};
-            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(flags);
+            String[] flags = {};
+            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                    "-noverify",
+                    "-XX:-TieredCompilation",
+                    "-XX:CompileCommand=dontinline,compiler/linkage/OSRWithBadOperandStack.m*",
+                    "-XX:-CreateCoredumpOnCrash",
+                    "-Xmx64m",
+                    "compiler.linkage.TestLinkageErrorInGenerateOopMap",
+                    "run");
             OutputAnalyzer out = new OutputAnalyzer(pb.start());
             if (out.getExitValue() != 0) {
                 // OSR compilation should exit with an error during OopMap verification

--- a/test/hotspot/jtreg/gc/TestAgeOutput.java
+++ b/test/hotspot/jtreg/gc/TestAgeOutput.java
@@ -84,7 +84,7 @@ public class TestAgeOutput {
     }
 
     public static void runTest(String gcArg) throws Exception {
-        final String[] arguments = {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-Xbootclasspath/a:.",
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+UnlockDiagnosticVMOptions",
@@ -92,10 +92,7 @@ public class TestAgeOutput {
             "-XX:+" + gcArg,
             "-Xmx10M",
             "-Xlog:gc+age=trace",
-            GCTest.class.getName()
-            };
-
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(arguments);
+            GCTest.class.getName());
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
         output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAt.java
@@ -40,15 +40,13 @@ import java.util.Collections;
 
 public class TestAllocateHeapAt {
   public static void main(String args[]) throws Exception {
-    String test_dir = System.getProperty("test.dir", ".");
-    String[] flags = {
-        "-XX:AllocateHeapAt=" + test_dir,
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+        true,
+        "-XX:AllocateHeapAt=" + System.getProperty("test.dir", "."),
         "-Xlog:gc+heap=info",
         "-Xmx32m",
         "-Xms32m",
-        "-version"};
-
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, flags);
+        "-version");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAt.java
@@ -29,7 +29,7 @@ package gc;
  * @requires vm.gc != "Z" & os.family != "aix"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run main gc.TestAllocateHeapAt
+ * @run driver gc.TestAllocateHeapAt
  */
 
 import jdk.test.lib.JDKToolFinder;
@@ -40,28 +40,15 @@ import java.util.Collections;
 
 public class TestAllocateHeapAt {
   public static void main(String args[]) throws Exception {
-    ArrayList<String> vmOpts = new ArrayList<>();
-
-    String testVmOptsStr = System.getProperty("test.java.opts");
-    if (!testVmOptsStr.isEmpty()) {
-      String[] testVmOpts = testVmOptsStr.split(" ");
-      Collections.addAll(vmOpts, testVmOpts);
-    }
     String test_dir = System.getProperty("test.dir", ".");
-    Collections.addAll(vmOpts, new String[] {"-XX:AllocateHeapAt=" + test_dir,
-                                             "-Xlog:gc+heap=info",
-                                             "-Xmx32m",
-                                             "-Xms32m",
-                                             "-version"});
+    String[] flags = {
+        "-XX:AllocateHeapAt=" + test_dir,
+        "-Xlog:gc+heap=info",
+        "-Xmx32m",
+        "-Xms32m",
+        "-version"};
 
-    System.out.print("Testing:\n" + JDKToolFinder.getJDKTool("java"));
-    for (int i = 0; i < vmOpts.size(); i += 1) {
-      System.out.print(" " + vmOpts.get(i));
-    }
-    System.out.println();
-
-    ProcessBuilder pb =
-      ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, flags);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAtError.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAtError.java
@@ -29,26 +29,16 @@ package gc;
  * @requires vm.gc != "Z" & os.family != "aix"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run main gc.TestAllocateHeapAtError
+ * @run driver gc.TestAllocateHeapAtError
  */
 
 import java.io.File;
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.UUID;
 
 public class TestAllocateHeapAtError {
   public static void main(String args[]) throws Exception {
-    ArrayList<String> vmOpts = new ArrayList<>();
-
-    String testVmOptsStr = System.getProperty("test.java.opts");
-    if (!testVmOptsStr.isEmpty()) {
-      String[] testVmOpts = testVmOptsStr.split(" ");
-      Collections.addAll(vmOpts, testVmOpts);
-    }
     String test_dir = System.getProperty("test.dir", ".");
 
     File f = null;
@@ -56,20 +46,14 @@ public class TestAllocateHeapAtError {
       f = new File(test_dir, UUID.randomUUID().toString());
     } while(f.exists());
 
-    Collections.addAll(vmOpts, new String[] {"-XX:AllocateHeapAt=" + f.getName(),
-                                             "-Xlog:gc+heap=info",
-                                             "-Xmx32m",
-                                             "-Xms32m",
-                                             "-version"});
+    String[] flags = {
+        "-XX:AllocateHeapAt=" + f.getName(),
+        "-Xlog:gc+heap=info",
+        "-Xmx32m",
+        "-Xms32m",
+        "-version"};
 
-    System.out.print("Testing:\n" + JDKToolFinder.getJDKTool("java"));
-    for (int i = 0; i < vmOpts.size(); i += 1) {
-      System.out.print(" " + vmOpts.get(i));
-    }
-    System.out.println();
-
-    ProcessBuilder pb =
-      ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, flags);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAtError.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAtError.java
@@ -46,14 +46,13 @@ public class TestAllocateHeapAtError {
       f = new File(test_dir, UUID.randomUUID().toString());
     } while(f.exists());
 
-    String[] flags = {
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+        true,
         "-XX:AllocateHeapAt=" + f.getName(),
         "-Xlog:gc+heap=info",
         "-Xmx32m",
         "-Xms32m",
-        "-version"};
-
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, flags);
+        "-version");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
@@ -29,7 +29,7 @@ package gc;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @requires vm.bits == "64" & vm.gc != "Z" & os.family != "aix"
- * @run main/timeout=360 gc.TestAllocateHeapAtMultiple
+ * @run driver/timeout=360 gc.TestAllocateHeapAtMultiple
  */
 
 import jdk.test.lib.JDKToolFinder;
@@ -40,48 +40,30 @@ import java.util.Collections;
 
 public class TestAllocateHeapAtMultiple {
   public static void main(String args[]) throws Exception {
-    ArrayList<String> vmOpts = new ArrayList<>();
-    String[] testVmOpts = null;
+    ArrayList<String> flags = new ArrayList<>();
 
     String test_dir = System.getProperty("test.dir", ".");
 
-    String testVmOptsStr = System.getProperty("test.java.opts");
-    if (!testVmOptsStr.isEmpty()) {
-      testVmOpts = testVmOptsStr.split(" ");
-    }
-
-    // Extra options for each of the sub-tests
-    String[] extraOptsList = new String[] {
-      "-Xmx32m -Xms32m -XX:+UseCompressedOops",     // 1. With compressedoops enabled.
-      "-Xmx32m -Xms32m -XX:-UseCompressedOops",     // 2. With compressedoops disabled.
-      "-Xmx32m -Xms32m -XX:HeapBaseMinAddress=3g",  // 3. With user specified HeapBaseMinAddress.
-      "-Xmx32m -Xms32m -XX:+UseLargePages",         // 4. Set UseLargePages.
-      "-Xmx32m -Xms32m -XX:+UseNUMA"                // 5. Set UseNUMA.
+    // Extra flags for each of the sub-tests
+    String[][] extraFlagsList = new String[][] {
+      {"-Xmx32m", "-Xms32m", "-XX:+UseCompressedOops"},     // 1. With compressedoops enabled.
+      {"-Xmx32m", "-Xms32m", "-XX:-UseCompressedOops"},     // 2. With compressedoops disabled.
+      {"-Xmx32m", "-Xms32m", "-XX:HeapBaseMinAddress=3g"},  // 3. With user specified HeapBaseMinAddress.
+      {"-Xmx32m", "-Xms32m", "-XX:+UseLargePages"},         // 4. Set UseLargePages.
+      {"-Xmx32m", "-Xms32m", "-XX:+UseNUMA"}                // 5. Set UseNUMA.
     };
 
-    for(String extraOpts : extraOptsList) {
-      vmOpts.clear();
-      if(testVmOpts != null) {
-        Collections.addAll(vmOpts, testVmOpts);
-      }
-      // Add extra options specific to the sub-test.
-      String[] extraOptsArray = extraOpts.split(" ");
-      if(extraOptsArray != null) {
-        Collections.addAll(vmOpts, extraOptsArray);
-      }
-      // Add common options
-      Collections.addAll(vmOpts, new String[] {"-XX:AllocateHeapAt=" + test_dir,
-                                               "-Xlog:gc+heap=info",
-                                               "-version"});
-
-      System.out.print("Testing:\n" + JDKToolFinder.getJDKTool("java"));
-      for (int i = 0; i < vmOpts.size(); i += 1) {
-        System.out.print(" " + vmOpts.get(i));
-      }
-      System.out.println();
+    for (String[] extraFlags : extraFlagsList) {
+      flags.clear();
+      // Add extra flags specific to the sub-test.
+      Collections.addAll(flags, extraFlags);
+      // Add common flags
+      Collections.addAll(flags, new String[] {"-XX:AllocateHeapAt=" + test_dir,
+                                              "-Xlog:gc+heap=info",
+                                              "-version"});
 
       ProcessBuilder pb =
-        ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+          ProcessTools.createJavaProcessBuilder(true, flags.toArray(String[]::new));
       OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
       System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
@@ -62,8 +62,7 @@ public class TestAllocateHeapAtMultiple {
                                               "-Xlog:gc+heap=info",
                                               "-version"});
 
-      ProcessBuilder pb =
-          ProcessTools.createJavaProcessBuilder(true, flags.toArray(String[]::new));
+      ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, flags);
       OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
       System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/TestCardTablePageCommits.java
+++ b/test/hotspot/jtreg/gc/TestCardTablePageCommits.java
@@ -45,8 +45,11 @@ public class TestCardTablePageCommits {
         // because of 8kB pages, assume 4 KB pages for all other CPUs.
         String Xmx = Platform.isSparc() ? "-Xmx8m" : "-Xmx4m";
 
-        String[] opts = {Xmx, "-XX:NativeMemoryTracking=detail", "-XX:+UseParallelGC", "-version"};
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(opts);
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            Xmx,
+            "-XX:NativeMemoryTracking=detail",
+            "-XX:+UseParallelGC",
+            "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
     }

--- a/test/hotspot/jtreg/gc/TestNumWorkerOutput.java
+++ b/test/hotspot/jtreg/gc/TestNumWorkerOutput.java
@@ -75,7 +75,7 @@ public class TestNumWorkerOutput {
     }
 
     public static void runTest(String gcArg) throws Exception {
-        final String[] arguments = {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-Xbootclasspath/a:.",
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+UnlockDiagnosticVMOptions",
@@ -83,10 +83,7 @@ public class TestNumWorkerOutput {
             "-XX:+" + gcArg,
             "-Xmx10M",
             "-XX:+PrintGCDetails",
-            GCTest.class.getName()
-            };
-
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(arguments);
+            GCTest.class.getName());
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
         output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/TestSmallHeap.java
+++ b/test/hotspot/jtreg/gc/TestSmallHeap.java
@@ -102,13 +102,11 @@ public class TestSmallHeap {
 
     private static void verifySmallHeapSize(String gc, long expectedMaxHeap) throws Exception {
         long minMaxHeap = 4 * 1024 * 1024;
-        LinkedList<String> vmOptions = new LinkedList<>();
-        vmOptions.add(gc);
-        vmOptions.add("-Xmx" + minMaxHeap);
-        vmOptions.add("-XX:+PrintFlagsFinal");
-        vmOptions.add(VerifyHeapSize.class.getName());
-
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(vmOptions.toArray(new String[0]));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            gc,
+            "-Xmx" + minMaxHeap,
+            "-XX:+PrintFlagsFinal",
+            VerifyHeapSize.class.getName());
         OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
         analyzer.shouldHaveExitValue(0);
 

--- a/test/hotspot/jtreg/gc/TestVerifyDuringStartup.java
+++ b/test/hotspot/jtreg/gc/TestVerifyDuringStartup.java
@@ -30,38 +30,22 @@ package gc;
  * @requires vm.gc != "Z"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run main gc.TestVerifyDuringStartup
+ * @run driver gc.TestVerifyDuringStartup
  */
 
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
-import java.util.ArrayList;
-import java.util.Collections;
 
 public class TestVerifyDuringStartup {
   public static void main(String args[]) throws Exception {
-    ArrayList<String> vmOpts = new ArrayList<>();
+    String[] flags = {
+        "-XX:-UseTLAB",
+        "-XX:+UnlockDiagnosticVMOptions",
+        "-XX:+VerifyDuringStartup",
+        "-Xlog:gc+verify=debug",
+        "-version"};
 
-    String testVmOptsStr = System.getProperty("test.java.opts");
-    if (!testVmOptsStr.isEmpty()) {
-      String[] testVmOpts = testVmOptsStr.split(" ");
-      Collections.addAll(vmOpts, testVmOpts);
-    }
-    Collections.addAll(vmOpts, new String[] {"-XX:-UseTLAB",
-                                             "-XX:+UnlockDiagnosticVMOptions",
-                                             "-XX:+VerifyDuringStartup",
-                                             "-Xlog:gc+verify=debug",
-                                             "-version"});
-
-    System.out.print("Testing:\n" + JDKToolFinder.getJDKTool("java"));
-    for (int i = 0; i < vmOpts.size(); i += 1) {
-      System.out.print(" " + vmOpts.get(i));
-    }
-    System.out.println();
-
-    ProcessBuilder pb =
-      ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, flags);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/TestVerifyDuringStartup.java
+++ b/test/hotspot/jtreg/gc/TestVerifyDuringStartup.java
@@ -38,14 +38,13 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class TestVerifyDuringStartup {
   public static void main(String args[]) throws Exception {
-    String[] flags = {
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+        true,
         "-XX:-UseTLAB",
         "-XX:+UnlockDiagnosticVMOptions",
         "-XX:+VerifyDuringStartup",
         "-Xlog:gc+verify=debug",
-        "-version"};
-
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, flags);
+        "-version");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/TestVerifySilently.java
+++ b/test/hotspot/jtreg/gc/TestVerifySilently.java
@@ -58,8 +58,7 @@ public class TestVerifySilently {
                                              "-XX:+VerifyAfterGC",
                                              (verifySilently ? "-Xlog:gc":"-Xlog:gc+verify=debug"),
                                              TestVerifySilentlyRunSystemGC.class.getName()});
-    ProcessBuilder pb =
-      ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(vmOpts);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/TestVerifySubSet.java
+++ b/test/hotspot/jtreg/gc/TestVerifySubSet.java
@@ -56,8 +56,7 @@ public class TestVerifySubSet {
                                                  "-Xlog:gc+verify=debug",
                                                  "-XX:VerifySubSet="+subset,
                                                  TestVerifySubSetRunSystemGC.class.getName()});
-        ProcessBuilder pb =
-            ProcessTools.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(vmOpts);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
         System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/arguments/GCArguments.java
+++ b/test/hotspot/jtreg/gc/arguments/GCArguments.java
@@ -66,6 +66,16 @@ public final class GCArguments {
         return augmented.toArray(new String[augmented.size()]);
     }
 
+    static public ProcessBuilder createJavaProcessBuilder(List<String> arguments) {
+        return createJavaProcessBuilder(false, arguments);
+    }
+
+    static public ProcessBuilder createJavaProcessBuilder(boolean addTestVmAndJavaOptions,
+                                                          List<String> arguments) {
+        return createJavaProcessBuilder(addTestVmAndJavaOptions,
+                                        arguments.toArray(String[]::new));
+    }
+
     static public ProcessBuilder createJavaProcessBuilder(String... arguments) {
         return createJavaProcessBuilder(false, arguments);
     }
@@ -75,5 +85,4 @@ public final class GCArguments {
         return ProcessTools.createJavaProcessBuilder(addTestVmAndJavaOptions,
                                                      withDefaults(arguments));
     }
-
 }

--- a/test/hotspot/jtreg/gc/arguments/TestG1ConcMarkStepDurationMillis.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1ConcMarkStepDurationMillis.java
@@ -80,7 +80,7 @@ public class TestG1ConcMarkStepDurationMillis {
 
     Collections.addAll(vmOpts, "-XX:+UseG1GC", "-XX:G1ConcMarkStepDurationMillis="+expectedValue, "-XX:+PrintFlagsFinal", "-version");
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     output.shouldHaveExitValue(expectedResult == PASS ? 0 : 1);

--- a/test/hotspot/jtreg/gc/arguments/TestG1ConcRefinementThreads.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1ConcRefinementThreads.java
@@ -71,7 +71,7 @@ public class TestG1ConcRefinementThreads {
     }
     Collections.addAll(vmOpts, "-XX:+UseG1GC", "-XX:+PrintFlagsFinal", "-version");
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java
@@ -54,7 +54,7 @@ public class TestG1HeapRegionSize {
     flagList.add("-XX:+PrintFlagsFinal");
     flagList.add("-version");
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flagList.toArray(new String[0]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flagList);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(exitValue);
 

--- a/test/hotspot/jtreg/gc/arguments/TestG1PercentageOptions.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1PercentageOptions.java
@@ -65,8 +65,8 @@ public class TestG1PercentageOptions {
     };
 
     private static void check(String flag, boolean is_valid) throws Exception {
-        String[] flags = new String[] { "-XX:+UseG1GC", flag, "-version" };
-        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flags);
+        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
+                "-XX:+UseG1GC", flag, "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         if (is_valid) {
             output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
@@ -152,10 +152,9 @@ class TestMaxHeapSizeTools {
    * @param vmargs Arguments to the VM to run
    * @param classname Name of the class to run
    * @param arguments Arguments to the class
-   * @param useTestDotJavaDotOpts Use test.java.opts as part of the VM argument string
    * @return The OutputAnalyzer with the results for the invocation.
    */
-  public static OutputAnalyzer runWhiteBoxTest(String[] vmargs, String classname, String[] arguments, boolean useTestDotJavaDotOpts) throws Exception {
+  public static OutputAnalyzer runWhiteBoxTest(String[] vmargs, String classname, String[] arguments) throws Exception {
     ArrayList<String> finalargs = new ArrayList<String>();
 
     String[] whiteboxOpts = new String[] {
@@ -164,22 +163,12 @@ class TestMaxHeapSizeTools {
       "-cp", System.getProperty("java.class.path"),
     };
 
-    if (useTestDotJavaDotOpts) {
-      // System.getProperty("test.java.opts") is '' if no options is set,
-      // we need to skip such a result
-      String[] externalVMOpts = new String[0];
-      if (System.getProperty("test.java.opts") != null && System.getProperty("test.java.opts").length() != 0) {
-        externalVMOpts = System.getProperty("test.java.opts").split(" ");
-      }
-      finalargs.addAll(Arrays.asList(externalVMOpts));
-    }
-
     finalargs.addAll(Arrays.asList(vmargs));
     finalargs.addAll(Arrays.asList(whiteboxOpts));
     finalargs.add(classname);
     finalargs.addAll(Arrays.asList(arguments));
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(new String[0]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(String[]::new));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
 
@@ -187,7 +176,7 @@ class TestMaxHeapSizeTools {
   }
 
   private static void getMinInitialMaxHeap(String[] args, MinInitialMaxValues val) throws Exception {
-    OutputAnalyzer output = runWhiteBoxTest(args, ErgoArgsPrinter.class.getName(), new String[] {}, false);
+    OutputAnalyzer output = runWhiteBoxTest(args, ErgoArgsPrinter.class.getName(), new String[] {});
 
     // the output we watch for has the following format:
     //

--- a/test/hotspot/jtreg/gc/arguments/TestMaxMinHeapFreeRatioFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxMinHeapFreeRatioFlags.java
@@ -100,7 +100,7 @@ public class TestMaxMinHeapFreeRatioFlags {
                 Boolean.toString(shrinkHeapInSteps)
         );
 
-        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions);
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
         analyzer.shouldHaveExitValue(0);
     }
@@ -125,7 +125,7 @@ public class TestMaxMinHeapFreeRatioFlags {
                 "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
                 "-version"
         );
-        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions);
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
         analyzer.shouldHaveExitValue(1);
         analyzer.shouldContain("Error: Could not create the Java Virtual Machine.");

--- a/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
@@ -108,7 +108,7 @@ public class TestMaxNewSize {
     finalargs.addAll(Arrays.asList(flags));
     finalargs.add("-version");
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(new String[0]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldContain("Initial young gen size set larger than the maximum young gen size");
   }
@@ -131,7 +131,7 @@ public class TestMaxNewSize {
     finalargs.add("-XX:+PrintFlagsFinal");
     finalargs.add("-version");
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(new String[0]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
     String stdout = output.getStdout();

--- a/test/hotspot/jtreg/gc/arguments/TestMinAndInitialSurvivorRatioFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMinAndInitialSurvivorRatioFlags.java
@@ -104,7 +104,7 @@ public class TestMinAndInitialSurvivorRatioFlags {
                 Boolean.toString(useAdaptiveSizePolicy)
         );
         vmOptions.removeIf((String p) -> p.isEmpty());
-        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions);
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
         analyzer.shouldHaveExitValue(0);
     }

--- a/test/hotspot/jtreg/gc/arguments/TestNewRatioFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestNewRatioFlag.java
@@ -84,7 +84,7 @@ public class TestNewRatioFlag {
                 Integer.toString(ratio)
         );
 
-        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions);
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
         analyzer.shouldHaveExitValue(0);
         System.out.println(analyzer.getOutput());

--- a/test/hotspot/jtreg/gc/arguments/TestNewSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestNewSizeFlags.java
@@ -168,7 +168,7 @@ public class TestNewSizeFlags {
                 Long.toString(maxHeapSize)
         );
         vmOptions.removeIf(String::isEmpty);
-        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions);
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
         return analyzer;
     }

--- a/test/hotspot/jtreg/gc/arguments/TestObjectTenuringFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestObjectTenuringFlags.java
@@ -163,7 +163,7 @@ public class TestObjectTenuringFlags {
     }
     Collections.addAll(vmOpts, "-XX:+UseParallelGC", "-XX:+PrintFlagsFinal", "-version");
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts.toArray(new String[vmOpts.size()]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     if (shouldFail) {

--- a/test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java
@@ -98,17 +98,22 @@ public class TestParallelGCThreads {
     }
 
     for (String gc : supportedGC) {
-
       // Make sure the VM does not allow ParallelGCThreads set to 0
-      String[] flags = new String[] {"-XX:+Use" + gc + "GC", "-XX:ParallelGCThreads=0", "-XX:+PrintFlagsFinal", "-version"};
-      ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flags);
+      ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
+          "-XX:+Use" + gc + "GC",
+          "-XX:ParallelGCThreads=0",
+          "-XX:+PrintFlagsFinal",
+          "-version");
       OutputAnalyzer output = new OutputAnalyzer(pb.start());
       output.shouldHaveExitValue(1);
 
       // Do some basic testing to ensure the flag updates the count
       for (long i = 1; i <= 3; i++) {
-        flags = new String[] {"-XX:+Use" + gc + "GC", "-XX:ParallelGCThreads=" + i, "-XX:+PrintFlagsFinal", "-version"};
-        long count = getParallelGCThreadCount(flags);
+        long count = getParallelGCThreadCount(
+            "-XX:+Use" + gc + "GC",
+            "-XX:ParallelGCThreads=" + i,
+            "-XX:+PrintFlagsFinal",
+            "-version");
         Asserts.assertEQ(count, i, "Specifying ParallelGCThreads=" + i + " for " + gc + "GC does not set the thread count properly!");
       }
     }
@@ -117,13 +122,16 @@ public class TestParallelGCThreads {
     // So setting ParallelGCThreads=4294967295 should give back 4294967295
     // and setting ParallelGCThreads=4294967296 should give back 0. (SerialGC is ok with ParallelGCThreads=0)
     for (long i = 4294967295L; i <= 4294967296L; i++) {
-      String[] flags = new String[] {"-XX:+UseSerialGC", "-XX:ParallelGCThreads=" + i, "-XX:+PrintFlagsFinal", "-version"};
-      long count = getParallelGCThreadCount(flags);
+      long count = getParallelGCThreadCount(
+          "-XX:+UseSerialGC",
+          "-XX:ParallelGCThreads=" + i,
+          "-XX:+PrintFlagsFinal",
+          "-version");
       Asserts.assertEQ(count, i % 4294967296L, "Specifying ParallelGCThreads=" + i + " does not set the thread count properly!");
     }
   }
 
-  public static long getParallelGCThreadCount(String flags[]) throws Exception {
+  public static long getParallelGCThreadCount(String... flags) throws Exception {
     ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flags);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelRefProc.java
@@ -81,7 +81,7 @@ public class TestParallelRefProc {
         result.addAll(Arrays.asList(args));
         result.add("-XX:+PrintFlagsFinal");
         result.add("-version");
-        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(result.toArray(new String[0]));
+        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(result);
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 

--- a/test/hotspot/jtreg/gc/arguments/TestSelectDefaultGC.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSelectDefaultGC.java
@@ -48,15 +48,12 @@ public class TestSelectDefaultGC {
     }
 
     public static void testDefaultGC(boolean actAsServer) throws Exception {
-        String[] args = new String[] {
-          "-XX:" + (actAsServer ? "+" : "-") + "AlwaysActAsServerClassMachine",
-          "-XX:" + (actAsServer ? "-" : "+") + "NeverActAsServerClassMachine",
-          "-XX:+PrintFlagsFinal",
-          "-version"
-        };
-
         // Start VM without specifying GC
-        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(args);
+        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
+            "-XX:" + (actAsServer ? "+" : "-") + "AlwaysActAsServerClassMachine",
+            "-XX:" + (actAsServer ? "-" : "+") + "NeverActAsServerClassMachine",
+            "-XX:+PrintFlagsFinal",
+            "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
 

--- a/test/hotspot/jtreg/gc/arguments/TestSmallInitialHeapWithLargePageAndNUMA.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSmallInitialHeapWithLargePageAndNUMA.java
@@ -60,15 +60,14 @@ public class TestSmallInitialHeapWithLargePageAndNUMA {
     long initHeap = heapAlignment;
     long maxHeap = heapAlignment * 2;
 
-    String[] vmArgs = {"-XX:+UseParallelGC",
-                       "-Xms" + String.valueOf(initHeap),
-                       "-Xmx" + String.valueOf(maxHeap),
-                       "-XX:+UseNUMA",
-                       "-XX:+UseHugeTLBFS",
-                       "-XX:+PrintFlagsFinal",
-                       "-version"};
-
-    ProcessBuilder pb_enabled = GCArguments.createJavaProcessBuilder(vmArgs);
+    ProcessBuilder pb_enabled = GCArguments.createJavaProcessBuilder(
+        "-XX:+UseParallelGC",
+        "-Xms" + String.valueOf(initHeap),
+        "-Xmx" + String.valueOf(maxHeap),
+        "-XX:+UseNUMA",
+        "-XX:+UseHugeTLBFS",
+        "-XX:+PrintFlagsFinal",
+        "-version");
     OutputAnalyzer analyzer = new OutputAnalyzer(pb_enabled.start());
 
     if (largePageOrNumaEnabled(analyzer)) {

--- a/test/hotspot/jtreg/gc/arguments/TestSurvivorRatioFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSurvivorRatioFlag.java
@@ -89,7 +89,7 @@ public class TestSurvivorRatioFlag {
                 Integer.toString(ratio)
         );
 
-        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions);
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
         analyzer.shouldHaveExitValue(0);
     }

--- a/test/hotspot/jtreg/gc/arguments/TestTargetSurvivorRatioFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestTargetSurvivorRatioFlag.java
@@ -117,7 +117,7 @@ public class TestTargetSurvivorRatioFlag {
         vmOptions.add("-XX:TargetSurvivorRatio=" + ratio);
         vmOptions.add("-version");
 
-        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions);
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
 
         analyzer.shouldHaveExitValue(1);
@@ -152,7 +152,7 @@ public class TestTargetSurvivorRatioFlag {
                 Integer.toString(ratio)
         );
 
-        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions.toArray(new String[vmOptions.size()]));
+        ProcessBuilder procBuilder = GCArguments.createJavaProcessBuilder(vmOptions);
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
 
         analyzer.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgo.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgo.java
@@ -35,8 +35,8 @@ package gc.arguments;
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseSerialGC
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run driver gc.arguments.TestUseCompressedOopsErgo -XX:+UseSerialGC
  */
 
 /*
@@ -51,9 +51,9 @@ package gc.arguments;
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC -XX:-UseParallelOldGC
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run driver gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC
+ * @run driver gc.arguments.TestUseCompressedOopsErgo -XX:+UseParallelGC -XX:-UseParallelOldGC
  */
 
 /*
@@ -68,8 +68,8 @@ package gc.arguments;
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseG1GC
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run driver gc.arguments.TestUseCompressedOopsErgo -XX:+UseG1GC
  */
 
 /*
@@ -84,8 +84,8 @@ package gc.arguments;
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UseConcMarkSweepGC
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run driver gc.arguments.TestUseCompressedOopsErgo -XX:+UseConcMarkSweepGC
  */
 
 /*
@@ -100,8 +100,8 @@ package gc.arguments;
  *          java.management/sun.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                              sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm gc.arguments.TestUseCompressedOopsErgo -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run driver gc.arguments.TestUseCompressedOopsErgo -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC
  */
 
 public class TestUseCompressedOopsErgo {

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
@@ -56,7 +56,7 @@ class TestUseCompressedOopsErgoTools {
 
 
   public static long getMaxHeapForCompressedOops(String[] vmargs) throws Exception {
-    OutputAnalyzer output = runWhiteBoxTest(vmargs, DetermineMaxHeapForCompressedOops.class.getName(), new String[] {}, false);
+    OutputAnalyzer output = runWhiteBoxTest(vmargs, DetermineMaxHeapForCompressedOops.class.getName(), new String[] {});
     return Long.parseLong(output.getStdout());
   }
 
@@ -78,10 +78,9 @@ class TestUseCompressedOopsErgoTools {
    * @param vmargs Arguments to the VM to run
    * @param classname Name of the class to run
    * @param arguments Arguments to the class
-   * @param useTestDotJavaDotOpts Use test.java.opts as part of the VM argument string
    * @return The OutputAnalyzer with the results for the invocation.
    */
-  public static OutputAnalyzer runWhiteBoxTest(String[] vmargs, String classname, String[] arguments, boolean useTestDotJavaDotOpts) throws Exception {
+  public static OutputAnalyzer runWhiteBoxTest(String[] vmargs, String classname, String[] arguments) throws Exception {
     ArrayList<String> finalargs = new ArrayList<String>();
 
     String[] whiteboxOpts = new String[] {
@@ -90,22 +89,12 @@ class TestUseCompressedOopsErgoTools {
       "-cp", System.getProperty("java.class.path"),
     };
 
-    if (useTestDotJavaDotOpts) {
-      // System.getProperty("test.java.opts") is '' if no options is set,
-      // we need to skip such a result
-      String[] externalVMOpts = new String[0];
-      if (System.getProperty("test.java.opts") != null && System.getProperty("test.java.opts").length() != 0) {
-        externalVMOpts = System.getProperty("test.java.opts").split(" ");
-      }
-      finalargs.addAll(Arrays.asList(externalVMOpts));
-    }
-
     finalargs.addAll(Arrays.asList(vmargs));
     finalargs.addAll(Arrays.asList(whiteboxOpts));
     finalargs.add(classname);
     finalargs.addAll(Arrays.asList(arguments));
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(new String[0]));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(String[]::new));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
     return output;
@@ -115,7 +104,7 @@ class TestUseCompressedOopsErgoTools {
     ArrayList<String> result = new ArrayList<String>();
     result.addAll(Arrays.asList(part1));
     result.add(part2);
-    return result.toArray(new String[0]);
+    return result.toArray(String[]::new);
   }
 
   public static void checkCompressedOopsErgo(String[] gcflags) throws Exception {

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
@@ -94,7 +94,7 @@ class TestUseCompressedOopsErgoTools {
     finalargs.add(classname);
     finalargs.addAll(Arrays.asList(arguments));
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(String[]::new));
+    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
     return output;

--- a/test/hotspot/jtreg/gc/arguments/TestUseNUMAInterleaving.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseNUMAInterleaving.java
@@ -41,12 +41,11 @@ import jdk.test.lib.process.ProcessTools;
 public class TestUseNUMAInterleaving {
 
     public static void main(String[] args) throws Exception {
-        String[] vmargs = new String[]{
+        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
+            true,
             "-XX:+UseNUMA",
             "-XX:+PrintFlagsFinal",
-            "-version"
-        };
-        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(true, vmargs);
+            "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
         boolean isNUMAEnabled

--- a/test/hotspot/jtreg/gc/arguments/TestVerifyBeforeAndAfterGCFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestVerifyBeforeAndAfterGCFlags.java
@@ -88,10 +88,8 @@ public class TestVerifyBeforeAndAfterGCFlags {
                                        (verifyAfterGC ? "-XX:+VerifyAfterGC"
                                                       : "-XX:-VerifyAfterGC"),
                                        GarbageProducer.class.getName() });
-        ProcessBuilder procBuilder =
-            GCArguments.createJavaProcessBuilder(vmOpts.toArray(
-                                                     new String[vmOpts.size()]));
-        OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
+        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts);
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
 
         analyzer.shouldHaveExitValue(0);
         analyzer.shouldNotMatch(VERIFY_BEFORE_GC_CORRUPTED_PATTERN);

--- a/test/hotspot/jtreg/gc/ergonomics/TestInitialGCThreadLogging.java
+++ b/test/hotspot/jtreg/gc/ergonomics/TestInitialGCThreadLogging.java
@@ -75,11 +75,14 @@ public class TestInitialGCThreadLogging {
   }
 
   private static void testInitialGCThreadLogging(String gcFlag, String threadName) throws Exception {
-    // UseDynamicNumberOfGCThreads and TraceDynamicGCThreads enabled
-    String[] baseArgs = {"-XX:+UnlockExperimentalVMOptions", "-XX:+" + gcFlag, "-Xmx10M", "-XX:+UseDynamicNumberOfGCThreads", "-Xlog:gc+task=trace", "-version"};
-
     // Base test with gc and +UseDynamicNumberOfGCThreads:
-    ProcessBuilder pb_enabled = ProcessTools.createJavaProcessBuilder(baseArgs);
+    ProcessBuilder pb_enabled = ProcessTools.createJavaProcessBuilder(
+        "-XX:+UnlockExperimentalVMOptions",
+        "-XX:+" + gcFlag,
+        "-Xmx10M",
+        "-XX:+UseDynamicNumberOfGCThreads",
+        "-Xlog:gc+task=trace",
+        "-version");
     verifyDynamicNumberOfGCThreads(new OutputAnalyzer(pb_enabled.start()), threadName);
   }
 }

--- a/test/hotspot/jtreg/gc/g1/Test2GbHeap.java
+++ b/test/hotspot/jtreg/gc/g1/Test2GbHeap.java
@@ -50,7 +50,7 @@ public class Test2GbHeap {
     testArguments.add("-Xmx2g");
     testArguments.add("-version");
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(testArguments.toArray(new String[0]));
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(testArguments);
 
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsLog.java
+++ b/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsLog.java
@@ -53,7 +53,7 @@ public class TestEagerReclaimHumongousRegionsLog {
     private static final String LogSeparator = ": ";
 
     public static void runTest() throws Exception {
-        final String[] arguments = {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-Xbootclasspath/a:.",
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+UnlockDiagnosticVMOptions",
@@ -63,10 +63,7 @@ public class TestEagerReclaimHumongousRegionsLog {
             "-Xms128M",
             "-Xmx128M",
             "-Xlog:gc+phases=trace,gc+heap=info",
-            GCTest.class.getName()
-            };
-
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(arguments);
+            GCTest.class.getName());
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
         output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/g1/TestHumongousCodeCacheRoots.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousCodeCacheRoots.java
@@ -33,10 +33,10 @@ package gc.g1;
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- *                              sun.hotspot.WhiteBox$WhiteBoxPermission
+ *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @summary Humongous objects may have references from the code cache
- * @run main gc.g1.TestHumongousCodeCacheRoots
-*/
+ * @run driver gc.g1.TestHumongousCodeCacheRoots
+ */
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
@@ -92,10 +92,9 @@ public class TestHumongousCodeCacheRoots {
    * @param vmargs Arguments to the VM to run
    * @param classname Name of the class to run
    * @param arguments Arguments to the class
-   * @param useTestDotJavaDotOpts Use test.java.opts as part of the VM argument string
    * @return The OutputAnalyzer with the results for the invocation.
    */
-  public static OutputAnalyzer runWhiteBoxTest(String[] vmargs, String classname, String[] arguments, boolean useTestDotJavaDotOpts) throws Exception {
+  public static OutputAnalyzer runWhiteBoxTest(String[] vmargs, String classname, String[] arguments) throws Exception {
     ArrayList<String> finalargs = new ArrayList<String>();
 
     String[] whiteboxOpts = new String[] {
@@ -104,22 +103,12 @@ public class TestHumongousCodeCacheRoots {
       "-cp", System.getProperty("java.class.path"),
     };
 
-    if (useTestDotJavaDotOpts) {
-      // System.getProperty("test.java.opts") is '' if no options is set,
-      // we need to skip such a result
-      String[] externalVMOpts = new String[0];
-      if (System.getProperty("test.java.opts") != null && System.getProperty("test.java.opts").length() != 0) {
-        externalVMOpts = System.getProperty("test.java.opts").split(" ");
-      }
-      finalargs.addAll(Arrays.asList(externalVMOpts));
-    }
-
     finalargs.addAll(Arrays.asList(vmargs));
     finalargs.addAll(Arrays.asList(whiteboxOpts));
     finalargs.add(classname);
     finalargs.addAll(Arrays.asList(arguments));
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs.toArray(new String[0]));
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs.toArray(String[]::new));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
     return output;
@@ -133,8 +122,7 @@ public class TestHumongousCodeCacheRoots {
       "-XX:+G1VerifyHeapRegionCodeRoots", "-XX:+VerifyAfterGC", // make sure that verification is run
     };
 
-    runWhiteBoxTest(baseArguments, TestHumongousCodeCacheRootsHelper.class.getName(),
-      new String[] {}, false);
+    runWhiteBoxTest(baseArguments, TestHumongousCodeCacheRootsHelper.class.getName(), new String[] { });
   }
 }
 

--- a/test/hotspot/jtreg/gc/g1/TestHumongousCodeCacheRoots.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousCodeCacheRoots.java
@@ -108,7 +108,7 @@ public class TestHumongousCodeCacheRoots {
     finalargs.add(classname);
     finalargs.addAll(Arrays.asList(arguments));
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs.toArray(String[]::new));
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
     return output;

--- a/test/hotspot/jtreg/gc/g1/TestPLABSizeBounds.java
+++ b/test/hotspot/jtreg/gc/g1/TestPLABSizeBounds.java
@@ -63,7 +63,7 @@ public class TestPLABSizeBounds {
         testArguments.add("-XX:OldPLABSize=" + plabSize);
         testArguments.add(GCTest.class.getName());
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(testArguments.toArray(new String[0]));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(testArguments);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
         if (shouldSucceed) {

--- a/test/hotspot/jtreg/gc/g1/TestPrintRegionRememberedSetInfo.java
+++ b/test/hotspot/jtreg/gc/g1/TestPrintRegionRememberedSetInfo.java
@@ -70,8 +70,7 @@ public class TestPrintRegionRememberedSetInfo {
 
         finalargs.add(RunAndWaitForMarking.class.getName());
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            finalargs.toArray(new String[0]));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
 

--- a/test/hotspot/jtreg/gc/g1/TestRemsetLoggingTools.java
+++ b/test/hotspot/jtreg/gc/g1/TestRemsetLoggingTools.java
@@ -80,8 +80,7 @@ public class TestRemsetLoggingTools {
         finalargs.add(VerifySummaryOutput.class.getName());
         finalargs.add(String.valueOf(numGCs));
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            finalargs.toArray(new String[0]));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
         output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/gc/g1/TestSharedArchiveWithPreTouch.java
+++ b/test/hotspot/jtreg/gc/g1/TestSharedArchiveWithPreTouch.java
@@ -60,7 +60,7 @@ public class TestSharedArchiveWithPreTouch {
         }
         dump_args.addAll(Arrays.asList(new String[] { "-Xshare:dump" }));
 
-        pb = ProcessTools.createJavaProcessBuilder(dump_args.toArray(new String[0]));
+        pb = ProcessTools.createJavaProcessBuilder(dump_args);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         try {
             output.shouldContain("Loading classes to share");

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData.java
@@ -104,10 +104,7 @@ public class TestShrinkAuxiliaryData {
     }
 
     private void performTest(List<String> opts) throws Exception {
-        ProcessBuilder pb
-                = ProcessTools.createJavaProcessBuilder(true,
-                        opts.toArray(new String[opts.size()])
-                );
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, opts);
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         System.out.println(output.getStdout());

--- a/test/hotspot/jtreg/gc/g1/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/g1/TestStringDeduplicationTools.java
@@ -200,7 +200,7 @@ class TestStringDeduplicationTools {
         args.addAll(Arrays.asList(defaultArgs));
         args.addAll(Arrays.asList(extraArgs));
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args.toArray(new String[args.size()]));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         System.err.println(output.getStderr());
         System.out.println(output.getStdout());

--- a/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
+++ b/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
@@ -155,8 +155,7 @@ public class TestVerifyGCType {
 
         basicOpts.add(TriggerGCs.class.getName());
 
-        ProcessBuilder procBuilder =  ProcessTools.createJavaProcessBuilder(basicOpts.toArray(
-                                                                            new String[basicOpts.size()]));
+        ProcessBuilder procBuilder =  ProcessTools.createJavaProcessBuilder(basicOpts);
         OutputAnalyzer analyzer = new OutputAnalyzer(procBuilder.start());
         return analyzer;
     }

--- a/test/hotspot/jtreg/gc/g1/ihop/TestIHOPErgo.java
+++ b/test/hotspot/jtreg/gc/g1/ihop/TestIHOPErgo.java
@@ -128,8 +128,7 @@ public class TestIHOPErgo {
     }
 
     private static OutputAnalyzer executeTest(List<String> options) throws Throwable, RuntimeException {
-        OutputAnalyzer out;
-        out = ProcessTools.executeTestJvm(options.toArray(new String[options.size()]));
+        OutputAnalyzer out = ProcessTools.executeTestJvm(options);
         if (out.getExitValue() != 0) {
             System.out.println(out.getOutput());
             throw new RuntimeException("AppIHOP failed with exit code" + out.getExitValue());

--- a/test/hotspot/jtreg/gc/g1/ihop/TestIHOPStatic.java
+++ b/test/hotspot/jtreg/gc/g1/ihop/TestIHOPStatic.java
@@ -127,7 +127,7 @@ public class TestIHOPStatic {
         Collections.addAll(options, COMMON_OPTIONS);
         options.add(AppIHOP.class.getName());
 
-        OutputAnalyzer out = ProcessTools.executeTestJvm(options.toArray(new String[options.size()]));
+        OutputAnalyzer out = ProcessTools.executeTestJvm(options);
 
         if (out.getExitValue() != 0) {
             System.out.println(out.getOutput());

--- a/test/hotspot/jtreg/gc/g1/logging/TestG1LoggingFailure.java
+++ b/test/hotspot/jtreg/gc/g1/logging/TestG1LoggingFailure.java
@@ -63,7 +63,7 @@ public class TestG1LoggingFailure {
     }
 
     private static void startVM(List<String> options) throws Throwable, RuntimeException {
-        OutputAnalyzer out = ProcessTools.executeTestJvm(options.toArray(new String[options.size()]));
+        OutputAnalyzer out = ProcessTools.executeTestJvm(options);
 
         out.shouldNotContain("pure virtual method called");
 

--- a/test/hotspot/jtreg/gc/g1/mixedgc/TestLogging.java
+++ b/test/hotspot/jtreg/gc/g1/mixedgc/TestLogging.java
@@ -96,7 +96,7 @@ public class TestLogging {
         testOpts.add(MixedGCProvoker.class.getName());
         System.out.println(testOpts);
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(false,
-                testOpts.toArray(new String[testOpts.size()]));
+                testOpts);
         return new OutputAnalyzer(pb.start());
     }
 }

--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABEvacuationFailure.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABEvacuationFailure.java
@@ -108,7 +108,7 @@ public class TestPLABEvacuationFailure {
                 "-XX:" + (plabIsFixed ? "-" : "+") + "ResizePLAB",
                 "-XX:MaxHeapSize=" + heapSize + "m");
         testOptions.add(AppPLABEvacuationFailure.class.getName());
-        OutputAnalyzer out = ProcessTools.executeTestJvm(testOptions.toArray(new String[testOptions.size()]));
+        OutputAnalyzer out = ProcessTools.executeTestJvm(testOptions);
 
         appPlabEvacFailureOutput = out.getOutput();
         if (out.getExitValue() != 0) {

--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
@@ -117,7 +117,7 @@ public class TestPLABPromotion {
             testCase.print(System.out);
             List<String> options = PLABUtils.prepareOptions(testCase.toOptions());
             options.add(AppPLABPromotion.class.getName());
-            OutputAnalyzer out = ProcessTools.executeTestJvm(options.toArray(new String[options.size()]));
+            OutputAnalyzer out = ProcessTools.executeTestJvm(options);
             PLABUtils.commonCheck(out);
             output = out.getOutput();
             checkResults(testCase);

--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABResize.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABResize.java
@@ -88,7 +88,7 @@ public class TestPLABResize {
             testCase.print(System.out);
             List<String> options = PLABUtils.prepareOptions(testCase.toOptions());
             options.add(AppPLABResize.class.getName());
-            OutputAnalyzer out = ProcessTools.executeTestJvm(options.toArray(new String[options.size()]));
+            OutputAnalyzer out = ProcessTools.executeTestJvm(options);
             PLABUtils.commonCheck(out);
             checkResults(out.getOutput(), testCase);
         }

--- a/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
+++ b/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
@@ -63,9 +63,8 @@ public class TestReclaimStringsLeaksMemory {
                                                                    "-XX:+PrintNMTStatistics" ));
         baseargs.addAll(Arrays.asList(args));
         baseargs.add(GCTest.class.getName());
-        ProcessBuilder pb_default =
-            ProcessTools.createJavaProcessBuilder(baseargs.toArray(new String[] {}));
-        verifySymbolMemoryUsageNotTooHigh(new OutputAnalyzer(pb_default.start()));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(baseargs);
+        verifySymbolMemoryUsageNotTooHigh(new OutputAnalyzer(pb.start()));
     }
 
     private static void verifySymbolMemoryUsageNotTooHigh(OutputAnalyzer output) throws Exception {

--- a/test/hotspot/jtreg/gc/stress/TestStressG1Humongous.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressG1Humongous.java
@@ -72,7 +72,7 @@ public class TestStressG1Humongous{
                 "-Dregionsize=" + regionSize,
                 TestStressG1HumongousImpl.class.getName()
         );
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(options.toArray(new String[options.size()]));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(options);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
     }

--- a/test/hotspot/jtreg/gc/stress/gclocker/TestExcessGCLockerCollections.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestExcessGCLockerCollections.java
@@ -176,7 +176,7 @@ public class TestExcessGCLockerCollections {
 
         // GC and other options obtained from test framework.
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            true, finalArgs.toArray(new String[0]));
+            true, finalArgs);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         //System.out.println("------------- begin stdout ----------------");

--- a/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/JVMOption.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/JVMOption.java
@@ -412,7 +412,7 @@ public abstract class JVMOption {
         runJava.add(optionValue);
         runJava.add(JVMStartup.class.getName());
 
-        out = new OutputAnalyzer(ProcessTools.createJavaProcessBuilder(runJava.toArray(new String[0])).start());
+        out = new OutputAnalyzer(ProcessTools.createJavaProcessBuilder(runJava).start());
 
         exitCode = out.getExitValue();
         String exitCodeString = null;

--- a/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/JVMOptionsUtils.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/common/optionsvalidation/JVMOptionsUtils.java
@@ -488,7 +488,7 @@ public class JVMOptionsUtils {
         runJava.add(PRINT_FLAGS_RANGES);
         runJava.add("-version");
 
-        p = ProcessTools.createJavaProcessBuilder(runJava.toArray(new String[0])).start();
+        p = ProcessTools.createJavaProcessBuilder(runJava).start();
 
         result = getJVMOptions(new InputStreamReader(p.getInputStream()), withRanges, acceptOrigin);
 

--- a/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethods.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethods.java
@@ -40,16 +40,22 @@ import jdk.test.lib.JDKToolFinder;
 public class PrintTouchedMethods {
 
     public static void main(String args[]) throws Exception {
-      String[] javaArgs1 = {"-XX:-UnlockDiagnosticVMOptions", "-XX:+LogTouchedMethods", "-XX:+PrintTouchedMethodsAtExit", "TestLogTouchedMethods"};
-      ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(javaArgs1);
+      ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+          "-XX:-UnlockDiagnosticVMOptions",
+          "-XX:+LogTouchedMethods",
+          "-XX:+PrintTouchedMethodsAtExit",
+          "TestLogTouchedMethods");
 
       // UnlockDiagnostic turned off, should fail
       OutputAnalyzer output = new OutputAnalyzer(pb.start());
       output.shouldContain("Error: VM option 'LogTouchedMethods' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.");
       output.shouldContain("Error: Could not create the Java Virtual Machine.");
 
-      String[] javaArgs2 = {"-XX:+UnlockDiagnosticVMOptions", "-XX:+LogTouchedMethods", "-XX:+PrintTouchedMethodsAtExit", "TestLogTouchedMethods"};
-      pb = ProcessTools.createJavaProcessBuilder(javaArgs2);
+      pb = ProcessTools.createJavaProcessBuilder(
+          "-XX:+UnlockDiagnosticVMOptions",
+          "-XX:+LogTouchedMethods",
+          "-XX:+PrintTouchedMethodsAtExit",
+          "TestLogTouchedMethods");
       output = new OutputAnalyzer(pb.start());
       // check order:
       // 1 "# Method::print_touched_methods version 1" is the first in first line
@@ -71,8 +77,12 @@ public class PrintTouchedMethods {
       output.shouldNotContain("TestLogTouchedMethods.methodB:()V");
       output.shouldHaveExitValue(0);
 
-      String[] javaArgs3 = {"-XX:+UnlockDiagnosticVMOptions", "-Xint", "-XX:+LogTouchedMethods", "-XX:+PrintTouchedMethodsAtExit", "TestLogTouchedMethods"};
-      pb = ProcessTools.createJavaProcessBuilder(javaArgs3);
+      pb = ProcessTools.createJavaProcessBuilder(
+          "-XX:+UnlockDiagnosticVMOptions",
+          "-Xint",
+          "-XX:+LogTouchedMethods",
+          "-XX:+PrintTouchedMethodsAtExit",
+          "TestLogTouchedMethods");
       output = new OutputAnalyzer(pb.start());
       lines = output.asLines();
 
@@ -89,8 +99,13 @@ public class PrintTouchedMethods {
       output.shouldNotContain("TestLogTouchedMethods.methodB:()V");
       output.shouldHaveExitValue(0);
 
-      String[] javaArgs4 = {"-XX:+UnlockDiagnosticVMOptions", "-Xint", "-XX:+LogTouchedMethods", "-XX:+PrintTouchedMethodsAtExit", "-XX:-TieredCompilation", "TestLogTouchedMethods"};
-      pb = ProcessTools.createJavaProcessBuilder(javaArgs4);
+      pb = ProcessTools.createJavaProcessBuilder(
+          "-XX:+UnlockDiagnosticVMOptions",
+          "-Xint",
+          "-XX:+LogTouchedMethods",
+          "-XX:+PrintTouchedMethodsAtExit",
+          "-XX:-TieredCompilation",
+          "TestLogTouchedMethods");
       output = new OutputAnalyzer(pb.start());
       lines = output.asLines();
 

--- a/test/hotspot/jtreg/runtime/CommandLine/TestHexArguments.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/TestHexArguments.java
@@ -37,15 +37,14 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class TestHexArguments {
     public static void main(String args[]) throws Exception {
-      String[] javaArgs = {"-XX:SharedBaseAddress=0x1D000000", "-version"};
-      ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(javaArgs);
-
+      ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+          "-XX:SharedBaseAddress=0x1D000000", "-version");
       OutputAnalyzer output = new OutputAnalyzer(pb.start());
       output.shouldNotContain("Could not create the Java Virtual Machine");
       output.shouldHaveExitValue(0);
 
-      String[] javaArgs1 = {"-XX:SharedBaseAddress=1D000000", "-version"};
-      pb = ProcessTools.createJavaProcessBuilder(javaArgs1);
+      pb = ProcessTools.createJavaProcessBuilder(
+          "-XX:SharedBaseAddress=1D000000", "-version");
       output = new OutputAnalyzer(pb.start());
       output.shouldContain("Could not create the Java Virtual Machine");
   }

--- a/test/hotspot/jtreg/runtime/CommandLine/VMOptionsFile/TestVMOptionsFile.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMOptionsFile/TestVMOptionsFile.java
@@ -247,7 +247,7 @@ public class TestVMOptionsFile {
         runJava.add(PrintPropertyAndOptions.class.getName());
         runJava.addAll(appParams);
 
-        pb = ProcessTools.createJavaProcessBuilder(runJava.toArray(new String[0]));
+        pb = ProcessTools.createJavaProcessBuilder(runJava);
 
         VMParams.clear();
         appParams.clear();

--- a/test/hotspot/jtreg/runtime/CompressedOops/UseCompressedOops.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/UseCompressedOops.java
@@ -189,7 +189,7 @@ public class UseCompressedOops {
 
         args.add("-version");
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args.toArray(new String[0]));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args);
         return new OutputAnalyzer(pb.start());
     }
 }

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/MaxMetaspaceSize.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/MaxMetaspaceSize.java
@@ -51,7 +51,7 @@ public class MaxMetaspaceSize {
     }
 
     String msg = "Failed allocating metaspace object";
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(processArgs.toArray(new String[0]));
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(processArgs);
     CDSTestUtils.executeAndLog(pb, "dump").shouldContain(msg).shouldHaveExitValue(1);
   }
 }

--- a/test/hotspot/jtreg/runtime/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/appcds/TestCommon.java
@@ -147,8 +147,7 @@ public class TestCommon extends CDSTestUtils {
 
         for (String s : opts.suffix) cmd.add(s);
 
-        String[] cmdLine = cmd.toArray(new String[cmd.size()]);
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, makeCommandLineForAppCDS(cmdLine));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, cmd);
         return executeAndLog(pb, "dump");
     }
 
@@ -173,8 +172,7 @@ public class TestCommon extends CDSTestUtils {
 
         for (String s : opts.suffix) cmd.add(s);
 
-        String[] cmdLine = cmd.toArray(new String[cmd.size()]);
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, makeCommandLineForAppCDS(cmdLine));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, cmd);
         return executeAndLog(pb, "exec");
     }
 

--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -77,7 +77,7 @@ public class ClassLoadUnloadTest {
         Collections.addAll(argsList, "-Xmn8m");
         Collections.addAll(argsList, "-Dtest.class.path=" + System.getProperty("test.class.path", "."));
         Collections.addAll(argsList, ClassUnloadTestMain.class.getName());
-        return ProcessTools.createJavaProcessBuilder(argsList.toArray(new String[argsList.size()]));
+        return ProcessTools.createJavaProcessBuilder(argsList);
     }
 
     public static void main(String... args) throws Exception {

--- a/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
@@ -58,7 +58,7 @@ public class LoaderConstraintsTest {
         Collections.addAll(argsList, "-Xmn8m");
         Collections.addAll(argsList, "-Dtest.classes=" + System.getProperty("test.classes","."));
         Collections.addAll(argsList, ClassUnloadTestMain.class.getName());
-        return ProcessTools.createJavaProcessBuilder(argsList.toArray(new String[argsList.size()]));
+        return ProcessTools.createJavaProcessBuilder(argsList);
     }
 
     public static void main(String... args) throws Exception {

--- a/test/hotspot/jtreg/runtime/memory/LargePages/TestLargePagesFlags.java
+++ b/test/hotspot/jtreg/runtime/memory/LargePages/TestLargePagesFlags.java
@@ -327,7 +327,7 @@ public class TestLargePagesFlags {
     args.add("-XX:+PrintFlagsFinal");
     args.add("-version");
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args.toArray(new String[args.size()]));
+    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     return output;

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/RunFinalizationTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/RunFinalizationTest.java
@@ -46,7 +46,7 @@ public class RunFinalizationTest {
         javaArgs.add("-cp");
         javaArgs.add(System.getProperty("test.class.path"));
         javaArgs.add(TEST_APP_NAME);
-        ProcessBuilder testAppPb = ProcessTools.createJavaProcessBuilder(javaArgs.toArray(new String[javaArgs.size()]));
+        ProcessBuilder testAppPb = ProcessTools.createJavaProcessBuilder(javaArgs);
 
         final AtomicBoolean failed = new AtomicBoolean();
         final AtomicBoolean passed = new AtomicBoolean();

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeak.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeak.java
@@ -101,10 +101,11 @@ public class RedefineLeak {
         }
         if (argv.length == 1 && argv[0].equals("runtest")) {
             // run outside of jtreg to not OOM on jtreg classes that are loaded after metaspace is full
-            String[] javaArgs1 = { "-XX:MetaspaceSize=12m", "-XX:MaxMetaspaceSize=12m",
-                                   "-javaagent:redefineagent.jar", "RedefineLeak"};
-            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(javaArgs1);
-
+            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                    "-XX:MetaspaceSize=12m",
+                    "-XX:MaxMetaspaceSize=12m",
+                    "-javaagent:redefineagent.jar",
+                    "RedefineLeak");
             OutputAnalyzer output = new OutputAnalyzer(pb.start());
             output.shouldContain("transformCount:10000");
         }

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestRedefineWithUnresolvedClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/TestRedefineWithUnresolvedClass.java
@@ -78,11 +78,10 @@ public class TestRedefineWithUnresolvedClass {
     }
 
     private static void launchTest() throws Throwable {
-        String[] args = {
+        OutputAnalyzer output = ProcessTools.executeTestJvm(
             "-javaagent:" + testClasses + "UnresolvedClassAgent.jar",
             "-Dtest.classes=" + testClasses,
-            "UnresolvedClassAgent" };
-        OutputAnalyzer output = ProcessTools.executeTestJvm(args);
+            "UnresolvedClassAgent");
         output.shouldHaveExitValue(0);
     }
 }

--- a/test/hotspot/jtreg/serviceability/logging/TestLogRotation.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestLogRotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm/timeout=600 TestLogRotation
+ * @run driver/timeout=600 TestLogRotation
  *
  */
 import jdk.test.lib.process.ProcessTools;
@@ -72,22 +72,16 @@ public class TestLogRotation {
 
     public static void runTest(int numberOfFiles) throws Exception {
 
-        ArrayList<String> args = new ArrayList();
-        String[] logOpts = new String[]{
-            "-cp", System.getProperty("java.class.path"),
-            "-Xlog:gc=debug:" + logFileName + "::filesize=" + logFileSizeK + "k,filecount=" + numberOfFiles,
-            "-XX:-DisableExplicitGC", // to ensure that System.gc() works
-            "-Xmx128M"};
-        // System.getProperty("test.java.opts") is '' if no options is set
-        // need to skip such empty
-        String[] externalVMopts = System.getProperty("test.java.opts").length() == 0
-                ? new String[0]
-                : System.getProperty("test.java.opts").split(" ");
-        args.addAll(Arrays.asList(externalVMopts));
-        args.addAll(Arrays.asList(logOpts));
-        args.add(GCLoggingGenerator.class.getName());
-        args.add(String.valueOf(numberOfFiles * logFileSizeK * 1024));
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args.toArray(new String[0]));
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                true,
+                "-cp", System.getProperty("java.class.path"),
+                "-Xlog:gc=debug:" + logFileName
+                        + "::filesize=" + logFileSizeK + "k"
+                        + ",filecount=" + numberOfFiles,
+                "-XX:-DisableExplicitGC", // to ensure that System.gc() works
+                "-Xmx128M",
+                GCLoggingGenerator.class.getName(),
+                String.valueOf(numberOfFiles * logFileSizeK * 1024));
         pb.redirectErrorStream(true);
         pb.redirectOutput(new File(GCLoggingGenerator.class.getName() + ".log"));
         Process process = pb.start();

--- a/test/hotspot/jtreg/serviceability/sa/TestCpoolForInvokeDynamic.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestCpoolForInvokeDynamic.java
@@ -90,8 +90,8 @@ public class TestCpoolForInvokeDynamic {
     private static void createAnotherToAttach(
                             String[] instanceKlassNames,
                             long lingeredAppPid) throws Exception {
-
-        String[] toolArgs = {
+        // Start a new process to attach to the lingered app
+        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
             "--add-modules=jdk.hotspot.agent",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.utilities=ALL-UNNAMED",
@@ -99,11 +99,7 @@ public class TestCpoolForInvokeDynamic {
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.debugger=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.ui.classbrowser=ALL-UNNAMED",
             "TestCpoolForInvokeDynamic",
-            Long.toString(lingeredAppPid)
-        };
-
-        // Start a new process to attach to the lingered app
-        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(toolArgs);
+            Long.toString(lingeredAppPid));
         SATestUtils.addPrivilegesIfNeeded(processBuilder);
         OutputAnalyzer SAOutput = ProcessTools.executeProcess(processBuilder);
         SAOutput.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/serviceability/sa/TestDefaultMethods.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestDefaultMethods.java
@@ -97,19 +97,15 @@ public class TestDefaultMethods {
     private static void createAnotherToAttach(
                             String[] instanceKlassNames,
                             long lingeredAppPid) throws Exception {
-
-        String[] toolArgs = {
+        // Start a new process to attach to the lingered app
+        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
             "--add-modules=jdk.hotspot.agent",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.utilities=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.oops=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.debugger=ALL-UNNAMED",
             "TestDefaultMethods",
-            Long.toString(lingeredAppPid)
-        };
-
-        // Start a new process to attach to the lingered app
-        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(toolArgs);
+             Long.toString(lingeredAppPid));
         SATestUtils.addPrivilegesIfNeeded(processBuilder);
         OutputAnalyzer SAOutput = ProcessTools.executeProcess(processBuilder);
         SAOutput.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/serviceability/sa/TestG1HeapRegion.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestG1HeapRegion.java
@@ -71,18 +71,15 @@ public class TestG1HeapRegion {
 
     private static void createAnotherToAttach(long lingeredAppPid)
                                                          throws Exception {
-        String[] toolArgs = {
+        // Start a new process to attach to the lingered app
+        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
             "--add-modules=jdk.hotspot.agent",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.gc.g1=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.memory=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.runtime=ALL-UNNAMED",
             "TestG1HeapRegion",
-            Long.toString(lingeredAppPid)
-        };
-
-        // Start a new process to attach to the lingered app
-        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(toolArgs);
+            Long.toString(lingeredAppPid));
         SATestUtils.addPrivilegesIfNeeded(processBuilder);
         OutputAnalyzer SAOutput = ProcessTools.executeProcess(processBuilder);
         SAOutput.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSize.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSize.java
@@ -108,21 +108,18 @@ public class TestInstanceKlassSize {
                                               " java.lang.Thread",
                                               " java.lang.Byte",
                                           };
-            String[] toolArgs = {
+            ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                 "--add-modules=jdk.hotspot.agent",
                 "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED",
                 "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.utilities=ALL-UNNAMED",
                 "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.oops=ALL-UNNAMED",
                 "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.debugger=ALL-UNNAMED",
                 "TestInstanceKlassSize",
-                Long.toString(app.getPid())
-            };
+                Long.toString(app.getPid()));
 
             OutputAnalyzer jcmdOutput = jcmd(
                            app.getPid(),
                            "GC.class_stats", "VTab,ITab,OopMap,KlassBytes");
-            ProcessBuilder processBuilder = ProcessTools
-                                            .createJavaProcessBuilder(toolArgs);
             SATestUtils.addPrivilegesIfNeeded(processBuilder);
             output = ProcessTools.executeProcess(processBuilder);
             System.out.println(output.getOutput());

--- a/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSizeForInterface.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSizeForInterface.java
@@ -97,20 +97,16 @@ public class TestInstanceKlassSizeForInterface {
     private static void createAnotherToAttach(
                             String[] instanceKlassNames,
                             int lingeredAppPid) throws Exception {
-
-        String[] toolArgs = {
+        // Start a new process to attach to the LingeredApp process to get SA info
+        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
             "--add-modules=jdk.hotspot.agent",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.utilities=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.oops=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.debugger=ALL-UNNAMED",
             "TestInstanceKlassSizeForInterface",
-            Integer.toString(lingeredAppPid)
-        };
+            Integer.toString(lingeredAppPid));
 
-        // Start a new process to attach to the LingeredApp process
-        ProcessBuilder processBuilder = ProcessTools
-                  .createJavaProcessBuilder(toolArgs);
         SATestUtils.addPrivilegesIfNeeded(processBuilder);
         OutputAnalyzer SAOutput = ProcessTools.executeProcess(processBuilder);
         SAOutput.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/serviceability/sa/TestRevPtrsForInvokeDynamic.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestRevPtrsForInvokeDynamic.java
@@ -65,16 +65,13 @@ public class TestRevPtrsForInvokeDynamic {
 
     private static void createAnotherToAttach(long lingeredAppPid)
                                                          throws Exception {
-        String[] toolArgs = {
+        // Start a new process to attach to the lingered app
+        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
             "--add-modules=jdk.hotspot.agent",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED",
             "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.utilities=ALL-UNNAMED",
             "TestRevPtrsForInvokeDynamic",
-            Long.toString(lingeredAppPid)
-        };
-
-        // Start a new process to attach to the lingered app
-        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(toolArgs);
+            Long.toString(lingeredAppPid));
         SATestUtils.addPrivilegesIfNeeded(processBuilder);
         OutputAnalyzer SAOutput = ProcessTools.executeProcess(processBuilder);
         SAOutput.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/vmTestbase/gc/huge/quicklook/largeheap/MemOptions/MemOptionsTest.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/huge/quicklook/largeheap/MemOptions/MemOptionsTest.java
@@ -94,8 +94,7 @@ public class MemOptionsTest {
         var cmd = new ArrayList<String>();
         Collections.addAll(cmd, opts);
         cmd.add(MemStat.class.getName());
-        var pb = ProcessTools.createJavaProcessBuilder(true,
-                cmd.toArray(new String[cmd.size()]));
+        var pb = ProcessTools.createJavaProcessBuilder(true, cmd);
         var output = new OutputAnalyzer(pb.start());
         if (output.getExitValue() != 0) {
             output.reportDiagnosticSummary();
@@ -108,8 +107,7 @@ public class MemOptionsTest {
         var cmd = new ArrayList<String>();
         Collections.addAll(cmd, opts);
         cmd.add(MemStat.class.getName());
-        var pb = ProcessTools.createJavaProcessBuilder(true,
-                cmd.toArray(new String[cmd.size()]));
+        var pb = ProcessTools.createJavaProcessBuilder(true, cmd);
         var output = new OutputAnalyzer(pb.start());
         if (output.getExitValue() == 0) {
             output.reportDiagnosticSummary();

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -30,8 +30,9 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.concurrent.CountDownLatch;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -259,19 +260,40 @@ public final class ProcessTools {
         return ProcessHandle.current().pid();
     }
 
-
+    /**
+     * Create ProcessBuilder using the java launcher from the jdk to be tested.
+     *
+     * @param command Arguments to pass to the java command.
+     * @return The ProcessBuilder instance representing the java command.
+     */
+    public static ProcessBuilder createJavaProcessBuilder(List<String> command) {
+        return createJavaProcessBuilder(false, command);
+    }
 
     /**
-     * Create ProcessBuilder using the java launcher from the jdk to be tested and
-     * with any platform specific arguments prepended
+     * Create ProcessBuilder using the java launcher from the jdk to be tested.
+     *
+     * @param addTestVmAndJavaOptions If true, adds test.vm.opts and test.java.opts
+     *        to the java arguments.
+     * @param command Arguments to pass to the java command.
+     * @return The ProcessBuilder instance representing the java command.
+     */
+    public static ProcessBuilder createJavaProcessBuilder(boolean addTestVmAndJavaOptions, List<String> command) {
+        return createJavaProcessBuilder(addTestVmAndJavaOptions, command.toArray(String[]::new));
+    }
+
+    /**
+     * Create ProcessBuilder using the java launcher from the jdk to be tested.
+     *
+     * @param command Arguments to pass to the java command.
+     * @return The ProcessBuilder instance representing the java command.
      */
     public static ProcessBuilder createJavaProcessBuilder(String... command) {
         return createJavaProcessBuilder(false, command);
     }
 
     /**
-     * Create ProcessBuilder using the java launcher from the jdk to be tested,
-     * and with any platform specific arguments prepended.
+     * Create ProcessBuilder using the java launcher from the jdk to be tested.
      *
      * @param addTestVmAndJavaOptions If true, adds test.vm.opts and test.java.opts
      *        to the java arguments.
@@ -299,7 +321,7 @@ public final class ProcessTools {
             cmdLine.append(cmd).append(' ');
         System.out.println("Command line: [" + cmdLine.toString() + "]");
 
-        return new ProcessBuilder(args.toArray(new String[args.size()]));
+        return new ProcessBuilder(args);
     }
 
     private static void printStack(Thread t, StackTraceElement[] stack) {
@@ -326,8 +348,25 @@ public final class ProcessTools {
      * @param cmds User specified arguments.
      * @return The output from the process.
      */
+    public static OutputAnalyzer executeTestJvm(List<String> cmds) throws Exception {
+        return executeTestJvm(cmds.toArray(String[]::new));
+    }
+
+    /**
+     * Executes a test jvm process, waits for it to finish and returns the process output.
+     * The default jvm options from jtreg, test.vm.opts and test.java.opts, are added.
+     * The java from the test.jdk is used to execute the command.
+     *
+     * The command line will be like:
+     * {test.jdk}/bin/java {test.vm.opts} {test.java.opts} cmds
+     *
+     * The jvm process will have exited before this method returns.
+     *
+     * @param cmds User specified arguments.
+     * @return The output from the process.
+     */
     public static OutputAnalyzer executeTestJvm(String... cmds) throws Exception {
-        ProcessBuilder pb = createJavaProcessBuilder(Utils.addTestJavaOpts(cmds));
+        ProcessBuilder pb = createJavaProcessBuilder(true, cmds);
         return executeProcess(pb);
     }
 


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.


test/hotspot/jtreg/compiler/graalunit/common/GraalUnitTestLauncher.java
Simple resolve due to context

test/hotspot/jtreg/compiler/linkage/TestLinkageErrorInGenerateOopMap.java
Flags differ. Resolved.

test/hotspot/jtreg/compiler/loopstripmining/CheckLoopStripMining.java
Change already in 11.  Skipped.

test/hotspot/jtreg/gc/arguments/TestMaxRAMFlags.java
Test not in 11, skipped.

test/hotspot/jtreg/gc/arguments/TestSoftMaxHeapSizeFlag.java
Test was added in 13. skipped.

test/hotspot/jtreg/gc/g1/TestMarkStackSizes.java
Test was added in 15 by 8238855: Move G1ConcurrentMark flag sanity checks to g1Arguments

test/hotspot/jtreg/gc/metaspace/TestSizeTransitions.java
Test was added in 14 by 8227179: Test for new gc+metaspace=info output format

nvdimm tests not i 11

test/hotspot/jtreg/gc/z/TestAllocateHeapAt.java
Test was added in 15 by 8239129: ZGC: Allow -XX:AllocateHeapAt to use any filesystem

test/hotspot/jtreg/gc/z/TestHighUsage.java
Test was added in 13 by 8224185: ZGC: Introduce "High Usage" rule

test/hotspot/jtreg/gc/z/TestSmallHeap.java
Test was added in 14 by 8234338: ZGC: Improve small heap usage

test/hotspot/jtreg/runtime/Shutdown/ShutdownTest.java
Test was added in 13 by 8074355: make MutexLocker smarter about non-JavaThreads

test/hotspot/jtreg/runtime/cds/MaxMetaspaceSize.java
In 11, the test is at test/hotspot/jtreg/runtime/SharedArchiveFile/MaxMetaspaceSize.java
It was moved in 14 by 8202339: [TESTBUG] Consolidate the tests in runtime/SharedArchiveFile and runtime/appcds
Applied patch by hand.

test/hotspot/jtreg/runtime/cds/appcds/TestCommon.javaj
In 11, the test is in test/hotspot/jtreg/runtime/appcds/TestCommon.java
It was moved in 14 by 8202339: [TESTBUG] Consolidate the tests in runtime/SharedArchiveFile and runtime/appcds
Applied patch by hand. In addition, I removed makeCommandLineForAppCDS()

test/hotspot/jtreg/runtime/records/RedefineRecord.java
Skipped. Feature and test not in 11.

test/hotspot/jtreg/serviceability/logging/TestLogRotation.java
Arguments used differ.  Resolved.  Probably clean after pushing 8243568.

test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSize.java
test/hotspot/jtreg/serviceability/sa/TestInstanceKlassSizeForInterface.java
Resolved due to context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8244010](https://bugs.openjdk.org/browse/JDK-8244010): Simplify usages of ProcessTools.createJavaProcessBuilder in our tests


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1397/head:pull/1397` \
`$ git checkout pull/1397`

Update a local copy of the PR: \
`$ git checkout pull/1397` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1397`

View PR using the GUI difftool: \
`$ git pr show -t 1397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1397.diff">https://git.openjdk.org/jdk11u-dev/pull/1397.diff</a>

</details>
