### PR TITLE
8249694: java/lang/StringBuffer/HugeCapacity.java and j/l/StringBuilder/HugeCapacity.java tests shouldn't be @ignore-d

### DIFF
--- a/test/jdk/java/lang/StringBuilder/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuilder/HugeCapacity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
  * @bug 8149330
  * @summary Capacity should not get close to Integer.MAX_VALUE unless
  *          necessary
+ * @requires (sun.arch.data.model == "64" & os.maxMemory >= 6G)
  * @run main/othervm -Xmx5G HugeCapacity
- * @ignore This test has huge memory requirements
  */
 
 public class HugeCapacity {


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

I dropped one patch and had to resolve the other because 
8218227: StringBuilder/StringBuffer constructor throws confusing NegativeArraySizeException
is not in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8249694](https://bugs.openjdk.org/browse/JDK-8249694): java/lang/StringBuffer/HugeCapacity.java and j/l/StringBuilder/HugeCapacity.java tests shouldn't be @ignore-d


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1398/head:pull/1398` \
`$ git checkout pull/1398`

Update a local copy of the PR: \
`$ git checkout pull/1398` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1398`

View PR using the GUI difftool: \
`$ git pr show -t 1398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1398.diff">https://git.openjdk.org/jdk11u-dev/pull/1398.diff</a>

</details>
