### PR TITLE
8198343: Test java/awt/print/PrinterJob/TestPgfmtSetMPA.java may fail w/o printer

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -218,7 +218,6 @@ java/awt/image/DrawImage/IncorrectUnmanagedImageRotatedClip.java 8196087 windows
 java/awt/image/MultiResolutionImage/MultiResolutionDrawImageWithTransformTest.java 8198390 generic-all
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8169187 macosx-all
 java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all
-java/awt/print/PrinterJob/TestPgfmtSetMPA.java 8198343 generic-all
 sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all
 sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all
 sun/awt/shell/FileSystemViewMemoryLeak.java 8241806 windows-all

--- a/test/jdk/java/awt/print/PrinterJob/TestPgfmtSetMPA.java
+++ b/test/jdk/java/awt/print/PrinterJob/TestPgfmtSetMPA.java
@@ -23,6 +23,7 @@
 /*
  * @test
  * @bug 6789262
+ * @key printer
  * @summary  Verifies if getPageFormat returns correct mediaprintable value
  * @run main TestPgfmtSetMPA
  */
@@ -38,6 +39,10 @@ public class TestPgfmtSetMPA {
         PrinterJob job;
 
         job = PrinterJob.getPrinterJob();
+        if (job.getPrintService() == null) {
+            System.out.println("No printers. Test cannot continue");
+            return;
+        }
 
         PrintRequestAttributeSet pras = new HashPrintRequestAttributeSet();
 


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8198343](https://bugs.openjdk.org/browse/JDK-8198343): Test java/awt/print/PrinterJob/TestPgfmtSetMPA.java may fail w/o printer


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1402/head:pull/1402` \
`$ git checkout pull/1402`

Update a local copy of the PR: \
`$ git checkout pull/1402` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1402`

View PR using the GUI difftool: \
`$ git pr show -t 1402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1402.diff">https://git.openjdk.org/jdk11u-dev/pull/1402.diff</a>

</details>
