### PR TITLE
8263326: Remove ReceiverTypeData check from serviceability/sa/TestPrintMdo.java

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestPrintMdo.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestPrintMdo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,6 @@ public class TestPrintMdo {
             expStrMap.put("printmdo -a", List.of(
                 "VirtualCallData",
                 "CounterData",
-                "ReceiverTypeData",
                 "bci",
                 "MethodData",
                 "java/lang/Object"));


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

Resolved Copyright, will mark as /clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8263326](https://bugs.openjdk.org/browse/JDK-8263326): Remove ReceiverTypeData check from serviceability/sa/TestPrintMdo.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1403/head:pull/1403` \
`$ git checkout pull/1403`

Update a local copy of the PR: \
`$ git checkout pull/1403` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1403`

View PR using the GUI difftool: \
`$ git pr show -t 1403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1403.diff">https://git.openjdk.org/jdk11u-dev/pull/1403.diff</a>

</details>
