### PR TITLE
8269873: serviceability/sa/Clhsdb tests are using a C2 specific VMStruct field

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbField.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,6 @@ public class ClhsdbField {
                 "field Klass _name Symbol*",
                 "field JavaThread _next JavaThread*",
                 "field JavaThread _osthread OSThread*",
-                "field JVMState _bci",
                 "field TenuredGeneration _the_space ContiguousSpace*",
                 "field VirtualSpace _low_boundary char*",
                 "field MethodCounters _backedge_counter InvocationCounter",

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbVmStructsDump.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbVmStructsDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,6 @@ public class ClhsdbVmStructsDump {
                 "field JavaThread _next JavaThread*",
                 "field JavaThread _osthread OSThread*",
                 "type TenuredGeneration CardGeneration",
-                "field JVMState _bci",
                 "type Universe null",
                 "type ConstantPoolCache MetaspaceObj"));
             test.run(theApp.getPid(), cmds, expStrMap, null);


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269873](https://bugs.openjdk.org/browse/JDK-8269873): serviceability/sa/Clhsdb tests are using a C2 specific VMStruct field


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1410/head:pull/1410` \
`$ git checkout pull/1410`

Update a local copy of the PR: \
`$ git checkout pull/1410` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1410`

View PR using the GUI difftool: \
`$ git pr show -t 1410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1410.diff">https://git.openjdk.org/jdk11u-dev/pull/1410.diff</a>

</details>
