### PR TITLE
4819544: SwingSet2 JTable Demo throws NullPointerException

### DIFF
--- a/src/demo/share/jfc/SwingSet2/TableDemo.java
+++ b/src/demo/share/jfc/SwingSet2/TableDemo.java
@@ -549,7 +549,10 @@ public class TableDemo extends DemoModule {
             public int getRowCount() { return data.length;}
             public Object getValueAt(int row, int col) {return data[row][col];}
             public String getColumnName(int column) {return names[column];}
-            public Class getColumnClass(int c) {return getValueAt(0, c).getClass();}
+            public Class getColumnClass(int c) {
+                Object obj = getValueAt(0, c);
+                return obj != null ? obj.getClass() : Object.class;
+            }
             public boolean isCellEditable(int row, int col) {return col != 5;}
             public void setValueAt(Object aValue, int row, int column) { data[row][column] = aValue; }
          };


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

Simple resolve.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4819544](https://bugs.openjdk.org/browse/JDK-4819544): SwingSet2 JTable Demo throws NullPointerException


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1411/head:pull/1411` \
`$ git checkout pull/1411`

Update a local copy of the PR: \
`$ git checkout pull/1411` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1411`

View PR using the GUI difftool: \
`$ git pr show -t 1411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1411.diff">https://git.openjdk.org/jdk11u-dev/pull/1411.diff</a>

</details>
