### PR TITLE
8277159: Fix java/nio/file/FileStore/Basic.java test by ignoring /run/user/* mount points

### DIFF
--- a/test/jdk/java/nio/file/FileStore/Basic.java
+++ b/test/jdk/java/nio/file/FileStore/Basic.java
@@ -145,6 +145,16 @@ public class Basic {
                     // reflect whether the space attributes would be accessible
                     // were access to be permitted
                     System.err.format("%s is inaccessible\n", store);
+                } catch (FileSystemException fse) {
+                    // On Linux, ignore the FSE if the path is one of the
+                    // /run/user/$UID mounts created by pam_systemd(8) as it
+                    // might be mounted as a fuse.portal filesystem and
+                    // its access attempt might fail with EPERM
+                    if (!Platform.isLinux() || store.toString().indexOf("/run/user") == -1) {
+                        throw new RuntimeException(fse);
+                    } else {
+                        System.err.format("%s error: %s\n", store, fse);
+                    }
                 }
 
                 // two distinct FileStores should not be equal


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277159](https://bugs.openjdk.org/browse/JDK-8277159): Fix java/nio/file/FileStore/Basic.java test by ignoring /run/user/* mount points


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1414/head:pull/1414` \
`$ git checkout pull/1414`

Update a local copy of the PR: \
`$ git checkout pull/1414` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1414`

View PR using the GUI difftool: \
`$ git pr show -t 1414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1414.diff">https://git.openjdk.org/jdk11u-dev/pull/1414.diff</a>

</details>
