### PR TITLE
8279695: [TESTBUG] modify compiler/loopopts/TestSkeletonPredicateNegation.java to run on C1 also

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestSkeletonPredicateNegation.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSkeletonPredicateNegation.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
 
 /**
  * @test
- * @requires vm.compiler2.enabled
  * @bug 8273277
  * @summary Skeleton predicates sometimes need to be negated
  * @run main compiler.loopopts.TestSkeletonPredicateNegation
@@ -50,11 +49,11 @@ public class TestSkeletonPredicateNegation {
     }
 
     public void mainTest (String[] args){
-        long loa11[] = new long[1987];
+        long loa11[] = new long[19];
 
         for (long lo14 : loa11) {
             TestSkeletonPredicateNegation.in0 = -128;
-            for (int i18 = 0; i18 < 52; i18++) {
+            for (int i18 = 0; i18 < 13; i18++) {
                 try {
                     loa11[TestSkeletonPredicateNegation.in0] %= 2275269548L;
                     Math.ceil(1374905370.2785515599);


### PR DESCRIPTION
I backport this for parity with 11.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279695](https://bugs.openjdk.org/browse/JDK-8279695): [TESTBUG] modify compiler/loopopts/TestSkeletonPredicateNegation.java to run on C1 also


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1416/head:pull/1416` \
`$ git checkout pull/1416`

Update a local copy of the PR: \
`$ git checkout pull/1416` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1416`

View PR using the GUI difftool: \
`$ git pr show -t 1416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1416.diff">https://git.openjdk.org/jdk11u-dev/pull/1416.diff</a>

</details>
