### PR TITLE
Backport ad83ec7e281cb3ab7c42e71fab47ea21b93079ea

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -94,6 +94,7 @@ hotspot_slow_compiler = \
   compiler/codegen/aes \
   compiler/codecache/stress \
   compiler/gcbarriers/PreserveFPRegistersTest.java \
+  resourcehogs/compiler \
   :hotspot_compiler_arraycopy
 
 tier1_compiler_1 = \

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIntrinsics2.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIntrinsics2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -706,4 +706,18 @@ public class TestStringIntrinsics2 {
         }
     }
 
+    static String longLatin1 = "0123456789A".repeat(100);
+    static String longUTF = "0123456789\ubeef".repeat(100);
+
+    @Test(role = Role.TEST_HELPER, compileAt = 4, warmup = 1, warmupArgs = { "0123456789", "1" })
+    public static boolean indexOf_use_result_immediately(String a, String b) {
+        char ch = b.charAt(0);
+        return ch == a.charAt(a.indexOf(ch));
+    }
+
+    @Test(role = Role.TEST_ENTRY)
+    public static void test_indexOf_use_result_immediately() {
+        assertTrue(indexOf_use_result_immediately(longLatin1, "A"));
+        assertTrue(indexOf_use_result_immediately(longUTF, "\ubeef"));
+    }
 }

--- a/test/hotspot/jtreg/resourcehogs/compiler/intrinsics/string/TestStringIntrinsics2LargeArray.java
+++ b/test/hotspot/jtreg/resourcehogs/compiler/intrinsics/string/TestStringIntrinsics2LargeArray.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 SAP SE. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8254790
+ * @requires vm.bits == "64" & os.maxMemory > 8G
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /test/hotspot/jtreg
+ *
+ * @build compiler.intrinsics.string.TestStringIntrinsics2
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm
+ *        -mx8G
+ *        -Xbootclasspath/a:.
+ *        -Xmixed
+ *        -XX:+UnlockDiagnosticVMOptions
+ *        -XX:+WhiteBoxAPI
+ *        -XX:+IgnoreUnrecognizedVMOptions
+ *        -XX:MaxInlineSize=70
+ *        -XX:MinInlineFrequencyRatio=0
+ *        resourcehogs.compiler.intrinsics.string.TestStringIntrinsics2LargeArray
+ */
+
+package resourcehogs.compiler.intrinsics.string;
+
+import java.lang.ref.Reference;
+
+import compiler.intrinsics.string.TestStringIntrinsics2;
+
+public final class TestStringIntrinsics2LargeArray {
+    public static void main(String[] args) throws Exception {
+        int[] hugeArray = new int[Integer.MAX_VALUE / 2];
+        TestStringIntrinsics2.main(args);
+        Reference.reachabilityFence(hugeArray);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

I had to resolve Copyright. 
To make the new test work, I had to adapt ClassFileInstaller in the test description.