### PR TITLE
8263871: On sem_destroy() failing we should assert

### DIFF
--- a/src/hotspot/os/posix/semaphore_posix.cpp
+++ b/src/hotspot/os/posix/semaphore_posix.cpp
@@ -46,7 +46,8 @@ PosixSemaphore::PosixSemaphore(uint value) {
 }
 
 PosixSemaphore::~PosixSemaphore() {
-  sem_destroy(&_semaphore);
+  int ret = sem_destroy(&_semaphore);
+  assert_with_errno(ret == 0, "sem_destroy failed");
 }
 
 void PosixSemaphore::signal(uint count) {


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8263871](https://bugs.openjdk.org/browse/JDK-8263871): On sem_destroy() failing we should assert


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1429/head:pull/1429` \
`$ git checkout pull/1429`

Update a local copy of the PR: \
`$ git checkout pull/1429` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1429`

View PR using the GUI difftool: \
`$ git pr show -t 1429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1429.diff">https://git.openjdk.org/jdk11u-dev/pull/1429.diff</a>

</details>
