### PR TITLE
8233558: [TESTBUG] WindowOwnedByEmbeddedFrameTest.java fails on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -481,7 +481,6 @@ java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsDocModalTest.java 816
 
 java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 7099223 linux-all,solaris-all,windows-all
 java/awt/Window/WindowResizing/DoubleClickTitleBarTest.java 8233557 macosx-all
-java/awt/Window/WindowOwnedByEmbeddedFrameTest/WindowOwnedByEmbeddedFrameTest.java 8233558 macosx-all
 java/awt/keyboard/AllKeyCode/AllKeyCode.java 8242930 macosx-all
 java/awt/FullScreen/8013581/bug8013581.java 8169471 macosx-all
 java/awt/event/MouseEvent/RobotLWTest/RobotLWTest.java 8233568 macosx-all

--- a/test/jdk/java/awt/Window/WindowOwnedByEmbeddedFrameTest/WindowOwnedByEmbeddedFrameTest.java
+++ b/test/jdk/java/awt/Window/WindowOwnedByEmbeddedFrameTest/WindowOwnedByEmbeddedFrameTest.java
@@ -26,7 +26,7 @@
  * @bug 8130655
  * @summary Tests that window owned by EmbeddedFrame can receive keyboard input
  * @requires (os.family == "mac")
- * @modules java.desktop/sun.awt
+ * @modules java.desktop/sun.awt java.desktop/sun.lwawt.macosx:open
  * @library ../../regtesthelpers
  * @build Util
  * @run main WindowOwnedByEmbeddedFrameTest


### PR DESCRIPTION
Backport for parity with oracle. Passes WindowOwnedByEmbeddedFrameTest.java on my Macos.

Fix conflict in ProblemList.txt. Clean backport otherwise.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233558](https://bugs.openjdk.org/browse/JDK-8233558): [TESTBUG] WindowOwnedByEmbeddedFrameTest.java fails on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1431/head:pull/1431` \
`$ git checkout pull/1431`

Update a local copy of the PR: \
`$ git checkout pull/1431` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1431`

View PR using the GUI difftool: \
`$ git pr show -t 1431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1431.diff">https://git.openjdk.org/jdk11u-dev/pull/1431.diff</a>

</details>
