### PR TITLE
8254874: ZGC: JNIHandleBlock verification failure in stack watermark processing

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/cm03t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/cm03t001.cpp
@@ -339,6 +339,10 @@ static int prepare(jvmtiEnv* jvmti, JNIEnv* jni) {
     if (!NSK_JNI_VERIFY(jni, (klass = jni->GetObjectClass(thread)) != NULL))
         return NSK_FALSE;
 
+    /* klass is used by other threads - convert to global handle */
+    if (!NSK_JNI_VERIFY(jni, (klass = (jclass)jni->NewGlobalRef(klass)) != NULL))
+        return NSK_FALSE;
+
     /* get tested thread method 'delay' */
     if (!NSK_JNI_VERIFY(jni, (method = jni->GetMethodID(klass, "delay", "()V")) != NULL))
         return NSK_FALSE;
@@ -811,6 +815,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
         nsk_jvmti_setFailStatus();
 
     NSK_TRACE(jni->DeleteGlobalRef(thread));
+    NSK_TRACE(jni->DeleteGlobalRef(klass));
 
     /* resume debugee and wait for sync */
     if (!nsk_jvmti_resumeSync())


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8254874](https://bugs.openjdk.org/browse/JDK-8254874): ZGC: JNIHandleBlock verification failure in stack watermark processing


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1433/head:pull/1433` \
`$ git checkout pull/1433`

Update a local copy of the PR: \
`$ git checkout pull/1433` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1433`

View PR using the GUI difftool: \
`$ git pr show -t 1433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1433.diff">https://git.openjdk.org/jdk11u-dev/pull/1433.diff</a>

</details>
