### PR TITLE
8285617: Fix java/awt/print/PrinterJob/ImagePrinting/PrintARGBImage.java manual test

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/ImagePrinting/PrintARGBImage.java
+++ b/test/jdk/java/awt/print/PrinterJob/ImagePrinting/PrintARGBImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,42 +21,58 @@
  * questions.
  */
 
-/**
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+import java.lang.reflect.InvocationTargetException;
+
+/*
  * @test
  * @bug 6581756
+ * @library ../../../regtesthelpers
+ * @build PassFailJFrame
  * @summary Test printing of images which need to have src area clipped
- * @run main/manual=yesno PrintARGBImage
+ * @run main/manual PrintARGBImage
  */
-
-import java.awt.*;
-import java.awt.image.*;
-import java.awt.print.*;
 
 public class PrintARGBImage implements Printable {
 
-    static String[] text = {
-     "This is a manual test which needs a printer installed",
-     "If you have no printer installed you CANNOT use this test",
-     "It runs automatically and sends one page to the default printer",
-     "It passes if the text shows through the rectangular image",
-    };
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        if (PrinterJob.lookupPrintServices().length > 0) {
 
-    public static void main( String[] args ) {
+            String instruction =
+                    "This is a manual test which needs a printer installed.\n" +
+                    "If you have no printer installed the test passes automatically.\n" +
+                    "The test runs automatically and sends one page to the default printer.\n" +
+                    "The test passes if the text shows through the rectangular image.\n";
 
-        for (int i=0;i<text.length;i++) {
-            System.out.println(text[i]);
-        }
-
-        try {
-            PrinterJob pj = PrinterJob.getPrinterJob();
-            pj.setPrintable(new PrintARGBImage());
-            pj.print();
+            PassFailJFrame passFailJFrame = new PassFailJFrame(instruction, 10);
+            try {
+                PrinterJob pj = PrinterJob.getPrinterJob();
+                pj.setPrintable(new PrintARGBImage());
+                pj.print();
             } catch (Exception ex) {
+                ex.printStackTrace();
+                throw new RuntimeException("Exception whilst printing.");
+            }
+
+            passFailJFrame.awaitAndCheck();
+
+        } else {
+            System.out.println("Printer not configured or available."
+                    + " Test cannot continue.");
+            PassFailJFrame.forcePass();
         }
     }
 
     public int print(Graphics g, PageFormat pf, int pageIndex)
-               throws PrinterException{
+               throws PrinterException {
 
         if (pageIndex != 0) {
             return NO_SUCH_PAGE;
@@ -77,3 +93,5 @@ public class PrintARGBImage implements Printable {
         return PAGE_EXISTS;
     }
 }
+
+


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

I had to replace a string text block by common string concatenation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285617](https://bugs.openjdk.org/browse/JDK-8285617): Fix java/awt/print/PrinterJob/ImagePrinting/PrintARGBImage.java manual test


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1435/head:pull/1435` \
`$ git checkout pull/1435`

Update a local copy of the PR: \
`$ git checkout pull/1435` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1435`

View PR using the GUI difftool: \
`$ git pr show -t 1435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1435.diff">https://git.openjdk.org/jdk11u-dev/pull/1435.diff</a>

</details>
