### PR TITLE
8233557: [TESTBUG] DoubleClickTitleBarTest.java fails on macOs

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -476,7 +476,6 @@ java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsDocModalTest.java 816
 
 
 java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 7099223 linux-all,solaris-all,windows-all
-java/awt/Window/WindowResizing/DoubleClickTitleBarTest.java 8233557 macosx-all
 java/awt/Window/WindowOwnedByEmbeddedFrameTest/WindowOwnedByEmbeddedFrameTest.java 8233558 macosx-all
 java/awt/keyboard/AllKeyCode/AllKeyCode.java 8242930 macosx-all
 java/awt/FullScreen/8013581/bug8013581.java 8169471 macosx-all


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.
I had to resolve due to context, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233557](https://bugs.openjdk.org/browse/JDK-8233557): [TESTBUG] DoubleClickTitleBarTest.java fails on macOs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1438/head:pull/1438` \
`$ git checkout pull/1438`

Update a local copy of the PR: \
`$ git checkout pull/1438` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1438`

View PR using the GUI difftool: \
`$ git pr show -t 1438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1438.diff">https://git.openjdk.org/jdk11u-dev/pull/1438.diff</a>

</details>
