### PR TITLE
8286663: Resolve IDE warnings in WTrayIconPeer and SystemTray

### DIFF
--- a/src/java.desktop/share/classes/java/awt/SystemTray.java
+++ b/src/java.desktop/share/classes/java/awt/SystemTray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,15 +131,7 @@ public class SystemTray {
     private static final TrayIcon[] EMPTY_TRAY_ARRAY = new TrayIcon[0];
 
     static {
-        AWTAccessor.setSystemTrayAccessor(
-            new AWTAccessor.SystemTrayAccessor() {
-                public void firePropertyChange(SystemTray tray,
-                                               String propertyName,
-                                               Object oldValue,
-                                               Object newValue) {
-                    tray.firePropertyChange(propertyName, oldValue, newValue);
-                }
-            });
+        AWTAccessor.setSystemTrayAccessor(SystemTray::firePropertyChange);
     }
 
     /**
@@ -257,15 +249,16 @@ public class SystemTray {
         if (trayIcon == null) {
             throw new NullPointerException("adding null TrayIcon");
         }
-        TrayIcon[] oldArray = null, newArray = null;
-        Vector<TrayIcon> icons = null;
+        TrayIcon[] oldArray;
+        TrayIcon[] newArray;
+        Vector<TrayIcon> icons;
         synchronized (this) {
             oldArray = systemTray.getTrayIcons();
             @SuppressWarnings("unchecked")
             Vector<TrayIcon> tmp = (Vector<TrayIcon>)AppContext.getAppContext().get(TrayIcon.class);
             icons = tmp;
             if (icons == null) {
-                icons = new Vector<TrayIcon>(3);
+                icons = new Vector<>(3);
                 AppContext.getAppContext().put(TrayIcon.class, icons);
 
             } else if (icons.contains(trayIcon)) {
@@ -305,7 +298,8 @@ public class SystemTray {
         if (trayIcon == null) {
             return;
         }
-        TrayIcon[] oldArray = null, newArray = null;
+        TrayIcon[] oldArray;
+        TrayIcon[] newArray;
         synchronized (this) {
             oldArray = systemTray.getTrayIcons();
             @SuppressWarnings("unchecked")
@@ -343,7 +337,7 @@ public class SystemTray {
         @SuppressWarnings("unchecked")
         Vector<TrayIcon> icons = (Vector<TrayIcon>)AppContext.getAppContext().get(TrayIcon.class);
         if (icons != null) {
-            return icons.toArray(new TrayIcon[icons.size()]);
+            return icons.toArray(EMPTY_TRAY_ARRAY);
         }
         return EMPTY_TRAY_ARRAY;
     }
@@ -475,7 +469,7 @@ public class SystemTray {
     private void firePropertyChange(String propertyName,
                                     Object oldValue, Object newValue)
     {
-        if (oldValue != null && newValue != null && oldValue.equals(newValue)) {
+        if (oldValue != null && oldValue.equals(newValue)) {
             return;
         }
         getCurrentChangeSupport().firePropertyChange(propertyName, oldValue, newValue);

--- a/src/java.desktop/windows/classes/sun/awt/windows/WTrayIconPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WTrayIconPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,20 @@
 
 package sun.awt.windows;
 
-import java.awt.Graphics2D;
 import java.awt.AWTEvent;
 import java.awt.Frame;
+import java.awt.Graphics2D;
 import java.awt.GraphicsEnvironment;
-import java.awt.PopupMenu;
-import java.awt.Point;
-import java.awt.TrayIcon;
 import java.awt.Image;
+import java.awt.Point;
+import java.awt.PopupMenu;
+import java.awt.TrayIcon;
 import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferInt;
+import java.awt.image.ImageObserver;
+import java.awt.image.Raster;
 import java.awt.peer.TrayIconPeer;
-import java.awt.image.*;
 
 import sun.awt.AWTAccessor;
 import sun.awt.SunToolkit;
@@ -49,14 +52,11 @@ final class WTrayIconPeer extends WObjectPeer implements TrayIconPeer {
 
     IconObserver observer = new IconObserver();
     boolean firstUpdate = true;
-    Frame popupParent = new Frame("PopupMessageWindow");
+    final Frame popupParent = new Frame("PopupMessageWindow");
     PopupMenu popup;
 
     @Override
     protected void disposeImpl() {
-        if (popupParent != null) {
-            popupParent.dispose();
-        }
         popupParent.dispose();
         _dispose();
         WToolkit.targetDisposedPeer(target, this);


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

I had to resovle copyright.  Will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286663](https://bugs.openjdk.org/browse/JDK-8286663): Resolve IDE warnings in WTrayIconPeer and SystemTray


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1440/head:pull/1440` \
`$ git checkout pull/1440`

Update a local copy of the PR: \
`$ git checkout pull/1440` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1440`

View PR using the GUI difftool: \
`$ git pr show -t 1440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1440.diff">https://git.openjdk.org/jdk11u-dev/pull/1440.diff</a>

</details>
