### PR TITLE
8288599: com/sun/management/OperatingSystemMXBean/TestTotalSwap.java: Expected total swap size ... but getTotalSwapSpaceSize returned ...

### DIFF
--- a/test/jdk/com/sun/management/OperatingSystemMXBean/TestTotalSwap.java
+++ b/test/jdk/com/sun/management/OperatingSystemMXBean/TestTotalSwap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,21 +34,7 @@
  */
 
 /*
- * This test tests the actual swap size on linux and solaris.
- * The correct value should be checked manually:
- * Solaris:
- *   1. In a shell, enter the command: "swap -l"
- *   2. The value (reported in blocks) is in the "blocks" column.
- * Linux:
- *   1. In a shell, enter the command: "cat /proc/meminfo"
- *   2. The value (reported in bytes) is in "Swap" entry, "total" column.
- * Windows NT/XP/2000:
- *   1. Run Start->Accessories->System Tools->System Information.
- *   2. The value (reported in Kbytes) is in the "Page File Space" entry
- * Windows 98/ME:
- *   Unknown.
- *
- * Usage: GetTotalSwapSpaceSize <expected swap size | "sanity-only"> [trace]
+ * This test tests the actual swap size on Linux and MacOS only.
  */
 
 import com.sun.management.OperatingSystemMXBean;
@@ -71,19 +57,31 @@ public class TestTotalSwap {
     private static final long MAX_SIZE_FOR_PASS = Long.MAX_VALUE;
 
     public static void main(String args[]) throws Throwable {
+
         // yocto might ignore the request to report swap size in bytes
         boolean swapInKB = mbean.getVersion().contains("yocto");
-
-        long expected_swap_size = getSwapSizeFromOs();
 
         long min_size = mbean.getFreeSwapSpaceSize();
         if (min_size > 0) {
             min_size_for_pass = min_size;
         }
 
+        long expected_swap_size = getSwapSizeFromOs();
         long size = mbean.getTotalSwapSpaceSize();
 
-        System.out.println("Total swap space size in bytes: " + size);
+        System.out.println("Total swap space size from OS in bytes: " + expected_swap_size);
+        System.out.println("Total swap space size in MBean bytes: " + size);
+
+        // if swap data from OS chnaged re-read OS and MBean data
+        while (expected_swap_size != getSwapSizeFromOs()) {
+            System.out.println("Total swap space reported by OS changed form " + expected_swap_size
+                               + " current value = " + getSwapSizeFromOs());
+            expected_swap_size = getSwapSizeFromOs();
+            size = mbean.getTotalSwapSpaceSize();
+
+            System.out.println("Re-read total swap space size from OS in bytes: " + expected_swap_size);
+            System.out.println("Total swap space size in MBean bytes: " + size);
+        }
 
         if (expected_swap_size > -1) {
             if (size != expected_swap_size) {


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

Resolved Copyright, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288599](https://bugs.openjdk.org/browse/JDK-8288599): com/sun/management/OperatingSystemMXBean/TestTotalSwap.java: Expected total swap size ... but getTotalSwapSpaceSize returned ...


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1441/head:pull/1441` \
`$ git checkout pull/1441`

Update a local copy of the PR: \
`$ git checkout pull/1441` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1441`

View PR using the GUI difftool: \
`$ git pr show -t 1441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1441.diff">https://git.openjdk.org/jdk11u-dev/pull/1441.diff</a>

</details>
