### PR TITLE
8284358: Unreachable loop is not removed from C2 IR, leading to a broken graph

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/systemDictionary.hpp"
+#include "libadt/vectset.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/objArrayKlass.hpp"
@@ -312,7 +313,7 @@ static bool check_compare_clipping( bool less_than, IfNode *iff, ConNode *limit,
 }
 
 //------------------------------is_unreachable_region--------------------------
-// Find if the Region node is reachable from the root.
+// Check if the RegionNode is part of an unsafe loop and unreachable from root.
 bool RegionNode::is_unreachable_region(PhaseGVN *phase) const {
   assert(req() == 2, "");
 
@@ -349,7 +350,7 @@ bool RegionNode::is_unreachable_region(PhaseGVN *phase) const {
   VectorSet visited(a);
 
   // Mark all control nodes reachable from root outputs
-  Node *n = (Node*)phase->C->root();
+  Node* n = (Node*)phase->C->root();
   nstack.push(n);
   visited.set(n->_idx);
   while (nstack.size() != 0) {
@@ -452,7 +453,7 @@ Node *RegionNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 
   // Remove TOP or NULL input paths. If only 1 input path remains, this Region
   // degrades to a copy.
-  bool add_to_worklist = false;
+  bool add_to_worklist = true;
   bool modified = false;
   int cnt = 0;                  // Count of values merging
   DEBUG_ONLY( int cnt_orig = req(); ) // Save original inputs count
@@ -478,7 +479,7 @@ Node *RegionNode::Ideal(PhaseGVN *phase, bool can_reshape) {
         }
       }
       if( phase->type(n) == Type::TOP ) {
-        set_req(i, NULL);       // Ignore TOP inputs
+        set_req_X(i, NULL, phase); // Ignore TOP inputs
         modified = true;
         i--;
         continue;
@@ -509,7 +510,8 @@ Node *RegionNode::Ideal(PhaseGVN *phase, bool can_reshape) {
           }
         }
       }
-      add_to_worklist = true;
+      add_to_worklist = false;
+      phase->is_IterGVN()->add_users_to_worklist(this);
       i--;
     }
   }
@@ -524,44 +526,50 @@ Node *RegionNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     if ((this->is_Loop() && (del_it == LoopNode::EntryControl ||
                              (del_it == 0 && is_unreachable_region(phase)))) ||
         (!this->is_Loop() && has_phis && is_unreachable_region(phase))) {
-      // Yes,  the region will be removed during the next step below.
-      // Cut the backedge input and remove phis since no data paths left.
-      // We don't cut outputs to other nodes here since we need to put them
-      // on the worklist.
-      PhaseIterGVN *igvn = phase->is_IterGVN();
-      if (in(1)->outcnt() == 1) {
-        igvn->_worklist.push(in(1));
-      }
-      del_req(1);
-      cnt = 0;
-      assert( req() == 1, "no more inputs expected" );
-      uint max = outcnt();
-      bool progress = true;
-      Node *top = phase->C->top();
-      DUIterator j;
-      while(progress) {
-        progress = false;
-        for (j = outs(); has_out(j); j++) {
-          Node *n = out(j);
-          if( n->is_Phi() ) {
-            assert( igvn->eqv(n->in(0), this), "" );
-            assert( n->req() == 2 &&  n->in(1) != NULL, "Only one data input expected" );
-            // Break dead loop data path.
-            // Eagerly replace phis with top to avoid phis copies generation.
-            igvn->replace_node(n, top);
-            if( max != outcnt() ) {
-              progress = true;
-              j = refresh_out_pos(j);
-              max = outcnt();
+      // This region and therefore all nodes on the input control path(s) are unreachable
+      // from root. To avoid incomplete removal of unreachable subgraphs, walk up the CFG
+      // and aggressively replace all nodes by top.
+      PhaseIterGVN* igvn = phase->is_IterGVN();
+      Node* top = phase->C->top();
+      ResourceMark rm;
+      Node_List nstack;
+      VectorSet visited(Thread::current()->resource_area());
+      nstack.push(this);
+      visited.set(_idx);
+      while (nstack.size() != 0) {
+        Node* n = nstack.pop();
+        for (uint i = 0; i < n->req(); ++i) {
+          Node* m = n->in(i);
+          assert(m != (Node*)phase->C->root(), "Should be unreachable from root");
+          if (m != NULL && m->is_CFG() && !visited.test_set(m->_idx)) {
+            nstack.push(m);
+          }
+        }
+        if (n->is_Region()) {
+          // Eagerly replace phis with top to avoid regionless phis.
+          n->set_req(0, NULL);
+          bool progress = true;
+          uint max = n->outcnt();
+          DUIterator j;
+          while (progress) {
+            progress = false;
+            for (j = n->outs(); n->has_out(j); j++) {
+              Node* u = n->out(j);
+              if (u->is_Phi()) {
+                igvn->replace_node(u, top);
+                if (max != n->outcnt()) {
+                  progress = true;
+                  j = n->refresh_out_pos(j);
+                  max = n->outcnt();
+                }
+              }
             }
           }
         }
+        igvn->replace_node(n, top);
       }
-      add_to_worklist = true;
+      return NULL;
     }
-  }
-  if (add_to_worklist) {
-    phase->is_IterGVN()->add_users_to_worklist(this); // Revisit collapsed Phis
   }
 
   if( cnt <= 1 ) {              // Only 1 path in?
@@ -597,8 +605,9 @@ Node *RegionNode::Ideal(PhaseGVN *phase, bool can_reshape) {
         assert(parent_ctrl != NULL, "Region is a copy of some non-null control");
         assert(!igvn->eqv(parent_ctrl, this), "Close dead loop");
       }
-      if (!add_to_worklist)
+      if (add_to_worklist) {
         igvn->add_users_to_worklist(this); // Check for further allowed opts
+      }
       for (DUIterator_Last imin, i = last_outs(imin); i >= imin; --i) {
         Node* n = last_out(i);
         igvn->hash_delete(n); // Remove from worklist before modifying edges

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -525,6 +525,7 @@ public:
     disconnect_inputs(NULL, c);
   }
   void set_req_X( uint i, Node *n, PhaseIterGVN *igvn );
+  void set_req_X(uint i, Node *n, PhaseGVN *gvn);
   // Find the one non-null required input.  RegionNode only
   Node *nonnull_req() const;
   // Add or remove precedence edges

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -2234,6 +2234,15 @@ void Node::set_req_X( uint i, Node *n, PhaseIterGVN *igvn ) {
 
 }
 
+void Node::set_req_X(uint i, Node *n, PhaseGVN *gvn) {
+  PhaseIterGVN* igvn = gvn->is_IterGVN();
+  if (igvn == NULL) {
+    set_req(i, n);
+    return;
+  }
+  set_req_X(i, n, igvn);
+}
+
 //-------------------------------replace_by-----------------------------------
 // Using def-use info, replace one node for another.  Follow the def-use info
 // to all users of the OLD node.  Then make all uses point to the NEW node.

--- a/test/hotspot/jtreg/compiler/c2/TestDeadDataLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDeadDataLoop.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8284358
+ * @summary An unreachable loop is not removed, leading to a broken graph.
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:CompileCommand=compileonly,*TestDeadDataLoop::test* -XX:CompileCommand=dontinline,*TestDeadDataLoop::notInlined
+ *                   compiler.c2.TestDeadDataLoop
+ */
+
+package compiler.c2;
+
+public class TestDeadDataLoop {
+
+    static class MyValue {
+        final int x;
+
+        MyValue(int x) {
+            this.x = x;
+        }
+    }
+
+    static boolean flag = false;
+    static MyValue escape = null;
+    static volatile int volInt = 0;
+
+    static boolean test1() {
+        Integer box;
+        if (flag) {
+            box = 0;
+        } else {
+            box = 1;
+        }
+        if (box == 2) {
+            // Not reachable but that's only known after Incremental Boxing Inline
+            for (int i = 0; i < 1000;) {
+                if (notInlined()) {
+                    break;
+                }
+            }
+            MyValue val = new MyValue(4);
+
+            escape = new MyValue(42);
+
+            // Trigger scalarization of val in safepoint debug info
+            notInlined();
+            if (val.x < 0) {
+              return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean test2() {
+        MyValue box = new MyValue(1);
+        if (box.x == 0) {
+            // Not reachable but that's only known once the box.x load is folded during IGVN
+            for (int i = 0; i < 1000;) {
+                if (notInlined()) {
+                    break;
+                }
+            }
+            MyValue val = new MyValue(4);
+
+            escape = new MyValue(42);
+
+            // Trigger scalarization of val in safepoint debug info
+            notInlined();
+            if (val.x < 0) {
+              return true;
+            }
+        }
+        return false;
+    }
+
+    static void test3() {
+        Integer box = 0;
+        if (flag) {
+            box = 1;
+        }
+        if (box == 2) {
+            for (int i = 0; i < 1000;) {
+                if (notInlined()) {
+                    break;
+                }
+            }
+            escape = new MyValue(42);
+        }
+    }
+
+    static void test4() {
+        MyValue box = new MyValue(1);
+        if (box.x == 0) {
+            for (int i = 0; i < 1000;) {
+                if (notInlined()) {
+                    break;
+                }
+            }
+            escape = new MyValue(42);
+        }
+    }
+
+    static void test5() {
+        MyValue box = new MyValue(1);
+        if (box.x == 0) {
+            while (true) {
+                if (notInlined()) {
+                    break;
+                }
+            }
+            escape = new MyValue(42);
+        }
+    }
+
+    static void test6() {
+        MyValue box = new MyValue(1);
+        if (box.x == 0) {
+            while (notInlined()) { }
+            escape = new MyValue(42);
+        }
+    }
+
+    static void test7() {
+        MyValue box = new MyValue(1);
+        if (box.x == 0) {
+            while (true) {
+                escape = new MyValue(2);
+                if (notInlined()) {
+                    break;
+                }
+            }
+            escape = new MyValue(42);
+        }
+    }
+
+    static void test8() {
+        MyValue box = new MyValue(1);
+        if (box.x == 0) {
+            for (int i = 0; i < 1000;) {
+                notInlined();
+                if (flag) {
+                    break;
+                }
+            }
+            escape = new MyValue(42);
+        }
+    }
+
+    static boolean test9() {
+        Integer box;
+        if (flag) {
+            box = 0;
+        } else {
+            box = 1;
+        }
+        if (box == 2) {
+            for (int i = 0; i < 1000;) {
+                // MemBarRelease as only Phi user
+                volInt = 42;
+                if (flag) {
+                    break;
+                }
+            }
+            MyValue val = new MyValue(4);
+
+            escape = new MyValue(42);
+
+            notInlined();
+            if (val.x < 0) {
+              return true;
+            }
+        }
+        return false;
+    }
+
+    static void test10() {
+        MyValue box = new MyValue(1);
+        if (box.x == 0) {
+            while (true) {
+                // Allocate node as only Phi user
+                escape = new MyValue(2);
+                if (flag) {
+                    break;
+                }
+            }
+            escape = new MyValue(42);
+        }
+    }
+
+    public static boolean notInlined() {
+        return false;
+    }
+
+    public static void main(String[] args) {
+        // Make sure classes are initialized
+        Integer i = 42;
+        new MyValue(i);
+        test1();
+        test2();
+        test3();
+        test4();
+        test5();
+        test6();
+        test7();
+        test8();
+        test9();
+        test10();
+    }
+}
+


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

I had to resolve this.
The only reason for this I spotted is the difference
in this comment:
// Eagerly replace phis with top to avoid regionless phis.

I added include vectset.hpp.

The new code needs set_req_X with argument PhaseGVN.
I added 
  void set_req_X( uint i, Node *n, PhaseGVN *igvn );
  to node.hpp and the implementation to phaseX.cpp.

I added an arena to the VectorSet constructor.

Flag StressIGVN is not available in 11.
I removed it from the test and reduced the
test cases accordingly.
Test passes with and without the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284358](https://bugs.openjdk.org/browse/JDK-8284358): Unreachable loop is not removed from C2 IR, leading to a broken graph


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1443/head:pull/1443` \
`$ git checkout pull/1443`

Update a local copy of the PR: \
`$ git checkout pull/1443` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1443`

View PR using the GUI difftool: \
`$ git pr show -t 1443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1443.diff">https://git.openjdk.org/jdk11u-dev/pull/1443.diff</a>

</details>
