### PR TITLE
8169187: [macosx] Aqua: java/awt/image/multiresolution/MultiresolutionIconTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -214,7 +214,6 @@ java/awt/image/DrawImage/IncorrectClipXorModeSurface2Surface.java 8196025 window
 java/awt/image/DrawImage/IncorrectSourceOffset.java 8196086 windows-all
 java/awt/image/DrawImage/IncorrectUnmanagedImageRotatedClip.java 8196087 windows-all
 java/awt/image/MultiResolutionImage/MultiResolutionDrawImageWithTransformTest.java 8198390 generic-all
-java/awt/image/multiresolution/MultiresolutionIconTest.java 8169187 macosx-all
 java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all
 sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all
 sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all

--- a/test/jdk/java/awt/image/multiresolution/MultiresolutionIconTest.java
+++ b/test/jdk/java/awt/image/multiresolution/MultiresolutionIconTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ public class MultiresolutionIconTest extends JFrame {
 
     private boolean checkPressedColor(int x, int y, Color ok) {
 
-        r.mouseMove(x, y);
+        r.mouseMove(x+5, y+5);
         r.waitForIdle();
         r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         r.waitForIdle(100);
@@ -217,6 +217,10 @@ public class MultiresolutionIconTest extends JFrame {
     public static void main(String[] args) throws Exception {
 
         for (UIManager.LookAndFeelInfo LF: UIManager.getInstalledLookAndFeels()) {
+            // skip AquaL&F because Aqua icon darkening fails the test
+            if (LF.getName().equalsIgnoreCase("Mac OS X")) {
+                continue;
+            }
             System.out.println("\nL&F: " + LF.getName());
             (new MultiresolutionIconTest(LF)).doTest();
         }


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8169187](https://bugs.openjdk.org/browse/JDK-8169187): [macosx] Aqua: java/awt/image/multiresolution/MultiresolutionIconTest.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1444/head:pull/1444` \
`$ git checkout pull/1444`

Update a local copy of the PR: \
`$ git checkout pull/1444` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1444`

View PR using the GUI difftool: \
`$ git pr show -t 1444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1444.diff">https://git.openjdk.org/jdk11u-dev/pull/1444.diff</a>

</details>
