### PR TITLE
8289043: C2: Vector constant materialization attempt

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1139,11 +1139,16 @@ Node* MemNode::can_see_stored_value(Node* st, PhaseTransform* phase) const {
       // (This is one of the few places where a generic PhaseTransform
       // can create new nodes.  Think of it as lazily manifesting
       // virtually pre-existing constants.)
-      if (ReduceBulkZeroing || find_array_copy_clone(phase, ld_alloc, in(MemNode::Memory)) == NULL) {
-        // If ReduceBulkZeroing is disabled, we need to check if the allocation does not belong to an
-        // ArrayCopyNode clone. If it does, then we cannot assume zero since the initialization is done
-        // by the ArrayCopyNode.
-        return phase->zerocon(memory_type());
+      if (memory_type() != T_VOID) {
+        if (ReduceBulkZeroing || find_array_copy_clone(phase, ld_alloc, in(MemNode::Memory)) == NULL) {
+          // If ReduceBulkZeroing is disabled, we need to check if the allocation does not belong to an
+          // ArrayCopyNode clone. If it does, then we cannot assume zero since the initialization is done
+          // by the ArrayCopyNode.
+          return phase->zerocon(memory_type());
+        }
+      } else {
+        // TODO: materialize all-zero vector constant
+        assert(!isa_Load() || as_Load()->type()->isa_vect(), "");
       }
     }
 


### PR DESCRIPTION
Backport a small part of [JDK-8223347](https://bugs.openjdk.org/browse/JDK-8223347) which fixes crashes described in [JDK-8289043](https://bugs.openjdk.org/browse/JDK-8289043).
Test-1.java from the latter doesn't crash anymore with this fix.
We will test this PR for some time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289043](https://bugs.openjdk.org/browse/JDK-8289043): C2: Vector constant materialization attempt


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1445/head:pull/1445` \
`$ git checkout pull/1445`

Update a local copy of the PR: \
`$ git checkout pull/1445` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1445`

View PR using the GUI difftool: \
`$ git pr show -t 1445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1445.diff">https://git.openjdk.org/jdk11u-dev/pull/1445.diff</a>

</details>
