### PR TITLE
8287091: aarch64 : guarantee(val < (1ULL << nbits)) failed: Field too big for insn

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -13889,10 +13889,10 @@ instruct overflowAddL_reg_imm(rFlagsReg cr, iRegL op1, immLAddSub op2)
 %{
   match(Set cr (OverflowAddL op1 op2));
 
-  format %{ "cmn   $op1, $op2\t# overflow check long" %}
+  format %{ "adds  zr, $op1, $op2\t# overflow check long" %}
   ins_cost(INSN_COST);
   ins_encode %{
-    __ cmn($op1$$Register, $op2$$constant);
+    __ adds(zr, $op1$$Register, $op2$$constant);
   %}
 
   ins_pipe(icmp_reg_imm);


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287091](https://bugs.openjdk.org/browse/JDK-8287091): aarch64 : guarantee(val < (1ULL << nbits)) failed: Field too big for insn


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1446/head:pull/1446` \
`$ git checkout pull/1446`

Update a local copy of the PR: \
`$ git checkout pull/1446` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1446`

View PR using the GUI difftool: \
`$ git pr show -t 1446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1446.diff">https://git.openjdk.org/jdk11u-dev/pull/1446.diff</a>

</details>
