### PR TITLE
8285921: serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java fails on Alpine

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@ import jdk.test.lib.process.OutputAnalyzer;
 /*
  * @test
  * @bug 8165736
+ * @comment muslc dlclose is a no-op, see 8285921
+ * @requires !vm.musl
  * @library /test/lib
  * @run testng AttachReturnError
  */


### PR DESCRIPTION
Adjust the test for muslc / Alpine

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285921](https://bugs.openjdk.org/browse/JDK-8285921): serviceability/dcmd/jvmti/AttachFailed/AttachReturnError.java fails on Alpine


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1449/head:pull/1449` \
`$ git checkout pull/1449`

Update a local copy of the PR: \
`$ git checkout pull/1449` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1449`

View PR using the GUI difftool: \
`$ git pr show -t 1449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1449.diff">https://git.openjdk.org/jdk11u-dev/pull/1449.diff</a>

</details>
