### PR TITLE
8254976: Re-enable swing jtreg tests which were broken due to samevm mode

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -721,26 +721,11 @@ javax/swing/JInternalFrame/8146321/JInternalFrameIconTest.java 8225045 linux-all
 javax/swing/JLabel/6596966/bug6596966.java 8040914 macosx-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all
 javax/swing/JSpinner/8223788/JSpinnerButtonFocusTest.java 8238085 macosx-all
-javax/swing/MultiUIDefaults/Test6860438.java 8198391 generic-all
-javax/swing/UITest/UITest.java 8198392 generic-all
-javax/swing/plaf/basic/BasicComboBoxEditor/Test8015336.java 8198394 generic-all
-javax/swing/plaf/metal/MetalLookAndFeel/Test8039750.java 8198395 generic-all
-javax/swing/text/DevanagariEditor.java 8198397 generic-all
-javax/swing/SpringLayout/4726194/bug4726194.java 8198399 generic-all
-javax/swing/SwingUtilities/6797139/bug6797139.java 8198400 generic-all
-javax/swing/text/html/parser/Parser/6836089/bug6836089.java 8198401 generic-all
-javax/swing/JTable/8133919/DrawGridLinesTest.java 8198407 generic-all
-javax/swing/text/html/StyleSheet/BackgroundImage/BackgroundImagePosition.java 8198409 generic-all
-javax/swing/text/AbstractDocument/DocumentInsert/DocumentInsertAtWrongPositionTest.java 8198396 generic-all
 javax/swing/JFileChooser/6868611/bug6868611.java 7059834 windows-all
 javax/swing/SwingWorker/6493680/bug6493680.java 8198410 windows-all
 javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java 8065099,8208565 macosx-all,linux-all
 javax/swing/DataTransfer/8059739/bug8059739.java 8199074 generic-all
-javax/swing/JCheckBox/8032667/bug8032667_image_diff.java 8199063 macosx-all
-javax/swing/JComboBox/7031551/bug7031551.java 8199056 generic-all
-javax/swing/JScrollBar/6924059/bug6924059.java 8199078 generic-all
 javax/swing/JTabbedPane/TabProb.java 8236635 linux-all
-javax/swing/JTree/8003830/bug8003830.java 8199057 generic-all
 javax/swing/text/GlyphPainter2/6427244/bug6427244.java 8208566 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JMenuItem/6249972/bug6249972.java 8233640 macosx-all
@@ -752,7 +737,6 @@ java/awt/Robot/HiDPIScreenCapture/HiDPIRobotScreenCaptureTest.java 8282270 windo
 
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 
-javax/swing/plaf/nimbus/ColorCustomizationTest.java 8199080 generic-all
 javax/swing/SwingWorker/6432565/bug6432565.java 8199077 generic-all
 javax/swing/SwingWorker/6880336/NestedWorkers.java 8199049 windows-all
 javax/swing/text/DefaultCaret/6938583/bug6938583.java 8199058 generic-all
@@ -761,9 +745,7 @@ javax/swing/text/html/parser/Parser/HtmlCommentTagParseTest/HtmlCommentTagParseT
 javax/swing/text/StyledEditorKit/8016833/bug8016833.java 8199055 generic-all
 javax/swing/text/Utilities/8134721/bug8134721.java 8199062 generic-all
 javax/swing/tree/DefaultTreeCellRenderer/7142955/bug7142955.java 8199076 generic-all
-javax/swing/UIDefaults/8133926/InternalFrameIcon.java 8199075 generic-all
 javax/swing/UIDefaults/8149879/InternalResourceBundle.java 8199054 windows-all
-javax/swing/text/html/parser/Parser/8078268/bug8078268.java 8199092 generic-all
 javax/swing/PopupFactory/8048506/bug8048506.java 8202660 windows-all
 javax/swing/JTextArea/TextViewOOM/TextViewOOM.java 8167355 generic-all
 javax/swing/JEditorPane/8195095/ImageViewTest.java 8202656 windows-all


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.


I had to resolve.
I found all the lines removed in the ProblemList of 11 except for
javax/swing/UIDefaults/6302464/bug6302464.java.
That one is not listed in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8254976](https://bugs.openjdk.org/browse/JDK-8254976): Re-enable swing jtreg tests which were broken due to samevm mode


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1450/head:pull/1450` \
`$ git checkout pull/1450`

Update a local copy of the PR: \
`$ git checkout pull/1450` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1450`

View PR using the GUI difftool: \
`$ git pr show -t 1450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1450.diff">https://git.openjdk.org/jdk11u-dev/pull/1450.diff</a>

</details>
