### PR TITLE
8282642: vmTestbase/gc/gctests/LoadUnloadGC2/LoadUnloadGC2.java fails intermittently with exit code 1

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/LoadUnloadGC2/LoadUnloadGC2.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/LoadUnloadGC2/LoadUnloadGC2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,12 +31,14 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run driver jdk.test.lib.FileInstaller . .
- * @run main/othervm -XX:-UseGCOverheadLimit gc.gctests.LoadUnloadGC2.LoadUnloadGC2
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI gc.gctests.LoadUnloadGC2.LoadUnloadGC2
  */
 
 package gc.gctests.LoadUnloadGC2;
 
+import sun.hotspot.WhiteBox;
 import nsk.share.*;
 import nsk.share.test.*;
 import nsk.share.gc.*;
@@ -45,15 +47,24 @@ import nsk.share.gc.gp.classload.*;
 import java.lang.reflect.Array;
 
 public class LoadUnloadGC2 extends GCTestBase {
+        private static int CYCLE = 1000;
         public void run() {
                 Stresser stresser = new Stresser(runParams.getStressOptions());
                 stresser.start(500000);
+                int iteration = 0;
                 try {
+                        GarbageProducer garbageProducer = new GeneratedClassProducer();
                         while (stresser.iteration()) {
-                                GarbageProducer garbageProducer = new GeneratedClassProducer();
-                                log.info("Iteration: " + stresser.getIteration());
-                                GarbageUtils.eatMemory(stresser, garbageProducer, 0);
-                                garbageProducer = null;
+                                garbageProducer.create(512L);
+                                if(iteration++ > CYCLE) {
+                                    // Unload once every cycle.
+                                    iteration = 0;
+                                    garbageProducer = null;
+                                    // Perform GC so that
+                                    // class gets unloaded
+                                    WhiteBox.getWhiteBox().fullGC();
+                                    garbageProducer = new GeneratedClassProducer();
+                               }
                         }
                 } finally {
                         stresser.finish();


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

I had to resolve and adapt the test description.
WhiteBox and ClassFileInstaller are at different locations in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282642](https://bugs.openjdk.org/browse/JDK-8282642): vmTestbase/gc/gctests/LoadUnloadGC2/LoadUnloadGC2.java fails intermittently with exit code 1


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1456/head:pull/1456` \
`$ git checkout pull/1456`

Update a local copy of the PR: \
`$ git checkout pull/1456` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1456`

View PR using the GUI difftool: \
`$ git pr show -t 1456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1456.diff">https://git.openjdk.org/jdk11u-dev/pull/1456.diff</a>

</details>
