### PR TITLE
8290529: C2: assert(BoolTest(btest).is_canonical()) failure

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1532,14 +1532,15 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
 
   // Change x u< 1 or x u<= 0 to x == 0
+  // and    x u> 0 or u>= 1   to x != 0
   if (cop == Op_CmpU &&
       cmp1_op != Op_LoadRange &&
-      ((_test._test == BoolTest::lt &&
+      (((_test._test == BoolTest::lt || _test._test == BoolTest::ge) &&
         cmp2->find_int_con(-1) == 1) ||
-       (_test._test == BoolTest::le &&
+       ((_test._test == BoolTest::le || _test._test == BoolTest::gt) &&
         cmp2->find_int_con(-1) == 0))) {
     Node* ncmp = phase->transform(new CmpINode(cmp1, phase->intcon(0)));
-    return new BoolNode(ncmp, BoolTest::eq);
+    return new BoolNode(ncmp, _test.is_less() ? BoolTest::eq : BoolTest::ne);
   }
 
   // Change (arraylength <= 0) or (arraylength == 0)

--- a/test/hotspot/jtreg/compiler/c2/TestUnsignedCompareIntoEqualityNotCanonical.java
+++ b/test/hotspot/jtreg/compiler/c2/TestUnsignedCompareIntoEqualityNotCanonical.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8290529
+ * @summary C2: assert(BoolTest(btest).is_canonical()) failure
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:-TieredCompilation TestUnsignedCompareIntoEqualityNotCanonical
+ */
+
+
+public class TestUnsignedCompareIntoEqualityNotCanonical {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test(0);
+            test(1);
+        }
+    }
+
+    private static int test(int x) {
+        if (Integer.compareUnsigned(0, x) >= 0) {
+            return 42;
+        }
+        return -42;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

I had to skip parts of the tests because the C2 testing framwork ir_framework is not available in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290529](https://bugs.openjdk.org/browse/JDK-8290529): C2: assert(BoolTest(btest).is_canonical()) failure


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1457/head:pull/1457` \
`$ git checkout pull/1457`

Update a local copy of the PR: \
`$ git checkout pull/1457` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1457`

View PR using the GUI difftool: \
`$ git pr show -t 1457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1457.diff">https://git.openjdk.org/jdk11u-dev/pull/1457.diff</a>

</details>
