### PR TITLE
8295322: Tests for JDK-8271459 were not backported to 11u

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestNegativeStringBuilderCapacity.java
+++ b/test/hotspot/jtreg/compiler/c2/TestNegativeStringBuilderCapacity.java
@@ -38,7 +38,7 @@ class TestNegativeStringBuilderCapacity {
     static final String doIdenticalPositiveConst() throws Throwable {
         // C2 knows that argument is 5 and applies string opts without runtime check.
         StringBuilder sb = new StringBuilder(5); // StringBuilder object optimized away by string opts.
-        return sb.toString(); // Call optimized away by string opts.        
+        return sb.toString(); // Call optimized away by string opts.
     }
 
     @Test

--- a/test/hotspot/jtreg/compiler/c2/TestNegativeStringBuilderCapacity.java
+++ b/test/hotspot/jtreg/compiler/c2/TestNegativeStringBuilderCapacity.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  */
 class TestNegativeStringBuilderCapacity {
 
-    static final int pass_count = 100;
+    static final int pass_count = 10000;
 
     static final String doIdenticalPositiveConst() throws Throwable {
         // C2 knows that argument is 5 and applies string opts without runtime check.

--- a/test/hotspot/jtreg/compiler/c2/TestNegativeStringBuilderCapacity.java
+++ b/test/hotspot/jtreg/compiler/c2/TestNegativeStringBuilderCapacity.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @bug 8271459
+ * @requires vm.compiler2.enabled
+ * @summary C2 applies string opts to StringBuilder object created with a negative size and misses the NegativeArraySizeException.
+ * @run testng TestNegativeStringBuilderCapacity
+ */
+class TestNegativeStringBuilderCapacity {
+
+    static final int pass_count = 100;
+
+    static final String doIdenticalPositiveConst() throws Throwable {
+        // C2 knows that argument is 5 and applies string opts without runtime check.
+        StringBuilder sb = new StringBuilder(5); // StringBuilder object optimized away by string opts.
+        return sb.toString(); // Call optimized away by string opts.        
+    }
+
+    @Test
+    static final void testIdenticalPositiveConst() {
+        int throw_count = 0;
+        for ( int pass = 0; pass < pass_count; pass++ ) {
+            try {
+                String s = doIdenticalPositiveConst();
+            } catch (NegativeArraySizeException e) {
+                throw_count++;
+            } catch (Throwable e) {
+                Assert.fail("Unexpected exception thrown");
+            }
+        }
+        Assert.assertEquals( throw_count, 0, String.format("%d exception were thrown, 0 expected", throw_count));
+    }
+
+    static final String doIdenticalNegativeConst() throws Throwable {
+        // C2 knows that we always have a negative int -> bail out of string opts
+        StringBuilder sb = new StringBuilder(-5);
+        return sb.toString(); // Call stays due to bailout.
+    }
+
+    @Test
+    static final void testIdenticalNegativeConst() {
+        int throw_count = 0;
+        for ( int pass = 0; pass < pass_count; pass++ ) {
+            try {
+                String s = doIdenticalNegativeConst();
+            } catch (NegativeArraySizeException e) {
+                throw_count++;
+            } catch (Throwable e) {
+                Assert.fail("Unexpected exception thrown");
+            }
+        }
+        Assert.assertEquals( throw_count, pass_count, String.format("%d exception were thrown, %d expected", throw_count, pass_count));
+    }
+
+    static int aField;
+
+    static final String doField() throws Throwable {
+        // C2 does not know if iFld is positive or negative. It applies string opts but inserts a runtime check to
+        // bail out to interpreter
+        StringBuilder sb = new StringBuilder(aField);
+        return sb.toString();
+    }
+
+    @Test
+    static final void testPositiveField() {
+        aField = 4;
+        int throw_count = 0;
+        for ( int pass = 0; pass < pass_count; pass++ ) {
+            try {
+                String s = doField();
+            } catch (NegativeArraySizeException e) {
+                throw_count++;
+            } catch (Throwable e) {
+                Assert.fail("Unexpected exception thrown");
+            }
+        }
+        Assert.assertEquals( throw_count, 0, String.format("%d exception were thrown, 0 expected", throw_count));
+    }
+
+    @Test
+    static final void testNegativeField() {
+        aField = -4;
+        int throw_count = 0;
+        for ( int pass = 0; pass < pass_count; pass++ ) {
+            try {
+                String s = doField();
+            } catch (NegativeArraySizeException e) {
+                throw_count++;
+            } catch (Throwable e) {
+                Assert.fail("Unexpected exception thrown");
+            }
+        }
+        Assert.assertEquals( throw_count, pass_count, String.format("%d exception were thrown, %d expected", throw_count, pass_count));
+    }
+
+    static final String doPossiblyNegativeConst(boolean flag) throws Throwable {
+        // C2 knows that cap is between -5 and 5. It applies string opts but inserts a runtime check to
+        // bail out to interpreter. This path is sometimes taken and sometimes not.
+        final int capacity = flag ? 5 : -5;
+        StringBuilder sb = new StringBuilder(capacity);
+        return sb.toString();
+    }
+
+    @Test
+    static final void testPossiblyNegativeConst() {
+        int throw_count = 0;
+        for ( int pass = 0; pass < pass_count; pass++ ) {
+            try {
+                String s = doPossiblyNegativeConst((pass % 2) == 0);
+            } catch (NegativeArraySizeException e) {
+                throw_count++;
+            } catch (Throwable e) {
+                Assert.fail("Unexpected exception thrown");
+            }
+        }
+        Assert.assertEquals( throw_count, pass_count/2, String.format("%d exception were thrown, %d expected", throw_count, pass_count/2));
+    }
+
+    static final String doPositiveConst(boolean flag) throws Throwable {
+        // C2 knows that cap is between 1 and 100 and applies string opts without runtime check.
+        final int capacity = flag ? 1 : 100;
+        StringBuilder sb = new StringBuilder(capacity);
+        return sb.toString();
+    }
+
+    @Test
+    static final void testPositiveConst() {
+        int throw_count = 0;
+        for ( int pass = 0; pass < pass_count; pass++ ) {
+            try {
+                String s = doPositiveConst((pass % 2) == 0);
+            } catch (NegativeArraySizeException e) {
+                throw_count++;
+            } catch (Throwable e) {
+                Assert.fail("Unexpected exception thrown");
+            }
+        }
+        Assert.assertEquals( throw_count, 0, String.format("%d exception were thrown, 0 expected", throw_count));
+    }
+
+    static final String doArg(int capacity) throws Throwable {
+        // C2 does not know if cap is positive or negative. It applies string opts but inserts a runtime check to
+        // bail out to interpreter. This path is always taken because cap is always negative.
+        StringBuilder sb = new StringBuilder(capacity);
+        return sb.toString();
+    }
+
+    @Test
+    static final void testArg() {
+        int throw_count = 0;
+        for ( int pass = 0; pass < pass_count; pass++ ) {
+            try {
+                String s = doArg((pass % 2) == 0 ? 3 : -3 );
+            } catch (NegativeArraySizeException e) {
+                throw_count++;
+            } catch (Throwable e) {
+                Assert.fail("Unexpected exception thrown");
+            }
+        }
+        Assert.assertEquals( throw_count, pass_count/2, String.format("%d exception were thrown, %d expected", throw_count, pass_count/2));
+    }
+}

--- a/test/jdk/com/sun/management/OperatingSystemMXBean/TestTotalSwap.java
+++ b/test/jdk/com/sun/management/OperatingSystemMXBean/TestTotalSwap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,21 +34,7 @@
  */
 
 /*
- * This test tests the actual swap size on linux and solaris.
- * The correct value should be checked manually:
- * Solaris:
- *   1. In a shell, enter the command: "swap -l"
- *   2. The value (reported in blocks) is in the "blocks" column.
- * Linux:
- *   1. In a shell, enter the command: "cat /proc/meminfo"
- *   2. The value (reported in bytes) is in "Swap" entry, "total" column.
- * Windows NT/XP/2000:
- *   1. Run Start->Accessories->System Tools->System Information.
- *   2. The value (reported in Kbytes) is in the "Page File Space" entry
- * Windows 98/ME:
- *   Unknown.
- *
- * Usage: GetTotalSwapSpaceSize <expected swap size | "sanity-only"> [trace]
+ * This test tests the actual swap size on Linux and MacOS only.
  */
 
 import com.sun.management.OperatingSystemMXBean;
@@ -71,19 +57,31 @@ public class TestTotalSwap {
     private static final long MAX_SIZE_FOR_PASS = Long.MAX_VALUE;
 
     public static void main(String args[]) throws Throwable {
+
         // yocto might ignore the request to report swap size in bytes
         boolean swapInKB = mbean.getVersion().contains("yocto");
-
-        long expected_swap_size = getSwapSizeFromOs();
 
         long min_size = mbean.getFreeSwapSpaceSize();
         if (min_size > 0) {
             min_size_for_pass = min_size;
         }
 
+        long expected_swap_size = getSwapSizeFromOs();
         long size = mbean.getTotalSwapSpaceSize();
 
-        System.out.println("Total swap space size in bytes: " + size);
+        System.out.println("Total swap space size from OS in bytes: " + expected_swap_size);
+        System.out.println("Total swap space size in MBean bytes: " + size);
+
+        // if swap data from OS chnaged re-read OS and MBean data
+        while (expected_swap_size != getSwapSizeFromOs()) {
+            System.out.println("Total swap space reported by OS changed form " + expected_swap_size
+                               + " current value = " + getSwapSizeFromOs());
+            expected_swap_size = getSwapSizeFromOs();
+            size = mbean.getTotalSwapSpaceSize();
+
+            System.out.println("Re-read total swap space size from OS in bytes: " + expected_swap_size);
+            System.out.println("Total swap space size in MBean bytes: " + size);
+        }
 
         if (expected_swap_size > -1) {
             if (size != expected_swap_size) {


### PR DESCRIPTION
Hi!

Here is a portion of tests from [JDK-8271459](https://bugs.openjdk.org/browse/JDK-8271459) adopted to the 11. Original tests were not backported to the 11 because of the fact they use IR test framework that does not exists in the 11.

Verified on amd64/20.04LTS:

7 of 7 new tests PASS on https://github.com/openjdk/jdk11u-dev/commit/844c504bc18fa8a79ceacc6b6f235650f5e643bf
4 of 7 new tests FAIL on the previous https://github.com/openjdk/jdk11u-dev/commit/4940e2e8d85f2eef88c6132923b165253c13aa73

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295322](https://bugs.openjdk.org/browse/JDK-8295322): Tests for JDK-8271459 were not backported to 11u


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Contributors
 * Christian Hagedorn `<chagedorn@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1460/head:pull/1460` \
`$ git checkout pull/1460`

Update a local copy of the PR: \
`$ git checkout pull/1460` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1460`

View PR using the GUI difftool: \
`$ git pr show -t 1460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1460.diff">https://git.openjdk.org/jdk11u-dev/pull/1460.diff</a>

</details>
