### PR TITLE
8280158: New test from JDK-8274736 failed with/without patch in JDK11u

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionImpl.java
@@ -383,8 +383,12 @@ final class SSLSessionImpl extends ExtendedSSLSession {
      * maximum lifetime in any case.
      */
     boolean isRejoinable() {
+        // TLS 1.3 can have no session id
+        if (protocolVersion.useTLS13PlusSpec()) {
+            return (!invalidated && isLocalAuthenticationValid());
+        }
         return sessionId != null && sessionId.length() != 0 &&
-            !invalidated && isLocalAuthenticationValid();
+                !invalidated && isLocalAuthenticationValid();
     }
 
     @Override

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -645,7 +645,7 @@ javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
-sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java 8277970,8280158 generic-all
+sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java 8277970 linux-all,macosx-x64
 
 ############################################################################
 


### PR DESCRIPTION
Fix as per [suggestion of Daniel Jelinski](https://bugs.openjdk.org/browse/JDK-8280158?focusedCommentId=14529129&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14529129), backport part of [JDK-8211018](https://bugs.openjdk.org/browse/JDK-8211018)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280158](https://bugs.openjdk.org/browse/JDK-8280158): New test from JDK-8274736 failed with/without patch in JDK11u


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - no project role)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1465/head:pull/1465` \
`$ git checkout pull/1465`

Update a local copy of the PR: \
`$ git checkout pull/1465` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1465`

View PR using the GUI difftool: \
`$ git pr show -t 1465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1465.diff">https://git.openjdk.org/jdk11u-dev/pull/1465.diff</a>

</details>
