### PR TITLE
8295469: S390X: Optimized builds are broken

### DIFF
--- a/src/hotspot/cpu/s390/assembler_s390.cpp
+++ b/src/hotspot/cpu/s390/assembler_s390.cpp
@@ -139,7 +139,7 @@ Assembler::branch_condition Assembler::inverse_float_condition(Assembler::branch
   return inverse_cc;
 }
 
-#ifdef ASSERT
+#ifndef PRODUCT
 void Assembler::print_dbg_msg(outputStream* out, unsigned long inst, const char* msg, int ilen) {
   out->flush();
   switch (ilen) {

--- a/src/hotspot/cpu/s390/interp_masm_s390.hpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.hpp
@@ -164,7 +164,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
 
   // Accessors to the template interpreter state.
 
-  void asm_assert_ijava_state_magic(Register tmp) PRODUCT_RETURN;
+  void asm_assert_ijava_state_magic(Register tmp) NOT_DEBUG_RETURN;
 
   void save_bcp();
 


### PR DESCRIPTION
Fixes S390X optimized builds.

Additional testing:
 - [x] Linux S390X {fastdebug, release, optimized} builds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295469](https://bugs.openjdk.org/browse/JDK-8295469): S390X: Optimized builds are broken


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1466/head:pull/1466` \
`$ git checkout pull/1466`

Update a local copy of the PR: \
`$ git checkout pull/1466` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1466`

View PR using the GUI difftool: \
`$ git pr show -t 1466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1466.diff">https://git.openjdk.org/jdk11u-dev/pull/1466.diff</a>

</details>
