### PR TITLE
8227179: Test for new gc+metaspace=info output format

### DIFF
--- a/test/hotspot/jtreg/gc/metaspace/TestSizeTransitions.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestSizeTransitions.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Twitter, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package gc.metaspace;
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+/* @test TestSizeTransitionsSerial
+ * @key gc
+ * @requires vm.gc.Serial
+ * @summary Tests that the metaspace size transition logging is done correctly.
+ * @library /test/lib
+ * @run driver gc.metaspace.TestSizeTransitions false -XX:+UseSerialGC
+ * @run driver gc.metaspace.TestSizeTransitions true  -XX:+UseSerialGC
+ */
+
+/* @test TestSizeTransitionsParallel
+ * @key gc
+ * @requires vm.gc.Parallel
+ * @summary Tests that the metaspace size transition logging is done correctly.
+ * @library /test/lib
+ * @run driver gc.metaspace.TestSizeTransitions false -XX:+UseParallelGC
+ * @run driver gc.metaspace.TestSizeTransitions true  -XX:+UseParallelGC
+ */
+
+/* @test TestSizeTransitionsG1
+ * @key gc
+ * @requires vm.gc.G1
+ * @summary Tests that the metaspace size transition logging is done correctly.
+ * @library /test/lib
+ * @run driver gc.metaspace.TestSizeTransitions false -XX:+UseG1GC
+ * @run driver gc.metaspace.TestSizeTransitions true  -XX:+UseG1GC
+ */
+
+/* @test TestSizeTransitionsCMS
+ * @key gc
+ * @requires vm.gc.ConcMarkSweep
+ * @summary Tests that the metaspace size transition logging is done correctly.
+ * @library /test/lib
+ * @run driver gc.metaspace.TestSizeTransitions false -XX:+UseConcMarkSweepGC
+ * @run driver gc.metaspace.TestSizeTransitions true  -XX:+UseConcMarkSweepGC
+ */
+
+public class TestSizeTransitions {
+  public static class Run {
+    public static void main(String... args) throws Exception {
+      System.out.println("Run started.");
+
+      // easiest way to generate a metaspace transition is to ask for a full GC
+      System.gc();
+
+      System.out.println("Run finished.");
+    }
+  }
+
+  // matches the log tags
+  //   e.g., [0.043s][info][gc]
+  private static final String LOG_TAGS_REGEX = "(\\[.*\\])+ ";
+
+  // matches a size transition
+  //   e.g., 177K(4864K)->177K(4864K)
+  private static final String SIZE_TRANSITION_REGEX = "\\d+K\\(\\d+K\\)->\\d+K\\(\\d+K\\)";
+
+  // matches -coops metaspace size transitions
+  private static final String NO_COOPS_REGEX =
+    String.format("^%s.* Metaspace: %s$",
+                  LOG_TAGS_REGEX,
+                  SIZE_TRANSITION_REGEX);
+
+  // matches +coops metaspace size transitions
+  private static final String COOPS_REGEX =
+    String.format("^%s.* Metaspace: %s NonClass: %s Class: %s$",
+                  LOG_TAGS_REGEX,
+                  SIZE_TRANSITION_REGEX,
+                  SIZE_TRANSITION_REGEX,
+                  SIZE_TRANSITION_REGEX);
+
+  public static void main(String... args) throws Exception {
+    // args: <use-coops> <gc-arg>
+    if (args.length != 2) {
+      throw new RuntimeException("wrong number of args: " + args.length);
+    }
+
+    final boolean useCoops = Boolean.parseBoolean(args[0]);
+    final String gcArg = args[1];
+    final String[] jvmArgs = {
+      useCoops ? "-XX:+UseCompressedOops" : "-XX:-UseCompressedOops",
+      gcArg,
+      "-Xmx256m",
+      "-Xlog:gc,gc+metaspace=info",
+      TestSizeTransitions.Run.class.getName()
+    };
+
+    System.out.println("JVM args:");
+    for (String a : jvmArgs) {
+      System.out.println("  " + a);
+    }
+
+    final ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(jvmArgs);
+    final OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    System.out.println(output.getStdout());
+    output.shouldHaveExitValue(0);
+
+    if (useCoops) {
+      output.stdoutShouldMatch(COOPS_REGEX);
+      output.stdoutShouldNotMatch(NO_COOPS_REGEX);
+    } else {
+      output.stdoutShouldMatch(NO_COOPS_REGEX);
+      output.stdoutShouldNotMatch(COOPS_REGEX);
+    }
+  }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.
Requires a follow up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8227179](https://bugs.openjdk.org/browse/JDK-8227179): Test for new gc+metaspace=info output format


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1467/head:pull/1467` \
`$ git checkout pull/1467`

Update a local copy of the PR: \
`$ git checkout pull/1467` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1467`

View PR using the GUI difftool: \
`$ git pr show -t 1467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1467.diff">https://git.openjdk.org/jdk11u-dev/pull/1467.diff</a>

</details>
