### PR TITLE
8222091: Javadoc does not handle package annotations correctly on package-info.java

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -2975,11 +2975,11 @@ public class Utils {
      */
     public TreePath getTreePath(Element e) {
         DocCommentDuo duo = dcTreeCache.get(e);
-        if (isValidDuo(duo) && duo.treePath != null) {
+        if (duo != null && duo.treePath != null) {
             return duo.treePath;
         }
         duo = configuration.cmtUtils.getSyntheticCommentDuo(e);
-        if (isValidDuo(duo) && duo.treePath != null) {
+        if (duo != null && duo.treePath != null) {
             return duo.treePath;
         }
         Map<Element, TreePath> elementToTreePath = configuration.workArounds.getElementToTreePath();
@@ -3005,20 +3005,20 @@ public class Utils {
         ElementKind kind = element.getKind();
         if (kind == ElementKind.PACKAGE || kind == ElementKind.OTHER) {
             duo = dcTreeCache.get(element); // local cache
-            if (!isValidDuo(duo) && kind == ElementKind.PACKAGE) {
+            if (duo == null && kind == ElementKind.PACKAGE) {
                 // package-info.java
                 duo = getDocCommentTuple(element);
             }
-            if (!isValidDuo(duo)) {
+            if (duo == null) {
                 // package.html or overview.html
                 duo = configuration.cmtUtils.getHtmlCommentDuo(element); // html source
             }
         } else {
             duo = configuration.cmtUtils.getSyntheticCommentDuo(element);
-            if (!isValidDuo(duo)) {
+            if (duo == null) {
                 duo = dcTreeCache.get(element); // local cache
             }
-            if (!isValidDuo(duo)) {
+            if (duo == null) {
                 duo = getDocCommentTuple(element); // get the real mccoy
             }
         }

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug  8222091
+ * @summary  Javadoc does not handle package annotations correctly on package-info.java
+ * @library  ../../lib/
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build   javadoc.tester.*
+ * @run main TestPackageAnnotation
+ */
+
+import javadoc.tester.JavadocTester;
+
+public class TestPackageAnnotation extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestPackageAnnotation tester = new TestPackageAnnotation();
+        tester.runTests();
+    }
+
+    @Test
+    public void testPackageInfoAnnotationNoComment() {
+        javadoc("-d", "out-annotation",
+                "-sourcepath", testSrc,
+                "-use",
+                "pkg1");
+        checkExit(Exit.OK);
+        checkOutput("pkg1/package-summary.html", true,
+                "<main role=\"main\">\n<div class=\"header\">\n"
+                + "<p>@Deprecated(since=\"1&lt;2&gt;3\")\n"
+                + "</p>\n"
+                + "<h1 title=\"Package\" class=\"title\">Package&nbsp;pkg1</h1>\n"
+                + "</div>\n");
+    }
+
+    @Test
+    public void testPackageHtmlTag() {
+        javadoc("-d", "out-annotation-2",
+                "-sourcepath", testSrc,
+                "-use",
+                "pkg2");
+        checkExit(Exit.OK);
+        checkOutput("pkg2/package-summary.html", true,
+                "<div class=\"deprecationBlock\"><span class=\"deprecatedLabel\">Deprecated.</span>\n"
+                + "<div class=\"deprecationComment\">This package is deprecated.</div>\n"
+                + "</div>\n"
+                + "<div class=\"block\">This is the description of package pkg2.</div>\n"
+                + "</section>");
+    }
+
+    @Test
+    public void testPackageInfoAndHtml() {
+        javadoc("-d", "out-annotation-3",
+                "-sourcepath", testSrc,
+                "-use",
+                "pkg3");
+        checkExit(Exit.OK);
+        checkOutput("pkg3/package-summary.html", true,
+                "<main role=\"main\">\n"
+                + "<div class=\"header\">\n"
+                + "<p>@Deprecated(since=\"1&lt;2&gt;3\")\n"
+                + "</p>\n"
+                + "<h1 title=\"Package\" class=\"title\">Package&nbsp;pkg3</h1>\n"
+                + "</div>\n");
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg1/A.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg1/A.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg1;
+
+public class A {
+}

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg1/package-info.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg1/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// Contains no javadoc comment, but should still be honored by javadoc.
+
+@Deprecated(since="1<2>3")
+package pkg1;

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg2/A.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg2/A.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg2;
+
+public class A {
+}

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg2/package.html
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg2/package.html
@@ -1,0 +1,9 @@
+<html lang="en">
+<head>
+    <title>Package Summary</title>
+</head>
+<body>
+This is the description of package pkg2.
+@deprecated This package is deprecated.
+</body>
+</html>

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg3/A.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg3/A.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg3;
+
+public class A {
+}

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg3/package-info.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg3/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// Contains no javadoc comment, but should still be honored by javadoc.
+
+@Deprecated(since="1<2>3")
+package pkg3;

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg3/package.html
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg3/package.html
@@ -1,0 +1,8 @@
+<html lang="en">
+<head>
+    <title>Package Summary</title>
+</head>
+<body>
+This file is ignored by javadoc as the package contains a package-info.java file.
+</body>
+</html>


### PR DESCRIPTION
This is a backport of [JDK-8222091: Javadoc does not handle package annotations correctly on package-info.java](https://bugs.openjdk.java.net/browse/JDK-8222091)

This fixes a regression in 11.0.17 caused by the backport of [JDK-8193462](https://bugs.openjdk.org/browse/JDK-8193462), see [JDK-8295850](https://bugs.openjdk.org/browse/JDK-8295850)

Original patch applied cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8222091](https://bugs.openjdk.org/browse/JDK-8222091): Javadoc does not handle package annotations correctly on package-info.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1472/head:pull/1472` \
`$ git checkout pull/1472`

Update a local copy of the PR: \
`$ git checkout pull/1472` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1472`

View PR using the GUI difftool: \
`$ git pr show -t 1472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1472.diff">https://git.openjdk.org/jdk11u-dev/pull/1472.diff</a>

</details>
