### PR TITLE
8295288: Some vm_flags tests associate with a wrong BugID

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/whitebox/vm_flags/BooleanTest.java
+++ b/test/hotspot/jtreg/testlibrary_tests/whitebox/vm_flags/BooleanTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test BooleanTest
- * @bug 8028756
+ * @bug 8038756
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.compiler

--- a/test/hotspot/jtreg/testlibrary_tests/whitebox/vm_flags/DoubleTest.java
+++ b/test/hotspot/jtreg/testlibrary_tests/whitebox/vm_flags/DoubleTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test DoubleTest
- * @bug 8028756
+ * @bug 8038756
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.management/sun.management

--- a/test/hotspot/jtreg/testlibrary_tests/whitebox/vm_flags/StringTest.java
+++ b/test/hotspot/jtreg/testlibrary_tests/whitebox/vm_flags/StringTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test StringTest
- * @bug 8028756
+ * @bug 8038756
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.management/sun.management

--- a/test/hotspot/jtreg/testlibrary_tests/whitebox/vm_flags/Uint64Test.java
+++ b/test/hotspot/jtreg/testlibrary_tests/whitebox/vm_flags/Uint64Test.java
@@ -23,7 +23,7 @@
 
 /*
  * @test Uint64Test
- * @bug 8028756
+ * @bug 8038756
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.management/sun.management

--- a/test/hotspot/jtreg/testlibrary_tests/whitebox/vm_flags/UintxTest.java
+++ b/test/hotspot/jtreg/testlibrary_tests/whitebox/vm_flags/UintxTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test UintxTest
- * @bug 8028756
+ * @bug 8038756
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management/sun.management


### PR DESCRIPTION
clean backport. passes failed tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295288](https://bugs.openjdk.org/browse/JDK-8295288): Some vm_flags tests associate with a wrong BugID


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1473/head:pull/1473` \
`$ git checkout pull/1473`

Update a local copy of the PR: \
`$ git checkout pull/1473` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1473`

View PR using the GUI difftool: \
`$ git pr show -t 1473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1473.diff">https://git.openjdk.org/jdk11u-dev/pull/1473.diff</a>

</details>
