### PR TITLE
8273578: javax/swing/JMenu/4515762/bug4515762.java fails on macOS 12

### DIFF
--- a/test/jdk/javax/swing/JMenu/4515762/bug4515762.java
+++ b/test/jdk/javax/swing/JMenu/4515762/bug4515762.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,9 +21,15 @@
  * questions.
  */
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
 
 /**
  * @test
@@ -37,8 +43,8 @@ import javax.swing.*;
  */
 public class bug4515762 {
 
-    private static volatile boolean actionExpected = false;
-    private static volatile boolean actionRecieved = false;
+    private static volatile boolean actionExpected;
+    private static volatile boolean actionRecieved;
     private static JFrame frame;
 
     /**
@@ -99,18 +105,18 @@ public class bug4515762 {
         return menuItem;
     }
 
-    public static void checkAction() {
+    public static void checkAction(String str) {
         if (actionRecieved == true) {
             actionRecieved = false;
         } else {
-            throw new RuntimeException("Action has not been received");
+            throw new RuntimeException("Action has not been received: " + str);
         }
     }
 
     public static void main(String[] args) throws Throwable {
         try {
             Robot robot = new Robot();
-            robot.setAutoDelay(250);
+            robot.setAutoDelay(100);
 
             SwingUtilities.invokeAndWait(new Runnable() {
 
@@ -119,6 +125,7 @@ public class bug4515762 {
                     frame = new JFrame("Test");
                     frame.setJMenuBar(createMenuBar());
                     frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                    frame.setLocationRelativeTo(null);
                     frame.pack();
                     frame.setVisible(true);
                     frame.toFront();
@@ -126,6 +133,7 @@ public class bug4515762 {
             });
 
             robot.waitForIdle();
+            robot.delay(1000);
 
             Util.hitMnemonics(robot, KeyEvent.VK_D);
             robot.waitForIdle();
@@ -133,7 +141,9 @@ public class bug4515762 {
             // Press the S key many times (should not cause an action peformed)
             int TIMES = 5;
             for (int i = 0; i < TIMES; i++) {
-                Util.hitKeys(robot, KeyEvent.VK_S);
+                robot.keyPress(KeyEvent.VK_S);
+                robot.keyRelease(KeyEvent.VK_S);
+                robot.waitForIdle();
             }
             robot.waitForIdle();
 
@@ -146,7 +156,7 @@ public class bug4515762 {
             robot.keyRelease(KeyEvent.VK_S);
             robot.waitForIdle();
 
-            checkAction();
+            checkAction("pressing VK_S");
 
             Util.hitMnemonics(robot, KeyEvent.VK_U);
             robot.waitForIdle();
@@ -155,28 +165,31 @@ public class bug4515762 {
             robot.keyRelease(KeyEvent.VK_M);
             robot.waitForIdle();
 
-            checkAction();
+            checkAction("pressing VK_M");
 
             Util.hitMnemonics(robot, KeyEvent.VK_U);
             robot.waitForIdle();
-            Util.hitKeys(robot, KeyEvent.VK_T);
+            robot.keyPress(KeyEvent.VK_T);
+            robot.keyRelease(KeyEvent.VK_T);
             robot.waitForIdle();
 
-            checkAction();
-
-            Util.hitMnemonics(robot, KeyEvent.VK_U);
-            robot.waitForIdle();
-            Util.hitKeys(robot, KeyEvent.VK_W);
-            robot.waitForIdle();
-
-            checkAction();
+            checkAction("pressing VK_T");
 
             Util.hitMnemonics(robot, KeyEvent.VK_U);
             robot.waitForIdle();
-            Util.hitKeys(robot, KeyEvent.VK_U);
+            robot.keyPress(KeyEvent.VK_W);
+            robot.keyRelease(KeyEvent.VK_W);
             robot.waitForIdle();
 
-            checkAction();
+            checkAction("pressing VK_W");
+
+            Util.hitMnemonics(robot, KeyEvent.VK_U);
+            robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_U);
+            robot.keyRelease(KeyEvent.VK_U);
+            robot.waitForIdle();
+
+            checkAction("pressing VK_U");
         } finally {
             if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());
         }


### PR DESCRIPTION
Not a clean backport because this test in not in ProblemList.txt in JDK11. Clean otherwise. Test passing on my MacOS 12 machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273578](https://bugs.openjdk.org/browse/JDK-8273578): javax/swing/JMenu/4515762/bug4515762.java fails on macOS 12


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1474/head:pull/1474` \
`$ git checkout pull/1474`

Update a local copy of the PR: \
`$ git checkout pull/1474` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1474`

View PR using the GUI difftool: \
`$ git pr show -t 1474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1474.diff">https://git.openjdk.org/jdk11u-dev/pull/1474.diff</a>

</details>
