### PR TITLE
Backport 4d08dd703e4d742635c3dbc8acc4b07b3a298657

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -2975,11 +2975,11 @@ public class Utils {
      */
     public TreePath getTreePath(Element e) {
         DocCommentDuo duo = dcTreeCache.get(e);
-        if (isValidDuo(duo) && duo.treePath != null) {
+        if (duo != null && duo.treePath != null) {
             return duo.treePath;
         }
         duo = configuration.cmtUtils.getSyntheticCommentDuo(e);
-        if (isValidDuo(duo) && duo.treePath != null) {
+        if (duo != null && duo.treePath != null) {
             return duo.treePath;
         }
         Map<Element, TreePath> elementToTreePath = configuration.workArounds.getElementToTreePath();
@@ -3005,20 +3005,20 @@ public class Utils {
         ElementKind kind = element.getKind();
         if (kind == ElementKind.PACKAGE || kind == ElementKind.OTHER) {
             duo = dcTreeCache.get(element); // local cache
-            if (!isValidDuo(duo) && kind == ElementKind.PACKAGE) {
+            if (duo == null && kind == ElementKind.PACKAGE) {
                 // package-info.java
                 duo = getDocCommentTuple(element);
             }
-            if (!isValidDuo(duo)) {
+            if (duo == null) {
                 // package.html or overview.html
                 duo = configuration.cmtUtils.getHtmlCommentDuo(element); // html source
             }
         } else {
             duo = configuration.cmtUtils.getSyntheticCommentDuo(element);
-            if (!isValidDuo(duo)) {
+            if (duo == null) {
                 duo = dcTreeCache.get(element); // local cache
             }
-            if (!isValidDuo(duo)) {
+            if (duo == null) {
                 duo = getDocCommentTuple(element); // get the real mccoy
             }
         }

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug  8222091
+ * @summary  Javadoc does not handle package annotations correctly on package-info.java
+ * @library  ../lib/
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build   JavadocTester
+ * @run main TestPackageAnnotation
+ */
+
+public class TestPackageAnnotation extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestPackageAnnotation tester = new TestPackageAnnotation();
+        tester.runTests();
+    }
+
+    @Test
+    public void testPackageInfoAnnotationNoComment() {
+        javadoc("-d", "out-annotation",
+                "-sourcepath", testSrc,
+                "-use",
+                "pkg1");
+        checkExit(Exit.OK);
+        checkOutput("pkg1/package-summary.html", true,
+                "<main role=\"main\">\n<div class=\"header\">\n"
+                + "<p>@Deprecated(since=\"1&lt;2&gt;3\")\n"
+                + "</p>\n"
+                + "<h1 title=\"Package\" class=\"title\">Package&nbsp;pkg1</h1>\n"
+                + "</div>\n");
+    }
+
+    @Test
+    public void testPackageHtmlTag() {
+        javadoc("-d", "out-annotation-2",
+                "-sourcepath", testSrc,
+                "-use",
+                "pkg2");
+        checkExit(Exit.OK);
+        checkOutput("pkg2/package-summary.html", true,
+                "<div class=\"deprecationBlock\"><span class=\"deprecatedLabel\">Deprecated.</span>\n"
+                + "<div class=\"deprecationComment\">This package is deprecated.</div>\n"
+                + "</div>\n"
+                + "<div class=\"block\">This is the description of package pkg2.</div>\n"
+                + "</section>");
+    }
+
+    @Test
+    public void testPackageInfoAndHtml() {
+        javadoc("-d", "out-annotation-3",
+                "-sourcepath", testSrc,
+                "-use",
+                "pkg3");
+        checkExit(Exit.OK);
+        checkOutput("pkg3/package-summary.html", true,
+                "<main role=\"main\">\n"
+                + "<div class=\"header\">\n"
+                + "<p>@Deprecated(since=\"1&lt;2&gt;3\")\n"
+                + "</p>\n"
+                + "<h1 title=\"Package\" class=\"title\">Package&nbsp;pkg3</h1>\n"
+                + "</div>\n");
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg1/A.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg1/A.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg1;
+
+public class A {
+}

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg1/package-info.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg1/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// Contains no javadoc comment, but should still be honored by javadoc.
+
+@Deprecated(since="1<2>3")
+package pkg1;

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg2/A.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg2/A.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg2;
+
+public class A {
+}

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg2/package.html
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg2/package.html
@@ -1,0 +1,9 @@
+<html lang="en">
+<head>
+    <title>Package Summary</title>
+</head>
+<body>
+This is the description of package pkg2.
+@deprecated This package is deprecated.
+</body>
+</html>

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg3/A.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg3/A.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg3;
+
+public class A {
+}

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg3/package-info.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg3/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// Contains no javadoc comment, but should still be honored by javadoc.
+
+@Deprecated(since="1<2>3")
+package pkg3;

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg3/package.html
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/pkg3/package.html
@@ -1,0 +1,8 @@
+<html lang="en">
+<head>
+    <title>Package Summary</title>
+</head>
+<body>
+This file is ignored by javadoc as the package contains a package-info.java file.
+</body>
+</html>


### PR DESCRIPTION
This is a backport of [JDK-8222091: Javadoc does not handle package annotations correctly on package-info.java](https://bugs.openjdk.java.net/browse/JDK-8222091)

This fixes a regression in 11.0.17 caused by the backport of [JDK-8193462](https://bugs.openjdk.org/browse/JDK-8193462), see [JDK-8295850](https://bugs.openjdk.org/browse/JDK-8295850)

Original patch applied cleanly, the test was updated due to some changes in test infrastructrure:

```diff
diff --git a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
index cd9697eede..9f04777f81 100644
--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
@@ -25,14 +25,12 @@
  * @test
  * @bug  8222091
  * @summary  Javadoc does not handle package annotations correctly on package-info.java
- * @library  ../../lib/
+ * @library  ../lib/
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
- * @build   javadoc.tester.*
+ * @build   JavadocTester
  * @run main TestPackageAnnotation
  */

-import javadoc.tester.JavadocTester;
-
 public class TestPackageAnnotation extends JavadocTester {

     public static void main(String... args) throws Exception {
```

Tested: tier1 langtools tests passed