### PR TITLE
8280550: SplittableRandom#nextDouble(double,double) can return result >= bound

### DIFF
--- a/src/java.base/share/classes/java/util/Random.java
+++ b/src/java.base/share/classes/java/util/Random.java
@@ -303,7 +303,8 @@ class Random implements java.io.Serializable {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+                //r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+                r = Math.nextAfter(r, origin);
         }
         return r;
     }

--- a/src/java.base/share/classes/java/util/Random.java
+++ b/src/java.base/share/classes/java/util/Random.java
@@ -303,7 +303,6 @@ class Random implements java.io.Serializable {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                //r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
                 r = Math.nextAfter(r, origin);
         }
         return r;

--- a/src/java.base/share/classes/java/util/SplittableRandom.java
+++ b/src/java.base/share/classes/java/util/SplittableRandom.java
@@ -350,7 +350,6 @@ public final class SplittableRandom {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                //r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
                 r = Math.nextAfter(r, origin);
         }
         return r;

--- a/src/java.base/share/classes/java/util/SplittableRandom.java
+++ b/src/java.base/share/classes/java/util/SplittableRandom.java
@@ -350,7 +350,8 @@ public final class SplittableRandom {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+                //r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+                r = Math.nextAfter(r, origin);
         }
         return r;
     }
@@ -547,7 +548,7 @@ public final class SplittableRandom {
             throw new IllegalArgumentException(BAD_BOUND);
         double result = (mix64(nextSeed()) >>> 11) * DOUBLE_UNIT * bound;
         return (result < bound) ?  result : // correct for rounding
-            Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+            Math.nextDown(result);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -282,7 +282,8 @@ public class ThreadLocalRandom extends Random {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+                //r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+                Math.nextAfter(r, origin);
         }
         return r;
     }
@@ -414,7 +415,7 @@ public class ThreadLocalRandom extends Random {
             throw new IllegalArgumentException(BAD_BOUND);
         double result = (mix64(nextSeed()) >>> 11) * DOUBLE_UNIT * bound;
         return (result < bound) ? result : // correct for rounding
-            Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+            Math.nextDown(result);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -282,7 +282,6 @@ public class ThreadLocalRandom extends Random {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                //r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
                 Math.nextAfter(r, origin);
         }
         return r;

--- a/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
+++ b/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verify nextDouble stays within range
+ * @bug 8280550
+ */
+
+import java.util.SplittableRandom;
+
+public class RandomNextDoubleBoundary {
+    public static void main(String... args) {
+        // Both bounds are negative
+        double lowerBound = -1.0000000000000002;
+        double upperBound = -1.0;
+        var sr = new SplittableRandom(42L);
+        var r = sr.nextDouble(lowerBound, upperBound);
+
+        if (r >= upperBound) {
+            System.err.println("r = " + r + "\t" + Double.toHexString(r));
+            System.err.println("ub = " + upperBound + "\t" + Double.toHexString(upperBound));
+            throw new RuntimeException("Greater than upper bound");
+        }
+
+        if (r < lowerBound) {
+            System.err.println("r = " + r + "\t" + Double.toHexString(r));
+            System.err.println("lb = " + lowerBound + "\t" + Double.toHexString(lowerBound));
+            throw new RuntimeException("Less than lower bound");
+        }
+    }
+}


### PR DESCRIPTION
The original fix patches jdk/internal/util/random/RandomSupport.java.
This class is not in 11.

The Random code was completely reworked by
"8248862: Implement Enhanced Pseudo-Random Number Generators"
In the old 11 code there are several methods 'nextDouble' or
'internalNextDouble' all using the same pattern.  They were
replaced by the implementation in the new class
RandomSupport in 17.

I adapted the following methods:
in java/util/Random.java:
  final double internalNextDouble(double origin, double bound)

in java/util/SplittableRandom.java
  final double internalNextDouble(double origin, double bound)
  public double nextDouble(double bound)

in java/util/concurrent/ThreadLocalRandom.java
  final double internalNextDouble(double origin, double bound)
  public double nextDouble(double bound)

I think this are all affected methods, but please double-check.

The change requires follow-up 8280950 which needs to be
adapted to touch the three internalNextDouble()
methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280550](https://bugs.openjdk.org/browse/JDK-8280550): SplittableRandom#nextDouble(double,double) can return result >= bound


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1478/head:pull/1478` \
`$ git checkout pull/1478`

Update a local copy of the PR: \
`$ git checkout pull/1478` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1478`

View PR using the GUI difftool: \
`$ git pr show -t 1478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1478.diff">https://git.openjdk.org/jdk11u-dev/pull/1478.diff</a>

</details>
