### PR TITLE
8233648: [TESTBUG] DefaultMenuBarTest.java failing on macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -479,7 +479,6 @@ java/awt/event/MouseEvent/MultipleMouseButtonsTest/MultipleMouseButtonsTest.java
 java/awt/event/MouseEvent/ClickDuringKeypress/ClickDuringKeypress.java 8233568 macosx-all
 java/awt/event/KeyEvent/DeadKey/DeadKeyMacOSXInputText.java 8233568 macosx-all
 java/awt/event/KeyEvent/DeadKey/deadKeyMacOSX.java 8233568 macosx-all
-com/apple/eawt/DefaultMenuBar/DefaultMenuBarTest.java 8233648 macosx-all
 java/awt/TrayIcon/RightClickWhenBalloonDisplayed/RightClickWhenBalloonDisplayed.java 8238720 windows-all
 java/awt/PopupMenu/PopupMenuLocation.java 8238720 windows-all
 java/awt/GridLayout/ComponentPreferredSize/ComponentPreferredSize.java 8238720 windows-all

--- a/test/jdk/com/apple/eawt/DefaultMenuBar/DefaultMenuBarTest.java
+++ b/test/jdk/com/apple/eawt/DefaultMenuBar/DefaultMenuBarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,18 +24,21 @@
 /**
  * @test
  * @key headful
- * @bug 8007267
+ * @bug 8007267 8233648
  * @summary [macosx] com.apple.eawt.Application.setDefaultMenuBar is not working
  * @requires (os.family == "mac")
- * @author leonid.romanov@oracle.com
- * @modules java.desktop/sun.awt
- *          java.desktop/com.apple.eawt
- * @run main DefaultMenuBarTest
+ * @modules java.desktop/com.apple.eawt
+ * @run main/othervm DefaultMenuBarTest
  */
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import java.awt.Robot;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.lang.reflect.Method;
 
 
@@ -50,14 +53,11 @@ public class DefaultMenuBarTest {
         }
 
         System.setProperty("apple.laf.useScreenMenuBar", "true");
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                createAndShowGUI();
-            }
-        });
+        SwingUtilities.invokeAndWait(DefaultMenuBarTest::createAndShowGUI);
 
         Robot robot = new Robot();
         robot.setAutoDelay(100);
+        robot.waitForIdle();
 
         robot.keyPress(KeyEvent.VK_META);
         robot.keyPress(ks.getKeyCode());
@@ -76,13 +76,7 @@ public class DefaultMenuBarTest {
         JMenuItem newItem = new JMenuItem("Open");
 
         newItem.setAccelerator(ks);
-        newItem.addActionListener(
-            new ActionListener(){
-                public void actionPerformed(ActionEvent e) {
-                    listenerCallCounter++;
-                }
-            }
-        );
+        newItem.addActionListener(e -> listenerCallCounter++);
         menu.add(newItem);
 
         JMenuBar defaultMenu = new JMenuBar();
@@ -104,7 +98,7 @@ public class DefaultMenuBarTest {
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 }


### PR DESCRIPTION
Backport for https://bugs.openjdk.org/browse/JDK-8233648 [TESTBUG] DefaultMenuBarTest.java failing on macos

Test update is clean, had to merge ProblemList.txt (simple)
Tested locally, test pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233648](https://bugs.openjdk.org/browse/JDK-8233648): [TESTBUG] DefaultMenuBarTest.java failing on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1479/head:pull/1479` \
`$ git checkout pull/1479`

Update a local copy of the PR: \
`$ git checkout pull/1479` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1479`

View PR using the GUI difftool: \
`$ git pr show -t 1479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1479.diff">https://git.openjdk.org/jdk11u-dev/pull/1479.diff</a>

</details>
