### PR TITLE
8261445: Use memory_order_relaxed for os::random().

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -864,7 +864,7 @@ int os::random() {
   while (true) {
     unsigned int seed = _rand_seed;
     unsigned int rand = random_helper(seed);
-    if (Atomic::cmpxchg(rand, &_rand_seed, seed) == seed) {
+    if (Atomic::cmpxchg(rand, &_rand_seed, seed, memory_order_relaxed) == seed) {
       return static_cast<int>(rand);
     }
   }


### PR DESCRIPTION
Backport https://bugs.openjdk.org/browse/JDK-8261445 Use memory_order_relaxed for os::random() for jdk11u

Backport not clean, however the change is trivial.
Tested in linux x64/aarch64: tier1, tier2, jck's passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8261445](https://bugs.openjdk.org/browse/JDK-8261445): Use memory_order_relaxed for os::random().


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1480/head:pull/1480` \
`$ git checkout pull/1480`

Update a local copy of the PR: \
`$ git checkout pull/1480` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1480`

View PR using the GUI difftool: \
`$ git pr show -t 1480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1480.diff">https://git.openjdk.org/jdk11u-dev/pull/1480.diff</a>

</details>
