### PR TITLE
8285373: Create an automated test for JDK-4702233

### DIFF
--- a/test/jdk/javax/accessibility/4702233/AccessibleActionConstants.java
+++ b/test/jdk/javax/accessibility/4702233/AccessibleActionConstants.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @summary Constant for testing public fields in AccessibleAction.
+ */
+
+public interface AccessibleActionConstants {
+
+    String CLASS_NAME = "javax.accessibility.AccessibleAction";
+
+    /**
+     * Public fields values in AccessibleAction class.
+     */
+    String[][] FIELDS =
+        new String[][] { { "CLICK", "click" }, { "DECREMENT", "decrement" },
+        { "INCREMENT", "increment" }, { "TOGGLE_EXPAND", "toggleexpand" },
+        { "TOGGLE_POPUP", "toggle popup" } };
+        /**
+         * Old(removed) fields in AccessibleAction class.
+         */
+        String[] OLD_FIELDS = new String[] {};
+}
+

--- a/test/jdk/javax/accessibility/4702233/AccessibleContextConstants.java
+++ b/test/jdk/javax/accessibility/4702233/AccessibleContextConstants.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @summary Constant for testing public fields in AccessibleContext.
+ */
+
+public interface AccessibleContextConstants {
+
+    String CLASS_NAME = "javax.accessibility.AccessibleContext";
+
+    /**
+     * Public fields values in AccessibleContext class.
+     */
+    String[][] FIELDS = new String[][] {
+        { "ACCESSIBLE_NAME_PROPERTY", "AccessibleName" },
+        { "ACCESSIBLE_DESCRIPTION_PROPERTY", "AccessibleDescription" },
+        { "ACCESSIBLE_STATE_PROPERTY", "AccessibleState" },
+        { "ACCESSIBLE_VALUE_PROPERTY", "AccessibleValue" },
+        { "ACCESSIBLE_SELECTION_PROPERTY", "AccessibleSelection" },
+        { "ACCESSIBLE_CARET_PROPERTY", "AccessibleCaret" },
+        { "ACCESSIBLE_VISIBLE_DATA_PROPERTY", "AccessibleVisibleData" },
+        { "ACCESSIBLE_CHILD_PROPERTY", "AccessibleChild" },
+        { "ACCESSIBLE_ACTIVE_DESCENDANT_PROPERTY",
+        "AccessibleActiveDescendant" },
+        { "ACCESSIBLE_TABLE_CAPTION_CHANGED", "accessibleTableCaptionChanged" },
+        { "ACCESSIBLE_TABLE_SUMMARY_CHANGED", "accessibleTableSummaryChanged" },
+        { "ACCESSIBLE_TABLE_MODEL_CHANGED", "accessibleTableModelChanged" },
+        { "ACCESSIBLE_TABLE_ROW_HEADER_CHANGED",
+        "accessibleTableRowHeaderChanged" },
+        { "ACCESSIBLE_TABLE_ROW_DESCRIPTION_CHANGED",
+        "accessibleTableRowDescriptionChanged" },
+        { "ACCESSIBLE_TABLE_COLUMN_HEADER_CHANGED",
+        "accessibleTableColumnHeaderChanged" },
+        { "ACCESSIBLE_TABLE_COLUMN_DESCRIPTION_CHANGED",
+        "accessibleTableColumnDescriptionChanged" },
+        { "ACCESSIBLE_ACTION_PROPERTY", "accessibleActionProperty" },
+        { "ACCESSIBLE_HYPERTEXT_OFFSET", "AccessibleHypertextOffset" },
+        { "ACCESSIBLE_TEXT_PROPERTY", "AccessibleText" },
+        { "ACCESSIBLE_INVALIDATE_CHILDREN", "accessibleInvalidateChildren" },
+        { "ACCESSIBLE_TEXT_ATTRIBUTES_CHANGED",
+        "accessibleTextAttributesChanged" },
+        { "ACCESSIBLE_COMPONENT_BOUNDS_CHANGED",
+        "accessibleComponentBoundsChanged" } };
+
+        /**
+         * Old(removed) fields in AccessibleContext class.
+         */
+        String[] OLD_FIELDS = new String[] {};
+}
+

--- a/test/jdk/javax/accessibility/4702233/AccessiblePropertiesTest.java
+++ b/test/jdk/javax/accessibility/4702233/AccessiblePropertiesTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4702233
+ * @summary Testing current and old(removed) public fields in AccessibleAction,
+ * AccessibleContext, AccessibleRelation, AccessibleRole and AccessibleState.
+ * @run main AccessiblePropertiesTest
+ */
+
+import java.lang.reflect.Field;
+
+public class AccessiblePropertiesTest {
+
+    private static void checkFields(String className, String[][] fields,
+        String[] oldFields) {
+        try {
+            Class<?> klass = Class.forName(className);
+
+            if (klass.getFields().length != fields.length) {
+                throw new RuntimeException("Fields in " + className
+                    + " were changed. Test should be updated!");
+            }
+
+            for (int i = 0; i < fields.length; ++i) {
+                String key = fields[i][0];
+                String value = fields[i][1];
+                Field field = klass.getDeclaredField(key);
+                String current = field.get(String.class).toString();
+
+                if (!current.equals(value)) {
+                    throw new RuntimeException(
+                        "Field " + field.getName() + " current value=" + current
+                        + " , expected value=" + value);
+                }
+            }
+
+            for (int i = 0; i < oldFields.length; ++i) {
+                String key = oldFields[i];
+
+                try {
+                    klass.getDeclaredField(key);
+
+                    throw new RuntimeException(key + " exists in " + klass);
+                } catch (NoSuchFieldException ignored) {
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void main(String[] args) {
+
+        checkFields(AccessibleActionConstants.CLASS_NAME,
+            AccessibleActionConstants.FIELDS,
+            AccessibleActionConstants.OLD_FIELDS);
+
+        checkFields(AccessibleRelationConstants.CLASS_NAME,
+            AccessibleRelationConstants.FIELDS,
+            AccessibleRelationConstants.OLD_FIELDS);
+
+        checkFields(AccessibleRoleConstants.CLASS_NAME,
+            AccessibleRoleConstants.FIELDS, AccessibleRoleConstants.OLD_FIELDS);
+
+        checkFields(AccessibleStateConstants.CLASS_NAME,
+            AccessibleStateConstants.FIELDS,
+            AccessibleStateConstants.OLD_FIELDS);
+
+        checkFields(AccessibleContextConstants.CLASS_NAME,
+            AccessibleContextConstants.FIELDS,
+            AccessibleContextConstants.OLD_FIELDS);
+    }
+}
+

--- a/test/jdk/javax/accessibility/4702233/AccessibleRelationConstants.java
+++ b/test/jdk/javax/accessibility/4702233/AccessibleRelationConstants.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @summary Constant for testing public fields in AccessibleRelation.
+ */
+public interface AccessibleRelationConstants {
+
+    /**
+     * Fully-qualified name of the class.
+     */
+    String CLASS_NAME = "javax.accessibility.AccessibleRelation";
+
+    /**
+     * Public fields values in AccessibleRelation class.
+     */
+    String[][] FIELDS = new String[][] { { "CHILD_NODE_OF", "childNodeOf" },
+        { "CHILD_NODE_OF_PROPERTY", "childNodeOfProperty" },
+        { "CONTROLLED_BY", "controlledBy" },
+        { "CONTROLLED_BY_PROPERTY", "controlledByProperty" },
+        { "CONTROLLER_FOR", "controllerFor" },
+        { "CONTROLLER_FOR_PROPERTY", "controllerForProperty" },
+        { "EMBEDDED_BY", "embeddedBy" },
+        { "EMBEDDED_BY_PROPERTY", "embeddedByProperty" },
+        { "EMBEDS", "embeds" }, { "EMBEDS_PROPERTY", "embedsProperty" },
+        { "FLOWS_FROM", "flowsFrom" },
+        { "FLOWS_FROM_PROPERTY", "flowsFromProperty" },
+        { "FLOWS_TO", "flowsTo" }, { "FLOWS_TO_PROPERTY", "flowsToProperty" },
+        { "LABELED_BY", "labeledBy" },
+        { "LABELED_BY_PROPERTY", "labeledByProperty" },
+        { "LABEL_FOR", "labelFor" },
+        { "LABEL_FOR_PROPERTY", "labelForProperty" },
+        { "MEMBER_OF", "memberOf" },
+        { "MEMBER_OF_PROPERTY", "memberOfProperty" },
+        { "PARENT_WINDOW_OF", "parentWindowOf" },
+        { "PARENT_WINDOW_OF_PROPERTY", "parentWindowOfProperty" },
+        { "SUBWINDOW_OF", "subwindowOf" },
+        { "SUBWINDOW_OF_PROPERTY", "subwindowOfProperty" }, };
+
+    /**
+     * Old(removed) fields in AccessibleRelation class.
+     */
+    String[] OLD_FIELDS = new String[] {};
+}
+

--- a/test/jdk/javax/accessibility/4702233/AccessibleRoleConstants.java
+++ b/test/jdk/javax/accessibility/4702233/AccessibleRoleConstants.java
@@ -1,0 +1,77 @@
+package bug4702233;
+
+/*
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @summary Constant for testing public fields in AccessibleRole.
+ */
+
+public interface AccessibleRoleConstants {
+
+    /**
+     * Fully-qualified name of the class.
+     */
+    String CLASS_NAME = "javax.accessibility.AccessibleRole";
+
+    /**
+     * Public fields values in AccessibleRole class.
+     */
+    String[][] FIELDS = new String[][] { { "ALERT", "alert" },
+        { "AWT_COMPONENT", "AWT component" }, { "CANVAS", "canvas" },
+        { "CHECK_BOX", "check box" }, { "COLOR_CHOOSER", "color chooser" },
+        { "COLUMN_HEADER", "column header" }, { "COMBO_BOX", "combo box" },
+        { "DATE_EDITOR", "dateeditor" }, { "DESKTOP_ICON", "desktop icon" },
+        { "DESKTOP_PANE", "desktop pane" }, { "DIALOG", "dialog" },
+        { "DIRECTORY_PANE", "directory pane" }, { "EDITBAR", "editbar" },
+        { "FILE_CHOOSER", "file chooser" }, { "FILLER", "filler" },
+        { "FONT_CHOOSER", "fontchooser" }, { "FOOTER", "footer" },
+        { "FRAME", "frame" }, { "GLASS_PANE", "glass pane" },
+        { "GROUP_BOX", "groupbox" }, { "HEADER", "header" },
+        { "HTML_CONTAINER", "HTML container" }, { "HYPERLINK", "hyperlink" },
+        { "ICON", "icon" }, { "INTERNAL_FRAME", "internal frame" },
+        { "LABEL", "label" }, { "LAYERED_PANE", "layered pane" },
+        { "LIST", "list" }, { "LIST_ITEM", "list item" }, { "MENU", "menu" },
+        { "MENU_BAR", "menu bar" }, { "MENU_ITEM", "menu item" },
+        { "OPTION_PANE", "option pane" }, { "PAGE_TAB", "page tab" },
+        { "PAGE_TAB_LIST", "page tab list" }, { "PANEL", "panel" },
+        { "PARAGRAPH", "paragraph" }, { "PASSWORD_TEXT", "password text" },
+        { "POPUP_MENU", "popup menu" }, { "PROGRESS_BAR", "progress bar" },
+        { "PROGRESS_MONITOR", "progress monitor" },
+        { "PUSH_BUTTON", "push JButton" }, { "RADIO_BUTTON", "radio JButton" },
+        { "ROOT_PANE", "root pane" }, { "ROW_HEADER", "row header" },
+        { "RULER", "ruler" }, { "SCROLL_BAR", "scroll bar" },
+        { "SCROLL_PANE", "scroll pane" }, { "SEPARATOR", "separator" },
+        { "SLIDER", "slider" }, { "SPIN_BOX", "spinbox" },
+        { "SPLIT_PANE", "split pane" }, { "STATUS_BAR", "statusbar" },
+        { "SWING_COMPONENT", "swing component" }, { "TABLE", "table" },
+        { "TEXT", "text" }, { "TOGGLE_BUTTON", "toggle JButton" },
+        { "TOOL_BAR", "tool bar" }, { "TOOL_TIP", "tool tip" },
+        { "TREE", "tree" }, { "UNKNOWN", "unknown" },
+        { "VIEWPORT", "viewport" }, { "WINDOW", "window" } };
+
+        /**
+         * Old(removed) fields in AccessibleRole class.
+         */
+        String[] OLD_FIELDS = new String[] {};
+}

--- a/test/jdk/javax/accessibility/4702233/AccessibleStateConstants.java
+++ b/test/jdk/javax/accessibility/4702233/AccessibleStateConstants.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @summary Constant for testing public fields in AccessibleState.
+ */
+
+public interface AccessibleStateConstants {
+
+    /**
+     * Fully-qualified name of the class.
+     */
+    String CLASS_NAME = "javax.accessibility.AccessibleState";
+
+    /**
+     * Public fields values in AccessibleState class.
+     */
+    String[][] FIELDS = new String[][] { { "ACTIVE", "active" },
+        { "ARMED", "armed" }, { "BUSY", "busy" }, { "CHECKED", "checked" },
+        { "COLLAPSED", "collapsed" }, { "EDITABLE", "editable" },
+        { "ENABLED", "enabled" }, { "EXPANDABLE", "expandable" },
+        { "EXPANDED", "expanded" }, { "FOCUSABLE", "focusable" },
+        { "FOCUSED", "focused" }, { "HORIZONTAL", "horizontal" },
+        { "ICONIFIED", "iconified" }, { "INDETERMINATE", "indeterminate" },
+        { "MANAGES_DESCENDANTS", "manages descendants" }, { "MODAL", "modal" },
+        { "MULTISELECTABLE", "multiselectable" },
+        { "MULTI_LINE", "multiple line" }, { "OPAQUE", "opaque" },
+        { "PRESSED", "pressed" }, { "RESIZABLE", "resizable" },
+        { "SELECTABLE", "selectable" }, { "SELECTED", "selected" },
+        { "SHOWING", "showing" }, { "SINGLE_LINE", "single line" },
+        { "TRANSIENT", "transient" }, { "TRUNCATED", "truncated" },
+        { "VERTICAL", "vertical" }, { "VISIBLE", "visible" } };
+
+        /**
+         * Old(removed) fields in AccessibleState class.
+         */
+        String[] OLD_FIELDS = new String[] {
+
+            // CR 4981070 INCONSISTENT was replaced by INDETERMINATE.
+        "INCONSISTENT" };
+}
+


### PR DESCRIPTION
Backport of 
[JDK-8285373](https://bugs.openjdk.org/browse/JDK-8285373) Create an automated test for JDK-4702233

First backport adds a test, that does not compile, second backport fixes the test. 

Clean backport, trivial, low risk - new test. 
tests pass during manual run after second backport pr commit

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8285373](https://bugs.openjdk.org/browse/JDK-8285373): Create an automated test for JDK-4702233
 * [JDK-8285373](https://bugs.openjdk.org/browse/JDK-8285373): Create an automated test for JDK-4702233


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1483/head:pull/1483` \
`$ git checkout pull/1483`

Update a local copy of the PR: \
`$ git checkout pull/1483` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1483`

View PR using the GUI difftool: \
`$ git pr show -t 1483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1483.diff">https://git.openjdk.org/jdk11u-dev/pull/1483.diff</a>

</details>
