### PR TITLE
8222251: preflow visitor is not visiting lambda expressions

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2723,7 +2723,7 @@ public class Attr extends JCTree.Visitor {
                 public void visitLambda(JCLambda that) {
                     // or lambda expressions!
                 }
-            }.scan(tree);
+            }.scan(tree.body);
         }
 
         Types.MapVisitor<DiagnosticPosition> targetChecker = new Types.MapVisitor<DiagnosticPosition>() {

--- a/test/langtools/tools/javac/T8222251/PreflowNotVisitingLambdaExpTest.java
+++ b/test/langtools/tools/javac/T8222251/PreflowNotVisitingLambdaExpTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8222251
+ * @summary preflow visitor is not visiting lambda expressions
+ * @compile PreflowNotVisitingLambdaExpTest.java
+ */
+
+public class PreflowNotVisitingLambdaExpTest {
+    interface HandleCallback<T, X extends Exception> {
+        T withHandle(Handle handle) throws X;
+    }
+
+    interface HandleConsumer<X extends Exception> {
+        void useHandle(Handle handle) throws X;
+    }
+
+    interface Handle {}
+
+    interface Jdbi {
+        <R, X extends Exception> R withHandle(HandleCallback<R, X> callback) throws X;
+        <X extends Exception> void useHandle(final HandleConsumer<X> callback) throws X;
+    }
+
+    interface ObjectAssert<ACTUAL> {
+        void isSameAs(ACTUAL t);
+    }
+
+    static <T> ObjectAssert<T> assertThat(T actual) {
+        return null;
+    }
+
+    private Jdbi jdbi;
+
+    public void nestedUseHandle() {
+        jdbi.withHandle(h1 -> {
+            jdbi.useHandle(h2 ->
+                    assertThat(h1).isSameAs(h2));
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
Backport a regression fix after JDK-8203277

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8222251](https://bugs.openjdk.org/browse/JDK-8222251): preflow visitor is not visiting lambda expressions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1484/head:pull/1484` \
`$ git checkout pull/1484`

Update a local copy of the PR: \
`$ git checkout pull/1484` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1484`

View PR using the GUI difftool: \
`$ git pr show -t 1484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1484.diff">https://git.openjdk.org/jdk11u-dev/pull/1484.diff</a>

</details>
