### PR TITLE
8287826: javax/accessibility/4702233/AccessiblePropertiesTest.java fails to compile

### DIFF
--- a/test/jdk/javax/accessibility/4702233/AccessibleRoleConstants.java
+++ b/test/jdk/javax/accessibility/4702233/AccessibleRoleConstants.java
@@ -1,5 +1,3 @@
-package bug4702233;
-
 /*
  * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.


### PR DESCRIPTION
Backport of
[JDK-8287826](https://bugs.openjdk.org/browse/JDK-8287826) javax/accessibility/4702233/AccessiblePropertiesTest.java fails to compile

This is second backport in a series that fixes the test first backport added.

Clean backport, trivial, low risk - new test update.
tests pass during manual run

This pr depends on this pr: https://github.com/openjdk/jdk11u-dev/pull/1483

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287826](https://bugs.openjdk.org/browse/JDK-8287826): javax/accessibility/4702233/AccessiblePropertiesTest.java fails to compile


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1485/head:pull/1485` \
`$ git checkout pull/1485`

Update a local copy of the PR: \
`$ git checkout pull/1485` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1485`

View PR using the GUI difftool: \
`$ git pr show -t 1485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1485.diff">https://git.openjdk.org/jdk11u-dev/pull/1485.diff</a>

</details>
