### PR TITLE
8281183: RandomGenerator:NextDouble() default behavior partially fixed by JDK-8280950

### DIFF
--- a/src/java.base/share/classes/java/util/Random.java
+++ b/src/java.base/share/classes/java/util/Random.java
@@ -303,7 +303,7 @@ class Random implements java.io.Serializable {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                r = Math.nextAfter(r, origin);
+                r = Math.nextAfter(bound, origin);
         }
         return r;
     }

--- a/src/java.base/share/classes/java/util/Random.java
+++ b/src/java.base/share/classes/java/util/Random.java
@@ -303,7 +303,8 @@ class Random implements java.io.Serializable {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+                //r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+                r = Math.nextAfter(r, origin);
         }
         return r;
     }

--- a/src/java.base/share/classes/java/util/Random.java
+++ b/src/java.base/share/classes/java/util/Random.java
@@ -303,7 +303,6 @@ class Random implements java.io.Serializable {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                //r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
                 r = Math.nextAfter(r, origin);
         }
         return r;

--- a/src/java.base/share/classes/java/util/SplittableRandom.java
+++ b/src/java.base/share/classes/java/util/SplittableRandom.java
@@ -547,7 +547,7 @@ public final class SplittableRandom {
             throw new IllegalArgumentException(BAD_BOUND);
         double result = (mix64(nextSeed()) >>> 11) * DOUBLE_UNIT * bound;
         return (result < bound) ?  result : // correct for rounding
-            Math.nextDown(result);
+            Math.nextDown(bound);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/SplittableRandom.java
+++ b/src/java.base/share/classes/java/util/SplittableRandom.java
@@ -350,7 +350,7 @@ public final class SplittableRandom {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                r = Math.nextAfter(r, origin);
+                r = Math.nextAfter(bound, origin);
         }
         return r;
     }

--- a/src/java.base/share/classes/java/util/SplittableRandom.java
+++ b/src/java.base/share/classes/java/util/SplittableRandom.java
@@ -350,7 +350,6 @@ public final class SplittableRandom {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                //r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
                 r = Math.nextAfter(r, origin);
         }
         return r;

--- a/src/java.base/share/classes/java/util/SplittableRandom.java
+++ b/src/java.base/share/classes/java/util/SplittableRandom.java
@@ -350,7 +350,8 @@ public final class SplittableRandom {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+                //r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+                r = Math.nextAfter(r, origin);
         }
         return r;
     }
@@ -547,7 +548,7 @@ public final class SplittableRandom {
             throw new IllegalArgumentException(BAD_BOUND);
         double result = (mix64(nextSeed()) >>> 11) * DOUBLE_UNIT * bound;
         return (result < bound) ?  result : // correct for rounding
-            Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+            Math.nextDown(result);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -282,7 +282,7 @@ public class ThreadLocalRandom extends Random {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                Math.nextAfter(r, origin);
+                Math.nextAfter(bound, origin);
         }
         return r;
     }

--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -414,7 +414,7 @@ public class ThreadLocalRandom extends Random {
             throw new IllegalArgumentException(BAD_BOUND);
         double result = (mix64(nextSeed()) >>> 11) * DOUBLE_UNIT * bound;
         return (result < bound) ? result : // correct for rounding
-            Math.nextDown(result);
+            Math.nextDown(bound);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -282,7 +282,8 @@ public class ThreadLocalRandom extends Random {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+                //r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+                Math.nextAfter(r, origin);
         }
         return r;
     }
@@ -414,7 +415,7 @@ public class ThreadLocalRandom extends Random {
             throw new IllegalArgumentException(BAD_BOUND);
         double result = (mix64(nextSeed()) >>> 11) * DOUBLE_UNIT * bound;
         return (result < bound) ? result : // correct for rounding
-            Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+            Math.nextDown(result);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -282,7 +282,6 @@ public class ThreadLocalRandom extends Random {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound) // correct for rounding
-                //r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
                 Math.nextAfter(r, origin);
         }
         return r;

--- a/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
+++ b/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verify nextDouble stays within range
+ * @bug 8280550
+ */
+
+import java.util.SplittableRandom;
+
+public class RandomNextDoubleBoundary {
+    public static void main(String... args) {
+        // Both bounds are negative
+        double lowerBound = -1.0000000000000002;
+        double upperBound = -1.0;
+        var sr = new SplittableRandom(42L);
+        var r = sr.nextDouble(lowerBound, upperBound);
+
+        if (r >= upperBound) {
+            System.err.println("r = " + r + "\t" + Double.toHexString(r));
+            System.err.println("ub = " + upperBound + "\t" + Double.toHexString(upperBound));
+            throw new RuntimeException("Greater than upper bound");
+        }
+
+        if (r < lowerBound) {
+            System.err.println("r = " + r + "\t" + Double.toHexString(r));
+            System.err.println("lb = " + lowerBound + "\t" + Double.toHexString(lowerBound));
+            throw new RuntimeException("Less than lower bound");
+        }
+    }
+}

--- a/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
+++ b/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
@@ -24,13 +24,19 @@
 /*
  * @test
  * @summary Verify nextDouble stays within range
- * @bug 8280550
+ * @bug 8280550 8280950
  */
 
 import java.util.SplittableRandom;
+import java.util.random.RandomGenerator;
 
 public class RandomNextDoubleBoundary {
     public static void main(String... args) {
+        negativeBounds();
+        positiveBounds();
+    }
+
+    private static void negativeBounds() {
         // Both bounds are negative
         double lowerBound = -1.0000000000000002;
         double upperBound = -1.0;
@@ -47,6 +53,39 @@ public class RandomNextDoubleBoundary {
             System.err.println("r = " + r + "\t" + Double.toHexString(r));
             System.err.println("lb = " + lowerBound + "\t" + Double.toHexString(lowerBound));
             throw new RuntimeException("Less than lower bound");
+        }
+    }
+
+    private static void positiveBounds() {
+        double[][] originAndBounds = {{10, 100},
+                                      {12345, 123456},
+                                      {5432167.234, 54321678.1238}};
+        for (double[] originAndBound : originAndBounds) {
+            nextDoublesWithRange(originAndBound[0], originAndBound[1]);
+        }
+    }
+
+    public static void nextDoublesWithRange(double origin, double bound) {
+        RandomGenerator rg = new RandomGenerator() {
+            @Override
+            public double nextDouble() {
+                return Double.MAX_VALUE;
+            }
+
+            @Override
+            public long nextLong() {
+                return 0;
+            }
+        };
+        double value = rg.nextDouble(origin, bound);
+
+        assertTrue(value >= origin);
+        assertTrue(value < bound);
+    }
+
+    public static void assertTrue(boolean condition) {
+        if (!condition) {
+            throw new AssertionError();
         }
     }
 }

--- a/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
+++ b/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Verify nextDouble stays within range
- * @bug 8280550 8280950
+ * @bug 8280550 8280950 8281183
  */
 
 import java.util.SplittableRandom;
@@ -68,8 +68,11 @@ public class RandomNextDoubleBoundary {
         SplittableRandom rg = new SplittableRandom(42L);
         double value = rg.nextDouble(origin, bound);
 
-        assertTrue(value >= origin);
-        assertTrue(value < bound);
+        if (bound > 0) {
+            value = rg.nextDouble(bound); // Equivalent to nextDouble(0.0, bound)
+            assertTrue(value >= 0.0);
+            assertTrue(value < bound);
+        }
     }
 
     public static void assertTrue(boolean condition) {

--- a/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
+++ b/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
@@ -28,7 +28,6 @@
  */
 
 import java.util.SplittableRandom;
-import java.util.random.RandomGenerator;
 
 public class RandomNextDoubleBoundary {
     public static void main(String... args) {
@@ -66,17 +65,7 @@ public class RandomNextDoubleBoundary {
     }
 
     public static void nextDoublesWithRange(double origin, double bound) {
-        RandomGenerator rg = new RandomGenerator() {
-            @Override
-            public double nextDouble() {
-                return Double.MAX_VALUE;
-            }
-
-            @Override
-            public long nextLong() {
-                return 0;
-            }
-        };
+        SplittableRandom rg = new SplittableRandom(42L);
         double value = rg.nextDouble(origin, bound);
 
         assertTrue(value >= origin);


### PR DESCRIPTION
I had to do similar resolves as in the two underlying changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281183](https://bugs.openjdk.org/browse/JDK-8281183): RandomGenerator:NextDouble() default behavior partially fixed by JDK-8280950


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to [8b95f223](https://git.openjdk.org/jdk11u-dev/pull/1488/files/8b95f2239b24f6c31642431ad8c9e76b93d7249a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1488/head:pull/1488` \
`$ git checkout pull/1488`

Update a local copy of the PR: \
`$ git checkout pull/1488` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1488`

View PR using the GUI difftool: \
`$ git pr show -t 1488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1488.diff">https://git.openjdk.org/jdk11u-dev/pull/1488.diff</a>

</details>
