### PR TITLE
8277497: Last column cell in the JTable row is read as empty cell

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JLabel.java
+++ b/src/java.desktop/share/classes/javax/swing/JLabel.java
@@ -1052,6 +1052,10 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
          * @see AccessibleContext#setAccessibleName
          */
         public String getAccessibleName() {
+            return getAccessibleNameCheckIcon(getAccessibleNameImpl());
+        }
+
+        private String getAccessibleNameImpl() {
             String name = accessibleName;
 
             if (name == null) {
@@ -1066,6 +1070,19 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
             return name;
         }
 
+        private String getAccessibleNameCheckIcon(String name) {
+            if (((name == null) || name.isEmpty()) &&
+                    (JLabel.this.getIcon() != null)) {
+                if (JLabel.this.getIcon() instanceof Accessible) {
+                    AccessibleContext ac = ((Accessible) JLabel.this.getIcon()).getAccessibleContext();
+                    if (ac != null) {
+                        name = ac.getAccessibleName();
+                    }
+                }
+            }
+            return name;
+        }
+
         /**
          * Get the role of this object.
          *
@@ -1074,6 +1091,11 @@ public class JLabel extends JComponent implements SwingConstants, Accessible
          * @see AccessibleRole
          */
         public AccessibleRole getAccessibleRole() {
+            String name = getAccessibleNameImpl();
+            if (((name == null) || name.isEmpty()) &&
+                    (JLabel.this.getIcon() != null)) {
+                return AccessibleRole.ICON;
+            }
             return AccessibleRole.LABEL;
         }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [70bad89b](https://github.com/openjdk/jdk/commit/70bad89b012eb200ca1e76f384a6e5fb307cf26d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Artem Semenov on 6 Dec 2021 and was reviewed by Anton Tarasov, Alexander Zuev and Pankaj Bansal. This backport brings parity with oracle 11.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277497](https://bugs.openjdk.org/browse/JDK-8277497): Last column cell in the JTable row is read as empty cell


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1490/head:pull/1490` \
`$ git checkout pull/1490`

Update a local copy of the PR: \
`$ git checkout pull/1490` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1490`

View PR using the GUI difftool: \
`$ git pr show -t 1490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1490.diff">https://git.openjdk.org/jdk11u-dev/pull/1490.diff</a>

</details>
