### PR TITLE
8277970: Test jdk/sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java fails with "tag mismatch"

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketInputRecord.java
@@ -255,7 +255,11 @@ final class SSLSocketInputRecord extends InputRecord implements SSLRecord {
         // Decrypt the fragment
         //
         ByteBuffer fragment;
+        recordLock.lock();
         try {
+            if (isClosed) {
+                return null;
+            }
             Plaintext plaintext =
                     readCipher.decrypt(contentType, recordBody, null);
             fragment = plaintext.fragment;
@@ -265,6 +269,8 @@ final class SSLSocketInputRecord extends InputRecord implements SSLRecord {
         } catch (GeneralSecurityException gse) {
             throw (SSLProtocolException)(new SSLProtocolException(
                     "Unexpected exception")).initCause(gse);
+        } finally {
+            recordLock.unlock();
         }
 
         if (contentType != ContentType.HANDSHAKE.id &&

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -647,7 +647,6 @@ javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
-sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java 8277970 linux-all,macosx-x64
 
 ############################################################################
 

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
 
 /*
  * @test
- * @bug 8274736
+ * @bug 8274736 8277970
  * @summary Concurrent read/close of SSLSockets causes SSLSessions to be
  *          invalidated unnecessarily
  * @library /javax/net/ssl/templates


### PR DESCRIPTION
Backport of JDK-8277970.
I had to trivially resolve because JDK-8282723 is not in 11u. Let's see whether the bots will flag it as clean...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277970](https://bugs.openjdk.org/browse/JDK-8277970): Test jdk/sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java fails with "tag mismatch"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1499/head:pull/1499` \
`$ git checkout pull/1499`

Update a local copy of the PR: \
`$ git checkout pull/1499` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1499`

View PR using the GUI difftool: \
`$ git pr show -t 1499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1499.diff">https://git.openjdk.org/jdk11u-dev/pull/1499.diff</a>

</details>
