### PR TITLE
8293826: Closed test fails after JDK-8276108 on aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -147,7 +147,7 @@ LIR_Address* LIRGenerator::generate_address(LIR_Opr base, LIR_Opr index,
   if (index->is_constant()) {
     LIR_Const *constant = index->as_constant_ptr();
     if (constant->type() == T_INT) {
-      large_disp += index->as_jint() << shift;
+      large_disp += ((intx)index->as_jint()) << shift;
     } else {
       assert(constant->type() == T_LONG, "should be");
       jlong c = index->as_jlong() << shift;
@@ -193,7 +193,7 @@ LIR_Address* LIRGenerator::generate_address(LIR_Opr base, LIR_Opr index,
   if (large_disp == 0 && index->is_register()) {
     return new LIR_Address(base, index, type);
   } else {
-    assert(Address::offset_ok_for_immed(large_disp, 0), "must be");
+    assert(Address::offset_ok_for_immed(large_disp, shift), "failed for large_disp: " INTPTR_FORMAT " and shift %d", large_disp, shift);
     return new LIR_Address(base, large_disp, type);
   }
 }
@@ -203,24 +203,7 @@ LIR_Address* LIRGenerator::emit_array_address(LIR_Opr array_opr, LIR_Opr index_o
   int offset_in_bytes = arrayOopDesc::base_offset_in_bytes(type);
   int elem_size = type2aelembytes(type);
   int shift = exact_log2(elem_size);
-
-  LIR_Address* addr;
-  if (index_opr->is_constant()) {
-    addr = new LIR_Address(array_opr,
-                           offset_in_bytes + (intx)(index_opr->as_jint()) * elem_size, type);
-  } else {
-    if (offset_in_bytes) {
-      LIR_Opr tmp = new_pointer_register();
-      __ add(array_opr, LIR_OprFact::intConst(offset_in_bytes), tmp);
-      array_opr = tmp;
-      offset_in_bytes = 0;
-    }
-    addr =  new LIR_Address(array_opr,
-                            index_opr,
-                            LIR_Address::scale(type),
-                            offset_in_bytes, type);
-  }
-  return addr;
+  return generate_address(array_opr, index_opr, shift, offset_in_bytes, type);
 }
 
 LIR_Opr LIRGenerator::load_immediate(int x, BasicType type) {


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

A quite special backport as the original issue is not public.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293826](https://bugs.openjdk.org/browse/JDK-8293826): Closed test fails after JDK-8276108 on aarch64


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1500/head:pull/1500` \
`$ git checkout pull/1500`

Update a local copy of the PR: \
`$ git checkout pull/1500` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1500`

View PR using the GUI difftool: \
`$ git pr show -t 1500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1500.diff">https://git.openjdk.org/jdk11u-dev/pull/1500.diff</a>

</details>
