### PR TITLE
8272791: java -XX:BlockZeroingLowLimit=1 crashes after 8270947

### DIFF
--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -116,7 +116,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Use DC ZVA for block zeroing")                               \
   product(intx, BlockZeroingLowLimit, 256,                              \
           "Minimum size in bytes when block zeroing will be used")      \
-          range(1, max_jint)                                            \
+          range(wordSize, max_jint)                                     \
   product(bool, TraceTraps, false, "Trace all traps the signal handler")\
   product(int, SoftwarePrefetchHintDistance, -1,                        \
           "Use prfm hint with specified distance in compiled code."     \

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5432,7 +5432,7 @@ address MacroAssembler::zero_words(Register ptr, Register cnt)
 // r10, r11, rscratch1, and rscratch2 are clobbered.
 address MacroAssembler::zero_words(Register base, uint64_t cnt)
 {
-  guarantee(zero_words_block_size < BlockZeroingLowLimit,
+  assert(wordSize <= BlockZeroingLowLimit,
             "increase BlockZeroingLowLimit");
   address result = NULL;
   if (cnt <= (uint64_t)BlockZeroingLowLimit / BytesPerWord) {


### PR DESCRIPTION
This is a stacked PR(3/3) of https://github.com/openjdk/jdk11u-dev/pull/1502.

This patch is one of the trailing bugfix of JDK-8270947. We can apply to jdk11u cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #1503 must be integrated first

### Issue
 * [JDK-8272791](https://bugs.openjdk.org/browse/JDK-8272791): java -XX:BlockZeroingLowLimit=1 crashes after 8270947


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1504/head:pull/1504` \
`$ git checkout pull/1504`

Update a local copy of the PR: \
`$ git checkout pull/1504` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1504`

View PR using the GUI difftool: \
`$ git pr show -t 1504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1504.diff">https://git.openjdk.org/jdk11u-dev/pull/1504.diff</a>

</details>
