### PR TITLE
8271956: AArch64: C1 build failed after JDK-8270947

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -34,6 +34,7 @@
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
 #include "interpreter/interpreter.hpp"
+#include "compiler/compileTask.hpp"
 #include "compiler/disassembler.hpp"
 #include "memory/resourceArea.hpp"
 #include "nativeInst_aarch64.hpp"


### PR DESCRIPTION
This is a stacked PR(4/4) of https://github.com/openjdk/jdk11u-dev/pull/1502.

This patch is one of the trailing bugfix of JDK-8270947. We can apply to jdk11u cleanly.

---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #1504 must be integrated first

### Issue
 * [JDK-8271956](https://bugs.openjdk.org/browse/JDK-8271956): AArch64: C1 build failed after JDK-8270947


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1507/head:pull/1507` \
`$ git checkout pull/1507`

Update a local copy of the PR: \
`$ git checkout pull/1507` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1507`

View PR using the GUI difftool: \
`$ git pr show -t 1507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1507.diff">https://git.openjdk.org/jdk11u-dev/pull/1507.diff</a>

</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #1504 must be integrated first

### Issue
 * [JDK-8271956](https://bugs.openjdk.org/browse/JDK-8271956): AArch64: C1 build failed after JDK-8270947


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1507/head:pull/1507` \
`$ git checkout pull/1507`

Update a local copy of the PR: \
`$ git checkout pull/1507` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1507`

View PR using the GUI difftool: \
`$ git pr show -t 1507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1507.diff">https://git.openjdk.org/jdk11u-dev/pull/1507.diff</a>

</details>
