### PR TITLE
8296652: Restore windows aarch64 fixpath patch that was removed in 8239708

### DIFF
--- a/make/autoconf/basic_windows.m4
+++ b/make/autoconf/basic_windows.m4
@@ -99,10 +99,39 @@ AC_DEFUN_ONCE([BASIC_COMPILE_FIXPATH],
   # called fixpath.
   FIXPATH=
   if test "x$OPENJDK_BUILD_OS" = xwindows; then
-    AC_MSG_CHECKING([if fixpath can be created])
     FIXPATH_SRC="$TOPDIR/make/src/native/fixpath.c"
-    FIXPATH_BIN="$CONFIGURESUPPORT_OUTPUTDIR/bin/fixpath.exe"
     FIXPATH_DIR="$CONFIGURESUPPORT_OUTPUTDIR/fixpath"
+
+    if test "x$OPENJDK_TARGET_CPU" != "xaarch64"; then
+      AC_MSG_CHECKING([if fixpath can be created])
+      FIXPATH_BIN="$CONFIGURESUPPORT_OUTPUTDIR/bin/fixpath.exe"
+      FIXPATH_SRC_W="$FIXPATH_SRC"
+      FIXPATH_BIN_W="$FIXPATH_BIN"
+      BASIC_WINDOWS_REWRITE_AS_WINDOWS_MIXED_PATH([FIXPATH_SRC_W])
+      BASIC_WINDOWS_REWRITE_AS_WINDOWS_MIXED_PATH([FIXPATH_BIN_W])
+      $RM -rf $FIXPATH_BIN $FIXPATH_DIR
+      $MKDIR -p $FIXPATH_DIR $CONFIGURESUPPORT_OUTPUTDIR/bin
+      cd $FIXPATH_DIR
+      $CC $FIXPATH_SRC_W -Fe$FIXPATH_BIN_W > $FIXPATH_DIR/fixpath1.log 2>&1
+      cd $CURDIR
+      if test ! -x $FIXPATH_BIN; then
+        AC_MSG_RESULT([no])
+        cat $FIXPATH_DIR/fixpath1.log
+        AC_MSG_ERROR([Could not create $FIXPATH_BIN])
+      fi
+      AC_MSG_RESULT([yes])
+    else # OPENJDK_TARGET_CPU is aarch64
+      AC_MSG_CHECKING([if fixpath is in place])
+      FIXPATH_BIN="$TOPDIR/fixpath.exe"
+      $RM -rf $FIXPATH_DIR
+      $MKDIR -p $FIXPATH_DIR
+      if test ! -x $FIXPATH_BIN; then
+        AC_MSG_RESULT([no])
+        AC_MSG_ERROR([Could not find fixpath.exe under $TOPDIR])
+      fi
+      AC_MSG_RESULT([yes])
+    fi
+    
     if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin; then
       # Important to keep the .exe suffix on Cygwin for Hotspot makefiles
       FIXPATH="$FIXPATH_BIN -c"
@@ -114,22 +143,6 @@ AC_DEFUN_ONCE([BASIC_COMPILE_FIXPATH],
       fixpath_argument_list=`echo $all_unique_prefixes  | tr ' ' '@'`
       FIXPATH="$FIXPATH_BIN -m$fixpath_argument_list"
     fi
-    FIXPATH_SRC_W="$FIXPATH_SRC"
-    FIXPATH_BIN_W="$FIXPATH_BIN"
-    UTIL_REWRITE_AS_WINDOWS_MIXED_PATH([FIXPATH_SRC_W])
-    UTIL_REWRITE_AS_WINDOWS_MIXED_PATH([FIXPATH_BIN_W])
-    $RM -rf $FIXPATH_BIN $FIXPATH_DIR
-    $MKDIR -p $FIXPATH_DIR $CONFIGURESUPPORT_OUTPUTDIR/bin
-    cd $FIXPATH_DIR
-    $CC $FIXPATH_SRC_W -Fe$FIXPATH_BIN_W > $FIXPATH_DIR/fixpath1.log 2>&1
-    cd $CONFIGURE_START_DIR
-
-    if test ! -x $FIXPATH_BIN; then
-      AC_MSG_RESULT([no])
-      cat $FIXPATH_DIR/fixpath1.log
-      AC_MSG_ERROR([Could not create $FIXPATH_BIN])
-    fi
-    AC_MSG_RESULT([yes])
 
     AC_MSG_CHECKING([if fixpath.exe works])
     cd $FIXPATH_DIR


### PR DESCRIPTION
When https://bugs.openjdk.org/browse/JDK-8239708 was backported to 11u, the Windows aarch64 specific fixpath patch added in https://github.com/openjdk/jdk11u/commit/7bdb8ac7f9f9a83779427da7a6d7f5e9ae548db7#diff-cbf3a26a7e5854d626b3c7e11c8bcb3c287ed95113360aaf220108bfa018e066was missed out. This will need restoring