### PR TITLE
8255439: System Tray icons get corrupted when Windows scaling changes

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,10 +70,12 @@ typedef struct tagBitmapheader  {
 
 jfieldID AwtTrayIcon::idID;
 jfieldID AwtTrayIcon::actionCommandID;
+jmethodID AwtTrayIcon::updateImageID;
 
 HWND AwtTrayIcon::sm_msgWindow = NULL;
 AwtTrayIcon::TrayIconListItem* AwtTrayIcon::sm_trayIconList = NULL;
 int AwtTrayIcon::sm_instCount = 0;
+bool AwtTrayIcon::m_bDPIChanged = false;
 
 /************************************************************************
  * AwtTrayIcon methods
@@ -221,6 +223,18 @@ void AwtTrayIcon::InitNID(UINT uID)
     m_nid.uVersion = NOTIFYICON_VERSION;
 }
 
+// Call updateImage() method on the peer when screen scale changes
+void AwtTrayIcon::UpdateImage()
+{
+    JNIEnv *env =(JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
+
+    jobject peer = GetPeer(env);
+    if (peer != NULL) {
+        env->CallVoidMethod(peer, updateImageID);
+        env->ExceptionClear();
+    }
+}
+
 BOOL AwtTrayIcon::SendTrayMessage(DWORD dwMessage)
 {
     return Shell_NotifyIcon(dwMessage, (PNOTIFYICONDATA)&m_nid);
@@ -247,6 +261,10 @@ LRESULT CALLBACK AwtTrayIcon::TrayWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam
                     mr = trayIcon->WmAwtTrayNotify(wParam, lParam);
                 }
             }
+            break;
+        case WM_DPICHANGED:
+            // Set the flag to update icon images, see WmTaskbarCreated
+            m_bDPIChanged = true;
             break;
         default:
             if(uMsg == s_msgTaskbarCreated) {
@@ -474,12 +492,17 @@ MsgRouting AwtTrayIcon::WmContextMenu(UINT flags, int x, int y)
 MsgRouting AwtTrayIcon::WmTaskbarCreated() {
     TrayIconListItem* item;
     for (item = sm_trayIconList; item != NULL; item = item->m_next) {
+        if (m_bDPIChanged) {
+            // Update the icon image
+            item->m_trayIcon->UpdateImage();
+        }
         BOOL result = item->m_trayIcon->SendTrayMessage(NIM_ADD);
         // 6270114: Instructs the taskbar to behave according to the Shell version 5.0
         if (result) {
             item->m_trayIcon->SendTrayMessage(NIM_SETVERSION);
         }
     }
+    m_bDPIChanged = false;
     return mrDoDefault;
 }
 
@@ -916,6 +939,14 @@ Java_java_awt_TrayIcon_initIDs(JNIEnv *env, jclass cls)
     AwtTrayIcon::actionCommandID = env->GetFieldID(cls, "actionCommand", "Ljava/lang/String;");
     DASSERT(AwtTrayIcon::actionCommandID != NULL);
     CHECK_NULL( AwtTrayIcon::actionCommandID);
+
+    jclass wPeerCls = env->FindClass("sun/awt/windows/WTrayIconPeer");
+    DASSERT(wPeerCls != NULL);
+    CHECK_NULL(wPeerCls);
+
+    AwtTrayIcon::updateImageID = env->GetMethodID(wPeerCls, "updateImage", "()V");
+    DASSERT(AwtTrayIcon::updateImageID != NULL);
+    CHECK_NULL(AwtTrayIcon::updateImageID);
 
     CATCH_BAD_ALLOC;
 }

--- a/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,6 +86,8 @@ public:
 
     void DisplayMessage(LPCTSTR caption, LPCTSTR text, LPCTSTR msgType);
 
+    void UpdateImage();
+
     // Adds to the head of the list
     INLINE void AddTrayIconItem(UINT id) {
         TrayIconListItem* item = new TrayIconListItem(id, this);
@@ -121,6 +123,7 @@ public:
      */
     static jfieldID idID;
     static jfieldID actionCommandID;
+    static jmethodID updateImageID;
 
     // ************************
 
@@ -150,6 +153,8 @@ private:
         AwtTrayIcon* m_trayIcon;
         TrayIconListItem* m_next;
     };
+
+    static bool m_bDPIChanged;
 
 public:
     static TrayIconListItem* sm_trayIconList;

--- a/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8255439
+ * @key headful
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary To test tray icon scaling with on-the-fly DPI/Scale changes on Windows
+ * @run main/manual TrayIconScalingTest
+ * @requires (os.family == "windows")
+ */
+
+import java.awt.AWTException;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.RenderingHints;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
+import java.awt.font.TextLayout;
+import java.awt.image.BaseMultiResolutionImage;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+
+public class TrayIconScalingTest {
+
+    private static SystemTray tray;
+    private static TrayIcon icon;
+
+    private static final String INSTRUCTIONS =
+            "This test checks if the tray icon gets updated when DPI / Scale" +
+            " is changed on the fly.\n\n" +
+            "STEPS: \n\n" +
+            "1. Check the system tray / notification area on Windows" +
+            " taskbar, you should see a white icon which displays a" +
+            " number.\n\n" +
+            "2. Navigate to Settings > System > Display and change the" +
+            " display scale by selecting any value from" +
+            " Scale & Layout dropdown.\n\n"+
+            "3. When the scale changes, check the white tray icon," +
+            " there should be no distortion, it should be displayed sharp,\n" +
+            " and the displayed number should correspond to the current"+
+            " scale:\n" +
+            " 100% - 16, 125% - 20, 150% - 24, 175% - 28, 200% - 32.\n\n"+
+            " If the icon is displayed sharp and without any distortion," +
+            " press PASS, otherwise press FAIL.\n";
+
+    private static final Font font = new Font("Dialog", Font.BOLD, 12);
+
+    public static void main(String[] args)
+            throws InterruptedException, InvocationTargetException {
+        // check if SystemTray supported on the machine
+        if (!SystemTray.isSupported()) {
+            System.out.println("SystemTray is not supported");
+            return;
+        }
+        PassFailJFrame passFailJFrame = new PassFailJFrame("TrayIcon " +
+                "Test Instructions", INSTRUCTIONS, 8, 18, 85);
+        createAndShowGUI();
+        try {
+            passFailJFrame.awaitAndCheck();
+        } finally {
+            tray.remove(icon);
+        }
+    }
+
+    private static void createAndShowGUI() {
+        ArrayList<Image> imageList = new ArrayList<>();
+        for (int size = 16; size <= 48; size += 4) {
+            imageList.add(createIcon(size));
+        }
+        Image mRImage =
+                new BaseMultiResolutionImage(imageList.toArray(new Image[0]));
+
+        tray = SystemTray.getSystemTray();
+        icon = new TrayIcon(mRImage);
+
+        try {
+            tray.add(icon);
+        } catch (AWTException e) {
+            throw new RuntimeException("Error while adding icon to system tray");
+        }
+    }
+
+    private static Image createIcon(int size) {
+        BufferedImage image = new BufferedImage(size, size,
+                BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = image.createGraphics();
+        g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        g.setColor(Color.WHITE);
+        g.fillRect(0, 0, size, size);
+        g.setFont(font);
+        g.setColor(Color.BLACK);
+
+        TextLayout layout = new TextLayout(String.valueOf(size),
+                g.getFont(), g.getFontRenderContext());
+        int height = (int) layout.getBounds().getHeight();
+        int width = (int) layout.getBounds().getWidth();
+        layout.draw(g, (size - width) / 2f - 1, (size + height) / 2f);
+        g.dispose();
+        return image;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255439](https://bugs.openjdk.org/browse/JDK-8255439): System Tray icons get corrupted when Windows scaling changes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1511/head:pull/1511` \
`$ git checkout pull/1511`

Update a local copy of the PR: \
`$ git checkout pull/1511` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1511`

View PR using the GUI difftool: \
`$ git pr show -t 1511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1511.diff">https://git.openjdk.org/jdk11u-dev/pull/1511.diff</a>

</details>
