### PR TITLE
8286872: Refactor add/modify notification icon (TrayIcon)

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.cpp
@@ -496,11 +496,7 @@ MsgRouting AwtTrayIcon::WmTaskbarCreated() {
             // Update the icon image
             item->m_trayIcon->UpdateImage();
         }
-        BOOL result = item->m_trayIcon->SendTrayMessage(NIM_ADD);
-        // 6270114: Instructs the taskbar to behave according to the Shell version 5.0
-        if (result) {
-            item->m_trayIcon->SendTrayMessage(NIM_SETVERSION);
-        }
+        item->m_trayIcon->AddTrayIcon();
     }
     m_bDPIChanged = false;
     return mrDoDefault;
@@ -748,7 +744,7 @@ void AwtTrayIcon::SetToolTip(LPCTSTR tooltip)
         _tcscpy_s(m_nid.szTip, TRAY_ICON_TOOLTIP_MAX_SIZE, tooltip);
     }
 
-    SendTrayMessage(NIM_MODIFY);
+    ModifyTrayIcon();
 }
 
 void AwtTrayIcon::_SetToolTip(void *param)
@@ -816,10 +812,10 @@ void AwtTrayIcon::_UpdateIcon(void *param)
     JNI_CHECK_PEER_GOTO(self, ret);
     trayIcon = (AwtTrayIcon *)pData;
 
-    BOOL result = trayIcon->SendTrayMessage(jupdate == JNI_TRUE ? NIM_MODIFY : NIM_ADD);
-    // 6270114: Instructs the taskbar to behave according to the Shell version 5.0
-    if (result && jupdate == JNI_FALSE) {
-        trayIcon->SendTrayMessage(NIM_SETVERSION);
+    if (jupdate == JNI_TRUE) {
+        trayIcon->ModifyTrayIcon();
+    } else {
+        trayIcon->AddTrayIcon();
     }
 ret:
     env->DeleteGlobalRef(self);
@@ -868,7 +864,7 @@ void AwtTrayIcon::DisplayMessage(LPCTSTR caption, LPCTSTR text, LPCTSTR msgType)
         _tcscpy_s(m_nid.szInfo, TRAY_ICON_BALLOON_INFO_MAX_SIZE, text);
     }
 
-    SendTrayMessage(NIM_MODIFY);
+    ModifyTrayIcon();
     m_nid.uFlags &= ~NIF_INFO;
 }
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TrayIcon.h
@@ -52,7 +52,6 @@ public:
 
     virtual void Dispose();
 
-    BOOL SendTrayMessage(DWORD dwMessage);
     void LinkObjects(JNIEnv *env, jobject peer);
     void UnlinkObjects();
 
@@ -153,6 +152,20 @@ private:
         AwtTrayIcon* m_trayIcon;
         TrayIconListItem* m_next;
     };
+
+    BOOL SendTrayMessage(DWORD dwMessage);
+
+    INLINE void AddTrayIcon() {
+        BOOL result = SendTrayMessage(NIM_ADD);
+        // 6270114: Instructs the taskbar to behave according to the Shell version 5.0
+        if (result) {
+            SendTrayMessage(NIM_SETVERSION);
+        }
+    }
+
+    INLINE void ModifyTrayIcon() {
+        SendTrayMessage(NIM_MODIFY);
+    }
 
     static bool m_bDPIChanged;
 


### PR DESCRIPTION
I backport this for parity with 11.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286872](https://bugs.openjdk.org/browse/JDK-8286872): Refactor add/modify notification icon (TrayIcon)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1513/head:pull/1513` \
`$ git checkout pull/1513`

Update a local copy of the PR: \
`$ git checkout pull/1513` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1513`

View PR using the GUI difftool: \
`$ git pr show -t 1513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1513.diff">https://git.openjdk.org/jdk11u-dev/pull/1513.diff</a>

</details>
