### PR TITLE
8296108: (tz) Update Timezone Data to 2022f

### DIFF
--- a/make/data/tzdata/VERSION
+++ b/make/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2022e
+tzdata2022f

--- a/make/data/tzdata/africa
+++ b/make/data/tzdata/africa
@@ -120,22 +120,6 @@ Zone	Africa/Algiers	0:12:12 -	LMT	1891 Mar 16
 			0:00	Algeria	WE%sT	1981 May
 			1:00	-	CET
 
-# Angola
-# Benin
-# See Africa/Lagos.
-
-# Botswana
-# See Africa/Maputo.
-
-# Burkina Faso
-# See Africa/Abidjan.
-
-# Burundi
-# See Africa/Maputo.
-
-# Cameroon
-# See Africa/Lagos.
-
 # Cape Verde / Cabo Verde
 #
 # From Paul Eggert (2018-02-16):
@@ -150,9 +134,6 @@ Zone Atlantic/Cape_Verde -1:34:04 -	LMT	1912 Jan 01  2:00u # Praia
 			-2:00	-	-02	1975 Nov 25  2:00
 			-1:00	-	-01
 
-# Central African Republic
-# See Africa/Lagos.
-
 # Chad
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Ndjamena	1:00:12 -	LMT	1912        # N'Djamena
@@ -160,33 +141,29 @@ Zone	Africa/Ndjamena	1:00:12 -	LMT	1912        # N'Djamena
 			1:00	1:00	WAST	1980 Mar  8
 			1:00	-	WAT
 
-# Comoros
-# See Africa/Nairobi.
+# Burkina Faso
+# Côte d'Ivoire (Ivory Coast)
+# The Gambia
+# Ghana
+# Guinea
+# Iceland
+# Mali
+# Mauritania
+# St Helena
+# Senegal
+# Sierra Leone
+# Togo
 
-# Democratic Republic of the Congo
-# See Africa/Lagos for the western part and Africa/Maputo for the eastern.
+# The other parts of the St Helena territory are similar:
+#	Tristan da Cunha: on GMT, say Whitman and the CIA
+#	Ascension: on GMT, say the USNO (1995-12-21) and the CIA
+#	Gough (scientific station since 1955; sealers wintered previously):
+#		on GMT, says the CIA
+#	Inaccessible, Nightingale: uninhabited
 
-# Republic of the Congo
-# See Africa/Lagos.
-
-# Côte d'Ivoire / Ivory Coast
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Abidjan	-0:16:08 -	LMT	1912
 			 0:00	-	GMT
-Link Africa/Abidjan Africa/Accra	# Ghana
-Link Africa/Abidjan Africa/Bamako	# Mali
-Link Africa/Abidjan Africa/Banjul	# The Gambia
-Link Africa/Abidjan Africa/Conakry	# Guinea
-Link Africa/Abidjan Africa/Dakar	# Senegal
-Link Africa/Abidjan Africa/Freetown	# Sierra Leone
-Link Africa/Abidjan Africa/Lome		# Togo
-Link Africa/Abidjan Africa/Nouakchott	# Mauritania
-Link Africa/Abidjan Africa/Ouagadougou	# Burkina Faso
-Link Africa/Abidjan Atlantic/Reykjavik	# Iceland
-Link Africa/Abidjan Atlantic/St_Helena	# St Helena
-
-# Djibouti
-# See Africa/Nairobi.
 
 ###############################################################################
 
@@ -382,33 +359,6 @@ Rule	Egypt	2014	only	-	Sep	lastThu	24:00	0	-
 Zone	Africa/Cairo	2:05:09 -	LMT	1900 Oct
 			2:00	Egypt	EE%sT
 
-# Equatorial Guinea
-# See Africa/Lagos.
-
-# Eritrea
-# See Africa/Nairobi.
-
-# Eswatini (formerly Swaziland)
-# See Africa/Johannesburg.
-
-# Ethiopia
-# See Africa/Nairobi.
-#
-# Unfortunately tzdb records only Western clock time in use in Ethiopia,
-# as the tzdb format is not up to properly recording a common Ethiopian
-# timekeeping practice that is based on solar time.  See:
-# Mortada D. If you have a meeting in Ethiopia, you'd better double
-# check the time. PRI's The World. 2015-01-30 15:15 -05.
-# https://www.pri.org/stories/2015-01-30/if-you-have-meeting-ethiopia-you-better-double-check-time
-
-# Gabon
-# See Africa/Lagos.
-
-# The Gambia
-# Ghana
-# Guinea
-# See Africa/Abidjan.
-
 # Guinea-Bissau
 #
 # From Paul Eggert (2018-02-16):
@@ -421,7 +371,16 @@ Zone	Africa/Bissau	-1:02:20 -	LMT	1912 Jan  1  1:00u
 			-1:00	-	-01	1975
 			 0:00	-	GMT
 
+# Comoros
+# Djibouti
+# Eritrea
+# Ethiopia
 # Kenya
+# Madagascar
+# Mayotte
+# Somalia
+# Tanzania
+# Uganda
 
 # From P Chan (2020-10-24):
 #
@@ -464,6 +423,14 @@ Zone	Africa/Bissau	-1:02:20 -	LMT	1912 Jan  1  1:00u
 # The 1908-05-01 announcement does not give an effective date,
 # so just say "1908 May".
 
+# From Paul Eggert (2018-09-11):
+# Unfortunately tzdb records only Western clock time in use in Ethiopia,
+# as the tzdb format is not up to properly recording a common Ethiopian
+# timekeeping practice that is based on solar time.  See:
+# Mortada D. If you have a meeting in Ethiopia, you'd better double
+# check the time. PRI's The World. 2015-01-30 15:15 -05.
+# https://www.pri.org/stories/2015-01-30/if-you-have-meeting-ethiopia-you-better-double-check-time
+
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Nairobi	2:27:16	-	LMT	1908 May
 			2:30	-	+0230	1928 Jun 30 24:00
@@ -471,18 +438,6 @@ Zone	Africa/Nairobi	2:27:16	-	LMT	1908 May
 			2:30	-	+0230	1936 Dec 31 24:00
 			2:45	-	+0245	1942 Jul 31 24:00
 			3:00	-	EAT
-Link Africa/Nairobi Africa/Addis_Ababa	 # Ethiopia
-Link Africa/Nairobi Africa/Asmara	 # Eritrea
-Link Africa/Nairobi Africa/Dar_es_Salaam # Tanzania
-Link Africa/Nairobi Africa/Djibouti
-Link Africa/Nairobi Africa/Kampala	 # Uganda
-Link Africa/Nairobi Africa/Mogadishu	 # Somalia
-Link Africa/Nairobi Indian/Antananarivo	 # Madagascar
-Link Africa/Nairobi Indian/Comoro
-Link Africa/Nairobi Indian/Mayotte
-
-# Lesotho
-# See Africa/Johannesburg.
 
 # Liberia
 #
@@ -562,16 +517,6 @@ Zone	Africa/Tripoli	0:52:44 -	LMT	1920
 			2:00	-	EET	2012 Nov 10  2:00
 			1:00	Libya	CE%sT	2013 Oct 25  2:00
 			2:00	-	EET
-
-# Madagascar
-# See Africa/Nairobi.
-
-# Malawi
-# See Africa/Maputo.
-
-# Mali
-# Mauritania
-# See Africa/Abidjan.
 
 # Mauritius
 
@@ -665,12 +610,6 @@ Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
 			4:00 Mauritius	+04/+05
 # Agalega Is, Rodriguez
 # no information; probably like Indian/Mauritius
-
-# Mayotte
-# See Africa/Nairobi.
-
-# Morocco
-# See Africa/Ceuta for Spanish Morocco.
 
 # From Alex Krivenyshev (2008-05-09):
 # Here is an article that Morocco plan to introduce Daylight Saving Time between
@@ -1160,7 +1099,14 @@ Zone Africa/El_Aaiun	-0:52:48 -	LMT	1934 Jan # El Aaiún
 			 0:00	Morocco	+00/+01	2018 Oct 28  3:00
 			 1:00	Morocco	+01/+00
 
+# Botswana
+# Burundi
+# Democratic Republic of the Congo (eastern)
+# Malawi
 # Mozambique
+# Rwanda
+# Zambia
+# Zimbabwe
 #
 # Shanks gives 1903-03-01 for the transition to CAT.
 # Perhaps the 1911-05-26 Portuguese decree
@@ -1170,14 +1116,6 @@ Zone Africa/El_Aaiun	-0:52:48 -	LMT	1934 Jan # El Aaiún
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Maputo	2:10:20 -	LMT	1903 Mar
 			2:00	-	CAT
-Link Africa/Maputo Africa/Blantyre	# Malawi
-Link Africa/Maputo Africa/Bujumbura	# Burundi
-Link Africa/Maputo Africa/Gaborone	# Botswana
-Link Africa/Maputo Africa/Harare	# Zimbabwe
-Link Africa/Maputo Africa/Kigali	# Rwanda
-Link Africa/Maputo Africa/Lubumbashi	# E Dem. Rep. of Congo
-Link Africa/Maputo Africa/Lusaka	# Zambia
-
 
 # Namibia
 
@@ -1256,9 +1194,16 @@ Zone	Africa/Windhoek	1:08:24 -	LMT	1892 Feb 8
 #			2:00	-	CAT
 # End of rearguard section.
 
-# Niger
-# See Africa/Lagos.
 
+# Angola
+# Benin
+# Cameroon
+# Central African Republic
+# Democratic Republic of the Congo (western)
+# Republic of the Congo
+# Equatorial Guinea
+# Gabon
+# Niger
 # Nigeria
 
 # From P Chan (2020-12-03):
@@ -1324,32 +1269,6 @@ Zone	Africa/Lagos	0:13:35 -	LMT	1905 Jul  1
 			0:13:35	-	LMT	1914 Jan  1
 			0:30	-	+0030	1919 Sep  1
 			1:00	-	WAT
-Link Africa/Lagos Africa/Bangui		# Central African Republic
-Link Africa/Lagos Africa/Brazzaville	# Rep. of the Congo
-Link Africa/Lagos Africa/Douala		# Cameroon
-Link Africa/Lagos Africa/Kinshasa	# Dem. Rep. of the Congo (west)
-Link Africa/Lagos Africa/Libreville	# Gabon
-Link Africa/Lagos Africa/Luanda		# Angola
-Link Africa/Lagos Africa/Malabo		# Equatorial Guinea
-Link Africa/Lagos Africa/Niamey		# Niger
-Link Africa/Lagos Africa/Porto-Novo	# Benin
-
-# Réunion
-# See Asia/Dubai.
-#
-# The Crozet Islands also observe Réunion time; see the 'antarctica' file.
-
-# Rwanda
-# See Africa/Maputo.
-
-# St Helena
-# See Africa/Abidjan.
-# The other parts of the St Helena territory are similar:
-#	Tristan da Cunha: on GMT, say Whitman and the CIA
-#	Ascension: on GMT, say the USNO (1995-12-21) and the CIA
-#	Gough (scientific station since 1955; sealers wintered previously):
-#		on GMT, says the CIA
-#	Inaccessible, Nightingale: uninhabited
 
 # São Tomé and Príncipe
 
@@ -1378,19 +1297,10 @@ Zone	Africa/Sao_Tome	 0:26:56 -	LMT	1884
 			 1:00	-	WAT	2019 Jan  1 02:00
 			 0:00	-	GMT
 
-# Senegal
-# See Africa/Abidjan.
-
-# Seychelles
-# See Asia/Dubai.
-
-# Sierra Leone
-# See Africa/Abidjan.
-
-# Somalia
-# See Africa/Nairobi.
-
+# Eswatini (Swaziland)
+# Lesotho
 # South Africa
+
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	SA	1942	1943	-	Sep	Sun>=15	2:00	1:00	-
 Rule	SA	1943	1944	-	Mar	Sun>=15	2:00	0	-
@@ -1398,8 +1308,6 @@ Rule	SA	1943	1944	-	Mar	Sun>=15	2:00	0	-
 Zone Africa/Johannesburg 1:52:00 -	LMT	1892 Feb 8
 			1:30	-	SAST	1903 Mar
 			2:00	SA	SAST
-Link Africa/Johannesburg Africa/Maseru	# Lesotho
-Link Africa/Johannesburg Africa/Mbabane	# Eswatini
 #
 # Marion and Prince Edward Is
 # scientific station since 1947
@@ -1447,12 +1355,6 @@ Zone	Africa/Juba	2:06:28 -	LMT	1931
 			2:00	Sudan	CA%sT	2000 Jan 15 12:00
 			3:00	-	EAT	2021 Feb  1 00:00
 			2:00	-	CAT
-
-# Tanzania
-# See Africa/Nairobi.
-
-# Togo
-# See Africa/Abidjan.
 
 # Tunisia
 
@@ -1551,10 +1453,3 @@ Rule	Tunisia	2006	2008	-	Oct	lastSun	 2:00s	0	-
 Zone	Africa/Tunis	0:40:44 -	LMT	1881 May 12
 			0:09:21	-	PMT	1911 Mar 11 # Paris Mean Time
 			1:00	Tunisia	CE%sT
-
-# Uganda
-# See Africa/Nairobi.
-
-# Zambia
-# Zimbabwe
-# See Africa/Maputo.

--- a/make/data/tzdata/antarctica
+++ b/make/data/tzdata/antarctica
@@ -329,4 +329,4 @@ Zone Antarctica/Rothera	0	-	-00	1976 Dec  1
 # we have to go around and set them back 5 minutes or so.
 # Maybe if we let them run fast all of the time, we'd get to leave here sooner!!
 #
-# See 'australasia' for Antarctica/McMurdo.
+# See Pacific/Auckland.

--- a/make/data/tzdata/asia
+++ b/make/data/tzdata/asia
@@ -172,9 +172,6 @@ Zone	Asia/Baku	3:19:24 -	LMT	1924 May  2
 			4:00	EUAsia	+04/+05	1997
 			4:00	Azer	+04/+05
 
-# Bahrain
-# See Asia/Qatar.
-
 # Bangladesh
 # From Alexander Krivenyshev (2009-05-13):
 # According to newspaper Asian Tribune (May 6, 2009) Bangladesh may introduce
@@ -277,10 +274,8 @@ Zone	Indian/Chagos	4:49:40	-	LMT	1907
 			5:00	-	+05	1996
 			6:00	-	+06
 
-# Brunei
-# See Asia/Kuching.
-
-# Burma / Myanmar
+# Cocos (Keeling) Islands
+# Myanmar (Burma)
 
 # Milne says 6:24:40 was the meridian of the time ball observatory at Rangoon.
 
@@ -296,11 +291,6 @@ Zone	Asia/Yangon	6:24:47 -	LMT	1880        # or Rangoon
 			6:30	-	+0630	1942 May
 			9:00	-	+09	1945 May  3
 			6:30	-	+0630
-Link Asia/Yangon Indian/Cocos
-
-# Cambodia
-# See Asia/Bangkok.
-
 
 # China
 
@@ -688,10 +678,9 @@ Zone	Asia/Shanghai	8:05:43	-	LMT	1901
 			8:00	PRC	C%sT
 # Xinjiang time, used by many in western China; represented by Ürümqi / Ürümchi
 # / Wulumuqi.  (Please use Asia/Shanghai if you prefer Beijing time.)
+# Vostok base in Antarctica matches this since 1970.
 Zone	Asia/Urumqi	5:50:20	-	LMT	1928
 			6:00	-	+06
-Link Asia/Urumqi Antarctica/Vostok
-
 
 # Hong Kong
 
@@ -1194,10 +1183,6 @@ Zone	Asia/Famagusta	2:15:48	-	LMT	1921 Nov 14
 			2:00	EUAsia	EE%sT	2016 Sep  8
 			3:00	-	+03	2017 Oct 29 1:00u
 			2:00	EUAsia	EE%sT
-
-# Classically, Cyprus belongs to Asia; e.g. see Herodotus, Histories, I.72.
-# However, for various reasons many users expect to find it under Europe.
-Link	Asia/Nicosia	Europe/Nicosia
 
 # Georgia
 # From Paul Eggert (1994-11-19):
@@ -2727,14 +2712,6 @@ Zone	Asia/Pyongyang	8:23:00 -	LMT	1908 Apr  1
 			8:30	-	KST	2018 May  4 23:30
 			9:00	-	KST
 
-###############################################################################
-
-# Kuwait
-# See Asia/Riyadh.
-
-# Laos
-# See Asia/Bangkok.
-
 
 # Lebanon
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
@@ -2766,7 +2743,9 @@ Rule	Lebanon	1999	max	-	Oct	lastSun	0:00	0	-
 Zone	Asia/Beirut	2:22:00 -	LMT	1880
 			2:00	Lebanon	EE%sT
 
-# Malaysia
+# Brunei
+# Malaysia (eastern)
+#
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	NBorneo	1935	1941	-	Sep	14	0:00	0:20	-
 Rule	NBorneo	1935	1941	-	Dec	14	0:00	0	-
@@ -2783,14 +2762,12 @@ Zone Asia/Kuching	7:21:20	-	LMT	1926 Mar
 			8:00 NBorneo  +08/+0820	1942 Feb 16
 			9:00	-	+09	1945 Sep 12
 			8:00	-	+08
-Link Asia/Kuching Asia/Brunei
 
 # Maldives
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Indian/Maldives	4:54:00 -	LMT	1880 # Malé
 			4:54:00	-	MMT	1960 # Malé Mean Time
 			5:00	-	+05
-Link Indian/Maldives Indian/Kerguelen
 
 # Mongolia
 
@@ -2952,9 +2929,6 @@ Zone	Asia/Choibalsan	7:38:00 -	LMT	1905 Aug
 Zone	Asia/Kathmandu	5:41:16 -	LMT	1920
 			5:30	-	+0530	1986
 			5:45	-	+0545
-
-# Oman
-# See Asia/Dubai.
 
 # Pakistan
 
@@ -3566,14 +3540,18 @@ Zone	Asia/Manila	-15:56:00 -	LMT	1844 Dec 31
 			9:00	-	JST	1944 Nov
 			8:00	Phil	P%sT
 
+# Bahrain
 # Qatar
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Qatar	3:26:08 -	LMT	1920     # Al Dawhah / Doha
 			4:00	-	+04	1972 Jun
 			3:00	-	+03
-Link Asia/Qatar Asia/Bahrain
 
+# Kuwait
 # Saudi Arabia
+# Yemen
+#
+# Japan's year-round bases in Antarctica match this since 1970.
 #
 # From Paul Eggert (2018-08-29):
 # Time in Saudi Arabia and other countries in the Arabian peninsula was not
@@ -3618,9 +3596,6 @@ Link Asia/Qatar Asia/Bahrain
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Riyadh	3:06:52 -	LMT	1947 Mar 14
 			3:00	-	+03
-Link Asia/Riyadh Antarctica/Syowa
-Link Asia/Riyadh Asia/Aden	# Yemen
-Link Asia/Riyadh Asia/Kuwait
 
 # Singapore
 # taken from Mok Ly Yng (2003-10-30)
@@ -3635,7 +3610,6 @@ Zone	Asia/Singapore	6:55:25 -	LMT	1901 Jan  1
 			9:00	-	+09	1945 Sep 12
 			7:30	-	+0730	1982 Jan  1
 			8:00	-	+08
-Link Asia/Singapore Asia/Kuala_Lumpur
 
 # Spratly Is
 # no information
@@ -3881,14 +3855,15 @@ Zone	Asia/Dushanbe	4:35:12 -	LMT	1924 May  2
 			5:00	1:00	+06	1991 Sep  9  2:00s
 			5:00	-	+05
 
+# Cambodia
+# Christmas I
+# Laos
 # Thailand
+# Vietnam (northern)
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Bangkok	6:42:04	-	LMT	1880
 			6:42:04	-	BMT	1920 Apr # Bangkok Mean Time
 			7:00	-	+07
-Link Asia/Bangkok Asia/Phnom_Penh	# Cambodia
-Link Asia/Bangkok Asia/Vientiane	# Laos
-Link Asia/Bangkok Indian/Christmas
 
 # Turkmenistan
 # From Shanks & Pottenger.
@@ -3899,13 +3874,15 @@ Zone	Asia/Ashgabat	3:53:32 -	LMT	1924 May  2 # or Ashkhabad
 			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00
 			5:00	-	+05
 
+# Oman
+# Réunion
+# Seychelles
 # United Arab Emirates
+#
+# The Crozet Is also observe Réunion time; see the 'antarctica' file.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Dubai	3:41:12 -	LMT	1920
 			4:00	-	+04
-Link Asia/Dubai Asia/Muscat	# Oman
-Link Asia/Dubai Indian/Mahe
-Link Asia/Dubai Indian/Reunion
 
 # Uzbekistan
 # Byalokoz 1919 says Uzbekistan was 4:27:53.
@@ -3925,7 +3902,7 @@ Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 			5:00 RussiaAsia	+05/+06	1992
 			5:00	-	+05
 
-# Vietnam
+# Vietnam (southern)
 
 # From Paul Eggert (2014-10-04):
 # Milne gives 7:16:56 for the meridian of Saigon in 1899, as being
@@ -3999,7 +3976,3 @@ Zone Asia/Ho_Chi_Minh	7:06:30 -	LMT	1906 Jul  1
 # For timestamps in north Vietnam back to 1970 (the tzdb cutoff),
 # use Asia/Bangkok; see the VN entries in the file zone1970.tab.
 # For timestamps before 1970, see Asia/Hanoi in the file 'backzone'.
-
-
-# Yemen
-# See Asia/Riyadh.

--- a/make/data/tzdata/australasia
+++ b/make/data/tzdata/australasia
@@ -274,13 +274,6 @@ Zone Antarctica/Macquarie 0	-	-00	1899 Nov
 			10:00	1:00	AEDT	2011
 			10:00	AT	AE%sT
 
-# Christmas
-# See Asia/Bangkok.
-
-# Cocos (Keeling) Is
-# See Asia/Yangon.
-
-
 # Fiji
 
 # Milne gives 11:55:44 for Suva.
@@ -416,8 +409,14 @@ Zone Antarctica/Macquarie 0	-	-00	1899 Nov
 # concerned shifting arrival and departure times, which may look like a simple
 # thing but requires some significant logistical adjustments domestically and
 # internationally."
-# Assume for now that DST will resume with the recent pre-2020 rules for the
-# 2022/2023 season.
+
+# From Shalvin Narayan (2022-10-27):
+# Please note that there will not be any daylight savings time change
+# in Fiji for 2022-2023....
+# https://www.facebook.com/FijianGovernment/posts/pfbid0mmWVTYmTibn66ybpFda75pDcf34SSpoSaskJW5gXwaKo5Sgc7273Q4fXWc6kQV6Hl
+#
+# From Paul Eggert (2022-10-27):
+# For now, assume DST is suspended indefinitely.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Fiji	1998	1999	-	Nov	Sun>=1	2:00	1:00	-
@@ -432,8 +431,6 @@ Rule	Fiji	2014	2018	-	Nov	Sun>=1	2:00	1:00	-
 Rule	Fiji	2015	2021	-	Jan	Sun>=12	3:00	0	-
 Rule	Fiji	2019	only	-	Nov	Sun>=8	2:00	1:00	-
 Rule	Fiji	2020	only	-	Dec	20	2:00	1:00	-
-Rule	Fiji	2022	max	-	Nov	Sun>=8	2:00	1:00	-
-Rule	Fiji	2023	max	-	Jan	Sun>=12	3:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Fiji	11:55:44 -	LMT	1915 Oct 26 # Suva
 			12:00	Fiji	+12/+13
@@ -449,7 +446,9 @@ Zone	Pacific/Tahiti	 -9:58:16 -	LMT	1912 Oct # Papeete
 # Clipperton (near North America) is administered from French Polynesia;
 # it is uninhabited.
 
+
 # Guam
+# N Mariana Is
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 # http://guamlegislature.com/Public_Laws_5th/PL05-025.pdf
@@ -489,17 +488,20 @@ Zone	Pacific/Guam	-14:21:00 -	LMT	1844 Dec 31
 			 9:00	-	+09	1944 Jul 31
 			10:00	Guam	G%sT	2000 Dec 23
 			10:00	-	ChST	# Chamorro Standard Time
-Link Pacific/Guam Pacific/Saipan # N Mariana Is
 
-# Kiribati
+
+# Kiribati (Gilbert Is)
+# Marshall Is
+# Tuvalu
+# Wake
+# Wallis & Futuna
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Tarawa	 11:32:04 -	LMT	1901 # Bairiki
 			 12:00	-	+12
-Link Pacific/Tarawa Pacific/Funafuti
-Link Pacific/Tarawa Pacific/Majuro
-Link Pacific/Tarawa Pacific/Wake
-Link Pacific/Tarawa Pacific/Wallis
 
+# Kiribati (except Gilbert Is)
+# See Pacific/Tarawa for the Gilbert Is.
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Kanton	  0	-	-00	1937 Aug 31
 			-12:00	-	-12	1979 Oct
 			-11:00	-	-11	1994 Dec 31
@@ -508,9 +510,6 @@ Zone Pacific/Kiritimati	-10:29:20 -	LMT	1901
 			-10:40	-	-1040	1979 Oct
 			-10:00	-	-10	1994 Dec 31
 			 14:00	-	+14
-
-# N Mariana Is
-# See Pacific/Guam.
 
 # Marshall Is
 # See Pacific/Tarawa for most locations.
@@ -561,6 +560,7 @@ Zone	Pacific/Noumea	11:05:48 -	LMT	1912 Jan 13 # Nouméa
 ###############################################################################
 
 # New Zealand
+# McMurdo Station and Scott Base in Antarctica use Auckland time.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	NZ	1927	only	-	Nov	 6	2:00	1:00	S
@@ -596,7 +596,6 @@ Rule	Chatham	2008	max	-	Apr	Sun>=1	2:45s	0	-
 Zone Pacific/Auckland	11:39:04 -	LMT	1868 Nov  2
 			11:30	NZ	NZ%sT	1946 Jan  1
 			12:00	NZ	NZ%sT
-Link Pacific/Auckland Antarctica/McMurdo
 
 Zone Pacific/Chatham	12:13:48 -	LMT	1868 Nov  2
 			12:15	-	+1215	1946 Jan  1
@@ -695,8 +694,6 @@ Zone Pacific/Palau	-15:02:04 -	LMT	1844 Dec 31	# Koror
 Zone Pacific/Port_Moresby 9:48:40 -	LMT	1880
 			9:48:32	-	PMMT	1895 # Port Moresby Mean Time
 			10:00	-	+10
-Link Pacific/Port_Moresby Antarctica/DumontDUrville
-Link Pacific/Port_Moresby Pacific/Chuuk
 #
 # From Paul Eggert (2014-10-13):
 # Base the Bougainville entry on the Arawa-Kieta region, which appears to have
@@ -729,10 +726,10 @@ Zone Pacific/Pitcairn	-8:40:20 -	LMT	1901        # Adamstown
 			-8:00	-	-08
 
 # American Samoa
+# Midway
 Zone Pacific/Pago_Pago	 12:37:12 -	LMT	1892 Jul  5
 			-11:22:48 -	LMT	1911
 			-11:00	-	SST	            # S=Samoa
-Link Pacific/Pago_Pago Pacific/Midway # in US minor outlying islands
 
 # Samoa (formerly and also known as Western Samoa)
 
@@ -824,7 +821,6 @@ Zone Pacific/Apia	 12:33:04 -	LMT	1892 Jul  5
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Guadalcanal 10:39:48 -	LMT	1912 Oct # Honiara
 			11:00	-	+11
-Link Pacific/Guadalcanal Pacific/Pohnpei
 
 # Tokelau
 #
@@ -863,9 +859,6 @@ Zone Pacific/Tongatapu	12:19:12 -	LMT	1945 Sep 10
 			12:20	-	+1220	1961
 			13:00	-	+13	1999
 			13:00	Tonga	+13/+14
-
-# Tuvalu
-# See Pacific/Tarawa.
 
 
 # US minor outlying islands
@@ -917,14 +910,8 @@ Zone Pacific/Tongatapu	12:19:12 -	LMT	1945 Sep 10
 # Kingman
 # uninhabited
 
-# Midway
-# See Pacific/Pago_Pago.
-
 # Palmyra
 # uninhabited since World War II; was probably like Pacific/Kiritimati
-
-# Wake
-# See Pacific/Tarawa.
 
 
 # Vanuatu
@@ -961,9 +948,6 @@ Rule	Vanuatu	1992	only	-	Oct	Sat>=22	24:00	1:00	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
 			11:00	Vanuatu	+11/+12
-
-# Wallis and Futuna
-# See Pacific/Tarawa.
 
 ###############################################################################
 

--- a/make/data/tzdata/backward
+++ b/make/data/tzdata/backward
@@ -27,7 +27,7 @@
 # 2009-05-17 by Arthur David Olson.
 
 # This file provides links from old or merged timezone names to current ones.
-# Many names changed in late 1993, and many merged names moved here
+# Many names changed in 1993 and in 1995, and many merged names moved here
 # in the period from 2013 through 2022.  Several of these names are
 # also present in the file 'backzone', which has data important only
 # for pre-1970 timestamps and so is out of scope for tzdb proper.
@@ -36,50 +36,24 @@
 # building with 'make BACKWARD=', in practice downstream users
 # typically use this file for backward compatibility.
 
-# Link	TARGET			LINK-NAME
-Link	Africa/Nairobi		Africa/Asmera
-Link	Africa/Abidjan		Africa/Timbuktu
-Link	America/Argentina/Catamarca	America/Argentina/ComodRivadavia
-Link	America/Adak		America/Atka
-Link	America/Argentina/Buenos_Aires	America/Buenos_Aires
-Link	America/Argentina/Catamarca	America/Catamarca
-Link	America/Panama		America/Coral_Harbour
-Link	America/Argentina/Cordoba	America/Cordoba
-Link	America/Tijuana		America/Ensenada
-Link	America/Indiana/Indianapolis	America/Fort_Wayne
-Link	America/Nuuk		America/Godthab
-Link	America/Indiana/Indianapolis	America/Indianapolis
-Link	America/Argentina/Jujuy	America/Jujuy
-Link	America/Indiana/Knox	America/Knox_IN
-Link	America/Kentucky/Louisville	America/Louisville
-Link	America/Argentina/Mendoza	America/Mendoza
-Link	America/Toronto		America/Montreal
-Link	America/Rio_Branco	America/Porto_Acre
-Link	America/Argentina/Cordoba	America/Rosario
-Link	America/Tijuana		America/Santa_Isabel
-Link	America/Denver		America/Shiprock
-Link	America/Puerto_Rico	America/Virgin
-Link	Pacific/Auckland	Antarctica/South_Pole
-Link	Asia/Ashgabat		Asia/Ashkhabad
-Link	Asia/Kolkata		Asia/Calcutta
-Link	Asia/Shanghai		Asia/Chongqing
-Link	Asia/Shanghai		Asia/Chungking
-Link	Asia/Dhaka		Asia/Dacca
-Link	Asia/Shanghai		Asia/Harbin
-Link	Asia/Urumqi		Asia/Kashgar
-Link	Asia/Kathmandu		Asia/Katmandu
-Link	Asia/Macau		Asia/Macao
-Link	Asia/Yangon		Asia/Rangoon
-Link	Asia/Ho_Chi_Minh	Asia/Saigon
-Link	Asia/Jerusalem		Asia/Tel_Aviv
-Link	Asia/Thimphu		Asia/Thimbu
-Link	Asia/Makassar		Asia/Ujung_Pandang
-Link	Asia/Ulaanbaatar	Asia/Ulan_Bator
-Link	Atlantic/Faroe		Atlantic/Faeroe
-Link	Europe/Berlin		Atlantic/Jan_Mayen
-Link	Australia/Sydney	Australia/ACT
-Link	Australia/Sydney	Australia/Canberra
-Link	Australia/Hobart	Australia/Currie
+# This file is divided into sections, one for each major reason for a
+# backward compatibility link.  Each section is sorted by link name.
+
+# A "#= TARGET1" comment labels each link inserted only because some
+# .zi parsers (including tzcode through 2022e) mishandle links to links.
+# The comment says what the target would be if these parsers were fixed
+# so that data could contain links to links.  For example, the line
+# "Link Australia/Sydney Australia/ACT #= Australia/Canberra" would be
+# "Link Australia/Canberra Australia/ACT" were it not that data lines
+# refrain from linking to links like Australia/Canberra, which means
+# the Australia/ACT line links instead to Australia/Sydney,
+# Australia/Canberra's target.
+
+
+# Pre-1993 naming conventions
+
+# Link	TARGET			LINK-NAME	#= TARGET1
+Link	Australia/Sydney	Australia/ACT	#= Australia/Canberra
 Link	Australia/Lord_Howe	Australia/LHI
 Link	Australia/Sydney	Australia/NSW
 Link	Australia/Darwin	Australia/North
@@ -89,7 +63,7 @@ Link	Australia/Hobart	Australia/Tasmania
 Link	Australia/Melbourne	Australia/Victoria
 Link	Australia/Perth		Australia/West
 Link	Australia/Broken_Hill	Australia/Yancowinna
-Link	America/Rio_Branco	Brazil/Acre
+Link	America/Rio_Branco	Brazil/Acre	#= America/Porto_Acre
 Link	America/Noronha		Brazil/DeNoronha
 Link	America/Sao_Paulo	Brazil/East
 Link	America/Manaus		Brazil/West
@@ -109,20 +83,36 @@ Link	Pacific/Easter		Chile/EasterIsland
 Link	America/Havana		Cuba
 Link	Africa/Cairo		Egypt
 Link	Europe/Dublin		Eire
+# Vanguard section, for most .zi parsers.
+#Link	GMT			Etc/GMT
+#Link	GMT			Etc/GMT+0
+#Link	GMT			Etc/GMT-0
+#Link	GMT			Etc/GMT0
+#Link	GMT			Etc/Greenwich
+# Rearguard section, for TZUpdater 2.3.2 and earlier.
+Link	Etc/GMT			Etc/GMT+0
+Link	Etc/GMT			Etc/GMT-0
+Link	Etc/GMT			Etc/GMT0
+Link	Etc/GMT			Etc/Greenwich
+# End of rearguard section.
 Link	Etc/UTC			Etc/UCT
-Link	Europe/London		Europe/Belfast
-Link	Europe/Kyiv		Europe/Kiev
-Link	Europe/Chisinau		Europe/Tiraspol
-Link	Europe/Kyiv		Europe/Uzhgorod
-Link	Europe/Kyiv		Europe/Zaporozhye
+Link	Etc/UTC			Etc/Universal
+Link	Etc/UTC			Etc/Zulu
 Link	Europe/London		GB
 Link	Europe/London		GB-Eire
+# Vanguard section, for most .zi parsers.
+#Link	GMT			GMT+0
+#Link	GMT			GMT-0
+#Link	GMT			GMT0
+#Link	GMT			Greenwich
+# Rearguard section, for TZUpdater 2.3.2 and earlier.
 Link	Etc/GMT			GMT+0
 Link	Etc/GMT			GMT-0
 Link	Etc/GMT			GMT0
 Link	Etc/GMT			Greenwich
+# End of rearguard section.
 Link	Asia/Hong_Kong		Hongkong
-Link	Africa/Abidjan		Iceland
+Link	Africa/Abidjan		Iceland	#= Atlantic/Reykjavik
 Link	Asia/Tehran		Iran
 Link	Asia/Jerusalem		Israel
 Link	America/Jamaica		Jamaica
@@ -134,14 +124,8 @@ Link	America/Mazatlan	Mexico/BajaSur
 Link	America/Mexico_City	Mexico/General
 Link	Pacific/Auckland	NZ
 Link	Pacific/Chatham		NZ-CHAT
-Link	America/Denver		Navajo
+Link	America/Denver		Navajo	#= America/Shiprock
 Link	Asia/Shanghai		PRC
-Link	Pacific/Kanton		Pacific/Enderbury
-Link	Pacific/Honolulu	Pacific/Johnston
-Link	Pacific/Guadalcanal	Pacific/Ponape
-Link	Pacific/Pago_Pago	Pacific/Samoa
-Link	Pacific/Port_Moresby	Pacific/Truk
-Link	Pacific/Port_Moresby	Pacific/Yap
 Link	Europe/Warsaw		Poland
 Link	Europe/Lisbon		Portugal
 Link	Asia/Taipei		ROC
@@ -165,3 +149,192 @@ Link	Etc/UTC			UTC
 Link	Etc/UTC			Universal
 Link	Europe/Moscow		W-SU
 Link	Etc/UTC			Zulu
+
+
+# Two-part names that were renamed mostly to three-part names in 1995
+
+# Link	TARGET				LINK-NAME	#= TARGET1
+Link	America/Argentina/Buenos_Aires	America/Buenos_Aires
+Link	America/Argentina/Catamarca	America/Catamarca
+Link	America/Argentina/Cordoba	America/Cordoba
+Link	America/Indiana/Indianapolis	America/Indianapolis
+Link	America/Argentina/Jujuy		America/Jujuy
+Link	America/Indiana/Knox		America/Knox_IN
+Link	America/Kentucky/Louisville	America/Louisville
+Link	America/Argentina/Mendoza	America/Mendoza
+Link	America/Puerto_Rico		America/Virgin	#= America/St_Thomas
+Link	Pacific/Pago_Pago		Pacific/Samoa
+
+
+# Pre-2013 practice, which typically had a Zone per zone.tab line
+
+# Link	TARGET			LINK-NAME
+Link	Africa/Abidjan		Africa/Accra
+Link	Africa/Nairobi		Africa/Addis_Ababa
+Link	Africa/Nairobi		Africa/Asmara
+Link	Africa/Abidjan		Africa/Bamako
+Link	Africa/Lagos		Africa/Bangui
+Link	Africa/Abidjan		Africa/Banjul
+Link	Africa/Maputo		Africa/Blantyre
+Link	Africa/Lagos		Africa/Brazzaville
+Link	Africa/Maputo		Africa/Bujumbura
+Link	Africa/Abidjan		Africa/Conakry
+Link	Africa/Abidjan		Africa/Dakar
+Link	Africa/Nairobi		Africa/Dar_es_Salaam
+Link	Africa/Nairobi		Africa/Djibouti
+Link	Africa/Lagos		Africa/Douala
+Link	Africa/Abidjan		Africa/Freetown
+Link	Africa/Maputo		Africa/Gaborone
+Link	Africa/Maputo		Africa/Harare
+Link	Africa/Nairobi		Africa/Kampala
+Link	Africa/Maputo		Africa/Kigali
+Link	Africa/Lagos		Africa/Kinshasa
+Link	Africa/Lagos		Africa/Libreville
+Link	Africa/Abidjan		Africa/Lome
+Link	Africa/Lagos		Africa/Luanda
+Link	Africa/Maputo		Africa/Lubumbashi
+Link	Africa/Maputo		Africa/Lusaka
+Link	Africa/Lagos		Africa/Malabo
+Link	Africa/Johannesburg	Africa/Maseru
+Link	Africa/Johannesburg	Africa/Mbabane
+Link	Africa/Nairobi		Africa/Mogadishu
+Link	Africa/Lagos		Africa/Niamey
+Link	Africa/Abidjan		Africa/Nouakchott
+Link	Africa/Abidjan		Africa/Ouagadougou
+Link	Africa/Lagos		Africa/Porto-Novo
+Link	America/Puerto_Rico	America/Anguilla
+Link	America/Puerto_Rico	America/Antigua
+Link	America/Puerto_Rico	America/Aruba
+Link	America/Panama		America/Atikokan
+Link	America/Puerto_Rico	America/Blanc-Sablon
+Link	America/Panama		America/Cayman
+Link	America/Phoenix		America/Creston
+Link	America/Puerto_Rico	America/Curacao
+Link	America/Puerto_Rico	America/Dominica
+Link	America/Puerto_Rico	America/Grenada
+Link	America/Puerto_Rico	America/Guadeloupe
+Link	America/Puerto_Rico	America/Kralendijk
+Link	America/Puerto_Rico	America/Lower_Princes
+Link	America/Puerto_Rico	America/Marigot
+Link	America/Puerto_Rico	America/Montserrat
+Link	America/Toronto		America/Nassau
+Link	America/Puerto_Rico	America/Port_of_Spain
+Link	America/Puerto_Rico	America/St_Barthelemy
+Link	America/Puerto_Rico	America/St_Kitts
+Link	America/Puerto_Rico	America/St_Lucia
+Link	America/Puerto_Rico	America/St_Thomas
+Link	America/Puerto_Rico	America/St_Vincent
+Link	America/Puerto_Rico	America/Tortola
+Link	Pacific/Port_Moresby	Antarctica/DumontDUrville
+Link	Pacific/Auckland	Antarctica/McMurdo
+Link	Asia/Riyadh		Antarctica/Syowa
+Link	Asia/Urumqi		Antarctica/Vostok
+Link	Europe/Berlin		Arctic/Longyearbyen
+Link	Asia/Riyadh		Asia/Aden
+Link	Asia/Qatar		Asia/Bahrain
+Link	Asia/Kuching		Asia/Brunei
+Link	Asia/Singapore		Asia/Kuala_Lumpur
+Link	Asia/Riyadh		Asia/Kuwait
+Link	Asia/Dubai		Asia/Muscat
+Link	Asia/Bangkok		Asia/Phnom_Penh
+Link	Asia/Bangkok		Asia/Vientiane
+Link	Africa/Abidjan		Atlantic/Reykjavik
+Link	Africa/Abidjan		Atlantic/St_Helena
+Link	Europe/Brussels		Europe/Amsterdam
+Link	Europe/Prague		Europe/Bratislava
+Link	Europe/Zurich		Europe/Busingen
+Link	Europe/Berlin		Europe/Copenhagen
+Link	Europe/London		Europe/Guernsey
+Link	Europe/London		Europe/Isle_of_Man
+Link	Europe/London		Europe/Jersey
+Link	Europe/Belgrade		Europe/Ljubljana
+Link	Europe/Brussels		Europe/Luxembourg
+Link	Europe/Helsinki		Europe/Mariehamn
+Link	Europe/Paris		Europe/Monaco
+Link	Europe/Berlin		Europe/Oslo
+Link	Europe/Belgrade		Europe/Podgorica
+Link	Europe/Rome		Europe/San_Marino
+Link	Europe/Belgrade		Europe/Sarajevo
+Link	Europe/Belgrade		Europe/Skopje
+Link	Europe/Berlin		Europe/Stockholm
+Link	Europe/Zurich		Europe/Vaduz
+Link	Europe/Rome		Europe/Vatican
+Link	Europe/Belgrade		Europe/Zagreb
+Link	Africa/Nairobi		Indian/Antananarivo
+Link	Asia/Bangkok		Indian/Christmas
+Link	Asia/Yangon		Indian/Cocos
+Link	Africa/Nairobi		Indian/Comoro
+Link	Indian/Maldives		Indian/Kerguelen
+Link	Asia/Dubai		Indian/Mahe
+Link	Africa/Nairobi		Indian/Mayotte
+Link	Asia/Dubai		Indian/Reunion
+Link	Pacific/Port_Moresby	Pacific/Chuuk
+Link	Pacific/Tarawa		Pacific/Funafuti
+Link	Pacific/Tarawa		Pacific/Majuro
+Link	Pacific/Pago_Pago	Pacific/Midway
+Link	Pacific/Guadalcanal	Pacific/Pohnpei
+Link	Pacific/Guam		Pacific/Saipan
+Link	Pacific/Tarawa		Pacific/Wake
+Link	Pacific/Tarawa		Pacific/Wallis
+
+
+# Non-zone.tab locations with timestamps since 1970 that duplicate
+# those of an existing location
+
+# Link	TARGET			LINK-NAME
+Link	Africa/Abidjan		Africa/Timbuktu
+Link	America/Argentina/Catamarca	America/Argentina/ComodRivadavia
+Link	America/Adak		America/Atka
+Link	America/Panama		America/Coral_Harbour
+Link	America/Tijuana		America/Ensenada
+Link	America/Indiana/Indianapolis	America/Fort_Wayne
+Link	America/Toronto		America/Montreal
+Link	America/Toronto		America/Nipigon
+Link	America/Rio_Branco	America/Porto_Acre
+Link	America/Winnipeg	America/Rainy_River
+Link	America/Argentina/Cordoba	America/Rosario
+Link	America/Tijuana		America/Santa_Isabel
+Link	America/Denver		America/Shiprock
+Link	America/Toronto		America/Thunder_Bay
+Link	Pacific/Auckland	Antarctica/South_Pole
+Link	Asia/Shanghai		Asia/Chongqing
+Link	Asia/Shanghai		Asia/Harbin
+Link	Asia/Urumqi		Asia/Kashgar
+Link	Asia/Jerusalem		Asia/Tel_Aviv
+Link	Europe/Berlin		Atlantic/Jan_Mayen
+Link	Australia/Sydney	Australia/Canberra
+Link	Australia/Hobart	Australia/Currie
+Link	Europe/London		Europe/Belfast
+Link	Europe/Chisinau		Europe/Tiraspol
+Link	Europe/Kyiv		Europe/Uzhgorod
+Link	Europe/Kyiv		Europe/Zaporozhye
+Link	Pacific/Kanton		Pacific/Enderbury
+Link	Pacific/Honolulu	Pacific/Johnston
+Link	Pacific/Port_Moresby	Pacific/Yap
+
+
+# Alternate names for the same location
+
+# Link	TARGET			LINK-NAME	#= TARGET1
+Link	Africa/Nairobi		Africa/Asmera	#= Africa/Asmara
+Link	America/Nuuk		America/Godthab
+Link	Asia/Ashgabat		Asia/Ashkhabad
+Link	Asia/Kolkata		Asia/Calcutta
+Link	Asia/Shanghai		Asia/Chungking	#= Asia/Chongqing
+Link	Asia/Dhaka		Asia/Dacca
+# Istanbul is in both continents.
+Link	Europe/Istanbul		Asia/Istanbul
+Link	Asia/Kathmandu		Asia/Katmandu
+Link	Asia/Macau		Asia/Macao
+Link	Asia/Yangon		Asia/Rangoon
+Link	Asia/Ho_Chi_Minh	Asia/Saigon
+Link	Asia/Thimphu		Asia/Thimbu
+Link	Asia/Makassar		Asia/Ujung_Pandang
+Link	Asia/Ulaanbaatar	Asia/Ulan_Bator
+Link	Atlantic/Faroe		Atlantic/Faeroe
+Link	Europe/Kyiv		Europe/Kiev
+# Classically, Cyprus is in Asia; e.g. see Herodotus, Histories, I.72.
+# However, for various reasons many users expect to find it under Europe.
+Link	Asia/Nicosia		Europe/Nicosia
+Link	Pacific/Guadalcanal	Pacific/Ponape	#= Pacific/Pohnpei
+Link	Pacific/Port_Moresby	Pacific/Truk	#= Pacific/Chuuk

--- a/make/data/tzdata/etcetera
+++ b/make/data/tzdata/etcetera
@@ -39,11 +39,15 @@
 # Do not use a POSIX TZ setting like TZ='GMT+4', which is four hours
 # behind GMT but uses the completely misleading abbreviation "GMT".
 
-Zone	Etc/GMT		0	-	GMT
-
 # The following zone is used by tzcode functions like gmtime,
 # which load the "UTC" file to handle seconds properly.
 Zone	Etc/UTC		0	-	UTC
+
+# Functions like gmtime load the "GMT" file to handle leap seconds properly.
+# Vanguard section, which works with most .zi parsers.
+#Zone	GMT		0	-	GMT
+# Rearguard section, for TZUpdater 2.3.2 and earlier.
+Zone	Etc/GMT		0	-	GMT
 
 # The following link uses older naming conventions,
 # but it belongs here, not in the file 'backward',
@@ -51,14 +55,7 @@ Zone	Etc/UTC		0	-	UTC
 # where functions like gmtime load "GMT" instead of the "Etc/UTC".
 # We want this to work even on installations that omit 'backward'.
 Link	Etc/GMT				GMT
-
-Link	Etc/UTC				Etc/Universal
-Link	Etc/UTC				Etc/Zulu
-
-Link	Etc/GMT				Etc/Greenwich
-Link	Etc/GMT				Etc/GMT-0
-Link	Etc/GMT				Etc/GMT+0
-Link	Etc/GMT				Etc/GMT0
+# End of rearguard section.
 
 # Be consistent with POSIX TZ settings in the Zone names,
 # even though this is the opposite of what many people expect.

--- a/make/data/tzdata/europe
+++ b/make/data/tzdata/europe
@@ -527,9 +527,6 @@ Zone	Europe/London	-0:01:15 -	LMT	1847 Dec  1
 			 1:00	-	BST	1971 Oct 31  2:00u
 			 0:00	GB-Eire	%s	1996
 			 0:00	EU	GMT/BST
-Link	Europe/London	Europe/Jersey
-Link	Europe/London	Europe/Guernsey
-Link	Europe/London	Europe/Isle_of_Man
 
 # From Paul Eggert (2018-02-15):
 # In January 2018 we discovered that the negative SAVE values in the
@@ -902,6 +899,8 @@ Zone	Europe/Minsk	1:50:16 -	LMT	1880
 			3:00	-	+03
 
 # Belgium
+# Luxembourg
+# Netherlands
 #
 # From Michael Deckers (2019-08-25):
 # The exposition in the web page
@@ -984,11 +983,6 @@ Zone	Europe/Brussels	0:17:30 -	LMT	1880
 			1:00	C-Eur	CE%sT	1944 Sep  3
 			1:00	Belgium	CE%sT	1977
 			1:00	EU	CE%sT
-Link Europe/Brussels Europe/Amsterdam
-Link Europe/Brussels Europe/Luxembourg
-
-# Bosnia and Herzegovina
-# See Europe/Belgrade.
 
 # Bulgaria
 #
@@ -1015,13 +1009,11 @@ Zone	Europe/Sofia	1:33:16 -	LMT	1880
 			2:00	E-Eur	EE%sT	1997
 			2:00	EU	EE%sT
 
-# Croatia
-# See Europe/Belgrade.
-
 # Cyprus
 # Please see the 'asia' file for Asia/Nicosia.
 
-# Czech Republic / Czechia
+# Czech Republic (Czechia)
+# Slovakia
 #
 # From Paul Eggert (2018-04-15):
 # The source for Czech data is: Kdy začíná a končí letní čas. 2018-04-15.
@@ -1048,15 +1040,14 @@ Zone	Europe/Prague	0:57:44 -	LMT	1850
 # End of rearguard section.
 			1:00	Czech	CE%sT	1979
 			1:00	EU	CE%sT
-Link Europe/Prague Europe/Bratislava
 
-
-# Denmark, Faroe Islands, and Greenland
-# For Denmark see Europe/Berlin.
-
+# Faroe Is
+# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Atlantic/Faroe	-0:27:04 -	LMT	1908 Jan 11 # Tórshavn
 			 0:00	-	WET	1981
 			 0:00	EU	WE%sT
+
+# Greenland
 #
 # From Paul Eggert (2004-10-31):
 # During World War II, Germany maintained secret manned weather stations in
@@ -1282,11 +1273,8 @@ Zone	Europe/Helsinki	1:39:49 -	LMT	1878 May 31
 			2:00	Finland	EE%sT	1983
 			2:00	EU	EE%sT
 
-# Åland Is
-Link	Europe/Helsinki	Europe/Mariehamn
-
-
 # France
+# Monaco
 
 # From Ciro Discepolo (2000-12-20):
 #
@@ -1423,9 +1411,11 @@ Zone	Europe/Paris	0:09:21 -	LMT	1891 Mar 16
 			0:00	France	WE%sT	1945 Sep 16  3:00
 			1:00	France	CE%sT	1977
 			1:00	EU	CE%sT
-Link Europe/Paris Europe/Monaco
 
+# Denmark
 # Germany
+# Norway
+# Sweden
 
 # From Markus Kuhn (1998-09-29):
 # The German time zone web site by the Physikalisch-Technische
@@ -1443,6 +1433,53 @@ Link Europe/Paris Europe/Monaco
 # However, Moscow did not observe daylight saving in 1945, so
 # this was equivalent to UT +03, not +04.
 
+# Svalbard & Jan Mayen
+
+# From Steffen Thorsen (2001-05-01):
+# Although I could not find it explicitly, it seems that Jan Mayen and
+# Svalbard have been using the same time as Norway at least since the
+# time they were declared as parts of Norway.  Svalbard was declared
+# as a part of Norway by law of 1925-07-17 no 11, section 4 and Jan
+# Mayen by law of 1930-02-27 no 2, section 2. (From
+# <http://www.lovdata.no/all/nl-19250717-011.html> and
+# <http://www.lovdata.no/all/nl-19300227-002.html>).  The law/regulation
+# for normal/standard time in Norway is from 1894-06-29 no 1 (came
+# into operation on 1895-01-01) and Svalbard/Jan Mayen seem to be a
+# part of this law since 1925/1930. (From
+# <http://www.lovdata.no/all/nl-18940629-001.html>) I have not been
+# able to find if Jan Mayen used a different time zone (e.g. -0100)
+# before 1930. Jan Mayen has only been "inhabited" since 1921 by
+# Norwegian meteorologists and maybe used the same time as Norway ever
+# since 1921.  Svalbard (Arctic/Longyearbyen) has been inhabited since
+# before 1895, and therefore probably changed the local time somewhere
+# between 1895 and 1925 (inclusive).
+
+# From Paul Eggert (2013-09-04):
+#
+# Actually, Jan Mayen was never occupied by Germany during World War II,
+# so it must have diverged from Oslo time during the war, as Oslo was
+# keeping Berlin time.
+#
+# <https://www.jan-mayen.no/history.htm> says that the meteorologists
+# burned down their station in 1940 and left the island, but returned in
+# 1941 with a small Norwegian garrison and continued operations despite
+# frequent air attacks from Germans.  In 1943 the Americans established a
+# radiolocating station on the island, called "Atlantic City".  Possibly
+# the UT offset changed during the war, but I think it unlikely that
+# Jan Mayen used German daylight-saving rules.
+#
+# Svalbard is more complicated, as it was raided in August 1941 by an
+# Allied party that evacuated the civilian population to England (says
+# <http://www.bartleby.com/65/sv/Svalbard.html>).  The Svalbard FAQ
+# <http://www.svalbard.com/SvalbardFAQ.html> says that the Germans were
+# expelled on 1942-05-14.  However, small parties of Germans did return,
+# and according to Wilhelm Dege's book "War North of 80" (1954)
+# http://www.ucalgary.ca/UofC/departments/UP/1-55238/1-55238-110-2.html
+# the German armed forces at the Svalbard weather station code-named
+# Haudegen did not surrender to the Allies until September 1945.
+#
+# All these events predate our cutoff date of 1970, so use Europe/Berlin
+# for these regions.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Germany	1946	only	-	Apr	14	2:00s	1:00	S
@@ -1467,11 +1504,6 @@ Zone	Europe/Berlin	0:53:28 -	LMT	1893 Apr
 			1:00 SovietZone	CE%sT	1946
 			1:00	Germany	CE%sT	1980
 			1:00	EU	CE%sT
-Link Europe/Berlin Arctic/Longyearbyen
-Link Europe/Berlin Europe/Copenhagen
-Link Europe/Berlin Europe/Oslo
-Link Europe/Berlin Europe/Stockholm
-
 
 # Georgia
 # Please see the "asia" file for Asia/Tbilisi.
@@ -1590,10 +1622,9 @@ Zone	Europe/Budapest	1:16:20 -	LMT	1890 Nov  1
 			1:00	Hungary	CE%sT	1984
 			1:00	EU	CE%sT
 
-# Iceland
-# See Africa/Abidjan.
-
 # Italy
+# San Marino
+# Vatican City
 #
 # From Paul Eggert (2001-03-06):
 # Sicily and Sardinia each had their own time zones from 1866 to 1893,
@@ -1712,13 +1743,6 @@ Zone	Europe/Rome	0:49:56 -	LMT	1866 Dec 12
 			1:00	C-Eur	CE%sT	1944 Jun  4
 			1:00	Italy	CE%sT	1980
 			1:00	EU	CE%sT
-Link Europe/Rome Europe/Vatican
-Link Europe/Rome Europe/San_Marino
-
-
-# Kosovo
-# See Europe/Belgrade.
-
 
 # Latvia
 
@@ -1802,10 +1826,6 @@ Zone	Europe/Riga	1:36:34	-	LMT	1880
 			2:00	-	EET	2001 Jan  2
 			2:00	EU	EE%sT
 
-# Liechtenstein
-# See Europe/Zurich.
-
-
 # Lithuania
 
 # From Paul Eggert (2016-03-18):
@@ -1857,12 +1877,6 @@ Zone	Europe/Vilnius	1:41:16	-	LMT	1880
 			1:00	EU	CE%sT	1999 Oct 31  1:00u
 			2:00	-	EET	2003 Jan  1
 			2:00	EU	EE%sT
-
-# Luxembourg
-# See Europe/Brussels.
-
-# North Macedonia
-# See Europe/Belgrade.
 
 # Malta
 #
@@ -1958,67 +1972,6 @@ Zone	Europe/Chisinau	1:55:20 -	LMT	1880
 			2:00	E-Eur	EE%sT	1997
 # See Romania commentary for the guessed 1997 transition to EU rules.
 			2:00	Moldova	EE%sT
-
-# Monaco
-# See Europe/Paris.
-
-# Montenegro
-# See Europe/Belgrade.
-
-# Netherlands
-# See Europe/Brussels.
-
-# Norway
-# See Europe/Berlin.
-
-# Svalbard & Jan Mayen
-
-# From Steffen Thorsen (2001-05-01):
-# Although I could not find it explicitly, it seems that Jan Mayen and
-# Svalbard have been using the same time as Norway at least since the
-# time they were declared as parts of Norway.  Svalbard was declared
-# as a part of Norway by law of 1925-07-17 no 11, section 4 and Jan
-# Mayen by law of 1930-02-27 no 2, section 2. (From
-# <http://www.lovdata.no/all/nl-19250717-011.html> and
-# <http://www.lovdata.no/all/nl-19300227-002.html>).  The law/regulation
-# for normal/standard time in Norway is from 1894-06-29 no 1 (came
-# into operation on 1895-01-01) and Svalbard/Jan Mayen seem to be a
-# part of this law since 1925/1930. (From
-# <http://www.lovdata.no/all/nl-18940629-001.html>) I have not been
-# able to find if Jan Mayen used a different time zone (e.g. -0100)
-# before 1930. Jan Mayen has only been "inhabited" since 1921 by
-# Norwegian meteorologists and maybe used the same time as Norway ever
-# since 1921.  Svalbard (Arctic/Longyearbyen) has been inhabited since
-# before 1895, and therefore probably changed the local time somewhere
-# between 1895 and 1925 (inclusive).
-
-# From Paul Eggert (2013-09-04):
-#
-# Actually, Jan Mayen was never occupied by Germany during World War II,
-# so it must have diverged from Oslo time during the war, as Oslo was
-# keeping Berlin time.
-#
-# <https://www.jan-mayen.no/history.htm> says that the meteorologists
-# burned down their station in 1940 and left the island, but returned in
-# 1941 with a small Norwegian garrison and continued operations despite
-# frequent air attacks from Germans.  In 1943 the Americans established a
-# radiolocating station on the island, called "Atlantic City".  Possibly
-# the UT offset changed during the war, but I think it unlikely that
-# Jan Mayen used German daylight-saving rules.
-#
-# Svalbard is more complicated, as it was raided in August 1941 by an
-# Allied party that evacuated the civilian population to England (says
-# <http://www.bartleby.com/65/sv/Svalbard.html>).  The Svalbard FAQ
-# <http://www.svalbard.com/SvalbardFAQ.html> says that the Germans were
-# expelled on 1942-05-14.  However, small parties of Germans did return,
-# and according to Wilhelm Dege's book "War North of 80" (1954)
-# http://www.ucalgary.ca/UofC/departments/UP/1-55238/1-55238-110-2.html
-# the German armed forces at the Svalbard weather station code-named
-# Haudegen did not surrender to the Allies until September 1945.
-#
-# All these events predate our cutoff date of 1970, so use Europe/Berlin
-# for these regions.
-
 
 # Poland
 
@@ -3301,11 +3254,13 @@ Zone Asia/Anadyr	11:49:56 -	LMT	1924 May  2
 			11:00	Russia	+11/+12	2011 Mar 27  2:00s
 			12:00	-	+12
 
-
-# San Marino
-# See Europe/Rome.
-
+# Bosnia & Herzegovina
+# Croatia
+# Kosovo
+# Montenegro
+# North Macedonia
 # Serbia
+# Slovenia
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Belgrade	1:22:00	-	LMT	1884
 			1:00	-	CET	1941 Apr 18 23:00
@@ -3317,17 +3272,6 @@ Zone	Europe/Belgrade	1:22:00	-	LMT	1884
 # Shanks & Pottenger don't give as much detail, so go with Koželj.
 			1:00	-	CET	1982 Nov 27
 			1:00	EU	CE%sT
-Link Europe/Belgrade Europe/Ljubljana	# Slovenia
-Link Europe/Belgrade Europe/Podgorica	# Montenegro
-Link Europe/Belgrade Europe/Sarajevo	# Bosnia and Herzegovina
-Link Europe/Belgrade Europe/Skopje	# North Macedonia
-Link Europe/Belgrade Europe/Zagreb	# Croatia
-
-# Slovakia
-# See Europe/Prague.
-
-# Slovenia
-# See Europe/Belgrade.
 
 # Spain
 #
@@ -3434,10 +3378,11 @@ Zone	Atlantic/Canary	-1:01:36 -	LMT	1922 Mar # Las Palmas de Gran C.
 # IATA SSIM (1996-09) says the Canaries switch at 2:00u, not 1:00u.
 # Ignore this for now, as the Canaries are part of the EU.
 
-# Sweden
-# See Europe/Berlin.
 
+# Germany (Busingen enclave)
+# Liechtenstein
 # Switzerland
+#
 # From Howse:
 # By the end of the 18th century clocks and watches became commonplace
 # and their performance improved enormously.  Communities began to keep
@@ -3550,9 +3495,6 @@ Zone	Europe/Zurich	0:34:08 -	LMT	1853 Jul 16 # See above comment.
 			0:29:46	-	BMT	1894 Jun    # Bern Mean Time
 			1:00	Swiss	CE%sT	1981
 			1:00	EU	CE%sT
-Link Europe/Zurich Europe/Busingen
-Link Europe/Zurich Europe/Vaduz
-
 
 # Turkey
 
@@ -3757,7 +3699,6 @@ Zone	Europe/Istanbul	1:55:52 -	LMT	1880
 			2:00	1:00	EEST	2015 Nov  8  1:00u
 			2:00	EU	EE%sT	2016 Sep  7
 			3:00	-	+03
-Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 
 # Ukraine
 #
@@ -3859,9 +3800,6 @@ Zone Europe/Kyiv	2:02:04 -	LMT	1880
 			2:00	1:00	EEST	1991 Sep 29  3:00
 			2:00	C-Eur	EE%sT	1996 May 13
 			2:00	EU	EE%sT
-
-# Vatican City
-# See Europe/Rome.
 
 ###############################################################################
 

--- a/make/data/tzdata/northamerica
+++ b/make/data/tzdata/northamerica
@@ -852,7 +852,6 @@ Zone America/Phoenix	-7:28:18 -	LMT	1883 Nov 18 19:00u
 			-7:00	-	MST	1967
 			-7:00	US	M%sT	1968 Mar 21
 			-7:00	-	MST
-Link America/Phoenix America/Creston
 
 # From Arthur David Olson (1988-02-13):
 # A writer from the Inter Tribal Council of Arizona, Inc.,
@@ -1626,23 +1625,6 @@ Zone America/Moncton	-4:19:08 -	LMT	1883 Dec  9
 
 # Ontario
 
-# From Paul Eggert (2006-07-09):
-# Shanks & Pottenger write that since 1970 most of Ontario has been like
-# Toronto.
-# Thunder Bay skipped DST in 1973.
-# Many smaller locales did not observe peacetime DST until 1974;
-# Nipigon (EST) and Rainy River (CST) are the largest that we know of.
-# Far west Ontario is like Winnipeg; far east Quebec is like Halifax.
-
-# From Jeffery Nichols (2020-02-06):
-# According to the [Shanks] atlas, those western Ontario zones are huge,
-# covering most of Ontario northwest of Sault Ste Marie and Timmins.
-# The zones seem to include towns bigger than the ones they're named after,
-# like Dryden in America/Rainy_River and Wawa (and maybe Attawapiskat) in
-# America/Nipigon.  I assume it's too much trouble to change the name of the
-# zone (like when you found out that America/Glace_Bay includes Sydney, Nova
-# Scotia)....
-
 # From Mark Brader (2003-07-26):
 # [According to the Toronto Star] Orillia, Ontario, adopted DST
 # effective Saturday, 1912-06-22, 22:00; the article mentions that
@@ -1663,17 +1645,6 @@ Zone America/Moncton	-4:19:08 -	LMT	1883 Dec  9
 
 # From Mark Brader (2010-03-06):
 #
-# Currently the database has:
-#
-# # Ontario
-#
-# # From Paul Eggert (2006-07-09):
-# # Shanks & Pottenger write that since 1970 most of Ontario has been like
-# # Toronto.
-# # Thunder Bay skipped DST in 1973.
-# # Many smaller locales did not observe peacetime DST until 1974;
-# # Nipigon (EST) and Rainy River (CST) are the largest that we know of.
-#
 # In the (Toronto) Globe and Mail for Saturday, 1955-09-24, in the bottom
 # right corner of page 1, it says that Toronto will return to standard
 # time at 2 am Sunday morning (which agrees with the database), and that:
@@ -1681,10 +1652,8 @@ Zone America/Moncton	-4:19:08 -	LMT	1883 Dec  9
 #     The one-hour setback will go into effect throughout most of Ontario,
 #     except in areas like Windsor which remains on standard time all year.
 #
-# Windsor is, of course, a lot larger than Nipigon.
-#
-# I only came across this incidentally.  I don't know if Windsor began
-# observing DST when Detroit did, or in 1974, or on some other date.
+# ... I don't know if Windsor began observing DST when Detroit did,
+# or in 1974, or on some other date.
 #
 # By the way, the article continues by noting that:
 #
@@ -1766,23 +1735,7 @@ Rule	Toronto	1951	1956	-	Sep	lastSun	2:00	0	S
 # Toronto Star, which said that DST was ending 1971-10-31 as usual.
 Rule	Toronto	1957	1973	-	Oct	lastSun	2:00	0	S
 
-# From Paul Eggert (2003-07-27):
-# Willett (1914-03) writes (p. 17) "In the Cities of Fort William, and
-# Port Arthur, Ontario, the principle of the Bill has been in
-# operation for the past three years, and in the City of Moose Jaw,
-# Saskatchewan, for one year."
-
-# From David Bryan via Tory Tronrud, Director/Curator,
-# Thunder Bay Museum (2003-11-12):
-# There is some suggestion, however, that, by-law or not, daylight
-# savings time was being practiced in Fort William and Port Arthur
-# before 1909.... [I]n 1910, the line between the Eastern and Central
-# Time Zones was permanently moved about two hundred miles west to
-# include the Thunder Bay area....  When Canada adopted daylight
-# savings time in 1916, Fort William and Port Arthur, having done so
-# already, did not change their clocks....  During the Second World
-# War,... [t]he cities agreed to implement DST during the summer
-# months for the remainder of the war years.
+# The Bahamas match Toronto since 1970.
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Toronto	-5:17:32 -	LMT	1895
@@ -1791,22 +1744,6 @@ Zone America/Toronto	-5:17:32 -	LMT	1895
 			-5:00	Canada	E%sT	1946
 			-5:00	Toronto	E%sT	1974
 			-5:00	Canada	E%sT
-Link America/Toronto America/Nassau
-Zone America/Thunder_Bay -5:57:00 -	LMT	1895
-			-6:00	-	CST	1910
-			-5:00	-	EST	1942
-			-5:00	Canada	E%sT	1970
-			-5:00	Toronto	E%sT	1973
-			-5:00	-	EST	1974
-			-5:00	Canada	E%sT
-Zone America/Nipigon	-5:53:04 -	LMT	1895
-			-5:00	Canada	E%sT	1940 Sep 29
-			-5:00	1:00	EDT	1942 Feb  9  2:00s
-			-5:00	Canada	E%sT
-Zone America/Rainy_River -6:18:16 -	LMT	1895
-			-6:00	Canada	C%sT	1940 Sep 29
-			-6:00	1:00	CDT	1942 Feb  9  2:00s
-			-6:00	Canada	C%sT
 # For Atikokan see America/Panama.
 
 
@@ -2639,6 +2576,12 @@ Zone America/Dawson	-9:17:40 -	LMT	1900 Aug 20
 # 5- The islands, reefs and keys shall take their timezone from the
 #    longitude they are located at.
 
+# From Paul Eggert (2022-10-28):
+# The new Mexican law was published today:
+# https://www.dof.gob.mx/nota_detalle.php?codigo=5670045&fecha=28/10/2022
+# This abolishes DST except where US DST rules are observed,
+# and in addition changes all of Chihuahua to -06 with no DST.
+
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Mexico	1931	only	-	May	1	23:00	1:00	D
 Rule	Mexico	1931	only	-	Oct	1	0:00	0	S
@@ -2654,8 +2597,8 @@ Rule	Mexico	1996	2000	-	Apr	Sun>=1	2:00	1:00	D
 Rule	Mexico	1996	2000	-	Oct	lastSun	2:00	0	S
 Rule	Mexico	2001	only	-	May	Sun>=1	2:00	1:00	D
 Rule	Mexico	2001	only	-	Sep	lastSun	2:00	0	S
-Rule	Mexico	2002	max	-	Apr	Sun>=1	2:00	1:00	D
-Rule	Mexico	2002	max	-	Oct	lastSun	2:00	0	S
+Rule	Mexico	2002	2022	-	Apr	Sun>=1	2:00	1:00	D
+Rule	Mexico	2002	2022	-	Oct	lastSun	2:00	0	S
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # Quintana Roo; represented by Cancún
 Zone America/Cancun	-5:47:04 -	LMT	1922 Jan  1  6:00u
@@ -2708,7 +2651,8 @@ Zone America/Ojinaga	-6:57:40 -	LMT	1922 Jan  1  7:00u
 			-6:00	Mexico	C%sT	1998
 			-6:00	-	CST	1998 Apr Sun>=1  3:00
 			-7:00	Mexico	M%sT	2010
-			-7:00	US	M%sT
+			-7:00	US	M%sT	2022 Oct 30  2:00
+			-6:00	-	CST
 # Chihuahua (away from US border)
 Zone America/Chihuahua	-7:04:20 -	LMT	1922 Jan  1  7:00u
 			-7:00	-	MST	1927 Jun 10 23:00
@@ -2717,7 +2661,8 @@ Zone America/Chihuahua	-7:04:20 -	LMT	1922 Jan  1  7:00u
 			-6:00	-	CST	1996
 			-6:00	Mexico	C%sT	1998
 			-6:00	-	CST	1998 Apr Sun>=1  3:00
-			-7:00	Mexico	M%sT
+			-7:00	Mexico	M%sT	2022 Oct 30  2:00
+			-6:00	-	CST
 # Sonora
 Zone America/Hermosillo	-7:23:52 -	LMT	1922 Jan  1  7:00u
 			-7:00	-	MST	1927 Jun 10 23:00
@@ -2815,19 +2760,15 @@ Zone America/Tijuana	-7:48:04 -	LMT	1922 Jan  1  7:00u
 # http://dof.gob.mx/nota_detalle.php?codigo=5127480&fecha=06/01/2010
 # It has been moved to the 'backward' file.
 #
+# From Paul Eggert (2022-10-28):
+# Today's new law states that the entire state of Baja California
+# follows US DST rules, which agrees with simplifications noted above.
+#
 #
 # Revillagigedo Is
 # no information
 
 ###############################################################################
-
-# Anguilla
-# Antigua and Barbuda
-# See America/Puerto_Rico.
-
-# The Bahamas
-# See America/Toronto.
-
 
 # Barbados
 
@@ -3040,12 +2981,6 @@ Zone Atlantic/Bermuda	-4:19:18 -	LMT	1890	# Hamilton
 			-4:00	Bermuda	A%sT	1974 Apr 28  2:00
 			-4:00	Canada	A%sT	1976
 			-4:00	US	A%sT
-
-# Caribbean Netherlands
-# See America/Puerto_Rico.
-
-# Cayman Is
-# See America/Panama.
 
 # Costa Rica
 
@@ -3272,9 +3207,6 @@ Zone	America/Havana	-5:29:28 -	LMT	1890
 			-5:29:36 -	HMT	1925 Jul 19 12:00 # Havana MT
 			-5:00	Cuba	C%sT
 
-# Dominica
-# See America/Puerto_Rico.
-
 # Dominican Republic
 
 # From Steffen Thorsen (2000-10-30):
@@ -3320,12 +3252,6 @@ Rule	Salv	1987	1988	-	Sep	lastSun	0:00	0	S
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/El_Salvador -5:56:48 -	LMT	1921 # San Salvador
 			-6:00	Salv	C%sT
-
-# Grenada
-# Guadeloupe
-# St Barthélemy
-# St Martin (French part)
-# See America/Puerto_Rico.
 
 # Guatemala
 #
@@ -3512,9 +3438,6 @@ Zone America/Martinique	-4:04:20 -      LMT	1890        # Fort-de-France
 			-4:00	1:00	ADT	1980 Sep 28
 			-4:00	-	AST
 
-# Montserrat
-# See America/Puerto_Rico.
-
 # Nicaragua
 #
 # This uses Shanks & Pottenger for times before 2005.
@@ -3580,44 +3503,39 @@ Zone	America/Managua	-5:45:08 -	LMT	1890
 			-5:00	-	EST	1997
 			-6:00	Nic	C%sT
 
+# Cayman Is
 # Panama
+#
+# Atikokan and Coral Harbour, Canada, match Panama since 1970.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	America/Panama	-5:18:08 -	LMT	1890
 			-5:19:36 -	CMT	1908 Apr 22 # Colón Mean Time
 			-5:00	-	EST
-Link America/Panama America/Atikokan
-Link America/Panama America/Cayman
 
+# Anguilla
+# Antigua & Barbuda
+# Aruba
+# Caribbean Netherlands
+# Curaçao
+# Dominica
+# Grenada
+# Guadeloupe
+# Montserrat
 # Puerto Rico
+# St Barthélemy
+# St Kitts-Nevis
+# Sint Maarten / St Martin
+# St Lucia
+# St Vincent & the Grenadines
+# Trinidad & Tobago
+# Virgin Is (UK & US)
+#
 # There are too many San Juans elsewhere, so we'll use 'Puerto_Rico'.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Puerto_Rico -4:24:25 -	LMT	1899 Mar 28 12:00 # San Juan
 			-4:00	-	AST	1942 May  3
 			-4:00	US	A%sT	1946
 			-4:00	-	AST
-Link America/Puerto_Rico America/Anguilla
-Link America/Puerto_Rico America/Antigua
-Link America/Puerto_Rico America/Aruba
-Link America/Puerto_Rico America/Curacao
-Link America/Puerto_Rico America/Blanc-Sablon	# Quebec (Lower North Shore)
-Link America/Puerto_Rico America/Dominica
-Link America/Puerto_Rico America/Grenada
-Link America/Puerto_Rico America/Guadeloupe
-Link America/Puerto_Rico America/Kralendijk	# Caribbean Netherlands
-Link America/Puerto_Rico America/Lower_Princes	# Sint Maarten
-Link America/Puerto_Rico America/Marigot	# St Martin (French part)
-Link America/Puerto_Rico America/Montserrat
-Link America/Puerto_Rico America/Port_of_Spain	# Trinidad & Tobago
-Link America/Puerto_Rico America/St_Barthelemy	# St Barthélemy
-Link America/Puerto_Rico America/St_Kitts	# St Kitts & Nevis
-Link America/Puerto_Rico America/St_Lucia
-Link America/Puerto_Rico America/St_Thomas	# Virgin Islands (US)
-Link America/Puerto_Rico America/St_Vincent
-Link America/Puerto_Rico America/Tortola	# Virgin Islands (UK)
-
-# St Kitts-Nevis
-# St Lucia
-# See America/Puerto_Rico.
 
 # St Pierre and Miquelon
 # There are too many St Pierres elsewhere, so we'll use 'Miquelon'.
@@ -3626,12 +3544,6 @@ Zone America/Miquelon	-3:44:40 -	LMT	1911 May 15 # St Pierre
 			-4:00	-	AST	1980 May
 			-3:00	-	-03	1987
 			-3:00	Canada	-03/-02
-
-# St Vincent and the Grenadines
-# See America/Puerto_Rico.
-
-# Sint Maarten
-# See America/Puerto_Rico.
 
 # Turks and Caicos
 #
@@ -3701,11 +3613,6 @@ Zone America/Grand_Turk	-4:44:32 -	LMT	1890
 			-5:00	US	E%sT	2015 Mar  8  2:00
 			-4:00	-	AST	2018 Mar 11  3:00
 			-5:00	US	E%sT
-
-# British Virgin Is
-# US Virgin Is
-# See America/Puerto_Rico.
-
 
 # Local Variables:
 # coding: utf-8

--- a/make/data/tzdata/southamerica
+++ b/make/data/tzdata/southamerica
@@ -608,9 +608,6 @@ Zone America/Argentina/Ushuaia -4:33:12 - LMT	1894 Oct 31
 			-3:00	Arg	-03/-02	2008 Oct 18
 			-3:00	-	-03
 
-# Aruba
-# See America/Puerto_Rico.
-
 # Bolivia
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	America/La_Paz	-4:32:36 -	LMT	1890
@@ -1455,15 +1452,6 @@ Zone	America/Bogota	-4:56:16 -	LMT	1884 Mar 13
 # Malpelo, Providencia, San Andres
 # no information; probably like America/Bogota
 
-# Curaçao
-# See America/Puerto_Rico.
-#
-# From Arthur David Olson (2011-06-15):
-# use links for places with new iso3166 codes.
-# The name "Lower Prince's Quarter" is both longer than fourteen characters
-# and contains an apostrophe; use "Lower_Princes"....
-# From Paul Eggert (2021-09-29):
-# These backward-compatibility links now are in the 'northamerica' file.
 
 # Ecuador
 #
@@ -1778,9 +1766,6 @@ Zone America/Paramaribo	-3:40:40 -	LMT	1911
 			-3:40:36 -	PMT	1945 Oct    # The capital moved?
 			-3:30	-	-0330	1984 Oct
 			-3:00	-	-03
-
-# Trinidad and Tobago
-# See America/Puerto_Rico.
 
 # Uruguay
 # From Paul Eggert (1993-11-18):

--- a/make/data/tzdata/zone.tab
+++ b/make/data/tzdata/zone.tab
@@ -137,13 +137,10 @@ CA	+4606-06447	America/Moncton	Atlantic - New Brunswick
 CA	+5320-06025	America/Goose_Bay	Atlantic - Labrador (most areas)
 CA	+5125-05707	America/Blanc-Sablon	AST - QC (Lower North Shore)
 CA	+4339-07923	America/Toronto	Eastern - ON, QC (most areas)
-CA	+4901-08816	America/Nipigon	Eastern - ON, QC (no DST 1967-73)
-CA	+4823-08915	America/Thunder_Bay	Eastern - ON (Thunder Bay)
 CA	+6344-06828	America/Iqaluit	Eastern - NU (most east areas)
 CA	+6608-06544	America/Pangnirtung	Eastern - NU (Pangnirtung)
 CA	+484531-0913718	America/Atikokan	EST - ON (Atikokan); NU (Coral H)
 CA	+4953-09709	America/Winnipeg	Central - ON (west); Manitoba
-CA	+4843-09434	America/Rainy_River	Central - ON (Rainy R, Ft Frances)
 CA	+744144-0944945	America/Resolute	Central - NU (Resolute)
 CA	+624900-0920459	America/Rankin_Inlet	Central - NU (central)
 CA	+5024-10439	America/Regina	CST - SK (most areas)

--- a/src/java.base/share/classes/sun/util/resources/TimeZoneNames.java
+++ b/src/java.base/share/classes/sun/util/resources/TimeZoneNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -429,7 +429,7 @@ public final class TimeZoneNames extends TimeZoneNamesBundle {
                                               "French Guiana Summer Time", "GFST",
                                               "French Guiana Time", "GFT"}},
             {"America/Cayman", EST},
-            {"America/Chihuahua", MST},
+            {"America/Chihuahua", CST},
             {"America/Creston", MST},
             {"America/Coral_Harbour", EST},
             {"America/Cordoba", AGT},
@@ -518,7 +518,7 @@ public final class TimeZoneNames extends TimeZoneNamesBundle {
             {"America/North_Dakota/Center", CST},
             {"America/North_Dakota/New_Salem", CST},
             {"America/Nuuk", WGT},
-            {"America/Ojinaga", MST},
+            {"America/Ojinaga", CST},
             {"America/Panama", EST},
             {"America/Pangnirtung", EST},
             {"America/Paramaribo", new String[] {"Suriname Time", "SRT",

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_de.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_de.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,7 +427,7 @@ public final class TimeZoneNames_de extends TimeZoneNamesBundle {
                                               "Franz\u00f6sisch-Guiana Sommerzeit", "GFST",
                                               "Franz\u00F6sisch-Guiana Zeit", "GFT"}},
             {"America/Cayman", EST},
-            {"America/Chihuahua", MST},
+            {"America/Chihuahua", CST},
             {"America/Creston", MST},
             {"America/Coral_Harbour", EST},
             {"America/Cordoba", AGT},
@@ -516,7 +516,7 @@ public final class TimeZoneNames_de extends TimeZoneNamesBundle {
             {"America/North_Dakota/Center", CST},
             {"America/North_Dakota/New_Salem", CST},
             {"America/Nuuk", WGT},
-            {"America/Ojinaga", MST},
+            {"America/Ojinaga", CST},
             {"America/Panama", EST},
             {"America/Pangnirtung", EST},
             {"America/Paramaribo", new String[] {"Suriname Zeit", "SRT",

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_es.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_es.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,7 +427,7 @@ public final class TimeZoneNames_es extends TimeZoneNamesBundle {
                                               "Hora de verano de la Guayana Francesa", "GFST",
                                               "Hora de la Guayana Francesa", "GFT"}},
             {"America/Cayman", EST},
-            {"America/Chihuahua", MST},
+            {"America/Chihuahua", CST},
             {"America/Creston", MST},
             {"America/Coral_Harbour", EST},
             {"America/Cordoba", AGT},
@@ -516,7 +516,7 @@ public final class TimeZoneNames_es extends TimeZoneNamesBundle {
             {"America/North_Dakota/Center", CST},
             {"America/North_Dakota/New_Salem", CST},
             {"America/Nuuk", WGT},
-            {"America/Ojinaga", MST},
+            {"America/Ojinaga", CST},
             {"America/Panama", EST},
             {"America/Pangnirtung", EST},
             {"America/Paramaribo", new String[] {"Hora de Surinam", "SRT",

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_fr.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_fr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,7 +427,7 @@ public final class TimeZoneNames_fr extends TimeZoneNamesBundle {
                                               "Heure d'\u00e9t\u00e9 de Guyane fran\u00e7aise", "GFST",
                                               "Heure de Guyane fran\u00E7aise", "GFT"}},
             {"America/Cayman", EST},
-            {"America/Chihuahua", MST},
+            {"America/Chihuahua", CST},
             {"America/Creston", MST},
             {"America/Coral_Harbour", EST},
             {"America/Cordoba", AGT},
@@ -516,7 +516,7 @@ public final class TimeZoneNames_fr extends TimeZoneNamesBundle {
             {"America/North_Dakota/Center", CST},
             {"America/North_Dakota/New_Salem", CST},
             {"America/Nuuk", WGT},
-            {"America/Ojinaga", MST},
+            {"America/Ojinaga", CST},
             {"America/Panama", EST},
             {"America/Pangnirtung", EST},
             {"America/Paramaribo", new String[] {"Heure du Surinam", "SRT",

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_it.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_it.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,7 +427,7 @@ public final class TimeZoneNames_it extends TimeZoneNamesBundle {
                                               "Ora estiva della Guyana Francese", "GFST",
                                               "Ora della Guyana Francese", "GFT"}},
             {"America/Cayman", EST},
-            {"America/Chihuahua", MST},
+            {"America/Chihuahua", CST},
             {"America/Creston", MST},
             {"America/Coral_Harbour", EST},
             {"America/Cordoba", AGT},
@@ -516,7 +516,7 @@ public final class TimeZoneNames_it extends TimeZoneNamesBundle {
             {"America/North_Dakota/Center", CST},
             {"America/North_Dakota/New_Salem", CST},
             {"America/Nuuk", WGT},
-            {"America/Ojinaga", MST},
+            {"America/Ojinaga", CST},
             {"America/Panama", EST},
             {"America/Pangnirtung", EST},
             {"America/Paramaribo", new String[] {"Ora di Suriname", "SRT",

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_ja.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_ja.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,7 +427,7 @@ public final class TimeZoneNames_ja extends TimeZoneNamesBundle {
                                               "\u4ecf\u9818\u30ae\u30a2\u30ca\u590f\u6642\u9593", "GFST",
                                               "\u30D5\u30E9\u30F3\u30B9\u9818\u30AE\u30A2\u30CA\u6642\u9593", "GFT"}},
             {"America/Cayman", EST},
-            {"America/Chihuahua", MST},
+            {"America/Chihuahua", CST},
             {"America/Creston", MST},
             {"America/Coral_Harbour", EST},
             {"America/Cordoba", AGT},
@@ -516,7 +516,7 @@ public final class TimeZoneNames_ja extends TimeZoneNamesBundle {
             {"America/North_Dakota/Center", CST},
             {"America/North_Dakota/New_Salem", CST},
             {"America/Nuuk", WGT},
-            {"America/Ojinaga", MST},
+            {"America/Ojinaga", CST},
             {"America/Panama", EST},
             {"America/Pangnirtung", EST},
             {"America/Paramaribo", new String[] {"\u30b9\u30ea\u30ca\u30e0\u6642\u9593", "SRT",

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_ko.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_ko.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,7 +427,7 @@ public final class TimeZoneNames_ko extends TimeZoneNamesBundle {
                                               "\ud504\ub791\uc2a4\ub839 \uae30\uc544\ub098 \uc77c\uad11\uc808\uc57d\uc2dc\uac04", "GFST",
                                               "\uD504\uB791\uC2A4\uB839 \uAE30\uC544\uB098 \uD45C\uC900\uC2DC", "GFT"}},
             {"America/Cayman", EST},
-            {"America/Chihuahua", MST},
+            {"America/Chihuahua", CST},
             {"America/Creston", MST},
             {"America/Coral_Harbour", EST},
             {"America/Cordoba", AGT},
@@ -516,7 +516,7 @@ public final class TimeZoneNames_ko extends TimeZoneNamesBundle {
             {"America/North_Dakota/Center", CST},
             {"America/North_Dakota/New_Salem", CST},
             {"America/Nuuk", WGT},
-            {"America/Ojinaga", MST},
+            {"America/Ojinaga", CST},
             {"America/Panama", EST},
             {"America/Pangnirtung", EST},
             {"America/Paramaribo", new String[] {"\uc218\ub9ac\ub0a8 \uc2dc\uac04", "SRT",

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_pt_BR.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_pt_BR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,7 +427,7 @@ public final class TimeZoneNames_pt_BR extends TimeZoneNamesBundle {
                                               "Fuso hor\u00e1rio de ver\u00e3o da Guiana Francesa", "GFST",
                                               "Hor\u00E1rio da Guiana Francesa", "GFT"}},
             {"America/Cayman", EST},
-            {"America/Chihuahua", MST},
+            {"America/Chihuahua", CST},
             {"America/Creston", MST},
             {"America/Coral_Harbour", EST},
             {"America/Cordoba", AGT},
@@ -516,7 +516,7 @@ public final class TimeZoneNames_pt_BR extends TimeZoneNamesBundle {
             {"America/North_Dakota/Center", CST},
             {"America/North_Dakota/New_Salem", CST},
             {"America/Nuuk", WGT},
-            {"America/Ojinaga", MST},
+            {"America/Ojinaga", CST},
             {"America/Panama", EST},
             {"America/Pangnirtung", EST},
             {"America/Paramaribo", new String[] {"Fuso hor\u00e1rio do Suriname", "SRT",

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_sv.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_sv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,7 +427,7 @@ public final class TimeZoneNames_sv extends TimeZoneNamesBundle {
                                               "Franska Guyana, sommartid", "GFST",
                                               "Franska Guyana-tid", "GFT"}},
             {"America/Cayman", EST},
-            {"America/Chihuahua", MST},
+            {"America/Chihuahua", CST},
             {"America/Creston", MST},
             {"America/Coral_Harbour", EST},
             {"America/Cordoba", AGT},
@@ -516,7 +516,7 @@ public final class TimeZoneNames_sv extends TimeZoneNamesBundle {
             {"America/North_Dakota/Center", CST},
             {"America/North_Dakota/New_Salem", CST},
             {"America/Nuuk", WGT},
-            {"America/Ojinaga", MST},
+            {"America/Ojinaga", CST},
             {"America/Panama", EST},
             {"America/Pangnirtung", EST},
             {"America/Paramaribo", new String[] {"Surinam, normaltid", "SRT",

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_zh_CN.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_zh_CN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,7 +427,7 @@ public final class TimeZoneNames_zh_CN extends TimeZoneNamesBundle {
                                               "\u6cd5\u5c5e\u572d\u4e9a\u90a3\u590f\u4ee4\u65f6", "GFST",
                                               "\u6CD5\u5C5E\u572D\u4E9A\u90A3\u65F6\u95F4", "GFT"}},
             {"America/Cayman", EST},
-            {"America/Chihuahua", MST},
+            {"America/Chihuahua", CST},
             {"America/Creston", MST},
             {"America/Coral_Harbour", EST},
             {"America/Cordoba", AGT},
@@ -516,7 +516,7 @@ public final class TimeZoneNames_zh_CN extends TimeZoneNamesBundle {
             {"America/North_Dakota/Center", CST},
             {"America/North_Dakota/New_Salem", CST},
             {"America/Nuuk", WGT},
-            {"America/Ojinaga", MST},
+            {"America/Ojinaga", CST},
             {"America/Panama", EST},
             {"America/Pangnirtung", EST},
             {"America/Paramaribo", new String[] {"\u82cf\u5229\u5357\u65f6\u95f4", "SRT",

--- a/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_zh_TW.java
+++ b/src/jdk.localedata/share/classes/sun/util/resources/ext/TimeZoneNames_zh_TW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,7 +427,7 @@ public final class TimeZoneNames_zh_TW extends TimeZoneNamesBundle {
                                               "\u6cd5\u5c6c\u572d\u4e9e\u90a3\u590f\u4ee4\u6642\u9593", "GFST",
                                               "\u6CD5\u5C6C\u572D\u4E9E\u90A3\u6642\u9593", "GFT"}},
             {"America/Cayman", EST},
-            {"America/Chihuahua", MST},
+            {"America/Chihuahua", CST},
             {"America/Creston", MST},
             {"America/Coral_Harbour", EST},
             {"America/Cordoba", AGT},
@@ -516,7 +516,7 @@ public final class TimeZoneNames_zh_TW extends TimeZoneNamesBundle {
             {"America/North_Dakota/Center", CST},
             {"America/North_Dakota/New_Salem", CST},
             {"America/Nuuk", WGT},
-            {"America/Ojinaga", MST},
+            {"America/Ojinaga", CST},
             {"America/Panama", EST},
             {"America/Pangnirtung", EST},
             {"America/Paramaribo", new String[] {"\u8607\u5229\u5357\u6642\u9593", "SRT",

--- a/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
@@ -1,1 +1,1 @@
-tzdata2022e
+tzdata2022f

--- a/test/jdk/java/util/TimeZone/TimeZoneData/aliases.txt
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/aliases.txt
@@ -1,158 +1,7 @@
-Link Africa/Abidjan Africa/Accra	# Ghana
-Link Africa/Abidjan Africa/Bamako	# Mali
-Link Africa/Abidjan Africa/Banjul	# The Gambia
-Link Africa/Abidjan Africa/Conakry	# Guinea
-Link Africa/Abidjan Africa/Dakar	# Senegal
-Link Africa/Abidjan Africa/Freetown	# Sierra Leone
-Link Africa/Abidjan Africa/Lome		# Togo
-Link Africa/Abidjan Africa/Nouakchott	# Mauritania
-Link Africa/Abidjan Africa/Ouagadougou	# Burkina Faso
-Link Africa/Abidjan Atlantic/Reykjavik	# Iceland
-Link Africa/Abidjan Atlantic/St_Helena	# St Helena
-Link Africa/Nairobi Africa/Addis_Ababa	 # Ethiopia
-Link Africa/Nairobi Africa/Asmara	 # Eritrea
-Link Africa/Nairobi Africa/Dar_es_Salaam # Tanzania
-Link Africa/Nairobi Africa/Djibouti
-Link Africa/Nairobi Africa/Kampala	 # Uganda
-Link Africa/Nairobi Africa/Mogadishu	 # Somalia
-Link Africa/Nairobi Indian/Antananarivo	 # Madagascar
-Link Africa/Nairobi Indian/Comoro
-Link Africa/Nairobi Indian/Mayotte
-Link Africa/Maputo Africa/Blantyre	# Malawi
-Link Africa/Maputo Africa/Bujumbura	# Burundi
-Link Africa/Maputo Africa/Gaborone	# Botswana
-Link Africa/Maputo Africa/Harare	# Zimbabwe
-Link Africa/Maputo Africa/Kigali	# Rwanda
-Link Africa/Maputo Africa/Lubumbashi	# E Dem. Rep. of Congo
-Link Africa/Maputo Africa/Lusaka	# Zambia
-Link Africa/Lagos Africa/Bangui		# Central African Republic
-Link Africa/Lagos Africa/Brazzaville	# Rep. of the Congo
-Link Africa/Lagos Africa/Douala		# Cameroon
-Link Africa/Lagos Africa/Kinshasa	# Dem. Rep. of the Congo (west)
-Link Africa/Lagos Africa/Libreville	# Gabon
-Link Africa/Lagos Africa/Luanda		# Angola
-Link Africa/Lagos Africa/Malabo		# Equatorial Guinea
-Link Africa/Lagos Africa/Niamey		# Niger
-Link Africa/Lagos Africa/Porto-Novo	# Benin
-Link Africa/Johannesburg Africa/Maseru	# Lesotho
-Link Africa/Johannesburg Africa/Mbabane	# Eswatini
-Link Asia/Yangon Indian/Cocos
-Link Asia/Urumqi Antarctica/Vostok
-Link	Asia/Nicosia	Europe/Nicosia
-Link Asia/Kuching Asia/Brunei
-Link Indian/Maldives Indian/Kerguelen
-Link Asia/Qatar Asia/Bahrain
-Link Asia/Riyadh Antarctica/Syowa
-Link Asia/Riyadh Asia/Aden	# Yemen
-Link Asia/Riyadh Asia/Kuwait
-Link Asia/Singapore Asia/Kuala_Lumpur
-Link Asia/Bangkok Asia/Phnom_Penh	# Cambodia
-Link Asia/Bangkok Asia/Vientiane	# Laos
-Link Asia/Bangkok Indian/Christmas
-Link Asia/Dubai Asia/Muscat	# Oman
-Link Asia/Dubai Indian/Mahe
-Link Asia/Dubai Indian/Reunion
-Link Pacific/Guam Pacific/Saipan # N Mariana Is
-Link Pacific/Tarawa Pacific/Funafuti
-Link Pacific/Tarawa Pacific/Majuro
-Link Pacific/Tarawa Pacific/Wake
-Link Pacific/Tarawa Pacific/Wallis
-Link Pacific/Auckland Antarctica/McMurdo
-Link Pacific/Port_Moresby Antarctica/DumontDUrville
-Link Pacific/Port_Moresby Pacific/Chuuk
-Link Pacific/Pago_Pago Pacific/Midway # in US minor outlying islands
-Link Pacific/Guadalcanal Pacific/Pohnpei
-Link	Europe/London	Europe/Jersey
-Link	Europe/London	Europe/Guernsey
-Link	Europe/London	Europe/Isle_of_Man
-Link Europe/Brussels Europe/Amsterdam
-Link Europe/Brussels Europe/Luxembourg
-Link Europe/Prague Europe/Bratislava
-Link	Europe/Helsinki	Europe/Mariehamn
-Link Europe/Paris Europe/Monaco
-Link Europe/Berlin Arctic/Longyearbyen
-Link Europe/Berlin Europe/Copenhagen
-Link Europe/Berlin Europe/Oslo
-Link Europe/Berlin Europe/Stockholm
-Link Europe/Rome Europe/Vatican
-Link Europe/Rome Europe/San_Marino
-Link Europe/Belgrade Europe/Ljubljana	# Slovenia
-Link Europe/Belgrade Europe/Podgorica	# Montenegro
-Link Europe/Belgrade Europe/Sarajevo	# Bosnia and Herzegovina
-Link Europe/Belgrade Europe/Skopje	# North Macedonia
-Link Europe/Belgrade Europe/Zagreb	# Croatia
-Link Europe/Zurich Europe/Busingen
-Link Europe/Zurich Europe/Vaduz
-Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
-Link America/Phoenix America/Creston
-Link America/Toronto America/Nassau
-Link America/Panama America/Atikokan
-Link America/Panama America/Cayman
-Link America/Puerto_Rico America/Anguilla
-Link America/Puerto_Rico America/Antigua
-Link America/Puerto_Rico America/Aruba
-Link America/Puerto_Rico America/Curacao
-Link America/Puerto_Rico America/Blanc-Sablon	# Quebec (Lower North Shore)
-Link America/Puerto_Rico America/Dominica
-Link America/Puerto_Rico America/Grenada
-Link America/Puerto_Rico America/Guadeloupe
-Link America/Puerto_Rico America/Kralendijk	# Caribbean Netherlands
-Link America/Puerto_Rico America/Lower_Princes	# Sint Maarten
-Link America/Puerto_Rico America/Marigot	# St Martin (French part)
-Link America/Puerto_Rico America/Montserrat
-Link America/Puerto_Rico America/Port_of_Spain	# Trinidad & Tobago
-Link America/Puerto_Rico America/St_Barthelemy	# St Barthélemy
-Link America/Puerto_Rico America/St_Kitts	# St Kitts & Nevis
-Link America/Puerto_Rico America/St_Lucia
-Link America/Puerto_Rico America/St_Thomas	# Virgin Islands (US)
-Link America/Puerto_Rico America/St_Vincent
-Link America/Puerto_Rico America/Tortola	# Virgin Islands (UK)
 Link	Asia/Riyadh87	Mideast/Riyadh87
 Link	Asia/Riyadh88	Mideast/Riyadh88
 Link	Asia/Riyadh89	Mideast/Riyadh89
-Link	Africa/Nairobi		Africa/Asmera
-Link	Africa/Abidjan		Africa/Timbuktu
-Link	America/Argentina/Catamarca	America/Argentina/ComodRivadavia
-Link	America/Adak		America/Atka
-Link	America/Argentina/Buenos_Aires	America/Buenos_Aires
-Link	America/Argentina/Catamarca	America/Catamarca
-Link	America/Panama		America/Coral_Harbour
-Link	America/Argentina/Cordoba	America/Cordoba
-Link	America/Tijuana		America/Ensenada
-Link	America/Indiana/Indianapolis	America/Fort_Wayne
-Link	America/Nuuk		America/Godthab
-Link	America/Indiana/Indianapolis	America/Indianapolis
-Link	America/Argentina/Jujuy	America/Jujuy
-Link	America/Indiana/Knox	America/Knox_IN
-Link	America/Kentucky/Louisville	America/Louisville
-Link	America/Argentina/Mendoza	America/Mendoza
-Link	America/Toronto		America/Montreal
-Link	America/Rio_Branco	America/Porto_Acre
-Link	America/Argentina/Cordoba	America/Rosario
-Link	America/Tijuana		America/Santa_Isabel
-Link	America/Denver		America/Shiprock
-Link	America/Puerto_Rico	America/Virgin
-Link	Pacific/Auckland	Antarctica/South_Pole
-Link	Asia/Ashgabat		Asia/Ashkhabad
-Link	Asia/Kolkata		Asia/Calcutta
-Link	Asia/Shanghai		Asia/Chongqing
-Link	Asia/Shanghai		Asia/Chungking
-Link	Asia/Dhaka		Asia/Dacca
-Link	Asia/Shanghai		Asia/Harbin
-Link	Asia/Urumqi		Asia/Kashgar
-Link	Asia/Kathmandu		Asia/Katmandu
-Link	Asia/Macau		Asia/Macao
-Link	Asia/Yangon		Asia/Rangoon
-Link	Asia/Ho_Chi_Minh	Asia/Saigon
-Link	Asia/Jerusalem		Asia/Tel_Aviv
-Link	Asia/Thimphu		Asia/Thimbu
-Link	Asia/Makassar		Asia/Ujung_Pandang
-Link	Asia/Ulaanbaatar	Asia/Ulan_Bator
-Link	Atlantic/Faroe		Atlantic/Faeroe
-Link	Europe/Berlin		Atlantic/Jan_Mayen
-Link	Australia/Sydney	Australia/ACT
-Link	Australia/Sydney	Australia/Canberra
-Link	Australia/Hobart	Australia/Currie
+Link	Australia/Sydney	Australia/ACT	#= Australia/Canberra
 Link	Australia/Lord_Howe	Australia/LHI
 Link	Australia/Sydney	Australia/NSW
 Link	Australia/Darwin	Australia/North
@@ -162,7 +11,7 @@ Link	Australia/Hobart	Australia/Tasmania
 Link	Australia/Melbourne	Australia/Victoria
 Link	Australia/Perth		Australia/West
 Link	Australia/Broken_Hill	Australia/Yancowinna
-Link	America/Rio_Branco	Brazil/Acre
+Link	America/Rio_Branco	Brazil/Acre	#= America/Porto_Acre
 Link	America/Noronha		Brazil/DeNoronha
 Link	America/Sao_Paulo	Brazil/East
 Link	America/Manaus		Brazil/West
@@ -179,12 +28,13 @@ Link	Pacific/Easter		Chile/EasterIsland
 Link	America/Havana		Cuba
 Link	Africa/Cairo		Egypt
 Link	Europe/Dublin		Eire
+Link	Etc/GMT			Etc/GMT+0
+Link	Etc/GMT			Etc/GMT-0
+Link	Etc/GMT			Etc/GMT0
+Link	Etc/GMT			Etc/Greenwich
 Link	Etc/UTC			Etc/UCT
-Link	Europe/London		Europe/Belfast
-Link	Europe/Kyiv		Europe/Kiev
-Link	Europe/Chisinau		Europe/Tiraspol
-Link	Europe/Kyiv		Europe/Uzhgorod
-Link	Europe/Kyiv		Europe/Zaporozhye
+Link	Etc/UTC			Etc/Universal
+Link	Etc/UTC			Etc/Zulu
 Link	Europe/London		GB
 Link	Europe/London		GB-Eire
 Link	Etc/GMT			GMT+0
@@ -192,7 +42,7 @@ Link	Etc/GMT			GMT-0
 Link	Etc/GMT			GMT0
 Link	Etc/GMT			Greenwich
 Link	Asia/Hong_Kong		Hongkong
-Link	Africa/Abidjan		Iceland
+Link	Africa/Abidjan		Iceland	#= Atlantic/Reykjavik
 Link	Asia/Tehran		Iran
 Link	Asia/Jerusalem		Israel
 Link	America/Jamaica		Jamaica
@@ -204,14 +54,8 @@ Link	America/Mazatlan	Mexico/BajaSur
 Link	America/Mexico_City	Mexico/General
 Link	Pacific/Auckland	NZ
 Link	Pacific/Chatham		NZ-CHAT
-Link	America/Denver		Navajo
+Link	America/Denver		Navajo	#= America/Shiprock
 Link	Asia/Shanghai		PRC
-Link	Pacific/Kanton		Pacific/Enderbury
-Link	Pacific/Honolulu	Pacific/Johnston
-Link	Pacific/Guadalcanal	Pacific/Ponape
-Link	Pacific/Pago_Pago	Pacific/Samoa
-Link	Pacific/Port_Moresby	Pacific/Truk
-Link	Pacific/Port_Moresby	Pacific/Yap
 Link	Europe/Warsaw		Poland
 Link	Europe/Lisbon		Portugal
 Link	Asia/Taipei		ROC
@@ -235,3 +79,168 @@ Link	Etc/UTC			UTC
 Link	Etc/UTC			Universal
 Link	Europe/Moscow		W-SU
 Link	Etc/UTC			Zulu
+Link	America/Argentina/Buenos_Aires	America/Buenos_Aires
+Link	America/Argentina/Catamarca	America/Catamarca
+Link	America/Argentina/Cordoba	America/Cordoba
+Link	America/Indiana/Indianapolis	America/Indianapolis
+Link	America/Argentina/Jujuy		America/Jujuy
+Link	America/Indiana/Knox		America/Knox_IN
+Link	America/Kentucky/Louisville	America/Louisville
+Link	America/Argentina/Mendoza	America/Mendoza
+Link	America/Puerto_Rico		America/Virgin	#= America/St_Thomas
+Link	Pacific/Pago_Pago		Pacific/Samoa
+Link	Africa/Abidjan		Africa/Accra
+Link	Africa/Nairobi		Africa/Addis_Ababa
+Link	Africa/Nairobi		Africa/Asmara
+Link	Africa/Abidjan		Africa/Bamako
+Link	Africa/Lagos		Africa/Bangui
+Link	Africa/Abidjan		Africa/Banjul
+Link	Africa/Maputo		Africa/Blantyre
+Link	Africa/Lagos		Africa/Brazzaville
+Link	Africa/Maputo		Africa/Bujumbura
+Link	Africa/Abidjan		Africa/Conakry
+Link	Africa/Abidjan		Africa/Dakar
+Link	Africa/Nairobi		Africa/Dar_es_Salaam
+Link	Africa/Nairobi		Africa/Djibouti
+Link	Africa/Lagos		Africa/Douala
+Link	Africa/Abidjan		Africa/Freetown
+Link	Africa/Maputo		Africa/Gaborone
+Link	Africa/Maputo		Africa/Harare
+Link	Africa/Nairobi		Africa/Kampala
+Link	Africa/Maputo		Africa/Kigali
+Link	Africa/Lagos		Africa/Kinshasa
+Link	Africa/Lagos		Africa/Libreville
+Link	Africa/Abidjan		Africa/Lome
+Link	Africa/Lagos		Africa/Luanda
+Link	Africa/Maputo		Africa/Lubumbashi
+Link	Africa/Maputo		Africa/Lusaka
+Link	Africa/Lagos		Africa/Malabo
+Link	Africa/Johannesburg	Africa/Maseru
+Link	Africa/Johannesburg	Africa/Mbabane
+Link	Africa/Nairobi		Africa/Mogadishu
+Link	Africa/Lagos		Africa/Niamey
+Link	Africa/Abidjan		Africa/Nouakchott
+Link	Africa/Abidjan		Africa/Ouagadougou
+Link	Africa/Lagos		Africa/Porto-Novo
+Link	America/Puerto_Rico	America/Anguilla
+Link	America/Puerto_Rico	America/Antigua
+Link	America/Puerto_Rico	America/Aruba
+Link	America/Panama		America/Atikokan
+Link	America/Puerto_Rico	America/Blanc-Sablon
+Link	America/Panama		America/Cayman
+Link	America/Phoenix		America/Creston
+Link	America/Puerto_Rico	America/Curacao
+Link	America/Puerto_Rico	America/Dominica
+Link	America/Puerto_Rico	America/Grenada
+Link	America/Puerto_Rico	America/Guadeloupe
+Link	America/Puerto_Rico	America/Kralendijk
+Link	America/Puerto_Rico	America/Lower_Princes
+Link	America/Puerto_Rico	America/Marigot
+Link	America/Puerto_Rico	America/Montserrat
+Link	America/Toronto		America/Nassau
+Link	America/Puerto_Rico	America/Port_of_Spain
+Link	America/Puerto_Rico	America/St_Barthelemy
+Link	America/Puerto_Rico	America/St_Kitts
+Link	America/Puerto_Rico	America/St_Lucia
+Link	America/Puerto_Rico	America/St_Thomas
+Link	America/Puerto_Rico	America/St_Vincent
+Link	America/Puerto_Rico	America/Tortola
+Link	Pacific/Port_Moresby	Antarctica/DumontDUrville
+Link	Pacific/Auckland	Antarctica/McMurdo
+Link	Asia/Riyadh		Antarctica/Syowa
+Link	Asia/Urumqi		Antarctica/Vostok
+Link	Europe/Berlin		Arctic/Longyearbyen
+Link	Asia/Riyadh		Asia/Aden
+Link	Asia/Qatar		Asia/Bahrain
+Link	Asia/Kuching		Asia/Brunei
+Link	Asia/Singapore		Asia/Kuala_Lumpur
+Link	Asia/Riyadh		Asia/Kuwait
+Link	Asia/Dubai		Asia/Muscat
+Link	Asia/Bangkok		Asia/Phnom_Penh
+Link	Asia/Bangkok		Asia/Vientiane
+Link	Africa/Abidjan		Atlantic/Reykjavik
+Link	Africa/Abidjan		Atlantic/St_Helena
+Link	Europe/Brussels		Europe/Amsterdam
+Link	Europe/Prague		Europe/Bratislava
+Link	Europe/Zurich		Europe/Busingen
+Link	Europe/Berlin		Europe/Copenhagen
+Link	Europe/London		Europe/Guernsey
+Link	Europe/London		Europe/Isle_of_Man
+Link	Europe/London		Europe/Jersey
+Link	Europe/Belgrade		Europe/Ljubljana
+Link	Europe/Brussels		Europe/Luxembourg
+Link	Europe/Helsinki		Europe/Mariehamn
+Link	Europe/Paris		Europe/Monaco
+Link	Europe/Berlin		Europe/Oslo
+Link	Europe/Belgrade		Europe/Podgorica
+Link	Europe/Rome		Europe/San_Marino
+Link	Europe/Belgrade		Europe/Sarajevo
+Link	Europe/Belgrade		Europe/Skopje
+Link	Europe/Berlin		Europe/Stockholm
+Link	Europe/Zurich		Europe/Vaduz
+Link	Europe/Rome		Europe/Vatican
+Link	Europe/Belgrade		Europe/Zagreb
+Link	Africa/Nairobi		Indian/Antananarivo
+Link	Asia/Bangkok		Indian/Christmas
+Link	Asia/Yangon		Indian/Cocos
+Link	Africa/Nairobi		Indian/Comoro
+Link	Indian/Maldives		Indian/Kerguelen
+Link	Asia/Dubai		Indian/Mahe
+Link	Africa/Nairobi		Indian/Mayotte
+Link	Asia/Dubai		Indian/Reunion
+Link	Pacific/Port_Moresby	Pacific/Chuuk
+Link	Pacific/Tarawa		Pacific/Funafuti
+Link	Pacific/Tarawa		Pacific/Majuro
+Link	Pacific/Pago_Pago	Pacific/Midway
+Link	Pacific/Guadalcanal	Pacific/Pohnpei
+Link	Pacific/Guam		Pacific/Saipan
+Link	Pacific/Tarawa		Pacific/Wake
+Link	Pacific/Tarawa		Pacific/Wallis
+Link	Africa/Abidjan		Africa/Timbuktu
+Link	America/Argentina/Catamarca	America/Argentina/ComodRivadavia
+Link	America/Adak		America/Atka
+Link	America/Panama		America/Coral_Harbour
+Link	America/Tijuana		America/Ensenada
+Link	America/Indiana/Indianapolis	America/Fort_Wayne
+Link	America/Toronto		America/Montreal
+Link	America/Toronto		America/Nipigon
+Link	America/Rio_Branco	America/Porto_Acre
+Link	America/Winnipeg	America/Rainy_River
+Link	America/Argentina/Cordoba	America/Rosario
+Link	America/Tijuana		America/Santa_Isabel
+Link	America/Denver		America/Shiprock
+Link	America/Toronto		America/Thunder_Bay
+Link	Pacific/Auckland	Antarctica/South_Pole
+Link	Asia/Shanghai		Asia/Chongqing
+Link	Asia/Shanghai		Asia/Harbin
+Link	Asia/Urumqi		Asia/Kashgar
+Link	Asia/Jerusalem		Asia/Tel_Aviv
+Link	Europe/Berlin		Atlantic/Jan_Mayen
+Link	Australia/Sydney	Australia/Canberra
+Link	Australia/Hobart	Australia/Currie
+Link	Europe/London		Europe/Belfast
+Link	Europe/Chisinau		Europe/Tiraspol
+Link	Europe/Kyiv		Europe/Uzhgorod
+Link	Europe/Kyiv		Europe/Zaporozhye
+Link	Pacific/Kanton		Pacific/Enderbury
+Link	Pacific/Honolulu	Pacific/Johnston
+Link	Pacific/Port_Moresby	Pacific/Yap
+Link	Africa/Nairobi		Africa/Asmera	#= Africa/Asmara
+Link	America/Nuuk		America/Godthab
+Link	Asia/Ashgabat		Asia/Ashkhabad
+Link	Asia/Kolkata		Asia/Calcutta
+Link	Asia/Shanghai		Asia/Chungking	#= Asia/Chongqing
+Link	Asia/Dhaka		Asia/Dacca
+Link	Europe/Istanbul		Asia/Istanbul
+Link	Asia/Kathmandu		Asia/Katmandu
+Link	Asia/Macau		Asia/Macao
+Link	Asia/Yangon		Asia/Rangoon
+Link	Asia/Ho_Chi_Minh	Asia/Saigon
+Link	Asia/Thimphu		Asia/Thimbu
+Link	Asia/Makassar		Asia/Ujung_Pandang
+Link	Asia/Ulaanbaatar	Asia/Ulan_Bator
+Link	Atlantic/Faroe		Atlantic/Faeroe
+Link	Europe/Kyiv		Europe/Kiev
+Link	Asia/Nicosia		Europe/Nicosia
+Link	Pacific/Guadalcanal	Pacific/Ponape	#= Pacific/Pohnpei
+Link	Pacific/Port_Moresby	Pacific/Truk	#= Pacific/Chuuk

--- a/test/jdk/java/util/TimeZone/TimeZoneData/displaynames.txt
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/displaynames.txt
@@ -24,7 +24,7 @@ America/Boise MST MDT
 America/Cambridge_Bay MST MDT
 America/Cancun EST
 America/Chicago CST CDT
-America/Chihuahua MST MDT
+America/Chihuahua CST
 America/Costa_Rica CST CDT
 America/Danmarkshavn GMT
 America/Dawson MST
@@ -67,18 +67,16 @@ America/Mexico_City CST CDT
 America/Moncton AST ADT
 America/Monterrey CST CDT
 America/New_York EST EDT
-America/Nipigon EST EDT
 America/Nome AKST AKDT
 America/North_Dakota/Beulah CST CDT
 America/North_Dakota/Center CST CDT
 America/North_Dakota/New_Salem CST CDT
-America/Ojinaga MST MDT
+America/Ojinaga CST
 America/Panama EST
 America/Pangnirtung EST EDT
 America/Phoenix MST
 America/Port-au-Prince EST EDT
 America/Puerto_Rico AST
-America/Rainy_River CST CDT
 America/Rankin_Inlet CST CDT
 America/Regina CST
 America/Resolute CST CDT
@@ -88,7 +86,6 @@ America/St_Johns NST NDT
 America/Swift_Current CST
 America/Tegucigalpa CST CDT
 America/Thule AST ADT
-America/Thunder_Bay EST EDT
 America/Tijuana PST PDT
 America/Toronto EST EDT
 America/Vancouver PST PDT


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296108](https://bugs.openjdk.org/browse/JDK-8296108): (tz) Update Timezone Data to 2022f


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1518/head:pull/1518` \
`$ git checkout pull/1518`

Update a local copy of the PR: \
`$ git checkout pull/1518` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1518`

View PR using the GUI difftool: \
`$ git pr show -t 1518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1518.diff">https://git.openjdk.org/jdk11u-dev/pull/1518.diff</a>

</details>
