### PR TITLE
8295872: [PPC64] JfrGetCallTrace: Need pc == nullptr check before frame constructor

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
@@ -32,7 +32,9 @@
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
 
-  intptr_t* sp = OrderAccess::load_acquire(&_anchor._last_Java_sp);
+  // Only called by current thread or when the thread is suspended.
+  // No memory barrier needed, here. Only writer must write sp last (for use by profiler).
+  intptr_t* sp = last_Java_sp();
   address pc = _anchor.last_Java_pc();
 
   // Last_Java_pc ist not set, if we come here from compiled code.
@@ -50,9 +52,12 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   if (has_last_Java_frame() && frame_anchor()->walkable()) {
-    frame last_frame = pd_last_frame();
-    if (last_frame.pc() == NULL) return false;
-    *fr_addr = last_frame;
+    intptr_t* sp = last_Java_sp();
+    address pc = _anchor.last_Java_pc();
+    // pc can be seen as null because not all writers use store pc + release store sp.
+    // Simply discard the sample in this very rare case.
+    if (pc == NULL) return false;
+    *fr_addr = frame(sp, pc);
     return true;
   }
 

--- a/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
@@ -30,7 +30,9 @@
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
 
-  intptr_t* sp = OrderAccess::load_acquire(&_anchor._last_Java_sp);
+  // Only called by current thread or when the thread is suspended.
+  // No memory barrier needed, here. Only writer must write sp last (for use by profiler).
+  intptr_t* sp = last_Java_sp();
   address pc = _anchor.last_Java_pc();
 
   // Last_Java_pc ist not set, if we come here from compiled code.
@@ -49,9 +51,12 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   // If we have a last_Java_frame, then we should use it even if
   // isInJava == true.  It should be more reliable than ucontext info.
   if (has_last_Java_frame() && frame_anchor()->walkable()) {
-    frame last_frame = pd_last_frame();
-    if (last_frame.pc() == NULL) return false;
-    *fr_addr = last_frame;
+    intptr_t* sp = last_Java_sp();
+    address pc = _anchor.last_Java_pc();
+    // pc can be seen as null because not all writers use store pc + release store sp.
+    // Simply discard the sample in this very rare case.
+    if (pc == NULL) return false;
+    *fr_addr = frame(sp, pc);
     return true;
   }
 


### PR DESCRIPTION
Backport of JDK-[8295872](https://github.com/openjdk/jdk17u-dev/commit/3486bb2f8f89c6266e67b6efbc68dac14b2e6e74). `nullptr` needs to get replaced by `NULL` because 11 uses an older C++ standard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295872](https://bugs.openjdk.org/browse/JDK-8295872): [PPC64] JfrGetCallTrace: Need pc == nullptr check before frame constructor


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1519/head:pull/1519` \
`$ git checkout pull/1519`

Update a local copy of the PR: \
`$ git checkout pull/1519` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1519`

View PR using the GUI difftool: \
`$ git pr show -t 1519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1519.diff">https://git.openjdk.org/jdk11u-dev/pull/1519.diff</a>

</details>
