### PR TITLE
8288302: Shenandoah: SIGSEGV in vm maybe related to jit compiling xerces

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -1006,7 +1006,8 @@ Node* ShenandoahBarrierSetC2::ideal_node(PhaseGVN* phase, Node* n, bool can_resh
   } else if (can_reshape &&
              n->Opcode() == Op_If &&
              ShenandoahBarrierC2Support::is_heap_stable_test(n) &&
-             n->in(0) != NULL) {
+             n->in(0) != NULL &&
+             n->outcnt() == 2) {
     Node* dom = n->in(0);
     Node* prev_dom = n;
     int op = n->Opcode();


### PR DESCRIPTION
This is a clean backport. Was fixed in jdk 20 and backported to 17u. Low risk and reported by users on 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288302](https://bugs.openjdk.org/browse/JDK-8288302): Shenandoah: SIGSEGV in vm maybe related to jit compiling xerces


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1520/head:pull/1520` \
`$ git checkout pull/1520`

Update a local copy of the PR: \
`$ git checkout pull/1520` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1520`

View PR using the GUI difftool: \
`$ git pr show -t 1520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1520.diff">https://git.openjdk.org/jdk11u-dev/pull/1520.diff</a>

</details>
