### PR TITLE
8022403: sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -218,7 +218,6 @@ java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all
 sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all
 sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all
 sun/awt/shell/FileSystemViewMemoryLeak.java 8241806 windows-all
-sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java 8022403 generic-all
 sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java 8196102 generic-all
 sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java 8196180 windows-all
 sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java 8144029 macosx-all

--- a/test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
+++ b/test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,25 +25,21 @@
  * @key headful
  * @bug 6664068 6666931
  * @summary Tests that resizing a window to which a tight loop is rendering
- * doesn't produce artifacts or crashes
- * @author Dmitri.Trembovetski@sun.com: area=Graphics
+ *          doesn't produce artifacts or crashes
  * @run main/othervm OnScreenRenderingResizeTest
  * @run main/othervm -Dsun.java2d.d3d=false OnScreenRenderingResizeTest
  */
 
 import java.awt.AWTException;
 import java.awt.Color;
-import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GraphicsConfiguration;
-import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
+import java.awt.EventQueue;
 import java.awt.image.BufferedImage;
 import java.awt.image.VolatileImage;
 import java.io.File;
@@ -52,19 +48,30 @@ import javax.imageio.ImageIO;
 
 public class OnScreenRenderingResizeTest {
 
-    private static volatile boolean done = false;
     private static volatile boolean nocheck = false;
 
-    private static final int FRAME_W = 256;
-    private static final int FRAME_H = 256;
-    private static final int IMAGE_W = 128;
-    private static final int IMAGE_H = 128;
+    private static int FRAME_W;
+    private static int FRAME_H;
+    private static int IMAGE_W;
+    private static int IMAGE_H;
+    private static final int tolerance = 12;
     private static long RUN_TIME = 1000*20;
 
     private static final Color renderColor = Color.green;
     private static final Color bgColor = Color.white;
 
-    public static void main(String[] args) {
+    private static Frame frame;
+
+    private static void createAndShowGUI() {
+        frame = new Frame();
+        frame.setBackground(bgColor);
+        frame.setUndecorated(true);
+        frame.setAlwaysOnTop(true);
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
 
         for (String arg : args) {
             if ("-inf".equals(arg)) {
@@ -74,126 +81,135 @@ public class OnScreenRenderingResizeTest {
                 System.err.println("Test will not check rendering results");
                 nocheck = true;
             } else {
-                System.err.println("Usage: OnScreenRenderingResizeTest [-inf][-nocheck]");
+                System.err.println("Usage: OnScreenRenderingResizeTest" +
+                                   " [-inf][-nocheck]");
             }
         }
 
-        BufferedImage output =
-            new BufferedImage(IMAGE_W, IMAGE_H, BufferedImage.TYPE_INT_RGB);
-        output.setAccelerationPriority(0.0f);
-        Graphics g = output.getGraphics();
-        g.setColor(renderColor);
-        g.fillRect(0, 0, output.getWidth(), output.getHeight());
-
-        final Frame frame = new Frame("OnScreenRenderingResizeTest") {
-            public void paint(Graphics g) {}
-            public void update(Graphics g) {}
-        };
-        frame.setBackground(bgColor);
-        frame.setUndecorated(true);
-        frame.pack();
-
-        GraphicsConfiguration gc = frame.getGraphicsConfiguration();
-        Rectangle gcBounds = gc.getBounds();
-        frame.setBounds(gcBounds.width / 4, gcBounds.height / 4, FRAME_W, FRAME_H);
-
-        frame.addWindowListener(new WindowAdapter() {
-            public void windowClosing(WindowEvent e) {
-                done = true;
-            }
-        });
         try {
             EventQueue.invokeAndWait(new Runnable() {
                 public void run() {
-                    frame.setVisible(true);
+                    createAndShowGUI();
                 }
             });
-            // wait for Vista's effects to complete
             Thread.sleep(2000);
         } catch (Exception ex) {
             ex.printStackTrace();
         }
 
-        int maxW = gcBounds.width /2;
-        int maxH = gcBounds.height/2;
-        int minW = frame.getWidth();
-        int minH = frame.getHeight();
-        int incW = 10, incH = 10, cnt = 0;
-        Robot robot = null;
-        if (!nocheck && gc.getColorModel().getPixelSize() > 8) {
-            try {
-                robot = new Robot();
-            } catch (AWTException ex) {
-                System.err.println("Robot creation failed, continuing.");
-            }
-        } else {
-            System.err.println("No screen rendering checks.");
-        }
+        try {
+            GraphicsConfiguration gc = frame.getGraphicsConfiguration();
+            Rectangle gcBounds = gc.getBounds();
+            FRAME_W = (gcBounds.width / 4);
+            FRAME_H = (gcBounds.height / 4);
+            IMAGE_W = (gcBounds.width / 8);
+            IMAGE_H = (gcBounds.height / 8);
+            frame.setBounds(gcBounds.width / 4, gcBounds.height / 4,
+                            FRAME_W, FRAME_H);
 
-        VolatileImage vi = gc.createCompatibleVolatileImage(512, 512);
-        vi.validate(gc);
+            BufferedImage output =
+                new BufferedImage(IMAGE_W, IMAGE_H,
+                                  BufferedImage.TYPE_INT_RGB);
+            output.setAccelerationPriority(0.0f);
+            Graphics g = output.getGraphics();
+            g.setColor(renderColor);
+            g.fillRect(0, 0, IMAGE_W, IMAGE_H);
 
-        long timeStarted = System.currentTimeMillis();
-        while (!done && (System.currentTimeMillis() - timeStarted) < RUN_TIME) {
-
-            if (++cnt > 100) {
-                int w = frame.getWidth() + incW;
-                int h = frame.getHeight() + incH;
-                if (w < minW || w > maxW ) {
-                    incW = -incW;
+            int maxW = gcBounds.width / 2;
+            int maxH = gcBounds.height / 2;
+            int minW = FRAME_W;
+            int minH = FRAME_H;
+            int incW = 10, incH = 10, cnt = 0;
+            Robot robot = null;
+            if (!nocheck && gc.getColorModel().getPixelSize() > 8) {
+                try {
+                    robot = new Robot();
+                    robot.setAutoDelay(100);
+                    robot.mouseMove(0,0);
+                } catch (AWTException ex) {
+                    System.err.println("Robot creation failed, continuing.");
                 }
-                if (h < minH || h > maxH ) {
-                    incH = -incH;
-                }
-                frame.setSize(w, h);
-                cnt = 0;
+            } else {
+                System.err.println("No screen rendering checks.");
             }
-
-            // try to put the device into non-default state, for example,
-            // this operation below will set the transform
+            VolatileImage vi = gc.
+                createCompatibleVolatileImage(IMAGE_W, IMAGE_H);
             vi.validate(gc);
-            Graphics2D vig = (Graphics2D)vi.getGraphics();
-            vig.rotate(30.0f, vi.getWidth()/2, vi.getHeight()/2);
-            vig.drawImage(output, 0, 0,
-                          vi.getWidth(), vi.getHeight(), null);
+            long timeStarted = System.currentTimeMillis();
+            while ((System.currentTimeMillis() - timeStarted) < RUN_TIME) {
 
-            Insets in = frame.getInsets();
-            frame.getGraphics().drawImage(output, in.left, in.top, null);
-            if (cnt == 90 && robot != null) {
-                robot.waitForIdle();
-                // area where we blitted to should be either white or green
-                Point p = frame.getLocationOnScreen();
-                p.translate(in.left+10, in.top+10);
-                BufferedImage bi =
-                    robot.createScreenCapture(
-                        new Rectangle(p.x, p.y, IMAGE_W/2, IMAGE_H/2));
-                int accepted1[] = { Color.white.getRGB(), Color.green.getRGB()};
-                checkBI(bi, accepted1);
+                if (++cnt > 100) {
+                    int w = frame.getWidth() + incW;
+                    int h = frame.getHeight() + incH;
+                    if (w < minW || w > maxW ) {
+                        incW = -incW;
+                    }
+                    if (h < minH || h > maxH ) {
+                        incH = -incH;
+                    }
+                    frame.setSize(w, h);
+                    cnt = 0;
+                }
+                // try to put the device into non-default state, for example,
+                // this operation below will set the transform
+                vi.validate(gc);
+                Graphics2D vig = (Graphics2D)vi.getGraphics();
+                vig.rotate(30.0f, IMAGE_W/2, IMAGE_H/2);
+                vig.drawImage(output, 0, 0,
+                              IMAGE_W, IMAGE_H, null);
 
-                // the are where we didn't render should stay white
-                p = frame.getLocationOnScreen();
-                p.translate(in.left, in.top+IMAGE_H+5);
-                bi = robot.createScreenCapture(
-                    new Rectangle(p.x, p.y,
-                                  frame.getWidth()-in.left-in.right,
-                                  frame.getHeight()-in.top-in.bottom-5-IMAGE_H));
-                int accepted2[] = { Color.white.getRGB() };
-                checkBI(bi, accepted2);
+                frame.getGraphics().
+                    drawImage(output, 0, 0, null);
+                if (cnt == 90 && robot != null) {
+                    robot.waitForIdle();
+                    // area where we blit and should be either white or green
+                    Point p = frame.getLocationOnScreen();
+                    p.translate(10, 10);
+                    BufferedImage bi =
+                        robot.createScreenCapture(
+                            new Rectangle(p.x, p.y,
+                                          (IMAGE_W / 2), (IMAGE_H / 2)));
+                    int accepted1[] = {Color.white.getRGB(),
+                                       Color.green.getRGB()};
+                    checkBI(bi, accepted1);
+
+                    // the area where we didn't render should stay white
+                    robot.waitForIdle();
+                    p = frame.getLocationOnScreen();
+                    p.translate(10, IMAGE_H + 10);
+                    bi = robot.createScreenCapture(
+                        new Rectangle(p.x, p.y,
+                                      frame.getWidth() - 20,
+                                      frame.getHeight() - 20 - (IMAGE_H)));
+                    int accepted2[] = { Color.white.getRGB() };
+                    checkBI(bi, accepted2);
+                }
+                Thread.yield();
             }
-
-            Thread.yield();
+        } finally {
+            frame.dispose();
         }
-        frame.dispose();
         System.out.println("Test Passed");
     }
 
     private static void checkBI(BufferedImage bi, int accepted[]) {
         for (int x = 0; x < bi.getWidth(); x++) {
             for (int y = 0; y < bi.getHeight(); y++) {
-                int pix = bi.getRGB(x, y);
+                int actual = bi.getRGB(x, y);
+                int alpha = (actual >> 24) & 0xFF;
+                int red = (actual >> 16) & 0xFF;
+                int green = (actual >> 8) & 0xFF;
+                int blue = (actual) & 0xFF;
                 boolean found = false;
                 for (int acc : accepted) {
-                    if (pix == acc) {
+                    int accAlpha = (acc >> 24) & 0xFF;
+                    int accRed = (acc >> 16) & 0xFF;
+                    int accGreen = (acc >> 8) & 0xFF;
+                    int accBlue = (acc) & 0xFF;
+                    if (!(Math.abs(alpha - accAlpha) > tolerance ||
+                          Math.abs(red - accRed) > tolerance ||
+                          Math.abs(green - accGreen) > tolerance ||
+                          Math.abs(blue - accBlue) > tolerance)) {
                         found = true;
                         break;
                     }
@@ -204,10 +220,10 @@ public class OnScreenRenderingResizeTest {
                         ImageIO.write(bi, "png", new File(name));
                         System.out.println("Screen shot file: " + name);
                     } catch (IOException ex) {}
-
                     throw new
                         RuntimeException("Test failed at " + x + "-" + y +
-                                         " rgb=0x" + Integer.toHexString(pix));
+                                         " rgb=0x" + Integer.
+                                         toHexString(actual));
                 }
             }
         }


### PR DESCRIPTION
Backport for [JDK-8022403](https://bugs.openjdk.org/browse/JDK-8022403) sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java fails

Cherry-picked from https://github.com/openjdk/jdk/commit/65f7de252366e30ba18a22c107fc301c0fdc9378

Clean test backport, had to merge ProblemList.txt.
Test update, low risk. 
Test passed during manual run using cmd: 
make run-test TEST=test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8022403](https://bugs.openjdk.org/browse/JDK-8022403): sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1529/head:pull/1529` \
`$ git checkout pull/1529`

Update a local copy of the PR: \
`$ git checkout pull/1529` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1529`

View PR using the GUI difftool: \
`$ git pr show -t 1529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1529.diff">https://git.openjdk.org/jdk11u-dev/pull/1529.diff</a>

</details>
