### PR TITLE
8219705: Wrong media-type for a given serialization method

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/OutputPropertiesFactory.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/OutputPropertiesFactory.java
@@ -70,7 +70,7 @@ import jdk.xml.internal.SecuritySupport;
  * @see SerializerFactory
  * @see Method
  * @see Serializer
- * @LastModified: Feb 2019
+ * @LastModified: Mar 2019
  */
 public final class OutputPropertiesFactory
 {
@@ -231,7 +231,7 @@ public final class OutputPropertiesFactory
     private static final String[] PROP_HTML = {
         "method",
         "indent",
-        "media",
+        "media-type",
         "version",
         "{http://xml.apache.org/xalan}indent-amount",
         "{http://xml.apache.org/xalan}content-handler",

--- a/test/jaxp/javax/xml/jaxp/unittest/transform/OutputPropertiesTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/transform/OutputPropertiesTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package transform;
+
+import java.io.StringReader;
+import java.util.Properties;
+import javax.xml.transform.Templates;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamSource;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @bug 8219705
+ * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
+ * @run testng transform.OutputPropertiesTest
+ * @summary Verifies the output properties are set correctly
+ */
+public class OutputPropertiesTest {
+    @Test
+    public void testOutputProperties() throws Exception {
+        String xslData = "<?xml version='1.0'?>"
+                + "<xsl:stylesheet"
+                + " xmlns:xsl='http://www.w3.org/1999/XSL/Transform'"
+                + " version='1.0'"
+                + ">\n"
+                + "   <xsl:output method='html'/>\n"
+                + "   <xsl:template match='/'>\n"
+                + "     Hello World! \n"
+                + "   </xsl:template>\n"
+                + "</xsl:stylesheet>";
+
+        System.out.println(xslData);
+
+        Templates templates = TransformerFactory.newInstance()
+                    .newTemplates(new StreamSource(new StringReader(xslData)));
+
+        Properties properties = templates.getOutputProperties();
+        String[] prNames = new String[]{"method", "version", "indent", "media-type"};
+        String[] prValues = new String[]{"html", "4.0", "yes", "text/html"};
+
+        for (int i = 0; i < prNames.length; i++) {
+            String value = properties.getProperty(prNames[i]);
+            String msg = "The value of the property '" + prNames[i] + "' should be '"
+                    + prValues[i] + "' when the method is '" + prValues[0] + "'. \n";
+            Assert.assertEquals(value, prValues[i], msg);
+            System.out.println(
+                    prNames[i] + ": actual: " + value + ", expected: " + prValues[i]);
+        }
+    }
+}


### PR DESCRIPTION
See comments in https://github.com/openjdk/jdk11u-dev/pull/1530

This backport requires a review. It is not marked clean because it does not make the change to jaxp/TEST.ROOT from the original commit. I kept the version bumped by https://github.com/openjdk/jdk11u-dev/commit/00d94836393b0fc0e7136aef379af0726778e0f0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #1530 must be integrated first

### Issue
 * [JDK-8219705](https://bugs.openjdk.org/browse/JDK-8219705): Wrong media-type for a given serialization method


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1531/head:pull/1531` \
`$ git checkout pull/1531`

Update a local copy of the PR: \
`$ git checkout pull/1531` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1531`

View PR using the GUI difftool: \
`$ git pr show -t 1531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1531.diff">https://git.openjdk.org/jdk11u-dev/pull/1531.diff</a>

</details>
