### PR TITLE
8287895: Some langtools tests fail on msys2

### DIFF
--- a/test/langtools/tools/javac/Paths/Util.sh
+++ b/test/langtools/tools/javac/Paths/Util.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
 jimage="${TESTJAVA+${TESTJAVA}/bin/}jimage"
 
 case `uname -s` in
-  Windows*|CYGWIN*)
+  Windows*|CYGWIN*|MSYS*|MINGW*)
     WindowsOnly() { "$@"; }
     UnixOnly() { :; }
     PS=";" ;;


### PR DESCRIPTION
applies cleanly (except for copyright header) -  [JDK-8287895](https://bugs.openjdk.org/browse/JDK-8287895): Some langtools tests fail on msys2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287895](https://bugs.openjdk.org/browse/JDK-8287895): Some langtools tests fail on msys2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1540/head:pull/1540` \
`$ git checkout pull/1540`

Update a local copy of the PR: \
`$ git checkout pull/1540` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1540`

View PR using the GUI difftool: \
`$ git pr show -t 1540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1540.diff">https://git.openjdk.org/jdk11u-dev/pull/1540.diff</a>

</details>
