### PR TITLE
8287896: PropertiesTest.sh fail on msys2

### DIFF
--- a/test/jdk/java/util/Currency/PropertiesTest.sh
+++ b/test/jdk/java/util/Currency/PropertiesTest.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ case "$OS" in
     PS=";"
     FS="/"
     ;;
-  CYGWIN* )
+  CYGWIN*|MSYS*|MINGW* )
     PS=";"
     FS="/"
     TESTJAVA=`cygpath -u ${TESTJAVA}`


### PR DESCRIPTION
Applies cleanly (except for copyright header) backport of [JDK-8287896](https://bugs.openjdk.org/browse/JDK-8287896): PropertiesTest.sh fail on msys2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287896](https://bugs.openjdk.org/browse/JDK-8287896): PropertiesTest.sh fail on msys2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1541/head:pull/1541` \
`$ git checkout pull/1541`

Update a local copy of the PR: \
`$ git checkout pull/1541` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1541`

View PR using the GUI difftool: \
`$ git pr show -t 1541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1541.diff">https://git.openjdk.org/jdk11u-dev/pull/1541.diff</a>

</details>
