### PR TITLE
8226236: win32: gc/metaspace/TestCapacityUntilGCWrapAround.java fails

### DIFF
--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -148,7 +148,7 @@ bool MetaspaceGC::inc_capacity_until_GC(size_t v, size_t* new_cap_until_GC, size
 
   if (new_value < old_capacity_until_GC) {
     // The addition wrapped around, set new_value to aligned max value.
-    new_value = align_down(max_uintx, Metaspace::commit_alignment());
+    new_value = align_down(max_uintx, Metaspace::reserve_alignment());
   }
 
   if (new_value > MaxMetaspaceSize) {


### PR DESCRIPTION
Clean backport. With plan to further backporting to JDK 8 where `gc/metaspace/TestCapacityUntilGCWrapAround.java`
also fails on 32-bit windows. 

Testing:
Passes GHA. Ran hotspot/tier1 on win32 build, with and without backport, it fixed that failure, all tests passed with this change (compare [1] [2]).

[1] https://github.com/zzambers/jdk-tester/actions/runs/3537285215/jobs/5937115368
[2] https://github.com/zzambers/jdk-tester/actions/runs/3537288999/jobs/5937124628

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8226236](https://bugs.openjdk.org/browse/JDK-8226236): win32: gc/metaspace/TestCapacityUntilGCWrapAround.java fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1549/head:pull/1549` \
`$ git checkout pull/1549`

Update a local copy of the PR: \
`$ git checkout pull/1549` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1549`

View PR using the GUI difftool: \
`$ git pr show -t 1549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1549.diff">https://git.openjdk.org/jdk11u-dev/pull/1549.diff</a>

</details>
