### PR TITLE
8245245: WebSocket can lose the URL encoding of URI query parameters

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/websocket/OpeningHandshake.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/websocket/OpeningHandshake.java
@@ -171,15 +171,15 @@ public class OpeningHandshake {
     static URI createRequestURI(URI uri) {
         String s = uri.getScheme();
         assert "ws".equalsIgnoreCase(s) || "wss".equalsIgnoreCase(s);
-        String scheme = "ws".equalsIgnoreCase(s) ? "http" : "https";
+        String newUri = uri.toString();
+        if (s.equalsIgnoreCase("ws")) {
+            newUri = "http" + newUri.substring(2);
+        }
+        else {
+            newUri = "https" + newUri.substring(3);
+        }
         try {
-            return new URI(scheme,
-                           uri.getUserInfo(),
-                           uri.getHost(),
-                           uri.getPort(),
-                           uri.getPath(),
-                           uri.getQuery(),
-                           null); // No fragment
+            return new URI(newUri);
         } catch (URISyntaxException e) {
             // Shouldn't happen: URI invariant
             throw new InternalError(e);

--- a/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
+++ b/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
@@ -124,7 +124,8 @@ public class HandshakeUrlEncodingTest {
                 final String rawQuery = wse.getResponse().uri().getRawQuery();
                 final String expectedRawQuery = "&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz";
                 assertEquals(rawQuery, expectedRawQuery);
-                // [JDK-8240666] Websocket client's OpeningHandshake discards the HTTP response body
+                // Unlike later JDKs, 11u does not have JDK-8240666 patched currently.
+                // We need to check whether a body is present. This is OK as previous assertions verify the fix of JDK-8245245.
                 if (wse.getResponse().body() != null &&
                         (wse.getResponse().body().getClass().equals(String.class))) {
                     final String body = (String) wse.getResponse().body();

--- a/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
+++ b/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8245245
+ * @summary Test for Websocket URI encoding during HandShake
+ * @library /lib/testlibrary
+ * @library /test/lib
+ * @build jdk.testlibrary.SimpleSSLContext
+ * @modules java.net.http
+ *          jdk.httpserver
+ * @run testng/othervm -Djdk.internal.httpclient.debug=true HandshakeUrlEncodingTest
+ */
+
+import com.sun.net.httpserver.*;
+import jdk.test.lib.net.URIBuilder;
+import jdk.testlibrary.SimpleSSLContext;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.net.http.WebSocketHandshakeException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static java.lang.System.out;
+import static java.net.http.HttpClient.Builder.NO_PROXY;
+import static org.testng.Assert.*;
+
+public class HandshakeUrlEncodingTest {
+
+    SSLContext sslContext;
+    HttpServer httpTestServer;
+    HttpsServer httpsTestServer;
+    String httpURI;
+    String httpsURI;
+
+    static String queryPart;
+
+    static final int ITERATION_COUNT = 10;
+    // a shared executor helps reduce the amount of threads created by the test
+    static final ExecutorService executor = Executors.newCachedThreadPool();
+
+    @DataProvider(name = "variants")
+    public Object[][] variants() {
+        return new Object[][]{
+                {httpURI, false},
+                {httpsURI, false},
+                {httpURI, true},
+                {httpsURI, true}
+        };
+    }
+
+    HttpClient newHttpClient() {
+        return HttpClient.newBuilder()
+                .proxy(NO_PROXY)
+                .executor(executor)
+                .sslContext(sslContext)
+                .build();
+    }
+
+    @Test(dataProvider = "variants")
+    public void test(String uri, boolean sameClient) {
+        HttpClient client = null;
+        out.println("The url is " + uri);
+        for (int i = 0; i < ITERATION_COUNT; i++) {
+            out.printf("iteration %s%n", i);
+            if (!sameClient || client == null)
+                client = newHttpClient();
+
+            try {
+                client.newWebSocketBuilder()
+                        .buildAsync(URI.create(uri), new WebSocket.Listener() {
+                        })
+                        .join();
+                fail("Expected to throw");
+            } catch (CompletionException ce) {
+                final Throwable t = getCompletionCause(ce);
+                if (!(t instanceof WebSocketHandshakeException)) {
+                    throw new AssertionError("Unexpected exception", t);
+                }
+                final WebSocketHandshakeException wse = (WebSocketHandshakeException) t;
+                assertNotNull(wse.getResponse());
+                assertNotNull(wse.getResponse().uri());
+                final String rawQuery = wse.getResponse().uri().getRawQuery();
+                final String expectedRawQuery = "&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz";
+                assertEquals(rawQuery, expectedRawQuery);
+                out.println("Status code is " + wse.getResponse().statusCode());
+                out.println("Response is " + wse.getResponse());
+                assertNotNull(wse.getResponse().statusCode());
+                out.println("Status code is " + wse.getResponse().statusCode());
+                assertEquals(wse.getResponse().statusCode(), 400);
+            }
+        }
+    }
+
+    @BeforeTest
+    public void setup() throws Exception {
+        sslContext = new SimpleSSLContext().get();
+        if (sslContext == null) {
+            throw new AssertionError("Unexpected null sslContext");
+        }
+
+        final InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        queryPart = "?&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz";
+        httpTestServer = HttpServer.create(sa, 10);
+        httpURI = URIBuilder.newBuilder()
+                .scheme("ws")
+                .host("localhost")
+                .port(httpTestServer.getAddress().getPort())
+                .path("/")
+                .build()
+                .toString() + queryPart;
+
+        httpTestServer.createContext("/", new UrlHandler());
+
+        httpsTestServer = HttpsServer.create(sa, 10);
+        httpsTestServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+        httpsURI = URIBuilder.newBuilder()
+                .scheme("wss")
+                .host("localhost")
+                .port(httpsTestServer.getAddress().getPort())
+                .path("/")
+                .build()
+                .toString() + queryPart;
+
+        httpsTestServer.createContext("/", new UrlHandler());
+
+        httpTestServer.start();
+        httpsTestServer.start();
+    }
+
+    @AfterTest
+    public void teardown() {
+        httpTestServer.stop(0);
+        httpsTestServer.stop(0);
+        executor.shutdownNow();
+    }
+
+    private static Throwable getCompletionCause(Throwable x) {
+        if (!(x instanceof CompletionException) && !(x instanceof ExecutionException)) {
+            return x;
+        }
+        final Throwable cause = x.getCause();
+        if (cause == null) {
+            throw new InternalError("Unexpected null cause", x);
+        }
+        return cause;
+    }
+
+    static class UrlHandler implements HttpHandler {
+
+        @Override
+        public void handle(HttpExchange e) throws IOException {
+            try (InputStream is = e.getRequestBody(); OutputStream os = e.getResponseBody()) {
+                final String testUri = "/?&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz";
+                final URI uri = e.getRequestURI();
+                byte[] bytes = is.readAllBytes();
+                if (uri.toString().equals(testUri)) {
+                    bytes = testUri.getBytes();
+                }
+                e.sendResponseHeaders(400, bytes.length);
+                os.write(bytes);
+            }
+        }
+    }
+}
+

--- a/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
+++ b/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
@@ -124,6 +124,7 @@ public class HandshakeUrlEncodingTest {
                 final String rawQuery = wse.getResponse().uri().getRawQuery();
                 final String expectedRawQuery = "&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz";
                 assertEquals(rawQuery, expectedRawQuery);
+                // [JDK-8240666] Websocket client's OpeningHandshake discards the HTTP response body
                 if (wse.getResponse().body() != null &&
                         (wse.getResponse().body().getClass().equals(String.class))) {
                     final String body = (String) wse.getResponse().body();

--- a/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
+++ b/test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
@@ -97,14 +97,13 @@ public class HandshakeUrlEncodingTest {
         HttpClient client = null;
         out.println("The url is " + uri);
         for (int i = 0; i < ITERATION_COUNT; i++) {
-            out.printf("iteration %s%n", i);
+            System.out.printf("iteration %s%n", i);
             if (!sameClient || client == null)
                 client = newHttpClient();
 
             try {
                 client.newWebSocketBuilder()
-                        .buildAsync(URI.create(uri), new WebSocket.Listener() {
-                        })
+                        .buildAsync(URI.create(uri), new WebSocket.Listener() { })
                         .join();
                 fail("Expected to throw");
             } catch (CompletionException ce) {
@@ -118,10 +117,14 @@ public class HandshakeUrlEncodingTest {
                 final String rawQuery = wse.getResponse().uri().getRawQuery();
                 final String expectedRawQuery = "&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz";
                 assertEquals(rawQuery, expectedRawQuery);
+                if (wse.getResponse().body() != null &&
+                        (wse.getResponse().body().getClass().equals(String.class))) {
+                    final String body = (String) wse.getResponse().body();
+                    final String expectedBody = "/?" + expectedRawQuery;
+                    assertEquals(body, expectedBody);
+                }
                 out.println("Status code is " + wse.getResponse().statusCode());
                 out.println("Response is " + wse.getResponse());
-                assertNotNull(wse.getResponse().statusCode());
-                out.println("Status code is " + wse.getResponse().statusCode());
                 assertEquals(wse.getResponse().statusCode(), 400);
             }
         }


### PR DESCRIPTION
Proposes to backport [JDK-8245245](https://bugs.openjdk.org/browse/JDK-8245245).

The backport is clean as far as the actual `OpeningHandshake.java` goes. The test needed a little tweak so as to compile with `SimpleSSLContext` and also to handle the fact that the erroneous response does not bring a response body.

The test passes with the patch, fails without it.

```
$ make clean run-test TEST="jtreg:test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java"
...
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/java/net/httpclient/websocket/HandshakeUrlEncodingTest.java
                                                         1     1     0     0   
==============================
TEST SUCCESS

Stopping sjavac server
Finished building targets 'clean run-test' in configuration 'linux-x86_64-normal-server-release'
```
In addition to that, I compiled and executed the original `WebSocketTest.java` reproducer found on  [JDK-8245245](https://bugs.openjdk.org/browse/JDK-8245245) JIRA.


## Unpatched Temurin-11.0.17+8  :x: 
```
$ java WebSocketTest 
Http Request
http://localhost:8000/?raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz
Server RequestURI: /?raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz
WebSocket Request
ws://localhost:8000/?&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz
Server RequestURI: /?&raw=abc+def/ghi=xyz&encoded=abc+def/ghi=xyz
```

## Patched jdk11u :heavy_check_mark: 
```
$ java WebSocketTest 
Http Request
http://localhost:8000/?raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz
Server RequestURI: /?raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz
WebSocket Request
ws://localhost:8000/?&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz
Server RequestURI: /?&raw=abc+def/ghi=xyz&encoded=abc%2Bdef%2Fghi%3Dxyz
```
The patched version correctly leaves the latter part of the query param encoded.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8245245](https://bugs.openjdk.org/browse/JDK-8245245): WebSocket can lose the URL encoding of URI query parameters
 * [JDK-8298588](https://bugs.openjdk.org/browse/JDK-8298588): WebSockets: HandshakeUrlEncodingTest unnecessarily depends on a response body


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1558/head:pull/1558` \
`$ git checkout pull/1558`

Update a local copy of the PR: \
`$ git checkout pull/1558` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1558`

View PR using the GUI difftool: \
`$ git pr show -t 1558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1558.diff">https://git.openjdk.org/jdk11u-dev/pull/1558.diff</a>

</details>
