### PR TITLE
8262981: Create implementation for NSAccessibilitySlider protocol

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -90,9 +90,6 @@ static jclass sjc_CAccessible = NULL;
 #define GET_CACCESSIBLE_CLASS_RETURN(ret) \
     GET_CLASS_RETURN(sjc_CAccessible, "sun/lwawt/macosx/CAccessible", ret);
 
-
-static jobject sAccessibilityClass = NULL;
-
 // sAttributeNamesForRoleCache holds the names of the attributes to which each java
 // AccessibleRole responds (see AccessibleRole.java).
 // This cache is queried before attempting to access a given attribute for a particular role.
@@ -291,39 +288,6 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     if (sRoles == nil) {
         initializeRoles();
-    }
-
-    if (sAccessibilityClass == NULL) {
-        JNIEnv *env = [ThreadUtilities getJNIEnv];
-
-        GET_CACCESSIBILITY_CLASS();
-        DECLARE_STATIC_METHOD(jm_getAccessibility, sjc_CAccessibility, "getAccessibility", "([Ljava/lang/String;)Lsun/lwawt/macosx/CAccessibility;");
-
-#ifdef JAVA_AX_NO_IGNORES
-        NSArray *ignoredKeys = [NSArray array];
-#else
-        NSArray *ignoredKeys = [sRoles allKeysForObject:JavaAccessibilityIgnore];
-#endif
-        jobjectArray result = NULL;
-        jsize count = [ignoredKeys count];
-
-        DECLARE_CLASS(jc_String, "java/lang/String");
-        result = (*env)->NewObjectArray(env, count, jc_String, NULL);
-        CHECK_EXCEPTION();
-        if (!result) {
-            NSLog(@"In %s, can't create Java array of String objects", __FUNCTION__);
-            return;
-        }
-
-        NSInteger i;
-        for (i = 0; i < count; i++) {
-            jstring jString = NSStringToJavaString(env, [ignoredKeys objectAtIndex:i]);
-            (*env)->SetObjectArrayElement(env, result, i, jString);
-            (*env)->DeleteLocalRef(env, jString);
-        }
-
-        sAccessibilityClass = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibility, result); // AWT_THREADING Safe (known object)
-        CHECK_EXCEPTION();
     }
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.h
@@ -23,19 +23,10 @@
  * questions.
  */
 
-#import "RadiobuttonAccessibility.h"
-#import "JNIUtilities.h"
-#import "ThreadUtilities.h"
+#import "ButtonAccessibility.h"
 
-/*
- * Implementation of the accessibility peer for the radiobutton role
- */
-@implementation RadiobuttonAccessibility
+@interface CheckboxAccessibility : ButtonAccessibility <NSAccessibilityCheckBox> {
 
-- (id) accessibilityValue
-{
-    AWT_ASSERT_APPKIT_THREAD;
-    return [self accessibilityValueAttribute];
-}
-
+};
+- (id)accessibilityValue;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.m
@@ -23,14 +23,14 @@
  * questions.
  */
 
-#import "RadiobuttonAccessibility.h"
+#import "CheckboxAccessibility.h"
 #import "JNIUtilities.h"
 #import "ThreadUtilities.h"
 
 /*
- * Implementation of the accessibility peer for the radiobutton role
+ * Implementation of the accessibility peer for the checkbox role
  */
-@implementation RadiobuttonAccessibility
+@implementation CheckboxAccessibility
 
 - (id) accessibilityValue
 {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.h
@@ -36,6 +36,7 @@
 + (JavaComponentAccessibility * _Nullable) getComponentAccessibility:(NSString * _Nonnull)role;
 - (NSRect)accessibilityFrame;
 - (nullable id)accessibilityParent;
+- (BOOL)performAccessibleAction:(int)index;
 @end
 
 #endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -46,9 +46,13 @@ static NSMutableDictionary * _Nullable rolesMap;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:1];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:4];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
+    [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
+    [rolesMap setObject:@"ImageAccessibility" forKey:@"desktopicon"];
+    [rolesMap setObject:@"SpinboxAccessibility" forKey:@"spinbox"];
+
 }
 
 /*
@@ -58,7 +62,6 @@ static NSMutableDictionary * _Nullable rolesMap;
 + (JavaComponentAccessibility *) getComponentAccessibility:(NSString *)role
 {
     AWT_ASSERT_APPKIT_THREAD;
-
     if (rolesMap == nil) {
         [self initializeRolesMap];
     }
@@ -93,6 +96,22 @@ static NSMutableDictionary * _Nullable rolesMap;
 - (nullable id)accessibilityParent
 {
     return [self accessibilityParentAttribute];
+}
+
+// AccessibleAction support
+- (BOOL)performAccessibleAction:(int)index
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+
+    GET_CACCESSIBILITY_CLASS_RETURN(FALSE);
+    DECLARE_STATIC_METHOD_RETURN(jm_doAccessibleAction, sjc_CAccessibility, "doAccessibleAction",
+                                 "(Ljavax/accessibility/AccessibleAction;ILjava/awt/Component;)V", FALSE);
+    (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_doAccessibleAction,
+                                 [self axContextWithEnv:(env)], index, fComponent);
+    CHECK_EXCEPTION();
+
+    return TRUE;
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -49,6 +49,8 @@ static jobject sAccessibilityClass = NULL;
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
     rolesMap = [[NSMutableDictionary alloc] initWithCapacity:26];
+
+    [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"desktopicon"];
     [rolesMap setObject:@"SpinboxAccessibility" forKey:@"spinbox"];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -49,8 +49,6 @@ static jobject sAccessibilityClass = NULL;
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
     rolesMap = [[NSMutableDictionary alloc] initWithCapacity:26];
-
-    [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"desktopicon"];
     [rolesMap setObject:@"SpinboxAccessibility" forKey:@"spinbox"];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -48,7 +48,7 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:26];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:6];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -48,7 +48,7 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:6];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:27];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
@@ -58,6 +58,7 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"StaticTextAccessibility" forKey:@"label"];
     [rolesMap setObject:@"RadiobuttonAccessibility" forKey:@"radiobutton"];
     [rolesMap setObject:@"CheckboxAccessibility" forKey:@"checkbox"];
+    [rolesMap setObject:@"SliderAccessibility" forKey:@"slider"];
 
     /*
      * All the components below should be ignored by the accessibility subsystem,

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ static jmethodID sjm_getAccessibleComponent = NULL;
            "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleComponent;", ret);
 
 static NSMutableDictionary * _Nullable rolesMap;
+NSString *const IgnoreClassName = @"IgnoreAccessibility";
+static jobject sAccessibilityClass = NULL;
 
 /*
  * Common ancestor for all the accessibility peers that implements the new method-based accessibility API
@@ -46,13 +48,73 @@ static NSMutableDictionary * _Nullable rolesMap;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:4];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:26];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"desktopicon"];
     [rolesMap setObject:@"SpinboxAccessibility" forKey:@"spinbox"];
+    [rolesMap setObject:@"StaticTextAccessibility" forKey:@"hyperlink"];
+    [rolesMap setObject:@"StaticTextAccessibility" forKey:@"label"];
+    [rolesMap setObject:@"RadiobuttonAccessibility" forKey:@"radiobutton"];
+    [rolesMap setObject:@"CheckboxAccessibility" forKey:@"checkbox"];
 
+    /*
+     * All the components below should be ignored by the accessibility subsystem,
+     * If any of the enclosed component asks for a parent the first ancestor
+     * participating in accessibility exchange should be returned.
+     */
+    [rolesMap setObject:IgnoreClassName forKey:@"alert"];
+    [rolesMap setObject:IgnoreClassName forKey:@"colorchooser"];
+    [rolesMap setObject:IgnoreClassName forKey:@"desktoppane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"dialog"];
+    [rolesMap setObject:IgnoreClassName forKey:@"directorypane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"filechooser"];
+    [rolesMap setObject:IgnoreClassName forKey:@"filler"];
+    [rolesMap setObject:IgnoreClassName forKey:@"fontchooser"];
+    [rolesMap setObject:IgnoreClassName forKey:@"frame"];
+    [rolesMap setObject:IgnoreClassName forKey:@"glasspane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"layeredpane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"optionpane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"panel"];
+    [rolesMap setObject:IgnoreClassName forKey:@"rootpane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"separator"];
+    [rolesMap setObject:IgnoreClassName forKey:@"tooltip"];
+    [rolesMap setObject:IgnoreClassName forKey:@"viewport"];
+    [rolesMap setObject:IgnoreClassName forKey:@"window"];
+
+    /*
+     * Initialize CAccessibility instance
+     */
+#ifdef JAVA_AX_NO_IGNORES
+    NSArray *ignoredKeys = [NSArray array];
+#else
+    NSArray *ignoredKeys = [rolesMap allKeysForObject:IgnoreClassName];
+#endif
+
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS();
+    DECLARE_STATIC_METHOD(jm_getAccessibility, sjc_CAccessibility, "getAccessibility", "([Ljava/lang/String;)Lsun/lwawt/macosx/CAccessibility;");
+    jobjectArray result = NULL;
+    jsize count = [ignoredKeys count];
+
+    DECLARE_CLASS(jc_String, "java/lang/String");
+    result = (*env)->NewObjectArray(env, count, jc_String, NULL);
+    CHECK_EXCEPTION();
+    if (!result) {
+        NSLog(@"In %s, can't create Java array of String objects", __FUNCTION__);
+        return;
+    }
+
+    NSInteger i;
+    for (i = 0; i < count; i++) {
+        jstring jString = NSStringToJavaString(env, [ignoredKeys objectAtIndex:i]);
+        (*env)->SetObjectArrayElement(env, result, i, jString);
+        (*env)->DeleteLocalRef(env, jString);
+    }
+
+    sAccessibilityClass = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibility, result);
+    CHECK_EXCEPTION();
 }
 
 /*
@@ -112,6 +174,10 @@ static NSMutableDictionary * _Nullable rolesMap;
     CHECK_EXCEPTION();
 
     return TRUE;
+}
+
+- (BOOL)isAccessibilityElement {
+    return YES;
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef COMMON_TEXT_ACCESSIBILITY
+#define COMMON_TEXT_ACCESSIBILITY
+
+#import "CommonComponentAccessibility.h"
+#import "JavaAccessibilityUtilities.h"
+
+#import <AppKit/NSAccessibility.h>
+
+@interface CommonTextAccessibility : CommonComponentAccessibility {
+
+}
+- (nullable NSString *)accessibilityValueAttribute;
+- (NSRange)accessibilityVisibleCharacterRangeAttribute;
+- (nullable NSString *)accessibilityStringForRangeAttribute:(NSRange)parameter;
+@end
+
+#endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.m
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "CommonTextAccessibility.h"
+#import "ThreadUtilities.h"
+#import "JNIUtilities.h"
+
+#define DEFAULT_RANGE NSMakeRange(0, 0)
+#define DEFAULT_RECT NSMakeRect(0, 0, 0, 0)
+
+static jclass sjc_CAccessibility = NULL;
+static jmethodID sjm_getAccessibleText = NULL;
+#define GET_ACCESSIBLETEXT_METHOD_RETURN(ret) \
+    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
+    GET_STATIC_METHOD_RETURN(sjm_getAccessibleText, sjc_CAccessibility, "getAccessibleText", \
+              "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleText;", ret);
+
+static jclass sjc_CAccessibleText = NULL;
+#define GET_CACCESSIBLETEXT_CLASS() \
+    GET_CLASS(sjc_CAccessibleText, "sun/lwawt/macosx/CAccessibleText");
+#define GET_CACCESSIBLETEXT_CLASS_RETURN(ret) \
+    GET_CLASS_RETURN(sjc_CAccessibleText, "sun/lwawt/macosx/CAccessibleText", ret);
+
+static jmethodID sjm_getAccessibleEditableText = NULL;
+#define GET_ACCESSIBLEEDITABLETEXT_METHOD_RETURN(ret) \
+    GET_CACCESSIBLETEXT_CLASS_RETURN(ret); \
+    GET_STATIC_METHOD_RETURN(sjm_getAccessibleEditableText, sjc_CAccessibleText, "getAccessibleEditableText", \
+              "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleEditableText;", ret);
+
+/*
+ * Converts an int array to an NSRange wrapped inside an NSValue
+ * takes [start, end] values and returns [start, end - start]
+ */
+static NSRange javaIntArrayToNSRange(JNIEnv* env, jintArray array) {
+    jint *values = (*env)->GetIntArrayElements(env, array, 0);
+    if (values == NULL) {
+        NSLog(@"%s failed calling GetIntArrayElements", __FUNCTION__);
+        return DEFAULT_RANGE;
+    };
+    return NSMakeRange(values[0], values[1] - values[0]);
+}
+
+@implementation CommonTextAccessibility
+
+- (nullable NSString *)accessibilityValueAttribute
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleName, sjc_CAccessibility, "getAccessibleName",
+                          "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", nil);
+    if ([[self accessibilityRoleAttribute] isEqualToString:NSAccessibilityStaticTextRole]) {
+        jobject axName = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
+                           sjm_getAccessibleName, fAccessible, fComponent);
+        CHECK_EXCEPTION();
+        if (axName != NULL) {
+            NSString* str = JNFJavaToNSString(env, axName);
+            (*env)->DeleteLocalRef(env, axName);
+            return str;
+        }
+        // value is still nil if no accessibleName for static text. Below, try to get the accessibleText.
+    }
+
+    GET_ACCESSIBLETEXT_METHOD_RETURN(@"");
+    jobject axText = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
+                      sjm_getAccessibleText, fAccessible, fComponent);
+    CHECK_EXCEPTION();
+    if (axText == NULL) return nil;
+    (*env)->DeleteLocalRef(env, axText);
+
+    GET_ACCESSIBLEEDITABLETEXT_METHOD_RETURN(nil);
+    jobject axEditableText = (*env)->CallStaticObjectMethod(env, sjc_CAccessibleText,
+                       sjm_getAccessibleEditableText, fAccessible, fComponent);
+    CHECK_EXCEPTION();
+    if (axEditableText == NULL) return nil;
+
+    DECLARE_STATIC_METHOD_RETURN(jm_getTextRange, sjc_CAccessibleText, "getTextRange",
+                    "(Ljavax/accessibility/AccessibleEditableText;IILjava/awt/Component;)Ljava/lang/String;", nil);
+    jobject jrange = (*env)->CallStaticObjectMethod(env, sjc_CAccessibleText, jm_getTextRange,
+                       axEditableText, 0, getAxTextCharCount(env, axEditableText, fComponent), fComponent);
+    CHECK_EXCEPTION();
+    NSString *string = JNFJavaToNSString(env, jrange); // AWT_THREADING Safe (AWTRunLoop)
+
+    (*env)->DeleteLocalRef(env, jrange);
+    (*env)->DeleteLocalRef(env, axEditableText);
+
+    if (string == nil) string = @"";
+    return string;
+}
+
+- (NSRange)accessibilityVisibleCharacterRangeAttribute
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBLETEXT_CLASS_RETURN(DEFAULT_RANGE);
+    DECLARE_STATIC_METHOD_RETURN(jm_getVisibleCharacterRange, sjc_CAccessibleText, "getVisibleCharacterRange",
+                          "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)[I", DEFAULT_RANGE);
+    jintArray axTextRange = (*env)->CallStaticObjectMethod(env, sjc_CAccessibleText,
+                 jm_getVisibleCharacterRange, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
+    if (axTextRange == NULL) return DEFAULT_RANGE;
+
+    return javaIntArrayToNSRange(env, axTextRange);
+}
+
+- (nullable NSString *)accessibilityStringForRangeAttribute:(NSRange)range
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBLETEXT_CLASS_RETURN(nil);
+    DECLARE_STATIC_METHOD_RETURN(jm_getStringForRange, sjc_CAccessibleText, "getStringForRange",
+                 "(Ljavax/accessibility/Accessible;Ljava/awt/Component;II)Ljava/lang/String;", nil);
+    jstring jstringForRange = (jstring)(*env)->CallStaticObjectMethod(env, sjc_CAccessibleText, jm_getStringForRange,
+                            fAccessible, fComponent, range.location, range.length); // AWT_THREADING Safe (AWTRunLoop)
+    CHECK_EXCEPTION();
+    if (jstringForRange == NULL) return @"";
+    NSString* str = JNFJavaToNSString(env, jstringForRange);
+    (*env)->DeleteLocalRef(env, jstringForRange);
+    return str;
+}
+
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/IgnoreAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/IgnoreAccessibility.h
@@ -23,21 +23,13 @@
  * questions.
  */
 
-#ifndef JAVA_COMPONENT_ACCESSIBILITY
-#define JAVA_COMPONENT_ACCESSIBILITY
-
 #import "JavaComponentAccessibility.h"
-#import "JavaAccessibilityUtilities.h"
+#import "CommonComponentAccessibility.h"
 
-@interface CommonComponentAccessibility : JavaComponentAccessibility <NSAccessibilityElement> {
+#import <AppKit/AppKit.h>
 
-}
-+ (void) initializeRolesMap;
-+ (JavaComponentAccessibility * _Nullable) getComponentAccessibility:(NSString * _Nonnull)role;
-- (NSRect)accessibilityFrame;
-- (nullable id)accessibilityParent;
-- (BOOL)performAccessibleAction:(int)index;
+@interface IgnoreAccessibility : CommonComponentAccessibility {
+
+};
 - (BOOL)isAccessibilityElement;
 @end
-
-#endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/IgnoreAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/IgnoreAccessibility.m
@@ -23,21 +23,15 @@
  * questions.
  */
 
-#ifndef JAVA_COMPONENT_ACCESSIBILITY
-#define JAVA_COMPONENT_ACCESSIBILITY
+#import "IgnoreAccessibility.h"
 
-#import "JavaComponentAccessibility.h"
-#import "JavaAccessibilityUtilities.h"
-
-@interface CommonComponentAccessibility : JavaComponentAccessibility <NSAccessibilityElement> {
-
+/*
+ * Indicates that component does not participate in accessibility exchange
+ */
+@implementation IgnoreAccessibility
+- (BOOL)isAccessibilityElement
+{
+    return NO;
 }
-+ (void) initializeRolesMap;
-+ (JavaComponentAccessibility * _Nullable) getComponentAccessibility:(NSString * _Nonnull)role;
-- (NSRect)accessibilityFrame;
-- (nullable id)accessibilityParent;
-- (BOOL)performAccessibleAction:(int)index;
-- (BOOL)isAccessibilityElement;
-@end
 
-#endif
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "JavaComponentAccessibility.h"
+#import "CommonComponentAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface ImageAccessibility : CommonComponentAccessibility <NSAccessibilityImage> {
+
+};
+- (nullable NSString *)accessibilityLabel;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.m
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "ImageAccessibility.h"
+
+/*
+ * Implementation of the accessibility peer for the icon role
+ */
+@implementation ImageAccessibility
+- (nullable NSString *)accessibilityLabel
+{
+    return [self accessibilityTitleAttribute];
+}
+
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "ButtonAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface RadiobuttonAccessibility : ButtonAccessibility <NSAccessibilityRadioButton> {
+
+};
+- (id)accessibilityValue;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.h
@@ -25,8 +25,6 @@
 
 #import "ButtonAccessibility.h"
 
-#import <AppKit/AppKit.h>
-
 @interface RadiobuttonAccessibility : ButtonAccessibility <NSAccessibilityRadioButton> {
 
 };

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.m
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "RadiobuttonAccessibility.h"
+#import "JNIUtilities.h"
+#import "ThreadUtilities.h"
+
+/*
+ * Implementation of the accessibility peer for the pushbutton role
+ */
+@implementation RadiobuttonAccessibility
+
+- (id) accessibilityValue
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    return [self accessibilityValueAttribute];
+}
+
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SliderAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SliderAccessibility.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "JavaComponentAccessibility.h"
+#import "CommonComponentAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface SliderAccessibility : CommonComponentAccessibility <NSAccessibilitySlider> {
+
+};
+
+- (nullable NSString *)accessibilityLabel;
+- (nullable id)accessibilityValue;
+- (BOOL)accessibilityPerformDecrement;
+- (BOOL)accessibilityPerformIncrement;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SliderAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SliderAccessibility.m
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "SliderAccessibility.h"
+
+#define INCREMENT 0
+#define DECREMENT 1
+
+/*
+ * Implementation of the accessibility peer for the slider role
+ */
+@implementation SliderAccessibility
+- (nullable NSString *)accessibilityLabel
+{
+    return [self accessibilityTitleAttribute];
+}
+
+- (nullable id)accessibilityValue
+{
+    return [self accessibilityValueAttribute];
+}
+
+- (BOOL)accessibilityPerformIncrement
+{
+    return [self performAccessibleAction:INCREMENT];
+}
+
+- (BOOL)accessibilityPerformDecrement
+{
+    return [self performAccessibleAction:DECREMENT];
+}
+
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.h
@@ -23,20 +23,17 @@
  * questions.
  */
 
-#import "ButtonAccessibility.h"
+#import "JavaComponentAccessibility.h"
+#import "CommonComponentAccessibility.h"
 
-/*
- * Implementation of the accessibility peer for the pushbutton role
- */
-@implementation ButtonAccessibility
-- (nullable NSString *)accessibilityLabel
-{
-    return [self accessibilityTitleAttribute];
-}
+#import <AppKit/AppKit.h>
 
-- (BOOL)accessibilityPerformPress
-{
-    return [self performAccessibleAction:0];
-}
+@interface SpinboxAccessibility : CommonComponentAccessibility <NSAccessibilityStepper> {
 
+};
+
+- (nullable NSString *)accessibilityLabel;
+- (nullable id)accessibilityValue;
+- (BOOL)accessibilityPerformDecrement;
+- (BOOL)accessibilityPerformIncrement;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.m
@@ -23,20 +23,34 @@
  * questions.
  */
 
-#import "ButtonAccessibility.h"
+#import "SpinboxAccessibility.h"
+
+#define INCREMENT 0
+#define DECREMENT 1
 
 /*
- * Implementation of the accessibility peer for the pushbutton role
+ * Implementation of the accessibility peer for the spinner role
  */
-@implementation ButtonAccessibility
+@implementation SpinboxAccessibility
 - (nullable NSString *)accessibilityLabel
 {
     return [self accessibilityTitleAttribute];
 }
 
-- (BOOL)accessibilityPerformPress
+- (nullable id)accessibilityValue
 {
-    return [self performAccessibleAction:0];
+    return [self accessibilityValueAttribute];
+}
+
+- (BOOL)accessibilityPerformIncrement
+{
+    return [self performAccessibleAction:INCREMENT];
+}
+
+
+- (BOOL)accessibilityPerformDecrement
+{
+    return [self performAccessibleAction:DECREMENT];
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef STATIC_TEXT_ACCESSIBILITY
+#define STATIC_TEXT_ACCESSIBILITY
+
+#import "CommonTextAccessibility.h"
+
+#import <AppKit/NSAccessibility.h>
+
+
+@interface StaticTextAccessibility : CommonTextAccessibility<NSAccessibilityStaticText> {
+
+};
+- (nullable NSString *)accessibilityAttributedString:(NSRange)range;
+- (nullable NSString *)accessibilityValue;
+- (NSRange)accessibilityVisibleCharacterRange;
+@end
+#endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "StaticTextAccessibility.h"
+
+@implementation StaticTextAccessibility
+
+- (nullable NSString *)accessibilityAttributedString:(NSRange)range
+{
+    return [self accessibilityStringForRangeAttribute:range];
+}
+
+- (nullable NSString *)accessibilityValue
+{
+    return [self accessibilityValueAttribute];
+}
+
+- (NSRange)accessibilityVisibleCharacterRange
+{
+    return [self accessibilityVisibleCharacterRangeAttribute];
+}
+
+@end

--- a/src/java.desktop/share/classes/javax/swing/JSlider.java
+++ b/src/java.desktop/share/classes/javax/swing/JSlider.java
@@ -39,6 +39,29 @@ import java.beans.BeanProperty;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.Hashtable;
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleAction;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleRole;
+import javax.accessibility.AccessibleState;
+import javax.accessibility.AccessibleStateSet;
+import javax.accessibility.AccessibleValue;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.EventListenerList;
+import javax.swing.plaf.SliderUI;
+import javax.swing.plaf.UIResource;
+
+
 /**
  * A component that lets the user graphically select a value by sliding
  * a knob within a bounded interval. The knob is always positioned
@@ -1413,7 +1436,11 @@ public class JSlider extends JComponent implements SwingConstants, Accessible {
      */
     @SuppressWarnings("serial") // Same-version serialization only
     protected class AccessibleJSlider extends AccessibleJComponent
-    implements AccessibleValue {
+
+
+
+    implements AccessibleValue, ChangeListener, AccessibleAction {
+
 
         /**
          * Get the state set of this object.
@@ -1499,5 +1526,71 @@ public class JSlider extends JComponent implements SwingConstants, Accessible {
             BoundedRangeModel model = JSlider.this.getModel();
             return Integer.valueOf(model.getMaximum() - model.getExtent());
         }
+
+        /**
+         * Gets the AccessibleAction associated with this object that supports
+         * one or more actions.
+         *
+         * @return AccessibleAction if supported by object; else return null
+         * @see AccessibleAction
+         */
+        public AccessibleAction getAccessibleAction() {
+            return this;
+        }
+
+        /* ===== Begin AccessibleAction impl ===== */
+
+        /**
+         * Returns the number of accessible actions available in this object
+         * If there are more than one, the first one is considered the "default"
+         * action of the object.
+         *
+         * Two actions are supported: AccessibleAction.INCREMENT which
+         * increments the slider value and AccessibleAction.DECREMENT
+         * which decrements the slider value
+         *
+         * @return the zero-based number of Actions in this object
+         */
+        public int getAccessibleActionCount() {
+            return 2;
+        }
+
+        /**
+         * Returns a description of the specified action of the object.
+         *
+         * @param i zero-based index of the actions
+         * @return a String description of the action
+         * @see #getAccessibleActionCount
+         */
+        public String getAccessibleActionDescription(int i) {
+            if (i == 0) {
+                return AccessibleAction.INCREMENT;
+            } else if (i == 1) {
+                return AccessibleAction.DECREMENT;
+            }
+            return null;
+        }
+
+        /**
+         * Performs the specified Action on the object
+         *
+         * @param i zero-based index of actions. The first action
+         * (index 0) is AccessibleAction.INCREMENT and the second
+         * action (index 1) is AccessibleAction.DECREMENT.
+         * @return true.
+         * @see #getAccessibleActionCount
+         */
+        public boolean doAccessibleAction(int direction) {
+            if (direction < 0 || direction > 1) {
+                return false;
+            }
+            //0 is increment, 1 is decrrement
+            int delta = ((direction > 0) ? -1 : 1);
+            JSlider.this.setValue(oldModelValue + delta);
+            return true;
+        }
+
+        /* ===== End AccessibleAction impl ===== */
+
     } // AccessibleJSlider
 }

--- a/test/jdk/sun/java2d/SunGraphics2D/CoordinateTruncationBug.java
+++ b/test/jdk/sun/java2d/SunGraphics2D/CoordinateTruncationBug.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4975116 7040022 8023577 8025447 8286624
+ * @key headful
+ * @summary verify the rounding of negative coordinates in Shape objects
+ * @run main/othervm CoordinateTruncationBug
+ */
+
+import java.awt.Frame;
+import java.awt.Canvas;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Robot;
+import java.awt.Rectangle;
+import java.awt.Point;
+import java.awt.Dimension;
+import java.awt.Color;
+import java.awt.AWTException;
+import java.awt.geom.Line2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.VolatileImage;
+
+public class CoordinateTruncationBug {
+    static boolean failure;
+    static boolean verbose;
+
+    static final int W = 80;
+    static final int H = 80;
+
+    static final Line2D vertline = new Line2D.Float(-0.7f, 0f, -0.7f, H);
+    static final Line2D horizline = new Line2D.Float(0f, -0.7f, W, -0.7f);
+
+    public static void main(String argv[]) {
+        verbose = (argv.length > 0);
+        new Screen().test();
+        new BufImg().test();
+        new VolImg().test();
+        if (failure) {
+            throw new RuntimeException("Test failed due to 1 or more failures");
+        }
+    }
+
+    public static abstract class Test {
+        public abstract String getName();
+        public abstract void makeDest();
+        public abstract void runTest();
+        public abstract void dispose();
+        public abstract BufferedImage getSnapshot();
+
+        public void test() {
+            makeDest();
+            runTest();
+            dispose();
+        }
+
+        public void runTest(Graphics2D g2d) {
+            g2d.setColor(Color.white);
+            g2d.fillRect(0, 0, W, H);
+
+            if (!checkAllWhite()) {
+                System.err.println("Aborting test of "+getName()+
+                                   " due to readback failure!");
+                return;
+            }
+
+            g2d.setColor(Color.red);
+            g2d.draw(vertline);
+            g2d.draw(horizline);
+            if (!checkAllWhite()) {
+                System.err.println(getName()+" failed!");
+                failure = true;
+            }
+        }
+
+        public boolean checkAllWhite() {
+            BufferedImage bimg = getSnapshot();
+            if (bimg == null) {
+                System.err.println(getName()+" returned null snapshot!");
+                return false;
+            }
+            boolean ret = true;
+            for (int y = 0; y < H; y++) {
+                for (int x = 0; x < W; x++) {
+                    int rgb = bimg.getRGB(x, y);
+                    if (rgb != -1) {
+                        System.err.println(getName()+"("+x+", "+y+") == "+
+                                           Integer.toHexString(rgb));
+                        if (verbose) {
+                            ret = false;
+                        } else {
+                            return false;
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+    }
+
+    public static class Screen extends Test {
+        Frame frame;
+        TestCanvas canvas;
+
+        public String getName() {
+            return "Screen";
+        }
+
+        public void makeDest() {
+            frame = new Frame("Screen test");
+            frame.setUndecorated(true);
+            canvas = new TestCanvas(this);
+            frame.add(canvas);
+            frame.pack();
+            frame.setLocationRelativeTo(null);
+        }
+
+        public void runTest() {
+            frame.show();
+            canvas.waitForTest();
+        }
+
+        public Graphics2D createGraphics() {
+            return null;
+        }
+
+        public BufferedImage getSnapshot() {
+            // bypass window animation
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+            };
+
+            try {
+                Robot r = new Robot();
+                Point p = canvas.getLocationOnScreen();
+                return r.createScreenCapture(new Rectangle(p.x, p.y, W, H));
+            } catch (AWTException e) {
+                return null;
+            }
+        }
+
+        public void dispose() {
+            frame.hide();
+            frame.dispose();
+        }
+
+        public static class TestCanvas extends Canvas {
+            Test test;
+            boolean done;
+
+            public TestCanvas(Test test) {
+                this.test = test;
+            }
+
+            public Dimension getPreferredSize() {
+                return new Dimension(W, H);
+            }
+
+            public synchronized void waitForTest() {
+                while (!done) {
+                    try {
+                        wait();
+                    } catch (InterruptedException e) {
+                        System.err.println(getName()+" interrupted!");
+                        failure = true;
+                        break;
+                    }
+                }
+            }
+
+            public void paint(Graphics g) {
+                if (!done) {
+                    test.runTest((Graphics2D) g);
+                    notifyDone();
+                }
+            }
+
+            public synchronized void notifyDone() {
+                done = true;
+                notifyAll();
+            }
+        }
+    }
+
+    public abstract static class Standalone extends Test {
+        public abstract Graphics2D createGraphics();
+
+        public void runTest() {
+            Graphics2D g2d = createGraphics();
+            runTest(g2d);
+            g2d.dispose();
+        }
+    }
+
+    public static class BufImg extends Standalone {
+        public BufferedImage bimg;
+
+        public String getName() {
+            return "BufferedImage";
+        }
+
+        public void makeDest() {
+            bimg = new BufferedImage(W, H, BufferedImage.TYPE_INT_RGB);
+        }
+
+        public Graphics2D createGraphics() {
+            return bimg.createGraphics();
+        }
+
+        public BufferedImage getSnapshot() {
+            return bimg;
+        }
+
+        public void dispose() {
+        }
+    }
+
+    public static class VolImg extends Standalone {
+        Frame frame;
+        VolatileImage vimg;
+
+        public String getName() {
+            return "VolatileImage";
+        }
+
+        public void makeDest() {
+            frame = new Frame();
+            frame.setSize(W, H);
+            frame.setLocationRelativeTo(null);
+            frame.show();
+            vimg = frame.createVolatileImage(W, H);
+        }
+
+        public Graphics2D createGraphics() {
+            return vimg.createGraphics();
+        }
+
+        public BufferedImage getSnapshot() {
+            return vimg.getSnapshot();
+        }
+
+        public void dispose() {
+            vimg.flush();
+            frame.hide();
+            frame.dispose();
+        }
+    }
+}


### PR DESCRIPTION
Backport for [JDK-8262981](https://bugs.openjdk.org/browse/JDK-8262981) (https://bugs.openjdk.org/browse/JDK-8262981) this backport is related to backport [JDK-8265278](https://bugs.openjdk.org/browse/JDK-8265278) or builds will fail. These backports are a part of a larger series of 28 plus backports [JDK-8152350](https://bugs.openjdk.org/browse/JDK-8152350).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8262981](https://bugs.openjdk.org/browse/JDK-8262981): Create implementation for NSAccessibilitySlider protocol


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1561/head:pull/1561` \
`$ git checkout pull/1561`

Update a local copy of the PR: \
`$ git checkout pull/1561` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1561`

View PR using the GUI difftool: \
`$ git pr show -t 1561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1561.diff">https://git.openjdk.org/jdk11u-dev/pull/1561.diff</a>

</details>
