### PR TITLE
8296878: Document Filter attached to JPasswordField and setText("") is not cleared instead inserted characters replaced with unicode null characters

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JPasswordField.java
+++ b/src/java.desktop/share/classes/javax/swing/JPasswordField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -285,21 +285,27 @@ public class JPasswordField extends JTextField {
     public void setText(String t) {
         // overwrite the old data first
         Document doc = getDocument();
-        int nleft = doc.getLength();
-        Segment text = new Segment();
-        // we would like to get direct data array access, not a copy of it
-        text.setPartialReturn(true);
-        int offs = 0;
-        try {
-            while (nleft > 0) {
-                doc.getText(offs, nleft, text);
-                Arrays.fill(text.array, text.offset,
-                            text.count + text.offset, '\u0000');
-                nleft -= text.count;
-                offs += text.count;
+        DocumentFilter filter = null;
+        if (doc instanceof AbstractDocument adoc) {
+            filter = adoc.getDocumentFilter();
+        }
+        if (filter == null) {
+            int nleft = doc.getLength();
+            Segment text = new Segment();
+            // we would like to get direct data array access, not a copy of it
+            text.setPartialReturn(true);
+            int offs = 0;
+            try {
+                while (nleft > 0) {
+                    doc.getText(offs, nleft, text);
+                    Arrays.fill(text.array, text.offset,
+                                text.count + text.offset, '\u0000');
+                    nleft -= text.count;
+                    offs += text.count;
+                }
+            } catch (BadLocationException ignored) {
+                // we tried
             }
-        } catch (BadLocationException ignored) {
-            // we tried
         }
         super.setText(t);
     }

--- a/src/java.desktop/share/classes/javax/swing/JPasswordField.java
+++ b/src/java.desktop/share/classes/javax/swing/JPasswordField.java
@@ -286,8 +286,8 @@ public class JPasswordField extends JTextField {
         // overwrite the old data first
         Document doc = getDocument();
         DocumentFilter filter = null;
-        if (doc instanceof AbstractDocument adoc) {
-            filter = adoc.getDocumentFilter();
+        if (doc instanceof AbstractDocument) {
+            filter = ((AbstractDocument) doc).getDocumentFilter();
         }
         if (filter == null) {
             int nleft = doc.getLength();

--- a/test/jdk/javax/swing/JPasswordField/OldPasswordInDocumentFilter.java
+++ b/test/jdk/javax/swing/JPasswordField/OldPasswordInDocumentFilter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.util.Arrays;
+
+import javax.swing.JPasswordField;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.DocumentFilter;
+import javax.swing.text.PlainDocument;
+
+/**
+ * @test
+ * @bug 8296878
+ * @summary can the old password be accessed in the DocumentFilter
+ */
+public final class OldPasswordInDocumentFilter {
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(OldPasswordInDocumentFilter::test);
+    }
+
+    private static void test() {
+        JPasswordField test = new JPasswordField();
+        PlainDocument document = (PlainDocument) test.getDocument();
+        document.setDocumentFilter(new DocumentFilter() {
+            @Override
+            public void replace(FilterBypass fb, int offset,
+                                int length, String text, AttributeSet attrs)
+                    throws BadLocationException
+            {
+                Document doc = fb.getDocument();
+                String string = doc.getText(0, doc.getLength()) + text;
+                if (string.length() <= 6 && string.matches("[0-9]+")) {
+                    super.replace(fb, offset, length, text, attrs);
+                }
+            }
+        });
+        test.setText("123456");
+        test.setText("");
+
+        char[] password = test.getPassword();
+        if (password.length != 0) {
+            throw new RuntimeException(Arrays.toString(password));
+        }
+    }
+}


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [87f00f4a](https://github.com/openjdk/jdk/commit/87f00f4a1bfb392be0684edcdfa0254caec4ca03) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 30 Nov 2022 and was reviewed by Phil Race and Alexey Ivanov.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296878](https://bugs.openjdk.org/browse/JDK-8296878): Document Filter attached to JPasswordField and setText("") is not cleared instead inserted characters replaced with unicode null characters


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1563/head:pull/1563` \
`$ git checkout pull/1563`

Update a local copy of the PR: \
`$ git checkout pull/1563` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1563`

View PR using the GUI difftool: \
`$ git pr show -t 1563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1563.diff">https://git.openjdk.org/jdk11u-dev/pull/1563.diff</a>

</details>
