### PR TITLE
8297147: UnexpectedSourceImageSize test times out on slow machines when fastdebug is used

### DIFF
--- a/test/jdk/sun/java2d/cmm/ColorConvertOp/UnexpectedSourceImageSize.java
+++ b/test/jdk/sun/java2d/cmm/ColorConvertOp/UnexpectedSourceImageSize.java
@@ -44,6 +44,7 @@ import static java.awt.image.BufferedImage.TYPE_USHORT_GRAY;
  * @test
  * @bug 8264666
  * @summary No exception or errors should occur in ColorConvertOp.filter().
+ * @run main/othervm/timeout=600 UnexpectedSourceImageSize
  */
 public final class UnexpectedSourceImageSize {
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297147](https://bugs.openjdk.org/browse/JDK-8297147): UnexpectedSourceImageSize test times out on slow machines when fastdebug is used


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1564/head:pull/1564` \
`$ git checkout pull/1564`

Update a local copy of the PR: \
`$ git checkout pull/1564` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1564`

View PR using the GUI difftool: \
`$ git pr show -t 1564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1564.diff">https://git.openjdk.org/jdk11u-dev/pull/1564.diff</a>

</details>
