### PR TITLE
8256108: Create implementation for NSAccessibilityElement protocol peer

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -1,4 +1,4 @@
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -1,5 +1,4 @@
-/*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,6 +147,24 @@ static NSObject *sAttributeNamesLOCK = nil;
 - (NSArray *)initializeAttributeNamesWithEnv:(JNIEnv *)env;
 - (NSArray *)accessibilityRowsAttribute;
 - (NSArray *)accessibilityColumnsAttribute;
+@end
+
+
+// In order to use a new NSAccessibility API and since our components
+// are represented as a custom UI elements we need to implement a set
+// of custom protocols. Definitions of these protocols will start here.
+
+// This is a root interface in the NSAccessibility* protocols hierarchy
+// and all the component-specific protocols should be derived from it.
+// It is also a place for the functions that might be exposed by all the
+// component accessibility peers.
+// Please see https://developer.apple.com/documentation/appkit/nsaccessibilityprotocol
+// for more details.
+@interface CommonComponentAccessibility : JavaComponentAccessibility <NSAccessibilityElement> {
+
+}
+- (NSRect)accessibilityFrame;
+- (nullable id)accessibilityParent;
 @end
 
 @implementation JavaComponentAccessibility
@@ -2061,6 +2078,32 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
 - (id)accessibilityColumnCountAttribute {
     return [self getTableInfo:JAVA_AX_COLS];
 }
+@end
+
+@implementation CommonComponentAccessibility
+// NSAccessibilityElement protocol implementation
+- (NSRect)accessibilityFrame
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+    jobject axComponent = JNFCallStaticObjectMethod(env, sjm_getAccessibleComponent,
+                                                    fAccessible, fComponent);
+
+    NSSize size = getAxComponentSize(env, axComponent, fComponent);
+    NSPoint point = getAxComponentLocationOnScreen(env, axComponent, fComponent);
+    (*env)->DeleteLocalRef(env, axComponent);
+    point.y += size.height;
+
+    point.y = [[[[self view] window] screen] frame].size.height - point.y;
+
+    NSRect retval = NSMakeRect(point.x, point.y, size.width, size.height);
+    return retval;
+}
+
+- (nullable id)accessibilityParent
+{
+    return [self accessibilityParentAttribute];
+}
+
 @end
 
 /*


### PR DESCRIPTION
[JDK-8256108](https://bugs.openjdk.org/browse/JDK-8256108) part of 28.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8256108](https://bugs.openjdk.org/browse/JDK-8256108): Create implementation for NSAccessibilityElement protocol peer


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1565/head:pull/1565` \
`$ git checkout pull/1565`

Update a local copy of the PR: \
`$ git checkout pull/1565` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1565`

View PR using the GUI difftool: \
`$ git pr show -t 1565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1565.diff">https://git.openjdk.org/jdk11u-dev/pull/1565.diff</a>

</details>
