### PR TITLE
8293834: Update CLDR data following tzdata 2022c update

### DIFF
--- a/src/jdk.localedata/share/classes/sun/util/cldr/resources/common/bcp47/timezone.xml
+++ b/src/jdk.localedata/share/classes/sun/util/cldr/resources/common/bcp47/timezone.xml
@@ -392,7 +392,7 @@ For terms of use, see http://www.unicode.org/copyright.html
             <type name="tvfun" description="Funafuti, Tuvalu" alias="Pacific/Funafuti"/>
             <type name="twtpe" description="Taipei, Taiwan" alias="Asia/Taipei ROC"/>
             <type name="tzdar" description="Dar es Salaam, Tanzania" alias="Africa/Dar_es_Salaam"/>
-            <type name="uaiev" description="Kiev, Ukraine" alias="Europe/Kiev"/>
+            <type name="uaiev" description="Kyiv, Ukraine" alias="Europe/Kiev Europe/Kyiv"/>
             <type name="uaozh" description="Zaporizhia (Zaporozhye), Ukraine" alias="Europe/Zaporozhye"/>
             <type name="uasip" description="Simferopol, Ukraine" alias="Europe/Simferopol"/>
             <type name="uauzh" description="Uzhhorod (Uzhgorod), Ukraine" alias="Europe/Uzhgorod"/>

--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -23,7 +23,7 @@
 
  /*
  * @test
- * @bug 8181157 8202537 8234347 8236548
+ * @bug 8181157 8202537 8234347 8236548 8293834
  * @modules jdk.localedata
  * @summary Checks CLDR time zone names are generated correctly at runtime
  * @run testng/othervm -Djava.locale.providers=CLDR TimeZoneNamesTest
@@ -102,6 +102,24 @@ public class TimeZoneNamesTest {
                                                     "UTC+04:00",
                                                     "heure : Astrakhan",
                                                     "UTC+04:00"},
+            {"Europe/Kyiv",             Locale.US, "Eastern European Standard Time",
+                                                    "GMT+02:00",
+                                                    "Eastern European Summer Time",
+                                                    "GMT+03:00",
+                                                    "Eastern European Time",
+                                                    "GMT+02:00"},
+            {"Europe/Kyiv",             Locale.FRANCE, "heure normale d\u2019Europe de l\u2019Est",
+                                                    "UTC+02:00",
+                                                    "heure d\u2019\u00e9t\u00e9 d\u2019Europe de l\u2019Est",
+                                                    "UTC+03:00",
+                                                    "heure d\u2019Europe de l\u2019Est",
+                                                    "UTC+02:00"},
+            {"Europe/Kyiv",             Locale.GERMANY, "Osteurop\u00e4ische Normalzeit",
+                                                    "OEZ",
+                                                    "Osteurop\u00e4ische Sommerzeit",
+                                                    "OESZ",
+                                                    "Osteurop\u00e4ische Zeit",
+                                                    "OEZ"},
             {"Europe/Saratov",          Locale.US, "Saratov Standard Time",
                                                     "GMT+04:00",
                                                     "Saratov Daylight Time",


### PR DESCRIPTION
This patch updates the CLDR data following the tzdata bump in JDK-8292579.

This will be handled in trunk by a larger update to CLDRv42.

It differs from the 17u version slightly in the bug ID line in the test, as 11u lacks JDK-8261279, but is otherwise clean and the updated test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293834](https://bugs.openjdk.org/browse/JDK-8293834): Update CLDR data following tzdata 2022c update


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1567/head:pull/1567` \
`$ git checkout pull/1567`

Update a local copy of the PR: \
`$ git checkout pull/1567` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1567`

View PR using the GUI difftool: \
`$ git pr show -t 1567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1567.diff">https://git.openjdk.org/jdk11u-dev/pull/1567.diff</a>

</details>
