### PR TITLE
8256108: Create implementation for NSAccessibilityElement protocol peer

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,11 +30,12 @@
 // <http://archives.java.sun.com/archives/java-access.html> (Sun's mailing list for Java accessibility)
 
 #import "JavaComponentAccessibility.h"
-#import "a11y/CommonComponentAccessibility.h"
+
 #import "sun_lwawt_macosx_CAccessibility.h"
 
 #import <AppKit/AppKit.h>
 
+#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <JavaRuntimeSupport/JavaRuntimeSupport.h>
 
 #import <dlfcn.h>
@@ -43,7 +44,6 @@
 #import "JavaAccessibilityUtilities.h"
 #import "JavaTextAccessibility.h"
 #import "ThreadUtilities.h"
-#import "JNIUtilities.h"
 #import "AWTView.h"
 
 
@@ -53,43 +53,19 @@
 #define JAVA_AX_VISIBLE_CHILDREN (-3)
 // If the value is >=0, it's an index
 
-// GET* macros defined in JavaAccessibilityUtilities.h, so they can be shared.
-static jclass sjc_CAccessibility = NULL;
+static JNF_STATIC_MEMBER_CACHE(jm_getChildrenAndRoles, sjc_CAccessibility, "getChildrenAndRoles", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;IZ)[Ljava/lang/Object;");
+static JNF_STATIC_MEMBER_CACHE(jm_getTableInfo, sjc_CAccessibility, "getTableInfo", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;I)I");
+static JNF_STATIC_MEMBER_CACHE(sjm_getAccessibleComponent, sjc_CAccessibility, "getAccessibleComponent", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleComponent;");
+static JNF_STATIC_MEMBER_CACHE(sjm_getAccessibleValue, sjc_CAccessibility, "getAccessibleValue", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleValue;");
+static JNF_STATIC_MEMBER_CACHE(sjm_getAccessibleName, sjc_CAccessibility, "getAccessibleName", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;");
+static JNF_STATIC_MEMBER_CACHE(sjm_getAccessibleDescription, sjc_CAccessibility, "getAccessibleDescription", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;");
+static JNF_STATIC_MEMBER_CACHE(sjm_isFocusTraversable, sjc_CAccessibility, "isFocusTraversable", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Z");
+static JNF_STATIC_MEMBER_CACHE(sjm_getAccessibleIndexInParent, sjc_CAccessibility, "getAccessibleIndexInParent", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)I");
 
-static jmethodID sjm_getAccessibleName = NULL;
-#define GET_ACCESSIBLENAME_METHOD_RETURN(ret) \
-    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
-    GET_STATIC_METHOD_RETURN(sjm_getAccessibleName, sjc_CAccessibility, "getAccessibleName", \
-                     "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", ret);
+static JNF_CLASS_CACHE(sjc_CAccessible, "sun/lwawt/macosx/CAccessible");
 
-static jmethodID jm_getChildrenAndRoles = NULL;
-#define GET_CHILDRENANDROLES_METHOD_RETURN(ret) \
-    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
-    GET_STATIC_METHOD_RETURN(jm_getChildrenAndRoles, sjc_CAccessibility, "getChildrenAndRoles",\
-                      "(Ljavax/accessibility/Accessible;Ljava/awt/Component;IZ)[Ljava/lang/Object;", ret);
-
-static jmethodID jm_getTableInfo = NULL;
-#define GET_TABLEINFO_METHOD_RETURN(ret) \
-    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
-    GET_STATIC_METHOD_RETURN(jm_getTableInfo, sjc_CAccessibility, "getTableInfo",\
-                      "(Ljavax/accessibility/Accessible;Ljava/awt/Component;IZ)[Ljava/lang/Object;", ret);
-
-static jmethodID sjm_getAccessibleComponent = NULL;
-#define GET_ACCESSIBLECOMPONENT_STATIC_METHOD_RETURN(ret) \
-    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
-    GET_STATIC_METHOD_RETURN(sjm_getAccessibleComponent, sjc_CAccessibility, "getAccessibleComponent", \
-           "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleComponent;", ret);
-
-static jmethodID sjm_getAccessibleIndexInParent = NULL;
-#define GET_ACCESSIBLEINDEXINPARENT_STATIC_METHOD_RETURN(ret) \
-    GET_CACCESSIBILITY_CLASS_RETURN(ret); \
-    GET_STATIC_METHOD_RETURN(sjm_getAccessibleIndexInParent, sjc_CAccessibility, "getAccessibleIndexInParent", \
-                             "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)I", ret);
-
-static jclass sjc_CAccessible = NULL;
-#define GET_CACCESSIBLE_CLASS_RETURN(ret) \
-    GET_CLASS_RETURN(sjc_CAccessible, "sun/lwawt/macosx/CAccessible", ret);
-
+static JNF_MEMBER_CACHE(jf_ptr, sjc_CAccessible, "ptr", "J");
+static JNF_STATIC_MEMBER_CACHE(sjm_getCAccessible, sjc_CAccessible, "getCAccessible", "(Ljavax/accessibility/Accessible;)Lsun/lwawt/macosx/CAccessible;");
 
 static jobject sAccessibilityClass = NULL;
 
@@ -148,6 +124,24 @@ static NSObject *sAttributeNamesLOCK = nil;
 - (NSArray *)initializeAttributeNamesWithEnv:(JNIEnv *)env;
 - (NSArray *)accessibilityRowsAttribute;
 - (NSArray *)accessibilityColumnsAttribute;
+@end
+
+
+// In order to use a new NSAccessibility API and since our components
+// are represented as a custom UI elements we need to implement a set
+// of custom protocols. Definitions of these protocols will start here.
+
+// This is a root interface in the NSAccessibility* protocols hierarchy
+// and all the component-specific protocols should be derived from it.
+// It is also a place for the functions that might be exposed by all the
+// component accessibility peers.
+// Please see https://developer.apple.com/documentation/appkit/nsaccessibilityprotocol
+// for more details.
+@interface CommonComponentAccessibility : JavaComponentAccessibility <NSAccessibilityElement> {
+
+}
+- (NSRect)accessibilityFrame;
+- (nullable id)accessibilityParent;
 @end
 
 @implementation JavaComponentAccessibility
@@ -294,10 +288,7 @@ static NSObject *sAttributeNamesLOCK = nil;
     }
 
     if (sAccessibilityClass == NULL) {
-        JNIEnv *env = [ThreadUtilities getJNIEnv];
-
-        GET_CACCESSIBILITY_CLASS();
-        DECLARE_STATIC_METHOD(jm_getAccessibility, sjc_CAccessibility, "getAccessibility", "([Ljava/lang/String;)Lsun/lwawt/macosx/CAccessibility;");
+        JNF_STATIC_MEMBER_CACHE(jm_getAccessibility, sjc_CAccessibility, "getAccessibility", "([Ljava/lang/String;)Lsun/lwawt/macosx/CAccessibility;");
 
 #ifdef JAVA_AX_NO_IGNORES
         NSArray *ignoredKeys = [NSArray array];
@@ -307,9 +298,10 @@ static NSObject *sAttributeNamesLOCK = nil;
         jobjectArray result = NULL;
         jsize count = [ignoredKeys count];
 
-        DECLARE_CLASS(jc_String, "java/lang/String");
-        result = (*env)->NewObjectArray(env, count, jc_String, NULL);
-        CHECK_EXCEPTION();
+        JNIEnv *env = [ThreadUtilities getJNIEnv];
+
+        static JNF_CLASS_CACHE(jc_String, "java/lang/String");
+        result = JNFNewObjectArray(env, &jc_String, count);
         if (!result) {
             NSLog(@"In %s, can't create Java array of String objects", __FUNCTION__);
             return;
@@ -317,13 +309,12 @@ static NSObject *sAttributeNamesLOCK = nil;
 
         NSInteger i;
         for (i = 0; i < count; i++) {
-            jstring jString = NSStringToJavaString(env, [ignoredKeys objectAtIndex:i]);
+            jstring jString = JNFNSToJavaString(env, [ignoredKeys objectAtIndex:i]);
             (*env)->SetObjectArrayElement(env, result, i, jString);
             (*env)->DeleteLocalRef(env, jString);
         }
 
-        sAccessibilityClass = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibility, result); // AWT_THREADING Safe (known object)
-        CHECK_EXCEPTION();
+        sAccessibilityClass = JNFCallStaticObjectMethod(env, jm_getAccessibility, result); // AWT_THREADING Safe (known object)
     }
 }
 
@@ -334,16 +325,10 @@ static NSObject *sAttributeNamesLOCK = nil;
 }
 
 + (jobject) getCAccessible:(jobject)jaccessible withEnv:(JNIEnv *)env {
-    DECLARE_CLASS_RETURN(sjc_Accessible, "javax/accessibility/Accessible", NULL);
-    GET_CACCESSIBLE_CLASS_RETURN(NULL);
-    DECLARE_STATIC_METHOD_RETURN(sjm_getCAccessible, sjc_CAccessible, "getCAccessible",
-                                "(Ljavax/accessibility/Accessible;)Lsun/lwawt/macosx/CAccessible;", NULL);
-    if ((*env)->IsInstanceOf(env, jaccessible, sjc_CAccessible)) {
+    if (JNFIsInstanceOf(env, jaccessible, &sjc_CAccessible)) {
         return jaccessible;
-    } else if ((*env)->IsInstanceOf(env, jaccessible, sjc_Accessible)) {
-        jobject o = (*env)->CallStaticObjectMethod(env, sjc_CAccessible,  sjm_getCAccessible, jaccessible);
-        CHECK_EXCEPTION();
-        return o;
+    } else if (JNFIsInstanceOf(env, jaccessible, &sjc_Accessible)) {
+        return JNFCallStaticObjectMethod(env, sjm_getCAccessible, jaccessible);
     }
     return NULL;
 }
@@ -351,10 +336,7 @@ static NSObject *sAttributeNamesLOCK = nil;
 + (NSArray *)childrenOfParent:(JavaComponentAccessibility *)parent withEnv:(JNIEnv *)env withChildrenCode:(NSInteger)whichChildren allowIgnored:(BOOL)allowIgnored
 {
     if (parent->fAccessible == NULL) return nil;
-    GET_CHILDRENANDROLES_METHOD_RETURN(nil);
-    jobjectArray jchildrenAndRoles = (jobjectArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getChildrenAndRoles,
-                  parent->fAccessible, parent->fComponent, whichChildren, allowIgnored);
-    CHECK_EXCEPTION();
+    jobjectArray jchildrenAndRoles = (jobjectArray)JNFCallStaticObjectMethod(env, jm_getChildrenAndRoles, parent->fAccessible, parent->fComponent, whichChildren, allowIgnored); // AWT_THREADING Safe (AWTRunLoop)
     if (jchildrenAndRoles == NULL) return nil;
 
     jsize arrayLen = (*env)->GetArrayLength(env, jchildrenAndRoles);
@@ -369,11 +351,8 @@ static NSObject *sAttributeNamesLOCK = nil;
 
         NSString *childJavaRole = nil;
         if (jchildJavaRole != NULL) {
-            DECLARE_CLASS_RETURN(sjc_AccessibleRole, "javax/accessibility/AccessibleRole", nil);
-            DECLARE_FIELD_RETURN(sjf_key, sjc_AccessibleRole, "key", "Ljava/lang/String;", nil);
-            jobject jkey = (*env)->GetObjectField(env, jchildJavaRole, sjf_key);
-            CHECK_EXCEPTION();
-            childJavaRole = JavaStringToNSString(env, jkey);
+            jobject jkey = JNFGetObjectField(env, jchildJavaRole, sjf_key);
+            childJavaRole = JNFJavaToNSString(env, jkey);
             (*env)->DeleteLocalRef(env, jkey);
         }
 
@@ -392,11 +371,9 @@ static NSObject *sAttributeNamesLOCK = nil;
 
 + (JavaComponentAccessibility *)createWithAccessible:(jobject)jaccessible withEnv:(JNIEnv *)env withView:(NSView *)view
 {
-    GET_ACCESSIBLEINDEXINPARENT_STATIC_METHOD_RETURN(nil);
     JavaComponentAccessibility *ret = nil;
     jobject jcomponent = [(AWTView *)view awtComponent:env];
-    jint index = (*env)->CallStaticIntMethod(env, sjc_CAccessibility, sjm_getAccessibleIndexInParent, jaccessible, jcomponent);
-    CHECK_EXCEPTION();
+    jint index = JNFCallStaticIntMethod(env, sjm_getAccessibleIndexInParent, jaccessible, jcomponent);
     if (index >= 0) {
       NSString *javaRole = getJavaRole(env, jaccessible, jcomponent);
       ret = [self createWithAccessible:jaccessible role:javaRole index:index withEnv:env withView:view];
@@ -412,12 +389,10 @@ static NSObject *sAttributeNamesLOCK = nil;
 
 + (JavaComponentAccessibility *) createWithParent:(JavaComponentAccessibility *)parent accessible:(jobject)jaccessible role:(NSString *)javaRole index:(jint)index withEnv:(JNIEnv *)env withView:(NSView *)view
 {
-    GET_CACCESSIBLE_CLASS_RETURN(NULL);
-    DECLARE_FIELD_RETURN(jf_ptr, sjc_CAccessible, "ptr", "J", NULL);
     // try to fetch the jCAX from Java, and return autoreleased
     jobject jCAX = [JavaComponentAccessibility getCAccessible:jaccessible withEnv:env];
     if (jCAX == NULL) return nil;
-    JavaComponentAccessibility *value = (JavaComponentAccessibility *) jlong_to_ptr((*env)->GetLongField(env, jCAX, jf_ptr));
+    JavaComponentAccessibility *value = (JavaComponentAccessibility *) jlong_to_ptr(JNFGetLongField(env, jCAX, jf_ptr));
     if (value != nil) {
         (*env)->DeleteLocalRef(env, jCAX);
         return [[value retain] autorelease];
@@ -425,23 +400,18 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     // otherwise, create a new instance
     JavaComponentAccessibility *newChild = nil;
-    newChild = [CommonComponentAccessibility getComponentAccessibility:javaRole];
-    if (newChild == nil) {
-        if ([javaRole isEqualToString:@"pagetablist"]) {
-            newChild = [TabGroupAccessibility alloc];
-        } else if ([javaRole isEqualToString:@"table"]) {
-            newChild = [TableAccessibility alloc];
-        } else if ([javaRole isEqualToString:@"scrollpane"]) {
-            newChild = [ScrollAreaAccessibility alloc];
+    if ([javaRole isEqualToString:@"pagetablist"]) {
+        newChild = [TabGroupAccessibility alloc];
+    } else if ([javaRole isEqualToString:@"table"]) {
+        newChild = [TableAccessibility alloc];
+    } else if ([javaRole isEqualToString:@"scrollpane"]) {
+        newChild = [ScrollAreaAccessibility alloc];
+    } else {
+        NSString *nsRole = [sRoles objectForKey:javaRole];
+        if ([nsRole isEqualToString:NSAccessibilityStaticTextRole] || [nsRole isEqualToString:NSAccessibilityTextAreaRole] || [nsRole isEqualToString:NSAccessibilityTextFieldRole]) {
+            newChild = [JavaTextAccessibility alloc];
         } else {
-            NSString *nsRole = [sRoles objectForKey:javaRole];
-            if ([nsRole isEqualToString:NSAccessibilityStaticTextRole] ||
-                [nsRole isEqualToString:NSAccessibilityTextAreaRole] ||
-                [nsRole isEqualToString:NSAccessibilityTextFieldRole]) {
-                newChild = [JavaTextAccessibility alloc];
-            } else {
-                newChild = [JavaComponentAccessibility alloc];
-            }
+            newChild = [JavaComponentAccessibility alloc];
         }
     }
 
@@ -458,7 +428,7 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     // must hard retain pointer poked into Java object
     [newChild retain];
-    (*env)->SetLongField(env, jCAX, jf_ptr, ptr_to_jlong(newChild));
+    JNFSetLongField(env, jCAX, jf_ptr, ptr_to_jlong(newChild));
     (*env)->DeleteLocalRef(env, jCAX);
 
     // return autoreleased instance
@@ -467,9 +437,7 @@ static NSObject *sAttributeNamesLOCK = nil;
 
 - (NSArray *)initializeAttributeNamesWithEnv:(JNIEnv *)env
 {
-    GET_CACCESSIBILITY_CLASS_RETURN(nil);
-    DECLARE_STATIC_METHOD_RETURN(jm_getInitialAttributeStates, sjc_CAccessibility, "getInitialAttributeStates",
-                                  "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)[Z", nil);
+    static JNF_STATIC_MEMBER_CACHE(jm_getInitialAttributeStates, sjc_CAccessibility, "getInitialAttributeStates", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)[Z");
 
     NSMutableArray *attributeNames = [NSMutableArray arrayWithCapacity:20];
     [attributeNames retain];
@@ -494,9 +462,7 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     // Get all the other accessibility attributes states we need in one swell foop.
     // javaRole isn't pulled in because we need protected access to AccessibleRole.key
-    jbooleanArray attributeStates = (jbooleanArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
-                     jm_getInitialAttributeStates, fAccessible, fComponent);
-    CHECK_EXCEPTION();
+    jbooleanArray attributeStates = (jbooleanArray)JNFCallStaticObjectMethod(env, jm_getInitialAttributeStates, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     if (attributeStates == NULL) return nil;
     jboolean *attributeStatesArray = (*env)->GetBooleanArrayElements(env, attributeStates, 0);
     if (attributeStatesArray == NULL) {
@@ -588,14 +554,11 @@ static NSObject *sAttributeNamesLOCK = nil;
 
 - (void)getActionsWithEnv:(JNIEnv *)env
 {
-    GET_CACCESSIBILITY_CLASS();
-    DECLARE_STATIC_METHOD(jm_getAccessibleAction, sjc_CAccessibility, "getAccessibleAction",
-                           "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleAction;");
+    static JNF_STATIC_MEMBER_CACHE(jm_getAccessibleAction, sjc_CAccessibility, "getAccessibleAction", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleAction;");
 
     // On MacOSX, text doesn't have actions, in java it does.
     // cmcnote: NOT TRUE - Editable text has AXShowMenu. Textfields have AXConfirm. Static text has no actions.
-    jobject axAction = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibleAction, fAccessible, fComponent);
-    CHECK_EXCEPTION();
+    jobject axAction = JNFCallStaticObjectMethod(env, jm_getAccessibleAction, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     if (axAction != NULL) {
         //+++gdb NOTE: In MacOSX, there is just a single Action, not multiple. In java,
         //  the first one seems to be the most basic, so this will be used.
@@ -614,27 +577,22 @@ static NSObject *sAttributeNamesLOCK = nil;
 
 - (id)parent
 {
+    static JNF_CLASS_CACHE(sjc_Window, "java/awt/Window");
+    static JNF_STATIC_MEMBER_CACHE(sjm_getAccessibleParent, sjc_CAccessibility, "getAccessibleParent", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/Accessible;");
+    static JNF_STATIC_MEMBER_CACHE(sjm_getSwingAccessible, sjc_CAccessible, "getSwingAccessible", "(Ljavax/accessibility/Accessible;)Ljavax/accessibility/Accessible;");
+
     if(fParent == nil) {
         JNIEnv* env = [ThreadUtilities getJNIEnv];
-        GET_CACCESSIBILITY_CLASS_RETURN(nil);
-        DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleParent, sjc_CAccessibility, "getAccessibleParent",
-                                 "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/Accessible;", nil);
-        GET_CACCESSIBLE_CLASS_RETURN(nil);
-        DECLARE_STATIC_METHOD_RETURN(sjm_getSwingAccessible, sjc_CAccessible, "getSwingAccessible",
-                                 "(Ljavax/accessibility/Accessible;)Ljavax/accessibility/Accessible;", nil);
-        DECLARE_CLASS_RETURN(sjc_Window, "java/awt/Window", nil);
 
-        jobject jparent = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,  sjm_getAccessibleParent, fAccessible, fComponent);
-        CHECK_EXCEPTION();
+        jobject jparent = JNFCallStaticObjectMethod(env, sjm_getAccessibleParent, fAccessible, fComponent);
 
         if (jparent == NULL) {
             fParent = fView;
         } else {
             AWTView *view = fView;
-            jobject jax = (*env)->CallStaticObjectMethod(env, sjc_CAccessible, sjm_getSwingAccessible, fAccessible);
-            CHECK_EXCEPTION();
+            jobject jax = JNFCallStaticObjectMethod(env, sjm_getSwingAccessible, fAccessible);
 
-            if ((*env)->IsInstanceOf(env, jax, sjc_Window)) {
+            if (JNFIsInstanceOf(env, jax, &sjc_Window)) {
                 // In this case jparent is an owner toplevel and we should retrieve its own view
                 view = [AWTView awtView:env ofAccessible:jparent];
             }
@@ -840,15 +798,11 @@ static NSObject *sAttributeNamesLOCK = nil;
         return [super accessibilityIndexOfChild:child];
     }
 
-    JNIEnv *env = [ThreadUtilities getJNIEnv];
-    GET_ACCESSIBLEINDEXINPARENT_STATIC_METHOD_RETURN(0);
     jint returnValue =
-        (*env)->CallStaticIntMethod( env,
-                                sjc_CAccessibility,
+        JNFCallStaticIntMethod( [ThreadUtilities getJNIEnv],
                                 sjm_getAccessibleIndexInParent,
                                 ((JavaComponentAccessibility *)child)->fAccessible,
                                 ((JavaComponentAccessibility *)child)->fComponent );
-    CHECK_EXCEPTION();
     return (returnValue == -1) ? NSNotFound : returnValue;
 }
 
@@ -867,12 +821,10 @@ static NSObject *sAttributeNamesLOCK = nil;
 // Flag indicating enabled state of element (NSNumber)
 - (NSNumber *)accessibilityEnabledAttribute
 {
-    JNIEnv* env = [ThreadUtilities getJNIEnv];
-    GET_CACCESSIBILITY_CLASS_RETURN(nil);
-    DECLARE_STATIC_METHOD_RETURN(jm_isEnabled, sjc_CAccessibility, "isEnabled", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Z", nil);
+    static JNF_STATIC_MEMBER_CACHE(jm_isEnabled, sjc_CAccessibility, "isEnabled", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Z");
 
-    NSNumber *value = [NSNumber numberWithBool:(*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, jm_isEnabled, fAccessible, fComponent)];
-    CHECK_EXCEPTION();
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+    NSNumber *value = [NSNumber numberWithBool:JNFCallStaticBooleanMethod(env, jm_isEnabled, fAccessible, fComponent)]; // AWT_THREADING Safe (AWTRunLoop)
     if (value == nil) {
         NSLog(@"WARNING: %s called on component that has no accessible component: %@", __FUNCTION__, self);
     }
@@ -896,32 +848,25 @@ static NSObject *sAttributeNamesLOCK = nil;
 - (BOOL)accessibilityIsFocusedAttributeSettable
 {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
-    GET_CACCESSIBILITY_CLASS_RETURN(NO);
-    DECLARE_STATIC_METHOD_RETURN(sjm_isFocusTraversable, sjc_CAccessibility, "isFocusTraversable",
-                                 "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Z", NO);
     // According to javadoc, a component that is focusable will return true from isFocusTraversable,
     // as well as having AccessibleState.FOCUSABLE in its AccessibleStateSet.
     // We use the former heuristic; if the component focus-traversable, add a focused attribute
     // See also initializeAttributeNamesWithEnv:
-    if ((*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, sjm_isFocusTraversable, fAccessible, fComponent)) {
+    if (JNFCallStaticBooleanMethod(env, sjm_isFocusTraversable, fAccessible, fComponent)) { // AWT_THREADING Safe (AWTRunLoop)
         return YES;
     }
-    CHECK_EXCEPTION();
 
     return NO;
 }
 
 - (void)accessibilitySetFocusedAttribute:(id)value
 {
-    JNIEnv* env = [ThreadUtilities getJNIEnv];
-
-    GET_CACCESSIBILITY_CLASS();
-    DECLARE_STATIC_METHOD(jm_requestFocus, sjc_CAccessibility, "requestFocus", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)V");
+    static JNF_STATIC_MEMBER_CACHE(jm_requestFocus, sjc_CAccessibility, "requestFocus", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)V");
 
     if ([(NSNumber*)value boolValue])
     {
-        (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_requestFocus, fAccessible, fComponent);
-        CHECK_EXCEPTION();
+        JNIEnv* env = [ThreadUtilities getJNIEnv];
+        JNFCallStaticVoidMethod(env, jm_requestFocus, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     }
 }
 
@@ -930,16 +875,11 @@ static NSObject *sAttributeNamesLOCK = nil;
 {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
 
-    GET_CACCESSIBILITY_CLASS_RETURN(nil);
-    DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleDescription, sjc_CAccessibility, "getAccessibleDescription",
-                                 "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", nil);
-    jobject val = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
-                                   sjm_getAccessibleDescription, fAccessible, fComponent);
-    CHECK_EXCEPTION();
+    jobject val = JNFCallStaticObjectMethod(env, sjm_getAccessibleDescription, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     if (val == NULL) {
         return nil;
     }
-    NSString* str = JavaStringToNSString(env, val);
+    NSString* str = JNFJavaToNSString(env, val);
     (*env)->DeleteLocalRef(env, val);
     return str;
 }
@@ -961,46 +901,18 @@ static NSObject *sAttributeNamesLOCK = nil;
     return NO;
 }
 
-/*
- * The java/lang/Number concrete class could be for any of the Java primitive
- * numerical types or some other subclass.
- * All existing A11Y code uses Integer so that is what we look for first
- * But all must be able to return a double and NSNumber accepts a double,
- * so that's the fall back.
- */
-static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
-    if (jnumber == NULL) {
-        return nil;
-    }
-    DECLARE_CLASS_RETURN(jnumber_Class, "java/lang/Number", nil);
-    DECLARE_CLASS_RETURN(jinteger_Class, "java/lang/Integer", nil);
-    DECLARE_METHOD_RETURN(jm_intValue, jnumber_Class, "intValue", "()I", nil);
-    DECLARE_METHOD_RETURN(jm_doubleValue, jnumber_Class, "doubleValue", "()D", nil);
-    if ((*env)->IsInstanceOf(env, jnumber, jinteger_Class)) {
-        jint i = (*env)->CallIntMethod(env, jnumber, jm_intValue);
-        CHECK_EXCEPTION();
-        return [NSNumber numberWithInteger:i];
-    } else {
-        jdouble d = (*env)->CallDoubleMethod(env, jnumber, jm_doubleValue);
-        CHECK_EXCEPTION();
-        return [NSNumber numberWithDouble:d];
-    }
-}
-
 // Element's maximum value (id)
 - (id)accessibilityMaxValueAttribute
 {
-    JNIEnv* env = [ThreadUtilities getJNIEnv];
-    GET_CACCESSIBILITY_CLASS_RETURN(nil);
-    DECLARE_STATIC_METHOD_RETURN(jm_getMaximumAccessibleValue, sjc_CAccessibility, "getMaximumAccessibleValue",
-                                  "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/Number;", nil);
+    static JNF_STATIC_MEMBER_CACHE(jm_getMaximumAccessibleValue, sjc_CAccessibility, "getMaximumAccessibleValue", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/Number;");
 
-    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getMaximumAccessibleValue, fAccessible, fComponent);
-    CHECK_EXCEPTION();
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+
+    jobject axValue = JNFCallStaticObjectMethod(env, jm_getMaximumAccessibleValue, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     if (axValue == NULL) {
         return [NSNumber numberWithInt:0];
     }
-    NSNumber* num = JavaNumberToNSNumber(env, axValue);
+    NSNumber* num = JNFJavaToNSNumber(env, axValue);
     (*env)->DeleteLocalRef(env, axValue);
     return num;
 }
@@ -1013,17 +925,15 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
 // Element's minimum value (id)
 - (id)accessibilityMinValueAttribute
 {
-    JNIEnv* env = [ThreadUtilities getJNIEnv];
-    GET_CACCESSIBILITY_CLASS_RETURN(nil);
-    DECLARE_STATIC_METHOD_RETURN(jm_getMinimumAccessibleValue, sjc_CAccessibility, "getMinimumAccessibleValue",
-                                  "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/Number;", nil);
+    static JNF_STATIC_MEMBER_CACHE(jm_getMinimumAccessibleValue, sjc_CAccessibility, "getMinimumAccessibleValue", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/Number;");
 
-    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getMinimumAccessibleValue, fAccessible, fComponent);
-    CHECK_EXCEPTION();
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+
+    jobject axValue = JNFCallStaticObjectMethod(env, jm_getMinimumAccessibleValue, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     if (axValue == NULL) {
         return [NSNumber numberWithInt:0];
     }
-    NSNumber* num = JavaNumberToNSNumber(env, axValue);
+    NSNumber* num = JNFJavaToNSNumber(env, axValue);
     (*env)->DeleteLocalRef(env, axValue);
     return num;
 }
@@ -1073,10 +983,7 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
 - (NSValue *)accessibilityPositionAttribute
 {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
-    GET_ACCESSIBLECOMPONENT_STATIC_METHOD_RETURN(nil);
-    jobject axComponent = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleComponent,
-                           fAccessible, fComponent);
-    CHECK_EXCEPTION();
+    jobject axComponent = JNFCallStaticObjectMethod(env, sjm_getAccessibleComponent, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
 
     // NSAccessibility wants the bottom left point of the object in
     // bottom left based screen coords
@@ -1137,16 +1044,13 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
 
     if (value == nil) {
         // query java if necessary
+        static JNF_STATIC_MEMBER_CACHE(jm_getAccessibleRoleDisplayString, sjc_CAccessibility, "getAccessibleRoleDisplayString", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;");
+
         JNIEnv* env = [ThreadUtilities getJNIEnv];
-        GET_CACCESSIBILITY_CLASS_RETURN(nil);
-        DECLARE_STATIC_METHOD_RETURN(jm_getAccessibleRoleDisplayString, sjc_CAccessibility, "getAccessibleRoleDisplayString",
-                                     "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", nil);
 
-
-        jobject axRole = (*env)->CallStaticObjectMethod(env, jm_getAccessibleRoleDisplayString, fAccessible, fComponent);
-        CHECK_EXCEPTION();
+        jobject axRole = JNFCallStaticObjectMethod(env, jm_getAccessibleRoleDisplayString, fAccessible, fComponent);
         if (axRole != NULL) {
-            value = JavaStringToNSString(env, axRole);
+            value = JNFJavaToNSString(env, axRole);
             (*env)->DeleteLocalRef(env, axRole);
         } else {
             value = @"unknown";
@@ -1194,26 +1098,21 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
 
 - (void)accessibilitySetSelectedAttribute:(id)value
 {
-   JNIEnv* env = [ThreadUtilities getJNIEnv];
-    GET_CACCESSIBILITY_CLASS();
-    DECLARE_STATIC_METHOD(jm_requestSelection,
-                          sjc_CAccessibility,
-                          "requestSelection",
-                          "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)V");
+    static JNF_STATIC_MEMBER_CACHE( jm_requestSelection,
+                                    sjc_CAccessibility,
+                                    "requestSelection",
+                                    "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)V" );
 
     if ([(NSNumber*)value boolValue]) {
-        (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_requestSelection, fAccessible, fComponent);
-        CHECK_EXCEPTION();
+        JNIEnv* env = [ThreadUtilities getJNIEnv];
+        JNFCallStaticVoidMethod(env, jm_requestSelection, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     }
 }
 
 // Element size (NSValue)
 - (NSValue *)accessibilitySizeAttribute {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
-    GET_ACCESSIBLECOMPONENT_STATIC_METHOD_RETURN(nil);
-    jobject axComponent = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
-                           sjm_getAccessibleComponent, fAccessible, fComponent);
-    CHECK_EXCEPTION();
+    jobject axComponent = JNFCallStaticObjectMethod(env, sjm_getAccessibleComponent, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     NSValue* size = [NSValue valueWithSize:getAxComponentSize(env, axComponent, fComponent)];
     (*env)->DeleteLocalRef(env, axComponent);
     return size;
@@ -1273,13 +1172,11 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
 
     JNIEnv* env = [ThreadUtilities getJNIEnv];
 
-    GET_ACCESSIBLENAME_METHOD_RETURN(nil);
-    jobject val = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleName, fAccessible, fComponent);
-    CHECK_EXCEPTION();
+    jobject val = JNFCallStaticObjectMethod(env, sjm_getAccessibleName, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     if (val == NULL) {
         return nil;
     }
-    NSString* str = JavaStringToNSString(env, val);
+    NSString* str = JNFJavaToNSString(env, val);
     (*env)->DeleteLocalRef(env, val);
     return str;
 }
@@ -1305,6 +1202,8 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
 // (https://docs.oracle.com/javase/8/docs/api/javax/accessibility/AccessibleValue.html#setCurrentAccessibleValue-java.lang.Number-)
 - (id)accessibilityValueAttribute
 {
+    static JNF_STATIC_MEMBER_CACHE(jm_getCurrentAccessibleValue, sjc_CAccessibility, "getCurrentAccessibleValue", "(Ljavax/accessibility/AccessibleValue;Ljava/awt/Component;)Ljava/lang/Number;");
+
     JNIEnv* env = [ThreadUtilities getJNIEnv];
 
     // Need to handle popupmenus differently.
@@ -1329,18 +1228,15 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
             JavaComponentAccessibility *selectedMenuItem =
                 [selectedChildrenOfMenu objectAtIndex:0];
             if (selectedMenuItem != nil) {
-                GET_CACCESSIBILITY_CLASS_RETURN(nil);
-                GET_ACCESSIBLENAME_METHOD_RETURN(nil);
                 jobject itemValue =
-                        (*env)->CallStaticObjectMethod( env,
+                        JNFCallStaticObjectMethod( env,
                                                    sjm_getAccessibleName,
                                                    selectedMenuItem->fAccessible,
-                                                   selectedMenuItem->fComponent );
-                CHECK_EXCEPTION();
+                                                   selectedMenuItem->fComponent ); // AWT_THREADING Safe (AWTRunLoop)
                 if (itemValue == NULL) {
                     return nil;
                 }
-                NSString* itemString = JavaStringToNSString(env, itemValue);
+                NSString* itemString = JNFJavaToNSString(env, itemValue);
                 (*env)->DeleteLocalRef(env, itemValue);
                 return itemString;
             } else {
@@ -1354,18 +1250,11 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
 
     // cmcnote should coalesce these calls into one java call
     NSNumber *num = nil;
-    GET_CACCESSIBILITY_CLASS_RETURN(nil);
-    DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleValue, sjc_CAccessibility, "getAccessibleValue",
-                "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleValue;", nil);
-    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleValue, fAccessible, fComponent);
-    CHECK_EXCEPTION();
+    jobject axValue = JNFCallStaticObjectMethod(env, sjm_getAccessibleValue, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     if (axValue != NULL) {
-        DECLARE_STATIC_METHOD_RETURN(jm_getCurrentAccessibleValue, sjc_CAccessibility, "getCurrentAccessibleValue",
-                                     "(Ljavax/accessibility/AccessibleValue;Ljava/awt/Component;)Ljava/lang/Number;", nil);
-        jobject str = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getCurrentAccessibleValue, axValue, fComponent);
-        CHECK_EXCEPTION();
+        jobject str = JNFCallStaticObjectMethod(env, jm_getCurrentAccessibleValue, axValue, fComponent);
         if (str != NULL) {
-            num = JavaNumberToNSNumber(env, str);
+            num = JNFJavaToNSNumber(env, str); // AWT_THREADING Safe (AWTRunLoop)
             (*env)->DeleteLocalRef(env, str);
         }
         (*env)->DeleteLocalRef(env, axValue);
@@ -1461,10 +1350,8 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
 
 - (id)accessibilityHitTest:(NSPoint)point withEnv:(JNIEnv *)env
 {
-    GET_CACCESSIBILITY_CLASS_RETURN(nil);
-    DECLARE_CLASS_RETURN(jc_Container, "java/awt/Container", nil);
-    DECLARE_STATIC_METHOD_RETURN(jm_accessibilityHitTest, sjc_CAccessibility, "accessibilityHitTest",
-                                 "(Ljava/awt/Container;FF)Ljavax/accessibility/Accessible;", nil);
+    static JNF_CLASS_CACHE(jc_Container, "java/awt/Container");
+    static JNF_STATIC_MEMBER_CACHE(jm_accessibilityHitTest, sjc_CAccessibility, "accessibilityHitTest", "(Ljava/awt/Container;FF)Ljavax/accessibility/Accessible;");
 
     // Make it into java screen coords
     point.y = [[[[self view] window] screen] frame].size.height - point.y;
@@ -1472,10 +1359,8 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
     jobject jparent = fComponent;
 
     id value = nil;
-    if ((*env)->IsInstanceOf(env, jparent, jc_Container)) {
-        jobject jaccessible = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_accessibilityHitTest,
-                               jparent, (jfloat)point.x, (jfloat)point.y);
-        CHECK_EXCEPTION();
+    if (JNFIsInstanceOf(env, jparent, &jc_Container)) {
+        jobject jaccessible = JNFCallStaticObjectMethod(env, jm_accessibilityHitTest, jparent, (jfloat)point.x, (jfloat)point.y); // AWT_THREADING Safe (AWTRunLoop)
         if (jaccessible != NULL) {
             value = [JavaComponentAccessibility createWithAccessible:jaccessible withEnv:env withView:fView];
             (*env)->DeleteLocalRef(env, jaccessible);
@@ -1498,23 +1383,19 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
 
 - (id)accessibilityFocusedUIElement
 {
+    static JNF_STATIC_MEMBER_CACHE(jm_getFocusOwner, sjc_CAccessibility, "getFocusOwner", "(Ljava/awt/Component;)Ljavax/accessibility/Accessible;");
+
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    GET_CACCESSIBILITY_CLASS_RETURN(nil);
-    DECLARE_STATIC_METHOD_RETURN(jm_getFocusOwner, sjc_CAccessibility, "getFocusOwner",
-                                  "(Ljava/awt/Component;)Ljavax/accessibility/Accessible;", nil);
     id value = nil;
 
     NSWindow* hostWindow = [[self->fView window] retain];
-    jobject focused = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getFocusOwner, fComponent);
+    jobject focused = JNFCallStaticObjectMethod(env, jm_getFocusOwner, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     [hostWindow release];
-    CHECK_EXCEPTION();
 
     if (focused != NULL) {
-        DECLARE_CLASS_RETURN(sjc_Accessible, "javax/accessibility/Accessible", nil);
-        if ((*env)->IsInstanceOf(env, focused, sjc_Accessible)) {
+        if (JNFIsInstanceOf(env, focused, &sjc_Accessible)) {
             value = [JavaComponentAccessibility createWithAccessible:focused withEnv:env withView:fView];
         }
-        CHECK_EXCEPTION();
         (*env)->DeleteLocalRef(env, focused);
     }
 
@@ -1537,23 +1418,10 @@ static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessibility_focusChanged
 (JNIEnv *env, jobject jthis)
 {
-JNI_COCOA_ENTER(env);
+JNF_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postFocusChanged:) on:[JavaComponentAccessibility class] withObject:nil waitUntilDone:NO];
-JNI_COCOA_EXIT(env);
+JNF_COCOA_EXIT(env);
 }
-
-/*
- * Class:     sun_lwawt_macosx_CAccessible
- * Method:    titleChanged
- * Signature: (I)V
- */
- JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_titleChanged
- (JNIEnv *env, jclass jklass, jlong element)
- {
-JNI_COCOA_ENTER(env);
-    [ThreadUtilities performOnMainThread:@selector(postTitleChanged) on:(JavaComponentAccessibility*)jlong_to_ptr(element) withObject:nil waitUntilDone:NO];
-JNI_COCOA_EXIT(env);
- }
 
 /*
  * Class:     sun_lwawt_macosx_CAccessible
@@ -1563,9 +1431,9 @@ JNI_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_valueChanged
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNI_COCOA_ENTER(env);
+JNF_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postValueChanged) on:(JavaComponentAccessibility *)jlong_to_ptr(element) withObject:nil waitUntilDone:NO];
-JNI_COCOA_EXIT(env);
+JNF_COCOA_EXIT(env);
 }
 
 /*
@@ -1576,12 +1444,12 @@ JNI_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_selectedTextChanged
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNI_COCOA_ENTER(env);
+JNF_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postSelectedTextChanged)
                      on:(JavaComponentAccessibility *)jlong_to_ptr(element)
                      withObject:nil
                      waitUntilDone:NO];
-JNI_COCOA_EXIT(env);
+JNF_COCOA_EXIT(env);
 }
 
 /*
@@ -1592,10 +1460,23 @@ JNI_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_selectionChanged
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNI_COCOA_ENTER(env);
+JNF_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postSelectionChanged) on:(JavaComponentAccessibility *)jlong_to_ptr(element) withObject:nil waitUntilDone:NO];
-JNI_COCOA_EXIT(env);
+JNF_COCOA_EXIT(env);
 }
+
+/*
+ * Class:     sun_lwawt_macosx_CAccessible
+ * Method:    titleChanged
+ * Signature: (I)V
+ */
+ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_titleChanged
+ (JNIEnv *env, jclass jklass, jlong element)
+ {
+JNF_COCOA_ENTER(env);
+    [ThreadUtilities performOnMainThread:@selector(postTitleChanged) on:(JavaComponentAccessibility*)jlong_to_ptr(element) withObject:nil waitUntilDone:NO];
+JNF_COCOA_EXIT(env);
+ }
 
 /*
  * Class:     sun_lwawt_macosx_CAccessible
@@ -1605,12 +1486,12 @@ JNI_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_menuOpened
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNI_COCOA_ENTER(env);
+JNF_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postMenuOpened)
                      on:(JavaComponentAccessibility *)jlong_to_ptr(element)
                      withObject:nil
                      waitUntilDone:NO];
-JNI_COCOA_EXIT(env);
+JNF_COCOA_EXIT(env);
 }
 
 /*
@@ -1621,12 +1502,12 @@ JNI_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_menuClosed
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNI_COCOA_ENTER(env);
+JNF_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postMenuClosed)
                      on:(JavaComponentAccessibility *)jlong_to_ptr(element)
                      withObject:nil
                      waitUntilDone:NO];
-JNI_COCOA_EXIT(env);
+JNF_COCOA_EXIT(env);
 }
 
 /*
@@ -1637,12 +1518,12 @@ JNI_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_menuItemSelected
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNI_COCOA_ENTER(env);
+JNF_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postMenuItemSelected)
                      on:(JavaComponentAccessibility *)jlong_to_ptr(element)
                      withObject:nil
                      waitUntilDone:NO];
-JNI_COCOA_EXIT(env);
+JNF_COCOA_EXIT(env);
 }
 
 /*
@@ -1653,9 +1534,9 @@ JNI_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_unregisterFromCocoaAXSystem
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNI_COCOA_ENTER(env);
+JNF_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(unregisterFromCocoaAXSystem) on:(JavaComponentAccessibility *)jlong_to_ptr(element) withObject:nil waitUntilDone:NO];
-JNI_COCOA_EXIT(env);
+JNF_COCOA_EXIT(env);
 }
 
 @implementation TabGroupAccessibility
@@ -1705,10 +1586,7 @@ JNI_COCOA_EXIT(env);
 
 - (NSArray *)tabControlsWithEnv:(JNIEnv *)env withTabGroupAxContext:(jobject)axContext withTabCode:(NSInteger)whichTabs allowIgnored:(BOOL)allowIgnored
 {
-    GET_CHILDRENANDROLES_METHOD_RETURN(nil);
-    jobjectArray jtabsAndRoles = (jobjectArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getChildrenAndRoles,
-                                  fAccessible, fComponent, whichTabs, allowIgnored);
-    CHECK_EXCEPTION();
+    jobjectArray jtabsAndRoles = (jobjectArray)JNFCallStaticObjectMethod(env, jm_getChildrenAndRoles, fAccessible, fComponent, whichTabs, allowIgnored); // AWT_THREADING Safe (AWTRunLoop)
     if(jtabsAndRoles == NULL) return nil;
 
     jsize arrayLen = (*env)->GetArrayLength(env, jtabsAndRoles);
@@ -1724,11 +1602,8 @@ JNI_COCOA_EXIT(env);
         (*env)->DeleteLocalRef(env, jtabsAndRoles);
         return nil;
     }
-    DECLARE_CLASS_RETURN(sjc_AccessibleRole, "javax/accessibility/AccessibleRole", nil);
-    DECLARE_FIELD_RETURN(sjf_key, sjc_AccessibleRole, "key", "Ljava/lang/String;", nil);
-    jobject jkey = (*env)->GetObjectField(env, jtabJavaRole, sjf_key);
-    CHECK_EXCEPTION();
-    NSString *tabJavaRole = JavaStringToNSString(env, jkey);
+    jobject jkey = JNFGetObjectField(env, jtabJavaRole, sjf_key);
+    NSString *tabJavaRole = JNFJavaToNSString(env, jkey);
     (*env)->DeleteLocalRef(env, jkey);
 
     NSInteger i;
@@ -1870,8 +1745,7 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
     self = [super initWithParent:parent withEnv:env withAccessible:accessible withIndex:index withView:view withJavaRole:javaRole];
     if (self) {
         if (tabGroup != NULL) {
-            fTabGroupAxContext = (*env)->NewWeakGlobalRef(env, tabGroup);
-            CHECK_EXCEPTION();
+            fTabGroupAxContext = JNFNewWeakGlobalRef(env, tabGroup);
         } else {
             fTabGroupAxContext = NULL;
         }
@@ -1884,7 +1758,7 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
     JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
 
     if (fTabGroupAxContext != NULL) {
-        (*env)->DeleteWeakGlobalRef(env, fTabGroupAxContext);
+        JNFDeleteWeakGlobalRef(env, fTabGroupAxContext);
         fTabGroupAxContext = NULL;
     }
 
@@ -1917,8 +1791,7 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
     if (fTabGroupAxContext == NULL) {
         JNIEnv* env = [ThreadUtilities getJNIEnv];
         jobject tabGroupAxContext = [(JavaComponentAccessibility *)[self parent] axContextWithEnv:env];
-        fTabGroupAxContext = (*env)->NewWeakGlobalRef(env, tabGroupAxContext);
-        CHECK_EXCEPTION();
+        fTabGroupAxContext = JNFNewWeakGlobalRef(env, tabGroupAxContext);
         (*env)->DeleteLocalRef(env, tabGroupAxContext);
     }
     return fTabGroupAxContext;
@@ -2045,10 +1918,8 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
     if (fAccessible == NULL) return 0;
 
     JNIEnv* env = [ThreadUtilities getJNIEnv];
-    GET_TABLEINFO_METHOD_RETURN(nil);
-    jint count = (*env)->CallStaticIntMethod(env, jm_getTableInfo, fAccessible,
-                                             fComponent, info);
-    CHECK_EXCEPTION();
+    jint count = JNFCallStaticIntMethod(env, jm_getTableInfo, fAccessible,
+                                        fComponent, info);
     NSNumber *index = [NSNumber numberWithInt:count];
     return index;
 }
@@ -2063,29 +1934,51 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
 }
 @end
 
+@implementation CommonComponentAccessibility
+// NSAccessibilityElement protocol implementation
+- (NSRect)accessibilityFrame
+{
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+    jobject axComponent = JNFCallStaticObjectMethod(env, sjm_getAccessibleComponent,
+                                                    fAccessible, fComponent);
+
+    NSSize size = getAxComponentSize(env, axComponent, fComponent);
+    NSPoint point = getAxComponentLocationOnScreen(env, axComponent, fComponent);
+    (*env)->DeleteLocalRef(env, axComponent);
+    point.y += size.height;
+
+    point.y = [[[[self view] window] screen] frame].size.height - point.y;
+
+    NSRect retval = NSMakeRect(point.x, point.y, size.width, size.height);
+    return retval;
+}
+
+- (nullable id)accessibilityParent
+{
+    return [self accessibilityParentAttribute];
+}
+
+@end
+
 /*
  * Returns Object.equals for the two items
  * This may use LWCToolkit.invokeAndWait(); don't call while holding fLock
  * and try to pass a component so the event happens on the correct thread.
  */
+static JNF_CLASS_CACHE(sjc_Object, "java/lang/Object");
 static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component)
 {
-    DECLARE_CLASS_RETURN(sjc_Object, "java/lang/Object", NO);
-    DECLARE_METHOD_RETURN(jm_equals, sjc_Object, "equals", "(Ljava/lang/Object;)Z", NO);
+    static JNF_MEMBER_CACHE(jm_equals, sjc_Object, "equals", "(Ljava/lang/Object;)Z");
 
     if ((a == NULL) && (b == NULL)) return YES;
     if ((a == NULL) || (b == NULL)) return NO;
 
     if (pthread_main_np() != 0) {
         // If we are on the AppKit thread
-        DECLARE_CLASS_RETURN(sjc_LWCToolkit, "sun/lwawt/macosx/LWCToolkit", NO);
-        DECLARE_STATIC_METHOD_RETURN(jm_doEquals, sjc_LWCToolkit, "doEquals",
-                                     "(Ljava/lang/Object;Ljava/lang/Object;Ljava/awt/Component;)Z", NO);
-        return (*env)->CallStaticBooleanMethod(env, sjc_LWCToolkit, jm_doEquals, a, b, component);
-        CHECK_EXCEPTION();
+        static JNF_CLASS_CACHE(sjc_LWCToolkit, "sun/lwawt/macosx/LWCToolkit");
+        static JNF_STATIC_MEMBER_CACHE(jm_doEquals, sjc_LWCToolkit, "doEquals", "(Ljava/lang/Object;Ljava/lang/Object;Ljava/awt/Component;)Z");
+        return JNFCallStaticBooleanMethod(env, jm_doEquals, a, b, component); // AWT_THREADING Safe (AWTRunLoopMode)
     }
 
-    jboolean jb = (*env)->CallBooleanMethod(env, a, jm_equals, b);
-    CHECK_EXCEPTION();
-    return jb;
+    return JNFCallBooleanMethod(env, a, jm_equals, b); // AWT_THREADING Safe (!appKit)
 }


### PR DESCRIPTION
Clean backport [JDK-8256108](https://bugs.openjdk.org/browse/JDK-8256108) part of 28.


by: Autumn808 <AutumnCapasso@gmail.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8256108](https://bugs.openjdk.org/browse/JDK-8256108): Create implementation for NSAccessibilityElement protocol peer ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1569/head:pull/1569` \
`$ git checkout pull/1569`

Update a local copy of the PR: \
`$ git checkout pull/1569` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1569`

View PR using the GUI difftool: \
`$ git pr show -t 1569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1569.diff">https://git.openjdk.org/jdk11u-dev/pull/1569.diff</a>

</details>
