### PR TITLE
8256126: Create implementation for NSAccessibilityImage protocol peer

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -217,7 +217,7 @@ void VM_Version::initialize() {
       UseAES = true;
     }
     if (FLAG_IS_DEFAULT(UseAESCTRIntrinsics)) {
-      FLAG_SET_DEFAULT(UseAESCTRIntrinsics, false);
+      FLAG_SET_DEFAULT(UseAESCTRIntrinsics, true);
     }
   } else {
     if (UseAES) {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -46,9 +46,11 @@ static NSMutableDictionary * _Nullable rolesMap;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:1];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:3];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
+    [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
+    [rolesMap setObject:@"ImageAccessibility" forKey:@"desktopicon"];
 }
 
 /*

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "JavaComponentAccessibility.h"
+#import "CommonComponentAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface ImageAccessibility : CommonComponentAccessibility <NSAccessibilityImage> {
+
+};
+- (nullable NSString *)accessibilityLabel;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.m
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "ImageAccessibility.h"
+
+/*
+ * Implementation of the accessibility peer for the icon role
+ */
+@implementation ImageAccessibility
+- (nullable NSString *)accessibilityLabel
+{
+    return [self accessibilityTitleAttribute];
+}
+
+@end

--- a/test/jdk/sun/java2d/cmm/ColorConvertOp/UnexpectedSourceImageSize.java
+++ b/test/jdk/sun/java2d/cmm/ColorConvertOp/UnexpectedSourceImageSize.java
@@ -44,6 +44,7 @@ import static java.awt.image.BufferedImage.TYPE_USHORT_GRAY;
  * @test
  * @bug 8264666
  * @summary No exception or errors should occur in ColorConvertOp.filter().
+ * @run main/othervm/timeout=600 UnexpectedSourceImageSize
  */
 public final class UnexpectedSourceImageSize {
 


### PR DESCRIPTION
clean backport [JDK-8256126](https://bugs.openjdk.org/browse/JDK-8256126) 3 of 28.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8256126](https://bugs.openjdk.org/browse/JDK-8256126): Create implementation for NSAccessibilityImage protocol peer


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1572/head:pull/1572` \
`$ git checkout pull/1572`

Update a local copy of the PR: \
`$ git checkout pull/1572` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1572`

View PR using the GUI difftool: \
`$ git pr show -t 1572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1572.diff">https://git.openjdk.org/jdk11u-dev/pull/1572.diff</a>

</details>
