### PR TITLE
8261350: Create implementation for NSAccessibilityCheckBox protocol peer

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/SystemMetrics.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/SystemMetrics.java
@@ -22,10 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package jdk.internal.platform;
 
-public class SystemMetrics {
-    public static Metrics instance() {
-        return CgroupMetrics.getInstance();
-    }
-}
+#import "ButtonAccessibility.h"
+
+@interface RadiobuttonAccessibility : ButtonAccessibility <NSAccessibilityRadioButton> {
+
+};
+- (id)accessibilityValue;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.h
@@ -23,19 +23,10 @@
  * questions.
  */
 
-#import "RadiobuttonAccessibility.h"
-#import "JNIUtilities.h"
-#import "ThreadUtilities.h"
+#import "ButtonAccessibility.h"
 
-/*
- * Implementation of the accessibility peer for the radiobutton role
- */
-@implementation RadiobuttonAccessibility
+@interface CheckboxAccessibility : ButtonAccessibility <NSAccessibilityCheckBox> {
 
-- (id) accessibilityValue
-{
-    AWT_ASSERT_APPKIT_THREAD;
-    return [self accessibilityValueAttribute];
-}
-
+};
+- (id)accessibilityValue;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.m
@@ -23,14 +23,14 @@
  * questions.
  */
 
-#import "RadiobuttonAccessibility.h"
+#import "CheckboxAccessibility.h"
 #import "JNIUtilities.h"
 #import "ThreadUtilities.h"
 
 /*
- * Implementation of the accessibility peer for the radiobutton role
+ * Implementation of the accessibility peer for the checkbox role
  */
-@implementation RadiobuttonAccessibility
+@implementation CheckboxAccessibility
 
 - (id) accessibilityValue
 {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -46,9 +46,16 @@ static NSMutableDictionary * _Nullable rolesMap;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:1];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:8];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
+    [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
+    [rolesMap setObject:@"ImageAccessibility" forKey:@"desktopicon"];
+    [rolesMap setObject:@"SpinboxAccessibility" forKey:@"spinbox"];
+    [rolesMap setObject:@"StaticTextAccessibility" forKey:@"hyperlink"];
+    [rolesMap setObject:@"StaticTextAccessibility" forKey:@"label"];
+    [rolesMap setObject:@"RadiobuttonAccessibility" forKey:@"radiobutton"];
+    [rolesMap setObject:@"CheckboxAccessibility" forKey:@"checkbox"];
 }
 
 /*
@@ -58,7 +65,6 @@ static NSMutableDictionary * _Nullable rolesMap;
 + (JavaComponentAccessibility *) getComponentAccessibility:(NSString *)role
 {
     AWT_ASSERT_APPKIT_THREAD;
-
     if (rolesMap == nil) {
         [self initializeRolesMap];
     }
@@ -93,6 +99,22 @@ static NSMutableDictionary * _Nullable rolesMap;
 - (nullable id)accessibilityParent
 {
     return [self accessibilityParentAttribute];
+}
+
+// AccessibleAction support
+- (BOOL)performAccessibleAction:(int)index
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+
+    GET_CACCESSIBILITY_CLASS_RETURN(FALSE);
+    DECLARE_STATIC_METHOD_RETURN(jm_doAccessibleAction, sjc_CAccessibility, "doAccessibleAction",
+                                 "(Ljavax/accessibility/AccessibleAction;ILjava/awt/Component;)V", FALSE);
+    (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_doAccessibleAction,
+                                 [self axContextWithEnv:(env)], index, fComponent);
+    CHECK_EXCEPTION();
+
+    return TRUE;
 }
 
 @end


### PR DESCRIPTION
[JDK-8261350](https://bugs.openjdk.org/browse/JDK-8261350) Merge conflict in file java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.m had to changed initWithCapacity. One of a series of 28 https://bugs.openjdk.org/browse/JDK-8152350

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8261350](https://bugs.openjdk.org/browse/JDK-8261350): Create implementation for NSAccessibilityCheckBox protocol peer


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1582/head:pull/1582` \
`$ git checkout pull/1582`

Update a local copy of the PR: \
`$ git checkout pull/1582` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1582`

View PR using the GUI difftool: \
`$ git pr show -t 1582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1582.diff">https://git.openjdk.org/jdk11u-dev/pull/1582.diff</a>

</details>
