### PR TITLE
8261352: Create implementation for component peer for all the components who should be ignored in a11y interactions

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -90,9 +90,6 @@ static jclass sjc_CAccessible = NULL;
 #define GET_CACCESSIBLE_CLASS_RETURN(ret) \
     GET_CLASS_RETURN(sjc_CAccessible, "sun/lwawt/macosx/CAccessible", ret);
 
-
-static jobject sAccessibilityClass = NULL;
-
 // sAttributeNamesForRoleCache holds the names of the attributes to which each java
 // AccessibleRole responds (see AccessibleRole.java).
 // This cache is queried before attempting to access a given attribute for a particular role.
@@ -291,39 +288,6 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     if (sRoles == nil) {
         initializeRoles();
-    }
-
-    if (sAccessibilityClass == NULL) {
-        JNIEnv *env = [ThreadUtilities getJNIEnv];
-
-        GET_CACCESSIBILITY_CLASS();
-        DECLARE_STATIC_METHOD(jm_getAccessibility, sjc_CAccessibility, "getAccessibility", "([Ljava/lang/String;)Lsun/lwawt/macosx/CAccessibility;");
-
-#ifdef JAVA_AX_NO_IGNORES
-        NSArray *ignoredKeys = [NSArray array];
-#else
-        NSArray *ignoredKeys = [sRoles allKeysForObject:JavaAccessibilityIgnore];
-#endif
-        jobjectArray result = NULL;
-        jsize count = [ignoredKeys count];
-
-        DECLARE_CLASS(jc_String, "java/lang/String");
-        result = (*env)->NewObjectArray(env, count, jc_String, NULL);
-        CHECK_EXCEPTION();
-        if (!result) {
-            NSLog(@"In %s, can't create Java array of String objects", __FUNCTION__);
-            return;
-        }
-
-        NSInteger i;
-        for (i = 0; i < count; i++) {
-            jstring jString = NSStringToJavaString(env, [ignoredKeys objectAtIndex:i]);
-            (*env)->SetObjectArrayElement(env, result, i, jString);
-            (*env)->DeleteLocalRef(env, jString);
-        }
-
-        sAccessibilityClass = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibility, result); // AWT_THREADING Safe (known object)
-        CHECK_EXCEPTION();
     }
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -46,9 +46,73 @@ static NSMutableDictionary * _Nullable rolesMap;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:1];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:26];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
+    [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
+    [rolesMap setObject:@"ImageAccessibility" forKey:@"desktopicon"];
+    [rolesMap setObject:@"SpinboxAccessibility" forKey:@"spinbox"];
+    [rolesMap setObject:@"StaticTextAccessibility" forKey:@"hyperlink"];
+    [rolesMap setObject:@"StaticTextAccessibility" forKey:@"label"];
+    [rolesMap setObject:@"RadiobuttonAccessibility" forKey:@"radiobutton"];
+    [rolesMap setObject:@"CheckboxAccessibility" forKey:@"checkbox"];
+
+    /*
+     * All the components below should be ignored by the accessibility subsystem,
+     * If any of the enclosed component asks for a parent the first ancestor
+     * participating in accessibility exchange should be returned.
+     */
+    [rolesMap setObject:IgnoreClassName forKey:@"alert"];
+    [rolesMap setObject:IgnoreClassName forKey:@"colorchooser"];
+    [rolesMap setObject:IgnoreClassName forKey:@"desktoppane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"dialog"];
+    [rolesMap setObject:IgnoreClassName forKey:@"directorypane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"filechooser"];
+    [rolesMap setObject:IgnoreClassName forKey:@"filler"];
+    [rolesMap setObject:IgnoreClassName forKey:@"fontchooser"];
+    [rolesMap setObject:IgnoreClassName forKey:@"frame"];
+    [rolesMap setObject:IgnoreClassName forKey:@"glasspane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"layeredpane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"optionpane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"panel"];
+    [rolesMap setObject:IgnoreClassName forKey:@"rootpane"];
+    [rolesMap setObject:IgnoreClassName forKey:@"separator"];
+    [rolesMap setObject:IgnoreClassName forKey:@"tooltip"];
+    [rolesMap setObject:IgnoreClassName forKey:@"viewport"];
+    [rolesMap setObject:IgnoreClassName forKey:@"window"];
+
+    /*
+     * Initialize CAccessibility instance
+     */
+#ifdef JAVA_AX_NO_IGNORES
+    NSArray *ignoredKeys = [NSArray array];
+#else
+    NSArray *ignoredKeys = [rolesMap allKeysForObject:IgnoreClassName];
+#endif
+
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    GET_CACCESSIBILITY_CLASS();
+    DECLARE_STATIC_METHOD(jm_getAccessibility, sjc_CAccessibility, "getAccessibility", "([Ljava/lang/String;)Lsun/lwawt/macosx/CAccessibility;");
+    jobjectArray result = NULL;
+    jsize count = [ignoredKeys count];
+
+    DECLARE_CLASS(jc_String, "java/lang/String");
+    result = (*env)->NewObjectArray(env, count, jc_String, NULL);
+    CHECK_EXCEPTION();
+    if (!result) {
+        NSLog(@"In %s, can't create Java array of String objects", __FUNCTION__);
+        return;
+    }
+
+    NSInteger i;
+    for (i = 0; i < count; i++) {
+        jstring jString = NSStringToJavaString(env, [ignoredKeys objectAtIndex:i]);
+        (*env)->SetObjectArrayElement(env, result, i, jString);
+        (*env)->DeleteLocalRef(env, jString);
+    }
+
+    sAccessibilityClass = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibility, result);
+    CHECK_EXCEPTION();
 }
 
 /*
@@ -58,7 +122,6 @@ static NSMutableDictionary * _Nullable rolesMap;
 + (JavaComponentAccessibility *) getComponentAccessibility:(NSString *)role
 {
     AWT_ASSERT_APPKIT_THREAD;
-
     if (rolesMap == nil) {
         [self initializeRolesMap];
     }
@@ -93,6 +156,26 @@ static NSMutableDictionary * _Nullable rolesMap;
 - (nullable id)accessibilityParent
 {
     return [self accessibilityParentAttribute];
+}
+
+// AccessibleAction support
+- (BOOL)performAccessibleAction:(int)index
+{
+    AWT_ASSERT_APPKIT_THREAD;
+    JNIEnv* env = [ThreadUtilities getJNIEnv];
+
+    GET_CACCESSIBILITY_CLASS_RETURN(FALSE);
+    DECLARE_STATIC_METHOD_RETURN(jm_doAccessibleAction, sjc_CAccessibility, "doAccessibleAction",
+                                 "(Ljavax/accessibility/AccessibleAction;ILjava/awt/Component;)V", FALSE);
+    (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_doAccessibleAction,
+                                 [self axContextWithEnv:(env)], index, fComponent);
+    CHECK_EXCEPTION();
+
+    return TRUE;
+}
+
+- (BOOL)isAccessibilityElement {
+    return YES;
 }
 
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/IgnoreAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/IgnoreAccessibility.h
@@ -23,20 +23,13 @@
  * questions.
  */
 
-#ifndef JAVA_COMPONENT_ACCESSIBILITY
-#define JAVA_COMPONENT_ACCESSIBILITY
-
 #import "JavaComponentAccessibility.h"
-#import "JavaAccessibilityUtilities.h"
+#import "CommonComponentAccessibility.h"
 
-@interface CommonComponentAccessibility : JavaComponentAccessibility <NSAccessibilityElement> {
+#import <AppKit/AppKit.h>
 
-}
-+ (void) initializeRolesMap;
-+ (JavaComponentAccessibility * _Nullable) getComponentAccessibility:(NSString * _Nonnull)role;
-- (NSRect)accessibilityFrame;
-- (nullable id)accessibilityParent;
-- (BOOL)performAccessibleAction:(int)index;
+@interface IgnoreAccessibility : CommonComponentAccessibility {
+
+};
+- (BOOL)isAccessibilityElement;
 @end
-
-#endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/IgnoreAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/IgnoreAccessibility.m
@@ -23,20 +23,15 @@
  * questions.
  */
 
-#ifndef JAVA_COMPONENT_ACCESSIBILITY
-#define JAVA_COMPONENT_ACCESSIBILITY
+#import "IgnoreAccessibility.h"
 
-#import "JavaComponentAccessibility.h"
-#import "JavaAccessibilityUtilities.h"
-
-@interface CommonComponentAccessibility : JavaComponentAccessibility <NSAccessibilityElement> {
-
+/*
+ * Indicates that component does not participate in accessibility exchange
+ */
+@implementation IgnoreAccessibility
+- (BOOL)isAccessibilityElement
+{
+    return NO;
 }
-+ (void) initializeRolesMap;
-+ (JavaComponentAccessibility * _Nullable) getComponentAccessibility:(NSString * _Nonnull)role;
-- (NSRect)accessibilityFrame;
-- (nullable id)accessibilityParent;
-- (BOOL)performAccessibleAction:(int)index;
-@end
 
-#endif
+@end


### PR DESCRIPTION
Backport [JDK-8261352](https://bugs.openjdk.org/browse/JDK-8261352) Merge conflict in file java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.m had to changed initWithCapacity. One of a series of 28 https://bugs.openjdk.org/browse/JDK-8152350
 Autumn808 <AutumnCapasso@gmail.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8261352](https://bugs.openjdk.org/browse/JDK-8261352): Create implementation for component peer for all the components who should be ignored in a11y interactions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1583/head:pull/1583` \
`$ git checkout pull/1583`

Update a local copy of the PR: \
`$ git checkout pull/1583` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1583`

View PR using the GUI difftool: \
`$ git pr show -t 1583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1583.diff">https://git.openjdk.org/jdk11u-dev/pull/1583.diff</a>

</details>
