### PR TITLE
8294580: frame::interpreter_frame_print_on() crashes if free BasicObjectLock exists in frame

### DIFF
--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -579,8 +579,8 @@ void frame::interpreter_frame_print_on(outputStream* st) const {
   for (BasicObjectLock* current = interpreter_frame_monitor_end();
        current < interpreter_frame_monitor_begin();
        current = next_monitor_in_interpreter_frame(current)) {
-    st->print(" - obj    [");
-    current->obj()->print_value_on(st);
+    st->print(" - obj    [%s", current->obj() == nullptr ? "null" : "");
+    if (current->obj() != nullptr) current->obj()->print_value_on(st);
     st->print_cr("]");
     st->print(" - lock   [");
     current->lock()->print_on(st);

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -579,8 +579,8 @@ void frame::interpreter_frame_print_on(outputStream* st) const {
   for (BasicObjectLock* current = interpreter_frame_monitor_end();
        current < interpreter_frame_monitor_begin();
        current = next_monitor_in_interpreter_frame(current)) {
-    st->print(" - obj    [%s", current->obj() == nullptr ? "null" : "");
-    if (current->obj() != nullptr) current->obj()->print_value_on(st);
+    st->print(" - obj    [%s", current->obj() == NULL ? "null" : "");
+    if (current->obj() != NULL) current->obj()->print_value_on(st);
     st->print_cr("]");
     st->print(" - lock   [");
     current->lock()->print_on(st);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [openjdk/jdk@bdb4ed0](https://github.com/openjdk/jdk/commit/bdb4ed0fb136e9e5391cfa520048de6b7f83067d).

The commit being backported was authored by Richard Reingruber on 12 Oct 2022 and was reviewed by dholmes and mdoerr. It applied cleanly but did not compile. As a fix, `nullptr` was replaced with `NULL`.

The fix passed our CI testing which includes JCK and JTREG tests on the standard platforms and also on Linux/PPC64le.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294580](https://bugs.openjdk.org/browse/JDK-8294580): frame::interpreter_frame_print_on() crashes if free BasicObjectLock exists in frame


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1590/head:pull/1590` \
`$ git checkout pull/1590`

Update a local copy of the PR: \
`$ git checkout pull/1590` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1590`

View PR using the GUI difftool: \
`$ git pr show -t 1590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1590.diff">https://git.openjdk.org/jdk11u-dev/pull/1590.diff</a>

</details>
