### PR TITLE
8292863: assert(_print_inlining_stream->size() > 0) failed: missing inlining msg

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -423,6 +423,7 @@ void LateInlineCallGenerator::do_late_inline() {
   // needs jvms for inlined state.
   if (!do_late_inline_check(jvms)) {
     map->disconnect_inputs(NULL, C);
+    C->print_inlining_update_delayed(this);
     return;
   }
 
@@ -491,8 +492,6 @@ class LateInlineMHCallGenerator : public LateInlineCallGenerator {
 bool LateInlineMHCallGenerator::do_late_inline_check(JVMState* jvms) {
 
   CallGenerator* cg = for_method_handle_inline(jvms, _caller, method(), _input_not_const);
-
-  Compile::current()->print_inlining_update_delayed(this);
 
   if (!_input_not_const) {
     _attempt++;


### PR DESCRIPTION
assert in print_inlining_update_delayed is checking for an empty inline stream buffer which is expected to be empty.

Fix is to call print_inlining_update_delayed() only when do_late_inline_check() fails in do_late_inline() which is similar to JDK17 code where this issue doesn't reproduce.

Note: This issue is already fixed in JDK17+ branches.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292863](https://bugs.openjdk.org/browse/JDK-8292863): assert(_print_inlining_stream->size() > 0) failed: missing inlining msg


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1595/head:pull/1595` \
`$ git checkout pull/1595`

Update a local copy of the PR: \
`$ git checkout pull/1595` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1595`

View PR using the GUI difftool: \
`$ git pr show -t 1595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1595.diff">https://git.openjdk.org/jdk11u-dev/pull/1595.diff</a>

</details>
