### PR TITLE
8290899: java/lang/String/StringRepeat.java test requests too much heap on windows x86

### DIFF
--- a/test/jdk/java/lang/String/StringRepeat.java
+++ b/test/jdk/java/lang/String/StringRepeat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  * @test
  * @summary This exercises String#repeat patterns with 16 * 1024 * 1024 repeats.
  * @requires os.maxMemory >= 2G
+ * @requires !(os.family == "windows" & sun.arch.data.model == "32")
  * @run main/othervm -Xmx2g StringRepeat 16777216
  */
 


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [2bb727c4](https://github.com/openjdk/jdk/commit/2bb727c4eaf8a948f17f6416a1e6fbaeade4d7ce) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 16 Dec 2022 and was reviewed by Jaikiran Pai and Paul Hohensee.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290899](https://bugs.openjdk.org/browse/JDK-8290899): java/lang/String/StringRepeat.java test requests too much heap on windows x86


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1599/head:pull/1599` \
`$ git checkout pull/1599`

Update a local copy of the PR: \
`$ git checkout pull/1599` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1599`

View PR using the GUI difftool: \
`$ git pr show -t 1599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1599.diff">https://git.openjdk.org/jdk11u-dev/pull/1599.diff</a>

</details>
