### PR TITLE
8221621: FindTests.gmk cannot handle "=" in TEST.groups comments

### DIFF
--- a/make/common/FindTests.gmk
+++ b/make/common/FindTests.gmk
@@ -53,6 +53,7 @@ define FindJtregGroupsBody
         -e 's/^groups\w*=//p' $1/TEST.ROOT)
     $1_JTREG_GROUP_FILES := $$(addprefix $1/, $$($1_JTREG_GROUP_FILENAMES))
     $1_JTREG_TEST_GROUPS := $$(strip $$(shell $$(SED) -n \
+        -e 's/^\#.*//g' \
         -e 's/\([^ ]*\)\w*=.*/\1/gp' $$(wildcard $$($1_JTREG_GROUP_FILES)) \
         | $$(SORT) -u))
   endif


### PR DESCRIPTION
clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8221621](https://bugs.openjdk.org/browse/JDK-8221621): FindTests.gmk cannot handle "=" in TEST.groups comments


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1603/head:pull/1603` \
`$ git checkout pull/1603`

Update a local copy of the PR: \
`$ git checkout pull/1603` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1603`

View PR using the GUI difftool: \
`$ git pr show -t 1603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1603.diff">https://git.openjdk.org/jdk11u-dev/pull/1603.diff</a>

</details>
