### PR TITLE
8298527: Cygwin's uname -m returns different string than before

### DIFF
--- a/make/autoconf/build-aux/config.guess
+++ b/make/autoconf/build-aux/config.guess
@@ -29,7 +29,40 @@
 # and fix the broken property, if needed.
 
 DIR=`dirname $0`
-OUT=`. $DIR/autoconf-config.guess`
+OUT=`. $DIR/autoconf-config.guess 2> /dev/null`
+
+# Handle some cases that autoconf-config.guess is not capable of
+if [ "x$OUT" = x ]; then
+  if [ `uname -s` = Linux ]; then
+    # Test and fix little endian MIPS.
+    if [ `uname -m` = mipsel ]; then
+      OUT=mipsel-unknown-linux-gnu
+    elif [ `uname -m` = mips64el ]; then
+      OUT=mips64el-unknown-linux-gnu
+    # Test and fix little endian PowerPC64.
+    elif [ `uname -m` = ppc64le ]; then
+      OUT=powerpc64le-unknown-linux-gnu
+    # Test and fix LoongArch64.
+    elif [ `uname -m` = loongarch64 ]; then
+      OUT=loongarch64-unknown-linux-gnu
+    # Test and fix RISC-V.
+    elif [ `uname -m` = riscv64 ]; then
+      OUT=riscv64-unknown-linux-gnu
+    fi
+  # Test and fix cygwin machine arch .x86_64
+  elif [[ `uname -s` = CYGWIN* ]]; then
+    if [ `uname -m` = ".x86_64" ]; then
+      OUT=x86_64-unknown-cygwin
+    fi
+  fi
+
+  if [ "x$OUT" = x ]; then
+    # Run autoconf-config.guess again to get the error message.
+    . $DIR/autoconf-config.guess > /dev/null
+  else
+    printf "guessed by custom config.guess... " >&2
+  fi
+fi
 
 # Test and fix solaris on x86_64
 echo $OUT | grep i386-pc-solaris > /dev/null 2> /dev/null
@@ -86,36 +119,6 @@ if test $? = 0; then
     fi
   fi
   OUT=powerpc$KERNEL_BITMODE`echo $OUT | sed -e 's/[^-]*//'`
-fi
-
-# Test and fix little endian PowerPC64.
-# TODO: should be handled by autoconf-config.guess.
-if [ "x$OUT" = x ]; then
-  if [ `uname -m` = ppc64le ]; then
-    if [ `uname -s` = Linux ]; then
-      OUT=powerpc64le-unknown-linux-gnu
-    fi
-  fi
-fi
-
-# Test and fix little endian MIPS.
-if [ "x$OUT" = x ]; then
-  if [ `uname -s` = Linux ]; then
-    if [ `uname -m` = mipsel ]; then
-      OUT=mipsel-unknown-linux-gnu
-    elif [ `uname -m` = mips64el ]; then
-      OUT=mips64el-unknown-linux-gnu
-    fi
-  fi
-fi
-
-# Test and fix LoongArch64.
-if [ "x$OUT" = x ]; then
-  if [ `uname -s` = Linux ]; then
-    if [ `uname -m` = loongarch64 ]; then
-      OUT=loongarch64-unknown-linux-gnu
-    fi
-  fi
 fi
 
 # Test and fix cpu on macos-aarch64, uname -p reports arm, buildsys expects aarch64


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8298527](https://bugs.openjdk.org/browse/JDK-8298527), commit [1da982b4](https://github.com/openjdk/jdk17u-dev/commit/1da982b4f4653002177b1bb2deee7688f2600c05) from the [openjdk/jdk17u-dev](https://git.openjdk.org/jdk17u-dev) repository.

The commit being backported was authored by Christoph Langer on 22 Dec 2022 and was reviewed by Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298527](https://bugs.openjdk.org/browse/JDK-8298527): Cygwin's uname -m returns different string than before


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1607/head:pull/1607` \
`$ git checkout pull/1607`

Update a local copy of the PR: \
`$ git checkout pull/1607` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1607`

View PR using the GUI difftool: \
`$ git pr show -t 1607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1607.diff">https://git.openjdk.org/jdk11u-dev/pull/1607.diff</a>

</details>
