### PR TITLE
8298271: java/security/SignedJar/spi-calendar-provider/TestSPISigned.java failing on Windows

### DIFF
--- a/test/jdk/java/security/SignedJar/spi-calendar-provider/TestSPISigned.java
+++ b/test/jdk/java/security/SignedJar/spi-calendar-provider/TestSPISigned.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.nio.file.Paths;
 import java.nio.file.Path;
 import java.nio.file.Files;
+import java.io.File;
 import static java.util.Calendar.WEDNESDAY;
 
 /*
@@ -95,7 +96,7 @@ public class TestSPISigned {
             testRun.add("-Djava.locale.providers=SPI");
             testRun.add("-cp");
             String classPath = System.getProperty("java.class.path");
-            classPath = classPath + ":" + SIGNED_JAR.toAbsolutePath().toString();
+            classPath = classPath + File.pathSeparator + SIGNED_JAR.toAbsolutePath().toString();
             testRun.add(classPath);
             testRun.add(TestSPISigned.class.getSimpleName());
             testRun.add("run-test");


### PR DESCRIPTION
Not clean backport, because the problem list bug [JDK-8298274](https://bugs.openjdk.org/browse/JDK-8298274) won't get backported. Omitted the ProblemList.txt hunk. Instead I propose to backport the fix (this PR) instead. Follow up for #1608 in order to fix the test on Windows.

Please review this test-only backport. Thanks!

Test passes with the fix of https://github.com/openjdk/jdk11u/pull/65 included.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298271](https://bugs.openjdk.org/browse/JDK-8298271): java/security/SignedJar/spi-calendar-provider/TestSPISigned.java failing on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1609/head:pull/1609` \
`$ git checkout pull/1609`

Update a local copy of the PR: \
`$ git checkout pull/1609` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1609`

View PR using the GUI difftool: \
`$ git pr show -t 1609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1609.diff">https://git.openjdk.org/jdk11u-dev/pull/1609.diff</a>

</details>
