### PR TITLE
8252715: Problem list java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java on Linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -171,6 +171,7 @@ java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java 8169476 windows
 java/awt/event/KeyEvent/KeyChar/KeyCharTest.java 8169474,8224055 macosx-all,windows-all
 java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java 8129778 generic-all
 java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java 8129778 generic-all
+java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java 8252713 linux-all
 java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java 8129778 generic-all
 
 java/awt/dnd/URIListToFileListBetweenJVMsTest/URIListToFileListBetweenJVMsTest.java 8194947 generic-all


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [d0f4366a](https://github.com/openjdk/jdk/commit/d0f4366a859dd7ba9243495dadb460e78ad27006) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Phil Race on 5 Sep 2020 and was reviewed by Sergey Bylokhov.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8252715](https://bugs.openjdk.org/browse/JDK-8252715): Problem list java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java on Linux


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1610/head:pull/1610` \
`$ git checkout pull/1610`

Update a local copy of the PR: \
`$ git checkout pull/1610` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1610`

View PR using the GUI difftool: \
`$ git pr show -t 1610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1610.diff">https://git.openjdk.org/jdk11u-dev/pull/1610.diff</a>

</details>
