### PR TITLE
8283606: Tests may fail with zh locale on MacOS

### DIFF
--- a/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,8 @@ public class TestEmptyBootstrapMethodsAttr {
         // ======= execute test case #1
         // Expect a lack of main method, this implies that the class loaded correctly
         // with an empty bootstrap_methods and did not generate a ClassFormatError.
-        pb = ProcessTools.createJavaProcessBuilder("-cp", ".", className);
+        pb = ProcessTools.createJavaProcessBuilder("-cp", ".",
+                "-Duser.language=en", "-Duser.country=US", className);
         output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("java.lang.ClassFormatError");
         output.shouldContain("Main method not found in class " + className);
@@ -70,7 +71,8 @@ public class TestEmptyBootstrapMethodsAttr {
         // ======= execute test case #2
         // Expect a lack of main method, this implies that the class loaded correctly
         // with an empty bootstrap_methods and did not generate ClassFormatError.
-        pb = ProcessTools.createJavaProcessBuilder("-cp", ".", className);
+        pb = ProcessTools.createJavaProcessBuilder("-cp", ".",
+                "-Duser.language=en", "-Duser.country=US", className);
         output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("java.lang.ClassFormatError");
         output.shouldContain("Main method not found in class " + className);

--- a/test/jdk/tools/pack200/DeprecatePack200.java
+++ b/test/jdk/tools/pack200/DeprecatePack200.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,19 +52,19 @@ public class DeprecatePack200 {
     public static final Object[][] provide() { return cases; }
 
     private static final Object[][] cases = {
-        { PACK200_MSG, 1, List.of(PACK200_CMD) },
-        { PACK200_MSG, 1, List.of(PACK200_CMD, "-V") },
-        { PACK200_MSG, 2, List.of(PACK200_CMD, "--help") },
-        { PACK200_MSG, 0, List.of(PACK200_CMD, "-XDsuppress-tool-removal-message") },
-        { PACK200_MSG, 0, List.of(PACK200_CMD, "--version", "-XDsuppress-tool-removal-message") },
-        { PACK200_MSG, 0, List.of(PACK200_CMD, "-h", "-XDsuppress-tool-removal-message") },
+        { PACK200_MSG, 1, List.of(PACK200_CMD, "-J-Duser.language=en", "-J-Duser.country=US") },
+        { PACK200_MSG, 1, List.of(PACK200_CMD, "-J-Duser.language=en", "-J-Duser.country=US", "-V") },
+        { PACK200_MSG, 2, List.of(PACK200_CMD, "-J-Duser.language=en", "-J-Duser.country=US", "--help") },
+        { PACK200_MSG, 0, List.of(PACK200_CMD, "-J-Duser.language=en", "-J-Duser.country=US", "-XDsuppress-tool-removal-message") },
+        { PACK200_MSG, 0, List.of(PACK200_CMD, "-J-Duser.language=en", "-J-Duser.country=US", "--version", "-XDsuppress-tool-removal-message") },
+        { PACK200_MSG, 0, List.of(PACK200_CMD, "-J-Duser.language=en", "-J-Duser.country=US", "-h", "-XDsuppress-tool-removal-message") },
 
-        { UNPACK200_MSG, 1, List.of(UNPACK200_CMD) },
-        { UNPACK200_MSG, 1, List.of(UNPACK200_CMD, "-V") },
-        { UNPACK200_MSG, 1, List.of(UNPACK200_CMD, "--help") },
-        { UNPACK200_MSG, 0, List.of(UNPACK200_CMD, "-XDsuppress-tool-removal-message") },
-        { UNPACK200_MSG, 0, List.of(UNPACK200_CMD, "--version", "-XDsuppress-tool-removal-message") },
-        { UNPACK200_MSG, 0, List.of(UNPACK200_CMD, "-h", "-XDsuppress-tool-removal-message") }
+        { UNPACK200_MSG, 1, List.of(UNPACK200_CMD, "-J-Duser.language=en", "-J-Duser.country=US") },
+        { UNPACK200_MSG, 1, List.of(UNPACK200_CMD, "-J-Duser.language=en", "-J-Duser.country=US", "-V") },
+        { UNPACK200_MSG, 1, List.of(UNPACK200_CMD, "-J-Duser.language=en", "-J-Duser.country=US", "--help") },
+        { UNPACK200_MSG, 0, List.of(UNPACK200_CMD, "-J-Duser.language=en", "-J-Duser.country=US", "-XDsuppress-tool-removal-message") },
+        { UNPACK200_MSG, 0, List.of(UNPACK200_CMD, "-J-Duser.language=en", "-J-Duser.country=US", "--version", "-XDsuppress-tool-removal-message") },
+        { UNPACK200_MSG, 0, List.of(UNPACK200_CMD, "-J-Duser.language=en", "-J-Duser.country=US", "-h", "-XDsuppress-tool-removal-message") }
     };
 
     @Test(dataProvider = "tools")

--- a/test/langtools/jdk/javadoc/tool/6964914/TestStdDoclet.java
+++ b/test/langtools/jdk/javadoc/tool/6964914/TestStdDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,8 @@ public class TestStdDoclet {
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add(javadoc.getPath());
         cmdArgs.addAll(Arrays.asList(
+                "-J-Duser.language=en",
+                "-J-Duser.country=US",
                 "-classpath", ".", // insulates us from ambient classpath
                 "-Xdoclint:none",
                 "-package",

--- a/test/langtools/jdk/javadoc/tool/6964914/TestUserDoclet.java
+++ b/test/langtools/jdk/javadoc/tool/6964914/TestUserDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,6 +69,8 @@ public class TestUserDoclet implements Doclet {
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add(javadoc.getPath());
         cmdArgs.addAll(Arrays.asList(
+                "-J-Duser.language=en",
+                "-J-Duser.country=US",
                 "-doclet", thisClassName,
                 "-docletpath", testClasses.getPath(),
                 new File(testSrc, thisClassName + ".java").getPath()

--- a/test/langtools/jdk/javadoc/tool/EnsureNewOldDoclet.java
+++ b/test/langtools/jdk/javadoc/tool/EnsureNewOldDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,8 @@ public class EnsureNewOldDoclet extends TestRunner {
     // outcome: new tool and new doclet
     @Test
     public void testDefault() throws Exception {
-        setArgs("-classpath", ".", // insulates us from ambient classpath
+        setArgs("-J-Duser.language=en", "-J-Duser.country=US",
+                "-classpath", ".", // insulates us from ambient classpath
                   testSrc.toString());
         Task.Result tr = task.run(Task.Expect.SUCCESS);
         List<String> out = tr.getOutputLines(Task.OutputKind.STDOUT);
@@ -122,7 +123,8 @@ public class EnsureNewOldDoclet extends TestRunner {
     // outcome: old tool
     @Test
     public void testOldDoclet() throws Exception {
-        setArgs("-classpath", ".", // ambient classpath insulation
+        setArgs("-J-Duser.language=en", "-J-Duser.country=US",
+                "-classpath", ".", // ambient classpath insulation
                 "-doclet",
                 OLD_DOCLET_CLASS_NAME,
                 "-docletpath",
@@ -139,7 +141,8 @@ public class EnsureNewOldDoclet extends TestRunner {
     // outcome: new doclet and new taglet should register
     @Test
     public void testNewDocletNewTaglet() throws Exception {
-        setArgs("-classpath", ".", // ambient classpath insulation
+        setArgs("-J-Duser.language=en", "-J-Duser.country=US",
+                "-classpath", ".", // ambient classpath insulation
                 "-doclet",
                 NEW_STDDOCLET,
                 "-taglet",

--- a/test/langtools/tools/javac/T8132562/ClassPathWithDoubleQuotesTest.java
+++ b/test/langtools/tools/javac/T8132562/ClassPathWithDoubleQuotesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,7 +119,7 @@ public class ClassPathWithDoubleQuotesTest extends TestRunner {
                 "and for which they are a legal filename character");
         String log = new JavacTask(tb, Task.Mode.EXEC)
                 .envVar("CLASSPATH", "Ztest/jarOut/J.jar" + File.pathSeparator + "test/srcZ")
-                .options("-XDrawDiagnostics")
+                .options("-XDrawDiagnostics", "-J-Duser.language=en", "-J-Duser.country=US")
                 .files("test/src/A.java").run(Task.Expect.FAIL)
                 .writeAll()
                 .getOutput(Task.OutputKind.STDERR);
@@ -131,7 +131,7 @@ public class ClassPathWithDoubleQuotesTest extends TestRunner {
         System.err.println("invoking javac EXEC mode with double quotes in the CLASSPATH env variable");
         String log2 = new JavacTask(tb, Task.Mode.EXEC)
                     .envVar("CLASSPATH", "\"test/jarOut/J.jar" + File.pathSeparator + "test/src\"")
-                    .options("-Xlint:path", "-XDrawDiagnostics")
+                    .options("-Xlint:path", "-XDrawDiagnostics", "-J-Duser.language=en", "-J-Duser.country=US")
                     .files("test/src/A.java").run(Task.Expect.FAIL)
                     .writeAll()
                     .getOutput(Task.OutputKind.STDERR);

--- a/test/langtools/tools/javac/options/smokeTests/OptionSmokeTest.java
+++ b/test/langtools/tools/javac/options/smokeTests/OptionSmokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -201,6 +201,7 @@ public class OptionSmokeTest extends TestRunner {
         tb.writeJavaFiles(src, "class Dummy {}");
         String log = new JavacTask(tb, Task.Mode.EXEC)
                 .envVar("JDK_JAVAC_OPTIONS", "--add-exports jdk.compiler" + fileSeparator + "com.sun.tools.javac.jvm=\"ALL-UNNAMED")
+                .options("-J-Duser.language=en", "-J-Duser.country=US")
                 .files(findJavaFiles(src))
                 .run(Task.Expect.FAIL)
                 .writeAll()

--- a/test/langtools/tools/javac/platform/PlatformProviderTest.java
+++ b/test/langtools/tools/javac/platform/PlatformProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,7 +130,9 @@ public class PlatformProviderTest implements PlatformProvider {
         Task.Result result =
                 new JavacTask(tb, Task.Mode.EXEC)
                   .outdir(".")
-                  .options("-J--class-path=" + System.getProperty("test.classes"),
+                  .options("-J-Duser.language=en", "-J-Duser.country=US",
+                           "-J--class-path=" + System.getProperty("test.classes"),
+
                            "-J--add-exports=jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED",
                            "-J--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
                            "--release",

--- a/test/langtools/tools/javadoc/6964914/TestStdDoclet.java
+++ b/test/langtools/tools/javadoc/6964914/TestStdDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,8 @@ public class TestStdDoclet {
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add(javadoc.getPath());
         cmdArgs.addAll(Arrays.asList(
+                "-J-Duser.language=en",
+                "-J-Duser.country=US",
                 "-classpath", ".", // insulates us from ambient classpath
                 "-Xdoclint:none",
                 "-package",

--- a/test/langtools/tools/javadoc/6964914/TestUserDoclet.java
+++ b/test/langtools/tools/javadoc/6964914/TestUserDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,8 @@ public class TestUserDoclet extends Doclet {
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add(javadoc.getPath());
         cmdArgs.addAll(Arrays.asList(
+                "-J-Duser.language=en",
+                "-J-Duser.country=US",
                 "-doclet", thisClassName,
                 "-docletpath", testClasses.getPath(),
                 new File(testSrc, thisClassName + ".java").getPath()

--- a/test/langtools/tools/jdeps/MultiReleaseJar.java
+++ b/test/langtools/tools/jdeps/MultiReleaseJar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,10 +80,10 @@ public class MultiReleaseJar {
 
     @Test
     public void basic() throws Exception {
-        Result r = run("jdeps --multi-release 9  -v missing.jar");
+        Result r = run("jdeps -J-Duser.language=en -J-Duser.country=US --multi-release 9  -v missing.jar");
         checkResult(r, false, "Warning: Path does not exist: missing.jar");
 
-        r = run("jdeps -v Version.jar");
+        r = run("jdeps -J-Duser.language=en -J-Duser.country=US -v Version.jar");
         checkResult(r, false, "--multi-release option is not set");
 
         r = run("jdeps --multi-release base  -v Version.jar");
@@ -115,10 +115,10 @@ public class MultiReleaseJar {
             "9/test.NonPublic"
         );
 
-        r = run("jdeps --multi-release 8  -v Version.jar");
+        r = run("jdeps -J-Duser.language=en -J-Duser.country=US --multi-release 8  -v Version.jar");
         checkResult(r, false, "Error: invalid argument for option: 8");
 
-        r = run("jdeps --multi-release 9.1  -v Version.jar");
+        r = run("jdeps -J-Duser.language=en -J-Duser.country=US --multi-release 9.1  -v Version.jar");
         checkResult(r, false, "Error: invalid argument for option: 9.1");
 
         runJdeps("Main.class");
@@ -127,10 +127,10 @@ public class MultiReleaseJar {
 
 
     private void runJdeps(String path) throws Exception {
-        Result r = run("jdeps -v -R -cp Version.jar " + path);
+        Result r = run("jdeps -J-Duser.language=en -J-Duser.country=US -v -R -cp Version.jar " + path);
         checkResult(r, false, "--multi-release option is not set");
 
-        r = run("jdeps -v -R -cp Version.jar --module-path Foo.jar -multi-release 9 " + path);
+        r = run("jdeps -J-Duser.language=en -J-Duser.country=US -v -R -cp Version.jar --module-path Foo.jar -multi-release 9 " + path);
         checkResult(r, false,
             "Error: unknown option: -multi-release",
             "Usage: jdeps <options> <path",
@@ -208,7 +208,7 @@ public class MultiReleaseJar {
             "p.Foo"
         );
 
-        r = run("jdeps -v -R -cp Version.jar --module-path  Foo.jar --multi-release 9.1 " + path);
+        r = run("jdeps -J-Duser.language=en -J-Duser.country=US -v -R -cp Version.jar --module-path  Foo.jar --multi-release 9.1 " + path);
         checkResult(r, false, "Error: invalid argument for option: 9.1");
 
         // Version_9.jar does not have any version 10 entry


### PR DESCRIPTION
I would like to backport JDK-8283606 to JDK11u. This fix cannot be applied cleanly.
- Test does not provided in JDK11u
  (test/langtools/jdk/javadoc/tool/testLocaleOption/TestLocaleOption.java)
- Need to add test items that is removed from the following test in the latest version
  (test/langtools/jdk/javadoc/tool/EnsureNewOldDoclet.java)
- Need to add more tests that are removed in latest version and have same problem.
  (test/langtools/tools/javadoc/6964914/TestStdDoclet.java,
   test/langtools/tools/javadoc/6964914/TestUserDoclet.java, and
   test/jdk/tools/pack200/DeprecatePack200.java)

I tried to run these tests on Japanese Windows 10, and all tests are passed.

But, I am not a author, so need a sponsor.
Would you plese review this fix?

Thank you.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283606](https://bugs.openjdk.org/browse/JDK-8283606): Tests may fail with zh locale on MacOS


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1611/head:pull/1611` \
`$ git checkout pull/1611`

Update a local copy of the PR: \
`$ git checkout pull/1611` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1611`

View PR using the GUI difftool: \
`$ git pr show -t 1611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1611.diff">https://git.openjdk.org/jdk11u-dev/pull/1611.diff</a>

</details>
