### PR TITLE
8212165: JGSS: Fix cut/paste error in NativeUtil.c

### DIFF
--- a/src/java.security.jgss/share/native/libj2gss/NativeUtil.c
+++ b/src/java.security.jgss/share/native/libj2gss/NativeUtil.c
@@ -145,7 +145,7 @@ DEF_JNI_OnLoad(JavaVM *jvm, void *reserved) {
     return JNI_ERR;
   }
   CLS_GSSNameElement = (*env)->NewGlobalRef(env, cls);
-  if (CLS_GSSException == NULL) {
+  if (CLS_GSSNameElement == NULL) {
     return JNI_ERR;
   }
   cls = (*env)->FindClass(env, "sun/security/jgss/wrapper/GSSCredElement");


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8212165](https://bugs.openjdk.org/browse/JDK-8212165): JGSS: Fix cut/paste error in NativeUtil.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1617/head:pull/1617` \
`$ git checkout pull/1617`

Update a local copy of the PR: \
`$ git checkout pull/1617` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1617`

View PR using the GUI difftool: \
`$ git pr show -t 1617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1617.diff">https://git.openjdk.org/jdk11u-dev/pull/1617.diff</a>

</details>
