### PR TITLE
8212216: JGSS: Fix leak in exception cases in getJavaOID()

### DIFF
--- a/src/java.security.jgss/share/native/libj2gss/NativeUtil.c
+++ b/src/java.security.jgss/share/native/libj2gss/NativeUtil.c
@@ -724,17 +724,14 @@ jobject getJavaOID(JNIEnv *env, gss_OID cOid) {
   if (jbytes == NULL) {
     return NULL;
   }
-  (*env)->SetByteArrayRegion(env, jbytes, 0, 2, (jbyte *) oidHdr);
-  if ((*env)->ExceptionCheck(env)) {
-    return NULL;
+  if (!(*env)->ExceptionCheck(env)) {
+    (*env)->SetByteArrayRegion(env, jbytes, 0, 2, (jbyte *) oidHdr);
   }
-  (*env)->SetByteArrayRegion(env, jbytes, 2, cLen, (jbyte *) cOid->elements);
-  if ((*env)->ExceptionCheck(env)) {
-    return NULL;
+  if (!(*env)->ExceptionCheck(env)) {
+    (*env)->SetByteArrayRegion(env, jbytes, 2, cLen, (jbyte *) cOid->elements);
   }
-  result = (*env)->NewObject(env, CLS_Oid, MID_Oid_ctor1, jbytes);
-  if ((*env)->ExceptionCheck(env)) {
-    return NULL;
+  if (!(*env)->ExceptionCheck(env)) {
+    result = (*env)->NewObject(env, CLS_Oid, MID_Oid_ctor1, jbytes);
   }
   (*env)->DeleteLocalRef(env, jbytes);
   return result;


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8212216](https://bugs.openjdk.org/browse/JDK-8212216): JGSS: Fix leak in exception cases in getJavaOID()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1618/head:pull/1618` \
`$ git checkout pull/1618`

Update a local copy of the PR: \
`$ git checkout pull/1618` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1618`

View PR using the GUI difftool: \
`$ git pr show -t 1618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1618.diff">https://git.openjdk.org/jdk11u-dev/pull/1618.diff</a>

</details>
