### PR TITLE
8230731: SA tests fail with "Windbg Error: ReadVirtual failed"

### DIFF
--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -742,11 +742,9 @@ JNIEXPORT jbyteArray JNICALL Java_sun_jvm_hotspot_debugger_windbg_WindbgDebugger
   CHECK_EXCEPTION_(0);
 
   ULONG bytesRead;
-  COM_VERIFY_OK_(ptrIDebugDataSpaces->ReadVirtual((ULONG64)address, arrayBytes,
-                                                  (ULONG)numBytes, &bytesRead),
-                 "Windbg Error: ReadVirtual failed!", 0);
-
-  if (bytesRead != numBytes) {
+  const HRESULT hr = ptrIDebugDataSpaces->ReadVirtual((ULONG64)address, arrayBytes,
+                                                      (ULONG)numBytes, &bytesRead);
+  if (hr != S_OK || bytesRead != numBytes) {
      return 0;
   }
 


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

Patches to ProblemLists don't apply, but are pointless:

test/hotspot/jtreg/ProblemList.txt:
Test is only ProblemListed for solaris. I leave that unchanged
as I can not double-checke the test is passing there.
test/jdk/ProblemList.txt:
Test is not problemlisted there.

Will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8230731](https://bugs.openjdk.org/browse/JDK-8230731): SA tests fail with "Windbg Error: ReadVirtual failed"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1619/head:pull/1619` \
`$ git checkout pull/1619`

Update a local copy of the PR: \
`$ git checkout pull/1619` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1619`

View PR using the GUI difftool: \
`$ git pr show -t 1619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1619.diff">https://git.openjdk.org/jdk11u-dev/pull/1619.diff</a>

</details>
