### PR TITLE
8271506: Add ResourceHashtable support for deleting selected entries

### DIFF
--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -173,6 +173,32 @@ class ResourceHashtable : public ResourceObj {
   static size_t node_size() {
     return sizeof(Node);
   }
+
+  // ITER contains bool do_entry(K const&, V const&), which will be
+  // called for each entry in the table.  If do_entry() returns true,
+  // the entry is deleted.
+  template<class ITER>
+  void unlink(ITER* iter) {
+    Node** bucket =  const_cast<Node**>(_table);
+    while (bucket < &_table[SIZE]) {
+      Node** ptr = bucket;
+      while (*ptr != NULL) {
+        Node* node = *ptr;
+        // do_entry must clean up the key and value in Node.
+        bool clean = iter->do_entry(node->_key, node->_value);
+        if (clean) {
+          *ptr = node->_next;
+          if (ALLOC_TYPE == ResourceObj::C_HEAP) {
+            delete node;
+          }
+        } else {
+          ptr = &(node->_next);
+        }
+      }
+      ++bucket;
+    }
+  }
+
 };
 
 

--- a/test/hotspot/gtest/utilities/test_resourceHash.cpp
+++ b/test/hotspot/gtest/utilities/test_resourceHash.cpp
@@ -58,6 +58,22 @@ class CommonResourceHashtableTest : public ::testing::Test {
       }
     }
   };
+
+  class DeleterTestIter {
+    int _val;
+   public:
+    DeleterTestIter(int i) : _val(i) {}
+
+    bool do_entry(K const& k, V const& v) {
+      if ((uintptr_t) k == (uintptr_t) _val) {
+        // Delete me!
+        return true;
+      } else {
+        return false; // continue iteration
+      }
+    }
+  };
+
 };
 
 class SmallResourceHashtableTest : public CommonResourceHashtableTest {
@@ -194,6 +210,15 @@ class GenericResourceHashtableTest : public CommonResourceHashtableTest {
         ASSERT_FALSE(rh.remove(as_K(index)));
       }
       rh.iterate(&et);
+
+      // Add more entries in and then delete one.
+      for (uintptr_t i = 10; i > 0; --i) {
+        uintptr_t index = i - 1;
+        ASSERT_TRUE(rh.put(as_K(index), index));
+      }
+      DeleterTestIter dt(5);
+      rh.unlink(&dt);
+      ASSERT_FALSE(rh.get(as_K(5)));
     }
   };
 };


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

I backported this from 17 because that already contains a needed adaption.

The test file did not resolve properly, context differs slightly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271506](https://bugs.openjdk.org/browse/JDK-8271506): Add ResourceHashtable support for deleting selected entries


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1621/head:pull/1621` \
`$ git checkout pull/1621`

Update a local copy of the PR: \
`$ git checkout pull/1621` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1621`

View PR using the GUI difftool: \
`$ git pr show -t 1621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1621.diff">https://git.openjdk.org/jdk11u-dev/pull/1621.diff</a>

</details>
