### PR TITLE
8284023: java.sun.awt.X11GraphicsDevice.getDoubleBufferVisuals() leaks XdbeScreenVisualInfo

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -1640,6 +1640,9 @@ Java_sun_awt_X11GraphicsDevice_getDoubleBufferVisuals(JNIEnv *env,
             break;
         }
     }
+    AWT_LOCK();
+    XdbeFreeVisualInfo(visScreenInfo);
+    AWT_UNLOCK();
 #endif /* !HEADLESS */
 }
 


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

I had to place the code by hand, patching hit the wrong method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284023](https://bugs.openjdk.org/browse/JDK-8284023): java.sun.awt.X11GraphicsDevice.getDoubleBufferVisuals() leaks XdbeScreenVisualInfo


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1623/head:pull/1623` \
`$ git checkout pull/1623`

Update a local copy of the PR: \
`$ git checkout pull/1623` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1623`

View PR using the GUI difftool: \
`$ git pr show -t 1623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1623.diff">https://git.openjdk.org/jdk11u-dev/pull/1623.diff</a>

</details>
