### PR TITLE
8285399: JNI exception pending in awt_GraphicsEnv.c:1432

### DIFF
--- a/src/java.desktop/unix/native/common/awt/awt.h
+++ b/src/java.desktop/unix/native/common/awt/awt.h
@@ -85,6 +85,9 @@ extern void awt_output_flush();
 
 #define AWT_LOCK_IMPL() \
     do { \
+        if ((*env)->ExceptionCheck(env)) { \
+            (*env)->ExceptionClear(env); \
+        } \
         (*env)->CallStaticVoidMethod(env, tkClass, awtLockMID); \
         if ((*env)->ExceptionCheck(env)) { \
             (*env)->ExceptionClear(env); \

--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -1635,10 +1635,10 @@ Java_sun_awt_X11GraphicsDevice_getDoubleBufferVisuals(JNIEnv *env,
     AWT_FLUSH_UNLOCK();
     for (i = 0; i < visScreenInfo->count; i++) {
         XdbeVisualInfo* visInfo = visScreenInfo->visinfo;
-        (*env)->CallVoidMethod(env, this, midAddVisual, (visInfo[i]).visual);
         if ((*env)->ExceptionCheck(env)) {
             break;
         }
+        (*env)->CallVoidMethod(env, this, midAddVisual, (visInfo[i]).visual);
     }
 #endif /* !HEADLESS */
 }


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285399](https://bugs.openjdk.org/browse/JDK-8285399): JNI exception pending in awt_GraphicsEnv.c:1432


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1624/head:pull/1624` \
`$ git checkout pull/1624`

Update a local copy of the PR: \
`$ git checkout pull/1624` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1624`

View PR using the GUI difftool: \
`$ git pr show -t 1624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1624.diff">https://git.openjdk.org/jdk11u-dev/pull/1624.diff</a>

</details>
