### PR TITLE
8065097: [macosx] javax/swing/Popup/TaskbarPositionTest.java fails because Popup is one pixel off

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -765,7 +765,6 @@ javax/swing/JTextArea/TextViewOOM/TextViewOOM.java 8167355 generic-all
 javax/swing/JEditorPane/8195095/ImageViewTest.java 8202656 windows-all
 javax/swing/JPopupMenu/8075063/ContextMenuScrollTest.java 202880 linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all
-javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JComboBox/WindowsComboBoxSize/WindowsComboBoxSizeTest.java 8213116 windows-all
 javax/swing/JComboBox/4199622/bug4199622.java 8213122 windows-all
 javax/swing/JFrame/NSTexturedJFrame/NSTexturedJFrame.java 8213122 windows-all


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

I resolved the ProblemList, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8065097](https://bugs.openjdk.org/browse/JDK-8065097): [macosx] javax/swing/Popup/TaskbarPositionTest.java fails because Popup is one pixel off


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1625/head:pull/1625` \
`$ git checkout pull/1625`

Update a local copy of the PR: \
`$ git checkout pull/1625` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1625`

View PR using the GUI difftool: \
`$ git pr show -t 1625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1625.diff">https://git.openjdk.org/jdk11u-dev/pull/1625.diff</a>

</details>
