### PR TITLE
8210373: Deadlock in libj2gss.so when loading "j2gss" and "net" libraries in parallel.

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,8 +73,12 @@ public final class SunNativeProvider extends Provider {
                         DEBUG = Boolean.parseBoolean
                             (System.getProperty(DEBUG_PROP));
                         try {
+                            // Ensure the InetAddress class is loaded before
+                            // loading j2gss. The library will access this class
+                            // and a deadlock might happen. See JDK-8210373.
+                            Class.forName("java.net.InetAddress");
                             System.loadLibrary("j2gss");
-                        } catch (Error err) {
+                        } catch (ClassNotFoundException | Error err) {
                             debug("No j2gss library found!");
                             if (DEBUG) err.printStackTrace();
                             return null;


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

Resolved Copyright, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210373](https://bugs.openjdk.org/browse/JDK-8210373): Deadlock in libj2gss.so when loading "j2gss" and "net" libraries in parallel.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1627/head:pull/1627` \
`$ git checkout pull/1627`

Update a local copy of the PR: \
`$ git checkout pull/1627` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1627`

View PR using the GUI difftool: \
`$ git pr show -t 1627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1627.diff">https://git.openjdk.org/jdk11u-dev/pull/1627.diff</a>

</details>
