### PR TITLE
8290964: C2 compilation fails with assert "non-reduction loop contains reduction nodes"

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2556,17 +2556,6 @@ uint IdealLoopTree::est_loop_flow_merge_sz() const {
   return 0;
 }
 
-#ifdef ASSERT
-bool IdealLoopTree::has_reduction_nodes() const {
-  for (uint i = 0; i < _body.size(); i++) {
-    if (_body[i]->is_reduction()) {
-      return true;
-    }
-  }
-  return false;
-}
-#endif // ASSERT
-
 #ifndef PRODUCT
 //------------------------------dump_head--------------------------------------
 // Dump 1 liner for loop header info

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -658,11 +658,6 @@ public:
 
   void remove_main_post_loops(CountedLoopNode *cl, PhaseIdealLoop *phase);
 
-#ifdef ASSERT
-  // Tell whether the body contains nodes marked as reductions.
-  bool has_reduction_nodes() const;
-#endif // ASSERT
-
 #ifndef PRODUCT
   void dump_head() const;       // Dump loop head only
   void dump() const;            // Dump this loop recursively

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2292,11 +2292,6 @@ void SuperWord::output() {
     return;
   }
 
-  // Check that the loop to be vectorized does not have inconsistent reduction
-  // information, which would likely lead to a miscompilation.
-  assert(!lpt()->has_reduction_nodes() || cl->is_reduction_loop(),
-         "non-reduction loop contains reduction nodes");
-
 #ifndef PRODUCT
   if (TraceLoopOpts) {
     tty->print("SuperWord::output    ");


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290964](https://bugs.openjdk.org/browse/JDK-8290964): C2 compilation fails with assert "non-reduction loop contains reduction nodes"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1630/head:pull/1630` \
`$ git checkout pull/1630`

Update a local copy of the PR: \
`$ git checkout pull/1630` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1630`

View PR using the GUI difftool: \
`$ git pr show -t 1630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1630.diff">https://git.openjdk.org/jdk11u-dev/pull/1630.diff</a>

</details>
