### PR TITLE
8215372: test/jdk/java/nio/file/DirectoryStream/Basic.java not correct when using a glob

### DIFF
--- a/test/jdk/java/nio/file/DirectoryStream/Basic.java
+++ b/test/jdk/java/nio/file/DirectoryStream/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,14 +73,18 @@ public class Basic {
             private PathMatcher matcher =
                 dir.getFileSystem().getPathMatcher("glob:f*");
             public boolean accept(Path file) {
-                return matcher.matches(file);
+                return matcher.matches(file.getFileName());
             }
         };
+
+        found = false;
         try (DirectoryStream<Path> ds = newDirectoryStream(dir, filter)) {
             for (Path entry: ds) {
-                if (!entry.getFileName().equals(foo))
-                    throw new RuntimeException("entry not expected");
+                if (entry.getFileName().equals(foo))
+                   found = true;
             }
+            if (!found)
+                throw new RuntimeException(String.format("Error: entry: %s was not found", foo));
         }
 
         // check filtering: z* should not match any files
@@ -88,7 +92,7 @@ public class Basic {
             private PathMatcher matcher =
                 dir.getFileSystem().getPathMatcher("glob:z*");
             public boolean accept(Path file) {
-                return matcher.matches(file);
+                return matcher.matches(file.getFileName());
             }
         };
         try (DirectoryStream<Path> ds = newDirectoryStream(dir, filter)) {


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8215372](https://bugs.openjdk.org/browse/JDK-8215372): test/jdk/java/nio/file/DirectoryStream/Basic.java not correct when using a glob


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1631/head:pull/1631` \
`$ git checkout pull/1631`

Update a local copy of the PR: \
`$ git checkout pull/1631` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1631`

View PR using the GUI difftool: \
`$ git pr show -t 1631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1631.diff">https://git.openjdk.org/jdk11u-dev/pull/1631.diff</a>

</details>
