### PR TITLE
8215759: [test] java/math/BigInteger/ModPow.java can throw an ArithmeticException

### DIFF
--- a/test/jdk/java/math/BigInteger/ModPow.java
+++ b/test/jdk/java/math/BigInteger/ModPow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +22,25 @@
  */
 
 /* @test
- * @bug 4181191
- * @summary test BigInteger modPow method
+ * @bug 4181191 8215759
+ * @summary test BigInteger modPow method (use -Dseed=X to set PRNG seed)
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run main ModPow
+ * @key randomness
  */
 import java.math.BigInteger;
 import java.util.Random;
+import jdk.test.lib.RandomFactory;
 
 public class ModPow {
     public static void main(String[] args) {
-        Random rnd = new Random(1234);
+        Random rnd = RandomFactory.getRandom();
 
         for (int i=0; i<2000; i++) {
-            BigInteger m = new BigInteger(800, rnd);
+            // Clamp random modulus to a positive value or modPow() will
+            // throw an ArithmeticException.
+            BigInteger m = new BigInteger(800, rnd).max(BigInteger.ONE);
             BigInteger base = new BigInteger(16, rnd);
             if (rnd.nextInt() % 1 == 0)
                 base = base.negate();


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8215759](https://bugs.openjdk.org/browse/JDK-8215759): [test] java/math/BigInteger/ModPow.java can throw an ArithmeticException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1632/head:pull/1632` \
`$ git checkout pull/1632`

Update a local copy of the PR: \
`$ git checkout pull/1632` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1632`

View PR using the GUI difftool: \
`$ git pr show -t 1632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1632.diff">https://git.openjdk.org/jdk11u-dev/pull/1632.diff</a>

</details>
