### PR TITLE
8213932: [TESTBUG] assertEquals is invoked with the arguments in the wrong order

### DIFF
--- a/test/jdk/java/lang/invoke/CompileThresholdBootstrapTest.java
+++ b/test/jdk/java/lang/invoke/CompileThresholdBootstrapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ public final class CompileThresholdBootstrapTest {
 
     @Test
     public void testBootstrap() throws Throwable {
-        Assert.assertEquals(0, (int)MethodHandles.constant(int.class, (int)0).invokeExact());
+        Assert.assertEquals((int)MethodHandles.constant(int.class, (int)0).invokeExact(), 0);
     }
 
     public static void main(String ... args) {

--- a/test/jdk/java/lang/invoke/ConstantIdentityMHTest.java
+++ b/test/jdk/java/lang/invoke/ConstantIdentityMHTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,11 +31,9 @@ package test.java.lang.invoke;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.util.List;
 import static java.lang.invoke.MethodHandles.*;
 import static java.lang.invoke.MethodType.*;
-import static org.testng.AssertJUnit.*;
+import static org.testng.Assert.*;
 import org.testng.annotations.*;
 
 public class ConstantIdentityMHTest {
@@ -69,9 +67,9 @@ public class ConstantIdentityMHTest {
     @Test
     void testEmpty() throws Throwable {
         MethodHandle cat = lookup().findVirtual(String.class, "concat", methodType(String.class, String.class));
-        assertEquals("xy", (String)cat.invoke("x","y"));
+        assertEquals((String)cat.invoke("x","y"), "xy");
         MethodHandle mhEmpty = MethodHandles.empty(cat.type());
-        assertEquals(null, (String)mhEmpty.invoke("x","y"));
+        assertEquals((String)mhEmpty.invoke("x","y"), null);
     }
 
     @Test(expectedExceptions = { NullPointerException.class })

--- a/test/jdk/java/lang/invoke/FilterArgumentsTest.java
+++ b/test/jdk/java/lang/invoke/FilterArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,8 +85,8 @@ public class FilterArgumentsTest {
 
         void run(List<String> expected) throws Throwable {
             filters.clear();
-            assertEquals("x-0-z", (String)mh.invokeExact("x", 0, 'z'));
-            assertEquals(expected, filters);
+            assertEquals((String)mh.invokeExact("x", 0, 'z'), "x-0-z");
+            assertEquals(filters, expected);
         }
 
         static String filterA(String s) {

--- a/test/jdk/java/lang/invoke/lookup/SpecialStatic.java
+++ b/test/jdk/java/lang/invoke/lookup/SpecialStatic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @summary JSR292: invokeSpecial: InternalError attempting to lookup a method
  * @modules java.base/jdk.internal.org.objectweb.asm
  * @compile -XDignore.symbol.file SpecialStatic.java
- * @run junit test.java.lang.invoke.lookup.SpecialStatic
+ * @run testng test.java.lang.invoke.lookup.SpecialStatic
  */
 package test.java.lang.invoke.lookup;
 
@@ -34,9 +34,9 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import jdk.internal.org.objectweb.asm.*;
-import org.junit.Test;
+import org.testng.annotations.*;
 import static jdk.internal.org.objectweb.asm.Opcodes.*;
-import static org.junit.Assert.*;
+import static org.testng.Assert.*;
 
 /**
  * Test case:


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8213932](https://bugs.openjdk.org/browse/JDK-8213932): [TESTBUG] assertEquals is invoked with the arguments in the wrong order


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1633/head:pull/1633` \
`$ git checkout pull/1633`

Update a local copy of the PR: \
`$ git checkout pull/1633` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1633`

View PR using the GUI difftool: \
`$ git pr show -t 1633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1633.diff">https://git.openjdk.org/jdk11u-dev/pull/1633.diff</a>

</details>
