### PR TITLE
8217353: java/util/logging/LogManager/Configuration/updateConfiguration/HandlersOnComplexResetUpdate.java fails with Unexpected reference: java.lang.ref.WeakReference

### DIFF
--- a/test/jdk/java/util/logging/LogManager/Configuration/updateConfiguration/HandlersOnComplexUpdate.java
+++ b/test/jdk/java/util/logging/LogManager/Configuration/updateConfiguration/HandlersOnComplexUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,6 +80,14 @@ public class HandlersOnComplexUpdate {
         }
     }
 
+    public static final double TIMEOUT_FACTOR;
+    static {
+        String toFactor = System.getProperty("test.timeout.factor", "1.0");
+        TIMEOUT_FACTOR = Double.parseDouble(toFactor);
+    }
+    static int adjustCount(int count) {
+        return (int) Math.ceil(TIMEOUT_FACTOR * count);
+    }
 
     private static final String PREFIX =
             "FileHandler-" + UUID.randomUUID() + ".log";
@@ -213,11 +221,11 @@ public class HandlersOnComplexUpdate {
                     + barChild.getParent() +"\n\texpected: " + barRef.get());
         }
         Reference<? extends Logger> ref2;
-        int max = 3;
+        int max = adjustCount(3);
         barChild = null;
         while ((ref2 = queue.poll()) == null) {
             System.gc();
-            Thread.sleep(100);
+            Thread.sleep(1000);
             if (--max == 0) break;
         }
 
@@ -316,21 +324,25 @@ public class HandlersOnComplexUpdate {
                     throw new RuntimeException(x);
                 }
             });
-            fooChild = null;
-            System.out.println("Setting fooChild to: " + fooChild);
-            while ((ref2 = queue.poll()) == null) {
-                System.gc();
-                Thread.sleep(1000);
-            }
-            if (ref2 != fooRef) {
-                throw new RuntimeException("Unexpected reference: "
-                        + ref2 +"\n\texpected: " + fooRef);
-            }
-            if (ref2.get() != null) {
-                throw new RuntimeException("Referent not cleared: " + ref2.get());
-            }
-            System.out.println("Got fooRef after reset(), fooChild is " + fooChild);
-
+            try {
+                fooChild = null;
+                System.out.println("Setting fooChild to: " + fooChild);
+                while ((ref2 = queue.poll()) == null) {
+                    System.gc();
+                    Thread.sleep(1000);
+                }
+                if (ref2 != fooRef) {
+                    throw new RuntimeException("Unexpected reference: "
+                            + ref2 +"\n\texpected: " + fooRef);
+                }
+                if (ref2.get() != null) {
+                    throw new RuntimeException("Referent not cleared: " + ref2.get());
+                }
+                System.out.println("Got fooRef after reset(), fooChild is " + fooChild);
+           } catch (Throwable t) {
+               if (failed != null) t.addSuppressed(failed);
+               throw t;
+           }
         }
         if (failed != null) {
             // should rarely happen...


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8217353](https://bugs.openjdk.org/browse/JDK-8217353): java/util/logging/LogManager/Configuration/updateConfiguration/HandlersOnComplexResetUpdate.java fails with Unexpected reference: java.lang.ref.WeakReference


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1634/head:pull/1634` \
`$ git checkout pull/1634`

Update a local copy of the PR: \
`$ git checkout pull/1634` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1634`

View PR using the GUI difftool: \
`$ git pr show -t 1634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1634.diff">https://git.openjdk.org/jdk11u-dev/pull/1634.diff</a>

</details>
