### PR TITLE
8299616: [11u] Bootcycle build fails after JDK-8257679 backport

### DIFF
--- a/make/autoconf/bootcycle-spec.gmk.in
+++ b/make/autoconf/bootcycle-spec.gmk.in
@@ -28,6 +28,14 @@
 # First include the real base spec.gmk file
 include @SPEC@
 
+# Check that the user did not try to specify a different java to use for compiling.
+# On windows we need to account for fixpath being first word.
+ifeq ($(firstword $(JAVA)),$(FIXPATH))
+  JAVA_EXEC_POS=2
+else
+  JAVA_EXEC_POS=1
+endif
+
 # Override specific values to do a boot cycle build
 ifneq ($(word $(JAVA_EXEC_POS),$(SJAVAC_SERVER_JAVA)),$(word $(JAVA_EXEC_POS),$(JAVA)))
   $(error Bootcycle builds are not possible if --with-sjavac-server-java is specified)

--- a/make/autoconf/bootcycle-spec.gmk.in
+++ b/make/autoconf/bootcycle-spec.gmk.in
@@ -35,11 +35,11 @@ ifeq ($(firstword $(JAVA)),$(FIXPATH))
 else
   JAVA_EXEC_POS=1
 endif
-
-# Override specific values to do a boot cycle build
 ifneq ($(word $(JAVA_EXEC_POS),$(SJAVAC_SERVER_JAVA)),$(word $(JAVA_EXEC_POS),$(JAVA)))
   $(error Bootcycle builds are not possible if --with-sjavac-server-java is specified)
 endif
+
+# Override specific values to do a boot cycle build
 
 # Use a different Boot JDK
 BOOT_JDK := $(JDK_IMAGE_DIR)


### PR DESCRIPTION
Currently, JDK 11u `make bootcycle-images` fails with:

```
 bootcycle-spec.gmk:32: *** non-numeric first argument to `word' function: ''. Stop.
```

The apparent reason is [JDK-8257679](https://bugs.openjdk.org/browse/JDK-8257679) that did the following change:
 https://github.com/openjdk/jdk11u-dev/commit/40f4fc2da8532252a1660c7f082eb19046f4bc70#diff-935527b393cb4625a8874febf5fe39d43479a2228ef437f4e104ba3001e1e30fL31-L40

Note that the left-over hunk uses `JAVA_EXEC_POS`, which is defined in the hunk that was removed. This PR reinstantiates that hunk.

Additional testing:
 - [x] Linux x86_64 fastdebug `make bootcycle-images`
 - [x] Windows x86_64 fastdebug `make bootcycle-images`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299616](https://bugs.openjdk.org/browse/JDK-8299616): [11u] Bootcycle build fails after JDK-8257679 backport


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**) ⚠️ Review applies to [b0ad92ed](https://git.openjdk.org/jdk11u-dev/pull/1639/files/b0ad92eda57ad20649d46d0654e48f5e534f9202)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [b0ad92ed](https://git.openjdk.org/jdk11u-dev/pull/1639/files/b0ad92eda57ad20649d46d0654e48f5e534f9202)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1639/head:pull/1639` \
`$ git checkout pull/1639`

Update a local copy of the PR: \
`$ git checkout pull/1639` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1639`

View PR using the GUI difftool: \
`$ git pr show -t 1639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1639.diff">https://git.openjdk.org/jdk11u-dev/pull/1639.diff</a>

</details>
