### PR TITLE
8209023: fix 2 compiler tests to avoid JDK-8208690

### DIFF
--- a/test/hotspot/jtreg/compiler/runtime/cr6891750/Test6891750.java
+++ b/test/hotspot/jtreg/compiler/runtime/cr6891750/Test6891750.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 6891750
  * @summary deopt blob kills values in O5
- * @run main compiler.runtime.cr6891750.Test6891750
+ * @run main/othervm compiler.runtime.cr6891750.Test6891750
  */
 
 package compiler.runtime.cr6891750;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8209023](https://bugs.openjdk.org/browse/JDK-8209023): fix 2 compiler tests to avoid JDK-8208690


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1645/head:pull/1645` \
`$ git checkout pull/1645`

Update a local copy of the PR: \
`$ git checkout pull/1645` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1645`

View PR using the GUI difftool: \
`$ git pr show -t 1645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1645.diff">https://git.openjdk.org/jdk11u-dev/pull/1645.diff</a>

</details>
