### PR TITLE
8214445: [test] java/net/URL/HandlerLoop has illegal reflective access

### DIFF
--- a/test/jdk/java/net/URL/HandlerLoop.java
+++ b/test/jdk/java/net/URL/HandlerLoop.java
@@ -21,16 +21,19 @@
  * questions.
  */
 
-import java.io.*;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+
 /*
  * @test
  * @bug 4135031
- * @summary Test boostrap problem when a URLStreamHandlerFactory is loaded
+ * @summary Test bootstrap problem when a URLStreamHandlerFactory is loaded
  *          by the application class loader.
- *
+ * @modules java.base/sun.net.www.protocol.file
+ * @run main HandlerLoop
  */
-import java.net.*;
-
 public class HandlerLoop {
 
     public static void main(String args[]) throws Exception {
@@ -57,13 +60,13 @@ public class HandlerLoop {
             // shares the same stream handler factory.
             new Dummy();
             try {
-                Class c = Class.forName(name);
-                return (URLStreamHandler)c.newInstance();
-            } catch (ClassNotFoundException e) {
-                e.printStackTrace();
-            } catch (IllegalAccessException e) {
-                e.printStackTrace();
-            } catch (InstantiationException e) {
+                Class<?> c = Class.forName(name);
+                return (URLStreamHandler)c.getDeclaredConstructor().newInstance();
+            } catch (ClassNotFoundException |
+                    IllegalAccessException |
+                    InstantiationException |
+                    NoSuchMethodException |
+                    InvocationTargetException e) {
                 e.printStackTrace();
             }
             return null;


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8214445](https://bugs.openjdk.org/browse/JDK-8214445): [test] java/net/URL/HandlerLoop has illegal reflective access


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1648/head:pull/1648` \
`$ git checkout pull/1648`

Update a local copy of the PR: \
`$ git checkout pull/1648` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1648`

View PR using the GUI difftool: \
`$ git pr show -t 1648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1648.diff">https://git.openjdk.org/jdk11u-dev/pull/1648.diff</a>

</details>
