### PR TITLE
8294378: URLPermission constructor exception when using tr locale

### DIFF
--- a/src/java.base/share/classes/java/net/HostPortrange.java
+++ b/src/java.base/share/classes/java/net/HostPortrange.java
@@ -149,6 +149,9 @@ class HostPortrange {
                         // regular domain name
                         hoststr = toLowerCase(hoststr);
                     }
+                } else {
+                    // regular domain name
+                    hoststr = toLowerCase(hoststr);
                 }
             }
             hostname = hoststr;

--- a/src/java.base/share/classes/java/net/URLPermission.java
+++ b/src/java.base/share/classes/java/net/URLPermission.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.security.Permission;
+import java.util.Locale;
 
 /**
  * Represents permission to access a resource or set of resources defined by a
@@ -444,7 +445,7 @@ public final class URLPermission extends Permission {
             throw new IllegalArgumentException(
                 "Invalid URL string: \"" + url + "\"");
         }
-        scheme = url.substring(0, delim).toLowerCase();
+        scheme = url.substring(0, delim).toLowerCase(Locale.ROOT);
         this.ssp = url.substring(delim + 1);
 
         if (!ssp.startsWith("//")) {
@@ -466,7 +467,7 @@ public final class URLPermission extends Permission {
             auth = authpath.substring(0, delim);
             this.path = authpath.substring(delim);
         }
-        this.authority = new Authority(scheme, auth.toLowerCase());
+        this.authority = new Authority(scheme, auth);
     }
 
     private String actions() {

--- a/test/jdk/java/net/URLPermission/URLPermissionTest.java
+++ b/test/jdk/java/net/URLPermission/URLPermissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,9 @@ import java.io.*;
 
 /**
  * @test
- * @bug 8010464 8027570 8027687 8029354 8114860 8071660 8161291
+ * @bug 8010464 8027570 8027687 8029354 8114860 8071660 8161291 8294378
+ * @run main URLPermissionTest
+ * @run main/othervm -Duser.language=tr URLPermissionTest
  */
 
 public class URLPermissionTest {
@@ -385,7 +387,9 @@ public class URLPermissionTest {
         eqtest("http://michael@foo.com/bar","http://michael@foo.com/bar", true),
         eqtest("http://Michael@foo.com/bar","http://michael@goo.com/bar",false),
         eqtest("http://michael@foo.com/bar","http://george@foo.com/bar", true),
-        eqtest("http://@foo.com/bar","http://foo.com/bar", true)
+        eqtest("http://@foo.com/bar","http://foo.com/bar", true),
+        eqtest("http://www.IOU.com", "http://www.iou.com", true),
+        eqtest("HTTPI://www.IOU.com", "httpi://www.iou.com", true)
     };
 
     static Test[] createTests = {


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294378](https://bugs.openjdk.org/browse/JDK-8294378): URLPermission constructor exception when using tr locale


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1650/head:pull/1650` \
`$ git checkout pull/1650`

Update a local copy of the PR: \
`$ git checkout pull/1650` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1650`

View PR using the GUI difftool: \
`$ git pr show -t 1650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1650.diff">https://git.openjdk.org/jdk11u-dev/pull/1650.diff</a>

</details>
