### PR TITLE
8297480: GetPrimitiveArrayCritical in imageioJPEG misses result - NULL check

### DIFF
--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -713,6 +713,7 @@ static int setQTables(JNIEnv *env,
         CHECK_NULL_RETURN(table, 0);
         qdata = (*env)->GetObjectField(env, table, JPEGQTable_tableID);
         qdataBody = (*env)->GetPrimitiveArrayCritical(env, qdata, NULL);
+        CHECK_NULL_RETURN(qdataBody, 0);
 
         if (cinfo->is_decompressor) {
             decomp = (j_decompress_ptr) cinfo;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297480](https://bugs.openjdk.org/browse/JDK-8297480): GetPrimitiveArrayCritical in imageioJPEG misses result - NULL check


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1652/head:pull/1652` \
`$ git checkout pull/1652`

Update a local copy of the PR: \
`$ git checkout pull/1652` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1652`

View PR using the GUI difftool: \
`$ git pr show -t 1652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1652.diff">https://git.openjdk.org/jdk11u-dev/pull/1652.diff</a>

</details>
