### PR TITLE
8294947: Use 64bit atomics in patch_verified_entry on x86_64

### DIFF
--- a/src/hotspot/cpu/x86/nativeInst_x86.cpp
+++ b/src/hotspot/cpu/x86/nativeInst_x86.cpp
@@ -544,12 +544,27 @@ void NativeJump::check_verified_entry_alignment(address entry, address verified_
 //
 void NativeJump::patch_verified_entry(address entry, address verified_entry, address dest) {
   // complete jump instruction (to be inserted) is in code_buffer;
+#ifdef _LP64
+  union {
+    jlong cb_long;
+    unsigned char code_buffer[8];
+  } u;
+
+  u.cb_long = *(jlong *)verified_entry;
+
+  intptr_t disp = (intptr_t)dest - ((intptr_t)verified_entry + 1 + 4);
+  guarantee(disp == (intptr_t)(int32_t)disp, "must be 32-bit offset");
+
+  u.code_buffer[0] = instruction_code;
+  *(int32_t*)(u.code_buffer + 1) = (int32_t)disp;
+
+  Atomic::store(u.cb_long, (jlong *) verified_entry);
+  ICache::invalidate_range(verified_entry, 8);
+
+#else
   unsigned char code_buffer[5];
   code_buffer[0] = instruction_code;
   intptr_t disp = (intptr_t)dest - ((intptr_t)verified_entry + 1 + 4);
-#ifdef AMD64
-  guarantee(disp == (intptr_t)(int32_t)disp, "must be 32-bit offset");
-#endif // AMD64
   *(int32_t*)(code_buffer + 1) = (int32_t)disp;
 
   check_verified_entry_alignment(entry, verified_entry);
@@ -580,6 +595,7 @@ void NativeJump::patch_verified_entry(address entry, address verified_entry, add
   *(int32_t*)verified_entry = *(int32_t *)code_buffer;
   // Invalidate.  Opteron requires a flush after every write.
   n_jump->wrote(0);
+#endif // _LP64
 
 }
 


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

I had to swap arguments in Atomic::store() because "8234736: Harmonize parameter order in Atomic - store " is not in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294947](https://bugs.openjdk.org/browse/JDK-8294947): Use 64bit atomics in patch_verified_entry on x86_64


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1654/head:pull/1654` \
`$ git checkout pull/1654`

Update a local copy of the PR: \
`$ git checkout pull/1654` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1654`

View PR using the GUI difftool: \
`$ git pr show -t 1654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1654.diff">https://git.openjdk.org/jdk11u-dev/pull/1654.diff</a>

</details>
