### PR TITLE
8298093: improve cleanup and error handling of awt_parseColorModel in awt_parseImage.c

### DIFF
--- a/src/java.desktop/share/native/libawt/awt/image/awt_parseImage.c
+++ b/src/java.desktop/share/native/libawt/awt/image/awt_parseImage.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -454,6 +454,7 @@ int awt_parseColorModel (JNIEnv *env, jobject jcmodel, int imageType,
 
     int i;
     static jobject s_jdefCM = NULL;
+    cmP->nBits = NULL;
 
     if (JNU_IsNull(env, jcmodel)) {
         JNU_ThrowNullPointerException(env, "null ColorModel object");
@@ -485,7 +486,6 @@ int awt_parseColorModel (JNIEnv *env, jobject jcmodel, int imageType,
         return -1;
     }
 
-    cmP->nBits = NULL;
     if (SAFE_TO_ALLOC_2(cmP->numComponents, sizeof(jint))) {
         cmP->nBits = (jint *)malloc(cmP->numComponents * sizeof(jint));
     }
@@ -508,7 +508,9 @@ int awt_parseColorModel (JNIEnv *env, jobject jcmodel, int imageType,
     cmP->csType = (*env)->GetIntField(env, cmP->jcmodel, g_CMcsTypeID);
 
     cmP->cmType = getColorModelType(env, jcmodel);
-    JNU_CHECK_EXCEPTION_RETURN(env, -1);
+    if ((*env)->ExceptionCheck(env)) {
+        goto cleanup;
+    }
 
     cmP->isDefaultCM = FALSE;
     cmP->isDefaultCompatCM = FALSE;
@@ -530,14 +532,21 @@ int awt_parseColorModel (JNIEnv *env, jobject jcmodel, int imageType,
         if (s_jdefCM == NULL) {
             jobject defCM;
             jclass jcm = (*env)->FindClass(env, "java/awt/image/ColorModel");
-            CHECK_NULL_RETURN(jcm, -1);
+            if (jcm == NULL) {
+                goto cleanup;
+            }
             defCM = (*env)->CallStaticObjectMethod(env, jcm,
                                                    g_CMgetRGBdefaultMID, NULL);
+            if ((*env)->ExceptionCheck(env)) {
+                (*env)->ExceptionClear(env);
+                JNU_ThrowNullPointerException(env, "Unable to find default CM");
+                goto cleanup;
+            }
             s_jdefCM = (*env)->NewGlobalRef(env, defCM);
             if (defCM == NULL || s_jdefCM == NULL) {
                 (*env)->ExceptionClear(env);
                 JNU_ThrowNullPointerException(env, "Unable to find default CM");
-                return -1;
+                goto cleanup;
             }
         }
         cmP->isDefaultCM = ((*env)->IsSameObject(env, s_jdefCM, jcmodel));
@@ -549,12 +558,12 @@ int awt_parseColorModel (JNIEnv *env, jobject jcmodel, int imageType,
         if (cmP->csType != java_awt_color_ColorSpace_TYPE_RGB ||
             !cmP->is_sRGB)
         {
-            return -1;
+            goto cleanup;
         }
 
         for (i = 0; i < cmP->numComponents; i++) {
             if (cmP->nBits[i] != 8) {
-                return -1;
+                goto cleanup;
             }
         }
     }
@@ -572,7 +581,7 @@ int awt_parseColorModel (JNIEnv *env, jobject jcmodel, int imageType,
                                                                  cmP->jrgb,
                                                                  NULL);
             if (rgb == NULL) {
-                return -1;
+                goto cleanup;
             }
             for (i=0; i < cmP->mapSize; i++) {
                 if ((rgb[i]&0xff000000) == 0) {
@@ -590,6 +599,10 @@ int awt_parseColorModel (JNIEnv *env, jobject jcmodel, int imageType,
     }
 
     return 1;
+
+cleanup:
+    free(cmP->nBits);
+    return -1;
 }
 
 void awt_freeParsedRaster(RasterS_t *rasterP, int freeRasterP) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298093](https://bugs.openjdk.org/browse/JDK-8298093): improve cleanup and error handling of awt_parseColorModel in awt_parseImage.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1655/head:pull/1655` \
`$ git checkout pull/1655`

Update a local copy of the PR: \
`$ git checkout pull/1655` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1655`

View PR using the GUI difftool: \
`$ git pr show -t 1655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1655.diff">https://git.openjdk.org/jdk11u-dev/pull/1655.diff</a>

</details>
