### PR TITLE
8296912: C2: CreateExNode::Identity fails with assert(i < _max) failed: oob: i=1, _max=1

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2439,9 +2439,8 @@ Node* CreateExNode::Identity(PhaseGVN* phase) {
   // exception oop through.
   CallNode *call = in(1)->in(0)->as_Call();
 
-  return ( in(0)->is_CatchProj() && in(0)->in(0)->in(1) == in(1) )
-    ? this
-    : call->in(TypeFunc::Parms);
+  return (in(0)->is_CatchProj() && in(0)->in(0)->is_Catch() &&
+          in(0)->in(0)->in(1) == in(1)) ? this : call->in(TypeFunc::Parms);
 }
 
 //=============================================================================

--- a/test/hotspot/jtreg/compiler/c2/TestDeadDataLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestDeadDataLoop.java
@@ -23,11 +23,11 @@
 
 /*
  * @test
- * @bug 8284358
+ * @bug 8284358 8296912
  * @summary An unreachable loop is not removed, leading to a broken graph.
  * @requires vm.compiler2.enabled
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:+UnlockDiagnosticVMOptions
- *                   -XX:CompileCommand=compileonly,*TestDeadDataLoop::test* -XX:CompileCommand=dontinline,*TestDeadDataLoop::notInlined
+ *                   -XX:CompileCommand=compileonly,*TestDeadDataLoop::test* -XX:CompileCommand=dontinline,*TestDeadDataLoop::notInlined*
  *                   compiler.c2.TestDeadDataLoop
  */
 
@@ -210,8 +210,27 @@ public class TestDeadDataLoop {
         }
     }
 
+    static long l;
+
+    static void test11(boolean never) {
+        float f = 1;
+        boolean b;
+        for (int i = 0; i < 5; ++i) {
+            b = (never || l < 0);
+            l = notInlined2();
+            if (!never) {
+                f += i;
+            }
+        }
+        l += f;
+    }
+
     public static boolean notInlined() {
         return false;
+    }
+
+    public static int notInlined2() {
+        return 42;
     }
 
     public static void main(String[] args) {
@@ -228,6 +247,7 @@ public class TestDeadDataLoop {
         test8();
         test9();
         test10();
+        test11(false);
     }
 }
 


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

I had to resolve the test @run description because -XX:+StresssIGVN is not in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296912](https://bugs.openjdk.org/browse/JDK-8296912): C2: CreateExNode::Identity fails with assert(i < _max) failed: oob: i=1, _max=1


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1657/head:pull/1657` \
`$ git checkout pull/1657`

Update a local copy of the PR: \
`$ git checkout pull/1657` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1657`

View PR using the GUI difftool: \
`$ git pr show -t 1657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1657.diff">https://git.openjdk.org/jdk11u-dev/pull/1657.diff</a>

</details>
