### PR TITLE
8245246: Deprecate -profile option in javac

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -78,7 +78,8 @@ javac.opt.J=\
 javac.opt.encoding=\
     Specify character encoding used by source files
 javac.opt.profile=\
-    Check that API used is available in the specified profile
+    Check that API used is available in the specified profile.\n\
+    This option is deprecated and may be removed in a future release.
 javac.opt.target=\
     Generate class files for specific VM version
 javac.opt.release=\
@@ -119,8 +120,6 @@ javac.opt.arg.encoding=\
     <encoding>
 javac.opt.arg.profile=\
     <profile>
-javac.opt.arg.release=\
-    <release>
 javac.opt.arg.release=\
     <release>
 javac.opt.arg.number=\


### PR DESCRIPTION
OpenJDK PR : https://github.com/openjdk/jdk/pull/11226
OpenJDK bug : https://bugs.openjdk.org/browse/JDK-8245246

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8245246](https://bugs.openjdk.org/browse/JDK-8245246): Deprecate -profile option in javac


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1665/head:pull/1665` \
`$ git checkout pull/1665`

Update a local copy of the PR: \
`$ git checkout pull/1665` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1665`

View PR using the GUI difftool: \
`$ git pr show -t 1665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1665.diff">https://git.openjdk.org/jdk11u-dev/pull/1665.diff</a>

</details>
