### PR TITLE
8300424: [11u] Chunk lost in backport of 8297569

### DIFF
--- a/src/java.base/share/classes/java/net/HostPortrange.java
+++ b/src/java.base/share/classes/java/net/HostPortrange.java
@@ -149,9 +149,6 @@ class HostPortrange {
                         // regular domain name
                         hoststr = toLowerCase(hoststr);
                     }
-                } else {
-                    // regular domain name
-                    hoststr = toLowerCase(hoststr);
                 }
             }
             hostname = hoststr;


### PR DESCRIPTION
This change belongs to JDK-8297569.

Please compare the push:
https://github.com/openjdk/jdk11u-dev/commit/71e89e121c318cd2627d2c1b46962b157483ab31
and what I originally backported:
https://github.com/openjdk/jdk11u-dev/pull/1651/commits/c7527505a3dd425914c3037f3e4e003654119bc7

8297569 was a dependent pull request on top of 8294378.
After pushing 8294378 skara rebased the PR on top and asked me to resolve.
The resolve dialog in the web interface only found conflicts in URLPermission.java.
The other two files were resolved automatically.  So I missed this difference.
As the merge change is empty, I did not detect this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300424](https://bugs.openjdk.org/browse/JDK-8300424): [11u] Chunk lost in backport of 8297569


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1668/head:pull/1668` \
`$ git checkout pull/1668`

Update a local copy of the PR: \
`$ git checkout pull/1668` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1668`

View PR using the GUI difftool: \
`$ git pr show -t 1668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1668.diff">https://git.openjdk.org/jdk11u-dev/pull/1668.diff</a>

</details>
