### PR TITLE
6528710: sRGB-ColorSpace to sRGB-ColorSpace Conversion

### DIFF
--- a/test/jdk/java/awt/color/ICC_ColorSpace/SimpleSRGBConversionQualityTest.java
+++ b/test/jdk/java/awt/color/ICC_ColorSpace/SimpleSRGBConversionQualityTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.color.ColorSpace;
+
+/**
+ * @test
+ * @bug 6528710
+ * @summary Verifies sRGB-ColorSpace to sRGB-ColorSpace conversion quality
+ */
+public final class SimpleSRGBConversionQualityTest {
+
+    public static void main(String[] args) {
+        ColorSpace cspace = ColorSpace.getInstance(ColorSpace.CS_sRGB);
+        float fvalue[] = {1.0f, 1.0f, 1.0f};
+
+        Color c = new Color(cspace, fvalue, 1.0f);
+        if (c.getRed() != 255 || c.getGreen() != 255 || c.getBlue() != 255) {
+            throw new RuntimeException("Wrong color: " + c);
+        }
+
+        float frgbvalue[] = cspace.toRGB(fvalue);
+        for (int i = 0; i < 3; ++i) {
+            if (frgbvalue[i] != 1.0f) {
+                System.err.println(fvalue[i] + " -> " + frgbvalue[i]);
+                throw new RuntimeException("Wrong value");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [abeddab9](https://github.com/openjdk/jdk/commit/abeddab991d71f4ea54665082ffcb284267d7f44) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 24 Nov 2022 and was reviewed by Jayathirth D V and Damon Nguyen.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6528710](https://bugs.openjdk.org/browse/JDK-6528710): sRGB-ColorSpace to sRGB-ColorSpace Conversion


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1677/head:pull/1677` \
`$ git checkout pull/1677`

Update a local copy of the PR: \
`$ git checkout pull/1677` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1677`

View PR using the GUI difftool: \
`$ git pr show -t 1677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1677.diff">https://git.openjdk.org/jdk11u-dev/pull/1677.diff</a>

</details>
