### PR TITLE
8290920: sspi_bridge.dll not built if BUILD_CRYPTO is false

### DIFF
--- a/make/lib/Lib-java.security.jgss.gmk
+++ b/make/lib/Lib-java.security.jgss.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,19 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJ2GSS, \
 
 TARGETS += $(BUILD_LIBJ2GSS)
 
+ifeq ($(call isTargetOs, windows), true)
+  $(eval $(call SetupJdkLibrary, BUILD_LIBSSPI_BRIDGE, \
+      NAME := sspi_bridge, \
+      OPTIMIZATION := LOW, \
+      CFLAGS := $(CFLAGS_JDKLIB) \
+          -I$(TOPDIR)/src/java.security.jgss/share/native/libj2gss, \
+      LDFLAGS := $(LDFLAGS_JDKLIB) \
+          $(call SET_SHARED_LIBRARY_ORIGIN) \
+  ))
+
+  TARGETS += $(BUILD_LIBSSPI_BRIDGE)
+endif
+
 ################################################################################
 
 ifneq ($(BUILD_CRYPTO), false)
@@ -55,17 +68,6 @@ ifneq ($(BUILD_CRYPTO), false)
     ))
 
     TARGETS += $(BUILD_LIBW2K_LSA_AUTH)
-
-    $(eval $(call SetupJdkLibrary, BUILD_LIBSSPI_BRIDGE, \
-        NAME := sspi_bridge, \
-        OPTIMIZATION := LOW, \
-        CFLAGS := $(CFLAGS_JDKLIB) \
-            -I$(TOPDIR)/src/java.security.jgss/share/native/libj2gss, \
-        LDFLAGS := $(LDFLAGS_JDKLIB) \
-            $(call SET_SHARED_LIBRARY_ORIGIN) \
-    ))
-
-    TARGETS += $(BUILD_LIBSSPI_BRIDGE)
   endif
 
   ifeq ($(call isTargetOs, macosx), true)


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

The file is named /make/lib/Lib-java.security.jgss.gmk in head, 
but make/lib/Lib-java.security.jgss.gmk in 11.
Modulo this file rename the patch applies clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290920](https://bugs.openjdk.org/browse/JDK-8290920): sspi_bridge.dll not built if BUILD_CRYPTO is false


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to [9289bbd6](https://git.openjdk.org/jdk11u-dev/pull/1679/files/9289bbd6d8e3926b7e3c58a61073f18a43ee03a3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1679/head:pull/1679` \
`$ git checkout pull/1679`

Update a local copy of the PR: \
`$ git checkout pull/1679` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1679`

View PR using the GUI difftool: \
`$ git pr show -t 1679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1679.diff">https://git.openjdk.org/jdk11u-dev/pull/1679.diff</a>

</details>
