### PR TITLE
8298073: gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java causes test task timeout on macosx

### DIFF
--- a/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
+++ b/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,11 +32,12 @@ package gc.metaspace;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:CompressedClassSpaceSize=50m gc.metaspace.CompressedClassSpaceSizeInJmapHeap
+ * @run main/timeout=240 gc.metaspace.CompressedClassSpaceSizeInJmapHeap
  */
 
 import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.Platform;
+import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.SA.SATestUtils;
@@ -55,7 +56,9 @@ public class CompressedClassSpaceSizeInJmapHeap {
             return;
         }
 
-        String pid = Long.toString(ProcessTools.getProcessId());
+        LingeredApp theApp = new LingeredApp();
+        LingeredApp.startApp(List.of("-XX:CompressedClassSpaceSize=50m"), theApp);
+        String pid = Long.toString(theApp.getPid());
 
         JDKToolLauncher jmap = JDKToolLauncher.create("jhsdb")
                                               .addToolArg("jmap")
@@ -75,6 +78,8 @@ public class CompressedClassSpaceSizeInJmapHeap {
         OutputAnalyzer output = new OutputAnalyzer(read(out));
         output.shouldContain("CompressedClassSpaceSize = 52428800 (50.0MB)");
         out.delete();
+
+        LingeredApp.stopApp(theApp);
     }
 
     private static void run(ProcessBuilder pb) throws Exception {


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

The patch to ProblemList did not apply. The test ist problemlisted for 
Solaris, but not for this issue.

Further, LingeredApp.startApp() has different argument requirements.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8298073](https://bugs.openjdk.org/browse/JDK-8298073): gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java causes test task timeout on macosx
 * [JDK-8241293](https://bugs.openjdk.org/browse/JDK-8241293): CompressedClassSpaceSizeInJmapHeap.java time out after 8 minutes


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1684/head:pull/1684` \
`$ git checkout pull/1684`

Update a local copy of the PR: \
`$ git checkout pull/1684` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1684`

View PR using the GUI difftool: \
`$ git pr show -t 1684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1684.diff">https://git.openjdk.org/jdk11u-dev/pull/1684.diff</a>

</details>
