### PR TITLE
8230374: maxOutputSize, instead of javatest.maxOutputSize, should be used in TEST.properties

### DIFF
--- a/test/jdk/jdk/lambda/TEST.properties
+++ b/test/jdk/jdk/lambda/TEST.properties
@@ -2,5 +2,5 @@
 
 TestNG.dirs = .
 
-javatest.maxOutputSize = 250000
+maxOutputSize = 250000
 modules = jdk.compiler jdk.zipfs


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8230374](https://bugs.openjdk.org/browse/JDK-8230374): maxOutputSize, instead of javatest.maxOutputSize, should be used in TEST.properties


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1687/head:pull/1687` \
`$ git checkout pull/1687`

Update a local copy of the PR: \
`$ git checkout pull/1687` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1687`

View PR using the GUI difftool: \
`$ git pr show -t 1687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1687.diff">https://git.openjdk.org/jdk11u-dev/pull/1687.diff</a>

</details>
