### PR TITLE
8300773: Address the inconsistency between the constant array and pool size

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantPool.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/bcel/internal/classfile/ConstantPool.java
@@ -37,7 +37,7 @@ import com.sun.org.apache.bcel.internal.generic.ConstantPoolGen;
 
  * @see     Constant
  * @see     com.sun.org.apache.bcel.internal.generic.ConstantPoolGen
- * @LastModified: May 2022
+ * @LastModified: June 2022
  */
 public class ConstantPool implements Cloneable, Node {
 
@@ -228,8 +228,8 @@ public class ConstantPool implements Cloneable, Node {
          * This is a redundant measure as the ConstantPoolGen should have already
          * reported an error back in the situation.
         */
-        int size = constantPool.length < ConstantPoolGen.CONSTANT_POOL_SIZE - 1 ?
-                constantPool.length : ConstantPoolGen.CONSTANT_POOL_SIZE - 1;
+        int size = constantPool.length < ConstantPoolGen.CONSTANT_POOL_SIZE ?
+                constantPool.length : ConstantPoolGen.CONSTANT_POOL_SIZE;
 
         file.writeShort(size);
         for (int i = 1; i < size; i++) {


### PR DESCRIPTION
A fix in the bcel library.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300773](https://bugs.openjdk.org/browse/JDK-8300773): Address the inconsistency between the constant array and pool size


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1689/head:pull/1689` \
`$ git checkout pull/1689`

Update a local copy of the PR: \
`$ git checkout pull/1689` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1689`

View PR using the GUI difftool: \
`$ git pr show -t 1689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1689.diff">https://git.openjdk.org/jdk11u-dev/pull/1689.diff</a>

</details>
