### PR TITLE
8295405: Add cause in a couple of IllegalArgumentException and InvalidParameterException shown by sun/security/pkcs11 tests

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/CertAndKeyGen.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/CertAndKeyGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -144,7 +144,7 @@ public final class CertAndKeyGen {
             }
 
         } catch (Exception e) {
-            throw new IllegalArgumentException(e.getMessage());
+            throw new IllegalArgumentException(e.getMessage(), e);
         }
         generateInternal();
     }
@@ -160,7 +160,7 @@ public final class CertAndKeyGen {
                 keyGen.initialize(keyBits, prng);
 
             } catch (Exception e) {
-                throw new IllegalArgumentException(e.getMessage());
+                throw new IllegalArgumentException(e.getMessage(), e);
             }
         }
         generateInternal();
@@ -317,7 +317,7 @@ public final class CertAndKeyGen {
 
         } catch (IOException e) {
              throw new CertificateEncodingException("getSelfCert: " +
-                                                    e.getMessage());
+                                                    e.getMessage(), e);
         } catch (InvalidAlgorithmParameterException e2) {
             throw new SignatureException(
                     "Unsupported PSSParameterSpec: " + e2.getMessage());

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -357,7 +357,7 @@ final class Config {
         try {
             return PropertyExpander.expand(s);
         } catch (Exception e) {
-            throw new RuntimeException(e.getMessage());
+            throw new RuntimeException(e.getMessage(), e);
         }
     }
 
@@ -393,6 +393,10 @@ final class Config {
 
     private ConfigurationException excLine(String msg) {
         return new ConfigurationException(msg + ", line " + st.lineno());
+    }
+
+    private ConfigurationException excLine(String msg, Throwable e) {
+        return new ConfigurationException(msg + ", line " + st.lineno(), e);
     }
 
     private void parse() throws IOException {
@@ -799,7 +803,7 @@ final class Config {
             try {
                 return Functions.getMechanismId(mech);
             } catch (IllegalArgumentException e) {
-                throw excLine("Unknown mechanism: " + mech);
+                throw excLine("Unknown mechanism: " + mech, e);
             }
         }
     }
@@ -959,7 +963,7 @@ final class Config {
         try {
             return Functions.getObjectClassId(name);
         } catch (IllegalArgumentException e) {
-            throw excLine("Unknown object class " + name);
+            throw excLine("Unknown object class " + name, e);
         }
     }
 
@@ -971,7 +975,7 @@ final class Config {
             try {
                 return Functions.getKeyId(name);
             } catch (IllegalArgumentException e) {
-                throw excLine("Unknown key algorithm " + name);
+                throw excLine("Unknown key algorithm " + name, e);
             }
         }
     }
@@ -983,7 +987,7 @@ final class Config {
             try {
                 return Functions.getAttributeId(name);
             } catch (IllegalArgumentException e) {
-                throw excLine("Unknown attribute name " + name);
+                throw excLine("Unknown attribute name " + name, e);
             }
         }
     }
@@ -1038,5 +1042,9 @@ class ConfigurationException extends IOException {
     private static final long serialVersionUID = 254492758807673194L;
     ConfigurationException(String msg) {
         super(msg);
+    }
+
+    ConfigurationException(String msg, Throwable e) {
+        super(msg, e);
     }
 }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,7 +139,7 @@ final class P11AEADCipher extends CipherSpi {
             try {
                 engineSetPadding(algoParts[2]);
             } catch (NoSuchPaddingException e) {
-                throw new NoSuchAlgorithmException();
+                throw new NoSuchAlgorithmException(e);
             }
         } else if (algoParts[0].equals("ChaCha20-Poly1305")) {
             fixedKeySize = 32;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyPairGenerator.java
@@ -145,7 +145,7 @@ final class P11KeyPairGenerator extends KeyPairGeneratorSpi {
         try {
             checkKeySize(keySize, null);
         } catch (InvalidAlgorithmParameterException e) {
-            throw new InvalidParameterException(e.getMessage());
+            throw (InvalidParameterException) new InvalidParameterException(e.getMessage()).initCause(e);
         }
         this.params = null;
         if (algorithm.equals("EC")) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyStore.java
@@ -1321,7 +1321,7 @@ final class P11KeyStore extends KeyStoreSpi {
                 RSAKeyFactory.checkKeyLengths(keyLength, null,
                     -1, Integer.MAX_VALUE);
             } catch (InvalidKeyException e) {
-                throw new KeyStoreException(e.getMessage());
+                throw new KeyStoreException(e.getMessage(), e);
             }
 
             return P11Key.privateKey(session,

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -440,7 +440,7 @@ final class P11Signature extends SignatureSpi {
             padding = RSAPadding.getInstance
                 (RSAPadding.PAD_BLOCKTYPE_1, (len + 7) >> 3);
         } catch (InvalidAlgorithmParameterException iape) {
-            throw new InvalidKeyException(iape.getMessage());
+            throw new InvalidKeyException(iape.getMessage(), iape);
         }
         int maxDataSize = padding.getMaxDataSize();
         int encodedLength;
@@ -801,7 +801,7 @@ final class P11Signature extends SignatureSpi {
             DerValue result = new DerValue(DerValue.tag_Sequence,
                                            outseq.toByteArray());
             return result.toByteArray();
-        } catch (java.io.IOException e) {
+        } catch (IOException e) {
             throw new RuntimeException("Internal error", e);
         }
     }


### PR DESCRIPTION
backport 8295405 to jdk11u-dev

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295405](https://bugs.openjdk.org/browse/JDK-8295405): Add cause in a couple of IllegalArgumentException and InvalidParameterException shown by sun/security/pkcs11 tests


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1696/head:pull/1696` \
`$ git checkout pull/1696`

Update a local copy of the PR: \
`$ git checkout pull/1696` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1696`

View PR using the GUI difftool: \
`$ git pr show -t 1696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1696.diff">https://git.openjdk.org/jdk11u-dev/pull/1696.diff</a>

</details>
