### PR TITLE
8241806: The sun/awt/shell/FileSystemViewMemoryLeak.java is unstable

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -216,7 +216,6 @@ java/awt/image/MultiResolutionImage/MultiResolutionDrawImageWithTransformTest.ja
 java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all
 sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all
 sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all
-sun/awt/shell/FileSystemViewMemoryLeak.java 8241806 windows-all
 sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java 8196102 generic-all
 sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java 8196180 windows-all
 sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java 8144029 macosx-all

--- a/test/jdk/sun/awt/shell/FileSystemViewMemoryLeak.java
+++ b/test/jdk/sun/awt/shell/FileSystemViewMemoryLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,10 +27,12 @@
  * @summary FileSystemView.isDrive(File) memory leak on "C:\" file reference
  * @modules java.desktop/sun.awt.shell
  * @requires (os.family == "windows")
- * @run main/othervm  -Xmx8m FileSystemViewMemoryLeak
+ * @run main/othervm/timeout=320 -Xmx8m FileSystemViewMemoryLeak
  */
 import java.io.File;
 import java.text.NumberFormat;
+import java.util.concurrent.TimeUnit;
+
 import javax.swing.filechooser.FileSystemView;
 
 public class FileSystemViewMemoryLeak {
@@ -38,6 +40,9 @@ public class FileSystemViewMemoryLeak {
     public static void main(String[] args) {
         test();
     }
+
+    // Will run the test no more than 300 seconds
+    static long endtime = System.nanoTime() + TimeUnit.SECONDS.toNanos(300);
 
     private static void test() {
 
@@ -52,6 +57,10 @@ public class FileSystemViewMemoryLeak {
         int iMax = 50000;
         long lastPercentFinished = 0L;
         for (int i = 0; i < iMax; i++) {
+            if (isComplete()) {
+                System.out.println("Time is over");
+                return;
+            }
 
             long percentFinished = Math.round(((i * 1000d) / (double) iMax));
 
@@ -76,6 +85,10 @@ public class FileSystemViewMemoryLeak {
             // "isDrive()" seems to be the painful method...
             boolean drive = fileSystemView.isDrive(root);
         }
+    }
+
+    private static boolean isComplete() {
+        return endtime - System.nanoTime() < 0;
     }
 }
 


### PR DESCRIPTION
Backport the patch for the test bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8241806](https://bugs.openjdk.org/browse/JDK-8241806): The sun/awt/shell/FileSystemViewMemoryLeak.java is unstable


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1707/head:pull/1707` \
`$ git checkout pull/1707`

Update a local copy of the PR: \
`$ git checkout pull/1707` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1707`

View PR using the GUI difftool: \
`$ git pr show -t 1707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1707.diff">https://git.openjdk.org/jdk11u-dev/pull/1707.diff</a>

</details>
