### PR TITLE
8223716: sun/net/www/http/HttpClient/MultiThreadTest.java should be more resilient to unexpected traffic

### DIFF
--- a/test/jdk/sun/net/www/http/HttpClient/MultiThreadTest.java
+++ b/test/jdk/sun/net/www/http/HttpClient/MultiThreadTest.java
@@ -42,6 +42,7 @@ import java.io.*;
 import java.time.Duration;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class MultiThreadTest extends Thread {
 
@@ -60,13 +61,11 @@ public class MultiThreadTest extends Thread {
             System.out.println(msg);
     }
 
-    static int reqnum = 0;
+    static final AtomicInteger reqnum = new AtomicInteger();
 
     void doRequest(String uri) throws Exception {
-        URL url = new URL(uri + "?foo="+reqnum);
-        reqnum ++;
+        URL url = new URL(uri + "?foo="+reqnum.getAndIncrement());
         HttpURLConnection http = (HttpURLConnection)url.openConnection();
-
         InputStream in = http.getInputStream();
         byte b[] = new byte[100];
         int total = 0;
@@ -157,12 +156,37 @@ public class MultiThreadTest extends Thread {
         int reqs = Worker.getRequests ();
         MultiThreadTest.debug("Requests = " + reqs);
         System.out.println ("Connection count = " + cnt + " Request count = " + reqs);
-        if (cnt > threads) { // could be less
-            throw new RuntimeException ("Expected "+threads + " connections: used " +cnt);
+
+        // We may have received traffic from something else than
+        // our client. We should only count those workers for which
+        // the expected header has been found.
+        int validConnections = 0;
+        for (Worker w : svr.workers()) {
+            if (w.headerFound) validConnections++;
         }
-        if  (reqs != threads*requests) {
+
+        if (validConnections > threads + 1 || validConnections == 0) { // could be less
+            throw new RuntimeException ("Expected " + threads + " connections: used " + validConnections);
+        }
+
+        // Sometimes the client drops a connection after a while and
+        // spawns a new one. Why this is happening is not clear,
+        // and JDK-8223783 is logged to follow up on this. For the sake
+        // of test stabilization we don't fail on `threads + 1` connections
+        // but log a warning instead.
+        if (validConnections == threads + 1) {
+            debug("WARNING: " + validConnections
+                + " have been used, where only " + threads
+                + " were expected!");
+        }
+
+        if (validConnections != cnt) {
+            debug("WARNING: got " + (cnt - validConnections) + " unexpected connections!");
+        }
+        if  (validConnections == cnt && reqs != threads*requests) {
             throw new RuntimeException ("Expected "+ threads*requests+ " requests: got " +reqs);
         }
+
         for (Thread worker : svr.workers()) {
             worker.join(60_000);
         }
@@ -179,7 +203,7 @@ public class MultiThreadTest extends Thread {
         ServerSocket ss;
         int connectionCount;
         boolean shutdown = false;
-        private Queue<Worker> workers = new ConcurrentLinkedQueue<>();
+        private final Queue<Worker> workers = new ConcurrentLinkedQueue<>();
 
         Server(ServerSocket ss) {
             this.ss = ss;
@@ -246,8 +270,10 @@ public class MultiThreadTest extends Thread {
     class Worker extends Thread {
         Socket s;
         int id;
+        volatile boolean headerFound;
 
         Worker(Socket s, int id) {
+            super("Worker-" + id);
             this.s = s;
             this.id = id;
         }
@@ -260,18 +286,20 @@ public class MultiThreadTest extends Thread {
                 return requests;
             }
         }
+
         public static void incRequests () {
             synchronized (rlock) {
                 requests++;
             }
         }
 
-        int readUntil(InputStream in, char[] seq) throws IOException {
+        int readUntil(InputStream in, StringBuilder headers, char[] seq) throws IOException {
             int i=0, count=0;
             while (true) {
                 int c = in.read();
                 if (c == -1)
                     return -1;
+                headers.append((char)c);
                 count++;
                 if (c == seq[i]) {
                     i++;
@@ -300,13 +328,17 @@ public class MultiThreadTest extends Thread {
 
                     // read entire request from client
                     int n=0;
-
-                    n = readUntil(in, new char[] {'\r','\n', '\r','\n'});
-
+                    StringBuilder headers = new StringBuilder();
+                    n = readUntil(in, headers, new char[] {'\r','\n', '\r','\n'});
                     if (n <= 0) {
                         MultiThreadTest.debug("worker: " + id + ": Shutdown");
                         s.close();
                         return;
+                    }
+                    if (headers.toString().contains("/foo.html?foo=")) {
+                        headerFound = true;
+                    } else {
+                        MultiThreadTest.debug("worker: " + id + ": Unexpected request received: " + headers);
                     }
 
                     MultiThreadTest.debug("worker " + id +


### PR DESCRIPTION
I backport this as prerequisite of 8223783.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8223716](https://bugs.openjdk.org/browse/JDK-8223716): sun/net/www/http/HttpClient/MultiThreadTest.java should be more resilient to unexpected traffic


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1714/head:pull/1714` \
`$ git checkout pull/1714`

Update a local copy of the PR: \
`$ git checkout pull/1714` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1714`

View PR using the GUI difftool: \
`$ git pr show -t 1714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1714.diff">https://git.openjdk.org/jdk11u-dev/pull/1714.diff</a>

</details>
