### PR TITLE
8170705: sun/net/www/protocol/http/StackTraceTest.java fails intermittently with Invalid Http response

### DIFF
--- a/test/jdk/sun/net/www/protocol/http/StackTraceTest.java
+++ b/test/jdk/sun/net/www/protocol/http/StackTraceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,22 +21,30 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 4773417 5003746
+ * @library /test/lib
+ * @build jdk.test.lib.Utils
+ * @run main StackTraceTest
  * @summary  HttpURLConnection.getInputStream() produces IOException with
  *           bad stack trace; HttpURLConnection.getInputStream loses
  *           exception message, exception class
  */
 import java.net.*;
 import java.io.IOException;
+import jdk.test.lib.Utils;
 
 public class StackTraceTest {
     public static void main(String[] args) throws Exception {
-        URL url;
-        try (ServerSocket ss = new ServerSocket(0)) {  // refusing socket
-            url = new URL("http://localhost:" + ss.getLocalPort() + "/");
-        }
+        InetSocketAddress refusing = Utils.refusingEndpoint();
+        int port = refusing.getPort();
+        String host = refusing.getAddress().getHostAddress();
+        if (host.contains(":"))
+            host = "[" + host + "]";
+        URL url = URI.create("http://" + host + ":" + port + "/").toURL();
+        System.out.println("URL: " + url);
+
         URLConnection uc = url.openConnection();
 
         // Trigger implicit connection by trying to retrieve bogus


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8170705](https://bugs.openjdk.org/browse/JDK-8170705): sun/net/www/protocol/http/StackTraceTest.java fails intermittently with Invalid Http response


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1724/head:pull/1724` \
`$ git checkout pull/1724`

Update a local copy of the PR: \
`$ git checkout pull/1724` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1724`

View PR using the GUI difftool: \
`$ git pr show -t 1724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1724.diff">https://git.openjdk.org/jdk11u-dev/pull/1724.diff</a>

</details>
