### PR TITLE
8221098: Run java/net/URL/HandlerLoop.java in othervm mode

### DIFF
--- a/test/jdk/java/net/URL/HandlerLoop.java
+++ b/test/jdk/java/net/URL/HandlerLoop.java
@@ -32,7 +32,7 @@ import java.net.URLStreamHandlerFactory;
  * @summary Test bootstrap problem when a URLStreamHandlerFactory is loaded
  *          by the application class loader.
  * @modules java.base/sun.net.www.protocol.file
- * @run main HandlerLoop
+ * @run main/othervm HandlerLoop
  */
 public class HandlerLoop {
 


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8221098](https://bugs.openjdk.org/browse/JDK-8221098): Run java/net/URL/HandlerLoop.java in othervm mode


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1725/head:pull/1725` \
`$ git checkout pull/1725`

Update a local copy of the PR: \
`$ git checkout pull/1725` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1725`

View PR using the GUI difftool: \
`$ git pr show -t 1725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1725.diff">https://git.openjdk.org/jdk11u-dev/pull/1725.diff</a>

</details>
