### PR TITLE
8129315: java/net/Socket/LingerTest.java and java/net/Socket/ShutdownBoth.java timeout intermittently

### DIFF
--- a/test/jdk/java/net/Socket/LingerTest.java
+++ b/test/jdk/java/net/Socket/LingerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,11 +71,13 @@ public class LingerTest {
     }
 
     static class Other implements Runnable {
-        int port;
-        long delay;
+        final InetAddress address;
+        final int port;
+        final long delay;
         boolean connected = false;
 
-        public Other(int port, long delay) {
+        public Other(InetAddress address, int port, long delay) {
+            this.address = address;
             this.port = port;
             this.delay = delay;
         }
@@ -85,7 +87,7 @@ public class LingerTest {
             try {
                 Thread.sleep(delay);
                 System.out.println ("Other opening socket");
-                Socket s = new Socket("localhost", port);
+                Socket s = new Socket(address, port);
                 synchronized (this) {
                     connected = true;
                 }
@@ -103,9 +105,10 @@ public class LingerTest {
     }
 
     public static void main(String args[]) throws Exception {
-        ServerSocket ss = new ServerSocket(0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        ServerSocket ss = new ServerSocket(0, 50, loopback);
 
-        Socket s1 = new Socket("localhost", ss.getLocalPort());
+        Socket s1 = new Socket(loopback, ss.getLocalPort());
         Socket s2 = ss.accept();
 
         // setup conditions for untransmitted data and lengthy
@@ -119,7 +122,7 @@ public class LingerTest {
         senderThread.start();
 
         // other thread that will connect after 5 seconds.
-        Other other = new Other(ss.getLocalPort(), 5000);
+        Other other = new Other(loopback, ss.getLocalPort(), 5000);
         Thread otherThread = new Thread(other);
         otherThread.start();
 

--- a/test/jdk/java/net/Socket/ShutdownBoth.java
+++ b/test/jdk/java/net/Socket/ShutdownBoth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,8 @@ import java.net.*;
 public class ShutdownBoth {
 
     public static void main(String args[]) throws Exception {
-        ServerSocket ss = new ServerSocket(0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        ServerSocket ss = new ServerSocket(0, 50, loopback);
         Socket s1 = new Socket(ss.getInetAddress(), ss.getLocalPort());
         Socket s2 = ss.accept();
 

--- a/test/jdk/java/net/Socks/SocksServer.java
+++ b/test/jdk/java/net/Socks/SocksServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -488,6 +488,25 @@ public class SocksServer extends Thread {
             this.port = server.getLocalPort();
         } else {
             server.bind(new InetSocketAddress(port));
+        }
+    }
+
+    public SocksServer(InetAddress addr, int port, boolean useV4) throws IOException {
+        this.port = port;
+        this.useV4 = useV4;
+        server = new ServerSocket();
+        if (port == 0 && addr == null) {
+            server.bind(null);
+            this.port = server.getLocalPort();
+        } else if (port == 0 && addr != null) {
+            server.bind(new InetSocketAddress(addr, 0));
+            this.port = server.getLocalPort();
+        } else if (addr == null) {
+            assert port != 0;
+            server.bind(new InetSocketAddress(port));
+        } else {
+            assert port != 0;
+            server.bind(new InetSocketAddress(addr, port));
         }
     }
 

--- a/test/jdk/sun/net/www/http/HttpURLConnection/PostOnDelete.java
+++ b/test/jdk/sun/net/www/http/HttpURLConnection/PostOnDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class PostOnDelete {
         try {
             s = new Server();
             s.startServer();
-            URL url = new URL("http://localhost:" + s.getPort());
+            URL url = new URL("http://" + s.getAuthority());
             HttpURLConnection urlConnection = (HttpURLConnection)url.openConnection();
             urlConnection.setRequestMethod("DELETE");
             urlConnection.setDoOutput(true);
@@ -70,7 +70,8 @@ public class PostOnDelete {
         HttpServer server;
 
         public void startServer() {
-            InetSocketAddress addr = new InetSocketAddress(0);
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            InetSocketAddress addr = new InetSocketAddress(loopback,0);
             try {
                 server = HttpServer.create(addr, 0);
             } catch (IOException ioe) {
@@ -79,6 +80,12 @@ public class PostOnDelete {
 
             server.createContext("/", new EmptyPathHandler());
             server.start();
+        }
+
+        public String getAuthority() {
+            String address = server.getAddress().getHostString();
+            address =  (address.indexOf(':') >= 0) ? ("[" + address + "]") : address;
+            return address + ":" + getPort();
         }
 
         public int getPort() {


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8129315](https://bugs.openjdk.org/browse/JDK-8129315): java/net/Socket/LingerTest.java and java/net/Socket/ShutdownBoth.java timeout intermittently


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1727/head:pull/1727` \
`$ git checkout pull/1727`

Update a local copy of the PR: \
`$ git checkout pull/1727` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1727`

View PR using the GUI difftool: \
`$ git pr show -t 1727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1727.diff">https://git.openjdk.org/jdk11u-dev/pull/1727.diff</a>

</details>
