### PR TITLE
8224024: java/util/concurrent/BlockingQueue/DrainToFails.java testBounded fails intermittently

### DIFF
--- a/test/jdk/java/util/concurrent/BlockingQueue/DrainToFails.java
+++ b/test/jdk/java/util/concurrent/BlockingQueue/DrainToFails.java
@@ -35,6 +35,7 @@
 /*
  * @test
  * @summary Test drainTo failing due to c.add throwing
+ * @library /test/lib
  */
 
 import java.util.ArrayList;
@@ -50,9 +51,11 @@ import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.RunnableScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import jdk.test.lib.Utils;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class DrainToFails {
+    static final long LONG_DELAY_MS = Utils.adjustTimeout(10_000);
     final int CAPACITY = 10;
     final int SMALL = 2;
 
@@ -169,7 +172,7 @@ public class DrainToFails {
             fail("should throw");
         } catch (IllegalStateException success) {
             for (Thread putter : putters) {
-                putter.join(2000L);
+                putter.join(LONG_DELAY_MS);
                 check(! putter.isAlive());
             }
             assertContentsInOrder(q2, 2, 3);
@@ -183,11 +186,10 @@ public class DrainToFails {
         }
     }
 
-    Runnable putter(final BlockingQueue q, final int elt) {
-        return new Runnable() {
-            public void run() {
-                try { q.put(elt); }
-                catch (Throwable t) { unexpected(t); }}};
+    Runnable putter(BlockingQueue q, int elt) {
+        return () -> {
+            try { q.put(elt); }
+            catch (Throwable t) { unexpected(t); }};
     }
 
     void assertContentsInOrder(Iterable it, Object... contents) {


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8224024](https://bugs.openjdk.org/browse/JDK-8224024): java/util/concurrent/BlockingQueue/DrainToFails.java testBounded fails intermittently


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1728/head:pull/1728` \
`$ git checkout pull/1728`

Update a local copy of the PR: \
`$ git checkout pull/1728` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1728`

View PR using the GUI difftool: \
`$ git pr show -t 1728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1728.diff">https://git.openjdk.org/jdk11u-dev/pull/1728.diff</a>

</details>
