### PR TITLE
8171405: java/net/URLConnection/ResendPostBody.java failed with "Error while cleaning up threads after test"

### DIFF
--- a/test/jdk/java/net/URLConnection/ResendPostBody.java
+++ b/test/jdk/java/net/URLConnection/ResendPostBody.java
@@ -48,25 +48,23 @@ public class ResendPostBody {
 
     static class Server extends Thread {
 
-        InputStream     in;
-        OutputStream out;
-        Socket  sock;
-        StringBuffer response;
-        ServerSocket server;
+        private InputStream in;
+        private OutputStream out;
+        private Socket sock;
+        private StringBuffer response;
+        private ServerSocket server;
 
-        Server (ServerSocket s) throws IOException
-        {
+        Server(ServerSocket s) throws IOException {
             server = s;
         }
 
-        void waitFor (String s) throws IOException
-        {
-            byte[] w = s.getBytes ();
-            for(int c=0; c<w.length; c++ ) {
+        void waitFor(String s) throws IOException {
+            byte[] w = s.getBytes();
+            for (int c = 0; c < w.length; c++) {
                 byte expected = w[c];
                 int b = in.read();
                 if (b == -1) {
-                    acceptConn ();
+                    acceptConn();
                 }
                 if ((byte)b != expected) {
                     c = 0;
@@ -74,101 +72,112 @@ public class ResendPostBody {
             }
         }
 
-        boolean done = false;
+        private boolean done = false;
 
-        public synchronized boolean finished () {
+        public synchronized boolean finished() {
             return done;
         }
 
-        public synchronized void setFinished (boolean b) {
+        public synchronized void setFinished(boolean b) throws IOException {
             done = b;
+            this.closeConn();
+            server.close();
         }
 
-        void acceptConn () throws IOException
-        {
-            sock = server.accept ();
-            in = sock.getInputStream ();
-            out = sock.getOutputStream ();
+        void acceptConn() throws IOException {
+            sock = server.accept();
+            in = sock.getInputStream();
+            out = sock.getOutputStream();
         }
 
-        public void run () {
+        void closeConn() throws IOException {
+            in.close();
+            out.close();
+            sock.close();
+        }
+
+        public void run() {
             try {
-                response = new StringBuffer (1024);
-                acceptConn ();
-                waitFor ("POST");
-                waitFor ("ZZZ");
-                Thread.sleep (500);
-                sock.close ();
-                acceptConn ();
-                waitFor ("POST");
-                waitFor ("ZZZ");
-                response.append ("HTTP/1.1 200 OK\r\n");
-                response.append ("Server: Microsoft-IIS/5.0");
-                response.append ("Date: Wed, 26 Jul 2000 14:17:04 GMT\r\n\r\n");
-                out.write (response.toString().getBytes());
+                response = new StringBuffer(1024);
+                acceptConn();
+                waitFor("POST");
+                waitFor("ZZZ");
+                Thread.sleep(500);
+                sock.close();
+                acceptConn();
+                waitFor("POST");
+                waitFor("ZZZ");
+                response.append("HTTP/1.1 200 OK\r\n");
+                response.append("Server: Microsoft-IIS/5.0");
+                response.append("Date: Wed, 26 Jul 2000 14:17:04 GMT\r\n\r\n");
+                out.write(response.toString().getBytes());
+                out.flush();
                 while (!finished()) {
-                    Thread.sleep (1000);
+                    Thread.sleep(1000);
                 }
-                out.close();
             } catch (Exception e) {
-                System.err.println ("Server Exception: " + e);
+                if (!done) {
+                    System.err.println("Server Exception: " + e);
+                }
             } finally {
-                try { server.close(); } catch (IOException unused) {}
+                try {
+                    closeConn();
+                } catch (IOException ioe) {
+                    if (!done) {
+                        ioe.printStackTrace();
+                    }
+                }
             }
         }
     }
 
-    ServerSocket ss;
-    Server server;
+    private ServerSocket ss;
+    private Server server;
 
     public static void main(String[] args) throws Exception {
-        try {
-            if (args.length == 1 && args[0].equals ("-i")) {
-                System.out.println ("Press return when ready");
-                System.in.read ();
-                System.out.println ("Done");
-            }
-            ResendPostBody t = new ResendPostBody ();
-            t. execute ();
-        } catch (IOException  e) {
-            System.out.println ("IOException");
+        if (args.length == 1 && args[0].equals("-i")) {
+            System.out.println("Press return when ready");
+            System.in.read();
+            System.out.println("Done");
         }
+        ResendPostBody t = new ResendPostBody();
+        t.execute();
     }
 
-    public void execute () throws Exception {
-
+    public void execute() throws Exception {
         byte b[] = "X=ABCDEFGHZZZ".getBytes();
 
         ss = new ServerSocket (0);
-        server = new Server (ss);
-        server.start ();
+        server = new Server(ss);
+        server.start();
+
         /* Get the URL */
 
         String s = "http://localhost:"+ss.getLocalPort()+"/test";
         URL url = new URL(s);
-        HttpURLConnection conURL =  (HttpURLConnection)url.openConnection();
+        HttpURLConnection conURL = (HttpURLConnection) url.openConnection(Proxy.NO_PROXY);
 
         conURL.setDoOutput(true);
         conURL.setDoInput(true);
         conURL.setAllowUserInteraction(false);
         conURL.setUseCaches(false);
         conURL.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-        conURL.setRequestProperty("Content-Length", ""+b.length);
+        conURL.setRequestProperty("Content-Length", "" + b.length);
         conURL.setRequestProperty("Connection", "Close");
 
         /* POST some data */
-
         DataOutputStream OutStream = new DataOutputStream(conURL.getOutputStream());
-                          OutStream.write(b, 0, b.length);
+        OutStream.write(b, 0, b.length);
         OutStream.flush();
         OutStream.close();
 
         /* Read the response */
+        int resp = conURL.getResponseCode();
 
-        int resp = conURL.getResponseCode ();
-        server.setFinished (true);
+        server.setFinished(true);    // Set finished and close ServerSocket
+        server.join();            // Join server thread
 
         if (resp != 200)
-            throw new RuntimeException ("Response code was not 200: " + resp);
-  }
+            throw new RuntimeException("Response code was not 200: " + resp);
+    }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

I had to merge two larger chunks by hand.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8171405](https://bugs.openjdk.org/browse/JDK-8171405): java/net/URLConnection/ResendPostBody.java failed with "Error while cleaning up threads after test"


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1734/head:pull/1734` \
`$ git checkout pull/1734`

Update a local copy of the PR: \
`$ git checkout pull/1734` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1734`

View PR using the GUI difftool: \
`$ git pr show -t 1734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1734.diff">https://git.openjdk.org/jdk11u-dev/pull/1734.diff</a>

</details>
