### PR TITLE
8223463: Replace wildcard address with loopback or local host in tests - part 2

### DIFF
--- a/test/jdk/java/net/ipv6tests/TcpTest.java
+++ b/test/jdk/java/net/ipv6tests/TcpTest.java
@@ -25,7 +25,9 @@
  * @test
  * @bug 4868820
  * @key intermittent
- * @summary IPv6 support for Windows XP and 2003 server
+ * @summary IPv6 support for Windows XP and 2003 server. This test requires
+ *          binding to the wildcard address, and as such is susceptible
+ *          of intermittent failures caused by port reuse policy.
  * @library /test/lib
  * @build jdk.test.lib.NetworkConfiguration
  *        jdk.test.lib.Platform
@@ -240,4 +242,3 @@ public class TcpTest extends Tests {
         System.out.println ("Test4: OK");
     }
 }
-


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8223463](https://bugs.openjdk.org/browse/JDK-8223463): Replace wildcard address with loopback or local host in tests - part 2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1736/head:pull/1736` \
`$ git checkout pull/1736`

Update a local copy of the PR: \
`$ git checkout pull/1736` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1736`

View PR using the GUI difftool: \
`$ git pr show -t 1736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1736.diff">https://git.openjdk.org/jdk11u-dev/pull/1736.diff</a>

</details>
