### PR TITLE
8226917: jvmti/scenarios/contention/TC04/tc04t001/TestDescription.java fails on jvmti->InterruptThread (JVMTI_ERROR_THREAD_NOT_ALIVE)

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/contention/TC04/tc04t001/tc04t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/contention/TC04/tc04t001/tc04t001.cpp
@@ -119,18 +119,9 @@ MonitorContendedEnter(jvmtiEnv *jvmti, JNIEnv* jni, jthread thr, jobject obj) {
 
     /* check if event is for tested object */
     if (jni->IsSameObject(object_M, obj)) {
-        jvmtiMonitorUsage usageInfo;
-
         if (lockSyncLock(jvmti)) {
             enterEventsCount++;
             unlockSyncLock(jvmti);
-        }
-
-        if (!NSK_JVMTI_VERIFY(jvmti->GetObjectMonitorUsage(obj, &usageInfo))) {
-            nsk_jvmti_setFailStatus();
-        } else if (usageInfo.owner != NULL) {
-            if (!NSK_JVMTI_VERIFY(jvmti->InterruptThread(usageInfo.owner)))
-                nsk_jvmti_setFailStatus();
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8226917](https://bugs.openjdk.org/browse/JDK-8226917): jvmti/scenarios/contention/TC04/tc04t001/TestDescription.java fails on jvmti-&gt;InterruptThread (JVMTI_ERROR_THREAD_NOT_ALIVE)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1738/head:pull/1738` \
`$ git checkout pull/1738`

Update a local copy of the PR: \
`$ git checkout pull/1738` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1738`

View PR using the GUI difftool: \
`$ git pr show -t 1738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1738.diff">https://git.openjdk.org/jdk11u-dev/pull/1738.diff</a>

</details>
