### PR TITLE
8248306: gc/stress/gclocker/TestExcessGCLockerCollections.java does not compile

### DIFF
--- a/test/hotspot/jtreg/gc/stress/gclocker/TestExcessGCLockerCollections.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestExcessGCLockerCollections.java
@@ -175,9 +175,7 @@ public class TestExcessGCLockerCollections {
         finalArgs.addAll(Arrays.asList(args));
 
         // GC and other options obtained from test framework.
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            true, finalArgs);
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        OutputAnalyzer output = ProcessTools.executeTestJvm(finalArgs);
         output.shouldHaveExitValue(0);
         //System.out.println("------------- begin stdout ----------------");
         //System.out.println(output.getStdout());


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8248306](https://bugs.openjdk.org/browse/JDK-8248306): gc/stress/gclocker/TestExcessGCLockerCollections.java does not compile


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1744/head:pull/1744` \
`$ git checkout pull/1744`

Update a local copy of the PR: \
`$ git checkout pull/1744` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1744`

View PR using the GUI difftool: \
`$ git pr show -t 1744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1744.diff">https://git.openjdk.org/jdk11u-dev/pull/1744.diff</a>

</details>
