### PR TITLE
8202621: bad test with broken links needs to be updated

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/DocRootSlash/DocRootSlash.java
+++ b/test/langtools/jdk/javadoc/doclet/DocRootSlash/DocRootSlash.java
@@ -51,13 +51,12 @@ public class DocRootSlash extends JavadocTester {
         // Directory that contains source files that javadoc runs on
         String srcdir = System.getProperty("test.src", ".");
 
-        setAutomaticCheckLinks(false); // @ignore JDK-8202621
 
         javadoc("-d", "out",
                 "-Xdoclint:none",
                 "-overview", (srcdir + "/overview.html"),
                 "--frames",
-                "-header", "<A HREF=\"{@docroot}/package-list\">{&#064;docroot}</A> <A HREF=\"{@docRoot}/help-doc\">{&#064;docRoot}</A>",
+                "-header", "<A HREF=\"{@docroot}/element-list\">{&#064;docroot}</A> <A HREF=\"{@docRoot}/help-doc.html\">{&#064;docRoot}</A>",
                 "-sourcepath", srcdir,
                 "p1", "p2");
 
@@ -69,8 +68,8 @@ public class DocRootSlash extends JavadocTester {
         // Bug 4633447: Special test for overview-frame.html
         // Find two strings in file "overview-frame.html"
         checkOutput("overview-frame.html", true,
-                "<A HREF=\"./package-list\">",
-                "<A HREF=\"./help-doc\">");
+                "<A HREF=\"./element-list\">",
+                "<A HREF=\"./help-doc.html\">");
     }
 
     void checkFiles(String... filenameArray) {
@@ -81,7 +80,7 @@ public class DocRootSlash extends JavadocTester {
             String fileString = readFile(f);
             System.out.println("\nSub-tests for file: " + f + " --------------");
             // Loop over all tests in a single file
-            for ( int j = 0; j < 11; j++ ) {
+            for ( int j = 0; j < 7; j++ ) {
 
                 // Compare actual to expected string for a single subtest
                 compareActualToExpected(++count, fileString);
@@ -107,9 +106,6 @@ public class DocRootSlash extends JavadocTester {
      */
     private static final String prefix = "(?i)(<a\\s+href=";    // <a href=     (start group1)
     private static final String ref1   = "\")([^\"]*)(\".*?>)"; // doublequotes (end group1, group2, group3)
-    private static final String ref2   = ")(\\S+?)([^<>]*>)";   // no quotes    (end group1, group2, group3)
-    private static final String label  = "(.*?)";               // text label   (group4)
-    private static final String end    = "(</a>)";              // </a>         (group5)
 
     /**
      * Compares the actual string to the expected string in the specified string

--- a/test/langtools/jdk/javadoc/doclet/DocRootSlash/overview.html
+++ b/test/langtools/jdk/javadoc/doclet/DocRootSlash/overview.html
@@ -9,55 +9,33 @@ Dummy first sentence to suppress BreakIterator warning.
 
 Case 0 Actual: <A HREF=".">.</A> &nbsp; Current directory
 <p>
-Sub-test 23 Actual: <A HREF="{@docroot}">{&#064;docroot}</A> Bare tag - ALL LOWERCASE <br>
-Sub-test 23 Expect: <A HREF=""></A> <br>
-(Expect empty string because lowercase docroot is illegal) 
+Sub-test 15 Actual: <A HREF="{@docroot}">{&#064;docroot}</A> Bare tag - ALL LOWERCASE <br>
+Sub-test 15 Expect: <A HREF=""></A> <br>
+(Expect empty string because lowercase docroot is illegal)
 <p>
 
-Sub-test 24 Actual: <A HREF="{@docRoot}">{&#064;docRoot}</A> Bare tag - "R" UPPERCASE <br>
-Sub-test 24 Expect: <A HREF=".">.</A>
+Sub-test 16 Actual: <A HREF="{@docRoot}">{&#064;docRoot}</A> Bare tag - "R" UPPERCASE <br>
+Sub-test 16 Expect: <A HREF=".">.</A>
 <p>
 
-Sub-test 25 Actual: <A HREF="{@docRoot}/package-list">{&#064;docRoot}/package-list</A>  <br>
-Sub-test 25 Expect: <A HREF="./package-list">./package-list</A>
+Sub-test 17 Actual: <A HREF="{@docRoot}/element-list">{&#064;docRoot}/element-list</A>  <br>
+Sub-test 17 Expect: <A HREF="./element-list">./element-list</A>
 <p>
 
-Sub-test 26 Actual: <A HREF="{@docRoot}/p2/C2.html">{&#064;docRoot}/p2/C2.html</A>  <br>
-Sub-test 26 Expect: <A HREF="./p2/C2.html">./p2/C2.html</A>
+Sub-test 18 Actual: <A HREF="{@docRoot}/p2/C2.html">{&#064;docRoot}/p2/C2.html</A>  <br>
+Sub-test 18 Expect: <A HREF="./p2/C2.html">./p2/C2.html</A>
 <p>
 
-Sub-test 27 Actual: <A HREF="{@docRoot}/../docs1/p2/C2.html">{&#064;docRoot}/../docs1/p2/C2.html</A> <br>
-Sub-test 27 Expect: <A HREF="./../docs1/p2/C2.html">./../docs1/p2/C2.html</A>
+Sub-test 19 Actual: <A HREF="{@docRoot}/../out/p2/C2.html">{&#064;docRoot}/../out/p2/C2.html</A> <br>
+Sub-test 19 Expect: <A HREF="./../out/p2/C2.html">./../out/p2/C2.html</A>
 <p>
 
-Sub-test 28 Actual: <A HREF="{@docRoot}/p2/package-summary.html#package_description">{&#064;docRoot}/p2/package-summary.html#package_description</A>  <br>
-Sub-test 28 Expect: <A HREF="./p2/package-summary.html#package_description">./p2/package-summary.html#package_description</A>
+Sub-test 20 Actual: <A HREF="{@docRoot}/p2/package-summary.html#package.description">{&#064;docRoot}/p2/package-summary.html#package.description</A>  <br>
+Sub-test 20 Expect: <A HREF="./p2/package-summary.html#package.description">./p2/package-summary.html#package.description</A>
 <p>
 
-Sub-test 29 Actual: <A HREF="{@docRoot}/../docs1/p2/package-summary.html#package_description">{&#064;docRoot}/../docs1/p2/package-summary.html#package_description</A> <br>
-Sub-test 29 Expect: <A HREF="./../docs1/p2/package-summary.html#package_description">./../docs1/p2/package-summary.html#package_description</A>
-<p>
-
-<!-- ============================================================== -->
-
-Allow docRoot to work without a trailing slash for those who had to change their comments
-to work with the 1.4.0 bug:
-<p>
-
-Sub-test 30 Actual: <A HREF="{@docRoot}p2/C2.html">{&#064;docRoot}p2/C2.html</A>  <br>
-Sub-test 30 Expect: <A HREF=".p2/C2.html">./p2/C2.html</A>
-<p>
-
-Sub-test 31 Actual: <A HREF="{@docRoot}../docs1/p2/C2.html">{&#064;docRoot}../docs1/p2/C2.html</A> <br>
-Sub-test 31 Expect: <A HREF=".../docs1/p2/C2.html">./../docs1/p2/C2.html</A>
-<p>
-
-Sub-test 32 Actual: <A HREF="{@docRoot}p2/package-summary.html#package_description">{&#064;docRoot}/p2/package-summary.html#package_description</A>  <br>
-Sub-test 32 Expect: <A HREF=".p2/package-summary.html#package_description">./p2/package-summary.html#package_description</A>
-
-<p>
-Sub-test 33 Actual: <A HREF="{@docRoot}../docs1/p2/package-summary.html#package_description">{&#064;docRoot}/../docs1/p2/package-summary.html#package_description</A> <br>
-Sub-test 33 Expect: <A HREF=".../docs1/p2/package-summary.html#package_description">./../docs1/p2/package-summary.html#package_description</A>
+Sub-test 21 Actual: <A HREF="{@docRoot}/../out/p2/package-summary.html#package.description">{&#064;docRoot}/../out/p2/package-summary.html#package.description</A> <br>
+Sub-test 21 Expect: <A HREF="./../out/p2/package-summary.html#package.description">./../out/p2/package-summary.html#package.description</A>
 
 </BODY>
 </HTML>

--- a/test/langtools/jdk/javadoc/doclet/DocRootSlash/p1/C1.java
+++ b/test/langtools/jdk/javadoc/doclet/DocRootSlash/p1/C1.java
@@ -39,46 +39,24 @@ package p1;
  * Sub-test 2 Expect: <A HREF="..">..</A>
  * <p>
  *
- * Sub-test 3 Actual: <A HREF="{@docRoot}/package-list">{&#064;docRoot}/package-list</A> <br>
- * Sub-test 3 Expect: <A HREF="../package-list">../package-list</A>
+ * Sub-test 3 Actual: <A HREF="{@docRoot}/element-list">{&#064;docRoot}/element-list</A> <br>
+ * Sub-test 3 Expect: <A HREF="../element-list">../element-list</A>
  * <p>
  *
  * Sub-test 4 Actual: <A HREF="{@docRoot}/p2/C2.html">{&#064;docRoot}/p2/C2.html</A> <br>
  * Sub-test 4 Expect: <A HREF="../p2/C2.html">../p2/C2.html</A>
  * <p>
  *
- * Sub-test 5 Actual: <A HREF="{@docRoot}/../docs1/p2/C2.html">{&#064;docRoot}/../docs1/p2/C2.html</A> <br>
- * Sub-test 5 Expect: <A HREF="../../docs1/p2/C2.html">../../docs1/p2/C2.html</A>
+ * Sub-test 5 Actual: <A HREF="{@docRoot}/../out/p2/C2.html">{&#064;docRoot}/../out/p2/C2.html</A> <br>
+ * Sub-test 5 Expect: <A HREF="../../out/p2/C2.html">../../out/p2/C2.html</A>
  * <p>
  *
- * Sub-test 6 Actual: <A HREF="{@docRoot}/p2/package-summary.html#package_description">{&#064;docRoot}/p2/package-summary.html#package_description</A> <br>
- * Sub-test 6 Expect: <A HREF="../p2/package-summary.html#package_description">../p2/package-summary.html#package_description</A>
+ * Sub-test 6 Actual: <A HREF="{@docRoot}/p2/package-summary.html#package.description">{&#064;docRoot}/p2/package-summary.html#package.description</A> <br>
+ * Sub-test 6 Expect: <A HREF="../p2/package-summary.html#package.description">../p2/package-summary.html#package.description</A>
  * <p>
  *
- * Sub-test 7 Actual: <A HREF="{@docRoot}/../docs1/p2/package-summary.html#package_description">{&#064;docRoot}/../docs1/p2/package-summary.html#package_description</A> <br>
- * Sub-test 7 Expect: <A HREF="../../docs1/p2/package-summary.html#package_description">../../docs1/p2/package-summary.html#package_description</A>
- * <p>
- *
- * <!-- =================================================================== -->
- *
- * Allow docRoot to work without a trailing slash for those who had to change their comments
- * to work with the 1.4.0 bug:
- * <p>
- *
- * Sub-test 8 Actual: <A HREF="{@docRoot}p2/C2.html">{&#064;docRoot}p2/C2.html</A> <br>
- * Sub-test 8 Expect: <A HREF="..p2/C2.html">../p2/C2.html</A>
- * <p>
- *
- * Sub-test 9 Actual: <A HREF="{@docRoot}../docs1/p2/C2.html">{&#064;docRoot}../docs1/p2/C2.html</A> <br>
- * Sub-test 9 Expect: <A HREF="..../docs1/p2/C2.html">../../docs1/p2/C2.html</A>
- * <p>
- *
- * Sub-test 10 Actual: <A HREF="{@docRoot}p2/package-summary.html#package_description">{&#064;docRoot}/p2/package-summary.html#package_description</A> <br>
- * Sub-test 10 Expect: <A HREF="..p2/package-summary.html#package_description">../p2/package-summary.html#package_description#package_description</A>
- * <p>
- *
- * Sub-test 11 Actual: <A HREF="{@docRoot}../docs1/p2/package-summary.html#package_description">{&#064;docRoot}/../docs1/p2/package-summary.html#package_description</A> <br>
- * Sub-test 11 Expect: <A HREF="..../docs1/p2/package-summary.html#package_description">../../docs1/p2/package-summary.html#package_description</A>
+ * Sub-test 7 Actual: <A HREF="{@docRoot}/../out/p2/package-summary.html#package.description">{&#064;docRoot}/../out/p2/package-summary.html#package.description</A> <br>
+ * Sub-test 7 Expect: <A HREF="../../out/p2/package-summary.html#package.description">../../out/p2/package-summary.html#package.description</A>
  *
  */
 public class C1 {

--- a/test/langtools/jdk/javadoc/doclet/DocRootSlash/p1/package.html
+++ b/test/langtools/jdk/javadoc/doclet/DocRootSlash/p1/package.html
@@ -10,55 +10,33 @@ Dummy first sentence to suppress breakiterator warning.
 Case 0 Actual: <A HREF=".">.</A> &nbsp; Current directory
 <p>
 
-Sub-test 12 Actual: <A HREF="{@docroot}">{&#064;docroot}</A> Bare tag - ALL LOWERCASE <br>
-Sub-test 12 Expect: <A HREF=""></A> <br>
+Sub-test 8 Actual: <A HREF="{@docroot}">{&#064;docroot}</A> Bare tag - ALL LOWERCASE <br>
+Sub-test 8 Expect: <A HREF=""></A> <br>
 (Expect empty string because lowercase docroot is illegal)
 <p>
 
-Sub-test 13 Actual: <A HREF="{@docRoot}">{&#064;docRoot}</A> Bare tag - "R" UPPERCASE <br>
-Sub-test 13 Expect: <A HREF="..">..</A>
+Sub-test 9 Actual: <A HREF="{@docRoot}">{&#064;docRoot}</A> Bare tag - "R" UPPERCASE <br>
+Sub-test 9 Expect: <A HREF="..">..</A>
 <p>
 
-Sub-test 14 Actual: <A HREF="{@docRoot}/package-list">{&#064;docRoot}/package-list</A> <br>
-Sub-test 14 Expect: <A HREF="../package-list">../package-list</A>
+Sub-test 10 Actual: <A HREF="{@docRoot}/element-list">{&#064;docRoot}/element-list</A> <br>
+Sub-test 10 Expect: <A HREF="../element-list">../element-list</A>
 <p>
 
-Sub-test 15 Actual: <A HREF="{@docRoot}/p2/C2.html">{&#064;docRoot}/p2/C2.html</A> <br>
-Sub-test 15 Expect: <A HREF="../p2/C2.html">../p2/C2.html</A>
+Sub-test 11 Actual: <A HREF="{@docRoot}/p2/C2.html">{&#064;docRoot}/p2/C2.html</A> <br>
+Sub-test 11 Expect: <A HREF="../p2/C2.html">../p2/C2.html</A>
 <p>
 
-Sub-test 16 Actual: <A HREF="{@docRoot}/../docs1/p2/C2.html">{&#064;docRoot}/../docs1/p2/C2.html</A> <br>
-Sub-test 16 Expect: <A HREF="../../docs1/p2/C2.html">../../docs1/p2/C2.html</A>
+Sub-test 12 Actual: <A HREF="{@docRoot}/../out/p2/C2.html">{&#064;docRoot}/../out/p2/C2.html</A> <br>
+Sub-test 12 Expect: <A HREF="../../out/p2/C2.html">../../out/p2/C2.html</A>
 <p>
 
-Sub-test 17 Actual: <A HREF="{@docRoot}/p2/package-summary.html#package_description">{&#064;docRoot}/p2/package-summary.html#package_description</A> <br>
-Sub-test 17 Expect: <A HREF="../p2/package-summary.html#package_description">../p2/package-summary.html#package_description</A>
+Sub-test 13 Actual: <A HREF="{@docRoot}/p2/package-summary.html#package.description">{&#064;docRoot}/p2/package-summary.html#package.description</A> <br>
+Sub-test 13 Expect: <A HREF="../p2/package-summary.html#package.description">../p2/package-summary.html#package.description</A>
 <p>
 
-Sub-test 18 Actual: <A HREF="{@docRoot}/../docs1/p2/package-summary.html#package_description">{&#064;docRoot}/../docs1/p2/package-summary.html#package_description</A> <br>
-Sub-test 18 Expect: <A HREF="../../docs1/p2/package-summary.html#package_description">../../docs1/p2/package-summary.html#package_description</A>
-<p>
-
-<!-- ================================================================== -->
-
-Allow docRoot to work without a trailing slash for those who had to change their comments
-to work with the 1.4.0 bug:
-<p>
-
-Sub-test 19 Actual: <A HREF="{@docRoot}p2/C2.html">{&#064;docRoot}p2/C2.html</A> <br>
-Sub-test 19 Expect: <A HREF="..p2/C2.html">../p2/C2.html</A>
-<p>
-
-Sub-test 20 Actual: <A HREF="{@docRoot}../docs1/p2/C2.html">{&#064;docRoot}../docs1/p2/C2.html</A> <br>
-Sub-test 20 Expect: <A HREF="..../docs1/p2/C2.html">../../docs1/p2/C2.html</A>
-<p>
-
-Sub-test 21 Actual: <A HREF="{@docRoot}p2/package-summary.html#package_description">{&#064;docRoot}/p2/package-summary.html#package_description</A><br>
-Sub-test 21 Expect: <A HREF="..p2/package-summary.html#package_description">../p2/package-summary.html#package_description</A>
-<p>
-
-Sub-test 22 Actual: <A HREF="{@docRoot}../docs1/p2/package-summary.html#package_description">{&#064;docRoot}/../docs1/p2/package-summary.html#package_description</A> <br>
-Sub-test 22 Expect: <A HREF="..../docs1/p2/package-summary.html#package_description">../../docs1/p2/package-summary.html#package_description</A>
+Sub-test 14 Actual: <A HREF="{@docRoot}/../out/p2/package-summary.html#package.description">{&#064;docRoot}/../out/p2/package-summary.html#package.description</A> <br>
+Sub-test 14 Expect: <A HREF="../../out/p2/package-summary.html#package.description">../../out/p2/package-summary.html#package.description</A>
 
 </BODY>
 </HTML>


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8202621](https://bugs.openjdk.org/browse/JDK-8202621): bad test with broken links needs to be updated


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1746/head:pull/1746` \
`$ git checkout pull/1746`

Update a local copy of the PR: \
`$ git checkout pull/1746` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1746`

View PR using the GUI difftool: \
`$ git pr show -t 1746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1746.diff">https://git.openjdk.org/jdk11u-dev/pull/1746.diff</a>

</details>
