### PR TITLE
8252401: Introduce Utils.TEST_NATIVE_PATH

### DIFF
--- a/test/lib/jdk/test/lib/Utils.java
+++ b/test/lib/jdk/test/lib/Utils.java
@@ -107,7 +107,12 @@ public final class Utils {
      */
     public static final String TEST_NAME = System.getProperty("test.name", ".");
 
-   /**
+    /**
+     * Returns the value of 'test.nativepath' system property
+     */
+    public static final String TEST_NATIVE_PATH = System.getProperty("test.nativepath", ".");
+
+    /**
      * Defines property name for seed value.
      */
     public static final String SEED_PROPERTY_NAME = "jdk.test.lib.random.seed";


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8252401](https://bugs.openjdk.org/browse/JDK-8252401): Introduce Utils.TEST_NATIVE_PATH


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1750/head:pull/1750` \
`$ git checkout pull/1750`

Update a local copy of the PR: \
`$ git checkout pull/1750` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1750`

View PR using the GUI difftool: \
`$ git pr show -t 1750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1750.diff">https://git.openjdk.org/jdk11u-dev/pull/1750.diff</a>

</details>
