### PR TITLE
8260576: Typo in compiler/runtime/safepoints/TestRegisterRestoring.java

### DIFF
--- a/test/hotspot/jtreg/compiler/runtime/safepoints/TestRegisterRestoring.java
+++ b/test/hotspot/jtreg/compiler/runtime/safepoints/TestRegisterRestoring.java
@@ -47,7 +47,7 @@ public class TestRegisterRestoring {
             // Check result
             for (int i = 0; i < array.length; i++) {
                 if (array[i] != 10_000) {
-                    throw new RuntimeException("Test failed: array[" + i + "] = " + array[i] + " but should be 10.000");
+                    throw new RuntimeException("Test failed: array[" + i + "] = " + array[i] + " but should be 10,000");
                 }
                 array[i] = 0;
             }


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8260576](https://bugs.openjdk.org/browse/JDK-8260576): Typo in compiler/runtime/safepoints/TestRegisterRestoring.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1751/head:pull/1751` \
`$ git checkout pull/1751`

Update a local copy of the PR: \
`$ git checkout pull/1751` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1751`

View PR using the GUI difftool: \
`$ git pr show -t 1751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1751.diff">https://git.openjdk.org/jdk11u-dev/pull/1751.diff</a>

</details>
