### PR TITLE
8261270: MakeMethodNotCompilableTest fails with -XX:TieredStopAtLevel={1,2,3}

### DIFF
--- a/test/hotspot/jtreg/compiler/whitebox/MakeMethodNotCompilableTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/MakeMethodNotCompilableTest.java
@@ -202,7 +202,7 @@ public class MakeMethodNotCompilableTest extends CompilerWhiteBoxTest {
                 deoptimize();
             }
 
-            if (!isCompilable(COMP_LEVEL_ANY)) {
+            if (!isCompilable(COMP_LEVEL_ANY) && TIERED_STOP_AT_LEVEL == COMP_LEVEL_FULL_OPTIMIZATION) {
                 throw new RuntimeException(method
                         + " must be compilable at 'CompLevel::CompLevel_any'"
                         + ", if it is not compilable only at " + testedTier);


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8261270](https://bugs.openjdk.org/browse/JDK-8261270): MakeMethodNotCompilableTest fails with -XX:TieredStopAtLevel={1,2,3}


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1754/head:pull/1754` \
`$ git checkout pull/1754`

Update a local copy of the PR: \
`$ git checkout pull/1754` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1754/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1754`

View PR using the GUI difftool: \
`$ git pr show -t 1754`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1754.diff">https://git.openjdk.org/jdk11u-dev/pull/1754.diff</a>

</details>
