### PR TITLE
8264512: jdk/test/jdk/java/util/prefs/ExportNode.java relies on default platform encoding

### DIFF
--- a/test/jdk/java/util/prefs/ExportNode.java
+++ b/test/jdk/java/util/prefs/ExportNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,25 +30,46 @@
  * @run main/othervm -Djava.util.prefs.userRoot=. ExportNode
  * @author Konstantin Kladko
  */
-import java.util.prefs.*;
-import java.io.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
 
 public class ExportNode {
+    private static final String NODE_NAME_1 = "ExportNodeTestName1";
+    private static final String NODE_NAME_2 = "ExportNodeTestName2";
+
     public static void main(String[] args) throws
-                                            BackingStoreException, IOException {
-            Preferences N1 = Preferences.userRoot().node("ExportNodeTest1");
-            N1.put("ExportNodeTestName1","ExportNodeTestValue1");
-            Preferences N2 = N1.node("ExportNodeTest2");
-            N2.put("ExportNodeTestName2","ExportNodeTestValue2");
-            ByteArrayOutputStream exportStream = new ByteArrayOutputStream();
-            N2.exportNode(exportStream);
+        BackingStoreException, IOException {
+        Preferences N1 = Preferences.userRoot().node("ExportNodeTest1");
+        N1.put(NODE_NAME_1,"ExportNodeTestValue1");
+        Preferences N2 = N1.node("ExportNodeTest2");
+        N2.put(NODE_NAME_2,"ExportNodeTestValue2");
+        ByteArrayOutputStream exportStream = new ByteArrayOutputStream();
+        N2.exportNode(exportStream);
 
-            // Removal of preference node should always succeed on Solaris/Linux
-            // by successfully acquiring the appropriate file lock (4947349)
-            N1.removeNode();
+        // Removal of preference node should always succeed on Solaris/Linux
+        // by successfully acquiring the appropriate file lock (4947349)
+        N1.removeNode();
 
-            if (((exportStream.toString()).lastIndexOf("ExportNodeTestName2")== -1) ||
-               ((exportStream.toString()).lastIndexOf("ExportNodeTestName1")!= -1)) {
-            }
+        String streamAsString = exportStream.toString("UTF-8");
+
+        StringBuilder sb = null;
+        if (streamAsString.lastIndexOf(NODE_NAME_2) == -1) {
+            if (sb == null)
+                sb = new StringBuilder();
+            sb.append(NODE_NAME_2 + " should have been found");
+        }
+        if (streamAsString.lastIndexOf(NODE_NAME_1) != -1) {
+            if (sb == null)
+                sb = new StringBuilder();
+            else
+                sb.append("; ");
+            sb.append(NODE_NAME_1 + " should *not* have been found");
+        }
+
+        if (sb != null)
+            throw new RuntimeException(sb.toString());
    }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8264512](https://bugs.openjdk.org/browse/JDK-8264512): jdk/test/jdk/java/util/prefs/ExportNode.java relies on default platform encoding


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1755/head:pull/1755` \
`$ git checkout pull/1755`

Update a local copy of the PR: \
`$ git checkout pull/1755` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1755`

View PR using the GUI difftool: \
`$ git pr show -t 1755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1755.diff">https://git.openjdk.org/jdk11u-dev/pull/1755.diff</a>

</details>
