### PR TITLE
8262060: compiler/whitebox/BlockingCompilation.java timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/whitebox/BlockingCompilation.java
+++ b/test/hotspot/jtreg/compiler/whitebox/BlockingCompilation.java
@@ -46,14 +46,12 @@ import compiler.testlibrary.CompilerUtils;
 import sun.hotspot.WhiteBox;
 
 import java.lang.reflect.Method;
-import java.util.Random;
 
 public class BlockingCompilation {
     private static final WhiteBox WB = WhiteBox.getWhiteBox();
-    private static final Random RANDOM = new Random(42);
 
     public static int foo() {
-        return RANDOM.nextInt();
+        return 42; //constant's value is arbitrary and meaningless
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8262060](https://bugs.openjdk.org/browse/JDK-8262060): compiler/whitebox/BlockingCompilation.java timed out


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1757/head:pull/1757` \
`$ git checkout pull/1757`

Update a local copy of the PR: \
`$ git checkout pull/1757` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1757`

View PR using the GUI difftool: \
`$ git pr show -t 1757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1757.diff">https://git.openjdk.org/jdk11u-dev/pull/1757.diff</a>

</details>
