### PR TITLE
8271323: [TESTBUG] serviceability/sa/ClhsdbCDSCore.java fails with -XX:TieredStopAtLevel=1

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
@@ -167,8 +167,8 @@ public class ClhsdbCDSCore {
 
             List testJavaOpts = Arrays.asList(Utils.getTestJavaOpts());
 
-            if (testJavaOpts.contains("-Xcomp") && testJavaOpts.contains("-XX:TieredStopAtLevel=1")) {
-                // No MDOs are allocated in -XX:TieredStopAtLevel=1 + -Xcomp mode
+            if (testJavaOpts.contains("-XX:TieredStopAtLevel=1")) {
+                // No MDOs are allocated in -XX:TieredStopAtLevel=1
                 // The reason is methods being compiled aren't hot enough
                 // Let's not call printmdo in such scenario
                 cmds = List.of("printall", "jstack -v");


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271323](https://bugs.openjdk.org/browse/JDK-8271323): [TESTBUG] serviceability/sa/ClhsdbCDSCore.java fails with -XX:TieredStopAtLevel=1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1758/head:pull/1758` \
`$ git checkout pull/1758`

Update a local copy of the PR: \
`$ git checkout pull/1758` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1758`

View PR using the GUI difftool: \
`$ git pr show -t 1758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1758.diff">https://git.openjdk.org/jdk11u-dev/pull/1758.diff</a>

</details>
