### PR TITLE
8301842: JFR: increase checkpoint event size for stacktrace and string pool

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -135,7 +135,7 @@ class RotationLock : public StackObj {
 static int64_t write_checkpoint_event_prologue(JfrChunkWriter& cw, u8 type_id) {
   const int64_t last_cp_offset = cw.last_checkpoint_offset();
   const int64_t delta_to_last_checkpoint = 0 == last_cp_offset ? 0 : last_cp_offset - cw.current_offset();
-  cw.reserve(sizeof(u4));
+  cw.reserve(sizeof(u8));
   cw.write<u8>(EVENT_CHECKPOINT);
   cw.write(JfrTicks::now());
   cw.write((int64_t)0); // duration
@@ -176,7 +176,7 @@ class WriteCheckpointEvent : public StackObj {
     assert(number_of_elements > 0, "invariant");
     assert(_cw.current_offset() > num_elements_offset, "invariant");
     _cw.write_padded_at_offset<u4>(number_of_elements, num_elements_offset);
-    _cw.write_padded_at_offset<u4>((u4)_cw.current_offset() - current_cp_offset, current_cp_offset);
+    _cw.write_padded_at_offset<u8>((u8)(_cw.current_offset() - current_cp_offset), current_cp_offset);
     // update writer with last checkpoint position
     _cw.set_last_checkpoint_offset(current_cp_offset);
     return true;


### PR DESCRIPTION
I'd like to backport JDK-8301842 as a small follow up fix for JDK-8298129 which is already included in 11u.
The first two hunks don't apply cleanly, WriteContent class is absent in 11u as JDK-8226511 is not backported. 
Similar changes are made in WriteCheckpointEvent::proccess().
Tested with tier1 and jdk/jfr.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301842](https://bugs.openjdk.org/browse/JDK-8301842): JFR: increase checkpoint event size for stacktrace and string pool


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1759/head:pull/1759` \
`$ git checkout pull/1759`

Update a local copy of the PR: \
`$ git checkout pull/1759` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1759`

View PR using the GUI difftool: \
`$ git pr show -t 1759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1759.diff">https://git.openjdk.org/jdk11u-dev/pull/1759.diff</a>

</details>
