### PR TITLE
8302903: [11u] Add modified test snippet after backport of JDK-8221871

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testHtmlVersion/TestHtmlVersion.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlVersion/TestHtmlVersion.java
@@ -147,6 +147,25 @@ public class TestHtmlVersion extends JavadocTester {
                 + "<nav role=\"navigation\">\n"
                 + "<!-- ======= START OF BOTTOM NAVBAR ====== -->");
 
+        // Test for package-frame page
+        checkOutput("pkg/package-frame.html", true,
+                "<!DOCTYPE HTML>",
+                "<meta name=\"dc.created\"",
+                "<main role=\"main\">\n"
+                + "<h1 class=\"bar\"><a href=\"package-summary.html\" target=\"classFrame\">pkg</a></h1>",
+                "<section>\n"
+                + "<h2 title=\"Interfaces\">Interfaces</h2>",
+                "<section>\n"
+                + "<h2 title=\"Classes\">Classes</h2>",
+                "<section>\n"
+                + "<h2 title=\"Enums\">Enums</h2>",
+                "<section>\n"
+                + "<h2 title=\"Exceptions\">Exceptions</h2>",
+                "<section>\n"
+                + "<h2 title=\"Errors\">Errors</h2>",
+                "<section>\n"
+                + "<h2 title=\"Annotation Types\">Annotation Types</h2>");
+
         // Test for package-summary page
         checkOutput("pkg/package-summary.html", true,
                 "<!DOCTYPE HTML>",


### PR DESCRIPTION
Let's add back the test snippet that was removed with the backport of JDK-8221871 in a modified way, as suggested [here](https://github.com/openjdk/jdk11u-dev/pull/1219#discussion_r1088684519).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302903](https://bugs.openjdk.org/browse/JDK-8302903): [11u] Add modified test snippet after backport of JDK-8221871


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1761/head:pull/1761` \
`$ git checkout pull/1761`

Update a local copy of the PR: \
`$ git checkout pull/1761` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1761`

View PR using the GUI difftool: \
`$ git pr show -t 1761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1761.diff">https://git.openjdk.org/jdk11u-dev/pull/1761.diff</a>

</details>
