### PR TITLE
8273806: compiler/cpuflags/TestSSE4Disabled.java should test for CPU feature explicitly

### DIFF
--- a/test/hotspot/jtreg/compiler/cpuflags/TestSSE4Disabled.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/TestSSE4Disabled.java
@@ -24,7 +24,7 @@
 /*
  * @test TestSSE4Disabled
  * @bug 8158214
- * @requires (vm.simpleArch == "x64")
+ * @requires vm.cpu.features ~= ".*sse4.*"
  * @summary Test correct execution without SSE 4.
  *
  * @run main/othervm -Xcomp -XX:UseSSE=3 compiler.cpuflags.TestSSE4Disabled


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273806](https://bugs.openjdk.org/browse/JDK-8273806): compiler/cpuflags/TestSSE4Disabled.java should test for CPU feature explicitly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1767/head:pull/1767` \
`$ git checkout pull/1767`

Update a local copy of the PR: \
`$ git checkout pull/1767` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1767`

View PR using the GUI difftool: \
`$ git pr show -t 1767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1767.diff">https://git.openjdk.org/jdk11u-dev/pull/1767.diff</a>

</details>
