### PR TITLE
8277346: ProblemList 7 serviceability/sa tests on macosx-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -110,22 +110,22 @@ runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
 # :hotspot_serviceability
 
 serviceability/sa/ClhsdbAttach.java 8193639 solaris-all
-serviceability/sa/ClhsdbCDSCore.java 8193639 solaris-all
+serviceability/sa/ClhsdbCDSCore.java 8193639,8267433 solaris-all,macosx-x64
 serviceability/sa/ClhsdbCDSJstackPrintAll.java 8193639 solaris-all
 serviceability/sa/CDSJMapClstats.java 8193639 solaris-all
 serviceability/sa/ClhsdbField.java 8193639 solaris-all
-serviceability/sa/ClhsdbFindPC.java 8193639 solaris-all
+serviceability/sa/ClhsdbFindPC.java 8193639,8267433 solaris-all,macosx-x64
 serviceability/sa/ClhsdbFlags.java 8193639 solaris-all
 serviceability/sa/ClhsdbInspect.java 8193639 solaris-all
 serviceability/sa/ClhsdbJdis.java 8193639 solaris-all
 serviceability/sa/ClhsdbJhisto.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64
 serviceability/sa/ClhsdbJstack.java 8193639 solaris-all
 serviceability/sa/ClhsdbLongConstant.java 8193639 solaris-all
-serviceability/sa/ClhsdbPmap.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64
+serviceability/sa/ClhsdbPmap.java 8193639,8211767,8267433 solaris-all,linux-ppc64le,linux-ppc64,macosx-x64
 serviceability/sa/ClhsdbPrintAll.java 8193639 solaris-all
 serviceability/sa/ClhsdbPrintAs.java 8193639 solaris-all
 serviceability/sa/ClhsdbPrintStatics.java 8193639 solaris-all
-serviceability/sa/ClhsdbPstack.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64
+serviceability/sa/ClhsdbPstack.java 8193639,8211767,8267433 solaris-all,linux-ppc64le,linux-ppc64,macosx-x64
 serviceability/sa/ClhsdbRegionDetailsScanOopsForG1.java 8193639 solaris-all
 serviceability/sa/ClhsdbScanOops.java 8193639 solaris-all
 serviceability/sa/ClhsdbSource.java 8193639 solaris-all
@@ -149,8 +149,8 @@ serviceability/sa/TestInstanceKlassSize.java 8193639 solaris-all
 serviceability/sa/TestInstanceKlassSizeForInterface.java 8193639 solaris-all
 serviceability/sa/TestIntConstant.java 8193639,8211767 solaris-all,linux-ppc64le,linux-ppc64
 serviceability/sa/TestJhsdbJstackLock.java 8193639 solaris-all
-serviceability/sa/TestJmapCore.java 8193639 solaris-all
-serviceability/sa/TestJmapCoreMetaspace.java 8193639 solaris-all
+serviceability/sa/TestJmapCore.java 8193639,8267433 solaris-all,macosx-x64
+serviceability/sa/TestJmapCoreMetaspace.java 8193639,8267433 solaris-all,macosx-x64
 serviceability/sa/TestPrintMdo.java 8193639 solaris-all
 serviceability/sa/TestRevPtrsForInvokeDynamic.java 8191270 generic-all
 serviceability/sa/TestType.java 8193639 solaris-all


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

The tests are already problem listed in 11. I distributed
bugId and platform to the existing tests.

I verified we see some of these failing in our CI, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8277346](https://bugs.openjdk.org/browse/JDK-8277346): ProblemList 7 serviceability/sa tests on macosx-x64
 * [JDK-8277351](https://bugs.openjdk.org/browse/JDK-8277351): ProblemList runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java on macosx-x64


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1772/head:pull/1772` \
`$ git checkout pull/1772`

Update a local copy of the PR: \
`$ git checkout pull/1772` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1772`

View PR using the GUI difftool: \
`$ git pr show -t 1772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1772.diff">https://git.openjdk.org/jdk11u-dev/pull/1772.diff</a>

</details>
