### PR TITLE
8279941: sun/security/pkcs11/Signature/TestDSAKeyLength.java fails when NSS version detection fails

### DIFF
--- a/test/jdk/sun/security/pkcs11/Signature/TestDSAKeyLength.java
+++ b/test/jdk/sun/security/pkcs11/Signature/TestDSAKeyLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class TestDSAKeyLength extends PKCS11Test {
 
     @Override
     protected boolean skipTest(Provider provider) {
-        if (isNSS(provider) && getNSSVersion() >= 3.14) {
+        if (isNSS(provider) && (getNSSVersion() == 0.0 || getNSSVersion() >= 3.14)) {
             System.out.println("Skip testing NSS " + getNSSVersion());
             return true;
         }


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

Resolved Copyright, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279941](https://bugs.openjdk.org/browse/JDK-8279941): sun/security/pkcs11/Signature/TestDSAKeyLength.java fails when NSS version detection fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1777/head:pull/1777` \
`$ git checkout pull/1777`

Update a local copy of the PR: \
`$ git checkout pull/1777` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1777`

View PR using the GUI difftool: \
`$ git pr show -t 1777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1777.diff">https://git.openjdk.org/jdk11u-dev/pull/1777.diff</a>

</details>
