### PR TITLE
8292877: java/util/concurrent/atomic/Serial.java uses {Double,Long}Accumulator incorrectly

### DIFF
--- a/test/jdk/java/util/concurrent/atomic/Serial.java
+++ b/test/jdk/java/util/concurrent/atomic/Serial.java
@@ -64,8 +64,8 @@ public class Serial {
     }
 
     static void testDoubleAccumulator() {
-        DoubleBinaryOperator plus = (DoubleBinaryOperator & Serializable) (x, y) -> x + y;
-        DoubleAccumulator a = new DoubleAccumulator(plus, 13.9d);
+        DoubleBinaryOperator op = (DoubleBinaryOperator & Serializable) (x, y) -> Math.max(x, y);
+        DoubleAccumulator a = new DoubleAccumulator(op, Double.NEGATIVE_INFINITY);
         a.accumulate(17.5d);
         DoubleAccumulator result = echo(a);
         if (result.get() != a.get())
@@ -89,8 +89,8 @@ public class Serial {
     }
 
     static void testLongAccumulator() {
-        LongBinaryOperator plus = (LongBinaryOperator & Serializable) (x, y) -> x + y;
-        LongAccumulator a = new LongAccumulator(plus, -2);
+        LongBinaryOperator op = (LongBinaryOperator & Serializable) (x, y) -> Math.max(x, y);
+        LongAccumulator a = new LongAccumulator(op, Long.MIN_VALUE);
         a.accumulate(34);
         LongAccumulator result = echo(a);
         if (result.get() != a.get())


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292877](https://bugs.openjdk.org/browse/JDK-8292877): java/util/concurrent/atomic/Serial.java uses {Double,Long}Accumulator incorrectly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1778/head:pull/1778` \
`$ git checkout pull/1778`

Update a local copy of the PR: \
`$ git checkout pull/1778` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1778`

View PR using the GUI difftool: \
`$ git pr show -t 1778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1778.diff">https://git.openjdk.org/jdk11u-dev/pull/1778.diff</a>

</details>
