### PR TITLE
8280703: CipherCore.doFinal(...) causes potentially massive byte[] allocations during decryption

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -915,7 +915,7 @@ final class CipherCore {
         int estOutSize = getOutputSizeByOperation(inputLen, true);
         int outputCapacity = checkOutputCapacity(output, outputOffset,
                 estOutSize);
-        int offset = decrypting ? 0 : outputOffset; // 0 for decrypting
+        int offset = outputOffset; // 0 for decrypting
         byte[] finalBuf = prepareInputBuffer(input, inputOffset,
                 inputLen, output, outputOffset);
         byte[] outWithPadding = null; // for decrypting only
@@ -940,7 +940,7 @@ final class CipherCore {
                 offset = 0;
             }
         }
-        byte[] outBuffer = (decrypting && (outWithPadding != null)) ? outWithPadding : output;
+        byte[] outBuffer = (outWithPadding != null) ? outWithPadding : output;
 
         int outLen = fillOutputBuffer(finalBuf, finalOffset, outBuffer,
                 offset, finalBufLen, input);

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -956,9 +956,11 @@ final class CipherCore {
                                                + " bytes needed");
             }
             // copy the result into user-supplied output buffer
-            System.arraycopy(outWithPadding, 0, output, outputOffset, outLen);
-            // decrypt mode. Zero out output data that's not required
-            Arrays.fill(outWithPadding, (byte) 0x00);
+            if(outWithPadding != null) {
+              System.arraycopy(outWithPadding, 0, output, outputOffset, outLen);
+              // decrypt mode. Zero out output data that's not required
+              Arrays.fill(outWithPadding, (byte) 0x00);
+            }
         }
         endDoFinal();
         return outLen;

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -932,9 +932,13 @@ final class CipherCore {
             if (outputCapacity < estOutSize) {
                 cipher.save();
             }
-            // create temporary output buffer so that only "real"
-            // data bytes are passed to user's output buffer.
-            outWithPadding = new byte[estOutSize];
+            if (outputCapacity < estOutSize || padding != null) {
+                // create temporary output buffer if the estimated size is larger
+                // than the user-provided buffer or a padding needs to be removed
+                // before copying the unpadded result to the output buffer
+                outWithPadding = new byte[estOutSize];
+                offset = 0;
+            }
         }
         byte[] outBuffer = decrypting ? outWithPadding : output;
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -974,9 +974,9 @@ final class CipherCore {
         }
     }
 
-    private int unpad(int outLen, byte[] internalOutput)
+    private int unpad(int outLen, byte[] outWithPadding)
             throws BadPaddingException {
-        int padStart = padding.unpad(internalOutput, 0, outLen);
+        int padStart = padding.unpad(outWithPadding, 0, outLen);
         if (padStart < 0) {
             throw new BadPaddingException("Given final block not " +
             "properly padded. Such issues can arise if a bad key " +

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -940,7 +940,7 @@ final class CipherCore {
                 offset = 0;
             }
         }
-        byte[] outBuffer = decrypting ? outWithPadding : output;
+        byte[] outBuffer = (outWithPadding != null) ? outWithPadding : output;
 
         int outLen = fillOutputBuffer(finalBuf, finalOffset, outBuffer,
                 offset, finalBufLen, input);

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -918,7 +918,7 @@ final class CipherCore {
         int offset = outputOffset; // 0 for decrypting
         byte[] finalBuf = prepareInputBuffer(input, inputOffset,
                 inputLen, output, outputOffset);
-        byte[] outWithPadding = null; // for decrypting only
+        byte[] internalOutput = null; // for decrypting only
 
         int finalOffset = (finalBuf == input) ? inputOffset : 0;
         int finalBufLen = (finalBuf == input) ? inputLen : finalBuf.length;
@@ -936,11 +936,11 @@ final class CipherCore {
                 // create temporary output buffer if the estimated size is larger
                 // than the user-provided buffer or a padding needs to be removed
                 // before copying the unpadded result to the output buffer
-                outWithPadding = new byte[estOutSize];
+                internalOutput = new byte[estOutSize];
                 offset = 0;
             }
         }
-        byte[] outBuffer = (outWithPadding != null) ? outWithPadding : output;
+        byte[] outBuffer = (internalOutput != null) ? internalOutput : output;
 
         int outLen = fillOutputBuffer(finalBuf, finalOffset, outBuffer,
                 offset, finalBufLen, input);
@@ -956,10 +956,10 @@ final class CipherCore {
                                                + " bytes needed");
             }
             // copy the result into user-supplied output buffer
-            if(outWithPadding != null) {
-              System.arraycopy(outWithPadding, 0, output, outputOffset, outLen);
+            if (internalOutput != null) {
+              System.arraycopy(internalOutput, 0, output, outputOffset, outLen);
               // decrypt mode. Zero out output data that's not required
-              Arrays.fill(outWithPadding, (byte) 0x00);
+              Arrays.fill(internalOutput, (byte) 0x00);
             }
         }
         endDoFinal();
@@ -974,9 +974,9 @@ final class CipherCore {
         }
     }
 
-    private int unpad(int outLen, byte[] outWithPadding)
+    private int unpad(int outLen, byte[] internalOutput)
             throws BadPaddingException {
-        int padStart = padding.unpad(outWithPadding, 0, outLen);
+        int padStart = padding.unpad(internalOutput, 0, outLen);
         if (padStart < 0) {
             throw new BadPaddingException("Given final block not " +
             "properly padded. Such issues can arise if a bad key " +

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -940,7 +940,7 @@ final class CipherCore {
                 offset = 0;
             }
         }
-        byte[] outBuffer = (outWithPadding != null) ? outWithPadding : output;
+        byte[] outBuffer = (decrypting && (outWithPadding != null)) ? outWithPadding : output;
 
         int outLen = fillOutputBuffer(finalBuf, finalOffset, outBuffer,
                 offset, finalBufLen, input);


### PR DESCRIPTION
Backporting because this change results in ~3x performance improvement in AES-CTR.

Risk is low.  Tested with tier1 and benchmark.

The PR does not backport cleanly.  The buffer name was changed, but functionally remains the same.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280703](https://bugs.openjdk.org/browse/JDK-8280703): CipherCore.doFinal(...) causes potentially massive byte[] allocations during decryption


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1780/head:pull/1780` \
`$ git checkout pull/1780`

Update a local copy of the PR: \
`$ git checkout pull/1780` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1780`

View PR using the GUI difftool: \
`$ git pr show -t 1780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1780.diff">https://git.openjdk.org/jdk11u-dev/pull/1780.diff</a>

</details>
