### PR TITLE
8235448: code cleanup in SSLContextImpl.java

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
@@ -25,7 +25,7 @@
 
 package sun.security.ssl;
 
-import java.io.*;
+import java.io.FileInputStream;
 import java.net.Socket;
 import java.security.*;
 import java.security.cert.*;
@@ -617,26 +617,6 @@ public abstract class SSLContextImpl extends SSLContextSpi {
         boolean isDTLS() {
             return false;
         }
-
-        static ProtocolVersion[] getSupportedProtocols() {
-            if (SunJSSE.isFIPS()) {
-                return new ProtocolVersion[] {
-                        ProtocolVersion.TLS13,
-                        ProtocolVersion.TLS12,
-                        ProtocolVersion.TLS11,
-                        ProtocolVersion.TLS10
-                };
-            } else {
-                return new ProtocolVersion[]{
-                        ProtocolVersion.TLS13,
-                        ProtocolVersion.TLS12,
-                        ProtocolVersion.TLS11,
-                        ProtocolVersion.TLS10,
-                        ProtocolVersion.SSL30,
-                        ProtocolVersion.SSL20Hello
-                };
-            }
-        }
     }
 
     /*
@@ -934,9 +914,41 @@ public abstract class SSLContextImpl extends SSLContextSpi {
             ProtocolVersion[] candidates;
             if (refactored.isEmpty()) {
                 if (client) {
-                    candidates = getProtocols();
+                    // default client protocols
+                    if (SunJSSE.isFIPS()) {
+                        candidates = new ProtocolVersion[] {
+                            ProtocolVersion.TLS13,
+                            ProtocolVersion.TLS12,
+                            ProtocolVersion.TLS11,
+                            ProtocolVersion.TLS10
+                        };
+                    } else {
+                        candidates = new ProtocolVersion[] {
+                            ProtocolVersion.TLS13,
+                            ProtocolVersion.TLS12,
+                            ProtocolVersion.TLS11,
+                            ProtocolVersion.TLS10,
+                            ProtocolVersion.SSL30
+                        };
+                    }
                 } else {
-                    candidates = getSupportedProtocols();
+                    if (SunJSSE.isFIPS()) {
+                        candidates = new ProtocolVersion[] {
+                            ProtocolVersion.TLS13,
+                            ProtocolVersion.TLS12,
+                            ProtocolVersion.TLS11,
+                            ProtocolVersion.TLS10
+                        };
+                    } else {
+                        candidates = new ProtocolVersion[] {
+                            ProtocolVersion.TLS13,
+                            ProtocolVersion.TLS12,
+                            ProtocolVersion.TLS11,
+                            ProtocolVersion.TLS10,
+                            ProtocolVersion.SSL30,
+                            ProtocolVersion.SSL20Hello
+                        };
+                    }
                 }
             } else {
                 // Use the customized TLS protocols.
@@ -945,25 +957,6 @@ public abstract class SSLContextImpl extends SSLContextSpi {
             }
 
             return getAvailableProtocols(candidates);
-        }
-
-        static ProtocolVersion[] getProtocols() {
-            if (SunJSSE.isFIPS()) {
-                return new ProtocolVersion[]{
-                        ProtocolVersion.TLS13,
-                        ProtocolVersion.TLS12,
-                        ProtocolVersion.TLS11,
-                        ProtocolVersion.TLS10
-                };
-            } else {
-                return new ProtocolVersion[]{
-                        ProtocolVersion.TLS13,
-                        ProtocolVersion.TLS12,
-                        ProtocolVersion.TLS11,
-                        ProtocolVersion.TLS10,
-                        ProtocolVersion.SSL30
-                };
-            }
         }
 
         protected CustomizedTLSContext() {
@@ -991,8 +984,6 @@ public abstract class SSLContextImpl extends SSLContextSpi {
         List<CipherSuite> getServerDefaultCipherSuites() {
             return serverDefaultCipherSuites;
         }
-
-
     }
 
     /*
@@ -1243,7 +1234,6 @@ public abstract class SSLContextImpl extends SSLContextSpi {
         private static final List<CipherSuite> serverDefaultCipherSuites;
 
         static {
-            // Both DTLSv1.0 and DTLSv1.2 can be used in FIPS mode.
             supportedProtocols = Arrays.asList(
                 ProtocolVersion.DTLS12,
                 ProtocolVersion.DTLS10


### PR DESCRIPTION
I backport this as preparation for 8190492.

I had to resolve, because in 11 FIPS support is still implemented.  But it's trivial cut&paste.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8235448](https://bugs.openjdk.org/browse/JDK-8235448): code cleanup in SSLContextImpl.java


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1781/head:pull/1781` \
`$ git checkout pull/1781`

Update a local copy of the PR: \
`$ git checkout pull/1781` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1781`

View PR using the GUI difftool: \
`$ git pr show -t 1781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1781.diff">https://git.openjdk.org/jdk11u-dev/pull/1781.diff</a>

</details>
