### PR TITLE
8190492: Remove SSLv2Hello and SSLv3 from default enabled TLS protocols

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
@@ -571,9 +571,7 @@ public abstract class SSLContextImpl extends SSLContextSpi {
                     ProtocolVersion.TLS13,
                     ProtocolVersion.TLS12,
                     ProtocolVersion.TLS11,
-                    ProtocolVersion.TLS10,
-                    ProtocolVersion.SSL30,
-                    ProtocolVersion.SSL20Hello
+                    ProtocolVersion.TLS10
                 });
             }
 
@@ -637,8 +635,7 @@ public abstract class SSLContextImpl extends SSLContextSpi {
             } else {
                 clientDefaultProtocols = getAvailableProtocols(
                         new ProtocolVersion[] {
-                    ProtocolVersion.TLS10,
-                    ProtocolVersion.SSL30
+                    ProtocolVersion.TLS10
                 });
             }
 
@@ -677,8 +674,7 @@ public abstract class SSLContextImpl extends SSLContextSpi {
                 clientDefaultProtocols = getAvailableProtocols(
                         new ProtocolVersion[] {
                     ProtocolVersion.TLS11,
-                    ProtocolVersion.TLS10,
-                    ProtocolVersion.SSL30
+                    ProtocolVersion.TLS10
                 });
             }
 
@@ -720,8 +716,7 @@ public abstract class SSLContextImpl extends SSLContextSpi {
                         new ProtocolVersion[] {
                     ProtocolVersion.TLS12,
                     ProtocolVersion.TLS11,
-                    ProtocolVersion.TLS10,
-                    ProtocolVersion.SSL30
+                    ProtocolVersion.TLS10
                 });
             }
 
@@ -764,8 +759,7 @@ public abstract class SSLContextImpl extends SSLContextSpi {
                     ProtocolVersion.TLS13,
                     ProtocolVersion.TLS12,
                     ProtocolVersion.TLS11,
-                    ProtocolVersion.TLS10,
-                    ProtocolVersion.SSL30
+                    ProtocolVersion.TLS10
                 });
             }
 
@@ -927,8 +921,7 @@ public abstract class SSLContextImpl extends SSLContextSpi {
                             ProtocolVersion.TLS13,
                             ProtocolVersion.TLS12,
                             ProtocolVersion.TLS11,
-                            ProtocolVersion.TLS10,
-                            ProtocolVersion.SSL30
+                            ProtocolVersion.TLS10
                         };
                     }
                 } else {
@@ -944,9 +937,7 @@ public abstract class SSLContextImpl extends SSLContextSpi {
                             ProtocolVersion.TLS13,
                             ProtocolVersion.TLS12,
                             ProtocolVersion.TLS11,
-                            ProtocolVersion.TLS10,
-                            ProtocolVersion.SSL30,
-                            ProtocolVersion.SSL20Hello
+                            ProtocolVersion.TLS10
                         };
                     }
                 }

--- a/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
@@ -925,6 +925,7 @@ public abstract class SSLContextImpl extends SSLContextSpi {
                         };
                     }
                 } else {
+                    // default server protocols
                     if (SunJSSE.isFIPS()) {
                         candidates = new ProtocolVersion[] {
                             ProtocolVersion.TLS13,

--- a/test/jdk/javax/net/ssl/SSLEngine/NoAuthClientAuth.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/NoAuthClientAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 
 /*
  * @test
- * @bug 4495742
+ * @bug 4495742 8190492
  * @summary Demonstrate SSLEngine switch from no client auth to client auth.
  * @run main/othervm NoAuthClientAuth SSLv3
  * @run main/othervm NoAuthClientAuth TLSv1
@@ -303,6 +303,11 @@ public class NoAuthClientAuth {
         serverEngine = sslc.createSSLEngine();
         serverEngine.setUseClientMode(false);
         serverEngine.setNeedClientAuth(false);
+
+        // Enable all supported protocols on server side to test SSLv3
+        if ("SSLv3".equals(tlsProtocol)) {
+            serverEngine.setEnabledProtocols(serverEngine.getSupportedProtocols());
+        }
 
         /*
          * Similar to above, but using client mode instead.

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorer.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 
 /*
  * @test
- * @bug 7068321
+ * @bug 7068321 8190492
  * @summary Support TLS Server Name Indication (SNI) Extension in JSSE Server
  * @library ../SSLEngine ../templates
  * @build SSLEngineService SSLCapabilities SSLExplorer
@@ -79,6 +79,9 @@ public class SSLEngineExplorer extends SSLEngineService {
 
         // create SSLEngine.
         SSLEngine ssle = createSSLEngine(false);
+
+        // Enable all supported protocols on server side to test SSLv3
+        ssle.setEnabledProtocols(ssle.getSupportedProtocols());
 
         // Create a server socket channel.
         InetSocketAddress isa =

--- a/test/jdk/javax/net/ssl/ServerName/SSLSocketExplorer.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLSocketExplorer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 
 /**
  * @test
- * @bug 7068321
+ * @bug 7068321 8190492
  * @summary Support TLS Server Name Indication (SNI) Extension in JSSE Server
  * @library ../templates
  * @build SSLCapabilities SSLExplorer
@@ -147,6 +147,9 @@ public class SSLSocketExplorer {
         ByteArrayInputStream bais =
             new ByteArrayInputStream(buffer, 0, position);
         SSLSocket sslSocket = (SSLSocket)sslsf.createSocket(socket, bais, true);
+
+        // Enable all supported protocols on server side to test SSLv3
+        sslSocket.setEnabledProtocols(sslSocket.getSupportedProtocols());
 
         InputStream sslIS = sslSocket.getInputStream();
         OutputStream sslOS = sslSocket.getOutputStream();

--- a/test/jdk/javax/net/ssl/sanity/interop/JSSEServer.java
+++ b/test/jdk/javax/net/ssl/sanity/interop/JSSEServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,10 @@ class JSSEServer extends CipherTest.Server {
         serverSocket
                 = (SSLServerSocket) factory.createServerSocket(CipherTest.serverPort);
         CipherTest.serverPort = serverSocket.getLocalPort();
+
+        // JDK-8190492: Enable all supported protocols on server side to test SSLv3
+        serverSocket.setEnabledProtocols(serverSocket.getSupportedProtocols());
+
         serverSocket.setEnabledCipherSuites(factory.getSupportedCipherSuites());
         serverSocket.setWantClientAuth(true);
     }

--- a/test/jdk/sun/security/pkcs11/sslecc/JSSEServer.java
+++ b/test/jdk/sun/security/pkcs11/sslecc/JSSEServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,10 @@ class JSSEServer extends CipherTest.Server {
         serverSocket = (SSLServerSocket)factory.createServerSocket(0);
         serverSocket.setSoTimeout(CipherTest.TIMEOUT);
         CipherTest.serverPort = serverSocket.getLocalPort();
+
+        // JDK-8190492: Enable all supported protocols on server side to test SSLv3
+        serverSocket.setEnabledProtocols(serverSocket.getSupportedProtocols());
+
         serverSocket.setEnabledCipherSuites(factory.getSupportedCipherSuites());
         serverSocket.setWantClientAuth(true);
     }

--- a/test/jdk/sun/security/ssl/ProtocolVersion/HttpsProtocols.java
+++ b/test/jdk/sun/security/ssl/ProtocolVersion/HttpsProtocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4671289
+ * @bug 4671289 8190492
  * @summary passing https.protocols from command line doesn't work.
  * @run main/othervm -Dhttps.protocols=SSLv3 HttpsProtocols
  * @author Brad Wetmore
@@ -87,6 +87,9 @@ public class HttpsProtocols implements HostnameVerifier {
             (SSLServerSocketFactory) SSLServerSocketFactory.getDefault();
         SSLServerSocket sslServerSocket =
             (SSLServerSocket) sslssf.createServerSocket(serverPort);
+
+        // Enable all supported protocols on server side to test SSLv3
+        sslServerSocket.setEnabledProtocols(sslServerSocket.getSupportedProtocols());
 
         serverPort = sslServerSocket.getLocalPort();
 

--- a/test/jdk/sun/security/ssl/SSLContextImpl/CustomizedDefaultProtocols.java
+++ b/test/jdk/sun/security/ssl/SSLContextImpl/CustomizedDefaultProtocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 
 /*
  * @test
- * @bug 7093640
+ * @bug 7093640 8190492
  * @summary Enable TLS 1.1 and TLS 1.2 by default in client side of SunJSSE
  * @run main/othervm -Djdk.tls.client.protocols="SSLv3,TLSv1,TLSv1.1"
  *      CustomizedDefaultProtocols
@@ -54,15 +54,15 @@ public class CustomizedDefaultProtocols {
         TLS_CV_02("TLS",
                 new String[] {"SSLv3", "TLSv1", "TLSv1.1"}),
         TLS_CV_03("SSLv3",
-                new String[] {"SSLv3", "TLSv1"}),
+                new String[] {"TLSv1"}),
         TLS_CV_04("TLSv1",
-                new String[] {"SSLv3", "TLSv1"}),
+                new String[] {"TLSv1"}),
         TLS_CV_05("TLSv1.1",
-                new String[] {"SSLv3", "TLSv1", "TLSv1.1"}),
+                new String[] {"TLSv1", "TLSv1.1"}),
         TLS_CV_06("TLSv1.2",
-                new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"}),
+                new String[] {"TLSv1", "TLSv1.1", "TLSv1.2"}),
         TLS_CV_07("TLSv1.3",
-                new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
+                new String[] {"TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
         TLS_CV_08("Default",
                 new String[] {"SSLv3", "TLSv1", "TLSv1.1"});
 
@@ -70,6 +70,8 @@ public class CustomizedDefaultProtocols {
         final String[] enabledProtocols;
         final static String[] supportedProtocols = new String[] {
                 "SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"};
+        final static String[] serverDefaultProtocols = new String[] {
+                "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"};
 
         ContextVersion(String contextVersion, String[] enabledProtocols) {
             this.contextVersion = contextVersion;
@@ -80,16 +82,17 @@ public class CustomizedDefaultProtocols {
     private static boolean checkProtocols(String[] target, String[] expected) {
         boolean success = true;
         if (target.length == 0) {
-            System.out.println("\tError: No protocols");
+            System.out.println("\t\t\t*** Error: No protocols");
             success = false;
         }
 
         if (!protocolEquals(target, expected)) {
-            System.out.println("\tError: Expected to get protocols " +
+            System.out.println("\t\t\t*** Error: Expected to get protocols " +
                     Arrays.toString(expected));
             success = false;
         }
-        System.out.println("\t  Protocols found " + Arrays.toString(target));
+        System.out.println("\t\t\t  Protocols found " + Arrays.toString(target));
+        System.out.println("\t\t\t--> Protocol check passed!!");
 
         return success;
     }
@@ -114,10 +117,11 @@ public class CustomizedDefaultProtocols {
     private static boolean checkCipherSuites(String[] target) {
         boolean success = true;
         if (target.length == 0) {
-            System.out.println("\tError: No cipher suites");
+            System.out.println("\t\t\t*** Error: No cipher suites");
             success = false;
         }
 
+        System.out.println("\t\t\t--> Cipher check passed!!");
         return success;
     }
 
@@ -128,7 +132,8 @@ public class CustomizedDefaultProtocols {
 
         boolean failed = false;
         for (ContextVersion cv : ContextVersion.values()) {
-            System.out.println("Checking SSLContext of " + cv.contextVersion);
+            System.out.println("\n\nChecking SSLContext of " + cv.contextVersion);
+            System.out.println("============================");
             SSLContext context = SSLContext.getInstance(cv.contextVersion);
 
             // Default SSLContext is initialized automatically.
@@ -142,6 +147,7 @@ public class CustomizedDefaultProtocols {
             //
             // Check default SSLParameters of SSLContext
             System.out.println("\tChecking default SSLParameters");
+            System.out.println("\t\tChecking SSLContext.getDefaultSSLParameters().getProtocols");
             SSLParameters parameters = context.getDefaultSSLParameters();
 
             String[] protocols = parameters.getProtocols();
@@ -151,7 +157,7 @@ public class CustomizedDefaultProtocols {
             failed |= !checkCipherSuites(ciphers);
 
             // Check supported SSLParameters of SSLContext
-            System.out.println("\tChecking supported SSLParameters");
+            System.out.println("\t\tChecking supported SSLParameters");
             parameters = context.getSupportedSSLParameters();
 
             protocols = parameters.getProtocols();
@@ -166,7 +172,7 @@ public class CustomizedDefaultProtocols {
             // Check SSLParameters of SSLEngine
             System.out.println();
             System.out.println("\tChecking SSLEngine of this SSLContext");
-            System.out.println("\tChecking SSLEngine.getSSLParameters()");
+            System.out.println("\t\tChecking SSLEngine.getSSLParameters()");
             SSLEngine engine = context.createSSLEngine();
             engine.setUseClientMode(true);
             parameters = engine.getSSLParameters();
@@ -177,20 +183,20 @@ public class CustomizedDefaultProtocols {
             ciphers = parameters.getCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
-            System.out.println("\tChecking SSLEngine.getEnabledProtocols()");
+            System.out.println("\t\tChecking SSLEngine.getEnabledProtocols()");
             protocols = engine.getEnabledProtocols();
             failed |= !checkProtocols(protocols, cv.enabledProtocols);
 
-            System.out.println("\tChecking SSLEngine.getEnabledCipherSuites()");
+            System.out.println("\t\tChecking SSLEngine.getEnabledCipherSuites()");
             ciphers = engine.getEnabledCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
-            System.out.println("\tChecking SSLEngine.getSupportedProtocols()");
+            System.out.println("\t\tChecking SSLEngine.getSupportedProtocols()");
             protocols = engine.getSupportedProtocols();
             failed |= !checkProtocols(protocols, cv.supportedProtocols);
 
             System.out.println(
-                    "\tChecking SSLEngine.getSupportedCipherSuites()");
+                    "\t\tChecking SSLEngine.getSupportedCipherSuites()");
             ciphers = engine.getSupportedCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
@@ -200,7 +206,7 @@ public class CustomizedDefaultProtocols {
             // Check SSLParameters of SSLSocket
             System.out.println();
             System.out.println("\tChecking SSLSocket of this SSLContext");
-            System.out.println("\tChecking SSLSocket.getSSLParameters()");
+            System.out.println("\t\tChecking SSLSocket.getSSLParameters()");
             SocketFactory fac = context.getSocketFactory();
             SSLSocket socket = (SSLSocket)fac.createSocket();
             parameters = socket.getSSLParameters();
@@ -211,20 +217,20 @@ public class CustomizedDefaultProtocols {
             ciphers = parameters.getCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
-            System.out.println("\tChecking SSLEngine.getEnabledProtocols()");
+            System.out.println("\t\tChecking SSLEngine.getEnabledProtocols()");
             protocols = socket.getEnabledProtocols();
             failed |= !checkProtocols(protocols, cv.enabledProtocols);
 
-            System.out.println("\tChecking SSLEngine.getEnabledCipherSuites()");
+            System.out.println("\t\tChecking SSLEngine.getEnabledCipherSuites()");
             ciphers = socket.getEnabledCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
-            System.out.println("\tChecking SSLEngine.getSupportedProtocols()");
+            System.out.println("\t\tChecking SSLEngine.getSupportedProtocols()");
             protocols = socket.getSupportedProtocols();
             failed |= !checkProtocols(protocols, cv.supportedProtocols);
 
             System.out.println(
-                    "\tChecking SSLEngine.getSupportedCipherSuites()");
+                    "\t\tChecking SSLEngine.getSupportedCipherSuites()");
             ciphers = socket.getSupportedCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
@@ -234,39 +240,37 @@ public class CustomizedDefaultProtocols {
             // Check SSLParameters of SSLServerSocket
             System.out.println();
             System.out.println("\tChecking SSLServerSocket of this SSLContext");
-            System.out.println("\tChecking SSLServerSocket.getSSLParameters()");
+            System.out.println("\t\tChecking SSLServerSocket.getSSLParameters()");
             SSLServerSocketFactory sf = context.getServerSocketFactory();
             SSLServerSocket ssocket = (SSLServerSocket)sf.createServerSocket();
             parameters = ssocket.getSSLParameters();
 
             protocols = parameters.getProtocols();
-            failed |= !checkProtocols(protocols, cv.supportedProtocols);
+            failed |= !checkProtocols(protocols, cv.serverDefaultProtocols);
 
             ciphers = parameters.getCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
-            System.out.println("\tChecking SSLEngine.getEnabledProtocols()");
+            System.out.println("\t\tChecking SSLEngine.getEnabledProtocols()");
             protocols = ssocket.getEnabledProtocols();
-            failed |= !checkProtocols(protocols, cv.supportedProtocols);
+            failed |= !checkProtocols(protocols, cv.serverDefaultProtocols);
 
-            System.out.println("\tChecking SSLEngine.getEnabledCipherSuites()");
+            System.out.println("\t\tChecking SSLEngine.getEnabledCipherSuites()");
             ciphers = ssocket.getEnabledCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
-            System.out.println("\tChecking SSLEngine.getSupportedProtocols()");
+            System.out.println("\t\tChecking SSLEngine.getSupportedProtocols()");
             protocols = ssocket.getSupportedProtocols();
             failed |= !checkProtocols(protocols, cv.supportedProtocols);
 
             System.out.println(
-                    "\tChecking SSLEngine.getSupportedCipherSuites()");
+                    "\t\tChecking SSLEngine.getSupportedCipherSuites()");
             ciphers = ssocket.getSupportedCipherSuites();
             failed |= !checkCipherSuites(ciphers);
         }
 
         if (failed) {
             throw new Exception("Run into problems, see log for more details");
-        } else {
-            System.out.println("\t... Success");
         }
     }
 }

--- a/test/jdk/sun/security/ssl/SSLContextImpl/DefaultEnabledProtocols.java
+++ b/test/jdk/sun/security/ssl/SSLContextImpl/DefaultEnabledProtocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,26 +49,28 @@ import javax.net.ssl.TrustManager;
 public class DefaultEnabledProtocols {
     enum ContextVersion {
         TLS_CV_01("SSL",
-                new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
+                new String[] {"TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
         TLS_CV_02("TLS",
-                new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
+                new String[] {"TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
         TLS_CV_03("SSLv3",
-                new String[] {"SSLv3", "TLSv1"}),
+                new String[] {"TLSv1"}),
         TLS_CV_04("TLSv1",
-                new String[] {"SSLv3", "TLSv1"}),
+                new String[] {"TLSv1"}),
         TLS_CV_05("TLSv1.1",
-                new String[] {"SSLv3", "TLSv1", "TLSv1.1"}),
+                new String[] {"TLSv1", "TLSv1.1"}),
         TLS_CV_06("TLSv1.2",
-                new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"}),
+                new String[] {"TLSv1", "TLSv1.1", "TLSv1.2"}),
         TLS_CV_07("TLSv1.3",
-                new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
+                new String[] {"TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"}),
         TLS_CV_08("Default",
-                new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"});
+                new String[] {"TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"});
 
         final String contextVersion;
         final String[] enabledProtocols;
         final static String[] supportedProtocols = new String[] {
                 "SSLv2Hello", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"};
+        final static String[] serverDefaultProtocols = new String[] {
+                "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"};
 
         ContextVersion(String contextVersion, String[] enabledProtocols) {
             this.contextVersion = contextVersion;
@@ -79,16 +81,17 @@ public class DefaultEnabledProtocols {
     private static boolean checkProtocols(String[] target, String[] expected) {
         boolean success = true;
         if (target.length == 0) {
-            System.out.println("\tError: No protocols");
+            System.out.println("\t\t\t*** Error: No protocols");
             success = false;
         }
 
         if (!protocolEquals(target, expected)) {
-            System.out.println("\tError: Expected to get protocols " +
+            System.out.println("\t\t\t*** Error: Expected to get protocols " +
                     Arrays.toString(expected));
             success = false;
         }
-        System.out.println("\t  Protocols found " + Arrays.toString(target));
+        System.out.println("\t\t\t  Protocols found " + Arrays.toString(target));
+        System.out.println("\t\t\t--> Protocol check passed!!");
 
         return success;
     }
@@ -107,13 +110,14 @@ public class DefaultEnabledProtocols {
             }
         }
 
+        System.out.println("\t\t\t--> Cipher check passed!!");
         return true;
     }
 
     private static boolean checkCipherSuites(String[] target) {
         boolean success = true;
         if (target.length == 0) {
-            System.out.println("\tError: No cipher suites");
+            System.out.println("\t\t\t*** Error: No cipher suites");
             success = false;
         }
 
@@ -127,7 +131,8 @@ public class DefaultEnabledProtocols {
 
         boolean failed = false;
         for (ContextVersion cv : ContextVersion.values()) {
-            System.out.println("Checking SSLContext of " + cv.contextVersion);
+            System.out.println("\n\nChecking SSLContext of " + cv.contextVersion);
+            System.out.println("============================");
             SSLContext context = SSLContext.getInstance(cv.contextVersion);
 
             // Default SSLContext is initialized automatically.
@@ -141,6 +146,7 @@ public class DefaultEnabledProtocols {
             //
             // Check default SSLParameters of SSLContext
             System.out.println("\tChecking default SSLParameters");
+            System.out.println("\t\tChecking SSLContext.getDefaultSSLParameters().getProtocols");
             SSLParameters parameters = context.getDefaultSSLParameters();
 
             String[] protocols = parameters.getProtocols();
@@ -150,7 +156,7 @@ public class DefaultEnabledProtocols {
             failed |= !checkCipherSuites(ciphers);
 
             // Check supported SSLParameters of SSLContext
-            System.out.println("\tChecking supported SSLParameters");
+            System.out.println("\t\tChecking SSLContext.getSupportedSSLParameters().getProtocols()");
             parameters = context.getSupportedSSLParameters();
 
             protocols = parameters.getProtocols();
@@ -165,7 +171,7 @@ public class DefaultEnabledProtocols {
             // Check SSLParameters of SSLEngine
             System.out.println();
             System.out.println("\tChecking SSLEngine of this SSLContext");
-            System.out.println("\tChecking SSLEngine.getSSLParameters()");
+            System.out.println("\t\tChecking SSLEngine.getSSLParameters()");
             SSLEngine engine = context.createSSLEngine();
             engine.setUseClientMode(true);
             parameters = engine.getSSLParameters();
@@ -176,20 +182,20 @@ public class DefaultEnabledProtocols {
             ciphers = parameters.getCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
-            System.out.println("\tChecking SSLEngine.getEnabledProtocols()");
+            System.out.println("\t\tChecking SSLEngine.getEnabledProtocols()");
             protocols = engine.getEnabledProtocols();
             failed |= !checkProtocols(protocols, cv.enabledProtocols);
 
-            System.out.println("\tChecking SSLEngine.getEnabledCipherSuites()");
+            System.out.println("\t\tChecking SSLEngine.getEnabledCipherSuites()");
             ciphers = engine.getEnabledCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
-            System.out.println("\tChecking SSLEngine.getSupportedProtocols()");
+            System.out.println("\t\tChecking SSLEngine.getSupportedProtocols()");
             protocols = engine.getSupportedProtocols();
             failed |= !checkProtocols(protocols, cv.supportedProtocols);
 
             System.out.println(
-                    "\tChecking SSLEngine.getSupportedCipherSuites()");
+                    "\t\tChecking SSLEngine.getSupportedCipherSuites()");
             ciphers = engine.getSupportedCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
@@ -199,7 +205,7 @@ public class DefaultEnabledProtocols {
             // Check SSLParameters of SSLSocket
             System.out.println();
             System.out.println("\tChecking SSLSocket of this SSLContext");
-            System.out.println("\tChecking SSLSocket.getSSLParameters()");
+            System.out.println("\t\tChecking SSLSocket.getSSLParameters()");
             SocketFactory fac = context.getSocketFactory();
             SSLSocket socket = (SSLSocket)fac.createSocket();
             parameters = socket.getSSLParameters();
@@ -210,20 +216,20 @@ public class DefaultEnabledProtocols {
             ciphers = parameters.getCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
-            System.out.println("\tChecking SSLEngine.getEnabledProtocols()");
+            System.out.println("\t\tChecking SSLEngine.getEnabledProtocols()");
             protocols = socket.getEnabledProtocols();
             failed |= !checkProtocols(protocols, cv.enabledProtocols);
 
-            System.out.println("\tChecking SSLEngine.getEnabledCipherSuites()");
+            System.out.println("\t\tChecking SSLEngine.getEnabledCipherSuites()");
             ciphers = socket.getEnabledCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
-            System.out.println("\tChecking SSLEngine.getSupportedProtocols()");
+            System.out.println("\t\tChecking SSLEngine.getSupportedProtocols()");
             protocols = socket.getSupportedProtocols();
             failed |= !checkProtocols(protocols, cv.supportedProtocols);
 
             System.out.println(
-                    "\tChecking SSLEngine.getSupportedCipherSuites()");
+                    "\t\tChecking SSLEngine.getSupportedCipherSuites()");
             ciphers = socket.getSupportedCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
@@ -233,39 +239,37 @@ public class DefaultEnabledProtocols {
             // Check SSLParameters of SSLServerSocket
             System.out.println();
             System.out.println("\tChecking SSLServerSocket of this SSLContext");
-            System.out.println("\tChecking SSLServerSocket.getSSLParameters()");
+            System.out.println("\t\tChecking SSLServerSocket.getSSLParameters()");
             SSLServerSocketFactory sf = context.getServerSocketFactory();
             SSLServerSocket ssocket = (SSLServerSocket)sf.createServerSocket();
             parameters = ssocket.getSSLParameters();
 
             protocols = parameters.getProtocols();
-            failed |= !checkProtocols(protocols, cv.supportedProtocols);
+            failed |= !checkProtocols(protocols, cv.serverDefaultProtocols);
 
             ciphers = parameters.getCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
-            System.out.println("\tChecking SSLEngine.getEnabledProtocols()");
+            System.out.println("\t\tChecking SSLEngine.getEnabledProtocols()");
             protocols = ssocket.getEnabledProtocols();
-            failed |= !checkProtocols(protocols, cv.supportedProtocols);
+            failed |= !checkProtocols(protocols, cv.serverDefaultProtocols);
 
-            System.out.println("\tChecking SSLEngine.getEnabledCipherSuites()");
+            System.out.println("\t\tChecking SSLEngine.getEnabledCipherSuites()");
             ciphers = ssocket.getEnabledCipherSuites();
             failed |= !checkCipherSuites(ciphers);
 
-            System.out.println("\tChecking SSLEngine.getSupportedProtocols()");
+            System.out.println("\t\tChecking SSLEngine.getSupportedProtocols()");
             protocols = ssocket.getSupportedProtocols();
             failed |= !checkProtocols(protocols, cv.supportedProtocols);
 
             System.out.println(
-                    "\tChecking SSLEngine.getSupportedCipherSuites()");
+                    "\t\tChecking SSLEngine.getSupportedCipherSuites()");
             ciphers = ssocket.getSupportedCipherSuites();
             failed |= !checkCipherSuites(ciphers);
         }
 
         if (failed) {
             throw new Exception("Run into problems, see log for more details");
-        } else {
-            System.out.println("\t... Success");
         }
     }
 }

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/InvalidateServerSessionRenegotiate.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/InvalidateServerSessionRenegotiate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 
 /*
  * @test
- * @bug 4403428
+ * @bug 4403428 8190492
  * @summary Invalidating JSSE session on server causes SSLProtocolException
  * @run main/othervm InvalidateServerSessionRenegotiate SSLv3
  * @run main/othervm InvalidateServerSessionRenegotiate TLSv1
@@ -120,6 +120,12 @@ public class InvalidateServerSessionRenegotiate implements
 
         SSLSocket sslSocket = (SSLSocket) sslServerSocket.accept();
         sslSocket.addHandshakeCompletedListener(this);
+
+        // Enable all supported protocols on server side to test SSLv3
+        if ("SSLv3".equals(tlsProtocol)) {
+            sslSocket.setEnabledProtocols(sslSocket.getSupportedProtocols());
+        }
+
         InputStream sslIS = sslSocket.getInputStream();
         OutputStream sslOS = sslSocket.getOutputStream();
 

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/NoImpactServerRenego.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/NoImpactServerRenego.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 
 /*
  * @test
- * @bug 7188658
+ * @bug 7188658 8190492
  * @summary Add possibility to disable client initiated renegotiation
  * @run main/othervm  -Djdk.tls.rejectClientInitiatedRenegotiation=true
  *      NoImpactServerRenego SSLv3
@@ -121,6 +121,12 @@ public class NoImpactServerRenego implements
 
         SSLSocket sslSocket = (SSLSocket) sslServerSocket.accept();
         sslSocket.addHandshakeCompletedListener(this);
+
+        // Enable all supported protocols on server side to test SSLv3
+        if ("SSLv3".equals(tlsProtocol)) {
+            sslSocket.setEnabledProtocols(sslSocket.getSupportedProtocols());
+        }
+
         InputStream sslIS = sslSocket.getInputStream();
         OutputStream sslOS = sslSocket.getOutputStream();
 


### PR DESCRIPTION
I backport this for parity with 11.0.19-oracle. At least we found the corresponding CSR, the backport seems to be closed.

I had to adapt the code as 11 implements FIPS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8190492](https://bugs.openjdk.org/browse/JDK-8190492): Remove SSLv2Hello and SSLv3 from default enabled TLS protocols


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to [cfd8d3d1](https://git.openjdk.org/jdk11u-dev/pull/1787/files/cfd8d3d14b50ed7ed449cdada186008789f0eaff)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to [cfd8d3d1](https://git.openjdk.org/jdk11u-dev/pull/1787/files/cfd8d3d14b50ed7ed449cdada186008789f0eaff)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1787/head:pull/1787` \
`$ git checkout pull/1787`

Update a local copy of the PR: \
`$ git checkout pull/1787` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1787`

View PR using the GUI difftool: \
`$ git pr show -t 1787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1787.diff">https://git.openjdk.org/jdk11u-dev/pull/1787.diff</a>

</details>
