### PR TITLE
8264299: Create implementation of native accessibility peer for ScrollPane and ScrollBar Java Accessibility roles

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -46,13 +46,6 @@
 #import "JNIUtilities.h"
 #import "AWTView.h"
 
-
-// these constants are duplicated in CAccessibility.java
-#define JAVA_AX_ALL_CHILDREN (-1)
-#define JAVA_AX_SELECTED_CHILDREN (-2)
-#define JAVA_AX_VISIBLE_CHILDREN (-3)
-// If the value is >=0, it's an index
-
 // GET* macros defined in JavaAccessibilityUtilities.h, so they can be shared.
 static jclass sjc_CAccessibility = NULL;
 
@@ -124,19 +117,6 @@ static NSObject *sAttributeNamesLOCK = nil;
 - (void)getActionsWithEnv:(JNIEnv *)env;
 
 - (id)accessibilityValueAttribute;
-@end
-
-
-@interface ScrollAreaAccessibility : JavaComponentAccessibility {
-
-}
-- (NSArray *)initializeAttributeNamesWithEnv:(JNIEnv *)env;
-- (NSArray *)accessibilityContentsAttribute;
-- (BOOL)accessibilityIsContentsAttributeSettable;
-- (id)accessibilityVerticalScrollBarAttribute;
-- (BOOL)accessibilityIsVerticalScrollBarAttributeSettable;
-- (id)accessibilityHorizontalScrollBarAttribute;
-- (BOOL)accessibilityIsHorizontalScrollBarAttributeSettable;
 @end
 
 @interface TableAccessibility : JavaComponentAccessibility {
@@ -395,8 +375,6 @@ static NSObject *sAttributeNamesLOCK = nil;
             newChild = [TabGroupAccessibility alloc];
         } else if ([javaRole isEqualToString:@"table"]) {
             newChild = [TableAccessibility alloc];
-        } else if ([javaRole isEqualToString:@"scrollpane"]) {
-            newChild = [ScrollAreaAccessibility alloc];
         } else {
             NSString *nsRole = [sRoles objectForKey:javaRole];
             if ([nsRole isEqualToString:NSAccessibilityStaticTextRole] ||
@@ -1890,105 +1868,6 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
 
 @end
 
-
-@implementation ScrollAreaAccessibility
-
-- (NSArray *)initializeAttributeNamesWithEnv:(JNIEnv *)env
-{
-    NSMutableArray *names = (NSMutableArray *)[super initializeAttributeNamesWithEnv:env];
-
-    [names addObject:NSAccessibilityHorizontalScrollBarAttribute];
-    [names addObject:NSAccessibilityVerticalScrollBarAttribute];
-    [names addObject:NSAccessibilityContentsAttribute];
-
-    return names;
-}
-
-- (id)accessibilityHorizontalScrollBarAttribute
-{
-    JNIEnv *env = [ThreadUtilities getJNIEnv];
-
-    NSArray *children = [JavaComponentAccessibility childrenOfParent:self withEnv:env withChildrenCode:JAVA_AX_ALL_CHILDREN allowIgnored:YES];
-    if ([children count] <= 0) return nil;
-
-    // The scroll bars are in the children.
-    JavaComponentAccessibility *aElement;
-    NSEnumerator *enumerator = [children objectEnumerator];
-    while ((aElement = (JavaComponentAccessibility *)[enumerator nextObject])) {
-        if ([[aElement accessibilityRoleAttribute] isEqualToString:NSAccessibilityScrollBarRole]) {
-            jobject elementAxContext = [aElement axContextWithEnv:env];
-            if (isHorizontal(env, elementAxContext, fComponent)) {
-                (*env)->DeleteLocalRef(env, elementAxContext);
-                return aElement;
-            }
-            (*env)->DeleteLocalRef(env, elementAxContext);
-        }
-    }
-
-    return nil;
-}
-
-- (BOOL)accessibilityIsHorizontalScrollBarAttributeSettable
-{
-    return NO;
-}
-
-- (id)accessibilityVerticalScrollBarAttribute
-{
-    JNIEnv *env = [ThreadUtilities getJNIEnv];
-
-    NSArray *children = [JavaComponentAccessibility childrenOfParent:self withEnv:env withChildrenCode:JAVA_AX_ALL_CHILDREN allowIgnored:YES];
-    if ([children count] <= 0) return nil;
-
-    // The scroll bars are in the children.
-    NSEnumerator *enumerator = [children objectEnumerator];
-    JavaComponentAccessibility *aElement;
-    while ((aElement = (JavaComponentAccessibility *)[enumerator nextObject])) {
-        if ([[aElement accessibilityRoleAttribute] isEqualToString:NSAccessibilityScrollBarRole]) {
-            jobject elementAxContext = [aElement axContextWithEnv:env];
-            if (isVertical(env, elementAxContext, fComponent)) {
-                (*env)->DeleteLocalRef(env, elementAxContext);
-                return aElement;
-            }
-            (*env)->DeleteLocalRef(env, elementAxContext);
-        }
-    }
-
-    return nil;
-}
-
-- (BOOL)accessibilityIsVerticalScrollBarAttributeSettable
-{
-    return NO;
-}
-
-- (NSArray *)accessibilityContentsAttribute
-{
-    JNIEnv *env = [ThreadUtilities getJNIEnv];
-    NSArray *children = [JavaComponentAccessibility childrenOfParent:self withEnv:env withChildrenCode:JAVA_AX_ALL_CHILDREN allowIgnored:YES];
-
-    if ([children count] <= 0) return nil;
-    NSArray *contents = [NSMutableArray arrayWithCapacity:[children count]];
-
-    // The scroll bars are in the children. children less the scroll bars is the contents
-    NSEnumerator *enumerator = [children objectEnumerator];
-    JavaComponentAccessibility *aElement;
-    while ((aElement = (JavaComponentAccessibility *)[enumerator nextObject])) {
-        if (![[aElement accessibilityRoleAttribute] isEqualToString:NSAccessibilityScrollBarRole]) {
-            // no scroll bars in contents
-            [(NSMutableArray *)contents addObject:aElement];
-        }
-    }
-
-    return contents;
-}
-
-- (BOOL)accessibilityIsContentsAttributeSettable
-{
-    return NO;
-}
-
-@end
 
 // these constants are duplicated in CAccessibility.java
 #define JAVA_AX_ROWS (1)

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -48,7 +48,7 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:26];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:29];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
@@ -58,6 +58,9 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"StaticTextAccessibility" forKey:@"label"];
     [rolesMap setObject:@"RadiobuttonAccessibility" forKey:@"radiobutton"];
     [rolesMap setObject:@"CheckboxAccessibility" forKey:@"checkbox"];
+   // [rolesMap setObject:@"SliderAccessibility" forKey:@"slider"];
+    [rolesMap setObject:@"ScrollAreaAccessibility" forKey:@"scrollpane"];
+    [rolesMap setObject:@"ScrollBarAccessibility" forKey:@"scrollbar"];
 
     /*
      * All the components below should be ignored by the accessibility subsystem,

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.h
@@ -23,27 +23,19 @@
  * questions.
  */
 
-#ifndef JAVA_COMPONENT_ACCESSIBILITY
-#define JAVA_COMPONENT_ACCESSIBILITY
-
 #import "JavaComponentAccessibility.h"
-#import "JavaAccessibilityUtilities.h"
+#import "CommonComponentAccessibility.h"
 
-// these constants are duplicated in CAccessibility.java
-#define JAVA_AX_ALL_CHILDREN (-1)
-#define JAVA_AX_SELECTED_CHILDREN (-2)
-#define JAVA_AX_VISIBLE_CHILDREN (-3)
-// If the value is >=0, it's an index
+#import <AppKit/AppKit.h>
 
-@interface CommonComponentAccessibility : JavaComponentAccessibility <NSAccessibilityElement> {
+@interface ScrollAreaAccessibility : CommonComponentAccessibility {
 
-}
-+ (void) initializeRolesMap;
-+ (JavaComponentAccessibility * _Nullable) getComponentAccessibility:(NSString * _Nonnull)role;
-- (NSRect)accessibilityFrame;
-- (nullable id)accessibilityParent;
-- (BOOL)performAccessibleAction:(int)index;
-- (BOOL)isAccessibilityElement;
+};
+- (NSString * _Nonnull)accessibilityRole;
+- (NSArray * _Nullable)accessibilityContents;
+- (id _Nullable)accessibilityHorizontalScrollBar;
+- (id _Nullable)accessibilityVerticalScrollBar;
+
+- (NSArray * _Nullable)accessibilityContentsAttribute;
+- (id _Nullable)getScrollBarwithOrientation:(enum NSAccessibilityOrientation)orientation;
 @end
-
-#endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.m
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "ScrollAreaAccessibility.h"
+#import "ThreadUtilities.h"
+#import "JNIUtilities.h"
+
+/*
+ * Implementation of the accessibility peer for the ScrollArea role
+ */
+@implementation ScrollAreaAccessibility
+
+- (NSArray * _Nullable)accessibilityContentsAttribute
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    NSArray *children = [JavaComponentAccessibility childrenOfParent:self withEnv:env withChildrenCode:JAVA_AX_ALL_CHILDREN allowIgnored:YES];
+
+    if ([children count] <= 0) return nil;
+    NSArray *contents = [NSMutableArray arrayWithCapacity:[children count]];
+
+    // The scroll bars are in the children. children less the scroll bars is the contents
+    NSEnumerator *enumerator = [children objectEnumerator];
+    JavaComponentAccessibility *aElement;
+    while ((aElement = (JavaComponentAccessibility *)[enumerator nextObject])) {
+        if (![[aElement accessibilityRoleAttribute] isEqualToString:NSAccessibilityScrollBarRole]) {
+            // no scroll bars in contents
+            [(NSMutableArray *)contents addObject:aElement];
+        }
+    }
+    return contents;
+}
+
+- (id _Nullable)getScrollBarwithOrientation:(enum NSAccessibilityOrientation)orientation
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+
+    NSArray *children = [JavaComponentAccessibility childrenOfParent:self withEnv:env withChildrenCode:JAVA_AX_ALL_CHILDREN allowIgnored:YES];
+    if ([children count] <= 0) return nil;
+
+    // The scroll bars are in the children.
+    JavaComponentAccessibility *aElement;
+    NSEnumerator *enumerator = [children objectEnumerator];
+    while ((aElement = (JavaComponentAccessibility *)[enumerator nextObject])) {
+        if ([[aElement accessibilityRoleAttribute] isEqualToString:NSAccessibilityScrollBarRole]) {
+            jobject elementAxContext = [aElement axContextWithEnv:env];
+            if (orientation == NSAccessibilityOrientationHorizontal) {
+                if (isHorizontal(env, elementAxContext, fComponent)) {
+                    (*env)->DeleteLocalRef(env, elementAxContext);
+                    return aElement;
+                }
+            } else if (orientation == NSAccessibilityOrientationVertical) {
+                if (isVertical(env, elementAxContext, fComponent)) {
+                    (*env)->DeleteLocalRef(env, elementAxContext);
+                    return aElement;
+                }
+            } else {
+                (*env)->DeleteLocalRef(env, elementAxContext);
+            }
+        }
+    }
+    return nil;
+}
+
+- (NSString * _Nonnull)accessibilityRole
+{
+    return [self accessibilityRoleAttribute];
+}
+
+- (NSArray * _Nullable)accessibilityContents
+{
+    return [self accessibilityContentsAttribute];
+}
+
+- (id _Nullable)accessibilityHorizontalScrollBar
+{
+    return [self getScrollBarwithOrientation:NSAccessibilityOrientationHorizontal];
+}
+
+- (id _Nullable)accessibilityVerticalScrollBar
+{
+    return [self getScrollBarwithOrientation:NSAccessibilityOrientationVertical];
+}
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollBarAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollBarAccessibility.h
@@ -23,27 +23,14 @@
  * questions.
  */
 
-#ifndef JAVA_COMPONENT_ACCESSIBILITY
-#define JAVA_COMPONENT_ACCESSIBILITY
-
 #import "JavaComponentAccessibility.h"
-#import "JavaAccessibilityUtilities.h"
+#import "CommonComponentAccessibility.h"
 
-// these constants are duplicated in CAccessibility.java
-#define JAVA_AX_ALL_CHILDREN (-1)
-#define JAVA_AX_SELECTED_CHILDREN (-2)
-#define JAVA_AX_VISIBLE_CHILDREN (-3)
-// If the value is >=0, it's an index
+#import <AppKit/AppKit.h>
 
-@interface CommonComponentAccessibility : JavaComponentAccessibility <NSAccessibilityElement> {
+@interface ScrollBarAccessibility : CommonComponentAccessibility {
 
-}
-+ (void) initializeRolesMap;
-+ (JavaComponentAccessibility * _Nullable) getComponentAccessibility:(NSString * _Nonnull)role;
-- (NSRect)accessibilityFrame;
-- (nullable id)accessibilityParent;
-- (BOOL)performAccessibleAction:(int)index;
-- (BOOL)isAccessibilityElement;
+};
+- (NSString * _Nonnull)accessibilityRole;
+- (NSAccessibilityOrientation) accessibilityOrientation;
 @end
-
-#endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollBarAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollBarAccessibility.m
@@ -23,27 +23,33 @@
  * questions.
  */
 
-#ifndef JAVA_COMPONENT_ACCESSIBILITY
-#define JAVA_COMPONENT_ACCESSIBILITY
+#import "ScrollBarAccessibility.h"
+#import "ThreadUtilities.h"
+#import "JNIUtilities.h"
 
-#import "JavaComponentAccessibility.h"
-#import "JavaAccessibilityUtilities.h"
+/*
+ * Implementation of the accessibility peer for the ScrollBar role
+ */
+@implementation ScrollBarAccessibility
 
-// these constants are duplicated in CAccessibility.java
-#define JAVA_AX_ALL_CHILDREN (-1)
-#define JAVA_AX_SELECTED_CHILDREN (-2)
-#define JAVA_AX_VISIBLE_CHILDREN (-3)
-// If the value is >=0, it's an index
-
-@interface CommonComponentAccessibility : JavaComponentAccessibility <NSAccessibilityElement> {
-
+- (NSString * _Nonnull)accessibilityRole
+{
+    return [self accessibilityRoleAttribute];
 }
-+ (void) initializeRolesMap;
-+ (JavaComponentAccessibility * _Nullable) getComponentAccessibility:(NSString * _Nonnull)role;
-- (NSRect)accessibilityFrame;
-- (nullable id)accessibilityParent;
-- (BOOL)performAccessibleAction:(int)index;
-- (BOOL)isAccessibilityElement;
-@end
 
-#endif
+- (NSAccessibilityOrientation) accessibilityOrientation
+{
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+    jobject elementAxContext = [self axContextWithEnv:env];
+    if (isHorizontal(env, elementAxContext, fComponent)) {
+        (*env)->DeleteLocalRef(env, elementAxContext);
+        return NSAccessibilityOrientationHorizontal;
+    } else if (isVertical(env, elementAxContext, fComponent)) {
+        (*env)->DeleteLocalRef(env, elementAxContext);
+        return NSAccessibilityOrientationVertical;
+    } else {
+        (*env)->DeleteLocalRef(env, elementAxContext);
+        return NSAccessibilityOrientationUnknown;
+    }
+}
+@end


### PR DESCRIPTION
backport JDK-8264299 This backport is part of the 28 backport Accessibility series JDK-8152350. Commented out line 61 of commoneComponentAccesssibilty.m until backoport JDK-8262981 is reworked and built a slider and other GUIs and  components and manually tested the UI with Accessibility functions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8264299](https://bugs.openjdk.org/browse/JDK-8264299): Create implementation of native accessibility peer for ScrollPane and ScrollBar Java Accessibility roles


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1791/head:pull/1791` \
`$ git checkout pull/1791`

Update a local copy of the PR: \
`$ git checkout pull/1791` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1791`

View PR using the GUI difftool: \
`$ git pr show -t 1791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1791.diff">https://git.openjdk.org/jdk11u-dev/pull/1791.diff</a>

</details>
