### PR TITLE
8303102: jcmd: ManagementAgent.status truncates the text longer than O_BUFLEN

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -923,7 +923,8 @@ void JMXStatusDCmd::execute(DCmdSource source, TRAPS) {
   if (str != NULL) {
       char* out = java_lang_String::as_utf8_string(str);
       if (out) {
-          output()->print_cr("%s", out);
+          // Avoid using print_cr() because length maybe longer than O_BUFLEN
+          output()->print_raw_cr(out);
           return;
       }
   }

--- a/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import jdk.test.lib.process.ProcessTools;
 
 /**
  * @test
- * @bug 8023093 8138748 8142398
+ * @bug 8023093 8138748 8142398 8303102
  * @summary Performs a sanity test for the ManagementAgent.status diagnostic command.
  *          Management agent may be disabled, started (only local connections) and started.
  *          The test asserts that the expected text is being printed.


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [a43931b7](https://github.com/openjdk/jdk/commit/a43931b79cb25d218e8f9b4d4f3a106f59cb2d37) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 26 Feb 2023 and was reviewed by David Holmes.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303102](https://bugs.openjdk.org/browse/JDK-8303102): jcmd: ManagementAgent.status truncates the text longer than O_BUFLEN


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1795/head:pull/1795` \
`$ git checkout pull/1795`

Update a local copy of the PR: \
`$ git checkout pull/1795` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1795`

View PR using the GUI difftool: \
`$ git pr show -t 1795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1795.diff">https://git.openjdk.org/jdk11u-dev/pull/1795.diff</a>

</details>
