### PR TITLE
8282600: SSLSocketImpl should not use user_canceled workaround when not necessary

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -640,8 +640,12 @@ public final class SSLSocketImpl
             if (!conContext.protocolVersion.useTLS13PlusSpec()) {
                 hasCloseReceipt = true;
             } else {
-                // Use a user_canceled alert for TLS 1.3 duplex close.
-                useUserCanceled = true;
+                // Do not use user_canceled workaround if the other side has
+                // already half-closed the connection
+                if (!conContext.isInboundClosed()) {
+                    // Use a user_canceled alert for TLS 1.3 duplex close.
+                    useUserCanceled = true;
+                }
             }
         } else if (conContext.handshakeContext != null) {   // initial handshake
             // Use user_canceled alert regardless the protocol versions.


### PR DESCRIPTION
Backport fixing SSLSocket, not to use workaround with user_canceled alert for TLS 1.3 close, when not necessary, as it causes problems with gnutls client.

Clean. Passed [jdk_security](https://github.com/zzambers/jdk-tester/actions/runs/4347121530/jobs/7594040836) tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282600](https://bugs.openjdk.org/browse/JDK-8282600): SSLSocketImpl should not use user_canceled workaround when not necessary


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1796/head:pull/1796` \
`$ git checkout pull/1796`

Update a local copy of the PR: \
`$ git checkout pull/1796` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1796`

View PR using the GUI difftool: \
`$ git pr show -t 1796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1796.diff">https://git.openjdk.org/jdk11u-dev/pull/1796.diff</a>

</details>
