### PR TITLE
8293232: Fix race condition in pkcs11 SessionManager

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SessionManager.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,7 +207,12 @@ final class SessionManager {
             // will be added to correct pool on release, nothing to do now
             return;
         }
-        opSessions.release(session);
+        // Objects could have been added to this session by other thread between
+        // check in Session.removeObject method and objSessions.remove call
+        // higher. Therefore releaseSession method, which performs additional
+        // check for objects, is used here to avoid placing this session
+        // in wrong pool due to race condition.
+        releaseSession(session);
     }
 
     private Session openSession() throws PKCS11Exception {


### PR DESCRIPTION
Backport - fix for race condition in pkcs11 SessionManager.

Clean. Passed [jdk_security](https://github.com/zzambers/jdk-tester/actions/runs/4347091189/jobs/7593974147) tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293232](https://bugs.openjdk.org/browse/JDK-8293232): Fix race condition in pkcs11 SessionManager


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1797/head:pull/1797` \
`$ git checkout pull/1797`

Update a local copy of the PR: \
`$ git checkout pull/1797` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1797`

View PR using the GUI difftool: \
`$ git pr show -t 1797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1797.diff">https://git.openjdk.org/jdk11u-dev/pull/1797.diff</a>

</details>
