### PR TITLE
8302791: Add specific ClassLoader object to Proxy IllegalArgumentException message

### DIFF
--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -406,6 +406,11 @@ public abstract class ClassLoader {
         return nid;
     }
 
+    // Returns nameAndId string for exception message printing
+    String nameAndId() {
+        return nameAndId;
+    }
+
     /**
      * Creates a new class loader of the specified name and using the
      * specified parent class loader for delegation.

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2209,6 +2209,9 @@ public final class System {
                 return StringCoding.getBytesUTF8NoRepl(s);
             }
 
+            public String getLoaderNameID(ClassLoader loader) {
+                return loader.nameAndId();
+            }
         });
     }
 }

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -44,6 +44,8 @@ import java.util.stream.Stream;
 
 import jdk.internal.loader.BootLoader;
 import jdk.internal.module.Modules;
+import jdk.internal.misc.JavaLangAccess;
+import jdk.internal.misc.SharedSecrets;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.misc.VM;
 import jdk.internal.reflect.CallerSensitive;
@@ -469,6 +471,7 @@ public class Proxy implements java.io.Serializable {
      */
     private static final class ProxyBuilder {
         private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+        private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
 
         // prefix for all proxy class names
         private static final String proxyClassNamePrefix = "$Proxy";
@@ -856,7 +859,7 @@ public class Proxy implements java.io.Serializable {
             }
             if (type != c) {
                 throw new IllegalArgumentException(c.getName() +
-                        " referenced from a method is not visible from class loader");
+                        " referenced from a method is not visible from class loader: " + JLA.getLoaderNameID(ld));
             }
         }
 

--- a/src/java.base/share/classes/jdk/internal/misc/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/misc/JavaLangAccess.java
@@ -305,4 +305,10 @@ public interface JavaLangAccess {
      * @throws IllegalArgumentException for malformed surrogates
      */
     byte[] getBytesUTF8NoRepl(String s);
+
+    /**
+     * Returns '<loader-name>' @<id> if classloader has a name
+     * explicitly set otherwise <qualified-class-name> @<id>
+     */
+     String getLoaderNameID(ClassLoader loader);
 }


### PR DESCRIPTION
Added specific class loader object to proxy IllegalArgumentException from which the class was not visible

The bug report for the same: https://bugs.openjdk.org/browse/JDK-8302791

OpenJDK PR: https://github.com/openjdk/jdk/pull/12641

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302791](https://bugs.openjdk.org/browse/JDK-8302791): Add specific ClassLoader object to Proxy IllegalArgumentException message


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1802/head:pull/1802` \
`$ git checkout pull/1802`

Update a local copy of the PR: \
`$ git checkout pull/1802` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1802/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1802`

View PR using the GUI difftool: \
`$ git pr show -t 1802`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1802.diff">https://git.openjdk.org/jdk11u-dev/pull/1802.diff</a>

</details>
