### PR TITLE
8263420: Incorrect function name in NSAccessibilityStaticText native peer implementation

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
@@ -34,7 +34,7 @@
 @interface StaticTextAccessibility : CommonTextAccessibility<NSAccessibilityStaticText> {
 
 };
-- (nullable NSString *)accessibilityAttributedString:(NSRange)range;
+- (nullable NSString *)accessibilityAttributedStringForRange:(NSRange)range;
 - (nullable NSString *)accessibilityValue;
 - (NSRange)accessibilityVisibleCharacterRange;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
@@ -27,7 +27,7 @@
 
 @implementation StaticTextAccessibility
 
-- (nullable NSString *)accessibilityAttributedString:(NSRange)range
+- (nullable NSString *)accessibilityAttributedStringForRange:(NSRange)range
 {
     return [self accessibilityStringForRangeAttribute:range];
 }


### PR DESCRIPTION
This backport is part of the 28 backport Accessibility series JDK-8152350. Tested by building GUI and using the Accessibility components.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8263420](https://bugs.openjdk.org/browse/JDK-8263420): Incorrect function name in NSAccessibilityStaticText native peer implementation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1806/head:pull/1806` \
`$ git checkout pull/1806`

Update a local copy of the PR: \
`$ git checkout pull/1806` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1806`

View PR using the GUI difftool: \
`$ git pr show -t 1806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1806.diff">https://git.openjdk.org/jdk11u-dev/pull/1806.diff</a>

</details>
