### PR TITLE
8264302: Create implementation for Accessibility native peer for Splitpane java role

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -48,7 +48,7 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:35];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:36];
 
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
@@ -68,6 +68,7 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"GroupAccessibility" forKey:@"internalframe"];
     [rolesMap setObject:@"GroupAccessibility" forKey:@"swingcomponent"];
     [rolesMap setObject:@"ToolbarAccessibility" forKey:@"toolbar"];
+    [rolesMap setObject:@"SplitpaneAccessibility" forKey:@"splitpane"];
 
 
     /*

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "JavaComponentAccessibility.h"
+#import "GroupAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface SplitpaneAccessibility : GroupAccessibility {
+
+};
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.m
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "SplitpaneAccessibility.h"
+
+/*
+ * Implementation of the accessibility peer for the Splitpane role
+ */
+@implementation SplitpaneAccessibility
+
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilitySplitGroupRole;
+}
+
+@end


### PR DESCRIPTION
This backport is part of the 28 backport Accessibility series JDK-8152350. Tested by building GUI and using the Accessibility components.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #1807 must be integrated first

### Issue
 * [JDK-8264302](https://bugs.openjdk.org/browse/JDK-8264302): Create implementation for Accessibility native peer for Splitpane java role


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1808/head:pull/1808` \
`$ git checkout pull/1808`

Update a local copy of the PR: \
`$ git checkout pull/1808` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1808`

View PR using the GUI difftool: \
`$ git pr show -t 1808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1808.diff">https://git.openjdk.org/jdk11u-dev/pull/1808.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1808#issuecomment-1471302122)