### PR TITLE
8264305: Create implementation for native accessibility peer for Statusbar java role

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ButtonAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ButtonAccessibility.h
@@ -31,6 +31,7 @@
 @interface ButtonAccessibility : CommonComponentAccessibility <NSAccessibilityButton> {
 
 };
-- (nullable NSString *)accessibilityLabel;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (NSString * _Nullable)accessibilityLabel;
 - (BOOL)accessibilityPerformPress;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ButtonAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ButtonAccessibility.m
@@ -29,7 +29,12 @@
  * Implementation of the accessibility peer for the pushbutton role
  */
 @implementation ButtonAccessibility
-- (nullable NSString *)accessibilityLabel
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityButtonRole;
+}
+
+- (NSString * _Nullable)accessibilityLabel
 {
     return [self accessibilityTitleAttribute];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.h
@@ -28,5 +28,6 @@
 @interface CheckboxAccessibility : ButtonAccessibility <NSAccessibilityCheckBox> {
 
 };
-- (id)accessibilityValue;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (id _Nonnull)accessibilityValue;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CheckboxAccessibility.m
@@ -31,8 +31,12 @@
  * Implementation of the accessibility peer for the checkbox role
  */
 @implementation CheckboxAccessibility
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityCheckBoxRole;
+}
 
-- (id) accessibilityValue
+- (id _Nonnull) accessibilityValue
 {
     AWT_ASSERT_APPKIT_THREAD;
     return [self accessibilityValueAttribute];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.h
@@ -41,7 +41,7 @@
 + (void) initializeRolesMap;
 + (JavaComponentAccessibility * _Nullable) getComponentAccessibility:(NSString * _Nonnull)role;
 - (NSRect)accessibilityFrame;
-- (nullable id)accessibilityParent;
+- (id _Nullable)accessibilityParent;
 - (BOOL)performAccessibleAction:(int)index;
 - (BOOL)isAccessibilityElement;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -48,7 +48,7 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:35];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:36];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
@@ -67,6 +67,7 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"GroupAccessibility" forKey:@"internalframe"];
     [rolesMap setObject:@"GroupAccessibility" forKey:@"swingcomponent"];
     [rolesMap setObject:@"ToolbarAccessibility" forKey:@"toolbar"];
+    [rolesMap setObject:@"SplitpaneAccessibility" forKey:@"splitpane"];
 
     /*
      * All the components below should be ignored by the accessibility subsystem,

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -164,7 +164,7 @@ static jobject sAccessibilityClass = NULL;
     return NSMakeRect(point.x, point.y, size.width, size.height);
 }
 
-- (nullable id)accessibilityParent
+- (id _Nullable)accessibilityParent
 {
     return [self accessibilityParentAttribute];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -48,7 +48,7 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:36];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:37];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
@@ -68,6 +68,7 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"GroupAccessibility" forKey:@"swingcomponent"];
     [rolesMap setObject:@"ToolbarAccessibility" forKey:@"toolbar"];
     [rolesMap setObject:@"SplitpaneAccessibility" forKey:@"splitpane"];
+    [rolesMap setObject:@"StatusbarAccessibility" forKey:@"statusbar"];
 
     /*
      * All the components below should be ignored by the accessibility subsystem,

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -48,7 +48,7 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:29];
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:34];
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
@@ -61,6 +61,11 @@ static jobject sAccessibilityClass = NULL;
    // [rolesMap setObject:@"SliderAccessibility" forKey:@"slider"];
     [rolesMap setObject:@"ScrollAreaAccessibility" forKey:@"scrollpane"];
     [rolesMap setObject:@"ScrollBarAccessibility" forKey:@"scrollbar"];
+    [rolesMap setObject:@"GroupAccessibility" forKey:@"awtcomponent"];
+    [rolesMap setObject:@"GroupAccessibility" forKey:@"canvas"];
+    [rolesMap setObject:@"GroupAccessibility" forKey:@"groupbox"];
+    [rolesMap setObject:@"GroupAccessibility" forKey:@"internalframe"];
+    [rolesMap setObject:@"GroupAccessibility" forKey:@"swingcomponent"];
 
     /*
      * All the components below should be ignored by the accessibility subsystem,

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -48,7 +48,11 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
+<<<<<<< HEAD
+    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:35];
+=======
     rolesMap = [[NSMutableDictionary alloc] initWithCapacity:34];
+>>>>>>> 013e27dfe97 (Backport f07dcf471c160e09fbc748124998923e7d453e66)
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
@@ -58,14 +62,23 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"StaticTextAccessibility" forKey:@"label"];
     [rolesMap setObject:@"RadiobuttonAccessibility" forKey:@"radiobutton"];
     [rolesMap setObject:@"CheckboxAccessibility" forKey:@"checkbox"];
+<<<<<<< HEAD
    // [rolesMap setObject:@"SliderAccessibility" forKey:@"slider"];
     [rolesMap setObject:@"ScrollAreaAccessibility" forKey:@"scrollpane"];
+=======
+    [rolesMap setObject:@"SliderAccessibility" forKey:@"slider"];
+   //[rolesMap setObject:@"ScrollAreaAccessibility" forKey:@"scrollpane"];
+>>>>>>> 013e27dfe97 (Backport f07dcf471c160e09fbc748124998923e7d453e66)
     [rolesMap setObject:@"ScrollBarAccessibility" forKey:@"scrollbar"];
     [rolesMap setObject:@"GroupAccessibility" forKey:@"awtcomponent"];
     [rolesMap setObject:@"GroupAccessibility" forKey:@"canvas"];
     [rolesMap setObject:@"GroupAccessibility" forKey:@"groupbox"];
     [rolesMap setObject:@"GroupAccessibility" forKey:@"internalframe"];
     [rolesMap setObject:@"GroupAccessibility" forKey:@"swingcomponent"];
+<<<<<<< HEAD
+    [rolesMap setObject:@"ToolbarAccessibility" forKey:@"toolbar"];
+=======
+>>>>>>> 013e27dfe97 (Backport f07dcf471c160e09fbc748124998923e7d453e66)
 
     /*
      * All the components below should be ignored by the accessibility subsystem,

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -48,11 +48,7 @@ static jobject sAccessibilityClass = NULL;
     /*
      * Here we should keep all the mapping between the accessibility roles and implementing classes
      */
-<<<<<<< HEAD
     rolesMap = [[NSMutableDictionary alloc] initWithCapacity:35];
-=======
-    rolesMap = [[NSMutableDictionary alloc] initWithCapacity:34];
->>>>>>> 013e27dfe97 (Backport f07dcf471c160e09fbc748124998923e7d453e66)
 
     [rolesMap setObject:@"ButtonAccessibility" forKey:@"pushbutton"];
     [rolesMap setObject:@"ImageAccessibility" forKey:@"icon"];
@@ -62,23 +58,15 @@ static jobject sAccessibilityClass = NULL;
     [rolesMap setObject:@"StaticTextAccessibility" forKey:@"label"];
     [rolesMap setObject:@"RadiobuttonAccessibility" forKey:@"radiobutton"];
     [rolesMap setObject:@"CheckboxAccessibility" forKey:@"checkbox"];
-<<<<<<< HEAD
    // [rolesMap setObject:@"SliderAccessibility" forKey:@"slider"];
     [rolesMap setObject:@"ScrollAreaAccessibility" forKey:@"scrollpane"];
-=======
-    [rolesMap setObject:@"SliderAccessibility" forKey:@"slider"];
-   //[rolesMap setObject:@"ScrollAreaAccessibility" forKey:@"scrollpane"];
->>>>>>> 013e27dfe97 (Backport f07dcf471c160e09fbc748124998923e7d453e66)
     [rolesMap setObject:@"ScrollBarAccessibility" forKey:@"scrollbar"];
     [rolesMap setObject:@"GroupAccessibility" forKey:@"awtcomponent"];
     [rolesMap setObject:@"GroupAccessibility" forKey:@"canvas"];
     [rolesMap setObject:@"GroupAccessibility" forKey:@"groupbox"];
     [rolesMap setObject:@"GroupAccessibility" forKey:@"internalframe"];
     [rolesMap setObject:@"GroupAccessibility" forKey:@"swingcomponent"];
-<<<<<<< HEAD
     [rolesMap setObject:@"ToolbarAccessibility" forKey:@"toolbar"];
-=======
->>>>>>> 013e27dfe97 (Backport f07dcf471c160e09fbc748124998923e7d453e66)
 
     /*
      * All the components below should be ignored by the accessibility subsystem,

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonTextAccessibility.h
@@ -34,9 +34,9 @@
 @interface CommonTextAccessibility : CommonComponentAccessibility {
 
 }
-- (nullable NSString *)accessibilityValueAttribute;
+- (NSString * _Nullable)accessibilityValueAttribute;
 - (NSRange)accessibilityVisibleCharacterRangeAttribute;
-- (nullable NSString *)accessibilityStringForRangeAttribute:(NSRange)parameter;
+- (NSString * _Nullable)accessibilityStringForRangeAttribute:(NSRange)parameter;
 @end
 
 #endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "JavaComponentAccessibility.h"
+#import "CommonComponentAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface GroupAccessibility : CommonComponentAccessibility <NSAccessibilityGroup> {
+
+};
+
+- (NSArray * _Nullable)accessibilityChildren;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.h
@@ -31,6 +31,6 @@
 @interface GroupAccessibility : CommonComponentAccessibility <NSAccessibilityGroup> {
 
 };
-
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
 - (NSArray * _Nullable)accessibilityChildren;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.m
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "GroupAccessibility.h"
+#import "JNIUtilities.h"
+#import "ThreadUtilities.h"
+/*
+ * This is the protocol for the components that contain children.
+ * Basic logic of accessibilityChildren might be overridden in the specific implementing
+ * classes reflecting the logic of the class.
+ */
+@implementation GroupAccessibility
+
+/*
+ * Return all non-ignored children.
+ */
+- (NSArray *)accessibilityChildren {
+    JNIEnv *env = [ThreadUtilities getJNIEnv];
+
+    NSArray *children = [JavaComponentAccessibility childrenOfParent:self
+                                                             withEnv:env
+                                                    withChildrenCode:JAVA_AX_ALL_CHILDREN
+                                                        allowIgnored:NO];
+
+    if ([children count] == 0) {
+        return nil;
+    } else {
+        return children;
+    }
+}
+
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/GroupAccessibility.m
@@ -32,6 +32,10 @@
  * classes reflecting the logic of the class.
  */
 @implementation GroupAccessibility
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityGroupRole;
+}
 
 /*
  * Return all non-ignored children.

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.h
@@ -31,5 +31,6 @@
 @interface ImageAccessibility : CommonComponentAccessibility <NSAccessibilityImage> {
 
 };
-- (nullable NSString *)accessibilityLabel;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (NSString * _Nullable)accessibilityLabel;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ImageAccessibility.m
@@ -29,7 +29,12 @@
  * Implementation of the accessibility peer for the icon role
  */
 @implementation ImageAccessibility
-- (nullable NSString *)accessibilityLabel
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityImageRole;
+}
+
+- (NSString * _Nullable)accessibilityLabel
 {
     return [self accessibilityTitleAttribute];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.h
@@ -28,5 +28,6 @@
 @interface RadiobuttonAccessibility : ButtonAccessibility <NSAccessibilityRadioButton> {
 
 };
-- (id)accessibilityValue;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (id _Nonnull)accessibilityValue;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/RadiobuttonAccessibility.m
@@ -31,8 +31,12 @@
  * Implementation of the accessibility peer for the radiobutton role
  */
 @implementation RadiobuttonAccessibility
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityRadioButtonRole;
+}
 
-- (id) accessibilityValue
+- (id _Nonnull) accessibilityValue
 {
     AWT_ASSERT_APPKIT_THREAD;
     return [self accessibilityValueAttribute];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollAreaAccessibility.m
@@ -83,9 +83,9 @@
     return nil;
 }
 
-- (NSString * _Nonnull)accessibilityRole
+- (NSAccessibilityRole _Nonnull)accessibilityRole
 {
-    return [self accessibilityRoleAttribute];
+    return NSAccessibilityScrollAreaRole;
 }
 
 - (NSArray * _Nullable)accessibilityContents

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollBarAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollBarAccessibility.h
@@ -31,6 +31,6 @@
 @interface ScrollBarAccessibility : CommonComponentAccessibility {
 
 };
-- (NSString * _Nonnull)accessibilityRole;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
 - (NSAccessibilityOrientation) accessibilityOrientation;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollBarAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ScrollBarAccessibility.m
@@ -32,9 +32,9 @@
  */
 @implementation ScrollBarAccessibility
 
-- (NSString * _Nonnull)accessibilityRole
+- (NSAccessibilityRole _Nonnull)accessibilityRole
 {
-    return [self accessibilityRoleAttribute];
+    return NSAccessibilityScrollBarRole;
 }
 
 - (NSAccessibilityOrientation) accessibilityOrientation

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SliderAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SliderAccessibility.h
@@ -28,14 +28,12 @@
 
 #import <AppKit/AppKit.h>
 
-@interface ScrollAreaAccessibility : CommonComponentAccessibility {
+@interface SliderAccessibility : CommonComponentAccessibility <NSAccessibilitySlider> {
 
 };
 - (NSAccessibilityRole _Nonnull)accessibilityRole;
-- (NSArray * _Nullable)accessibilityContents;
-- (id _Nullable)accessibilityHorizontalScrollBar;
-- (id _Nullable)accessibilityVerticalScrollBar;
-
-- (NSArray * _Nullable)accessibilityContentsAttribute;
-- (id _Nullable)getScrollBarwithOrientation:(enum NSAccessibilityOrientation)orientation;
+- (NSString * _Nullable)accessibilityLabel;
+- (id _Nullable)accessibilityValue;
+- (BOOL)accessibilityPerformDecrement;
+- (BOOL)accessibilityPerformIncrement;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.h
@@ -31,9 +31,9 @@
 @interface SpinboxAccessibility : CommonComponentAccessibility <NSAccessibilityStepper> {
 
 };
-
-- (nullable NSString *)accessibilityLabel;
-- (nullable id)accessibilityValue;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (NSString * _Nullable)accessibilityLabel;
+- (id _Nullable)accessibilityValue;
 - (BOOL)accessibilityPerformDecrement;
 - (BOOL)accessibilityPerformIncrement;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SpinboxAccessibility.m
@@ -32,12 +32,17 @@
  * Implementation of the accessibility peer for the spinner role
  */
 @implementation SpinboxAccessibility
-- (nullable NSString *)accessibilityLabel
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityIncrementorRole;
+}
+
+- (NSString * _Nullable)accessibilityLabel
 {
     return [self accessibilityTitleAttribute];
 }
 
-- (nullable id)accessibilityValue
+- (id _Nullable)accessibilityValue
 {
     return [self accessibilityValueAttribute];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "JavaComponentAccessibility.h"
+#import "GroupAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface SplitpaneAccessibility : GroupAccessibility {
+
+};
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/SplitpaneAccessibility.m
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "SplitpaneAccessibility.h"
+
+/*
+ * Implementation of the accessibility peer for the Splitpane role
+ */
+@implementation SplitpaneAccessibility
+
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilitySplitGroupRole;
+}
+
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
@@ -34,8 +34,9 @@
 @interface StaticTextAccessibility : CommonTextAccessibility<NSAccessibilityStaticText> {
 
 };
-- (nullable NSString *)accessibilityAttributedStringForRange:(NSRange)range;
-- (nullable NSString *)accessibilityValue;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+- (NSString * _Nullable)accessibilityAttributedStringForRange:(NSRange)range;
+- (NSString * _Nullable)accessibilityValue;
 - (NSRange)accessibilityVisibleCharacterRange;
 @end
 #endif

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.h
@@ -34,7 +34,7 @@
 @interface StaticTextAccessibility : CommonTextAccessibility<NSAccessibilityStaticText> {
 
 };
-- (nullable NSString *)accessibilityAttributedString:(NSRange)range;
+- (nullable NSString *)accessibilityAttributedStringForRange:(NSRange)range;
 - (nullable NSString *)accessibilityValue;
 - (NSRange)accessibilityVisibleCharacterRange;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
@@ -27,12 +27,17 @@
 
 @implementation StaticTextAccessibility
 
-- (nullable NSString *)accessibilityAttributedStringForRange:(NSRange)range
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityStaticTextRole;
+}
+
+- (NSString * _Nullable)accessibilityAttributedStringForRange:(NSRange)range
 {
     return [self accessibilityStringForRangeAttribute:range];
 }
 
-- (nullable NSString *)accessibilityValue
+- (NSString * _Nullable)accessibilityValue
 {
     return [self accessibilityValueAttribute];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StaticTextAccessibility.m
@@ -27,7 +27,7 @@
 
 @implementation StaticTextAccessibility
 
-- (nullable NSString *)accessibilityAttributedString:(NSRange)range
+- (nullable NSString *)accessibilityAttributedStringForRange:(NSRange)range
 {
     return [self accessibilityStringForRangeAttribute:range];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StatusbarAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StatusbarAccessibility.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "JavaComponentAccessibility.h"
+#import "GroupAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface StatusbarAccessibility : GroupAccessibility {
+
+};
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StatusbarAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/StatusbarAccessibility.m
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "StatusbarAccessibility.h"
+
+/*
+ * Implementation of the accessibility peer for the Statusbar role
+ */
+@implementation StatusbarAccessibility
+
+- (NSAccessibilityRole _Nonnull)accessibilityRole
+{
+    return NSAccessibilityValueIndicatorRole;
+}
+
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ToolbarAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ToolbarAccessibility.h
@@ -31,5 +31,5 @@
 @interface ToolbarAccessibility : CommonComponentAccessibility {
 
 };
-- (NSString * _Nonnull)accessibilityRole;
+- (NSAccessibilityRole _Nonnull)accessibilityRole;
 @end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ToolbarAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ToolbarAccessibility.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "JavaComponentAccessibility.h"
+#import "CommonComponentAccessibility.h"
+
+#import <AppKit/AppKit.h>
+
+@interface ToolbarAccessibility : CommonComponentAccessibility {
+
+};
+- (NSString * _Nonnull)accessibilityRole;
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ToolbarAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ToolbarAccessibility.m
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "ToolbarAccessibility.h"
+
+/*
+ * Implementation of the accessibility peer for the Toolbar role
+ */
+@implementation ToolbarAccessibility
+
+- (NSString * _Nonnull)accessibilityRole
+{
+    return [self accessibilityRoleAttribute];
+}
+@end

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ToolbarAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/ToolbarAccessibility.m
@@ -30,8 +30,8 @@
  */
 @implementation ToolbarAccessibility
 
-- (NSString * _Nonnull)accessibilityRole
+- (NSAccessibilityRole _Nonnull)accessibilityRole
 {
-    return [self accessibilityRoleAttribute];
+    return NSAccessibilityToolbarRole;
 }
 @end


### PR DESCRIPTION
This backport is part of the 28 backport Accessibility series JDK-8152350. Tested by building GUI and using the Accessibility components.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)

### Issue
 * [JDK-8264305](https://bugs.openjdk.org/browse/JDK-8264305): Create implementation for native accessibility peer for Statusbar java role (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1809/head:pull/1809` \
`$ git checkout pull/1809`

Update a local copy of the PR: \
`$ git checkout pull/1809` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1809`

View PR using the GUI difftool: \
`$ git pr show -t 1809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1809.diff">https://git.openjdk.org/jdk11u-dev/pull/1809.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1809#issuecomment-1471323867)