### PR TITLE
8265486: ProblemList javax/sound/midi/Sequencer/Recording.java on macosx-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -666,7 +666,7 @@ javax/sound/sampled/Clip/Drain/ClipDrain.java          7062792 generic-all
 
 javax/sound/sampled/Mixers/DisabledAssertionCrash.java 7067310 generic-all
 
-javax/sound/midi/Sequencer/Recording.java 8167580 linux-all,solaris-all
+javax/sound/midi/Sequencer/Recording.java 8167580,8265485 linux-all,solaris-all,macosx-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
Backport done for Oracle Parity.

Simple backport of a problem list entry. I had to resolve because 11u still has Solaris.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8265486](https://bugs.openjdk.org/browse/JDK-8265486): ProblemList javax/sound/midi/Sequencer/Recording.java on macosx-aarch64


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev pull/1810/head:pull/1810` \
`$ git checkout pull/1810`

Update a local copy of the PR: \
`$ git checkout pull/1810` \
`$ git pull https://git.openjdk.org/jdk11u-dev pull/1810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1810`

View PR using the GUI difftool: \
`$ git pr show -t 1810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1810.diff">https://git.openjdk.org/jdk11u-dev/pull/1810.diff</a>

</details>
