### PR TITLE
8301170: perfMemory_windows.cpp add free_security_attr to early returns

### DIFF
--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1238,6 +1238,7 @@ static bool make_user_tmp_dir(const char* dirname) {
         if (PrintMiscellaneous && Verbose) {
           warning("%s directory is insecure\n", dirname);
         }
+        free_security_attr(pDirSA);
         return false;
       }
       // The administrator should be able to delete this directory.
@@ -1253,18 +1254,15 @@ static bool make_user_tmp_dir(const char* dirname) {
                                                         dirname, lasterror);
         }
       }
-    }
-    else {
+    } else {
       if (PrintMiscellaneous && Verbose) {
         warning("CreateDirectory failed: %d\n", GetLastError());
       }
+      free_security_attr(pDirSA);
       return false;
     }
   }
-
-  // free the security attributes structure
   free_security_attr(pDirSA);
-
   return true;
 }
 
@@ -1296,6 +1294,8 @@ static HANDLE create_sharedmem_resources(const char* dirname, const char* filena
   if (!make_user_tmp_dir(dirname)) {
     // could not make/find the directory or the found directory
     // was not secure
+    free_security_attr(lpFileSA);
+    free_security_attr(lpSmoSA);
     return NULL;
   }
 
@@ -1327,6 +1327,7 @@ static HANDLE create_sharedmem_resources(const char* dirname, const char* filena
     if (PrintMiscellaneous && Verbose) {
       warning("could not create file %s: %d\n", filename, lasterror);
     }
+    free_security_attr(lpSmoSA);
     return NULL;
   }
 


### PR DESCRIPTION
.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301170](https://bugs.openjdk.org/browse/JDK-8301170): perfMemory_windows.cpp add free_security_attr to early returns


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1813/head:pull/1813` \
`$ git checkout pull/1813`

Update a local copy of the PR: \
`$ git checkout pull/1813` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1813`

View PR using the GUI difftool: \
`$ git pr show -t 1813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1813.diff">https://git.openjdk.org/jdk11u-dev/pull/1813.diff</a>

</details>
