### PR TITLE
8305528: [11u] Backport of JDK-8259530 breaks build with JDK10 bootstrap VM

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
@@ -30,6 +30,7 @@ import java.io.OutputStream;
 import java.io.Writer;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.FileSystems;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.*;
@@ -243,14 +244,14 @@ public class HtmlDoclet extends AbstractDoclet {
         switch (legalNotices) {
             case "":
             case "default" :
-                Path javaHome = Path.of(System.getProperty("java.home"));
+                Path javaHome = FileSystems.getDefault().getPath(System.getProperty("java.home"));
                 legalNoticesDir = javaHome.resolve("legal").resolve(getClass().getModule().getName());
                 break;
             case "none":
                 return;
             default:
                 try {
-                    legalNoticesDir = Path.of(legalNotices);
+                    legalNoticesDir = FileSystems.getDefault().getPath(legalNotices);
                 } catch (InvalidPathException e) {
                     messages.error("doclet.Error_invalid_path_for_legal_notices",
                             legalNotices, e.getMessage());


### PR DESCRIPTION
Hello Christoph,

Could you review the fix please?

Thanks,
Kimura Yukihiro

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305528](https://bugs.openjdk.org/browse/JDK-8305528): [11u] Backport of JDK-8259530 breaks build with JDK10 bootstrap VM


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1823/head:pull/1823` \
`$ git checkout pull/1823`

Update a local copy of the PR: \
`$ git checkout pull/1823` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1823`

View PR using the GUI difftool: \
`$ git pr show -t 1823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1823.diff">https://git.openjdk.org/jdk11u-dev/pull/1823.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1823#issuecomment-1495883157)