### PR TITLE
8305711: Arm: C2 always enters slowpath for monitorexit

### DIFF
--- a/src/hotspot/cpu/arm/macroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/macroAssembler_arm.cpp
@@ -3085,7 +3085,7 @@ void MacroAssembler::fast_unlock(Register Roop, Register Rbox, Register Rscratch
   // Restore the object header
   bool allow_fallthrough_on_failure = true;
   bool one_shot = true;
-  cas_for_lock_release(Rmark, Rbox, Roop, Rscratch, done, allow_fallthrough_on_failure, one_shot);
+  cas_for_lock_release(Rbox, Rmark, Roop, Rscratch, done, allow_fallthrough_on_failure, one_shot);
 
   bind(done);
 


### PR DESCRIPTION
Fixes slow thin locking on Arm.

Not a clean backport since 8241436: "C2: Factor out C2-specific code from MacroAssembler" moved the unlock function from macroAssembler.cpp to c2_MacroAssembler.cpp.

Manually tested (with -UseBiasedLocking) on Arm.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305711](https://bugs.openjdk.org/browse/JDK-8305711): Arm: C2 always enters slowpath for monitorexit


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1826/head:pull/1826` \
`$ git checkout pull/1826`

Update a local copy of the PR: \
`$ git checkout pull/1826` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1826`

View PR using the GUI difftool: \
`$ git pr show -t 1826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1826.diff">https://git.openjdk.org/jdk11u-dev/pull/1826.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1826#issuecomment-1500819112)