### PR TITLE
8274864: Remove Amman/Cairo hacks in ZoneInfoFile

### DIFF
--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -607,34 +607,6 @@ public final class ZoneInfoFile {
                 params[8] = endRule.secondOfDay * 1000;
                 params[9] = toSTZTime[endRule.timeDefinition];
                 dstSavings = (startRule.offsetAfter - startRule.offsetBefore) * 1000;
-
-                // Note: known mismatching -> Asia/Amman
-                // ZoneInfo :      startDayOfWeek=5     <= Thursday
-                //                 startTime=86400000   <= 24 hours
-                // This:           startDayOfWeek=6
-                //                 startTime=0
-                // Similar workaround needs to be applied to Africa/Cairo and
-                // its endDayOfWeek and endTime
-                // Below is the workarounds, it probably slows down everyone a little
-                if (params[2] == 6 && params[3] == 0 &&
-                    (zoneId.equals("Asia/Amman"))) {
-                    params[2] = 5;
-                    params[3] = 86400000;
-                }
-                // Additional check for startDayOfWeek=6 and starTime=86400000
-                // is needed for Asia/Amman;
-                if (params[2] == 7 && params[3] == 0 &&
-                     (zoneId.equals("Asia/Amman"))) {
-                    params[2] = 6;        // Friday
-                    params[3] = 86400000; // 24h
-                }
-                //endDayOfWeek and endTime workaround
-                if (params[7] == 6 && params[8] == 0 &&
-                    (zoneId.equals("Africa/Cairo"))) {
-                    params[7] = 5;
-                    params[8] = 86400000;
-                }
-
             } else if (nTrans > 0) {  // only do this if there is something in table already
                 if (lastyear < LASTYEAR) {
                     // ZoneInfo has an ending entry for 2037
@@ -907,7 +879,6 @@ public final class ZoneInfoFile {
             this.dow = dowByte == 0 ? -1 : dowByte;
             this.secondOfDay = timeByte == 31 ? in.readInt() : timeByte * 3600;
             this.timeDefinition = (data & (3 << 12)) >>> 12;
-
             this.standardOffset = stdByte == 255 ? in.readInt() : (stdByte - 128) * 900;
             this.offsetBefore = beforeByte == 3 ? in.readInt() : standardOffset + beforeByte * 1800;
             this.offsetAfter = afterByte == 3 ? in.readInt() : standardOffset + afterByte * 1800;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ec199072](https://github.com/openjdk/jdk/commit/ec199072c5867624d66840238cc8828e16ae8da7) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Naoto Sato on 8 Oct 2021 and was reviewed by Iris Clark and Joe Wang.

It is a pre-requisite for backporting the latest tzdata update, [JDK-8305113](https://bugs.openjdk.org/browse/JDK-8305113) and has already been backported to Oracle's 11.0.20.

Backport is clean. Tests in `java/util/TimeZone`, `java/time/test`, `sun/util/calendar`, `sun/util/resources` and `sun/text/resources` show no regressions (I see `java/time/test/java/time/format/TestUTCParse.java` failing both patched and unpatched)

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274864](https://bugs.openjdk.org/browse/JDK-8274864): Remove Amman/Cairo hacks in ZoneInfoFile


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1828/head:pull/1828` \
`$ git checkout pull/1828`

Update a local copy of the PR: \
`$ git checkout pull/1828` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1828`

View PR using the GUI difftool: \
`$ git pr show -t 1828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1828.diff">https://git.openjdk.org/jdk11u-dev/pull/1828.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1828#issuecomment-1506174888)