### PR TITLE
8187522: test/sun/net/ftp/FtpURLConnectionLeak.java timed out

### DIFF
--- a/test/jdk/sun/net/ftp/FtpURLConnectionLeak.java
+++ b/test/jdk/sun/net/ftp/FtpURLConnectionLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
  * @run main/othervm FtpURLConnectionLeak
  */
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
@@ -44,27 +43,26 @@ public class FtpURLConnectionLeak {
         int port = server.getLocalPort();
         server.start();
         URL url = new URL("ftp://localhost:" + port + "/filedoesNotExist.txt");
-        for (int i = 0; i < 3; i++) {
-            try {
-                InputStream stream = url.openStream();
-            } catch (FileNotFoundException expectedFirstTimeAround) {
-                // should always reach this point since the path does not exist
-            } catch (IOException expected) {
-                System.out.println("caught expected " + expected);
-                int times = 1;
-                do {
-                    // give some time to close the connection...
-                    System.out.println("sleeping... " + times);
-                    Thread.sleep(times * 1000);
-                } while (server.activeClientsCount() > 0 && times++ < 5);
+        try (server) {
+            for (int i = 0; i < 3; i++) {
+                try {
+                    InputStream stream = url.openStream();
+                } catch (FileNotFoundException expected) {
+                    // should always reach this point since the path does not exist
+                    System.out.println("caught expected " + expected);
+                    int times = 1;
+                    do {
+                        // give some time to close the connection...
+                        System.out.println("sleeping... " + times);
+                        Thread.sleep(times * 1000);
+                    } while (server.activeClientsCount() > 0 && times++ < 5);
 
-                if (server.activeClientsCount() > 0) {
-                    server.killClients();
-                    throw new RuntimeException("URLConnection didn't close the" +
-                            " FTP connection on FileNotFoundException");
+                    if (server.activeClientsCount() > 0) {
+                        server.killClients();
+                        throw new RuntimeException("URLConnection didn't close the" +
+                                " FTP connection on FileNotFoundException");
+                    }
                 }
-            } finally {
-                server.terminate();
             }
         }
     }

--- a/test/jdk/sun/net/www/ftptest/FtpCommandHandler.java
+++ b/test/jdk/sun/net/www/ftptest/FtpCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -442,8 +442,14 @@ public class FtpCommandHandler extends Thread {
             // cmd.setSoTimeout(2000);
             in = new BufferedReader(new InputStreamReader(cmd.getInputStream()));
             out = new PrintStream(cmd.getOutputStream(), true, "ISO8859_1");
+            // Below corrupted message style was intentional to test 8151586, please
+            // make sure each message line not broken ftp communication (such as for
+            // message line lenght >=4, the 4th char required '-' to allow
+            // implementation thinks that it has seen multi-line reply '###-'
+            // sequence), otherwise it will affect normal ftp tests which depends
+            // on this.
             out.println("---------------------------------\n220 Java FTP test server"
-                    + " (j2se 6.0) ready.\n \n                Please send commands\n"
+                    + " (j2se 6.0) ready.\n \n   -            Please send commands\n"
                     + "-----------------------------\n\n\n");
             out.flush();
             if (auth.authType() == 0) // No auth needed

--- a/test/jdk/sun/net/www/ftptest/FtpServer.java
+++ b/test/jdk/sun/net/www/ftptest/FtpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ import java.util.ArrayList;
  *
  */
 
-public class FtpServer extends Thread {
+public class FtpServer extends Thread implements AutoCloseable {
     private ServerSocket listener = null;
     private FtpFileSystemHandler fsh = null;
     private FtpAuthHandler auth = null;
@@ -132,6 +132,15 @@ public class FtpServer extends Thread {
             listener.close();
         } catch (IOException e) {
 
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        terminate();
+        listener.close();
+        if (activeClientsCount() > 0) {
+            killClients();
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8187522](https://bugs.openjdk.org/browse/JDK-8187522): test/sun/net/ftp/FtpURLConnectionLeak.java timed out


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1840/head:pull/1840` \
`$ git checkout pull/1840`

Update a local copy of the PR: \
`$ git checkout pull/1840` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1840`

View PR using the GUI difftool: \
`$ git pr show -t 1840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1840.diff">https://git.openjdk.org/jdk11u-dev/pull/1840.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1840#issuecomment-1515926149)