### PR TITLE
8215015: [TESTBUG] remove unneeded -Xfuture option from tests

### DIFF
--- a/test/langtools/tools/javac/boxing/T6348760.java
+++ b/test/langtools/tools/javac/boxing/T6348760.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug     6348760
  * @summary crash: java.lang.AssertionError at com.sun.tools.javac.comp.Lower.abstractLval(Lower.java:1853)
  * @author  Peter von der Ah\u00e9
- * @run main/othervm -Xfuture T6348760
+ * @run main/othervm T6348760
  */
 
 public class T6348760<T> {

--- a/test/langtools/tools/javac/generics/inference/6240565/T6240565.java
+++ b/test/langtools/tools/javac/generics/inference/6240565/T6240565.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug     6240565
  * @summary Unboxing, arrays, and type variables doesn't work
  * @compile T6240565.java
- * @run main/othervm -Xfuture T6240565
+ * @run main/othervm T6240565
  */
 
 public class T6240565 {

--- a/test/langtools/tools/javac/scope/6225935/T6225935.java
+++ b/test/langtools/tools/javac/scope/6225935/T6225935.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary "import static" accessibility rules for symbols different for no reason
  * @author  Peter von der Ah\u00e9
  * @compile a/Private.java a/Named.java a/Star.java T6225935.java
- * @run main/othervm -Xfuture T6225935
+ * @run main/othervm T6225935
  */
 
 import static a.Named.x;


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8215015](https://bugs.openjdk.org/browse/JDK-8215015): [TESTBUG] remove unneeded -Xfuture option from tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1843/head:pull/1843` \
`$ git checkout pull/1843`

Update a local copy of the PR: \
`$ git checkout pull/1843` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1843`

View PR using the GUI difftool: \
`$ git pr show -t 1843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1843.diff">https://git.openjdk.org/jdk11u-dev/pull/1843.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1843#issuecomment-1515950200)