### PR TITLE
8306768: CodeCache Analytics reports wrong threshold

### DIFF
--- a/src/hotspot/share/code/codeHeapState.cpp
+++ b/src/hotspot/share/code/codeHeapState.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "code/codeHeapState.hpp"
+#include "code/codeBlob.hpp"
 #include "compiler/compileBroker.hpp"
 #include "runtime/safepoint.hpp"
 #include "runtime/sweeper.hpp"
@@ -1154,10 +1155,9 @@ void CodeHeapState::aggregate(outputStream* out, CodeHeap* heap, size_t granular
       ast->cr();
 
       int             reset_val = NMethodSweeper::hotness_counter_reset_val();
-      double reverse_free_ratio = (res_size > size) ? (double)res_size/(double)(res_size-size) : (double)res_size;
       printBox(ast, '-', "Method hotness information at time of this analysis", NULL);
       ast->print_cr("Highest possible method temperature:          %12d", reset_val);
-      ast->print_cr("Threshold for method to be considered 'cold': %12.3f", -reset_val + reverse_free_ratio * NmethodSweepActivity);
+      ast->print_cr("Threshold for method to be considered 'cold': %12.3f", -reset_val + (CodeCache::reverse_free_ratio(heap->code_blob_type()) * NmethodSweepActivity));
       if (n_methods > 0) {
         avgTemp = hotnessAccumulator/n_methods;
         ast->print_cr("min. hotness = %6d", minTemp);


### PR DESCRIPTION
Jcmd CodeCache_Analytics uses own implementation of threshold calculation, allowing an error to creep in, making report invalid. The suggestion is to use the existing method for free ratio calculation. After the fix, the reported values become sane.

```
java -XX:InitialCodeCacheSize=1G -XX:ReservedCodeCacheSize=1G ...

cmd jdk.compiler/com.sun.tools.javac.launcher.Main  Compiler.CodeHeap_Analytics | grep -A 2 "Threshold for method to be considered 'cold'"
Threshold for method to be considered 'cold':    -2037.994
min. hotness =   1016
avg. hotness =   2048
--
Threshold for method to be considered 'cold':    -2037.961
min. hotness =   1016
avg. hotness =   2048
--
Threshold for method to be considered 'cold':    -2031.906
No hotness data available
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306768](https://bugs.openjdk.org/browse/JDK-8306768): CodeCache Analytics reports wrong threshold


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1849/head:pull/1849` \
`$ git checkout pull/1849`

Update a local copy of the PR: \
`$ git checkout pull/1849` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1849`

View PR using the GUI difftool: \
`$ git pr show -t 1849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1849.diff">https://git.openjdk.org/jdk11u-dev/pull/1849.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1849#issuecomment-1520559873)