### PR TITLE
8306658: GHA: MSVC installation could be optional since it might already be pre-installed

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -88,12 +88,26 @@ jobs:
         id: jtreg
         uses: ./.github/actions/get-jtreg
 
+      - name: 'Check toolchain installed'
+        id: toolchain-check
+        run: |
+          set +e
+          '/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/vc/auxiliary/build/vcvars64.bat' -vcvars_ver=${{ inputs.msvc-toolset-version }}
+          if [ $? -eq 0 ]; then
+            echo "Toolchain is already installed"
+            echo "toolchain-installed=true" >> $GITHUB_OUTPUT
+          else
+            echo "Toolchain is not yet installed"
+            echo "toolchain-installed=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: 'Install toolchain and dependencies'
         run: |
           # Run Visual Studio Installer
           '/c/Program Files (x86)/Microsoft Visual Studio/Installer/vs_installer.exe' \
             modify --quiet --installPath 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise' \
             --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.${{ inputs.msvc-toolset-architecture }}
+        if: steps.toolchain-check.outputs.toolchain-installed != 'true'
 
       - name: 'Configure'
         run: >


### PR DESCRIPTION
This is a backport of JDK-8306658. I had to resolve because in jdk11u-dev there is no GTest download.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306658](https://bugs.openjdk.org/browse/JDK-8306658): GHA: MSVC installation could be optional since it might already be pre-installed


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1850/head:pull/1850` \
`$ git checkout pull/1850`

Update a local copy of the PR: \
`$ git checkout pull/1850` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1850`

View PR using the GUI difftool: \
`$ git pr show -t 1850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1850.diff">https://git.openjdk.org/jdk11u-dev/pull/1850.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1850#issuecomment-1520739572)