### PR TITLE
8283059: Uninitialized warning in check_code.c with GCC 11.2

### DIFF
--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -471,7 +471,8 @@ static void CCout_of_memory (context_type *);
 /* Because we can longjmp any time, we need to be very careful about
  * remembering what needs to be freed. */
 
-static void check_and_push(context_type *context, const void *ptr, int kind);
+static void check_and_push_malloc_block(context_type *context, void *ptr);
+static void check_and_push_string_utf(context_type *context, const char *ptr);
 static void pop_and_free(context_type *context);
 
 static int signature_to_args_size(const char *method_signature);
@@ -607,7 +608,7 @@ class_to_ID(context_type *context, jclass cb, jboolean loadable)
     unsigned short *pID;
     const char *name = JVM_GetClassNameUTF(env, cb);
 
-    check_and_push(context, name, VM_STRING_UTF);
+    check_and_push_string_utf(context, name);
     hash = class_hash_fun(name);
     pID = &(class_hash->table[hash % HASH_TABLE_SIZE]);
     while (*pID) {
@@ -954,10 +955,10 @@ read_all_code(context_type* context, jclass cb, int num_methods,
     int i;
 
     lengths = malloc(sizeof(int) * num_methods);
-    check_and_push(context, lengths, VM_MALLOC_BLK);
+    check_and_push_malloc_block(context, lengths);
 
     code = malloc(sizeof(unsigned char*) * num_methods);
-    check_and_push(context, code, VM_MALLOC_BLK);
+    check_and_push_malloc_block(context, code);
 
     *(lengths_addr) = lengths;
     *(code_addr) = code;
@@ -966,7 +967,7 @@ read_all_code(context_type* context, jclass cb, int num_methods,
         lengths[i] = JVM_GetMethodIxByteCodeLength(context->env, cb, i);
         if (lengths[i] > 0) {
             code[i] = malloc(sizeof(unsigned char) * (lengths[i] + 1));
-            check_and_push(context, code[i], VM_MALLOC_BLK);
+            check_and_push_malloc_block(context, code[i]);
             JVM_GetMethodIxByteCode(context->env, cb, i, code[i]);
         } else {
             code[i] = NULL;
@@ -1320,7 +1321,7 @@ verify_opcode_operands(context_type *context, unsigned int inumber, int offset)
         /* Make sure the constant pool item is the right type. */
         verify_constant_pool_type(context, key, kind);
         methodname = JVM_GetCPMethodNameUTF(env, cb, key);
-        check_and_push(context, methodname, VM_STRING_UTF);
+        check_and_push_string_utf(context, methodname);
         is_constructor = !strcmp(methodname, "<init>");
         is_internal = methodname[0] == '<';
         pop_and_free(context);
@@ -1369,7 +1370,7 @@ verify_opcode_operands(context_type *context, unsigned int inumber, int offset)
             unsigned int args2;
             const char *signature =
                 JVM_GetCPMethodSignatureUTF(env, context->class, key);
-            check_and_push(context, signature, VM_STRING_UTF);
+            check_and_push_string_utf(context, signature);
             args1 = signature_to_args_size(signature) + 1;
             args2 = code[offset + 3];
             if (args1 != args2) {
@@ -1667,7 +1668,7 @@ initialize_exception_table(context_type *context)
             classname = JVM_GetCPClassNameUTF(env,
                                               context->class,
                                               einfo.catchType);
-            check_and_push(context, classname, VM_STRING_UTF);
+            check_and_push_string_utf(context, classname);
             stack_item->item = make_class_info_from_name(context, classname);
             if (!isAssignableTo(context,
                                 stack_item->item,
@@ -1817,7 +1818,7 @@ initialize_dataflow(context_type *context)
         }
     }
     signature = JVM_GetMethodIxSignatureUTF(env, cb, mi);
-    check_and_push(context, signature, VM_STRING_UTF);
+    check_and_push_string_utf(context, signature);
     /* Fill in each of the arguments into the registers. */
     for (p = signature + 1; *p != JVM_SIGNATURE_ENDFUNC; ) {
         char fieldchar = signature_to_fieldtype(context, &p, &full_info);
@@ -2060,7 +2061,7 @@ pop_stack(context_type *context, unsigned int inumber, stack_info_type *new_stac
                                            context->class,
                                            operand);
             char *ip = buffer;
-            check_and_push(context, signature, VM_STRING_UTF);
+            check_and_push_string_utf(context, signature);
 #ifdef DEBUG
             if (verify_verbose) {
                 print_formatted_fieldname(context, operand);
@@ -2086,7 +2087,7 @@ pop_stack(context_type *context, unsigned int inumber, stack_info_type *new_stac
                                             operand);
             char *ip = buffer;
             const char *p;
-            check_and_push(context, signature, VM_STRING_UTF);
+            check_and_push_string_utf(context, signature);
 #ifdef DEBUG
             if (verify_verbose) {
                 print_formatted_methodname(context, operand);
@@ -2386,7 +2387,7 @@ pop_stack(context_type *context, unsigned int inumber, stack_info_type *new_stac
                                             operand);
             int item;
             const char *p;
-            check_and_push(context, signature, VM_STRING_UTF);
+            check_and_push_string_utf(context, signature);
             if (opcode == JVM_OPC_invokestatic) {
                 item = 0;
             } else if (opcode == JVM_OPC_invokeinit) {
@@ -2768,7 +2769,7 @@ push_stack(context_type *context, unsigned int inumber, stack_info_type *new_sta
             const char *signature = JVM_GetCPFieldSignatureUTF(context->env,
                                                                context->class,
                                                                operand);
-            check_and_push(context, signature, VM_STRING_UTF);
+            check_and_push_string_utf(context, signature);
 #ifdef DEBUG
             if (verify_verbose) {
                 print_formatted_fieldname(context, operand);
@@ -2790,7 +2791,7 @@ push_stack(context_type *context, unsigned int inumber, stack_info_type *new_sta
                                                                 context->class,
                                                                 operand);
             const char *result_signature;
-            check_and_push(context, signature, VM_STRING_UTF);
+            check_and_push_string_utf(context, signature);
             result_signature = get_result_signature(signature);
             if (result_signature++ == NULL) {
                 CCerror(context, "Illegal signature %s", signature);
@@ -3630,7 +3631,7 @@ cp_index_to_class_fullinfo(context_type *context, int cp_index, int kind)
         CCerror(context, "Internal error #5");
     }
 
-    check_and_push(context, classname, VM_STRING_UTF);
+    check_and_push_string_utf(context, classname);
     if (classname[0] == JVM_SIGNATURE_ARRAY) {
         /* This make recursively call us, in case of a class array */
         signature_to_fieldtype(context, &classname, &result);
@@ -3828,10 +3829,11 @@ signature_to_fieldtype(context_type *context,
                     result = 0;
                     break;
                 }
-                length = finish - p;
+                assert(finish >= p);
+                length = (int)(finish - p);
                 if (length + 1 > (int)sizeof(buffer_space)) {
-                    buffer = calloc(length + 1, sizeof(char));
-                    check_and_push(context, buffer, VM_MALLOC_BLK);
+                    buffer = malloc(length + 1);
+                    check_and_push_malloc_block(context, buffer);
                 }
                 memcpy(buffer, p, length);
                 buffer[length] = '\0';
@@ -4150,7 +4152,7 @@ static void free_block(void *ptr, int kind)
     }
 }
 
-static void check_and_push(context_type *context, const void *ptr, int kind)
+static void check_and_push_common(context_type *context, void *ptr, int kind)
 {
     alloc_stack_type *p;
     if (ptr == 0)
@@ -4162,14 +4164,22 @@ static void check_and_push(context_type *context, const void *ptr, int kind)
         p = malloc(sizeof(alloc_stack_type));
         if (p == 0) {
             /* Make sure we clean up. */
-            free_block((void *)ptr, kind);
+            free_block(ptr, kind);
             CCout_of_memory(context);
         }
     }
     p->kind = kind;
-    p->ptr = (void *)ptr;
+    p->ptr = ptr;
     p->next = context->allocated_memory;
     context->allocated_memory = p;
+}
+
+static void check_and_push_malloc_block(context_type *context, void *ptr) {
+  check_and_push_common(context, ptr, VM_MALLOC_BLK);
+}
+
+static void check_and_push_string_utf(context_type *context, const char *ptr) {
+  check_and_push_common(context, (void *)ptr, VM_STRING_UTF);
 }
 
 static void pop_and_free(context_type *context)


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

The patch did not apply cleanly. There was a conflict with a prior warning-elimination fix (JDK-8266168). Though it first appears as if this PR would revert the previous fix, it is a more elaborate solution.

SAP-internal test suite passes on multiple (actually on all tested) platforms.

Reviews are very much appreciated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283059](https://bugs.openjdk.org/browse/JDK-8283059): Uninitialized warning in check_code.c with GCC 11.2


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1855/head:pull/1855` \
`$ git checkout pull/1855`

Update a local copy of the PR: \
`$ git checkout pull/1855` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1855`

View PR using the GUI difftool: \
`$ git pr show -t 1855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1855.diff">https://git.openjdk.org/jdk11u-dev/pull/1855.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1855#issuecomment-1528077945)