### PR TITLE
8286398: Address possibly lossy conversions in jdk.internal.le

### DIFF
--- a/src/jdk.internal.le/windows/classes/jdk/internal/org/jline/terminal/impl/jna/win/WindowsAnsiWriter.java
+++ b/src/jdk.internal.le/windows/classes/jdk/internal/org/jline/terminal/impl/jna/win/WindowsAnsiWriter.java
@@ -183,26 +183,26 @@ public final class WindowsAnsiWriter extends AnsiWriter {
     protected void processCursorUpLine(int count) throws IOException {
         getConsoleInfo();
         info.dwCursorPosition.X = 0;
-        info.dwCursorPosition.Y -= count;
+        info.dwCursorPosition.Y -= (short)count;
         applyCursorPosition();
     }
 
     protected void processCursorDownLine(int count) throws IOException {
         getConsoleInfo();
         info.dwCursorPosition.X = 0;
-        info.dwCursorPosition.Y += count;
+        info.dwCursorPosition.Y += (short)count;
         applyCursorPosition();
     }
 
     protected void processCursorLeft(int count) throws IOException {
         getConsoleInfo();
-        info.dwCursorPosition.X -= count;
+        info.dwCursorPosition.X -= (short)count;
         applyCursorPosition();
     }
 
     protected void processCursorRight(int count) throws IOException {
         getConsoleInfo();
-        info.dwCursorPosition.X += count;
+        info.dwCursorPosition.X += (short)count;
         applyCursorPosition();
     }
 
@@ -210,7 +210,7 @@ public final class WindowsAnsiWriter extends AnsiWriter {
         getConsoleInfo();
         int nb = Math.max(0, info.dwCursorPosition.Y + count - info.dwSize.Y + 1);
         if (nb != count) {
-            info.dwCursorPosition.Y += count;
+            info.dwCursorPosition.Y += (short)count;
             applyCursorPosition();
         }
         if (nb > 0) {
@@ -226,7 +226,7 @@ public final class WindowsAnsiWriter extends AnsiWriter {
 
     protected void processCursorUp(int count) throws IOException {
         getConsoleInfo();
-        info.dwCursorPosition.Y -= count;
+        info.dwCursorPosition.Y -= (short)count;
         applyCursorPosition();
     }
 


### PR DESCRIPTION
I backport this as prerequisite of 8297587: Upgrade JLine to 3.22.0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286398](https://bugs.openjdk.org/browse/JDK-8286398): Address possibly lossy conversions in jdk.internal.le


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1857/head:pull/1857` \
`$ git checkout pull/1857`

Update a local copy of the PR: \
`$ git checkout pull/1857` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1857`

View PR using the GUI difftool: \
`$ git pr show -t 1857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1857.diff">https://git.openjdk.org/jdk11u-dev/pull/1857.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1857#issuecomment-1536261931)