### PR TITLE
8297450: ScaledTextFieldBorderTest.java fails when run with -show parameter

### DIFF
--- a/test/jdk/javax/swing/border/LineBorder/ScaledTextFieldBorderTest.java
+++ b/test/jdk/javax/swing/border/LineBorder/ScaledTextFieldBorderTest.java
@@ -246,6 +246,8 @@ public class ScaledTextFieldBorderTest {
             childPanel.add(Box.createHorizontalStrut(4));
 
             contentPanel.add(childPanel);
+            contentPanel.add(Box.createVerticalStrut(4));
+
             if (textFieldSize == null) {
                 textFieldSize = textField.getPreferredSize();
                 borderColor = tfBorder.getLineColor().getRGB();
@@ -254,17 +256,13 @@ public class ScaledTextFieldBorderTest {
             textField.setBounds(i, 0, textFieldSize.width, textFieldSize.height);
             childPanel.setBounds(0, (textFieldSize.height + 4) * i,
                     textFieldSize.width + i + 4, textFieldSize.height);
+            panelLocations.add(childPanel.getLocation());
         }
 
         contentPanel.setSize(textFieldSize.width + 4,
                 (textFieldSize.height + 4) * 4);
 
         panelColor = contentPanel.getBackground().getRGB();
-
-        // Save coordinates of the panels
-        for (Component comp : contentPanel.getComponents()) {
-            panelLocations.add(comp.getLocation());
-        }
 
         return contentPanel;
     }


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297450](https://bugs.openjdk.org/browse/JDK-8297450): ScaledTextFieldBorderTest.java fails when run with -show parameter


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1859/head:pull/1859` \
`$ git checkout pull/1859`

Update a local copy of the PR: \
`$ git checkout pull/1859` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1859`

View PR using the GUI difftool: \
`$ git pr show -t 1859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1859.diff">https://git.openjdk.org/jdk11u-dev/pull/1859.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1859#issuecomment-1536300824)