### PR TITLE
8209880: tzdb.dat is not reproducibly built

### DIFF
--- a/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesCompiler.java
+++ b/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesCompiler.java
+++ b/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,8 +65,6 @@ import java.nio.file.Paths;
 import java.text.ParsePosition;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -76,6 +74,7 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * A compiler that reads a set of TZDB time-zone files and builds a single
@@ -256,8 +255,10 @@ public final class TzdbZoneRulesCompiler {
             for (String regionId : regionArray) {
                 out.writeUTF(regionId);
             }
-            // rules  -- hashset -> remove the dup
-            List<ZoneRules> rulesList = new ArrayList<>(new HashSet<>(builtZones.values()));
+            // rules  -- remove the dup
+            List<ZoneRules> rulesList = builtZones.values().stream()
+                .distinct()
+                .collect(Collectors.toList());
             out.writeShort(rulesList.size());
             ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
             for (ZoneRules rules : rulesList) {

--- a/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesProvider.java
+++ b/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesProvider.java
+++ b/make/jdk/src/classes/build/tools/tzdb/TzdbZoneRulesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.time.*;
 import java.time.Year;
 import java.time.chrono.IsoChronology;
@@ -119,18 +119,18 @@ class TzdbZoneRulesProvider {
     /**
      * Zone region to rules mapping
      */
-    private final Map<String, Object> zones = new ConcurrentHashMap<>();
+    private final Map<String, Object> zones = new ConcurrentSkipListMap<>();
 
     /**
      * compatibility list
      */
-    private static HashSet<String> excludedZones;
+    private static Set<String> excludedZones;
     static {
         // (1) exclude EST, HST and MST. They are supported
         //     via the short-id mapping
         // (2) remove UTC and GMT
         // (3) remove ROC, which is not supported in j.u.tz
-        excludedZones = new HashSet<>(10);
+        excludedZones = new TreeSet<>();
         excludedZones.add("EST");
         excludedZones.add("HST");
         excludedZones.add("MST");
@@ -139,8 +139,8 @@ class TzdbZoneRulesProvider {
         excludedZones.add("ROC");
     }
 
-    private Map<String, String> links = new HashMap<>(150);
-    private Map<String, List<RuleLine>> rules = new HashMap<>(500);
+    private Map<String, String> links = new TreeMap<>();
+    private Map<String, List<RuleLine>> rules = new TreeMap<>();
 
     private void load(List<Path> files) throws IOException {
 


### PR DESCRIPTION
I back port this for parity with Oracle JDK 11.0.20.

Backport didn't integrate cleanly. There were copyright statement issues as well as incompatible import statement sequences.

Reviews are very welcome.

SAP-internal tests don't show any issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8209880](https://bugs.openjdk.org/browse/JDK-8209880): tzdb.dat is not reproducibly built


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1861/head:pull/1861` \
`$ git checkout pull/1861`

Update a local copy of the PR: \
`$ git checkout pull/1861` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1861`

View PR using the GUI difftool: \
`$ git pr show -t 1861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1861.diff">https://git.openjdk.org/jdk11u-dev/pull/1861.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1861#issuecomment-1536436195)