### PR TITLE
8300751: [17u] Remove duplicate entry in javac.properties

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -121,8 +121,6 @@ javac.opt.arg.profile=\
     <profile>
 javac.opt.arg.release=\
     <release>
-javac.opt.arg.release=\
-    <release>
 javac.opt.arg.number=\
     <number>
 javac.opt.plugin=\


### PR DESCRIPTION
OpenJDK PR : https://github.com/openjdk/jdk17u-dev/pull/1096
OpenJDK bug : https://bugs.openjdk.org/browse/JDK-8300751

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300751](https://bugs.openjdk.org/browse/JDK-8300751): [17u] Remove duplicate entry in javac.properties (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1865/head:pull/1865` \
`$ git checkout pull/1865`

Update a local copy of the PR: \
`$ git checkout pull/1865` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1865`

View PR using the GUI difftool: \
`$ git pr show -t 1865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1865.diff">https://git.openjdk.org/jdk11u-dev/pull/1865.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1865#issuecomment-1551460133)