### PR TITLE
8292206: TestCgroupMetrics.java fails as getMemoryUsage() is lower than expected

### DIFF
--- a/test/jdk/jdk/internal/platform/cgroup/TestCgroupMetrics.java
+++ b/test/jdk/jdk/internal/platform/cgroup/TestCgroupMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,16 +36,7 @@ import jdk.internal.platform.Metrics;
 public class TestCgroupMetrics {
 
     public static void main(String[] args) throws Exception {
-        // If cgroups is not configured, report success.
-        Metrics metrics = Metrics.systemMetrics();
-        if (metrics == null) {
-            System.out.println("TEST PASSED!!!");
-            return;
-        }
-
-        MetricsTester metricsTester = new MetricsTester();
-        metricsTester.testAll(metrics);
-        System.out.println("TEST PASSED!!!");
+        MetricsTester.main(args);
     }
 
 }

--- a/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,7 @@ public class TestSystemMetrics {
             opts.addDockerOpts("--memory=256m");
             opts.addJavaOpts("-cp", "/test-classes/");
             opts.addJavaOpts("--add-exports", "java.base/jdk.internal.platform=ALL-UNNAMED");
+            opts.addClassOptions("-incontainer");
             DockerTestUtils.dockerRunJava(opts).shouldHaveExitValue(0).shouldContain("TEST PASSED!!!");
         } finally {
             DockerTestUtils.removeDockerImage(imageName);


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292206](https://bugs.openjdk.org/browse/JDK-8292206): TestCgroupMetrics.java fails as getMemoryUsage() is lower than expected


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1868/head:pull/1868` \
`$ git checkout pull/1868`

Update a local copy of the PR: \
`$ git checkout pull/1868` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1868`

View PR using the GUI difftool: \
`$ git pr show -t 1868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1868.diff">https://git.openjdk.org/jdk11u-dev/pull/1868.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1868#issuecomment-1538461567)