### PR TITLE
8248701: On Windows generated modules-deps.gmk can contain backslash-r (CR) characters

### DIFF
--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -337,6 +337,7 @@ $(MODULE_DEPS_MAKEFILE): $(MODULE_INFOS) \
 	                          sub(/\/\*.*\*\//, ""); \
 	                          gsub(/^ +\*.*/, ""); \
 	                          gsub(/ /, ""); \
+                                  gsub(/\r/, ""); \
 	                          printf(" %s", $$0) } \
 	          END           { printf("\n") }' $m && \
 	      $(PRINTF) "TRANSITIVE_MODULES_$(call GetModuleNameFromModuleInfo, $m) :=" && \
@@ -350,6 +351,7 @@ $(MODULE_DEPS_MAKEFILE): $(MODULE_INFOS) \
 	                          sub(/\/\*.*\*\//, ""); \
 	                          gsub(/^ +\*.*/, ""); \
 	                          gsub(/ /, ""); \
+                                  gsub(/\r/, ""); \
 	                          printf(" %s", $$0) } \
 	          END           { printf("\n") }' $m \
 	    ) >> $@ $(NEWLINE))


### PR DESCRIPTION
I would like to backport this change for parity with Oracle JDK 11.0.20.
Fix applies cleanly. Tests (SAP and GHA) are pending.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8248701](https://bugs.openjdk.org/browse/JDK-8248701): On Windows generated modules-deps.gmk can contain backslash-r (CR) characters


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1872/head:pull/1872` \
`$ git checkout pull/1872`

Update a local copy of the PR: \
`$ git checkout pull/1872` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1872`

View PR using the GUI difftool: \
`$ git pr show -t 1872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1872.diff">https://git.openjdk.org/jdk11u-dev/pull/1872.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1872#issuecomment-1538641186)