### PR TITLE
8307811: [TEST] compilation of TimeoutInErrorHandlingTest fails after backport of JDK-8303861

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TimeoutInErrorHandlingTest.java
@@ -57,6 +57,8 @@ import jdk.test.lib.process.ProcessTools;
 
 public class TimeoutInErrorHandlingTest {
 
+    // 16 seconds for hs_err generation timeout = 4 seconds per step timeout
+    public static final int ERROR_LOG_TIMEOUT = 16;
 
     public static void main(String[] args) throws Exception {
 


### PR DESCRIPTION
Hi!

This one fixes compilation of 

runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java

broken by backport of JDK-8303861. The problem is about backported delta refers to ERROR_LOG_TIMEOUT member that was introduced by different changeset and so was not backported and it stayed covered because the test is selected only for debug VM build

Verification/regression (amd64/20.04LTS): 
```
alex@alex-VirtualBox:~/jdk11u-dev$ /opt/jtreg/bin/jtreg -v -jdk:./build/linux-x86_64-normal-server-fastdebug/images/jdk test/hotspot/jtreg/runtime/ErrorHandling
runner starting test: runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java
runner finished test: runtime/ErrorHandling/BadNativeStackInErrorHandlingTest.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/CreateCoredumpOnCrash.java
runner finished test: runtime/ErrorHandling/CreateCoredumpOnCrash.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/ErrorFileRedirectTest.java
runner finished test: runtime/ErrorHandling/ErrorFileRedirectTest.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/ErrorHandler.java
runner finished test: runtime/ErrorHandling/ErrorHandler.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
runner finished test: runtime/ErrorHandling/NestedThreadsListHandleInErrorHandlingTest.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/ProblematicFrameTest.java
runner finished test: runtime/ErrorHandling/ProblematicFrameTest.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/SafeFetchInErrorHandlingTest.java
runner finished test: runtime/ErrorHandling/SafeFetchInErrorHandlingTest.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/SecondaryErrorTest.java
runner finished test: runtime/ErrorHandling/SecondaryErrorTest.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/ShowRegistersOnAssertTest.java
runner finished test: runtime/ErrorHandling/ShowRegistersOnAssertTest.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
runner finished test: runtime/ErrorHandling/TestCrashOnOutOfMemoryError.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/TestExitOnOutOfMemoryError.java
runner finished test: runtime/ErrorHandling/TestExitOnOutOfMemoryError.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
runner finished test: runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryError.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryErrorInMetaspace.java
runner finished test: runtime/ErrorHandling/TestHeapDumpOnOutOfMemoryErrorInMetaspace.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/TestHeapDumpPath.java
runner finished test: runtime/ErrorHandling/TestHeapDumpPath.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/TestOnError.java
runner finished test: runtime/ErrorHandling/TestOnError.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/TestOnOutOfMemoryError.java
runner finished test: runtime/ErrorHandling/TestOnOutOfMemoryError.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
runner finished test: runtime/ErrorHandling/ThreadsListHandleInErrorHandlingTest.java
Passed. Execution successful
runner starting test: runtime/ErrorHandling/TimeoutInErrorHandlingTest.java#default
runner finished test: runtime/ErrorHandling/TimeoutInErrorHandlingTest.java#default
Passed. Execution successful
runner starting test: runtime/ErrorHandling/TimeoutInErrorHandlingTest.java#with-on-error
runner finished test: runtime/ErrorHandling/TimeoutInErrorHandlingTest.java#with-on-error
Passed. Execution successful
runner starting test: runtime/ErrorHandling/VeryEarlyAssertTest.java
runner finished test: runtime/ErrorHandling/VeryEarlyAssertTest.java
Passed. Execution successful
Test results: passed: 20
Report written to /home/alex/jdk11u-dev/JTreport/html/report.html
Results written to /home/alex/jdk11u-dev/JTwork
alex@alex-VirtualBox:~/jdk11u-dev$
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307811](https://bugs.openjdk.org/browse/JDK-8307811): [TEST] compilation of TimeoutInErrorHandlingTest fails after backport of JDK-8303861


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1882/head:pull/1882` \
`$ git checkout pull/1882`

Update a local copy of the PR: \
`$ git checkout pull/1882` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1882`

View PR using the GUI difftool: \
`$ git pr show -t 1882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1882.diff">https://git.openjdk.org/jdk11u-dev/pull/1882.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1882#issuecomment-1542063192)