### PR TITLE
8308006: Missing NMT memory tagging in CMS

### DIFF
--- a/src/hotspot/share/gc/cms/concurrentMarkSweepGeneration.cpp
+++ b/src/hotspot/share/gc/cms/concurrentMarkSweepGeneration.cpp
@@ -80,6 +80,7 @@
 #include "runtime/timer.hpp"
 #include "runtime/vmThread.hpp"
 #include "services/memoryService.hpp"
+#include "services/memTracker.hpp"
 #include "services/runtimeService.hpp"
 #include "utilities/align.hpp"
 #include "utilities/stack.inline.hpp"
@@ -5655,6 +5656,9 @@ bool CMSBitMap::allocate(MemRegion mr) {
     log_warning(gc)("CMS bit map backing store failure");
     return false;
   }
+
+  // Record NMT memory type 
+  MemTracker::record_virtual_memory_type(brs.base(), mtGC);
   assert(_virtual_space.committed_size() == brs.size(),
          "didn't reserve backing store for all of CMS bit map?");
   assert(_virtual_space.committed_size() << (_shifter + LogBitsPerByte) >=
@@ -5743,6 +5747,9 @@ bool CMSMarkStack::allocate(size_t size) {
     log_warning(gc)("CMSMarkStack backing store failure");
     return false;
   }
+
+  // Record NMT memory type
+  MemTracker::record_virtual_memory_type(rs.base(), mtGC);
   assert(_virtual_space.committed_size() == rs.size(),
          "didn't reserve backing store for all of CMS stack?");
   _base = (oop*)(_virtual_space.low());

--- a/src/hotspot/share/gc/cms/concurrentMarkSweepGeneration.cpp
+++ b/src/hotspot/share/gc/cms/concurrentMarkSweepGeneration.cpp
@@ -5657,7 +5657,7 @@ bool CMSBitMap::allocate(MemRegion mr) {
     return false;
   }
 
-  // Record NMT memory type 
+  // Record NMT memory type
   MemTracker::record_virtual_memory_type(brs.base(), mtGC);
   assert(_virtual_space.committed_size() == brs.size(),
          "didn't reserve backing store for all of CMS bit map?");


### PR DESCRIPTION
Please review this trivial fix that records CMS mark bitmap and mark stack to NMT.

Test:
- [x] hotspot_nmt

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308006](https://bugs.openjdk.org/browse/JDK-8308006): Missing NMT memory tagging in CMS


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1885/head:pull/1885` \
`$ git checkout pull/1885`

Update a local copy of the PR: \
`$ git checkout pull/1885` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1885`

View PR using the GUI difftool: \
`$ git pr show -t 1885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1885.diff">https://git.openjdk.org/jdk11u-dev/pull/1885.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1885#issuecomment-1545918434)