### PR TITLE
8304350: Font.getStringBounds calculates wrong width for TextAttribute.TRACKING other than 0.0

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Font.java
+++ b/src/java.desktop/share/classes/java/awt/Font.java
@@ -2601,8 +2601,10 @@ public class Font implements java.io.Serializable
         // quick check for simple text, assume GV ok to use if simple
 
         boolean simple = values == null ||
-            (values.getKerning() == 0 && values.getLigatures() == 0 &&
-              values.getBaselineTransform() == null);
+            (values.getKerning() == 0
+             && values.getLigatures() == 0
+             && values.getTracking() == 0
+             && values.getBaselineTransform() == null);
         if (simple) {
             simple = ! FontUtilities.isComplexText(chars, beginIndex, limit);
         }


### PR DESCRIPTION
This is a clean backport of 8304350 for jdk11u-dev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304350](https://bugs.openjdk.org/browse/JDK-8304350): Font.getStringBounds calculates wrong width for TextAttribute.TRACKING other than 0.0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1889/head:pull/1889` \
`$ git checkout pull/1889`

Update a local copy of the PR: \
`$ git checkout pull/1889` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1889/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1889`

View PR using the GUI difftool: \
`$ git pr show -t 1889`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1889.diff">https://git.openjdk.org/jdk11u-dev/pull/1889.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1889#issuecomment-1553590854)