### PR TITLE
8275735: [linux] Remove deprecated Metrics api (kernel memory limit)

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupV1Metrics.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupV1Metrics.java
@@ -54,16 +54,6 @@ public interface CgroupV1Metrics extends Metrics {
     public long getKernelMemoryFailCount();
 
     /**
-     * Returns the maximum amount of kernel physical memory, in bytes, that
-     * can be allocated in the Isolation Group.
-     *
-     * @return The maximum amount of memory in bytes or -1 if
-     *         there is no limit set.
-     *
-     */
-    public long getKernelMemoryLimit();
-
-    /**
      * Returns the largest amount of kernel physical memory, in bytes, that
      * have been allocated in the Isolation Group.
      *
@@ -92,16 +82,6 @@ public interface CgroupV1Metrics extends Metrics {
      *
      */
     public long getTcpMemoryFailCount();
-
-    /**
-     * Returns the maximum amount of networking physical memory, in bytes,
-     * that can be allocated in the Isolation Group.
-     *
-     * @return The maximum amount of memory in bytes or -1 if
-     *         there is no limit.
-     *
-     */
-    public long getTcpMemoryLimit();
 
     /**
      * Returns the largest amount of networking physical memory, in bytes,

--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupV1MetricsImpl.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupV1MetricsImpl.java
@@ -49,11 +49,6 @@ public class CgroupV1MetricsImpl extends CgroupMetrics implements CgroupV1Metric
     }
 
     @Override
-    public long getKernelMemoryLimit() {
-        return metrics.getKernelMemoryLimit();
-    }
-
-    @Override
     public long getKernelMemoryMaxUsage() {
         return metrics.getKernelMemoryMaxUsage();
     }
@@ -66,11 +61,6 @@ public class CgroupV1MetricsImpl extends CgroupMetrics implements CgroupV1Metric
     @Override
     public long getTcpMemoryFailCount() {
         return metrics.getTcpMemoryFailCount();
-    }
-
-    @Override
-    public long getTcpMemoryLimit() {
-        return metrics.getTcpMemoryLimit();
     }
 
     @Override

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
@@ -333,10 +333,6 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
         return getLongValue(memory, "memory.kmem.failcnt");
     }
 
-    public long getKernelMemoryLimit() {
-        return CgroupV1SubsystemController.longValOrUnlimited(getLongValue(memory, "memory.kmem.limit_in_bytes"));
-    }
-
     public long getKernelMemoryMaxUsage() {
         return getLongValue(memory, "memory.kmem.max_usage_in_bytes");
     }
@@ -347,10 +343,6 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
 
     public long getTcpMemoryFailCount() {
         return getLongValue(memory, "memory.kmem.tcp.failcnt");
-    }
-
-    public long getTcpMemoryLimit() {
-        return CgroupV1SubsystemController.longValOrUnlimited(getLongValue(memory, "memory.kmem.tcp.limit_in_bytes"));
     }
 
     public long getTcpMemoryMaxUsage() {

--- a/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
+++ b/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
@@ -39,9 +39,6 @@ public class MetricsMemoryTester {
             case "memoryswap":
                 testMemoryAndSwapLimit(args[1], args[2]);
                 break;
-            case "kernelmem":
-                testKernelMemoryLimit(args[1]);
-                break;
             case "oomkill":
                 testOomKillFlag(Boolean.parseBoolean(args[2]));
                 break;
@@ -117,23 +114,6 @@ public class MetricsMemoryTester {
                     + memorySoftLimit + "]");
         }
         System.out.println("TEST PASSED!!!");
-    }
-
-    private static void testKernelMemoryLimit(String value) {
-        Metrics m = Metrics.systemMetrics();
-        if (m instanceof CgroupV1Metrics) {
-            CgroupV1Metrics mCgroupV1 = (CgroupV1Metrics)m;
-            System.out.println("TEST PASSED!!!");
-            long limit = getMemoryValue(value);
-            long kmemlimit = mCgroupV1.getKernelMemoryLimit();
-            if (kmemlimit != UNLIMITED && limit != kmemlimit) {
-                throw new RuntimeException("Kernel Memory limit not equal, expected : ["
-                        + limit + "]" + ", got : ["
-                        + kmemlimit + "]");
-            }
-        } else {
-            throw new RuntimeException("kernel memory limit test not supported for cgroups v2");
-        }
     }
 
     private static void testMemoryAndSwapLimit(String memory, String memAndSwap) {

--- a/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
+++ b/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
@@ -126,13 +126,10 @@ public class MetricsMemoryTester {
             System.out.println("TEST PASSED!!!");
             long limit = getMemoryValue(value);
             long kmemlimit = mCgroupV1.getKernelMemoryLimit();
-            // Note that the kernel memory limit might get ignored by OCI runtimes
-            // This feature is deprecated. Only perform the check if we get an actual
-            // limit back.
             if (kmemlimit != UNLIMITED && limit != kmemlimit) {
                 throw new RuntimeException("Kernel Memory limit not equal, expected : ["
-                            + limit + "]" + ", got : ["
-                            + kmemlimit + "]");
+                        + limit + "]" + ", got : ["
+                        + kmemlimit + "]");
             }
         } else {
             throw new RuntimeException("kernel memory limit test not supported for cgroups v2");

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -63,18 +63,14 @@ public class TestDockerMemoryMetrics {
             testMemoryAndSwapLimit("100m", "200m");
 
             Metrics m = Metrics.systemMetrics();
-            // kernel memory, '--kernel-memory' switch, and OOM killer,
-            // '--oom-kill-disable' switch, tests not supported by cgroupv2
-            // runtimes
+            // OOM killer disable, '--oom-kill-disable' switch, test not supported
+            // by cgroupv2
             if (m != null) {
                 if ("cgroupv1".equals(m.getProvider())) {
-                    testKernelMemoryLimit("100m");
-                    testKernelMemoryLimit("1g");
-
                     testOomKillFlag("100m", false);
                 } else {
-                    System.out.println("kernel memory tests and OOM Kill flag tests not " +
-                                       "possible with cgroupv2.");
+                    System.out.println("OOM kill disable test not " +
+                                       "supported with cgroupv2.");
                 }
             }
             testOomKillFlag("100m", true);
@@ -134,30 +130,6 @@ public class TestDockerMemoryMetrics {
                 .addJavaOpts("--add-exports", "java.base/jdk.internal.platform=ALL-UNNAMED")
                 .addClassOptions("memoryswap", memory, memandswap);
         DockerTestUtils.dockerRunJava(opts).shouldHaveExitValue(0).shouldContain("TEST PASSED!!!");
-    }
-
-    private static void testKernelMemoryLimit(String value) throws Exception {
-        Common.logNewTestCase("testKernelMemoryLimit, value = " + value);
-        DockerRunOptions opts =
-                new DockerRunOptions(imageName, "/jdk/bin/java", "MetricsMemoryTester");
-        opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/")
-                .addDockerOpts("--kernel-memory=" + value)
-                .addJavaOpts("-cp", "/test-classes/")
-                .addJavaOpts("--add-exports", "java.base/jdk.internal.platform=ALL-UNNAMED")
-                .addClassOptions("kernelmem", value);
-        OutputAnalyzer oa = DockerTestUtils.dockerRunJava(opts);
-
-        // Some container runtimes (e.g. runc, docker 18.09)
-        // have been built without kernel memory accounting. In
-        // that case, the runtime issues a message on stderr saying
-        // so. Skip the test in that case.
-        if (oa.getStderr().contains("kernel memory accounting disabled")) {
-            System.out.println("Kernel memory accounting disabled, " +
-                                       "skipping the test case");
-            return;
-        }
-
-        oa.shouldHaveExitValue(0).shouldContain("TEST PASSED!!!");
     }
 
     private static void testOomKillFlag(String value, boolean oomKillFlag) throws Exception {

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -145,7 +145,19 @@ public class TestDockerMemoryMetrics {
                 .addJavaOpts("-cp", "/test-classes/")
                 .addJavaOpts("--add-exports", "java.base/jdk.internal.platform=ALL-UNNAMED")
                 .addClassOptions("kernelmem", value);
-        DockerTestUtils.dockerRunJava(opts).shouldHaveExitValue(0).shouldContain("TEST PASSED!!!");
+        OutputAnalyzer oa = DockerTestUtils.dockerRunJava(opts);
+
+        // Some container runtimes (e.g. runc, docker 18.09)
+        // have been built without kernel memory accounting. In
+        // that case, the runtime issues a message on stderr saying
+        // so. Skip the test in that case.
+        if (oa.getStderr().contains("kernel memory accounting disabled")) {
+            System.out.println("Kernel memory accounting disabled, " +
+                                       "skipping the test case");
+            return;
+        }
+
+        oa.shouldHaveExitValue(0).shouldContain("TEST PASSED!!!");
     }
 
     private static void testOomKillFlag(String value, boolean oomKillFlag) throws Exception {

--- a/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV1.java
+++ b/test/lib/jdk/test/lib/containers/cgroup/MetricsTesterCgroupV1.java
@@ -247,13 +247,6 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
             fail(Controller.MEMORY, "memory.kmem.failcnt", oldVal, newVal);
         }
 
-        oldVal = metrics.getKernelMemoryLimit();
-        newVal = getLongValueFromFile(Controller.MEMORY, "memory.kmem.limit_in_bytes");
-        newVal = newVal > unlimited_minimum ? CgroupSubsystem.LONG_RETVAL_UNLIMITED : newVal;
-        if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
-            fail(Controller.MEMORY, "memory.kmem.limit_in_bytes", oldVal, newVal);
-        }
-
         oldVal = metrics.getKernelMemoryMaxUsage();
         newVal = getLongValueFromFile(Controller.MEMORY, "memory.kmem.max_usage_in_bytes");
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
@@ -271,13 +264,6 @@ public class MetricsTesterCgroupV1 implements CgroupMetricsTester {
         newVal = getLongValueFromFile(Controller.MEMORY, "memory.kmem.tcp.failcnt");
         if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
             fail(Controller.MEMORY, "memory.kmem.tcp.failcnt", oldVal, newVal);
-        }
-
-        oldVal = metrics.getTcpMemoryLimit();
-        newVal = getLongValueFromFile(Controller.MEMORY, "memory.kmem.tcp.limit_in_bytes");
-        newVal = newVal > unlimited_minimum ? CgroupSubsystem.LONG_RETVAL_UNLIMITED: newVal;
-        if (!CgroupMetricsTester.compareWithErrorMargin(oldVal, newVal)) {
-            fail(Controller.MEMORY, "memory.kmem.tcp.limit_in_bytes", oldVal, newVal);
         }
 
         oldVal = metrics.getTcpMemoryMaxUsage();


### PR DESCRIPTION
This backport is for parity with Oracle JDK 11. 
The patch did not apply cleanly. I first had to adapt the jdk11u-dev files. These adaptations are visible in the first commit. The second commit contains the changes brought in by the original patch which then applied cleanly. 

Reviews are very much appreciated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275735](https://bugs.openjdk.org/browse/JDK-8275735): [linux] Remove deprecated Metrics api (kernel memory limit)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1893/head:pull/1893` \
`$ git checkout pull/1893`

Update a local copy of the PR: \
`$ git checkout pull/1893` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1893`

View PR using the GUI difftool: \
`$ git pr show -t 1893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1893.diff">https://git.openjdk.org/jdk11u-dev/pull/1893.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1893#issuecomment-1561273111)