### PR TITLE
8287246: DSAKeyValue should check for missing params instead of relying on KeyFactory provider

### DIFF
--- a/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMKeyValue.java
+++ b/src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMKeyValue.java
@@ -21,7 +21,7 @@
  * under the License.
  */
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 package org.jcp.xml.dsig.internal.dom;
 
@@ -300,35 +300,23 @@ public abstract class DOMKeyValue<K extends PublicKey> extends DOMStructure impl
                         ("unable to create DSA KeyFactory: " + e.getMessage());
                 }
             }
-            Element curElem = DOMUtils.getFirstChildElement(kvtElem);
-            if (curElem == null) {
-                throw new MarshalException("KeyValue must contain at least one type");
-            }
-            // check for P and Q
-            BigInteger p = null;
-            BigInteger q = null;
-            if ("P".equals(curElem.getLocalName()) && XMLSignature.XMLNS.equals(curElem.getNamespaceURI())) {
-                p = decode(curElem);
-                curElem = DOMUtils.getNextSiblingElement(curElem, "Q", XMLSignature.XMLNS);
-                q = decode(curElem);
-                curElem = DOMUtils.getNextSiblingElement(curElem);
-            }
-            BigInteger g = null;
-            if (curElem != null
-                && "G".equals(curElem.getLocalName()) && XMLSignature.XMLNS.equals(curElem.getNamespaceURI())) {
-                g = decode(curElem);
-                curElem = DOMUtils.getNextSiblingElement(curElem, "Y", XMLSignature.XMLNS);
-            }
-            BigInteger y = null;
-            if (curElem != null) {
-                y = decode(curElem);
-                curElem = DOMUtils.getNextSiblingElement(curElem);
-            }
-            //if (curElem != null && "J".equals(curElem.getLocalName())) {
-                //j = new DOMCryptoBinary(curElem.getFirstChild());
-                // curElem = DOMUtils.getNextSiblingElement(curElem);
-            //}
-            //@@@ do we care about j, pgenCounter or seed?
+            // P, Q, and G are optional according to the XML Signature
+            // Recommendation as they might be known from application context,
+            // but this implementation does not provide a mechanism or API for
+            // an application to supply the missing parameters, so they are
+            // required to be specified.
+            Element curElem =
+                DOMUtils.getFirstChildElement(kvtElem, "P", XMLSignature.XMLNS);
+            BigInteger p = decode(curElem);
+            curElem =
+                DOMUtils.getNextSiblingElement(curElem, "Q", XMLSignature.XMLNS);
+            BigInteger q = decode(curElem);
+            curElem =
+                DOMUtils.getNextSiblingElement(curElem, "G", XMLSignature.XMLNS);
+            BigInteger g = decode(curElem);
+            curElem =
+                DOMUtils.getNextSiblingElement(curElem, "Y", XMLSignature.XMLNS);
+            BigInteger y = decode(curElem);
             DSAPublicKeySpec spec = new DSAPublicKeySpec(y, p, q, g);
             return (DSAPublicKey) generatePublicKey(dsakf, spec);
         }


### PR DESCRIPTION
Hi all,

this backport is for parity with 11.0.20-oracle.

This pull request contains a backport of commit [f235955e](https://github.com/openjdk/jdk/commit/f235955eefb1141a2e72116dfcf345e40416f059) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sean Mullan on 26 May 2022 and was reviewed by Weijun Wang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287246](https://bugs.openjdk.org/browse/JDK-8287246): DSAKeyValue should check for missing params instead of relying on KeyFactory provider


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1895/head:pull/1895` \
`$ git checkout pull/1895`

Update a local copy of the PR: \
`$ git checkout pull/1895` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1895`

View PR using the GUI difftool: \
`$ git pr show -t 1895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1895.diff">https://git.openjdk.org/jdk11u-dev/pull/1895.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1895#issuecomment-1561391343)