### PR TITLE
8239264: Clearup the legacy ObjectIdentifier constructor from int array

### DIFF
--- a/src/java.base/macosx/classes/apple/security/KeychainStore.java
+++ b/src/java.base/macosx/classes/apple/security/KeychainStore.java
@@ -112,9 +112,9 @@ public final class KeychainStore extends KeyStoreSpi {
      * PKCS12 bag we get from the Keychain.
      */
     private static ObjectIdentifier PKCS8ShroudedKeyBag_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.12.10.1.2");
+            ObjectIdentifier.of1("1.2.840.113549.1.12.10.1.2");
     private static ObjectIdentifier pbeWithSHAAnd3KeyTripleDESCBC_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.12.1.3");
+            ObjectIdentifier.of1("1.2.840.113549.1.12.1.3");
 
     /**
      * Constnats used in PBE decryption.

--- a/src/java.base/macosx/classes/apple/security/KeychainStore.java
+++ b/src/java.base/macosx/classes/apple/security/KeychainStore.java
@@ -108,12 +108,13 @@ public final class KeychainStore extends KeyStoreSpi {
     private Hashtable<String, Object> entries = new Hashtable<>();
 
     /**
-     * Algorithm identifiers and corresponding OIDs for the contents of the PKCS12 bag we get from the Keychain.
+     * Algorithm identifiers and corresponding OIDs for the contents of the
+     * PKCS12 bag we get from the Keychain.
      */
-    private static final int keyBag[]  = {1, 2, 840, 113549, 1, 12, 10, 1, 2};
-    private static final int pbeWithSHAAnd3KeyTripleDESCBC[] =     {1, 2, 840, 113549, 1, 12, 1, 3};
-    private static ObjectIdentifier PKCS8ShroudedKeyBag_OID;
-    private static ObjectIdentifier pbeWithSHAAnd3KeyTripleDESCBC_OID;
+    private static ObjectIdentifier PKCS8ShroudedKeyBag_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.12.10.1.2");
+    private static ObjectIdentifier pbeWithSHAAnd3KeyTripleDESCBC_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.12.1.3");
 
     /**
      * Constnats used in PBE decryption.

--- a/src/java.base/macosx/classes/apple/security/KeychainStore.java
+++ b/src/java.base/macosx/classes/apple/security/KeychainStore.java
@@ -132,12 +132,6 @@ public final class KeychainStore extends KeyStoreSpi {
                     return null;
                 }
             });
-        try {
-            PKCS8ShroudedKeyBag_OID = new ObjectIdentifier(keyBag);
-            pbeWithSHAAnd3KeyTripleDESCBC_OID = new ObjectIdentifier(pbeWithSHAAnd3KeyTripleDESCBC);
-        } catch (IOException ioe) {
-            // should not happen
-        }
     }
 
     private static void permissionCheck() {

--- a/src/java.base/share/classes/com/sun/crypto/provider/DHPrivateKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/com/sun/crypto/provider/DHPrivateKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHPrivateKey.java
@@ -71,8 +71,6 @@ javax.crypto.interfaces.DHPrivateKey, Serializable {
     // the private-value length (optional)
     private int l;
 
-    private int DH_data[] = { 1, 2, 840, 113549, 1, 3, 1 };
-
     /**
      * Make a DH private key out of a private value <code>x</code>, a prime
      * modulus <code>p</code>, and a base generator <code>g</code>.
@@ -219,7 +217,7 @@ javax.crypto.interfaces.DHPrivateKey, Serializable {
                 DerOutputStream algid = new DerOutputStream();
 
                 // store OID
-                algid.putOID(new ObjectIdentifier(DH_data));
+                algid.putOID(DHPublicKey.DH_OID);
                 // encode parameters
                 DerOutputStream params = new DerOutputStream();
                 params.putInteger(this.p);

--- a/src/java.base/share/classes/com/sun/crypto/provider/DHPublicKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/com/sun/crypto/provider/DHPublicKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHPublicKey.java
@@ -70,7 +70,7 @@ javax.crypto.interfaces.DHPublicKey, Serializable {
 
     // Note: this OID is used by DHPrivateKey as well.
     static ObjectIdentifier DH_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.3.1");
+            ObjectIdentifier.of1("1.2.840.113549.1.3.1");
 
     /**
      * Make a DH public key out of a public value <code>y</code>, a prime

--- a/src/java.base/share/classes/com/sun/crypto/provider/DHPublicKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHPublicKey.java
@@ -68,7 +68,9 @@ javax.crypto.interfaces.DHPublicKey, Serializable {
     // the private-value length (optional)
     private int l;
 
-    private int DH_data[] = { 1, 2, 840, 113549, 1, 3, 1 };
+    // Note: this OID is used by DHPrivateKey as well.
+    static ObjectIdentifier DH_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.3.1");
 
     /**
      * Make a DH public key out of a public value <code>y</code>, a prime
@@ -202,7 +204,7 @@ javax.crypto.interfaces.DHPublicKey, Serializable {
                 DerOutputStream algid = new DerOutputStream();
 
                 // store oid in algid
-                algid.putOID(new ObjectIdentifier(DH_data));
+                algid.putOID(DH_OID);
 
                 // encode parameters
                 DerOutputStream params = new DerOutputStream();

--- a/src/java.base/share/classes/com/sun/crypto/provider/OAEPParameters.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/OAEPParameters.java
@@ -55,24 +55,10 @@ public final class OAEPParameters extends AlgorithmParametersSpi {
     private String mdName;
     private MGF1ParameterSpec mgfSpec;
     private byte[] p;
-    private static ObjectIdentifier OID_MGF1;
-    private static ObjectIdentifier OID_PSpecified;
-
-    static {
-        try {
-            OID_MGF1 = new ObjectIdentifier(new int[] {1,2,840,113549,1,1,8});
-        } catch (IOException ioe) {
-            // should not happen
-            OID_MGF1 = null;
-        }
-        try {
-            OID_PSpecified =
-                new ObjectIdentifier(new int[] {1,2,840,113549,1,1,9});
-        } catch (IOException ioe) {
-            // should not happen
-            OID_PSpecified = null;
-        }
-    }
+    private static ObjectIdentifier OID_MGF1 =
+            ObjectIdentifier.of("1.2.840.113549.1.1.8");
+    private static ObjectIdentifier OID_PSpecified =
+            ObjectIdentifier.of("1.2.840.113549.1.1.9");
 
     public OAEPParameters() {
     }

--- a/src/java.base/share/classes/com/sun/crypto/provider/OAEPParameters.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/OAEPParameters.java
@@ -56,9 +56,9 @@ public final class OAEPParameters extends AlgorithmParametersSpi {
     private MGF1ParameterSpec mgfSpec;
     private byte[] p;
     private static ObjectIdentifier OID_MGF1 =
-            ObjectIdentifier.of("1.2.840.113549.1.1.8");
+            ObjectIdentifier.of1("1.2.840.113549.1.1.8");
     private static ObjectIdentifier OID_PSpecified =
-            ObjectIdentifier.of("1.2.840.113549.1.1.9");
+            ObjectIdentifier.of1("1.2.840.113549.1.1.9");
 
     public OAEPParameters() {
     }

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBES2Parameters.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBES2Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,57 +90,28 @@ import sun.security.util.*;
  *
  * </pre>
  */
-
 abstract class PBES2Parameters extends AlgorithmParametersSpi {
 
-    private static final int pkcs5PBKDF2[] =
-                                        {1, 2, 840, 113549, 1, 5, 12};
-    private static final int pkcs5PBES2[] =
-                                        {1, 2, 840, 113549, 1, 5, 13};
-    private static final int hmacWithSHA1[] =
-                                        {1, 2, 840, 113549, 2, 7};
-    private static final int hmacWithSHA224[] =
-                                        {1, 2, 840, 113549, 2, 8};
-    private static final int hmacWithSHA256[] =
-                                        {1, 2, 840, 113549, 2, 9};
-    private static final int hmacWithSHA384[] =
-                                        {1, 2, 840, 113549, 2, 10};
-    private static final int hmacWithSHA512[] =
-                                        {1, 2, 840, 113549, 2, 11};
-    private static final int aes128CBC[] =
-                                        {2, 16, 840, 1, 101, 3, 4, 1, 2};
-    private static final int aes192CBC[] =
-                                        {2, 16, 840, 1, 101, 3, 4, 1, 22};
-    private static final int aes256CBC[] =
-                                        {2, 16, 840, 1, 101, 3, 4, 1, 42};
-
-    private static ObjectIdentifier pkcs5PBKDF2_OID;
-    private static ObjectIdentifier pkcs5PBES2_OID;
-    private static ObjectIdentifier hmacWithSHA1_OID;
-    private static ObjectIdentifier hmacWithSHA224_OID;
-    private static ObjectIdentifier hmacWithSHA256_OID;
-    private static ObjectIdentifier hmacWithSHA384_OID;
-    private static ObjectIdentifier hmacWithSHA512_OID;
-    private static ObjectIdentifier aes128CBC_OID;
-    private static ObjectIdentifier aes192CBC_OID;
-    private static ObjectIdentifier aes256CBC_OID;
-
-    static {
-        try {
-            pkcs5PBKDF2_OID = new ObjectIdentifier(pkcs5PBKDF2);
-            pkcs5PBES2_OID = new ObjectIdentifier(pkcs5PBES2);
-            hmacWithSHA1_OID = new ObjectIdentifier(hmacWithSHA1);
-            hmacWithSHA224_OID = new ObjectIdentifier(hmacWithSHA224);
-            hmacWithSHA256_OID = new ObjectIdentifier(hmacWithSHA256);
-            hmacWithSHA384_OID = new ObjectIdentifier(hmacWithSHA384);
-            hmacWithSHA512_OID = new ObjectIdentifier(hmacWithSHA512);
-            aes128CBC_OID = new ObjectIdentifier(aes128CBC);
-            aes192CBC_OID = new ObjectIdentifier(aes192CBC);
-            aes256CBC_OID = new ObjectIdentifier(aes256CBC);
-        } catch (IOException ioe) {
-            // should not happen
-        }
-    }
+    private static ObjectIdentifier pkcs5PBKDF2_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.5.12");
+    private static ObjectIdentifier pkcs5PBES2_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.5.13");
+    private static ObjectIdentifier hmacWithSHA1_OID =
+            ObjectIdentifier.of("1.2.840.113549.2.7");
+    private static ObjectIdentifier hmacWithSHA224_OID =
+            ObjectIdentifier.of("1.2.840.113549.2.8");
+    private static ObjectIdentifier hmacWithSHA256_OID =
+            ObjectIdentifier.of("1.2.840.113549.2.9");
+    private static ObjectIdentifier hmacWithSHA384_OID =
+            ObjectIdentifier.of("1.2.840.113549.2.10");
+    private static ObjectIdentifier hmacWithSHA512_OID =
+            ObjectIdentifier.of("1.2.840.113549.2.11");
+    private static ObjectIdentifier aes128CBC_OID =
+            ObjectIdentifier.of("2.16.840.1.101.3.4.1.2");
+    private static ObjectIdentifier aes192CBC_OID =
+            ObjectIdentifier.of("2.16.840.1.101.3.4.1.22");
+    private static ObjectIdentifier aes256CBC_OID =
+            ObjectIdentifier.of("2.16.840.1.101.3.4.1.42");
 
     // the PBES2 algorithm name
     private String pbes2AlgorithmName = null;

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBES2Parameters.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBES2Parameters.java
@@ -93,25 +93,25 @@ import sun.security.util.*;
 abstract class PBES2Parameters extends AlgorithmParametersSpi {
 
     private static ObjectIdentifier pkcs5PBKDF2_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.5.12");
+            ObjectIdentifier.of1("1.2.840.113549.1.5.12");
     private static ObjectIdentifier pkcs5PBES2_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.5.13");
+            ObjectIdentifier.of1("1.2.840.113549.1.5.13");
     private static ObjectIdentifier hmacWithSHA1_OID =
-            ObjectIdentifier.of("1.2.840.113549.2.7");
+            ObjectIdentifier.of1("1.2.840.113549.2.7");
     private static ObjectIdentifier hmacWithSHA224_OID =
-            ObjectIdentifier.of("1.2.840.113549.2.8");
+            ObjectIdentifier.of1("1.2.840.113549.2.8");
     private static ObjectIdentifier hmacWithSHA256_OID =
-            ObjectIdentifier.of("1.2.840.113549.2.9");
+            ObjectIdentifier.of1("1.2.840.113549.2.9");
     private static ObjectIdentifier hmacWithSHA384_OID =
-            ObjectIdentifier.of("1.2.840.113549.2.10");
+            ObjectIdentifier.of1("1.2.840.113549.2.10");
     private static ObjectIdentifier hmacWithSHA512_OID =
-            ObjectIdentifier.of("1.2.840.113549.2.11");
+            ObjectIdentifier.of1("1.2.840.113549.2.11");
     private static ObjectIdentifier aes128CBC_OID =
-            ObjectIdentifier.of("2.16.840.1.101.3.4.1.2");
+            ObjectIdentifier.of1("2.16.840.1.101.3.4.1.2");
     private static ObjectIdentifier aes192CBC_OID =
-            ObjectIdentifier.of("2.16.840.1.101.3.4.1.22");
+            ObjectIdentifier.of1("2.16.840.1.101.3.4.1.22");
     private static ObjectIdentifier aes256CBC_OID =
-            ObjectIdentifier.of("2.16.840.1.101.3.4.1.42");
+            ObjectIdentifier.of1("2.16.840.1.101.3.4.1.42");
 
     // the PBES2 algorithm name
     private String pbes2AlgorithmName = null;

--- a/src/java.base/share/classes/java/security/cert/X509CertSelector.java
+++ b/src/java.base/share/classes/java/security/cert/X509CertSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,7 +88,7 @@ public class X509CertSelector implements CertSelector {
     private static final Debug debug = Debug.getInstance("certpath");
 
     private static final ObjectIdentifier ANY_EXTENDED_KEY_USAGE =
-        ObjectIdentifier.newInternal(new int[] {2, 5, 29, 37, 0});
+        ObjectIdentifier.of("2.5.29.37.0");
 
     static {
         CertPathHelperImpl.initialize();

--- a/src/java.base/share/classes/java/security/cert/X509CertSelector.java
+++ b/src/java.base/share/classes/java/security/cert/X509CertSelector.java
@@ -88,7 +88,7 @@ public class X509CertSelector implements CertSelector {
     private static final Debug debug = Debug.getInstance("certpath");
 
     private static final ObjectIdentifier ANY_EXTENDED_KEY_USAGE =
-        ObjectIdentifier.of("2.5.29.37.0");
+        ObjectIdentifier.of1("2.5.29.37.0");
 
     static {
         CertPathHelperImpl.initialize();

--- a/src/java.base/share/classes/sun/security/pkcs/ContentInfo.java
+++ b/src/java.base/share/classes/sun/security/pkcs/ContentInfo.java
@@ -39,35 +39,35 @@ public class ContentInfo {
 
     // pkcs7 pre-defined content types
     public static ObjectIdentifier PKCS7_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.7");
+            ObjectIdentifier.of1("1.2.840.113549.1.7");
     public static ObjectIdentifier DATA_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.7.1");
+            ObjectIdentifier.of1("1.2.840.113549.1.7.1");
     public static ObjectIdentifier SIGNED_DATA_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.7.2");
+            ObjectIdentifier.of1("1.2.840.113549.1.7.2");
     public static ObjectIdentifier ENVELOPED_DATA_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.7.3");
+            ObjectIdentifier.of1("1.2.840.113549.1.7.3");
     public static ObjectIdentifier SIGNED_AND_ENVELOPED_DATA_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.7.4");
+            ObjectIdentifier.of1("1.2.840.113549.1.7.4");
     public static ObjectIdentifier DIGESTED_DATA_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.7.5");
+            ObjectIdentifier.of1("1.2.840.113549.1.7.5");
     public static ObjectIdentifier ENCRYPTED_DATA_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.7.6");
+            ObjectIdentifier.of1("1.2.840.113549.1.7.6");
 
     // this is for backwards-compatibility with JDK 1.1.x
     public static ObjectIdentifier OLD_SIGNED_DATA_OID =
-            ObjectIdentifier.of("1.2.840.1113549.1.7.2");
+            ObjectIdentifier.of1("1.2.840.1113549.1.7.2");
     public static ObjectIdentifier OLD_DATA_OID =
-            ObjectIdentifier.of("1.2.840.1113549.1.7.1");
+            ObjectIdentifier.of1("1.2.840.1113549.1.7.1");
 
     // The ASN.1 systax for the Netscape Certificate Sequence data type is
     // defined at:
     //      http://wp.netscape.com/eng/security/comm4-cert-download.html
     public static ObjectIdentifier NETSCAPE_CERT_SEQUENCE_OID =
-            ObjectIdentifier.of("2.16.840.1.113730.2.5");
+            ObjectIdentifier.of1("2.16.840.1.113730.2.5");
 
     // timestamp token (id-ct-TSTInfo) from RFC 3161
     public static ObjectIdentifier TIMESTAMP_TOKEN_INFO_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.9.16.1.4");
+            ObjectIdentifier.of1("1.2.840.113549.1.9.16.1.4");
 
     ObjectIdentifier contentType;
     DerValue content; // OPTIONAL

--- a/src/java.base/share/classes/sun/security/pkcs/ContentInfo.java
+++ b/src/java.base/share/classes/sun/security/pkcs/ContentInfo.java
@@ -38,50 +38,36 @@ import sun.security.util.*;
 public class ContentInfo {
 
     // pkcs7 pre-defined content types
-    private static int[]  pkcs7 = {1, 2, 840, 113549, 1, 7};
-    private static int[]   data = {1, 2, 840, 113549, 1, 7, 1};
-    private static int[]  sdata = {1, 2, 840, 113549, 1, 7, 2};
-    private static int[]  edata = {1, 2, 840, 113549, 1, 7, 3};
-    private static int[] sedata = {1, 2, 840, 113549, 1, 7, 4};
-    private static int[]  ddata = {1, 2, 840, 113549, 1, 7, 5};
-    private static int[] crdata = {1, 2, 840, 113549, 1, 7, 6};
-    private static int[] nsdata = {2, 16, 840, 1, 113730, 2, 5};
-    // timestamp token (id-ct-TSTInfo) from RFC 3161
-    private static int[] tstInfo = {1, 2, 840, 113549, 1, 9, 16, 1, 4};
-    // this is for backwards-compatibility with JDK 1.1.x
-    private static final int[] OLD_SDATA = {1, 2, 840, 1113549, 1, 7, 2};
-    private static final int[] OLD_DATA = {1, 2, 840, 1113549, 1, 7, 1};
-    public static ObjectIdentifier PKCS7_OID;
-    public static ObjectIdentifier DATA_OID;
-    public static ObjectIdentifier SIGNED_DATA_OID;
-    public static ObjectIdentifier ENVELOPED_DATA_OID;
-    public static ObjectIdentifier SIGNED_AND_ENVELOPED_DATA_OID;
-    public static ObjectIdentifier DIGESTED_DATA_OID;
-    public static ObjectIdentifier ENCRYPTED_DATA_OID;
-    public static ObjectIdentifier OLD_SIGNED_DATA_OID;
-    public static ObjectIdentifier OLD_DATA_OID;
-    public static ObjectIdentifier NETSCAPE_CERT_SEQUENCE_OID;
-    public static ObjectIdentifier TIMESTAMP_TOKEN_INFO_OID;
+    public static ObjectIdentifier PKCS7_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.7");
+    public static ObjectIdentifier DATA_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.7.1");
+    public static ObjectIdentifier SIGNED_DATA_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.7.2");
+    public static ObjectIdentifier ENVELOPED_DATA_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.7.3");
+    public static ObjectIdentifier SIGNED_AND_ENVELOPED_DATA_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.7.4");
+    public static ObjectIdentifier DIGESTED_DATA_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.7.5");
+    public static ObjectIdentifier ENCRYPTED_DATA_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.7.6");
 
-    static {
-        PKCS7_OID =  ObjectIdentifier.newInternal(pkcs7);
-        DATA_OID = ObjectIdentifier.newInternal(data);
-        SIGNED_DATA_OID = ObjectIdentifier.newInternal(sdata);
-        ENVELOPED_DATA_OID = ObjectIdentifier.newInternal(edata);
-        SIGNED_AND_ENVELOPED_DATA_OID = ObjectIdentifier.newInternal(sedata);
-        DIGESTED_DATA_OID = ObjectIdentifier.newInternal(ddata);
-        ENCRYPTED_DATA_OID = ObjectIdentifier.newInternal(crdata);
-        OLD_SIGNED_DATA_OID = ObjectIdentifier.newInternal(OLD_SDATA);
-        OLD_DATA_OID = ObjectIdentifier.newInternal(OLD_DATA);
-        /**
-         * The ASN.1 systax for the Netscape Certificate Sequence
-         * data type is defined
-         * <a href=http://wp.netscape.com/eng/security/comm4-cert-download.html>
-         * here.</a>
-         */
-        NETSCAPE_CERT_SEQUENCE_OID = ObjectIdentifier.newInternal(nsdata);
-        TIMESTAMP_TOKEN_INFO_OID = ObjectIdentifier.newInternal(tstInfo);
-    }
+    // this is for backwards-compatibility with JDK 1.1.x
+    public static ObjectIdentifier OLD_SIGNED_DATA_OID =
+            ObjectIdentifier.of("1.2.840.1113549.1.7.2");
+    public static ObjectIdentifier OLD_DATA_OID =
+            ObjectIdentifier.of("1.2.840.1113549.1.7.1");
+
+    // The ASN.1 systax for the Netscape Certificate Sequence data type is
+    // defined at:
+    //      http://wp.netscape.com/eng/security/comm4-cert-download.html
+    public static ObjectIdentifier NETSCAPE_CERT_SEQUENCE_OID =
+            ObjectIdentifier.of("2.16.840.1.113730.2.5");
+
+    // timestamp token (id-ct-TSTInfo) from RFC 3161
+    public static ObjectIdentifier TIMESTAMP_TOKEN_INFO_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.9.16.1.4");
 
     ObjectIdentifier contentType;
     DerValue content; // OPTIONAL

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
@@ -28,9 +28,7 @@ package sun.security.pkcs;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.security.cert.CertificateException;
-import java.util.Locale;
 import java.util.Date;
-import java.util.Hashtable;
 import sun.security.x509.CertificateExtensions;
 import sun.security.util.*;
 

--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -143,19 +143,19 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
     private static final Debug debug = Debug.getInstance("pkcs12");
 
     private static final ObjectIdentifier PKCS8ShroudedKeyBag_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.12.10.1.2");
+            ObjectIdentifier.of1("1.2.840.113549.1.12.10.1.2");
     private static final ObjectIdentifier CertBag_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.12.10.1.3");
+            ObjectIdentifier.of1("1.2.840.113549.1.12.10.1.3");
     private static final ObjectIdentifier SecretBag_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.12.10.1.5");
+            ObjectIdentifier.of1("1.2.840.113549.1.12.10.1.5");
     private static final ObjectIdentifier PKCS9FriendlyName_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.9.20");
+            ObjectIdentifier.of1("1.2.840.113549.1.9.20");
     private static final ObjectIdentifier PKCS9LocalKeyId_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.9.21");
+            ObjectIdentifier.of1("1.2.840.113549.1.9.21");
     private static final ObjectIdentifier PKCS9CertType_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.9.22.1");
+            ObjectIdentifier.of1("1.2.840.113549.1.9.22.1");
     private static final ObjectIdentifier pbes2_OID =
-            ObjectIdentifier.of("1.2.840.113549.1.5.13");
+            ObjectIdentifier.of1("1.2.840.113549.1.5.13");
 
     /*
      * Temporary Oracle OID
@@ -164,11 +164,11 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
      *  oracle(113894) jdk(746875) crypto(1) id-at-trustedKeyUsage(1)}
      */
     private static final ObjectIdentifier TrustedKeyUsage_OID =
-            ObjectIdentifier.of("2.16.840.1.113894.746875.1.1");
+            ObjectIdentifier.of1("2.16.840.1.113894.746875.1.1");
 
     private static final ObjectIdentifier[] AnyUsage = new ObjectIdentifier[] {
                 // AnyExtendedKeyUsage
-                ObjectIdentifier.of("2.5.29.37.0")
+                ObjectIdentifier.of1("2.5.29.37.0")
             };
 
     private int counter = 0;

--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -142,34 +142,34 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
 
     private static final Debug debug = Debug.getInstance("pkcs12");
 
-    private static final int[] keyBag  = {1, 2, 840, 113549, 1, 12, 10, 1, 2};
-    private static final int[] certBag = {1, 2, 840, 113549, 1, 12, 10, 1, 3};
-    private static final int[] secretBag = {1, 2, 840, 113549, 1, 12, 10, 1, 5};
+    private static final ObjectIdentifier PKCS8ShroudedKeyBag_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.12.10.1.2");
+    private static final ObjectIdentifier CertBag_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.12.10.1.3");
+    private static final ObjectIdentifier SecretBag_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.12.10.1.5");
+    private static final ObjectIdentifier PKCS9FriendlyName_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.9.20");
+    private static final ObjectIdentifier PKCS9LocalKeyId_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.9.21");
+    private static final ObjectIdentifier PKCS9CertType_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.9.22.1");
+    private static final ObjectIdentifier pbes2_OID =
+            ObjectIdentifier.of("1.2.840.113549.1.5.13");
 
-    private static final int[] pkcs9Name  = {1, 2, 840, 113549, 1, 9, 20};
-    private static final int[] pkcs9KeyId = {1, 2, 840, 113549, 1, 9, 21};
-
-    private static final int[] pkcs9certType = {1, 2, 840, 113549, 1, 9, 22, 1};
-
-    private static final int[] pbes2 = {1, 2, 840, 113549, 1, 5, 13};
-    // TODO: temporary Oracle OID
     /*
-     * { joint-iso-itu-t(2) country(16) us(840) organization(1) oracle(113894)
-     *   jdk(746875) crypto(1) id-at-trustedKeyUsage(1) }
+     * Temporary Oracle OID
+     *
+     * {joint-iso-itu-t(2) country(16) us(840) organization(1)
+     *  oracle(113894) jdk(746875) crypto(1) id-at-trustedKeyUsage(1)}
      */
-    private static final int[] TrustedKeyUsage =
-                                        {2, 16, 840, 1, 113894, 746875, 1, 1};
-    private static final int[] AnyExtendedKeyUsage = {2, 5, 29, 37, 0};
+    private static final ObjectIdentifier TrustedKeyUsage_OID =
+            ObjectIdentifier.of("2.16.840.1.113894.746875.1.1");
 
-    private static final ObjectIdentifier PKCS8ShroudedKeyBag_OID;
-    private static final ObjectIdentifier CertBag_OID;
-    private static final ObjectIdentifier SecretBag_OID;
-    private static final ObjectIdentifier PKCS9FriendlyName_OID;
-    private static final ObjectIdentifier PKCS9LocalKeyId_OID;
-    private static final ObjectIdentifier PKCS9CertType_OID;
-    private static final ObjectIdentifier pbes2_OID;
-    private static final ObjectIdentifier TrustedKeyUsage_OID;
-    private static final ObjectIdentifier[] AnyUsage;
+    private static final ObjectIdentifier[] AnyUsage = new ObjectIdentifier[] {
+                // AnyExtendedKeyUsage
+                ObjectIdentifier.of("2.5.29.37.0")
+            };
 
     private int counter = 0;
 
@@ -197,23 +197,6 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
 
     // the source of randomness
     private SecureRandom random;
-
-    static {
-        try {
-            PKCS8ShroudedKeyBag_OID = new ObjectIdentifier(keyBag);
-            CertBag_OID = new ObjectIdentifier(certBag);
-            SecretBag_OID = new ObjectIdentifier(secretBag);
-            PKCS9FriendlyName_OID = new ObjectIdentifier(pkcs9Name);
-            PKCS9LocalKeyId_OID = new ObjectIdentifier(pkcs9KeyId);
-            PKCS9CertType_OID = new ObjectIdentifier(pkcs9certType);
-            pbes2_OID = new ObjectIdentifier(pbes2);
-            TrustedKeyUsage_OID = new ObjectIdentifier(TrustedKeyUsage);
-            AnyUsage = new ObjectIdentifier[]{
-                new ObjectIdentifier(AnyExtendedKeyUsage)};
-        } catch (IOException ioe) {
-            throw new AssertionError("OID not initialized", ioe);
-        }
-    }
 
     // A keystore entry and associated attributes
     private static class Entry {

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
@@ -135,7 +135,7 @@ public final class OCSPResponse {
     private static final Debug debug = Debug.getInstance("certpath");
     private static final boolean dump = debug != null && Debug.isOn("ocsp");
     private static final ObjectIdentifier OCSP_BASIC_RESPONSE_OID =
-        ObjectIdentifier.newInternal(new int[] { 1, 3, 6, 1, 5, 5, 7, 48, 1, 1});
+        ObjectIdentifier.of("1.3.6.1.5.5.7.48.1.1");
     private static final int CERT_STATUS_GOOD = 0;
     private static final int CERT_STATUS_REVOKED = 1;
     private static final int CERT_STATUS_UNKNOWN = 2;

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
@@ -135,7 +135,7 @@ public final class OCSPResponse {
     private static final Debug debug = Debug.getInstance("certpath");
     private static final boolean dump = debug != null && Debug.isOn("ocsp");
     private static final ObjectIdentifier OCSP_BASIC_RESPONSE_OID =
-        ObjectIdentifier.of("1.3.6.1.5.5.7.48.1.1");
+        ObjectIdentifier.of1("1.3.6.1.5.5.7.48.1.1");
     private static final int CERT_STATUS_GOOD = 0;
     private static final int CERT_STATUS_REVOKED = 1;
     private static final int CERT_STATUS_UNKNOWN = 2;

--- a/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
+++ b/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
@@ -366,11 +366,6 @@ public final class ObjectIdentifier implements Serializable {
         }
     }
 
-    /**
-     * Returns an ObjectIdentifier instance for the specific String.
-     *
-     * If the String is not a valid OID string, an IOException is thrown.
-     */
     public static ObjectIdentifier of(String oidStr) throws IOException {
         // check cache first
         ObjectIdentifier oid = oidTable.get(oidStr);

--- a/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
+++ b/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
@@ -240,6 +240,20 @@ public final class ObjectIdentifier implements Serializable {
     }
 
     /**
+     * Constructor, from an array of integers.
+     * Validity check included.
+     */
+    public ObjectIdentifier(int[] values) throws IOException
+    {
+        checkCount(values.length);
+        checkFirstComponent(values[0]);
+        checkSecondComponent(values[0], values[1]);
+        for (int i=2; i<values.length; i++)
+            checkOtherComponent(i, values[i]);
+        init(values, values.length);
+    }
+
+    /**
      * Constructor, from an ASN.1 encoded input stream.
      * Validity check NOT included.
      * The encoding of the ID in the stream uses "DER", a BER/1 subset.
@@ -319,6 +333,24 @@ public final class ObjectIdentifier implements Serializable {
 
         encoding = new byte[pos];
         System.arraycopy(tmp, 0, encoding, 0, pos);
+    }
+
+    /**
+     * This method is kept for compatibility reasons. The new implementation
+     * does the check and conversion. All around the JDK, the method is called
+     * in static blocks to initialize pre-defined ObjectIdentifieies. No
+     * obvious performance hurt will be made after this change.
+     *
+     * Old doc: Create a new ObjectIdentifier for internal use. The values are
+     * neither checked nor cloned.
+     */
+    public static ObjectIdentifier newInternal(int[] values) {
+        try {
+            return new ObjectIdentifier(values);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+            // Should not happen, internal calls always uses legal values.
+        }
     }
 
     // oid cache index'ed by the oid string

--- a/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
+++ b/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
@@ -119,6 +119,7 @@ class ObjectIdentifier implements Serializable
      * @serial
      */
     private Object      components   = null;          // path from root
+
     /**
      * @serial
      */
@@ -163,15 +164,15 @@ class ObjectIdentifier implements Serializable
 
     static class HugeOidNotSupportedByOldJDK implements Serializable {
         private static final long serialVersionUID = 1L;
-        static HugeOidNotSupportedByOldJDK theOne = new HugeOidNotSupportedByOldJDK();
+        static HugeOidNotSupportedByOldJDK theOne =
+                new HugeOidNotSupportedByOldJDK();
     }
 
     /**
      * Constructs, from a string.  This string should be of the form 1.23.56.
      * Validity check included.
      */
-    public ObjectIdentifier (String oid) throws IOException
-    {
+    public ObjectIdentifier(String oid) throws IOException {
         int ch = '.';
         int start = 0;
         int end = 0;
@@ -242,20 +243,6 @@ class ObjectIdentifier implements Serializable
     }
 
     /**
-     * Constructor, from an array of integers.
-     * Validity check included.
-     */
-    public ObjectIdentifier(int[] values) throws IOException
-    {
-        checkCount(values.length);
-        checkFirstComponent(values[0]);
-        checkSecondComponent(values[0], values[1]);
-        for (int i=2; i<values.length; i++)
-            checkOtherComponent(i, values[i]);
-        init(values, values.length);
-    }
-
-    /**
      * Constructor, from an ASN.1 encoded input stream.
      * Validity check NOT included.
      * The encoding of the ID in the stream uses "DER", a BER/1 subset.
@@ -267,8 +254,7 @@ class ObjectIdentifier implements Serializable
      * @param in DER-encoded data holding an object ID
      * @exception IOException indicates a decoding error
      */
-    public ObjectIdentifier (DerInputStream in) throws IOException
-    {
+    public ObjectIdentifier(DerInputStream in) throws IOException {
         byte    type_id;
         int     bufferEnd;
 
@@ -281,7 +267,7 @@ class ObjectIdentifier implements Serializable
          * up so that we can use in.available() to check for the end of
          * this value in the data stream.
          */
-        type_id = (byte) in.getByte ();
+        type_id = (byte)in.getByte();
         if (type_id != DerValue.tag_ObjectId)
             throw new IOException (
                 "ObjectIdentifier() -- data isn't an object ID"
@@ -306,8 +292,7 @@ class ObjectIdentifier implements Serializable
      * the tag and length have been removed/verified
      * Validity check NOT included.
      */
-    ObjectIdentifier (DerInputBuffer buf) throws IOException
-    {
+    ObjectIdentifier(DerInputBuffer buf) throws IOException {
         DerInputStream in = new DerInputStream(buf);
         int len = in.available();
         checkOidSize(len);
@@ -541,7 +526,7 @@ class ObjectIdentifier implements Serializable
     /**
      * Repack all bits from input to output. On the both sides, only a portion
      * (from the least significant bit) of the 8 bits in a byte is used. This
-     * number is defined as the number of useful bits (NUB) for the array. All the
+     * number is defined as the number of useful bits (NUB) for the array. All
      * used bits from the input byte array and repacked into the output in the
      * exactly same order. The output bits are aligned so that the final bit of
      * the input (the least significant bit in the last byte), when repacked as
@@ -563,7 +548,8 @@ class ObjectIdentifier implements Serializable
      * @param ow        NUB for output
      * @return          the repacked bytes
      */
-    private static byte[] pack(byte[] in, int ioffset, int ilength, int iw, int ow) {
+    private static byte[] pack(byte[] in,
+            int ioffset, int ilength, int iw, int ow) {
         assert (iw > 0 && iw <= 8): "input NUB must be between 1 and 8";
         assert (ow > 0 && ow <= 8): "output NUB must be between 1 and 8";
 
@@ -585,12 +571,13 @@ class ObjectIdentifier implements Serializable
             if (count > ow - opos%ow) { // free space available in output byte
                 count = ow - opos%ow;   // choose the smaller number
             }
+
             // and move them!
-            out[opos/ow] |=                         // paste!
-                (((in[ioffset+ipos/iw]+256)         // locate the byte (+256 so that it's never negative)
-                    >> (iw-ipos%iw-count))          // move to the end of a byte
-                        & ((1 << (count))-1))       // zero out all other bits
-                            << (ow-opos%ow-count);  // move to the output position
+            out[opos/ow] |=                     // paste!
+                (((in[ioffset+ipos/iw]+256)     // locate the byte (+256 so that it's never negative)
+                    >> (iw-ipos%iw-count)) &    // move to the end of a byte
+                  ((1 << (count))-1))           // zero out all other bits
+                        << (ow-opos%ow-count);  // move to the output position
             ipos += count;  // advance
             opos += count;  // advance
         }
@@ -606,7 +593,8 @@ class ObjectIdentifier implements Serializable
      * @param ooffset the starting position to paste
      * @return the number of bytes pasted
      */
-    private static int pack7Oid(byte[] in, int ioffset, int ilength, byte[] out, int ooffset) {
+    private static int pack7Oid(byte[] in,
+            int ioffset, int ilength, byte[] out, int ooffset) {
         byte[] pack = pack(in, ioffset, ilength, 8, 7);
         int firstNonZero = pack.length-1;   // paste at least one byte
         for (int i=pack.length-2; i>=0; i--) {
@@ -615,7 +603,8 @@ class ObjectIdentifier implements Serializable
             }
             pack[i] |= 0x80;
         }
-        System.arraycopy(pack, firstNonZero, out, ooffset, pack.length-firstNonZero);
+        System.arraycopy(pack, firstNonZero,
+                out, ooffset, pack.length-firstNonZero);
         return pack.length-firstNonZero;
     }
 
@@ -626,7 +615,8 @@ class ObjectIdentifier implements Serializable
      * @param ooffset the starting position to paste
      * @return the number of bytes pasted
      */
-    private static int pack8(byte[] in, int ioffset, int ilength, byte[] out, int ooffset) {
+    private static int pack8(byte[] in,
+            int ioffset, int ilength, byte[] out, int ooffset) {
         byte[] pack = pack(in, ioffset, ilength, 7, 8);
         int firstNonZero = pack.length-1;   // paste at least one byte
         for (int i=pack.length-2; i>=0; i--) {
@@ -634,7 +624,8 @@ class ObjectIdentifier implements Serializable
                 firstNonZero = i;
             }
         }
-        System.arraycopy(pack, firstNonZero, out, ooffset, pack.length-firstNonZero);
+        System.arraycopy(pack, firstNonZero,
+                out, ooffset, pack.length-firstNonZero);
         return pack.length-firstNonZero;
     }
 
@@ -686,31 +677,39 @@ class ObjectIdentifier implements Serializable
             }
         }
     }
+
     private static void checkCount(int count) throws IOException {
         if (count < 2) {
             throw new IOException("ObjectIdentifier() -- " +
                     "Must be at least two oid components ");
         }
     }
+
     private static void checkFirstComponent(int first) throws IOException {
         if (first < 0 || first > 2) {
             throw new IOException("ObjectIdentifier() -- " +
                     "First oid component is invalid ");
         }
     }
-    private static void checkFirstComponent(BigInteger first) throws IOException {
+
+    private static void checkFirstComponent(
+            BigInteger first) throws IOException {
         if (first.signum() == -1 || first.compareTo(BigInteger.TWO) > 0) {
             throw new IOException("ObjectIdentifier() -- " +
                     "First oid component is invalid ");
         }
     }
-    private static void checkSecondComponent(int first, int second) throws IOException {
+
+    private static void checkSecondComponent(
+            int first, int second) throws IOException {
         if (second < 0 || first != 2 && second > 39) {
             throw new IOException("ObjectIdentifier() -- " +
                     "Second oid component is invalid ");
         }
     }
-    private static void checkSecondComponent(int first, BigInteger second) throws IOException {
+
+    private static void checkSecondComponent(
+            int first, BigInteger second) throws IOException {
         if (second.signum() == -1 ||
                 first != 2 &&
                 second.compareTo(BigInteger.valueOf(39)) == 1) {
@@ -718,13 +717,16 @@ class ObjectIdentifier implements Serializable
                     "Second oid component is invalid ");
         }
     }
+
     private static void checkOtherComponent(int i, int num) throws IOException {
         if (num < 0) {
             throw new IOException("ObjectIdentifier() -- " +
                     "oid component #" + (i+1) + " must be non-negative ");
         }
     }
-    private static void checkOtherComponent(int i, BigInteger num) throws IOException {
+
+    private static void checkOtherComponent(
+            int i, BigInteger num) throws IOException {
         if (num.signum() == -1) {
             throw new IOException("ObjectIdentifier() -- " +
                     "oid component #" + (i+1) + " must be non-negative ");

--- a/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
+++ b/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
@@ -324,7 +324,7 @@ public final class ObjectIdentifier implements Serializable {
     // oid cache index'ed by the oid string
     private static ConcurrentHashMap<String,ObjectIdentifier> oidTable =
             new ConcurrentHashMap<>();
-    
+
     // To be removed once 8242151 is backported to 11.
     public static ObjectIdentifier of1(String oid) {
         try {

--- a/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
+++ b/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
@@ -324,6 +324,15 @@ public final class ObjectIdentifier implements Serializable {
     // oid cache index'ed by the oid string
     private static ConcurrentHashMap<String,ObjectIdentifier> oidTable =
             new ConcurrentHashMap<>();
+    
+    // To be removed once 8242151 is backported to 11.
+    public static ObjectIdentifier of1(String oid) {
+        try {
+            return new ObjectIdentifier(oid);
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
+    }
 
     public static ObjectIdentifier of(String oidStr) throws IOException {
         // check cache first

--- a/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
+++ b/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
@@ -51,9 +51,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Hemma Prafullchandra
  */
 
-public final
-class ObjectIdentifier implements Serializable
-{
+public final class ObjectIdentifier implements Serializable {
     /*
      * The maximum encoded OID length, excluding the ASN.1 encoding tag and
      * length.
@@ -72,7 +70,6 @@ class ObjectIdentifier implements Serializable
      * as the restriction in JDK.
      */
     private static final int MAXIMUM_OID_SIZE = 4096;    // 2^12
-
 
     /**
      * We use the DER value (no tag, no length) as the internal format
@@ -324,24 +321,6 @@ class ObjectIdentifier implements Serializable
         System.arraycopy(tmp, 0, encoding, 0, pos);
     }
 
-    /**
-     * This method is kept for compatibility reasons. The new implementation
-     * does the check and conversion. All around the JDK, the method is called
-     * in static blocks to initialize pre-defined ObjectIdentifieies. No
-     * obvious performance hurt will be made after this change.
-     *
-     * Old doc: Create a new ObjectIdentifier for internal use. The values are
-     * neither checked nor cloned.
-     */
-    public static ObjectIdentifier newInternal(int[] values) {
-        try {
-            return new ObjectIdentifier(values);
-        } catch (IOException ex) {
-            throw new RuntimeException(ex);
-            // Should not happen, internal calls always uses legal values.
-        }
-    }
-
     // oid cache index'ed by the oid string
     private static ConcurrentHashMap<String,ObjectIdentifier> oidTable =
             new ConcurrentHashMap<>();
@@ -378,8 +357,7 @@ class ObjectIdentifier implements Serializable
     /*
      * n.b. the only public interface is DerOutputStream.putOID()
      */
-    void encode (DerOutputStream out) throws IOException
-    {
+    void encode(DerOutputStream out) throws IOException {
         out.write (DerValue.tag_ObjectId, encoding);
     }
 
@@ -420,17 +398,21 @@ class ObjectIdentifier implements Serializable
             if ((encoding[i] & 0x80) == 0) {
                 // one section [fromPos..i]
                 if (i - fromPos + 1 > 4) {
-                    BigInteger big = new BigInteger(1, pack(encoding, fromPos, i-fromPos+1, 7, 8));
+                    BigInteger big = new BigInteger(1, pack(encoding,
+                            fromPos, i-fromPos+1, 7, 8));
                     if (fromPos == 0) {
                         result[which++] = 2;
-                        BigInteger second = big.subtract(BigInteger.valueOf(80));
-                        if (second.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) == 1) {
+                        BigInteger second =
+                                big.subtract(BigInteger.valueOf(80));
+                        if (second.compareTo(
+                                BigInteger.valueOf(Integer.MAX_VALUE)) == 1) {
                             return null;
                         } else {
                             result[which++] = second.intValue();
                         }
                     } else {
-                        if (big.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) == 1) {
+                        if (big.compareTo(
+                                BigInteger.valueOf(Integer.MAX_VALUE)) == 1) {
                             return null;
                         } else {
                             result[which++] = big.intValue();
@@ -485,7 +467,8 @@ class ObjectIdentifier implements Serializable
                         sb.append('.');
                     }
                     if (i - fromPos + 1 > 4) { // maybe big integer
-                        BigInteger big = new BigInteger(1, pack(encoding, fromPos, i-fromPos+1, 7, 8));
+                        BigInteger big = new BigInteger(
+                                1, pack(encoding, fromPos, i-fromPos+1, 7, 8));
                         if (fromPos == 0) {
                             // first section encoded with more than 4 bytes,
                             // must be 2.something

--- a/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
+++ b/src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
@@ -366,6 +366,11 @@ public final class ObjectIdentifier implements Serializable {
         }
     }
 
+    /**
+     * Returns an ObjectIdentifier instance for the specific String.
+     *
+     * If the String is not a valid OID string, an IOException is thrown.
+     */
     public static ObjectIdentifier of(String oidStr) throws IOException {
         // check cache first
         ObjectIdentifier oid = oidTable.get(oidStr);

--- a/src/java.base/share/classes/sun/security/x509/AccessDescription.java
+++ b/src/java.base/share/classes/sun/security/x509/AccessDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,16 +42,16 @@ public final class AccessDescription {
     private GeneralName accessLocation;
 
     public static final ObjectIdentifier Ad_OCSP_Id =
-        ObjectIdentifier.newInternal(new int[] {1, 3, 6, 1, 5, 5, 7, 48, 1});
+        ObjectIdentifier.of("1.3.6.1.5.5.7.48.1");
 
     public static final ObjectIdentifier Ad_CAISSUERS_Id =
-        ObjectIdentifier.newInternal(new int[] {1, 3, 6, 1, 5, 5, 7, 48, 2});
+        ObjectIdentifier.of("1.3.6.1.5.5.7.48.2");
 
     public static final ObjectIdentifier Ad_TIMESTAMPING_Id =
-        ObjectIdentifier.newInternal(new int[] {1, 3, 6, 1, 5, 5, 7, 48, 3});
+        ObjectIdentifier.of("1.3.6.1.5.5.7.48.3");
 
     public static final ObjectIdentifier Ad_CAREPOSITORY_Id =
-        ObjectIdentifier.newInternal(new int[] {1, 3, 6, 1, 5, 5, 7, 48, 5});
+        ObjectIdentifier.of("1.3.6.1.5.5.7.48.5");
 
     public AccessDescription(ObjectIdentifier accessMethod, GeneralName accessLocation) {
         this.accessMethod = accessMethod;

--- a/src/java.base/share/classes/sun/security/x509/AccessDescription.java
+++ b/src/java.base/share/classes/sun/security/x509/AccessDescription.java
@@ -42,16 +42,16 @@ public final class AccessDescription {
     private GeneralName accessLocation;
 
     public static final ObjectIdentifier Ad_OCSP_Id =
-        ObjectIdentifier.of("1.3.6.1.5.5.7.48.1");
+        ObjectIdentifier.of1("1.3.6.1.5.5.7.48.1");
 
     public static final ObjectIdentifier Ad_CAISSUERS_Id =
-        ObjectIdentifier.of("1.3.6.1.5.5.7.48.2");
+        ObjectIdentifier.of1("1.3.6.1.5.5.7.48.2");
 
     public static final ObjectIdentifier Ad_TIMESTAMPING_Id =
-        ObjectIdentifier.of("1.3.6.1.5.5.7.48.3");
+        ObjectIdentifier.of1("1.3.6.1.5.5.7.48.3");
 
     public static final ObjectIdentifier Ad_CAREPOSITORY_Id =
-        ObjectIdentifier.of("1.3.6.1.5.5.7.48.5");
+        ObjectIdentifier.of1("1.3.6.1.5.5.7.48.5");
 
     public AccessDescription(ObjectIdentifier accessMethod, GeneralName accessLocation) {
         this.accessMethod = accessMethod;

--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -677,14 +677,14 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.113549.2.2
      */
     public static final ObjectIdentifier MD2_oid =
-        ObjectIdentifier.of("1.2.840.113549.2.2");
+        ObjectIdentifier.of1("1.2.840.113549.2.2");
 
     /**
      * Algorithm ID for the MD5 Message Digest Algorthm, from RFC 1321.
      * OID = 1.2.840.113549.2.5
      */
     public static final ObjectIdentifier MD5_oid =
-        ObjectIdentifier.of("1.2.840.113549.2.5");
+        ObjectIdentifier.of1("1.2.840.113549.2.5");
 
     /**
      * Algorithm ID for the SHA1 Message Digest Algorithm, from FIPS 180-1.
@@ -693,25 +693,25 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.3.14.3.2.26. Old SHA-0 OID: 1.3.14.3.2.18.
      */
     public static final ObjectIdentifier SHA_oid =
-        ObjectIdentifier.of("1.3.14.3.2.26");
+        ObjectIdentifier.of1("1.3.14.3.2.26");
 
     public static final ObjectIdentifier SHA224_oid =
-        ObjectIdentifier.of("2.16.840.1.101.3.4.2.4");
+        ObjectIdentifier.of1("2.16.840.1.101.3.4.2.4");
 
     public static final ObjectIdentifier SHA256_oid =
-        ObjectIdentifier.of("2.16.840.1.101.3.4.2.1");
+        ObjectIdentifier.of1("2.16.840.1.101.3.4.2.1");
 
     public static final ObjectIdentifier SHA384_oid =
-        ObjectIdentifier.of("2.16.840.1.101.3.4.2.2");
+        ObjectIdentifier.of1("2.16.840.1.101.3.4.2.2");
 
     public static final ObjectIdentifier SHA512_oid =
-        ObjectIdentifier.of("2.16.840.1.101.3.4.2.3");
+        ObjectIdentifier.of1("2.16.840.1.101.3.4.2.3");
 
     public static final ObjectIdentifier SHA512_224_oid =
-        ObjectIdentifier.of("2.16.840.1.101.3.4.2.5");
+        ObjectIdentifier.of1("2.16.840.1.101.3.4.2.5");
 
     public static final ObjectIdentifier SHA512_256_oid =
-        ObjectIdentifier.of("2.16.840.1.101.3.4.2.6");
+        ObjectIdentifier.of1("2.16.840.1.101.3.4.2.6");
 
     /*
      * COMMON PUBLIC KEY TYPES
@@ -730,7 +730,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.113549.1.3.1
      */
     public static final ObjectIdentifier DH_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.3.1");
+            ObjectIdentifier.of1("1.2.840.113549.1.3.1");
 
     /**
      * Algorithm ID for the Diffie Hellman Key Agreement (DH), from RFC 3279.
@@ -738,7 +738,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.10046.2.1
      */
     public static final ObjectIdentifier DH_PKIX_oid =
-            ObjectIdentifier.of("1.2.840.10046.2.1");
+            ObjectIdentifier.of1("1.2.840.10046.2.1");
 
     /**
      * Algorithm ID for the Digital Signing Algorithm (DSA), from the
@@ -749,7 +749,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.3.14.3.2.12
      */
     public static final ObjectIdentifier DSA_OIW_oid =
-            ObjectIdentifier.of("1.3.14.3.2.12");
+            ObjectIdentifier.of1("1.3.14.3.2.12");
 
     /**
      * Algorithm ID for the Digital Signing Algorithm (DSA), from RFC 3279.
@@ -759,7 +759,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.10040.4.1
      */
     public static final ObjectIdentifier DSA_oid =
-            ObjectIdentifier.of("1.2.840.10040.4.1");
+            ObjectIdentifier.of1("1.2.840.10040.4.1");
 
     /**
      * Algorithm ID for RSA keys used for any purpose, as defined in X.509.
@@ -768,26 +768,26 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 2.5.8.1.1
      */
     public static final ObjectIdentifier RSA_oid =
-            ObjectIdentifier.of("2.5.8.1.1");
+            ObjectIdentifier.of1("2.5.8.1.1");
 
     public static final ObjectIdentifier EC_oid =
-            ObjectIdentifier.of("1.2.840.10045.2.1");
+            ObjectIdentifier.of1("1.2.840.10045.2.1");
     public static final ObjectIdentifier ECDH_oid =
-            ObjectIdentifier.of("1.3.132.1.12");
+            ObjectIdentifier.of1("1.3.132.1.12");
     public static final ObjectIdentifier RSAEncryption_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.1.1");
+            ObjectIdentifier.of1("1.2.840.113549.1.1.1");
     public static final ObjectIdentifier RSAES_OAEP_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.1.7");
+            ObjectIdentifier.of1("1.2.840.113549.1.1.7");
     public static final ObjectIdentifier mgf1_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.1.8");
+            ObjectIdentifier.of1("1.2.840.113549.1.1.8");
     public static final ObjectIdentifier RSASSA_PSS_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.1.10");
+            ObjectIdentifier.of1("1.2.840.113549.1.1.10");
 
     /*
      * COMMON SECRET KEY TYPES
      */
     public static final ObjectIdentifier AES_oid =
-            ObjectIdentifier.of("2.16.840.1.101.3.4.1");
+            ObjectIdentifier.of1("2.16.840.1.101.3.4.1");
 
     /*
      * COMMON SIGNATURE ALGORITHMS
@@ -799,7 +799,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.113549.1.1.2
      */
     public static final ObjectIdentifier md2WithRSAEncryption_oid =
-        ObjectIdentifier.of("1.2.840.113549.1.1.2");
+        ObjectIdentifier.of1("1.2.840.113549.1.1.2");
 
     /**
      * Identifies a signing algorithm where an MD5 digest is
@@ -807,7 +807,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.113549.1.1.4
      */
     public static final ObjectIdentifier md5WithRSAEncryption_oid =
-        ObjectIdentifier.of("1.2.840.113549.1.1.4");
+        ObjectIdentifier.of1("1.2.840.113549.1.1.4");
 
     /**
      * Identifies a signing algorithm where a SHA1 digest is
@@ -815,7 +815,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.113549.1.1.5
      */
     public static final ObjectIdentifier sha1WithRSAEncryption_oid =
-        ObjectIdentifier.of("1.2.840.113549.1.1.5");
+        ObjectIdentifier.of1("1.2.840.113549.1.1.5");
 
     /**
      * Identifies a signing algorithm where a SHA1 digest is
@@ -823,7 +823,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.3.14.3.2.29
      */
     public static final ObjectIdentifier sha1WithRSAEncryption_OIW_oid =
-        ObjectIdentifier.of("1.3.14.3.2.29");
+        ObjectIdentifier.of1("1.3.14.3.2.29");
 
     /**
      * Identifies a signing algorithm where a SHA224 digest is
@@ -831,7 +831,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.113549.1.1.14
      */
     public static final ObjectIdentifier sha224WithRSAEncryption_oid =
-        ObjectIdentifier.of("1.2.840.113549.1.1.14");
+        ObjectIdentifier.of1("1.2.840.113549.1.1.14");
 
     /**
      * Identifies a signing algorithm where a SHA256 digest is
@@ -839,7 +839,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.113549.1.1.11
      */
     public static final ObjectIdentifier sha256WithRSAEncryption_oid =
-        ObjectIdentifier.of("1.2.840.113549.1.1.11");
+        ObjectIdentifier.of1("1.2.840.113549.1.1.11");
 
     /**
      * Identifies a signing algorithm where a SHA384 digest is
@@ -847,7 +847,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.113549.1.1.12
      */
     public static final ObjectIdentifier sha384WithRSAEncryption_oid =
-        ObjectIdentifier.of("1.2.840.113549.1.1.12");
+        ObjectIdentifier.of1("1.2.840.113549.1.1.12");
 
     /**
      * Identifies a signing algorithm where a SHA512 digest is
@@ -855,7 +855,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.113549.1.1.13
      */
     public static final ObjectIdentifier sha512WithRSAEncryption_oid =
-        ObjectIdentifier.of("1.2.840.113549.1.1.13");
+        ObjectIdentifier.of1("1.2.840.113549.1.1.13");
 
     /**
      * Identifies the FIPS 186 "Digital Signature Standard" (DSS), where a
@@ -864,7 +864,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.3.14.3.2.13
      */
     public static final ObjectIdentifier shaWithDSA_OIW_oid =
-            ObjectIdentifier.of("1.3.14.3.2.13");
+            ObjectIdentifier.of1("1.3.14.3.2.13");
 
     /**
      * Identifies the FIPS 186 "Digital Signature Standard" (DSS), where a
@@ -872,7 +872,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.3.14.3.2.27
      */
     public static final ObjectIdentifier sha1WithDSA_OIW_oid =
-            ObjectIdentifier.of("1.3.14.3.2.27");
+            ObjectIdentifier.of1("1.3.14.3.2.27");
 
     /**
      * Identifies the FIPS 186 "Digital Signature Standard" (DSS), where a
@@ -880,53 +880,53 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.10040.4.3
      */
     public static final ObjectIdentifier sha1WithDSA_oid =
-            ObjectIdentifier.of("1.2.840.10040.4.3");
+            ObjectIdentifier.of1("1.2.840.10040.4.3");
 
     public static final ObjectIdentifier sha512_224WithRSAEncryption_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.1.15");
+            ObjectIdentifier.of1("1.2.840.113549.1.1.15");
     public static final ObjectIdentifier sha512_256WithRSAEncryption_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.1.16");
+            ObjectIdentifier.of1("1.2.840.113549.1.1.16");
 
     public static final ObjectIdentifier sha224WithDSA_oid =
-            ObjectIdentifier.of("2.16.840.1.101.3.4.3.1");
+            ObjectIdentifier.of1("2.16.840.1.101.3.4.3.1");
     public static final ObjectIdentifier sha256WithDSA_oid =
-            ObjectIdentifier.of("2.16.840.1.101.3.4.3.2");
+            ObjectIdentifier.of1("2.16.840.1.101.3.4.3.2");
 
     public static final ObjectIdentifier sha1WithECDSA_oid =
-            ObjectIdentifier.of("1.2.840.10045.4.1");
+            ObjectIdentifier.of1("1.2.840.10045.4.1");
     public static final ObjectIdentifier sha224WithECDSA_oid =
-            ObjectIdentifier.of("1.2.840.10045.4.3.1");
+            ObjectIdentifier.of1("1.2.840.10045.4.3.1");
     public static final ObjectIdentifier sha256WithECDSA_oid =
-            ObjectIdentifier.of("1.2.840.10045.4.3.2");
+            ObjectIdentifier.of1("1.2.840.10045.4.3.2");
     public static final ObjectIdentifier sha384WithECDSA_oid =
-            ObjectIdentifier.of("1.2.840.10045.4.3.3");
+            ObjectIdentifier.of1("1.2.840.10045.4.3.3");
     public static final ObjectIdentifier sha512WithECDSA_oid =
-            ObjectIdentifier.of("1.2.840.10045.4.3.4");
+            ObjectIdentifier.of1("1.2.840.10045.4.3.4");
     public static final ObjectIdentifier specifiedWithECDSA_oid =
-            ObjectIdentifier.of("1.2.840.10045.4.3");
+            ObjectIdentifier.of1("1.2.840.10045.4.3");
 
     /**
      * Algorithm ID for the PBE encryption algorithms from PKCS#5 and
      * PKCS#12.
      */
     public static final ObjectIdentifier pbeWithMD5AndDES_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.5.3");
+            ObjectIdentifier.of1("1.2.840.113549.1.5.3");
     public static final ObjectIdentifier pbeWithMD5AndRC2_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.5.6");
+            ObjectIdentifier.of1("1.2.840.113549.1.5.6");
     public static final ObjectIdentifier pbeWithSHA1AndDES_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.5.10");
+            ObjectIdentifier.of1("1.2.840.113549.1.5.10");
     public static final ObjectIdentifier pbeWithSHA1AndRC2_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.5.11");
+            ObjectIdentifier.of1("1.2.840.113549.1.5.11");
     public static final ObjectIdentifier pbeWithSHA1AndRC4_128_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.12.1.1");
+            ObjectIdentifier.of1("1.2.840.113549.1.12.1.1");
     public static final ObjectIdentifier pbeWithSHA1AndRC4_40_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.12.1.2");
+            ObjectIdentifier.of1("1.2.840.113549.1.12.1.2");
     public static final ObjectIdentifier pbeWithSHA1AndDESede_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.12.1.3");
+            ObjectIdentifier.of1("1.2.840.113549.1.12.1.3");
     public static final ObjectIdentifier pbeWithSHA1AndRC2_128_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.12.1.5");
+            ObjectIdentifier.of1("1.2.840.113549.1.12.1.5");
     public static final ObjectIdentifier pbeWithSHA1AndRC2_40_oid =
-            ObjectIdentifier.of("1.2.840.113549.1.12.1.6");
+            ObjectIdentifier.of1("1.2.840.113549.1.12.1.6");
 
     static {
         nameTable = new HashMap<>();

--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -618,10 +618,6 @@ public class AlgorithmId implements Serializable, DerEncoder {
         return oidTable().get(name.toUpperCase(Locale.ENGLISH));
     }
 
-    private static ObjectIdentifier oid(int ... values) {
-        return ObjectIdentifier.newInternal(values);
-    }
-
     private static volatile Map<String,ObjectIdentifier> oidTable;
     private static final Map<ObjectIdentifier,String> nameTable;
 
@@ -681,14 +677,14 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.2.840.113549.2.2
      */
     public static final ObjectIdentifier MD2_oid =
-    ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 2, 2});
+        ObjectIdentifier.of("1.2.840.113549.2.2");
 
     /**
      * Algorithm ID for the MD5 Message Digest Algorthm, from RFC 1321.
      * OID = 1.2.840.113549.2.5
      */
     public static final ObjectIdentifier MD5_oid =
-    ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 2, 5});
+        ObjectIdentifier.of("1.2.840.113549.2.5");
 
     /**
      * Algorithm ID for the SHA1 Message Digest Algorithm, from FIPS 180-1.
@@ -697,142 +693,29 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * OID = 1.3.14.3.2.26. Old SHA-0 OID: 1.3.14.3.2.18.
      */
     public static final ObjectIdentifier SHA_oid =
-    ObjectIdentifier.newInternal(new int[] {1, 3, 14, 3, 2, 26});
+        ObjectIdentifier.of("1.3.14.3.2.26");
 
     public static final ObjectIdentifier SHA224_oid =
-    ObjectIdentifier.newInternal(new int[] {2, 16, 840, 1, 101, 3, 4, 2, 4});
+        ObjectIdentifier.of("2.16.840.1.101.3.4.2.4");
 
     public static final ObjectIdentifier SHA256_oid =
-    ObjectIdentifier.newInternal(new int[] {2, 16, 840, 1, 101, 3, 4, 2, 1});
+        ObjectIdentifier.of("2.16.840.1.101.3.4.2.1");
 
     public static final ObjectIdentifier SHA384_oid =
-    ObjectIdentifier.newInternal(new int[] {2, 16, 840, 1, 101, 3, 4, 2, 2});
+        ObjectIdentifier.of("2.16.840.1.101.3.4.2.2");
 
     public static final ObjectIdentifier SHA512_oid =
-    ObjectIdentifier.newInternal(new int[] {2, 16, 840, 1, 101, 3, 4, 2, 3});
+        ObjectIdentifier.of("2.16.840.1.101.3.4.2.3");
 
     public static final ObjectIdentifier SHA512_224_oid =
-    ObjectIdentifier.newInternal(new int[] {2, 16, 840, 1, 101, 3, 4, 2, 5});
+        ObjectIdentifier.of("2.16.840.1.101.3.4.2.5");
 
     public static final ObjectIdentifier SHA512_256_oid =
-    ObjectIdentifier.newInternal(new int[] {2, 16, 840, 1, 101, 3, 4, 2, 6});
+        ObjectIdentifier.of("2.16.840.1.101.3.4.2.6");
 
     /*
      * COMMON PUBLIC KEY TYPES
      */
-    private static final int[] DH_data = { 1, 2, 840, 113549, 1, 3, 1 };
-    private static final int[] DH_PKIX_data = { 1, 2, 840, 10046, 2, 1 };
-    private static final int[] DSA_OIW_data = { 1, 3, 14, 3, 2, 12 };
-    private static final int[] DSA_PKIX_data = { 1, 2, 840, 10040, 4, 1 };
-    private static final int[] RSA_data = { 2, 5, 8, 1, 1 };
-
-    public static final ObjectIdentifier DH_oid;
-    public static final ObjectIdentifier DH_PKIX_oid;
-    public static final ObjectIdentifier DSA_oid;
-    public static final ObjectIdentifier DSA_OIW_oid;
-    public static final ObjectIdentifier EC_oid = oid(1, 2, 840, 10045, 2, 1);
-    public static final ObjectIdentifier ECDH_oid = oid(1, 3, 132, 1, 12);
-    public static final ObjectIdentifier RSA_oid;
-    public static final ObjectIdentifier RSAEncryption_oid =
-                                            oid(1, 2, 840, 113549, 1, 1, 1);
-    public static final ObjectIdentifier RSAES_OAEP_oid =
-                                            oid(1, 2, 840, 113549, 1, 1, 7);
-    public static final ObjectIdentifier mgf1_oid =
-                                            oid(1, 2, 840, 113549, 1, 1, 8);
-    public static final ObjectIdentifier RSASSA_PSS_oid =
-                                            oid(1, 2, 840, 113549, 1, 1, 10);
-
-    /*
-     * COMMON SECRET KEY TYPES
-     */
-    public static final ObjectIdentifier AES_oid =
-                                            oid(2, 16, 840, 1, 101, 3, 4, 1);
-
-    /*
-     * COMMON SIGNATURE ALGORITHMS
-     */
-    private static final int[] md2WithRSAEncryption_data =
-                                       { 1, 2, 840, 113549, 1, 1, 2 };
-    private static final int[] md5WithRSAEncryption_data =
-                                       { 1, 2, 840, 113549, 1, 1, 4 };
-    private static final int[] sha1WithRSAEncryption_data =
-                                       { 1, 2, 840, 113549, 1, 1, 5 };
-    private static final int[] sha1WithRSAEncryption_OIW_data =
-                                       { 1, 3, 14, 3, 2, 29 };
-    private static final int[] sha224WithRSAEncryption_data =
-                                       { 1, 2, 840, 113549, 1, 1, 14 };
-    private static final int[] sha256WithRSAEncryption_data =
-                                       { 1, 2, 840, 113549, 1, 1, 11 };
-    private static final int[] sha384WithRSAEncryption_data =
-                                       { 1, 2, 840, 113549, 1, 1, 12 };
-    private static final int[] sha512WithRSAEncryption_data =
-                                       { 1, 2, 840, 113549, 1, 1, 13 };
-
-    private static final int[] shaWithDSA_OIW_data =
-                                       { 1, 3, 14, 3, 2, 13 };
-    private static final int[] sha1WithDSA_OIW_data =
-                                       { 1, 3, 14, 3, 2, 27 };
-    private static final int[] dsaWithSHA1_PKIX_data =
-                                       { 1, 2, 840, 10040, 4, 3 };
-
-    public static final ObjectIdentifier md2WithRSAEncryption_oid;
-    public static final ObjectIdentifier md5WithRSAEncryption_oid;
-    public static final ObjectIdentifier sha1WithRSAEncryption_oid;
-    public static final ObjectIdentifier sha1WithRSAEncryption_OIW_oid;
-    public static final ObjectIdentifier sha224WithRSAEncryption_oid;
-    public static final ObjectIdentifier sha256WithRSAEncryption_oid;
-    public static final ObjectIdentifier sha384WithRSAEncryption_oid;
-    public static final ObjectIdentifier sha512WithRSAEncryption_oid;
-    public static final ObjectIdentifier sha512_224WithRSAEncryption_oid =
-                                            oid(1, 2, 840, 113549, 1, 1, 15);
-    public static final ObjectIdentifier sha512_256WithRSAEncryption_oid =
-                                            oid(1, 2, 840, 113549, 1, 1, 16);;
-
-    public static final ObjectIdentifier shaWithDSA_OIW_oid;
-    public static final ObjectIdentifier sha1WithDSA_OIW_oid;
-    public static final ObjectIdentifier sha1WithDSA_oid;
-    public static final ObjectIdentifier sha224WithDSA_oid =
-                                            oid(2, 16, 840, 1, 101, 3, 4, 3, 1);
-    public static final ObjectIdentifier sha256WithDSA_oid =
-                                            oid(2, 16, 840, 1, 101, 3, 4, 3, 2);
-
-    public static final ObjectIdentifier sha1WithECDSA_oid =
-                                            oid(1, 2, 840, 10045, 4, 1);
-    public static final ObjectIdentifier sha224WithECDSA_oid =
-                                            oid(1, 2, 840, 10045, 4, 3, 1);
-    public static final ObjectIdentifier sha256WithECDSA_oid =
-                                            oid(1, 2, 840, 10045, 4, 3, 2);
-    public static final ObjectIdentifier sha384WithECDSA_oid =
-                                            oid(1, 2, 840, 10045, 4, 3, 3);
-    public static final ObjectIdentifier sha512WithECDSA_oid =
-                                            oid(1, 2, 840, 10045, 4, 3, 4);
-    public static final ObjectIdentifier specifiedWithECDSA_oid =
-                                            oid(1, 2, 840, 10045, 4, 3);
-
-    /**
-     * Algorithm ID for the PBE encryption algorithms from PKCS#5 and
-     * PKCS#12.
-     */
-    public static final ObjectIdentifier pbeWithMD5AndDES_oid =
-        ObjectIdentifier.newInternal(new int[]{1, 2, 840, 113549, 1, 5, 3});
-    public static final ObjectIdentifier pbeWithMD5AndRC2_oid =
-        ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 5, 6});
-    public static final ObjectIdentifier pbeWithSHA1AndDES_oid =
-        ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 5, 10});
-    public static final ObjectIdentifier pbeWithSHA1AndRC2_oid =
-        ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 5, 11});
-    public static ObjectIdentifier pbeWithSHA1AndRC4_128_oid =
-        ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 12, 1, 1});
-    public static ObjectIdentifier pbeWithSHA1AndRC4_40_oid =
-        ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 12, 1, 2});
-    public static ObjectIdentifier pbeWithSHA1AndDESede_oid =
-        ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 12, 1, 3});
-    public static ObjectIdentifier pbeWithSHA1AndRC2_128_oid =
-        ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 12, 1, 5});
-    public static ObjectIdentifier pbeWithSHA1AndRC2_40_oid =
-        ObjectIdentifier.newInternal(new int[] {1, 2, 840, 113549, 1, 12, 1, 6});
-
-    static {
     /*
      * Note the preferred OIDs are named simply with no "OIW" or
      * "PKIX" in them, even though they may point to data from these
@@ -846,14 +729,16 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * certificate.
      * OID = 1.2.840.113549.1.3.1
      */
-        DH_oid = ObjectIdentifier.newInternal(DH_data);
+    public static final ObjectIdentifier DH_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.3.1");
 
     /**
      * Algorithm ID for the Diffie Hellman Key Agreement (DH), from RFC 3279.
      * Parameters may include public values P and G.
      * OID = 1.2.840.10046.2.1
      */
-        DH_PKIX_oid = ObjectIdentifier.newInternal(DH_PKIX_data);
+    public static final ObjectIdentifier DH_PKIX_oid =
+            ObjectIdentifier.of("1.2.840.10046.2.1");
 
     /**
      * Algorithm ID for the Digital Signing Algorithm (DSA), from the
@@ -863,7 +748,8 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * another source such as a Certificate Authority's certificate.
      * OID = 1.3.14.3.2.12
      */
-        DSA_OIW_oid = ObjectIdentifier.newInternal(DSA_OIW_data);
+    public static final ObjectIdentifier DSA_OIW_oid =
+            ObjectIdentifier.of("1.3.14.3.2.12");
 
     /**
      * Algorithm ID for the Digital Signing Algorithm (DSA), from RFC 3279.
@@ -872,7 +758,8 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * certificate.
      * OID = 1.2.840.10040.4.1
      */
-        DSA_oid = ObjectIdentifier.newInternal(DSA_PKIX_data);
+    public static final ObjectIdentifier DSA_oid =
+            ObjectIdentifier.of("1.2.840.10040.4.1");
 
     /**
      * Algorithm ID for RSA keys used for any purpose, as defined in X.509.
@@ -880,72 +767,95 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * public modulus.
      * OID = 2.5.8.1.1
      */
-        RSA_oid = ObjectIdentifier.newInternal(RSA_data);
+    public static final ObjectIdentifier RSA_oid =
+            ObjectIdentifier.of("2.5.8.1.1");
 
+    public static final ObjectIdentifier EC_oid =
+            ObjectIdentifier.of("1.2.840.10045.2.1");
+    public static final ObjectIdentifier ECDH_oid =
+            ObjectIdentifier.of("1.3.132.1.12");
+    public static final ObjectIdentifier RSAEncryption_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.1.1");
+    public static final ObjectIdentifier RSAES_OAEP_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.1.7");
+    public static final ObjectIdentifier mgf1_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.1.8");
+    public static final ObjectIdentifier RSASSA_PSS_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.1.10");
+
+    /*
+     * COMMON SECRET KEY TYPES
+     */
+    public static final ObjectIdentifier AES_oid =
+            ObjectIdentifier.of("2.16.840.1.101.3.4.1");
+
+    /*
+     * COMMON SIGNATURE ALGORITHMS
+     */
     /**
      * Identifies a signing algorithm where an MD2 digest is encrypted
      * using an RSA private key; defined in PKCS #1.  Use of this
      * signing algorithm is discouraged due to MD2 vulnerabilities.
      * OID = 1.2.840.113549.1.1.2
      */
-        md2WithRSAEncryption_oid =
-            ObjectIdentifier.newInternal(md2WithRSAEncryption_data);
+    public static final ObjectIdentifier md2WithRSAEncryption_oid =
+        ObjectIdentifier.of("1.2.840.113549.1.1.2");
 
     /**
      * Identifies a signing algorithm where an MD5 digest is
      * encrypted using an RSA private key; defined in PKCS #1.
      * OID = 1.2.840.113549.1.1.4
      */
-        md5WithRSAEncryption_oid =
-            ObjectIdentifier.newInternal(md5WithRSAEncryption_data);
+    public static final ObjectIdentifier md5WithRSAEncryption_oid =
+        ObjectIdentifier.of("1.2.840.113549.1.1.4");
 
     /**
      * Identifies a signing algorithm where a SHA1 digest is
      * encrypted using an RSA private key; defined by RSA DSI.
      * OID = 1.2.840.113549.1.1.5
      */
-        sha1WithRSAEncryption_oid =
-            ObjectIdentifier.newInternal(sha1WithRSAEncryption_data);
+    public static final ObjectIdentifier sha1WithRSAEncryption_oid =
+        ObjectIdentifier.of("1.2.840.113549.1.1.5");
 
     /**
      * Identifies a signing algorithm where a SHA1 digest is
      * encrypted using an RSA private key; defined in NIST OIW.
      * OID = 1.3.14.3.2.29
      */
-        sha1WithRSAEncryption_OIW_oid =
-            ObjectIdentifier.newInternal(sha1WithRSAEncryption_OIW_data);
+    public static final ObjectIdentifier sha1WithRSAEncryption_OIW_oid =
+        ObjectIdentifier.of("1.3.14.3.2.29");
 
     /**
      * Identifies a signing algorithm where a SHA224 digest is
      * encrypted using an RSA private key; defined by PKCS #1.
      * OID = 1.2.840.113549.1.1.14
      */
-        sha224WithRSAEncryption_oid =
-            ObjectIdentifier.newInternal(sha224WithRSAEncryption_data);
+    public static final ObjectIdentifier sha224WithRSAEncryption_oid =
+        ObjectIdentifier.of("1.2.840.113549.1.1.14");
 
     /**
      * Identifies a signing algorithm where a SHA256 digest is
      * encrypted using an RSA private key; defined by PKCS #1.
      * OID = 1.2.840.113549.1.1.11
      */
-        sha256WithRSAEncryption_oid =
-            ObjectIdentifier.newInternal(sha256WithRSAEncryption_data);
+    public static final ObjectIdentifier sha256WithRSAEncryption_oid =
+        ObjectIdentifier.of("1.2.840.113549.1.1.11");
 
     /**
      * Identifies a signing algorithm where a SHA384 digest is
      * encrypted using an RSA private key; defined by PKCS #1.
      * OID = 1.2.840.113549.1.1.12
      */
-        sha384WithRSAEncryption_oid =
-            ObjectIdentifier.newInternal(sha384WithRSAEncryption_data);
+    public static final ObjectIdentifier sha384WithRSAEncryption_oid =
+        ObjectIdentifier.of("1.2.840.113549.1.1.12");
 
     /**
      * Identifies a signing algorithm where a SHA512 digest is
      * encrypted using an RSA private key; defined by PKCS #1.
      * OID = 1.2.840.113549.1.1.13
      */
-        sha512WithRSAEncryption_oid =
-            ObjectIdentifier.newInternal(sha512WithRSAEncryption_data);
+    public static final ObjectIdentifier sha512WithRSAEncryption_oid =
+        ObjectIdentifier.of("1.2.840.113549.1.1.13");
 
     /**
      * Identifies the FIPS 186 "Digital Signature Standard" (DSS), where a
@@ -953,22 +863,72 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * This should not be used.
      * OID = 1.3.14.3.2.13
      */
-        shaWithDSA_OIW_oid = ObjectIdentifier.newInternal(shaWithDSA_OIW_data);
+    public static final ObjectIdentifier shaWithDSA_OIW_oid =
+            ObjectIdentifier.of("1.3.14.3.2.13");
 
     /**
      * Identifies the FIPS 186 "Digital Signature Standard" (DSS), where a
      * SHA1 digest is signed using the Digital Signing Algorithm (DSA).
      * OID = 1.3.14.3.2.27
      */
-        sha1WithDSA_OIW_oid = ObjectIdentifier.newInternal(sha1WithDSA_OIW_data);
+    public static final ObjectIdentifier sha1WithDSA_OIW_oid =
+            ObjectIdentifier.of("1.3.14.3.2.27");
 
     /**
      * Identifies the FIPS 186 "Digital Signature Standard" (DSS), where a
      * SHA1 digest is signed using the Digital Signing Algorithm (DSA).
      * OID = 1.2.840.10040.4.3
      */
-        sha1WithDSA_oid = ObjectIdentifier.newInternal(dsaWithSHA1_PKIX_data);
+    public static final ObjectIdentifier sha1WithDSA_oid =
+            ObjectIdentifier.of("1.2.840.10040.4.3");
 
+    public static final ObjectIdentifier sha512_224WithRSAEncryption_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.1.15");
+    public static final ObjectIdentifier sha512_256WithRSAEncryption_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.1.16");
+
+    public static final ObjectIdentifier sha224WithDSA_oid =
+            ObjectIdentifier.of("2.16.840.1.101.3.4.3.1");
+    public static final ObjectIdentifier sha256WithDSA_oid =
+            ObjectIdentifier.of("2.16.840.1.101.3.4.3.2");
+
+    public static final ObjectIdentifier sha1WithECDSA_oid =
+            ObjectIdentifier.of("1.2.840.10045.4.1");
+    public static final ObjectIdentifier sha224WithECDSA_oid =
+            ObjectIdentifier.of("1.2.840.10045.4.3.1");
+    public static final ObjectIdentifier sha256WithECDSA_oid =
+            ObjectIdentifier.of("1.2.840.10045.4.3.2");
+    public static final ObjectIdentifier sha384WithECDSA_oid =
+            ObjectIdentifier.of("1.2.840.10045.4.3.3");
+    public static final ObjectIdentifier sha512WithECDSA_oid =
+            ObjectIdentifier.of("1.2.840.10045.4.3.4");
+    public static final ObjectIdentifier specifiedWithECDSA_oid =
+            ObjectIdentifier.of("1.2.840.10045.4.3");
+
+    /**
+     * Algorithm ID for the PBE encryption algorithms from PKCS#5 and
+     * PKCS#12.
+     */
+    public static final ObjectIdentifier pbeWithMD5AndDES_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.5.3");
+    public static final ObjectIdentifier pbeWithMD5AndRC2_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.5.6");
+    public static final ObjectIdentifier pbeWithSHA1AndDES_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.5.10");
+    public static final ObjectIdentifier pbeWithSHA1AndRC2_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.5.11");
+    public static final ObjectIdentifier pbeWithSHA1AndRC4_128_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.12.1.1");
+    public static final ObjectIdentifier pbeWithSHA1AndRC4_40_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.12.1.2");
+    public static final ObjectIdentifier pbeWithSHA1AndDESede_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.12.1.3");
+    public static final ObjectIdentifier pbeWithSHA1AndRC2_128_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.12.1.5");
+    public static final ObjectIdentifier pbeWithSHA1AndRC2_40_oid =
+            ObjectIdentifier.of("1.2.840.113549.1.12.1.6");
+
+    static {
         nameTable = new HashMap<>();
         nameTable.put(MD5_oid, "MD5");
         nameTable.put(MD2_oid, "MD2");

--- a/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,30 +97,19 @@ implements CertAttrSet<String> {
     // OID defined in RFC 5280 Sections 4.2.1.12
     // more from http://www.alvestrand.no/objectid/1.3.6.1.5.5.7.3.html
     private static final Map <ObjectIdentifier, String> map =
-            new HashMap <ObjectIdentifier, String> ();
-
-    private static final int[] anyExtendedKeyUsageOidData = {2, 5, 29, 37, 0};
-    private static final int[] serverAuthOidData = {1, 3, 6, 1, 5, 5, 7, 3, 1};
-    private static final int[] clientAuthOidData = {1, 3, 6, 1, 5, 5, 7, 3, 2};
-    private static final int[] codeSigningOidData = {1, 3, 6, 1, 5, 5, 7, 3, 3};
-    private static final int[] emailProtectionOidData = {1, 3, 6, 1, 5, 5, 7, 3, 4};
-    private static final int[] ipsecEndSystemOidData = {1, 3, 6, 1, 5, 5, 7, 3, 5};
-    private static final int[] ipsecTunnelOidData = {1, 3, 6, 1, 5, 5, 7, 3, 6};
-    private static final int[] ipsecUserOidData = {1, 3, 6, 1, 5, 5, 7, 3, 7};
-    private static final int[] timeStampingOidData = {1, 3, 6, 1, 5, 5, 7, 3, 8};
-    private static final int[] OCSPSigningOidData = {1, 3, 6, 1, 5, 5, 7, 3, 9};
+            new HashMap<ObjectIdentifier, String>();
 
     static {
-        map.put(ObjectIdentifier.newInternal(anyExtendedKeyUsageOidData), "anyExtendedKeyUsage");
-        map.put(ObjectIdentifier.newInternal(serverAuthOidData), "serverAuth");
-        map.put(ObjectIdentifier.newInternal(clientAuthOidData), "clientAuth");
-        map.put(ObjectIdentifier.newInternal(codeSigningOidData), "codeSigning");
-        map.put(ObjectIdentifier.newInternal(emailProtectionOidData), "emailProtection");
-        map.put(ObjectIdentifier.newInternal(ipsecEndSystemOidData), "ipsecEndSystem");
-        map.put(ObjectIdentifier.newInternal(ipsecTunnelOidData), "ipsecTunnel");
-        map.put(ObjectIdentifier.newInternal(ipsecUserOidData), "ipsecUser");
-        map.put(ObjectIdentifier.newInternal(timeStampingOidData), "timeStamping");
-        map.put(ObjectIdentifier.newInternal(OCSPSigningOidData), "OCSPSigning");
+        map.put(ObjectIdentifier.of("2.5.29.37.0"), "anyExtendedKeyUsage");
+        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.1"), "serverAuth");
+        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.2"), "clientAuth");
+        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.3"), "codeSigning");
+        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.4"), "emailProtection");
+        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.5"), "ipsecEndSystem");
+        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.6"), "ipsecTunnel");
+        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.7"), "ipsecUser");
+        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.8"), "timeStamping");
+        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.9"), "OCSPSigning");
     };
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
@@ -100,16 +100,16 @@ implements CertAttrSet<String> {
             new HashMap<ObjectIdentifier, String>();
 
     static {
-        map.put(ObjectIdentifier.of("2.5.29.37.0"), "anyExtendedKeyUsage");
-        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.1"), "serverAuth");
-        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.2"), "clientAuth");
-        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.3"), "codeSigning");
-        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.4"), "emailProtection");
-        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.5"), "ipsecEndSystem");
-        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.6"), "ipsecTunnel");
-        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.7"), "ipsecUser");
-        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.8"), "timeStamping");
-        map.put(ObjectIdentifier.of("1.3.6.1.5.5.7.3.9"), "OCSPSigning");
+        map.put(ObjectIdentifier.of1("2.5.29.37.0"), "anyExtendedKeyUsage");
+        map.put(ObjectIdentifier.of1("1.3.6.1.5.5.7.3.1"), "serverAuth");
+        map.put(ObjectIdentifier.of1("1.3.6.1.5.5.7.3.2"), "clientAuth");
+        map.put(ObjectIdentifier.of1("1.3.6.1.5.5.7.3.3"), "codeSigning");
+        map.put(ObjectIdentifier.of1("1.3.6.1.5.5.7.3.4"), "emailProtection");
+        map.put(ObjectIdentifier.of1("1.3.6.1.5.5.7.3.5"), "ipsecEndSystem");
+        map.put(ObjectIdentifier.of1("1.3.6.1.5.5.7.3.6"), "ipsecTunnel");
+        map.put(ObjectIdentifier.of1("1.3.6.1.5.5.7.3.7"), "ipsecUser");
+        map.put(ObjectIdentifier.of1("1.3.6.1.5.5.7.3.8"), "timeStamping");
+        map.put(ObjectIdentifier.of1("1.3.6.1.5.5.7.3.9"), "OCSPSigning");
     };
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/GeneralSubtrees.java
+++ b/src/java.base/share/classes/sun/security/x509/GeneralSubtrees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -270,8 +270,7 @@ public class GeneralSubtrees implements Cloneable {
                 newName = new GeneralName(new IPAddressName((byte[])null));
                 break;
             case GeneralNameInterface.NAME_OID:
-                newName = new GeneralName
-                    (new OIDName(new ObjectIdentifier((int[])null)));
+                newName = new GeneralName(new OIDName(""));
                 break;
             default:
                 throw new IOException

--- a/src/java.base/share/classes/sun/security/x509/InhibitAnyPolicyExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/InhibitAnyPolicyExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,14 +75,8 @@ implements CertAttrSet<String> {
     /**
      * Object identifier for "any-policy"
      */
-    public static ObjectIdentifier AnyPolicy_Id;
-    static {
-        try {
-            AnyPolicy_Id = new ObjectIdentifier("2.5.29.32.0");
-        } catch (IOException ioe) {
-            // Should not happen
-        }
-    }
+    public static ObjectIdentifier AnyPolicy_Id =
+            ObjectIdentifier.of("2.5.29.32.0");
 
     /**
      * Attribute names.

--- a/src/java.base/share/classes/sun/security/x509/InhibitAnyPolicyExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/InhibitAnyPolicyExtension.java
@@ -76,7 +76,7 @@ implements CertAttrSet<String> {
      * Object identifier for "any-policy"
      */
     public static ObjectIdentifier AnyPolicy_Id =
-            ObjectIdentifier.of("2.5.29.32.0");
+            ObjectIdentifier.of1("2.5.29.32.0");
 
     /**
      * Attribute names.

--- a/src/java.base/share/classes/sun/security/x509/NetscapeCertTypeExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NetscapeCertTypeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,20 +69,11 @@ implements CertAttrSet<String> {
     public static final String S_MIME_CA = "s_mime_ca";
     public static final String OBJECT_SIGNING_CA = "object_signing_ca";
 
-    private static final int[] CertType_data = { 2, 16, 840, 1, 113730, 1, 1 };
-
     /**
      * Object identifier for the Netscape-Cert-Type extension.
      */
-    public static ObjectIdentifier NetscapeCertType_Id;
-
-    static {
-        try {
-            NetscapeCertType_Id = new ObjectIdentifier(CertType_data);
-        } catch (IOException ioe) {
-            // should not happen
-        }
-    }
+    public static ObjectIdentifier NetscapeCertType_Id =
+            ObjectIdentifier.of("2.16.840.1.113730.1.1");
 
     private boolean[] bitString;
 

--- a/src/java.base/share/classes/sun/security/x509/NetscapeCertTypeExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NetscapeCertTypeExtension.java
@@ -73,7 +73,7 @@ implements CertAttrSet<String> {
      * Object identifier for the Netscape-Cert-Type extension.
      */
     public static ObjectIdentifier NetscapeCertType_Id =
-            ObjectIdentifier.of("2.16.840.1.113730.1.1");
+            ObjectIdentifier.of1("2.16.840.1.113730.1.1");
 
     private boolean[] bitString;
 

--- a/src/java.base/share/classes/sun/security/x509/OIDMap.java
+++ b/src/java.base/share/classes/sun/security/x509/OIDMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,9 +102,6 @@ public class OIDMap {
     private static final String OCSPNOCHECK = ROOT + "." +
                                         OCSPNoCheckExtension.NAME;
 
-    private static final int[] NetscapeCertType_data =
-        { 2, 16, 840, 1, 113730, 1, 1 };
-
     /** Map ObjectIdentifier(oid) -> OIDInfo(info) */
     private static final Map<ObjectIdentifier,OIDInfo> oidMap;
 
@@ -138,8 +135,8 @@ public class OIDMap {
                     "sun.security.x509.AuthorityKeyIdentifierExtension");
         addInternal(POLICY_CONSTRAINTS, PKIXExtensions.PolicyConstraints_Id,
                     "sun.security.x509.PolicyConstraintsExtension");
-        addInternal(NETSCAPE_CERT, ObjectIdentifier.newInternal
-                    (new int[] {2,16,840,1,113730,1,1}),
+        addInternal(NETSCAPE_CERT,
+                    ObjectIdentifier.of("2.16.840.1.113730.1.1"),
                     "sun.security.x509.NetscapeCertTypeExtension");
         addInternal(CERT_POLICIES, PKIXExtensions.CertificatePolicies_Id,
                     "sun.security.x509.CertificatePoliciesExtension");

--- a/src/java.base/share/classes/sun/security/x509/OIDMap.java
+++ b/src/java.base/share/classes/sun/security/x509/OIDMap.java
@@ -136,7 +136,7 @@ public class OIDMap {
         addInternal(POLICY_CONSTRAINTS, PKIXExtensions.PolicyConstraints_Id,
                     "sun.security.x509.PolicyConstraintsExtension");
         addInternal(NETSCAPE_CERT,
-                    ObjectIdentifier.of("2.16.840.1.113730.1.1"),
+                    ObjectIdentifier.of1("2.16.840.1.113730.1.1"),
                     "sun.security.x509.NetscapeCertTypeExtension");
         addInternal(CERT_POLICIES, PKIXExtensions.CertificatePolicies_Id,
                     "sun.security.x509.CertificatePoliciesExtension");

--- a/src/java.base/share/classes/sun/security/x509/PKIXExtensions.java
+++ b/src/java.base/share/classes/sun/security/x509/PKIXExtensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package sun.security.x509;
 
-import java.io.*;
 
 import sun.security.util.*;
 
@@ -48,163 +47,151 @@ import sun.security.util.*;
  * @author Hemma Prafullchandra
  */
 public class PKIXExtensions {
-    // The object identifiers
-    private static final int[] AuthorityKey_data = { 2, 5, 29, 35 };
-    private static final int[] SubjectKey_data = { 2, 5, 29, 14 };
-    private static final int[] KeyUsage_data = { 2, 5, 29, 15 };
-    private static final int[] PrivateKeyUsage_data = { 2, 5, 29, 16 };
-    private static final int[] CertificatePolicies_data = { 2, 5, 29, 32 };
-    private static final int[] PolicyMappings_data = { 2, 5, 29, 33 };
-    private static final int[] SubjectAlternativeName_data = { 2, 5, 29, 17 };
-    private static final int[] IssuerAlternativeName_data = { 2, 5, 29, 18 };
-    private static final int[] SubjectDirectoryAttributes_data = { 2, 5, 29, 9 };
-    private static final int[] BasicConstraints_data = { 2, 5, 29, 19 };
-    private static final int[] NameConstraints_data = { 2, 5, 29, 30 };
-    private static final int[] PolicyConstraints_data = { 2, 5, 29, 36 };
-    private static final int[] CRLDistributionPoints_data = { 2, 5, 29, 31 };
-    private static final int[] CRLNumber_data = { 2, 5, 29, 20 };
-    private static final int[] IssuingDistributionPoint_data = { 2, 5, 29, 28 };
-    private static final int[] DeltaCRLIndicator_data = { 2, 5, 29, 27 };
-    private static final int[] ReasonCode_data = { 2, 5, 29, 21 };
-    private static final int[] HoldInstructionCode_data = { 2, 5, 29, 23 };
-    private static final int[] InvalidityDate_data = { 2, 5, 29, 24 };
-    private static final int[] ExtendedKeyUsage_data = { 2, 5, 29, 37 };
-    private static final int[] InhibitAnyPolicy_data = { 2, 5, 29, 54 };
-    private static final int[] CertificateIssuer_data = { 2, 5, 29, 29 };
-    private static final int[] AuthInfoAccess_data = { 1, 3, 6, 1, 5, 5, 7, 1, 1};
-    private static final int[] SubjectInfoAccess_data = { 1, 3, 6, 1, 5, 5, 7, 1, 11};
-    private static final int[] FreshestCRL_data = { 2, 5, 29, 46 };
-    private static final int[] OCSPNoCheck_data = { 1, 3, 6, 1, 5, 5, 7,
-                                                    48, 1, 5};
-
-    // Additional extensions under the PKIX arc that are not necessarily
-    // used in X.509 Certificates or CRLs.
-    private static final int OCSPNonce_data [] = { 1, 3, 6, 1, 5, 5, 7,
-                                                  48, 1, 2};
-
     /**
      * Identifies the particular public key used to sign the certificate.
      */
-    public static final ObjectIdentifier AuthorityKey_Id;
+    public static final ObjectIdentifier AuthorityKey_Id =
+            ObjectIdentifier.of("2.5.29.35");
 
     /**
      * Identifies the particular public key used in an application.
      */
-    public static final ObjectIdentifier SubjectKey_Id;
+    public static final ObjectIdentifier SubjectKey_Id =
+            ObjectIdentifier.of("2.5.29.14");
 
     /**
      * Defines the purpose of the key contained in the certificate.
      */
-    public static final ObjectIdentifier KeyUsage_Id;
+    public static final ObjectIdentifier KeyUsage_Id =
+            ObjectIdentifier.of("2.5.29.15");
 
     /**
      * Allows the certificate issuer to specify a different validity period
      * for the private key than the certificate.
      */
-    public static final ObjectIdentifier PrivateKeyUsage_Id;
+    public static final ObjectIdentifier PrivateKeyUsage_Id =
+            ObjectIdentifier.of("2.5.29.16");
 
     /**
      * Contains the sequence of policy information terms.
      */
-    public static final ObjectIdentifier CertificatePolicies_Id;
+    public static final ObjectIdentifier CertificatePolicies_Id =
+            ObjectIdentifier.of("2.5.29.32");
 
     /**
      * Lists pairs of object identifiers of policies considered equivalent by
      * the issuing CA to the subject CA.
      */
-    public static final ObjectIdentifier PolicyMappings_Id;
+    public static final ObjectIdentifier PolicyMappings_Id =
+            ObjectIdentifier.of("2.5.29.33");
 
     /**
      * Allows additional identities to be bound to the subject of the
      * certificate.
      */
-    public static final ObjectIdentifier SubjectAlternativeName_Id;
+    public static final ObjectIdentifier SubjectAlternativeName_Id =
+            ObjectIdentifier.of("2.5.29.17");
 
     /**
      * Allows additional identities to be associated with the certificate
      * issuer.
      */
-    public static final ObjectIdentifier IssuerAlternativeName_Id;
+    public static final ObjectIdentifier IssuerAlternativeName_Id =
+            ObjectIdentifier.of("2.5.29.18");
 
     /**
      * Identifies additional directory attributes.
      * This extension is always non-critical.
      */
-    public static final ObjectIdentifier SubjectDirectoryAttributes_Id;
+    public static final ObjectIdentifier SubjectDirectoryAttributes_Id =
+            ObjectIdentifier.of("2.5.29.9");
 
     /**
      * Identifies whether the subject of the certificate is a CA and how deep
      * a certification path may exist through that CA.
      */
-    public static final ObjectIdentifier BasicConstraints_Id;
+    public static final ObjectIdentifier BasicConstraints_Id =
+            ObjectIdentifier.of("2.5.29.19");
 
     /**
      * Provides for permitted and excluded subtrees that place restrictions
      * on names that may be included within a certificate issued by a given CA.
      */
-    public static final ObjectIdentifier NameConstraints_Id;
+    public static final ObjectIdentifier NameConstraints_Id =
+            ObjectIdentifier.of("2.5.29.30");
 
     /**
      * Used to either prohibit policy mapping or limit the set of policies
      * that can be in subsequent certificates.
      */
-    public static final ObjectIdentifier PolicyConstraints_Id;
+    public static final ObjectIdentifier PolicyConstraints_Id =
+            ObjectIdentifier.of("2.5.29.36");
 
     /**
      * Identifies how CRL information is obtained.
      */
-    public static final ObjectIdentifier CRLDistributionPoints_Id;
+    public static final ObjectIdentifier CRLDistributionPoints_Id =
+            ObjectIdentifier.of("2.5.29.31");
 
     /**
      * Conveys a monotonically increasing sequence number for each CRL
      * issued by a given CA.
      */
-    public static final ObjectIdentifier CRLNumber_Id;
+    public static final ObjectIdentifier CRLNumber_Id =
+            ObjectIdentifier.of("2.5.29.20");
 
     /**
      * Identifies the CRL distribution point for a particular CRL.
      */
-    public static final ObjectIdentifier IssuingDistributionPoint_Id;
+    public static final ObjectIdentifier IssuingDistributionPoint_Id =
+            ObjectIdentifier.of("2.5.29.28");
 
     /**
      * Identifies the delta CRL.
      */
-    public static final ObjectIdentifier DeltaCRLIndicator_Id;
+    public static final ObjectIdentifier DeltaCRLIndicator_Id =
+            ObjectIdentifier.of("2.5.29.27");
 
     /**
      * Identifies the reason for the certificate revocation.
      */
-    public static final ObjectIdentifier ReasonCode_Id;
+    public static final ObjectIdentifier ReasonCode_Id =
+            ObjectIdentifier.of("2.5.29.21");
 
     /**
      * This extension provides a registered instruction identifier indicating
      * the action to be taken, after encountering a certificate that has been
      * placed on hold.
      */
-    public static final ObjectIdentifier HoldInstructionCode_Id;
+    public static final ObjectIdentifier HoldInstructionCode_Id =
+            ObjectIdentifier.of("2.5.29.23");
 
     /**
      * Identifies the date on which it is known or suspected that the private
      * key was compromised or that the certificate otherwise became invalid.
      */
-    public static final ObjectIdentifier InvalidityDate_Id;
+    public static final ObjectIdentifier InvalidityDate_Id =
+            ObjectIdentifier.of("2.5.29.24");
     /**
      * Identifies one or more purposes for which the certified public key
      * may be used, in addition to or in place of the basic purposes
      * indicated in the key usage extension field.
      */
-    public static final ObjectIdentifier ExtendedKeyUsage_Id;
+    public static final ObjectIdentifier ExtendedKeyUsage_Id =
+            ObjectIdentifier.of("2.5.29.37");
 
     /**
      * Specifies whether any-policy policy OID is permitted
      */
-    public static final ObjectIdentifier InhibitAnyPolicy_Id;
+    public static final ObjectIdentifier InhibitAnyPolicy_Id =
+            ObjectIdentifier.of("2.5.29.54");
 
     /**
      * Identifies the certificate issuer associated with an entry in an
      * indirect CRL.
      */
-    public static final ObjectIdentifier CertificateIssuer_Id;
+    public static final ObjectIdentifier CertificateIssuer_Id =
+            ObjectIdentifier.of("2.5.29.29");
 
     /**
      * This extension indicates how to access CA information and services for
@@ -212,73 +199,33 @@ public class PKIXExtensions {
      * This information may be used for on-line certification validation
      * services.
      */
-    public static final ObjectIdentifier AuthInfoAccess_Id;
+    public static final ObjectIdentifier AuthInfoAccess_Id =
+            ObjectIdentifier.of("1.3.6.1.5.5.7.1.1");
 
     /**
      * This extension indicates how to access CA information and services for
      * the subject of the certificate in which the extension appears.
      */
-    public static final ObjectIdentifier SubjectInfoAccess_Id;
+    public static final ObjectIdentifier SubjectInfoAccess_Id =
+            ObjectIdentifier.of("1.3.6.1.5.5.7.1.11");
 
     /**
      * Identifies how delta CRL information is obtained.
      */
-    public static final ObjectIdentifier FreshestCRL_Id;
+    public static final ObjectIdentifier FreshestCRL_Id =
+            ObjectIdentifier.of("2.5.29.46");
 
     /**
      * Identifies the OCSP client can trust the responder for the
      * lifetime of the responder's certificate.
      */
-    public static final ObjectIdentifier OCSPNoCheck_Id;
+    public static final ObjectIdentifier OCSPNoCheck_Id =
+            ObjectIdentifier.of("1.3.6.1.5.5.7.48.1.5");
 
     /**
      * This extension is used to provide nonce data for OCSP requests
      * or responses.
      */
-    public static final ObjectIdentifier OCSPNonce_Id;
-
-    static {
-        AuthorityKey_Id = ObjectIdentifier.newInternal(AuthorityKey_data);
-        SubjectKey_Id   = ObjectIdentifier.newInternal(SubjectKey_data);
-        KeyUsage_Id     = ObjectIdentifier.newInternal(KeyUsage_data);
-        PrivateKeyUsage_Id = ObjectIdentifier.newInternal(PrivateKeyUsage_data);
-        CertificatePolicies_Id =
-            ObjectIdentifier.newInternal(CertificatePolicies_data);
-        PolicyMappings_Id = ObjectIdentifier.newInternal(PolicyMappings_data);
-        SubjectAlternativeName_Id =
-            ObjectIdentifier.newInternal(SubjectAlternativeName_data);
-        IssuerAlternativeName_Id =
-            ObjectIdentifier.newInternal(IssuerAlternativeName_data);
-        ExtendedKeyUsage_Id = ObjectIdentifier.newInternal(ExtendedKeyUsage_data);
-        InhibitAnyPolicy_Id = ObjectIdentifier.newInternal(InhibitAnyPolicy_data);
-        SubjectDirectoryAttributes_Id =
-            ObjectIdentifier.newInternal(SubjectDirectoryAttributes_data);
-        BasicConstraints_Id =
-            ObjectIdentifier.newInternal(BasicConstraints_data);
-        ReasonCode_Id = ObjectIdentifier.newInternal(ReasonCode_data);
-        HoldInstructionCode_Id  =
-            ObjectIdentifier.newInternal(HoldInstructionCode_data);
-        InvalidityDate_Id = ObjectIdentifier.newInternal(InvalidityDate_data);
-
-        NameConstraints_Id = ObjectIdentifier.newInternal(NameConstraints_data);
-        PolicyConstraints_Id =
-            ObjectIdentifier.newInternal(PolicyConstraints_data);
-        CRLDistributionPoints_Id =
-            ObjectIdentifier.newInternal(CRLDistributionPoints_data);
-        CRLNumber_Id =
-            ObjectIdentifier.newInternal(CRLNumber_data);
-        IssuingDistributionPoint_Id =
-            ObjectIdentifier.newInternal(IssuingDistributionPoint_data);
-        DeltaCRLIndicator_Id =
-            ObjectIdentifier.newInternal(DeltaCRLIndicator_data);
-        CertificateIssuer_Id =
-            ObjectIdentifier.newInternal(CertificateIssuer_data);
-        AuthInfoAccess_Id =
-            ObjectIdentifier.newInternal(AuthInfoAccess_data);
-        SubjectInfoAccess_Id =
-            ObjectIdentifier.newInternal(SubjectInfoAccess_data);
-        FreshestCRL_Id = ObjectIdentifier.newInternal(FreshestCRL_data);
-        OCSPNoCheck_Id = ObjectIdentifier.newInternal(OCSPNoCheck_data);
-        OCSPNonce_Id = ObjectIdentifier.newInternal(OCSPNonce_data);
-    }
+    public static final ObjectIdentifier OCSPNonce_Id =
+            ObjectIdentifier.of("1.3.6.1.5.5.7.48.1.2");
 }

--- a/src/java.base/share/classes/sun/security/x509/PKIXExtensions.java
+++ b/src/java.base/share/classes/sun/security/x509/PKIXExtensions.java
@@ -51,112 +51,112 @@ public class PKIXExtensions {
      * Identifies the particular public key used to sign the certificate.
      */
     public static final ObjectIdentifier AuthorityKey_Id =
-            ObjectIdentifier.of("2.5.29.35");
+            ObjectIdentifier.of1("2.5.29.35");
 
     /**
      * Identifies the particular public key used in an application.
      */
     public static final ObjectIdentifier SubjectKey_Id =
-            ObjectIdentifier.of("2.5.29.14");
+            ObjectIdentifier.of1("2.5.29.14");
 
     /**
      * Defines the purpose of the key contained in the certificate.
      */
     public static final ObjectIdentifier KeyUsage_Id =
-            ObjectIdentifier.of("2.5.29.15");
+            ObjectIdentifier.of1("2.5.29.15");
 
     /**
      * Allows the certificate issuer to specify a different validity period
      * for the private key than the certificate.
      */
     public static final ObjectIdentifier PrivateKeyUsage_Id =
-            ObjectIdentifier.of("2.5.29.16");
+            ObjectIdentifier.of1("2.5.29.16");
 
     /**
      * Contains the sequence of policy information terms.
      */
     public static final ObjectIdentifier CertificatePolicies_Id =
-            ObjectIdentifier.of("2.5.29.32");
+            ObjectIdentifier.of1("2.5.29.32");
 
     /**
      * Lists pairs of object identifiers of policies considered equivalent by
      * the issuing CA to the subject CA.
      */
     public static final ObjectIdentifier PolicyMappings_Id =
-            ObjectIdentifier.of("2.5.29.33");
+            ObjectIdentifier.of1("2.5.29.33");
 
     /**
      * Allows additional identities to be bound to the subject of the
      * certificate.
      */
     public static final ObjectIdentifier SubjectAlternativeName_Id =
-            ObjectIdentifier.of("2.5.29.17");
+            ObjectIdentifier.of1("2.5.29.17");
 
     /**
      * Allows additional identities to be associated with the certificate
      * issuer.
      */
     public static final ObjectIdentifier IssuerAlternativeName_Id =
-            ObjectIdentifier.of("2.5.29.18");
+            ObjectIdentifier.of1("2.5.29.18");
 
     /**
      * Identifies additional directory attributes.
      * This extension is always non-critical.
      */
     public static final ObjectIdentifier SubjectDirectoryAttributes_Id =
-            ObjectIdentifier.of("2.5.29.9");
+            ObjectIdentifier.of1("2.5.29.9");
 
     /**
      * Identifies whether the subject of the certificate is a CA and how deep
      * a certification path may exist through that CA.
      */
     public static final ObjectIdentifier BasicConstraints_Id =
-            ObjectIdentifier.of("2.5.29.19");
+            ObjectIdentifier.of1("2.5.29.19");
 
     /**
      * Provides for permitted and excluded subtrees that place restrictions
      * on names that may be included within a certificate issued by a given CA.
      */
     public static final ObjectIdentifier NameConstraints_Id =
-            ObjectIdentifier.of("2.5.29.30");
+            ObjectIdentifier.of1("2.5.29.30");
 
     /**
      * Used to either prohibit policy mapping or limit the set of policies
      * that can be in subsequent certificates.
      */
     public static final ObjectIdentifier PolicyConstraints_Id =
-            ObjectIdentifier.of("2.5.29.36");
+            ObjectIdentifier.of1("2.5.29.36");
 
     /**
      * Identifies how CRL information is obtained.
      */
     public static final ObjectIdentifier CRLDistributionPoints_Id =
-            ObjectIdentifier.of("2.5.29.31");
+            ObjectIdentifier.of1("2.5.29.31");
 
     /**
      * Conveys a monotonically increasing sequence number for each CRL
      * issued by a given CA.
      */
     public static final ObjectIdentifier CRLNumber_Id =
-            ObjectIdentifier.of("2.5.29.20");
+            ObjectIdentifier.of1("2.5.29.20");
 
     /**
      * Identifies the CRL distribution point for a particular CRL.
      */
     public static final ObjectIdentifier IssuingDistributionPoint_Id =
-            ObjectIdentifier.of("2.5.29.28");
+            ObjectIdentifier.of1("2.5.29.28");
 
     /**
      * Identifies the delta CRL.
      */
     public static final ObjectIdentifier DeltaCRLIndicator_Id =
-            ObjectIdentifier.of("2.5.29.27");
+            ObjectIdentifier.of1("2.5.29.27");
 
     /**
      * Identifies the reason for the certificate revocation.
      */
     public static final ObjectIdentifier ReasonCode_Id =
-            ObjectIdentifier.of("2.5.29.21");
+            ObjectIdentifier.of1("2.5.29.21");
 
     /**
      * This extension provides a registered instruction identifier indicating
@@ -164,34 +164,34 @@ public class PKIXExtensions {
      * placed on hold.
      */
     public static final ObjectIdentifier HoldInstructionCode_Id =
-            ObjectIdentifier.of("2.5.29.23");
+            ObjectIdentifier.of1("2.5.29.23");
 
     /**
      * Identifies the date on which it is known or suspected that the private
      * key was compromised or that the certificate otherwise became invalid.
      */
     public static final ObjectIdentifier InvalidityDate_Id =
-            ObjectIdentifier.of("2.5.29.24");
+            ObjectIdentifier.of1("2.5.29.24");
     /**
      * Identifies one or more purposes for which the certified public key
      * may be used, in addition to or in place of the basic purposes
      * indicated in the key usage extension field.
      */
     public static final ObjectIdentifier ExtendedKeyUsage_Id =
-            ObjectIdentifier.of("2.5.29.37");
+            ObjectIdentifier.of1("2.5.29.37");
 
     /**
      * Specifies whether any-policy policy OID is permitted
      */
     public static final ObjectIdentifier InhibitAnyPolicy_Id =
-            ObjectIdentifier.of("2.5.29.54");
+            ObjectIdentifier.of1("2.5.29.54");
 
     /**
      * Identifies the certificate issuer associated with an entry in an
      * indirect CRL.
      */
     public static final ObjectIdentifier CertificateIssuer_Id =
-            ObjectIdentifier.of("2.5.29.29");
+            ObjectIdentifier.of1("2.5.29.29");
 
     /**
      * This extension indicates how to access CA information and services for
@@ -200,32 +200,32 @@ public class PKIXExtensions {
      * services.
      */
     public static final ObjectIdentifier AuthInfoAccess_Id =
-            ObjectIdentifier.of("1.3.6.1.5.5.7.1.1");
+            ObjectIdentifier.of1("1.3.6.1.5.5.7.1.1");
 
     /**
      * This extension indicates how to access CA information and services for
      * the subject of the certificate in which the extension appears.
      */
     public static final ObjectIdentifier SubjectInfoAccess_Id =
-            ObjectIdentifier.of("1.3.6.1.5.5.7.1.11");
+            ObjectIdentifier.of1("1.3.6.1.5.5.7.1.11");
 
     /**
      * Identifies how delta CRL information is obtained.
      */
     public static final ObjectIdentifier FreshestCRL_Id =
-            ObjectIdentifier.of("2.5.29.46");
+            ObjectIdentifier.of1("2.5.29.46");
 
     /**
      * Identifies the OCSP client can trust the responder for the
      * lifetime of the responder's certificate.
      */
     public static final ObjectIdentifier OCSPNoCheck_Id =
-            ObjectIdentifier.of("1.3.6.1.5.5.7.48.1.5");
+            ObjectIdentifier.of1("1.3.6.1.5.5.7.48.1.5");
 
     /**
      * This extension is used to provide nonce data for OCSP requests
      * or responses.
      */
     public static final ObjectIdentifier OCSPNonce_Id =
-            ObjectIdentifier.of("1.3.6.1.5.5.7.48.1.2");
+            ObjectIdentifier.of1("1.3.6.1.5.5.7.48.1.2");
 }

--- a/src/java.base/share/classes/sun/security/x509/X500Name.java
+++ b/src/java.base/share/classes/sun/security/x509/X500Name.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1102,104 +1102,83 @@ public class X500Name implements GeneralNameInterface, Principal {
      * Includes all those specified in RFC 5280 as MUST or SHOULD
      * be recognized
      */
-    private static final int[] commonName_data = { 2, 5, 4, 3 };
-    private static final int[] SURNAME_DATA = { 2, 5, 4, 4 };
-    private static final int[] SERIALNUMBER_DATA = { 2, 5, 4, 5 };
-    private static final int[] countryName_data = { 2, 5, 4, 6 };
-    private static final int[] localityName_data = { 2, 5, 4, 7 };
-    private static final int[] stateName_data = { 2, 5, 4, 8 };
-    private static final int[] streetAddress_data = { 2, 5, 4, 9 };
-    private static final int[] orgName_data = { 2, 5, 4, 10 };
-    private static final int[] orgUnitName_data = { 2, 5, 4, 11 };
-    private static final int[] title_data = { 2, 5, 4, 12 };
-    private static final int[] GIVENNAME_DATA = { 2, 5, 4, 42 };
-    private static final int[] INITIALS_DATA = { 2, 5, 4, 43 };
-    private static final int[] GENERATIONQUALIFIER_DATA = { 2, 5, 4, 44 };
-    private static final int[] DNQUALIFIER_DATA = { 2, 5, 4, 46 };
-
-    private static final int[] ipAddress_data = { 1, 3, 6, 1, 4, 1, 42, 2, 11, 2, 1 };
-    private static final int[] DOMAIN_COMPONENT_DATA =
-        { 0, 9, 2342, 19200300, 100, 1, 25 };
-    private static final int[] userid_data =
-        { 0, 9, 2342, 19200300, 100, 1, 1 };
-
 
     // OID for the "CN=" attribute, denoting a person's common name.
     public static final ObjectIdentifier commonName_oid =
-            ObjectIdentifier.newInternal(commonName_data);
+            ObjectIdentifier.of("2.5.4.3");
+
+    // OID for the "SURNAME=" attribute, denoting a person's surname.
+    public static final ObjectIdentifier SURNAME_OID =
+            ObjectIdentifier.of("2.5.4.4");
 
     // OID for the "SERIALNUMBER=" attribute, denoting a serial number for.
     // a name. Do not confuse with PKCS#9 issuerAndSerialNumber or the
     // certificate serial number.
     public static final ObjectIdentifier SERIALNUMBER_OID =
-            ObjectIdentifier.newInternal(SERIALNUMBER_DATA);
+            ObjectIdentifier.of("2.5.4.5");
 
     // OID for the "C=" attribute, denoting a country.
     public static final ObjectIdentifier countryName_oid =
-            ObjectIdentifier.newInternal(countryName_data);
+            ObjectIdentifier.of("2.5.4.6");
 
     // OID for the "L=" attribute, denoting a locality (such as a city).
     public static final ObjectIdentifier localityName_oid =
-            ObjectIdentifier.newInternal(localityName_data);
-
-    // OID for the "O=" attribute, denoting an organization name.
-    public static final ObjectIdentifier orgName_oid =
-            ObjectIdentifier.newInternal(orgName_data);
-
-    // OID for the "OU=" attribute, denoting an organizational unit name.
-    public static final ObjectIdentifier orgUnitName_oid =
-            ObjectIdentifier.newInternal(orgUnitName_data);
+            ObjectIdentifier.of("2.5.4.7");
 
     // OID for the "S=" attribute, denoting a state (such as Delaware).
     public static final ObjectIdentifier stateName_oid =
-            ObjectIdentifier.newInternal(stateName_data);
+            ObjectIdentifier.of("2.5.4.8");
 
     // OID for the "STREET=" attribute, denoting a street address.
     public static final ObjectIdentifier streetAddress_oid =
-            ObjectIdentifier.newInternal(streetAddress_data);
+            ObjectIdentifier.of("2.5.4.9");
+
+    // OID for the "O=" attribute, denoting an organization name.
+    public static final ObjectIdentifier orgName_oid =
+            ObjectIdentifier.of("2.5.4.10");
+
+    // OID for the "OU=" attribute, denoting an organizational unit name.
+    public static final ObjectIdentifier orgUnitName_oid =
+            ObjectIdentifier.of("2.5.4.11");
 
     // OID for the "T=" attribute, denoting a person's title.
     public static final ObjectIdentifier title_oid =
-            ObjectIdentifier.newInternal(title_data);
+            ObjectIdentifier.of("2.5.4.12");
+
+    // OID for the "GIVENNAME=" attribute, denoting a person's given name.
+    public static final ObjectIdentifier GIVENNAME_OID =
+            ObjectIdentifier.of("2.5.4.42");
+
+    // OID for the "INITIALS=" attribute, denoting a person's initials.
+    public static final ObjectIdentifier INITIALS_OID =
+            ObjectIdentifier.of("2.5.4.43");
+
+    // OID for the "GENERATION=" attribute, denoting Jr., II, etc.
+    public static final ObjectIdentifier GENERATIONQUALIFIER_OID =
+            ObjectIdentifier.of("2.5.4.44");
 
     // OID for the "DNQUALIFIER=" or "DNQ=" attribute, denoting DN
     // disambiguating information.
     public static final ObjectIdentifier DNQUALIFIER_OID =
-            ObjectIdentifier.newInternal(DNQUALIFIER_DATA);
-
-    // OID for the "SURNAME=" attribute, denoting a person's surname.
-    public static final ObjectIdentifier SURNAME_OID =
-            ObjectIdentifier.newInternal(SURNAME_DATA);
-
-    // OID for the "GIVENNAME=" attribute, denoting a person's given name.
-    public static final ObjectIdentifier GIVENNAME_OID =
-            ObjectIdentifier.newInternal(GIVENNAME_DATA);
-
-    // OID for the "INITIALS=" attribute, denoting a person's initials.
-    public static final ObjectIdentifier INITIALS_OID =
-            ObjectIdentifier.newInternal(INITIALS_DATA);
-
-    // OID for the "GENERATION=" attribute, denoting Jr., II, etc.
-    public static final ObjectIdentifier GENERATIONQUALIFIER_OID =
-            ObjectIdentifier.newInternal(GENERATIONQUALIFIER_DATA);
+            ObjectIdentifier.of("2.5.4.46");
 
     // OIDs from other sources which show up in X.500 names we
     // expect to deal with often.
     //
     // OID for "IP=" IP address attributes, used with SKIP.
     public static final ObjectIdentifier ipAddress_oid =
-            ObjectIdentifier.newInternal(ipAddress_data);
+            ObjectIdentifier.of("1.3.6.1.4.1.42.2.11.2.1");
 
     // Domain component OID from RFC 1274, RFC 2247, RFC 5280.
     //
-    // OID for "DC=" domain component attributes, used with DNSNames in DN
+    // OID for "DC=" domain component attributes.used with DNSNames in DN
     // format.
     public static final ObjectIdentifier DOMAIN_COMPONENT_OID =
-            ObjectIdentifier.newInternal(DOMAIN_COMPONENT_DATA);
+            ObjectIdentifier.of("0.9.2342.19200300.100.1.25");
 
     // OID for "UID=" denoting a user id, defined in RFCs 1274 & 2798.
     public static final ObjectIdentifier userid_oid =
-            ObjectIdentifier.newInternal(userid_data);
+            ObjectIdentifier.of("0.9.2342.19200300.100.1.1");
 
     /**
      * Return constraint type:<ul>

--- a/src/java.base/share/classes/sun/security/x509/X500Name.java
+++ b/src/java.base/share/classes/sun/security/x509/X500Name.java
@@ -1105,80 +1105,80 @@ public class X500Name implements GeneralNameInterface, Principal {
 
     // OID for the "CN=" attribute, denoting a person's common name.
     public static final ObjectIdentifier commonName_oid =
-            ObjectIdentifier.of("2.5.4.3");
+            ObjectIdentifier.of1("2.5.4.3");
 
     // OID for the "SURNAME=" attribute, denoting a person's surname.
     public static final ObjectIdentifier SURNAME_OID =
-            ObjectIdentifier.of("2.5.4.4");
+            ObjectIdentifier.of1("2.5.4.4");
 
     // OID for the "SERIALNUMBER=" attribute, denoting a serial number for.
     // a name. Do not confuse with PKCS#9 issuerAndSerialNumber or the
     // certificate serial number.
     public static final ObjectIdentifier SERIALNUMBER_OID =
-            ObjectIdentifier.of("2.5.4.5");
+            ObjectIdentifier.of1("2.5.4.5");
 
     // OID for the "C=" attribute, denoting a country.
     public static final ObjectIdentifier countryName_oid =
-            ObjectIdentifier.of("2.5.4.6");
+            ObjectIdentifier.of1("2.5.4.6");
 
     // OID for the "L=" attribute, denoting a locality (such as a city).
     public static final ObjectIdentifier localityName_oid =
-            ObjectIdentifier.of("2.5.4.7");
+            ObjectIdentifier.of1("2.5.4.7");
 
     // OID for the "S=" attribute, denoting a state (such as Delaware).
     public static final ObjectIdentifier stateName_oid =
-            ObjectIdentifier.of("2.5.4.8");
+            ObjectIdentifier.of1("2.5.4.8");
 
     // OID for the "STREET=" attribute, denoting a street address.
     public static final ObjectIdentifier streetAddress_oid =
-            ObjectIdentifier.of("2.5.4.9");
+            ObjectIdentifier.of1("2.5.4.9");
 
     // OID for the "O=" attribute, denoting an organization name.
     public static final ObjectIdentifier orgName_oid =
-            ObjectIdentifier.of("2.5.4.10");
+            ObjectIdentifier.of1("2.5.4.10");
 
     // OID for the "OU=" attribute, denoting an organizational unit name.
     public static final ObjectIdentifier orgUnitName_oid =
-            ObjectIdentifier.of("2.5.4.11");
+            ObjectIdentifier.of1("2.5.4.11");
 
     // OID for the "T=" attribute, denoting a person's title.
     public static final ObjectIdentifier title_oid =
-            ObjectIdentifier.of("2.5.4.12");
+            ObjectIdentifier.of1("2.5.4.12");
 
     // OID for the "GIVENNAME=" attribute, denoting a person's given name.
     public static final ObjectIdentifier GIVENNAME_OID =
-            ObjectIdentifier.of("2.5.4.42");
+            ObjectIdentifier.of1("2.5.4.42");
 
     // OID for the "INITIALS=" attribute, denoting a person's initials.
     public static final ObjectIdentifier INITIALS_OID =
-            ObjectIdentifier.of("2.5.4.43");
+            ObjectIdentifier.of1("2.5.4.43");
 
     // OID for the "GENERATION=" attribute, denoting Jr., II, etc.
     public static final ObjectIdentifier GENERATIONQUALIFIER_OID =
-            ObjectIdentifier.of("2.5.4.44");
+            ObjectIdentifier.of1("2.5.4.44");
 
     // OID for the "DNQUALIFIER=" or "DNQ=" attribute, denoting DN
     // disambiguating information.
     public static final ObjectIdentifier DNQUALIFIER_OID =
-            ObjectIdentifier.of("2.5.4.46");
+            ObjectIdentifier.of1("2.5.4.46");
 
     // OIDs from other sources which show up in X.500 names we
     // expect to deal with often.
     //
     // OID for "IP=" IP address attributes, used with SKIP.
     public static final ObjectIdentifier ipAddress_oid =
-            ObjectIdentifier.of("1.3.6.1.4.1.42.2.11.2.1");
+            ObjectIdentifier.of1("1.3.6.1.4.1.42.2.11.2.1");
 
     // Domain component OID from RFC 1274, RFC 2247, RFC 5280.
     //
     // OID for "DC=" domain component attributes.used with DNSNames in DN
     // format.
     public static final ObjectIdentifier DOMAIN_COMPONENT_OID =
-            ObjectIdentifier.of("0.9.2342.19200300.100.1.25");
+            ObjectIdentifier.of1("0.9.2342.19200300.100.1.25");
 
     // OID for "UID=" denoting a user id, defined in RFCs 1274 & 2798.
     public static final ObjectIdentifier userid_oid =
-            ObjectIdentifier.of("0.9.2342.19200300.100.1.1");
+            ObjectIdentifier.of1("0.9.2342.19200300.100.1.1");
 
     /**
      * Return constraint type:<ul>

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/XECParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,8 +120,8 @@ public class XECParameters {
         // set up X25519
         try {
             BigInteger p = TWO.pow(255).subtract(BigInteger.valueOf(19));
-            addParameters(255, p, 121665, (byte) 0x09, 3,
-                new int[]{1, 3, 101, 110}, NamedParameterSpec.X25519.getName(),
+            addParameters(255, p, 121665, (byte)0x09, 3,
+                "1.3.101.110", NamedParameterSpec.X25519.getName(),
                 bySize, byOid, byName);
 
         } catch (IOException ex) {
@@ -132,8 +132,8 @@ public class XECParameters {
         try {
             BigInteger p = TWO.pow(448).subtract(TWO.pow(224))
                 .subtract(BigInteger.ONE);
-            addParameters(448, p, 39081, (byte) 0x05, 2,
-                new int[]{1, 3, 101, 111}, NamedParameterSpec.X448.getName(),
+            addParameters(448, p, 39081, (byte)0x05, 2,
+                "1.3.101.111", NamedParameterSpec.X448.getName(),
                 bySize, byOid, byName);
 
         } catch (IOException ex) {
@@ -146,12 +146,12 @@ public class XECParameters {
     }
 
     private static void addParameters(int bits, BigInteger p, int a24,
-        byte basePoint, int logCofactor, int[] oidBytes, String name,
+        byte basePoint, int logCofactor, String objectId, String name,
         Map<Integer, XECParameters> bySize,
         Map<ObjectIdentifier, XECParameters> byOid,
         Map<String, XECParameters> byName) throws IOException {
 
-        ObjectIdentifier oid = new ObjectIdentifier(oidBytes);
+        ObjectIdentifier oid = new ObjectIdentifier(objectId);
         XECParameters params =
             new XECParameters(bits, p, a24, basePoint, logCofactor, oid, name);
         bySize.put(bits, params);

--- a/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
+++ b/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,8 +59,7 @@ import sun.security.util.ObjectIdentifier;
 public class SimpleOCSPServer {
     private final Debug debug = Debug.getInstance("oserv");
     private static final ObjectIdentifier OCSP_BASIC_RESPONSE_OID =
-            ObjectIdentifier.newInternal(
-                    new int[] { 1, 3, 6, 1, 5, 5, 7, 48, 1, 1});
+            ObjectIdentifier.of("1.3.6.1.5.5.7.48.1.1");
     private static final SimpleDateFormat utcDateFmt =
             new SimpleDateFormat("MMM dd yyyy, HH:mm:ss z");
 

--- a/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
+++ b/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
@@ -59,7 +59,7 @@ import sun.security.util.ObjectIdentifier;
 public class SimpleOCSPServer {
     private final Debug debug = Debug.getInstance("oserv");
     private static final ObjectIdentifier OCSP_BASIC_RESPONSE_OID =
-            ObjectIdentifier.of("1.3.6.1.5.5.7.48.1.1");
+          ObjectIdentifier.of1("1.3.6.1.5.5.7.48.1.1");
     private static final SimpleDateFormat utcDateFmt =
             new SimpleDateFormat("MMM dd yyyy, HH:mm:ss z");
 

--- a/test/jdk/sun/security/util/Oid/OidEquals.java
+++ b/test/jdk/sun/security/util/Oid/OidEquals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,13 +33,10 @@ import sun.security.util.ObjectIdentifier;
 public class OidEquals {
     public static void main(String[] args) throws Exception {
         ObjectIdentifier oid1 = new ObjectIdentifier("1.3.6.1.4.1.42.2.17");
-        ObjectIdentifier oid2 =
-                new ObjectIdentifier(new int[]{1, 3, 6, 1, 4, 1, 42, 2, 17});
-        ObjectIdentifier oid3 = new ObjectIdentifier("1.2.3.4");
+        ObjectIdentifier oid2 = new ObjectIdentifier("1.2.3.4");
 
         assertEquals(oid1, oid1);
-        assertEquals(oid1, oid2);
-        assertNotEquals(oid1, oid3);
+        assertNotEquals(oid1, oid2);
         assertNotEquals(oid1, "1.3.6.1.4.1.42.2.17");
 
         System.out.println("Tests passed.");

--- a/test/jdk/sun/security/util/Oid/OidFormat.java
+++ b/test/jdk/sun/security/util/Oid/OidFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,52 +85,6 @@ public class OidFormat {
 
         for (String s: goodOids) {
             testGood(s);
-        }
-
-        int[][] goodInts = {
-            {0,0}, {0,1}, {1,0}, {1,2},
-            {0,39}, {1,39}, {2,47}, {2,40,3,6}, {2,100,3}, {2,123456,3},
-            {1,2,3}, {1,2,3445},
-            {1,3,6,1,4,1,42,2,17},
-        };
-
-        for (int[] is: goodInts) {
-            testGood(is);
-        }
-
-        int[][] badInts = new int[][] {
-            {0}, {1}, {2},
-            {3,1,1}, {3}, {4},
-            {1,40}, {1,111,1},
-            {-1,2}, {0,-2}, {1,-2}, {2,-2},
-            {1,2,-3,4}, {1,2,3,-4},
-        };
-
-        for (int[] is: badInts) {
-            testBad(is);
-        }
-
-    }
-
-    static void testBad(int[] ints) throws Exception {
-        System.err.println("Trying " + Arrays.toString(ints));
-        try {
-            new ObjectIdentifier(ints);
-            throw new Exception("should be invalid ObjectIdentifier");
-        } catch (IOException ioe) {
-            System.err.println(ioe);
-        }
-    }
-
-    static void testGood(int[] ints) throws Exception {
-        System.err.println("Trying " + Arrays.toString(ints));
-        ObjectIdentifier oid = new ObjectIdentifier(ints);
-        DerOutputStream os = new DerOutputStream();
-        os.putOID(oid);
-        DerInputStream is = new DerInputStream(os.toByteArray());
-        ObjectIdentifier oid2 = is.getOID();
-        if (!oid.equals(oid2)) {
-            throw new Exception("Test DER I/O fails: " + oid + " and " + oid2);
         }
     }
 

--- a/test/jdk/sun/security/x509/AVA/AVAEqualsHashCode.java
+++ b/test/jdk/sun/security/x509/AVA/AVAEqualsHashCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,13 +40,11 @@ public class AVAEqualsHashCode {
 
    public static void main(String[] args) throws Exception {
 
-        int data[] = { 1, 2, 840, 113549, 2, 5 };
-
         // encode
         String name = "CN=eve s. dropper";
         X500Name dn = new X500Name(name);
         DerOutputStream deros = new DerOutputStream();
-        ObjectIdentifier oid = new ObjectIdentifier(data);
+        ObjectIdentifier oid = new ObjectIdentifier("1.2.840.113549.2.5");
 
         dn.encode(deros);
         byte[] ba = deros.toByteArray();

--- a/test/jdk/sun/security/x509/X509CertImpl/V3Certificate.java
+++ b/test/jdk/sun/security/x509/X509CertImpl/V3Certificate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,9 +153,9 @@ public class V3Certificate {
 
         GeneralNameInterface ipInf = new IPAddressName(address);
         GeneralName ip = new GeneralName(ipInf);
-        int[] oidData = new int[]{1, 2, 3, 4};
 
-        GeneralNameInterface oidInf = new OIDName(new ObjectIdentifier(oidData));
+        GeneralNameInterface oidInf =
+                new OIDName(new ObjectIdentifier("1.2.3.4"));
         GeneralName oid = new GeneralName(oidInf);
 
         SubjectAlternativeNameExtension subjectName


### PR DESCRIPTION
I had to work on this intensely to get it into 11.

First I resolved the conflicts:

src/java.base/macosx/classes/apple/security/KeychainStore.java
Copyright, different way to call loadLibrary.
This was wrongly removed anyways, see JDK-8240193

src/java.base/share/classes/com/sun/crypto/provider/DHPrivateKey.java
src/java.base/share/classes/com/sun/crypto/provider/DHPublicKey.java
src/java.base/share/classes/com/sun/crypto/provider/OAEPParameters.java
src/java.base/share/classes/sun/security/pkcs/ContentInfo.java
All Copyright

src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
The change is subsumed by 8268801: Improve PKCS attribute handling", a
closed issue that is not in head.
8268801 brought parts of this change to
11 as it was needed for some security fix.

src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
Copyright, Complex resolve due to context

src/java.base/share/classes/sun/security/util/ObjectIdentifier.java
Copyright
Complex resolve due to context.  Hunk in line 486 actually differs, but change
is only new formatting.

src/java.base/share/classes/sun/security/x509/AlgorithmId.java
Copyright

Second, to make it compile, I had to adapt the newly introduced calls to
ObjectIdentifier.of(). Unfortunately, "8268801: Improve PKCS attribute handling"
already backported parts of the later change
"8242151: Improve OID mapping and reuse among JDK security providers f..."
that make of() throw an exception. I restored the original function,
renamed it and adapted all the call sites.

This comes in a separate commit.  I will backport "JDK-8242151: Improve OID mapping and reuse among JDK security providers for aliases registration" on top of this, which will remove of1() again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8239264](https://bugs.openjdk.org/browse/JDK-8239264): Clearup the legacy ObjectIdentifier constructor from int array (**Enhancement** - P3)
 * [JDK-8240193](https://bugs.openjdk.org/browse/JDK-8240193): loadLibrary("osxsecurity") should not be removed (**Bug** - P3)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to [e5a830ad](https://git.openjdk.org/jdk11u-dev/pull/1898/files/e5a830adf1a6c62baddfa48cac6cdb6503d6f44a)
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - **Reviewer**) ⚠️ Review applies to [13750c33](https://git.openjdk.org/jdk11u-dev/pull/1898/files/13750c332b2a8b5153e2fe3f1a034c6f875e6622)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1898/head:pull/1898` \
`$ git checkout pull/1898`

Update a local copy of the PR: \
`$ git checkout pull/1898` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1898/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1898`

View PR using the GUI difftool: \
`$ git pr show -t 1898`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1898.diff">https://git.openjdk.org/jdk11u-dev/pull/1898.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1898#issuecomment-1562502291)