### PR TITLE
8269746: C2: assert(!in->is_CFG()) failed: CFG Node with no controlling input?

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1156,8 +1156,14 @@ Node *SafePointNode::Ideal(PhaseGVN *phase, bool can_reshape) {
 Node* SafePointNode::Identity(PhaseGVN* phase) {
 
   // If you have back to back safepoints, remove one
-  if( in(TypeFunc::Control)->is_SafePoint() )
-    return in(TypeFunc::Control);
+  if (in(TypeFunc::Control)->is_SafePoint()) {
+    Node* out_c = unique_ctrl_out();
+    // This can be the safepoint of an outer strip mined loop if the inner loop's backedge was removed. Replacing the
+    // outer loop's safepoint could confuse removal of the outer loop.
+    if (out_c != NULL && !out_c->is_OuterStripMinedLoopEnd()) {
+      return in(TypeFunc::Control);
+    }
+  }
 
   if( in(0)->is_Proj() ) {
     Node *n0 = in(0)->in(0);


### PR DESCRIPTION
This backport is for parity with 11.0.20-oracle.
The patch did not apply cleanly. The "before version" of the modified code block did not differ, though.

Tests (GHA and SAP-internal) were successful.

Reviews are welcome!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269746](https://bugs.openjdk.org/browse/JDK-8269746): C2: assert(!in-&gt;is_CFG()) failed: CFG Node with no controlling input?


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1900/head:pull/1900` \
`$ git checkout pull/1900`

Update a local copy of the PR: \
`$ git checkout pull/1900` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1900`

View PR using the GUI difftool: \
`$ git pr show -t 1900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1900.diff">https://git.openjdk.org/jdk11u-dev/pull/1900.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1900#issuecomment-1562622126)