### PR TITLE
8246383: NullPointerException in JceSecurity.getVerificationResult when using Entrust provider

### DIFF
--- a/src/java.base/share/classes/java/security/AlgorithmParameterGenerator.java
+++ b/src/java.base/share/classes/java/security/AlgorithmParameterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package java.security;
 
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.Objects;
+import sun.security.jca.JCAUtil;
 
 /**
  * The {@code AlgorithmParameterGenerator} class is used to generate a
@@ -308,7 +309,7 @@ public class AlgorithmParameterGenerator {
      * @param size the size (number of bits).
      */
     public final void init(int size) {
-        paramGenSpi.engineInit(size, new SecureRandom());
+        paramGenSpi.engineInit(size, JCAUtil.getSecureRandom());
     }
 
     /**
@@ -339,7 +340,7 @@ public class AlgorithmParameterGenerator {
      */
     public final void init(AlgorithmParameterSpec genParamSpec)
         throws InvalidAlgorithmParameterException {
-            paramGenSpi.engineInit(genParamSpec, new SecureRandom());
+            paramGenSpi.engineInit(genParamSpec, JCAUtil.getSecureRandom());
     }
 
     /**

--- a/src/java.base/share/classes/javax/crypto/Cipher.java
+++ b/src/java.base/share/classes/javax/crypto/Cipher.java
@@ -1220,7 +1220,7 @@ public class Cipher {
      * by the underlying {@code CipherSpi}.
      */
     public final void init(int opmode, Key key) throws InvalidKeyException {
-        init(opmode, key, JceSecurity.RANDOM);
+        init(opmode, key, JCAUtil.getSecureRandom());
     }
 
     /**
@@ -1361,7 +1361,7 @@ public class Cipher {
     public final void init(int opmode, Key key, AlgorithmParameterSpec params)
             throws InvalidKeyException, InvalidAlgorithmParameterException
     {
-        init(opmode, key, params, JceSecurity.RANDOM);
+        init(opmode, key, params, JCAUtil.getSecureRandom());
     }
 
     /**
@@ -1504,7 +1504,7 @@ public class Cipher {
     public final void init(int opmode, Key key, AlgorithmParameters params)
             throws InvalidKeyException, InvalidAlgorithmParameterException
     {
-        init(opmode, key, params, JceSecurity.RANDOM);
+        init(opmode, key, params, JCAUtil.getSecureRandom());
     }
 
     /**
@@ -1652,7 +1652,7 @@ public class Cipher {
     public final void init(int opmode, Certificate certificate)
             throws InvalidKeyException
     {
-        init(opmode, certificate, JceSecurity.RANDOM);
+        init(opmode, certificate, JCAUtil.getSecureRandom());
     }
 
     /**

--- a/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
+++ b/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,10 +74,7 @@ import sun.security.util.Debug;
 
 final class JceSecurity {
 
-
     private static final Debug debug = Debug.getInstance("jca");
-
-    static final SecureRandom RANDOM = new SecureRandom();
 
     // The defaultPolicy and exemptPolicy will be set up
     // in the static initializer.

--- a/src/java.base/share/classes/javax/crypto/KeyAgreement.java
+++ b/src/java.base/share/classes/javax/crypto/KeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -446,7 +446,7 @@ public class KeyAgreement {
      * has an incompatible algorithm type.
      */
     public final void init(Key key) throws InvalidKeyException {
-        init(key, JceSecurity.RANDOM);
+        init(key, JCAUtil.getSecureRandom());
     }
 
     /**
@@ -514,7 +514,7 @@ public class KeyAgreement {
     public final void init(Key key, AlgorithmParameterSpec params)
         throws InvalidKeyException, InvalidAlgorithmParameterException
     {
-        init(key, params, JceSecurity.RANDOM);
+        init(key, params, JCAUtil.getSecureRandom());
     }
 
     private String getProviderName() {

--- a/src/java.base/share/classes/javax/crypto/KeyGenerator.java
+++ b/src/java.base/share/classes/javax/crypto/KeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -450,7 +450,7 @@ public class KeyGenerator {
     public final void init(AlgorithmParameterSpec params)
         throws InvalidAlgorithmParameterException
     {
-        init(params, JceSecurity.RANDOM);
+        init(params, JCAUtil.getSecureRandom());
     }
 
     /**
@@ -514,7 +514,7 @@ public class KeyGenerator {
      * supported.
      */
     public final void init(int keysize) {
-        init(keysize, JceSecurity.RANDOM);
+        init(keysize, JCAUtil.getSecureRandom());
     }
 
     /**


### PR DESCRIPTION
This backport is a prerequisite to easily backport [JDK-8260274](https://bugs.openjdk.org/browse/JDK-8260274) (required for 11.0.20-oracle parity). The patch applies cleanly except for copyright header mismatches.

Tests (GHA and SAP internal) successful.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8246383](https://bugs.openjdk.org/browse/JDK-8246383): NullPointerException in JceSecurity.getVerificationResult when using Entrust provider


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1901/head:pull/1901` \
`$ git checkout pull/1901`

Update a local copy of the PR: \
`$ git checkout pull/1901` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1901`

View PR using the GUI difftool: \
`$ git pr show -t 1901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1901.diff">https://git.openjdk.org/jdk11u-dev/pull/1901.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1901#issuecomment-1562862228)