### PR TITLE
8303809: Dispose context in SPNEGO NegotiatorImpl

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
@@ -517,4 +517,13 @@ public abstract class AuthenticationInfo extends AuthCacheValue implements Clone
         s2 = new String (pw.getPassword());
         s.defaultWriteObject ();
     }
+
+    /**
+     * Releases any system or cryptographic resources.
+     * It is up to implementors to override disposeContext()
+     * to take necessary action.
+     */
+    public void disposeContext() {
+        // do nothing
+    }
 }

--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -1953,6 +1953,12 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
             if (serverAuthKey != null) {
                 AuthenticationInfo.endAuthRequest(serverAuthKey);
             }
+            if (proxyAuthentication != null) {
+                proxyAuthentication.disposeContext();
+            }
+            if (serverAuthentication != null) {
+                serverAuthentication.disposeContext();
+            }
         }
     }
 
@@ -2181,6 +2187,9 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
         } finally  {
             if (proxyAuthKey != null) {
                 AuthenticationInfo.endAuthRequest(proxyAuthKey);
+            }
+            if (proxyAuthentication != null) {
+                proxyAuthentication.disposeContext();
             }
         }
 
@@ -2428,6 +2437,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
             }
             if (ret != null) {
                 if (!ret.setHeaders(this, p, raw)) {
+                    ret.disposeContext();
                     ret = null;
                 }
             }
@@ -2596,6 +2606,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
 
             if (ret != null ) {
                 if (!ret.setHeaders(this, p, raw)) {
+                    ret.disposeContext();
                     ret = null;
                 }
             }
@@ -2622,6 +2633,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                     DigestAuthentication da = (DigestAuthentication)
                         currentProxyCredentials;
                     da.checkResponse (raw, method, getRequestURI());
+                    currentProxyCredentials.disposeContext();
                     currentProxyCredentials = null;
                 }
             }
@@ -2632,6 +2644,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                     DigestAuthentication da = (DigestAuthentication)
                         currentServerCredentials;
                     da.checkResponse (raw, method, url);
+                    currentServerCredentials.disposeContext();
                     currentServerCredentials = null;
                 }
             }

--- a/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
@@ -225,6 +225,22 @@ class NegotiateAuthentication extends AuthenticationInfo {
         return negotiator.nextToken(token);
     }
 
+    /**
+     * Releases any system resources and cryptographic information stored in
+     * the context object and invalidates the context.
+     */
+    @Override
+    public void disposeContext() {
+        if (negotiator != null) {
+            try {
+                negotiator.disposeContext();
+            } catch (IOException ioEx) {
+                //do not rethrow IOException
+            }
+            negotiator = null;
+        }
+    }
+
     // MS will send a final WWW-Authenticate even if the status is already
     // 200 OK. The token can be fed into initSecContext() again to determine
     // if the server can be trusted. This is not the same concept as Digest's

--- a/src/java.base/share/classes/sun/net/www/protocol/http/Negotiator.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/Negotiator.java
@@ -82,5 +82,7 @@ public abstract class Negotiator {
             logger.finest("NegotiateAuthentication: " + e);
         }
     }
+
+    public void disposeContext() throws IOException { };
 }
 


### PR DESCRIPTION
Clean backport from OpenJDK17

sun/security/jgss sun/security/krb5 sun/net/www/protocol/http tests passed successfully

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303809](https://bugs.openjdk.org/browse/JDK-8303809): Dispose context in SPNEGO NegotiatorImpl


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1906/head:pull/1906` \
`$ git checkout pull/1906`

Update a local copy of the PR: \
`$ git checkout pull/1906` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1906`

View PR using the GUI difftool: \
`$ git pr show -t 1906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1906.diff">https://git.openjdk.org/jdk11u-dev/pull/1906.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1906#issuecomment-1564790703)