### PR TITLE
8300079: SIGSEGV in LibraryCallKit::inline_string_copy due to constant NULL src argument

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1496,10 +1496,13 @@ bool LibraryCallKit::inline_string_copy(bool compress) {
   AllocateArrayNode* alloc = tightly_coupled_allocation(dst, NULL);
 
   // Figure out the size and type of the elements we will be copying.
-  const Type* src_type = src->Value(&_gvn);
-  const Type* dst_type = dst->Value(&_gvn);
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType dst_elem = dst_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  const TypeAryPtr* src_type = src->Value(&_gvn)->isa_aryptr();
+  const TypeAryPtr* dst_type = dst->Value(&_gvn)->isa_aryptr();
+  if (src_type == NULL || dst_type == NULL) {
+    return false;
+  }
+  BasicType src_elem = src_type->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType dst_elem = dst_type->klass()->as_array_klass()->element_type()->basic_type();
   assert((compress && dst_elem == T_BYTE && (src_elem == T_BYTE || src_elem == T_CHAR)) ||
          (!compress && src_elem == T_BYTE && (dst_elem == T_BYTE || dst_elem == T_CHAR)),
          "Unsupported array types for inline_string_copy");
@@ -5018,8 +5021,8 @@ bool LibraryCallKit::inline_encodeISOArray() {
   }
 
   // Figure out the size and type of the elements we will be copying.
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType dst_elem = dst_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType src_elem = top_src->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType dst_elem = top_dest->klass()->as_array_klass()->element_type()->basic_type();
   if (!((src_elem == T_CHAR) || (src_elem== T_BYTE)) || dst_elem != T_BYTE) {
     return false;
   }
@@ -5072,8 +5075,8 @@ bool LibraryCallKit::inline_multiplyToLen() {
     return false;
   }
 
-  BasicType x_elem = x_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType y_elem = y_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType x_elem = top_x->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType y_elem = top_y->klass()->as_array_klass()->element_type()->basic_type();
   if (x_elem != T_INT || y_elem != T_INT) {
     return false;
   }
@@ -5180,8 +5183,8 @@ bool LibraryCallKit::inline_squareToLen() {
     return false;
   }
 
-  BasicType x_elem = x_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType z_elem = z_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType x_elem = top_x->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType z_elem = top_z->klass()->as_array_klass()->element_type()->basic_type();
   if (x_elem != T_INT || z_elem != T_INT) {
     return false;
   }
@@ -5229,8 +5232,8 @@ bool LibraryCallKit::inline_mulAdd() {
     return false;
   }
 
-  BasicType out_elem = out_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType in_elem = in_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType out_elem = top_out->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType in_elem = top_in->klass()->as_array_klass()->element_type()->basic_type();
   if (out_elem != T_INT || in_elem != T_INT) {
     return false;
   }
@@ -5284,10 +5287,10 @@ bool LibraryCallKit::inline_montgomeryMultiply() {
     return false;
   }
 
-  BasicType a_elem = a_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType b_elem = b_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType n_elem = n_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType m_elem = m_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType a_elem = top_a->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType b_elem = top_b->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType n_elem = top_n->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType m_elem = top_m->klass()->as_array_klass()->element_type()->basic_type();
   if (a_elem != T_INT || b_elem != T_INT || n_elem != T_INT || m_elem != T_INT) {
     return false;
   }
@@ -5340,9 +5343,9 @@ bool LibraryCallKit::inline_montgomerySquare() {
     return false;
   }
 
-  BasicType a_elem = a_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType n_elem = n_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType m_elem = m_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType a_elem = top_a->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType n_elem = top_n->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType m_elem = top_m->klass()->as_array_klass()->element_type()->basic_type();
   if (a_elem != T_INT || n_elem != T_INT || m_elem != T_INT) {
     return false;
   }
@@ -5465,7 +5468,7 @@ bool LibraryCallKit::inline_updateBytesCRC32() {
   }
 
   // Figure out the size and type of the elements we will be copying.
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType src_elem = top_src->klass()->as_array_klass()->element_type()->basic_type();
   if (src_elem != T_BYTE) {
     return false;
   }
@@ -5554,7 +5557,7 @@ bool LibraryCallKit::inline_updateBytesCRC32C() {
   }
 
   // Figure out the size and type of the elements we will be copying.
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType src_elem = top_src->klass()->as_array_klass()->element_type()->basic_type();
   if (src_elem != T_BYTE) {
     return false;
   }
@@ -5647,7 +5650,7 @@ bool LibraryCallKit::inline_updateBytesAdler32() {
   }
 
   // Figure out the size and type of the elements we will be copying.
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType src_elem = top_src->klass()->as_array_klass()->element_type()->basic_type();
   if (src_elem != T_BYTE) {
     return false;
   }
@@ -6462,7 +6465,7 @@ bool LibraryCallKit::inline_sha_implCompress(vmIntrinsics::ID id) {
     return false;
   }
   // Figure out the size and type of the elements we will be copying.
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType src_elem = top_src->klass()->as_array_klass()->element_type()->basic_type();
   if (src_elem != T_BYTE) {
     return false;
   }
@@ -6532,7 +6535,7 @@ bool LibraryCallKit::inline_digestBase_implCompressMB(int predicate) {
     return false;
   }
   // Figure out the size and type of the elements we will be copying.
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType src_elem = top_src->klass()->as_array_klass()->element_type()->basic_type();
   if (src_elem != T_BYTE) {
     return false;
   }

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestCopyValueOf.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestCopyValueOf.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8300079
+ * @summary Verify that String.copyValueOf properly handles null input with intrinsified helper methods.
+ * @run main/othervm -XX:-TieredCompilation -Xcomp
+ *                   -XX:CompileCommand=compileonly,compiler.intrinsics.string.TestCopyValueOf::test
+ *                   -XX:CompileCommand=dontinline,java.lang.String::rangeCheck
+ *                   compiler.intrinsics.string.TestCopyValueOf
+ */
+
+package compiler.intrinsics.string;
+
+public class TestCopyValueOf {
+
+    public static boolean test() {
+        try {
+            String.copyValueOf(null, 42, 43);
+        } catch (NullPointerException e) {
+            return true;
+        }
+        return false;
+    }
+
+    public static void main(String[] args) {
+        // Warmup
+        char data[] = {42};
+        String.copyValueOf(data, 0, 1);
+
+        if (!test()) {
+            throw new RuntimeException("Unexpected result");
+        }
+    }
+}


### PR DESCRIPTION
I had to resolve three chunks. 

Also, I replaced nullptr by NULL in one place.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300079](https://bugs.openjdk.org/browse/JDK-8300079): SIGSEGV in LibraryCallKit::inline_string_copy due to constant NULL src argument


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1911/head:pull/1911` \
`$ git checkout pull/1911`

Update a local copy of the PR: \
`$ git checkout pull/1911` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1911/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1911`

View PR using the GUI difftool: \
`$ git pr show -t 1911`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1911.diff">https://git.openjdk.org/jdk11u-dev/pull/1911.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1911#issuecomment-1567463021)