### PR TITLE
8158880: test/java/time/tck/java/time/format/TCKDateTimeFormatterBuilder.java fail with zh_CN locale

### DIFF
--- a/test/jdk/java/time/tck/java/time/format/TCKDateTimeFormatterBuilder.java
+++ b/test/jdk/java/time/tck/java/time/format/TCKDateTimeFormatterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -614,7 +614,7 @@ public class TCKDateTimeFormatterBuilder {
 
     @Test(dataProvider = "parseGenericTimeZonePatterns")
     public void test_appendZoneText_parseGenericTimeZonePatterns(String pattern, LocalDateTime ldt, ZoneId zId, String input) {
-        DateTimeFormatter df = new DateTimeFormatterBuilder().appendPattern(pattern).toFormatter();
+        DateTimeFormatter df = new DateTimeFormatterBuilder().appendPattern(pattern).toFormatter(Locale.US);
         ZonedDateTime expected = ZonedDateTime.parse(input, df);
         ZonedDateTime actual = ZonedDateTime.of(ldt, zId);
         assertEquals(actual, expected);


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.
Set the locale in the DateTimeFormatter to fix the test.
No risk, only a test change.
Tests pass. SAP nightly testing passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8158880](https://bugs.openjdk.org/browse/JDK-8158880): test/java/time/tck/java/time/format/TCKDateTimeFormatterBuilder.java fail with zh_CN locale


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1913/head:pull/1913` \
`$ git checkout pull/1913`

Update a local copy of the PR: \
`$ git checkout pull/1913` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1913`

View PR using the GUI difftool: \
`$ git pr show -t 1913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1913.diff">https://git.openjdk.org/jdk11u-dev/pull/1913.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1913#issuecomment-1568077357)