### PR TITLE
8179503: Java should support GET OCSP calls

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
@@ -24,12 +24,12 @@
  */
 package sun.security.provider.certpath;
 
-import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
 import java.net.HttpURLConnection;
+import java.net.URLEncoder;
 import java.security.cert.CertificateException;
 import java.security.cert.CertPathValidatorException;
 import java.security.cert.CertPathValidatorException.BasicReason;
@@ -37,7 +37,7 @@ import java.security.cert.CRLReason;
 import java.security.cert.Extension;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -45,6 +45,7 @@ import java.util.Map;
 
 import sun.security.action.GetIntegerAction;
 import sun.security.util.Debug;
+import sun.security.util.IOUtils;
 import sun.security.validator.Validator;
 import sun.security.x509.AccessDescription;
 import sun.security.x509.AuthorityInfoAccessExtension;
@@ -224,69 +225,58 @@ public final class OCSP {
         OCSPRequest request = new OCSPRequest(certIds, extensions);
         byte[] bytes = request.encodeBytes();
 
-        InputStream in = null;
-        OutputStream out = null;
-        byte[] response = null;
+        if (debug != null) {
+            debug.println("connecting to OCSP service at: " + responderURI);
+        }
 
+        URL url;
+        HttpURLConnection con = null;
         try {
-            URL url = responderURI.toURL();
-            if (debug != null) {
-                debug.println("connecting to OCSP service at: " + url);
+            String encodedGetReq = responderURI.toString() + "/" +
+                    URLEncoder.encode(Base64.getEncoder().encodeToString(bytes),
+                            "UTF-8");
+
+            if (encodedGetReq.length() <= 255) {
+                url = new URL(encodedGetReq);
+                con = (HttpURLConnection)url.openConnection();
+                con.setDoOutput(true);
+                con.setDoInput(true);
+                con.setRequestMethod("GET");
+            } else {
+                url = responderURI.toURL();
+                con = (HttpURLConnection)url.openConnection();
+                con.setConnectTimeout(CONNECT_TIMEOUT);
+                con.setReadTimeout(CONNECT_TIMEOUT);
+                con.setDoOutput(true);
+                con.setDoInput(true);
+                con.setRequestMethod("POST");
+                con.setRequestProperty
+                    ("Content-type", "application/ocsp-request");
+                con.setRequestProperty
+                    ("Content-length", String.valueOf(bytes.length));
+                OutputStream out = con.getOutputStream();
+                out.write(bytes);
+                out.flush();
             }
-            HttpURLConnection con = (HttpURLConnection)url.openConnection();
-            con.setConnectTimeout(CONNECT_TIMEOUT);
-            con.setReadTimeout(CONNECT_TIMEOUT);
-            con.setDoOutput(true);
-            con.setDoInput(true);
-            con.setRequestMethod("POST");
-            con.setRequestProperty
-                ("Content-type", "application/ocsp-request");
-            con.setRequestProperty
-                ("Content-length", String.valueOf(bytes.length));
-            out = con.getOutputStream();
-            out.write(bytes);
-            out.flush();
             // Check the response
             if (debug != null &&
                 con.getResponseCode() != HttpURLConnection.HTTP_OK) {
                 debug.println("Received HTTP error: " + con.getResponseCode()
                     + " - " + con.getResponseMessage());
             }
-            in = con.getInputStream();
+
             int contentLength = con.getContentLength();
             if (contentLength == -1) {
                 contentLength = Integer.MAX_VALUE;
             }
-            response = new byte[contentLength > 2048 ? 2048 : contentLength];
-            int total = 0;
-            while (total < contentLength) {
-                int count = in.read(response, total, response.length - total);
-                if (count < 0)
-                    break;
 
-                total += count;
-                if (total >= response.length && total < contentLength) {
-                    response = Arrays.copyOf(response, total * 2);
-                }
-            }
-            response = Arrays.copyOf(response, total);
+            return IOUtils.readExactlyNBytes(con.getInputStream(),
+                    contentLength);
         } finally {
-            if (in != null) {
-                try {
-                    in.close();
-                } catch (IOException ioe) {
-                    throw ioe;
-                }
-            }
-            if (out != null) {
-                try {
-                    out.close();
-                } catch (IOException ioe) {
-                    throw ioe;
-                }
+            if (con != null) {
+                con.disconnect();
             }
         }
-        return response;
     }
 
     /**

--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8179503
+ * @summary Java should support GET OCSP calls
+ * @library /javax/net/ssl/templates /java/security/testlibrary
+ * @build SimpleOCSPServer
+ * @modules java.base/sun.security.util
+ *          java.base/sun.security.provider.certpath
+ *          java.base/sun.security.x509
+ * @run main/othervm GetAndPostTests
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.CertPath;
+import java.security.cert.CertPathValidator;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.Extension;
+import java.security.cert.PKIXCertPathChecker;
+import java.security.cert.PKIXParameters;
+import java.security.cert.PKIXRevocationChecker;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import sun.security.testlibrary.SimpleOCSPServer;
+import sun.security.testlibrary.SimpleOCSPServer;
+import sun.security.testlibrary.SimpleOCSPServer;
+import sun.security.util.DerOutputStream;
+import sun.security.util.DerValue;
+import sun.security.util.ObjectIdentifier;
+import sun.security.testlibrary.SimpleOCSPServer;
+
+public class GetAndPostTests {
+    private static final String PASS = "passphrase";
+    private static CertificateFactory certFac;
+
+    public static void main(String args[]) throws Exception {
+        SimpleOCSPServer ocspResponder = null;
+
+        try {
+            certFac = CertificateFactory.getInstance("X.509");
+
+            // Read in the certificates and keys needed for this test and
+            // create the keystore for the SimpleOCSPServer.  For the purposes
+            // of this test, the CA certificate will also be the OCSP responder
+            // signing certificate.
+            SSLSocketTemplate.Cert certAuth =
+                    SSLSocketTemplate.Cert.CA_ECDSA_SECP256R1;
+            X509Certificate caCert = pem2Cert(certAuth.certStr);
+            PrivateKey caKey = pem2Key(certAuth.privKeyStr, certAuth.keyAlgo);
+            X509Certificate endEntCert =
+                    pem2Cert(SSLSocketTemplate.Cert.EE_ECDSA_SECP256R1.certStr);
+
+            KeyStore.Builder keyStoreBuilder =
+                    KeyStore.Builder.newInstance("PKCS12", null,
+                        new KeyStore.PasswordProtection(PASS.toCharArray()));
+            KeyStore ocspStore = keyStoreBuilder.getKeyStore();
+            Certificate[] ocspChain = {caCert};
+            ocspStore.setKeyEntry("ocspsigner", caKey, PASS.toCharArray(),
+                    ocspChain);
+
+            // Create the certificate path we'll use for cert path validation.
+            CertPath path = certFac.generateCertPath(List.of(endEntCert));
+
+            // Next, create and start the OCSP responder.  Obtain the socket
+            // address so we can set that in the PKIXRevocationChecker since
+            // these certificates do not have AIA extensions on them.
+            ocspResponder = new SimpleOCSPServer(ocspStore, PASS,
+                    "ocspsigner", null);
+            ocspResponder.setSignatureAlgorithm("SHA256WithECDSA");
+            ocspResponder.enableLog(true);
+            ocspResponder.setNextUpdateInterval(3600);
+            ocspResponder.updateStatusDb(Map.of(
+                    endEntCert.getSerialNumber(),
+                    new SimpleOCSPServer.CertStatusInfo(
+                            SimpleOCSPServer.CertStatus.CERT_STATUS_GOOD)));
+            ocspResponder.start();
+            // Wait 5 seconds for server ready
+            for (int i = 0; (i < 100 && !ocspResponder.isServerReady()); i++) {
+                Thread.sleep(50);
+            }
+            if (!ocspResponder.isServerReady()) {
+                throw new RuntimeException("Server not ready yet");
+            }
+
+            int ocspPort = ocspResponder.getPort();
+            URI ocspURI = new URI("http://localhost:" + ocspPort);
+            System.out.println("Configured CPV to connect to " + ocspURI);
+
+            // Create the PKIXParameters needed for path validation and
+            // configure any necessary OCSP parameters to control the OCSP
+            // request size.
+            Set<TrustAnchor> anchors = Set.of(new TrustAnchor(caCert, null));
+
+            CertPathValidator validator = CertPathValidator.getInstance("PKIX");
+            PKIXRevocationChecker revChkr =
+                    (PKIXRevocationChecker)validator.getRevocationChecker();
+            revChkr.setOcspResponder(ocspURI);
+            revChkr.setOptions(Set.of(
+                    PKIXRevocationChecker.Option.ONLY_END_ENTITY,
+                    PKIXRevocationChecker.Option.NO_FALLBACK));
+
+            PKIXParameters params = new PKIXParameters(anchors);
+            params.setRevocationEnabled(true);
+            params.setDate(new Date(1590926400000L)); // 05/31/2020 @ 12:00:00Z
+            params.addCertPathChecker(revChkr);
+
+            System.out.println("Test 1: Request < 255 bytes, HTTP GET");
+            validator.validate(path, params);
+
+            System.out.println("Test 2: Request > 255 bytes, HTTP POST");
+            // Modify the PKIXRevocationChecker to include a bogus non-critical
+            // request extension that makes the request large enough to be
+            // issued as an HTTP POST.
+            List<PKIXCertPathChecker> chkrList = params.getCertPathCheckers();
+            for (PKIXCertPathChecker chkr : chkrList) {
+                if (chkr instanceof PKIXRevocationChecker) {
+                    ((PKIXRevocationChecker)chkr).setOcspExtensions(
+                            List.of(new BogusExtension("1.2.3.4.5.6.7.8.9",
+                                    false, 256)));
+                }
+            }
+            params.setCertPathCheckers(chkrList);
+            validator.validate(path, params);
+
+        } finally {
+            if (ocspResponder != null) {
+                ocspResponder.stop();
+            }
+        }
+    }
+
+    /**
+     * Create an X509Certificate object from its PEM encoding
+     *
+     * @param pemCert the base64 encoded certificate
+     *
+     * @return the corresponding X509Certificate object from the PEM encoding.
+     *
+     * @throws IOException if any InputStream or Base64 decoding failures occur.
+     * @throws CertificateException if any certificate parsing errors occur.
+     */
+    private static X509Certificate pem2Cert(String pemCert)
+            throws IOException, CertificateException {
+        return (X509Certificate)certFac.generateCertificate(
+                new ByteArrayInputStream(pemCert.getBytes()));
+    }
+
+    /**
+     * Create a private key from its PEM-encoded PKCS#8 representation.
+     *
+     * @param pemKey the private key in PEM-encoded PKCS#8 unencrypted format
+     * @param algorithm the private key algorithm
+     *
+     * @return the PrivateKey extracted from the PKCS#8 encoding.
+     *
+     * @throws GeneralSecurityException if any errors take place during
+     * decoding or parsing.
+     */
+    private static PrivateKey pem2Key(String pemKey, String algorithm)
+            throws GeneralSecurityException {
+        byte[] p8Der = Base64.getMimeDecoder().decode(pemKey);
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(p8Der, algorithm);
+        KeyFactory kf = KeyFactory.getInstance(algorithm);
+        return kf.generatePrivate(spec);
+    }
+
+    /**
+     * The BogusOcspExtension is an extension with random data in the
+     * extension value field.  It is used in this test to expand the size
+     * of the OCSP request so it crosses the boundary that forces an HTTP
+     * POST operation instead of a GET.
+     */
+    private static class BogusExtension implements Extension {
+        private final ObjectIdentifier oid;
+        private final boolean critical;
+        private final byte[] data;
+
+        public BogusExtension(String oidStr, boolean isCrit, int size)
+                throws IOException {
+            // For this test we don't need anything larger than 10K
+            if (size > 0 && size <= 10240) {
+                data = new byte[size];
+            } else {
+                throw new IllegalArgumentException(
+                        "Size must be 0 < X <= 10240");
+            }
+            oid = ObjectIdentifier.of(oidStr);
+            SecureRandom sr = new SecureRandom();
+            sr.nextBytes(data);
+            critical = isCrit;
+        }
+
+        @Override
+        public String getId() {
+            return oid.toString();
+        }
+
+        @Override
+        public boolean isCritical() {
+            return critical;
+        }
+
+        @Override
+        public byte[] getValue() {
+            return data.clone();
+        }
+
+        @Override
+        public void encode(OutputStream out) throws IOException {
+            Objects.requireNonNull(out, "Non-null OutputStream required");
+
+            DerOutputStream dos1 = new DerOutputStream();
+            DerOutputStream dos2 = new DerOutputStream();
+
+            dos1.putOID(oid);
+            if (critical) {
+                dos1.putBoolean(critical);
+            }
+            dos1.putOctetString(data);
+
+            dos2.write(DerValue.tag_Sequence, dos1);
+            out.write(dos2.toByteArray());
+        }
+    }
+}

--- a/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
+++ b/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
@@ -707,21 +707,21 @@ public class SimpleOCSPServer {
                     OutputStream out = ocspSocket.getOutputStream()) {
                 peerSockAddr =
                         (InetSocketAddress)ocspSocket.getRemoteSocketAddress();
-                log("Received incoming connection from " + peerSockAddr);
                 String[] headerTokens = readLine(in).split(" ");
                 LocalOcspRequest ocspReq = null;
                 LocalOcspResponse ocspResp = null;
                 ResponseStatus respStat = ResponseStatus.INTERNAL_ERROR;
                 try {
                     if (headerTokens[0] != null) {
+                        log("Received incoming HTTP " + headerTokens[0] +
+                                " from " + peerSockAddr);
                         switch (headerTokens[0]) {
                             case "POST":
-                                    ocspReq = parseHttpOcspPost(in);
+                                ocspReq = parseHttpOcspPost(in);
                                 break;
                             case "GET":
-                                // req = parseHttpOcspGet(in);
-                                // TODO implement the GET parsing
-                                throw new IOException("GET method unsupported");
+                                ocspReq = parseHttpOcspGet(headerTokens);
+                                break;
                             default:
                                 respStat = ResponseStatus.MALFORMED_REQUEST;
                                 throw new IOException("Not a GET or POST");
@@ -841,6 +841,30 @@ public class SimpleOCSPServer {
             } else {
                 return null;
             }
+        }
+
+        /**
+         * Parse the incoming HTTP GET of an OCSP Request.
+         *
+         * @param headerTokens the individual String tokens from the first
+         * line of the HTTP GET.
+         *
+         * @return the OCSP Request as a {@code LocalOcspRequest}
+         *
+         * @throws IOException if there are network related issues or problems
+         * occur during parsing of the OCSP request.
+         * @throws CertificateException if one or more of the certificates in
+         * the OCSP request cannot be read/parsed.
+         */
+        private LocalOcspRequest parseHttpOcspGet(String[] headerTokens)
+                throws IOException, CertificateException {
+            // We have already established headerTokens[0] to be "GET".
+            // We should have the URL-encoded base64 representation of the
+            // OCSP request in headerTokens[1].  We need to strip any leading
+            // "/" off before decoding.
+            return new LocalOcspRequest(Base64.getMimeDecoder().decode(
+                    URLDecoder.decode(headerTokens[1].replaceAll("/", ""),
+                            "UTF-8")));
         }
 
         /**


### PR DESCRIPTION
Hi, here is backport of [JDK-8179503](https://bugs.openjdk.org/browse/JDK-8179503) that adds support of GET OCSP calls for parity with Oracle: in spite of the fact that JBS issue is not labelled with any Oracle release, this one is mandatory for [JDK-8274471](https://bugs.openjdk.org/browse/JDK-8274471) released to 11.0.18-oracle

Original patch applied with the only change

**`src/java.base/share/classes/sun/security/provider/certpath/OCSP.java`**
- resolved baseline conflict related to revokation checking

Verification (amd64/20.04): newly added `test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java`
Regression  (amd64/20.04): `jdk_security`

@TheRealMDoerr I raised this one instead of already reviewed https://github.com/openjdk/jdk11u-dev/pull/847. Please check it out

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8179503](https://bugs.openjdk.org/browse/JDK-8179503) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8179503](https://bugs.openjdk.org/browse/JDK-8179503): Java should support GET OCSP calls (**Enhancement** - P3)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1917/head:pull/1917` \
`$ git checkout pull/1917`

Update a local copy of the PR: \
`$ git checkout pull/1917` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1917`

View PR using the GUI difftool: \
`$ git pr show -t 1917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1917.diff">https://git.openjdk.org/jdk11u-dev/pull/1917.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1917#issuecomment-1569819284)