### PR TITLE
Backport 6d63995ada6b4f2cdd8921dc254276fe724a12c4

### DIFF
--- a/test/jdk/java/net/DatagramSocket/UnreferencedDatagramSockets.java
+++ b/test/jdk/java/net/DatagramSocket/UnreferencedDatagramSockets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CountDownLatch;
 
 import com.sun.management.UnixOperatingSystemMXBean;
 
@@ -67,9 +68,10 @@ public class UnreferencedDatagramSockets {
     static class Server implements Runnable {
 
         DatagramSocket ss;
+        CountDownLatch latch = new CountDownLatch(1);
 
         Server() throws IOException {
-            ss = new DatagramSocket(0);
+            ss = new DatagramSocket(0, getHost());
             System.out.printf("  DatagramServer addr: %s: %d%n",
                     this.getHost(), this.getPort());
             pendingSockets.add(new NamedWeak(ss, pendingQueue, "serverDatagramSocket"));
@@ -77,7 +79,7 @@ public class UnreferencedDatagramSockets {
         }
 
         InetAddress getHost() throws UnknownHostException {
-            InetAddress localhost = InetAddress.getByName("localhost"); //.getLocalHost();
+            InetAddress localhost = lookupLocalHost();
             return localhost;
         }
 
@@ -93,6 +95,7 @@ public class UnreferencedDatagramSockets {
                 ss.receive(p);
                 buffer[0] += 1;
                 ss.send(p);         // send back +1
+                latch.await(); // wait for the client to receive the packet
 
                 // do NOT close but 'forget' the datagram socket reference
                 ss = null;
@@ -102,10 +105,14 @@ public class UnreferencedDatagramSockets {
         }
     }
 
+    static InetAddress lookupLocalHost() throws UnknownHostException {
+        return InetAddress.getByName("localhost"); //.getLocalHost();
+    }
+
     public static void main(String args[]) throws Exception {
 
         // Create and close a DatagramSocket to warm up the FD count for side effects.
-        try (DatagramSocket s = new DatagramSocket(0)) {
+        try (DatagramSocket s = new DatagramSocket(0, lookupLocalHost())) {
             // no-op; close immediately
             s.getLocalPort();   // no-op
         }
@@ -118,7 +125,7 @@ public class UnreferencedDatagramSockets {
         Thread thr = new Thread(svr);
         thr.start();
 
-        DatagramSocket client = new DatagramSocket(0);
+        DatagramSocket client = new DatagramSocket(0, lookupLocalHost());
         client.connect(svr.getHost(), svr.getPort());
         pendingSockets.add(new NamedWeak(client, pendingQueue, "clientDatagramSocket"));
         extractRefs(client, "clientDatagramSocket");
@@ -130,6 +137,7 @@ public class UnreferencedDatagramSockets {
 
         p = new DatagramPacket(msg, msg.length);
         client.receive(p);
+        svr.latch.countDown(); // unblock the server
 
         System.out.printf("echo received from: %s%n", p.getSocketAddress());
         if (msg[0] != 2) {


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.