### PR TITLE
8223573: Replace wildcard address with loopback or local host in tests - part 4

### DIFF
--- a/test/jdk/sun/net/ftp/FtpURLConnectionLeak.java
+++ b/test/jdk/sun/net/ftp/FtpURLConnectionLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,17 +32,19 @@
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.URL;
 
 public class FtpURLConnectionLeak {
 
     public static void main(String[] args) throws Exception {
-        FtpServer server = new FtpServer(0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        FtpServer server = new FtpServer(loopback, 0);
         server.setFileSystemHandler(new CustomFileSystemHandler("/"));
         server.setAuthHandler(new MyAuthHandler());
-        int port = server.getLocalPort();
+        String authority = server.getAuthority();
         server.start();
-        URL url = new URL("ftp://localhost:" + port + "/filedoesNotExist.txt");
+        URL url = new URL("ftp://" + authority + "/filedoesNotExist.txt");
         try (server) {
             for (int i = 0; i < 3; i++) {
                 try {

--- a/test/jdk/sun/net/www/AuthHeaderTest.java
+++ b/test/jdk/sun/net/www/AuthHeaderTest.java
@@ -96,10 +96,11 @@ public class AuthHeaderTest implements HttpCallback {
     public static void main (String[] args) throws Exception {
         MyAuthenticator auth = new MyAuthenticator ();
         Authenticator.setDefault (auth);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
         try {
-            server = new TestHttpServer (new AuthHeaderTest(), 1, 10, 0);
-            System.out.println ("Server: listening on port: " + server.getLocalPort());
-            client ("http://localhost:"+server.getLocalPort()+"/d1/foo.html");
+            server = new TestHttpServer (new AuthHeaderTest(), 1, 10, loopback, 0);
+            System.out.println ("Server: listening on port: " + server.getAuthority());
+            client ("http://" + server.getAuthority() + "/d1/foo.html");
         } catch (Exception e) {
             if (server != null) {
                 server.terminate();

--- a/test/jdk/sun/net/www/ftptest/FtpServer.java
+++ b/test/jdk/sun/net/www/ftptest/FtpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,6 +59,16 @@ public class FtpServer extends Thread implements AutoCloseable {
      * connections on the specified port. If the port is set to 0, it will
      * automatically select an available ephemeral port.
      */
+    public FtpServer(InetAddress addr, int port) throws IOException {
+        listener = new ServerSocket();
+        listener.bind(new InetSocketAddress(addr, port));
+    }
+
+    /**
+     * Creates an instance of an FTP server which will listen for incoming
+     * connections on the specified port. If the port is set to 0, it will
+     * automatically select an available ephemeral port.
+     */
     public FtpServer(int port) throws IOException {
         listener = new ServerSocket(port);
     }
@@ -99,6 +109,17 @@ public class FtpServer extends Thread implements AutoCloseable {
     public int getLocalPort() {
         return listener.getLocalPort();
     }
+
+    public String getAuthority() {
+        InetAddress address = listener.getInetAddress();
+        String hostaddr = address.isAnyLocalAddress()
+            ? "localhost" : address.getHostAddress();
+        if (hostaddr.indexOf(':') > -1) {
+            hostaddr = "[" + hostaddr + "]";
+        }
+        return hostaddr + ":" + getLocalPort();
+    }
+
 
     void addClient(Socket client) {
         FtpCommandHandler h = new FtpCommandHandler(client, this);

--- a/test/jdk/sun/net/www/http/ChunkedInputStream/ChunkedEncodingTest.java
+++ b/test/jdk/sun/net/www/http/ChunkedInputStream/ChunkedEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 4333920
  * @modules jdk.httpserver
+ * @library /test/lib
  * @run main ChunkedEncodingTest
  * @summary ChunkedEncodingTest unit test
  */
@@ -36,6 +37,7 @@ import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpExchange;
 import static java.lang.System.out;
+import jdk.test.lib.net.URIBuilder;
 
 public class ChunkedEncodingTest{
     private static MessageDigest serverDigest, clientDigest;
@@ -61,7 +63,13 @@ public class ChunkedEncodingTest{
 
             int port = server.getAddress().getPort();
             out.println ("Server listening on port: " + port);
-            client("http://localhost:" + port + "/chunked/");
+            String url = URIBuilder.newBuilder()
+                .scheme("http")
+                .host(server.getAddress().getAddress())
+                .port(port)
+                .path("/chunked/")
+                .build().toString();
+            client(url);
 
             if (!MessageDigest.isEqual(clientMac, serverMac)) {
                 throw new RuntimeException(
@@ -83,7 +91,8 @@ public class ChunkedEncodingTest{
      * Http Server
      */
     static HttpServer startHttpServer() throws IOException {
-        HttpServer httpServer = HttpServer.create(new InetSocketAddress(0), 0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress(loopback, 0), 0);
         HttpHandler httpHandler = new SimpleHandler();
         httpServer.createContext("/chunked/", httpHandler);
         httpServer.start();

--- a/test/jdk/sun/net/www/http/ChunkedInputStream/ChunkedEncodingWithProgressMonitorTest.java
+++ b/test/jdk/sun/net/www/http/ChunkedInputStream/ChunkedEncodingWithProgressMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary ChunkedEncoding unit test; MeteredStream/ProgressData problem
  * @modules java.base/sun.net
  *          jdk.httpserver
+ * @library /test/lib
  * @run main ChunkedEncodingWithProgressMonitorTest
  */
 

--- a/test/jdk/sun/net/www/http/ChunkedInputStream/TestAvailable.java
+++ b/test/jdk/sun/net/www/http/ChunkedInputStream/TestAvailable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 6446990
  * @modules jdk.httpserver
+ * @library /test/lib
  * @run main/othervm TestAvailable
  * @summary HttpURLConnection#available() reads more and more data into memory
  */
@@ -35,6 +36,7 @@ import java.io.*;
 import com.sun.net.httpserver.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
+import jdk.test.lib.net.URIBuilder;
 
 public class TestAvailable
 {
@@ -60,7 +62,13 @@ public class TestAvailable
         try {
             InetSocketAddress address = httpServer.getAddress();
 
-            URL url = new URL("http://localhost:" + address.getPort() + "/testAvailable/");
+            URL url = URIBuilder.newBuilder()
+                      .scheme("http")
+                      .host(address.getAddress())
+                      .port(address.getPort())
+                      .path("/testAvailable/")
+                      .toURLUnchecked();
+
             HttpURLConnection uc = (HttpURLConnection)url.openConnection();
 
             uc.setDoOutput(true);
@@ -102,7 +110,9 @@ public class TestAvailable
      * Http Server
      */
     public void startHttpServer() throws IOException {
-        httpServer = com.sun.net.httpserver.HttpServer.create(new InetSocketAddress(0), 0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        InetSocketAddress sockaddr = new InetSocketAddress(loopback, 0);
+        httpServer = com.sun.net.httpserver.HttpServer.create(sockaddr, 0);
 
         // create HttpServer context
         HttpContext ctx = httpServer.createContext("/testAvailable/", new MyHandler());

--- a/test/jdk/sun/net/www/http/HttpClient/MultiThreadTest.java
+++ b/test/jdk/sun/net/www/http/HttpClient/MultiThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,8 +83,8 @@ public class MultiThreadTest extends Thread {
     byte[] b;
     int requests;
 
-    MultiThreadTest(int port, int requests) throws Exception {
-        uri = "http://localhost:" + port + "/foo.html";
+    MultiThreadTest(String authority, int requests) throws Exception {
+        uri = "http://" + authority + "/foo.html";
 
         b = new byte [256];
         this.requests = requests;
@@ -133,14 +133,16 @@ public class MultiThreadTest extends Thread {
         }
 
         /* start the server */
-        ServerSocket ss = new ServerSocket(0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        ServerSocket ss = new ServerSocket();
+        ss.bind(new InetSocketAddress(loopback, 0));
         Server svr = new Server(ss);
         svr.start();
 
         Object lock = MultiThreadTest.getLock();
         synchronized (lock) {
             for (int i=0; i<threads; i++) {
-                MultiThreadTest t = new MultiThreadTest(ss.getLocalPort(), requests);
+                MultiThreadTest t = new MultiThreadTest(svr.getAuthority(), requests);
                 t.start ();
             }
             try {
@@ -207,6 +209,16 @@ public class MultiThreadTest extends Thread {
 
         Server(ServerSocket ss) {
             this.ss = ss;
+        }
+
+        public String getAuthority() {
+            InetAddress address = ss.getInetAddress();
+            String hostaddr = address.isAnyLocalAddress()
+                ? "localhost" : address.getHostAddress();
+            if (hostaddr.indexOf(':') > -1) {
+                hostaddr = "[" + hostaddr + "]";
+            }
+            return hostaddr + ":" + ss.getLocalPort();
         }
 
         public Queue<Worker> workers() {

--- a/test/jdk/sun/net/www/protocol/http/6550798/test.java
+++ b/test/jdk/sun/net/www/protocol/http/6550798/test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,14 +43,15 @@ public class test {
     public static void main(String[] args)  throws Exception {
 
         TestCache.reset();
-        HttpServer s = HttpServer.create (new InetSocketAddress(0), 10);
-        s.createContext ("/", new HttpHandler () {
-            public void handle (HttpExchange e) {
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        HttpServer s = HttpServer.create(new InetSocketAddress(loopback, 0), 10);
+        s.createContext("/", new HttpHandler() {
+            public void handle(HttpExchange e) {
                 try {
                     byte[] buf = new byte [LEN];
                     OutputStream o = e.getResponseBody();
                     e.sendResponseHeaders(200, LEN);
-                    o.write (buf);
+                    o.write(buf);
                     e.close();
                 } catch (IOException ex) {
                     ex.printStackTrace();
@@ -91,10 +92,10 @@ public class test {
         }
 
         if (TestCache.fail) {
-            System.out.println ("TEST FAILED");
-            throw new RuntimeException ();
+            System.out.println("TEST FAILED");
+            throw new RuntimeException();
         } else {
-            System.out.println ("TEST OK");
+            System.out.println("TEST OK");
         }
     }
 }

--- a/test/jdk/sun/net/www/protocol/http/CloseOptionHeader.java
+++ b/test/jdk/sun/net/www/protocol/http/CloseOptionHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 6189206
  * @modules java.base/sun.net.www
+ * @library /test/lib
  * @run main/othervm -Dhttp.keepAlive=false CloseOptionHeader
  * @summary  HTTP client should set "Connection: close" header in request when keepalive is disabled
  */
@@ -33,7 +34,7 @@ import java.net.*;
 import java.util.*;
 import java.io.*;
 import sun.net.www.MessageHeader;
-
+import jdk.test.lib.net.URIBuilder;
 
 public class CloseOptionHeader implements Runnable {
     static ServerSocket ss;
@@ -79,14 +80,20 @@ public class CloseOptionHeader implements Runnable {
         Thread tester = new Thread(new CloseOptionHeader());
 
         /* start the server */
-        ss = new ServerSocket(0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        ss = new ServerSocket();
+        ss.bind(new InetSocketAddress(loopback, 0));
         tester.start();
 
         /* connect to the server just started
          * server then check the request to see whether
          * there is a close connection option header in it
          */
-        URL url = new URL("http://localhost:" + ss.getLocalPort());
+        URL url = URIBuilder.newBuilder()
+            .scheme("http")
+            .host(ss.getInetAddress())
+            .port(ss.getLocalPort())
+            .toURL();
         HttpURLConnection huc = (HttpURLConnection)url.openConnection();
         huc.connect();
         huc.getResponseCode();


### PR DESCRIPTION
I backport this as prerequisite of 8223856 which fixes intermittent issues we see in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8223573](https://bugs.openjdk.org/browse/JDK-8223573): Replace wildcard address with loopback or local host in tests - part 4


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1924/head:pull/1924` \
`$ git checkout pull/1924`

Update a local copy of the PR: \
`$ git checkout pull/1924` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1924`

View PR using the GUI difftool: \
`$ git pr show -t 1924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1924.diff">https://git.openjdk.org/jdk11u-dev/pull/1924.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1924#issuecomment-1573787965)