### PR TITLE
8297523: Various GetPrimitiveArrayCritical miss result - NULL check

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
@@ -136,15 +136,16 @@ JNI_COCOA_ENTER(env);
     jint nElements = (*env)->GetArrayLength(env, inTypes);
     NSMutableArray *formatArray = [NSMutableArray arrayWithCapacity:nElements];
     jlong *elements = (*env)->GetPrimitiveArrayCritical(env, inTypes, NULL);
+    if (elements != NULL) {
+        for (i = 0; i < nElements; i++) {
+            NSString *pbFormat = formatForIndex(elements[i]);
+            if (pbFormat)
+                [formatArray addObject:pbFormat];
+        }
 
-    for (i = 0; i < nElements; i++) {
-        NSString *pbFormat = formatForIndex(elements[i]);
-        if (pbFormat)
-            [formatArray addObject:pbFormat];
+        (*env)->ReleasePrimitiveArrayCritical(env, inTypes, elements, JNI_ABORT);
+        [[CClipboard sharedClipboard] declareTypes:formatArray withOwner:inJavaClip jniEnv:env];
     }
-
-    (*env)->ReleasePrimitiveArrayCritical(env, inTypes, elements, JNI_ABORT);
-    [[CClipboard sharedClipboard] declareTypes:formatArray withOwner:inJavaClip jniEnv:env];
 JNI_COCOA_EXIT(env);
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/font/CCharToGlyphMapper.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/CCharToGlyphMapper.m
@@ -58,12 +58,14 @@ GetGlyphsFromUnicodes(JNIEnv *env, AWTFont *awtFont,
 {
     jint *glyphCodeInts = (*env)->GetPrimitiveArrayCritical(env, glyphs, 0);
 
-    CTS_GetGlyphsAsIntsForCharacters(awtFont, unicodes,
-                                     cgGlyphs, glyphCodeInts, count);
+    if (glyphCodeInts != NULL) {
+        CTS_GetGlyphsAsIntsForCharacters(awtFont, unicodes,
+                                         cgGlyphs, glyphCodeInts, count);
 
-    // Do not use JNI_COMMIT, as that will not free the buffer copy
-    // when +ProtectJavaHeap is on.
-    (*env)->ReleasePrimitiveArrayCritical(env, glyphs, glyphCodeInts, 0);
+        // Do not use JNI_COMMIT, as that will not free the buffer copy
+        // when +ProtectJavaHeap is on.
+        (*env)->ReleasePrimitiveArrayCritical(env, glyphs, glyphCodeInts, 0);
+    }
 }
 
 static inline void

--- a/src/java.desktop/macosx/native/libosxui/JRSUIController.m
+++ b/src/java.desktop/macosx/native/libosxui/JRSUIController.m
@@ -277,11 +277,13 @@ JNIEXPORT void JNICALL Java_apple_laf_JRSUIControl_getNativePartBounds
     CGRect partBounds = JRSUIControlGetScrollBarPartBounds(control, frame, part);
 
     jdouble *rect = (*env)->GetPrimitiveArrayCritical(env, rectArray, NULL);
-    rect[0] = partBounds.origin.x;
-    rect[1] = partBounds.origin.y;
-    rect[2] = partBounds.size.width;
-    rect[3] = partBounds.size.height;
-    (*env)->ReleasePrimitiveArrayCritical(env, rectArray, rect, 0);
+    if (rect != NULL) {
+        rect[0] = partBounds.origin.x;
+        rect[1] = partBounds.origin.y;
+        rect[2] = partBounds.size.width;
+        rect[3] = partBounds.size.height;
+        (*env)->ReleasePrimitiveArrayCritical(env, rectArray, rect, 0);
+    }
 }
 
 /*

--- a/src/java.desktop/unix/native/libawt_xawt/awt/swing_GTKEngine.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/swing_GTKEngine.c
@@ -331,6 +331,11 @@ Java_com_sun_java_swing_plaf_gtk_GTKEngine_nativeFinishPainting(
 {
     jint transparency;
     gint *buffer = (gint*) (*env)->GetPrimitiveArrayCritical(env, dest, 0);
+    if (buffer == 0) {
+        (*env)->ExceptionClear(env);
+        JNU_ThrowOutOfMemoryError(env, "Could not get image buffer");
+        return -1;
+    }
     gtk->gdk_threads_enter();
     transparency = gtk->copy_image(buffer, width, height);
     gtk->gdk_threads_leave();

--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -476,7 +476,7 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_ThemeReader_paintBackground
         // Copy the resulting pixels to our Java BufferedImage.
         pDstBits = (int *)env->GetPrimitiveArrayCritical(array, 0);
         if (pDstBits != NULL) {
-            BOOL transparent = IsThemeBackgroundPartiallyTransparentFunc(hTheme, part, state);
+            BOOL transparent = IsThemeBackgroundPartiallyTransparent(hTheme, part, state);
             copyDIBToBufferedImage(pDstBits, pSrcBits, transparent, w, h, stride);
             env->ReleasePrimitiveArrayCritical(array, pDstBits, 0);
         }

--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -476,7 +476,8 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_ThemeReader_paintBackground
         // Copy the resulting pixels to our Java BufferedImage.
         pDstBits = (int *)env->GetPrimitiveArrayCritical(array, 0);
         if (pDstBits != NULL) {
-            BOOL transparent = IsThemeBackgroundPartiallyTransparentFunc(hTheme, part, state);
+            BOOL transparent = FALSE;
+            transparent = IsThemeBackgroundPartiallyTransparentFunc(hTheme, part, state);
             copyDIBToBufferedImage(pDstBits, pSrcBits, transparent, w, h, stride);
             env->ReleasePrimitiveArrayCritical(array, pDstBits, 0);
         }

--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -476,8 +476,7 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_ThemeReader_paintBackground
         // Copy the resulting pixels to our Java BufferedImage.
         pDstBits = (int *)env->GetPrimitiveArrayCritical(array, 0);
         if (pDstBits != NULL) {
-            BOOL transparent = FALSE;
-            transparent = IsThemeBackgroundPartiallyTransparentFunc(hTheme, part, state);
+            BOOL transparent = IsThemeBackgroundPartiallyTransparentFunc(hTheme, part, state);
             copyDIBToBufferedImage(pDstBits, pSrcBits, transparent, w, h, stride);
             env->ReleasePrimitiveArrayCritical(array, pDstBits, 0);
         }

--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -475,10 +475,11 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_ThemeReader_paintBackground
         GdiFlush();
         // Copy the resulting pixels to our Java BufferedImage.
         pDstBits = (int *)env->GetPrimitiveArrayCritical(array, 0);
-        BOOL transparent = FALSE;
-        transparent = IsThemeBackgroundPartiallyTransparent(hTheme,part,state);
-        copyDIBToBufferedImage(pDstBits, pSrcBits, transparent, w, h, stride);
-        env->ReleasePrimitiveArrayCritical(array, pDstBits, 0);
+        if (pDstBits != NULL) {
+            BOOL transparent = IsThemeBackgroundPartiallyTransparentFunc(hTheme, part, state);
+            copyDIBToBufferedImage(pDstBits, pSrcBits, transparent, w, h, stride);
+            env->ReleasePrimitiveArrayCritical(array, pDstBits, 0);
+        }
     }
 
     // Delete resources.

--- a/src/java.desktop/windows/native/libawt/windows/awt_DataTransferer.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DataTransferer.cpp
@@ -163,6 +163,10 @@ AwtDataTransferer::GetPaletteBytes(HGDIOBJ hGdiObj, DWORD dwGdiObjType,
 
     LOGPALETTE* pLogPalette =
         (LOGPALETTE*)env->GetPrimitiveArrayCritical(paletteBytes, NULL);
+    if (pLogPalette == NULL) {
+        env->DeleteLocalRef(paletteBytes);
+        return NULL;
+    }
     PALETTEENTRY* pPalEntries = (PALETTEENTRY*)pLogPalette->palPalEntry;
 
     pLogPalette->palVersion = 0x300;

--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -2876,8 +2876,10 @@ Java_sun_awt_windows_WToolkit_loadSystemColors(JNIEnv *env, jobject self,
     jint* colorsPtr = NULL;
     try {
         colorsPtr = (jint *)env->GetPrimitiveArrayCritical(colors, 0);
-        for (int i = 0; i < (sizeof indexMap)/(sizeof *indexMap) && i < colorLen; i++) {
-            colorsPtr[i] = DesktopColor2RGB(indexMap[i]);
+        if (colorsPtr != NULL) {
+            for (int i = 0; i < (sizeof indexMap)/(sizeof *indexMap) && i < colorLen; i++) {
+                colorsPtr[i] = DesktopColor2RGB(indexMap[i]);
+            }
         }
     } catch (...) {
         if (colorsPtr != NULL) {


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

I had to resolve ThemeReader.cpp because it differs in formatting.
Also, on win, a function is named differently.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297523](https://bugs.openjdk.org/browse/JDK-8297523): Various GetPrimitiveArrayCritical miss result - NULL check (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1925/head:pull/1925` \
`$ git checkout pull/1925`

Update a local copy of the PR: \
`$ git checkout pull/1925` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1925`

View PR using the GUI difftool: \
`$ git pr show -t 1925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1925.diff">https://git.openjdk.org/jdk11u-dev/pull/1925.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1925#issuecomment-1573830419)