### PR TITLE
8301491: C2: java.lang.StringUTF16::indexOfChar intrinsic called with negative character argument

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1428,7 +1428,7 @@ bool LibraryCallKit::inline_string_indexOfChar() {
   }
   assert(callee()->signature()->size() == 4, "String.indexOfChar() has 4 arguments");
   Node* src         = argument(0); // byte[]
-  Node* tgt         = argument(1); // tgt is int ch
+  Node* int_ch      = argument(1);
   Node* from_index  = argument(2);
   Node* max         = argument(3);
 
@@ -1440,6 +1440,15 @@ bool LibraryCallKit::inline_string_indexOfChar() {
 
   // Range checks
   generate_string_range_check(src, src_offset, src_count, true);
+
+  // Check for int_ch >= 0
+  Node* int_ch_cmp = _gvn.transform(new CmpINode(int_ch, intcon(0)));
+  Node* int_ch_bol = _gvn.transform(new BoolNode(int_ch_cmp, BoolTest::ge));
+  {
+    BuildCutout unless(this, int_ch_bol, PROB_MAX);
+    uncommon_trap(Deoptimization::Reason_intrinsic,
+                  Deoptimization::Action_maybe_recompile);
+  }
   if (stopped()) {
     return true;
   }
@@ -1447,7 +1456,7 @@ bool LibraryCallKit::inline_string_indexOfChar() {
   RegionNode* region = new RegionNode(3);
   Node* phi = new PhiNode(region, TypeInt::INT);
 
-  Node* result = new StrIndexOfCharNode(control(), memory(TypeAryPtr::BYTES), src_start, src_count, tgt, StrIntrinsicNode::none);
+  Node* result = new StrIndexOfCharNode(control(), memory(TypeAryPtr::BYTES), src_start, src_count, int_ch, StrIntrinsicNode::none);
   C->set_has_split_ifs(true); // Has chance for split-if optimization
   _gvn.transform(result);
 

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIndexOfCharIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringIndexOfCharIntrinsics.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8301491
+ * @summary Check for correct return value when calling indexOfChar intrinsics with negative value.
+ * @library /test/lib
+ *
+ * @run main/othervm -XX:CompileCommand=quiet
+ *                   -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.intrinsics.string.TestStringIndexOfCharIntrinsics::testIndexOfChar*
+ *                   -XX:CompileCommand=inline,java.lang.String*::indexOf*
+ *                   -XX:PerBytecodeTrapLimit=20000
+ *                   -XX:PerMethodTrapLimit=20000
+ *                   compiler.intrinsics.string.TestStringIndexOfCharIntrinsics
+ */
+
+package compiler.intrinsics.string;
+
+import jdk.test.lib.Asserts;
+
+public class TestStringIndexOfCharIntrinsics {
+
+    static byte byArr[] = new byte[500];
+
+    public static void main(String[] args) {
+        for (int j = 0; j < byArr.length; j++) {
+            byArr[j] = (byte)j;
+        }
+        // Test value for aarch64
+        byArr[24] = 0x7;
+        byArr[23] = -0x80;
+        // Warmup
+        for (int i = 0; i < 10000; i++) {
+            testIndexOfCharArg(i);
+            testIndexOfCharConst();
+        }
+        Asserts.assertEquals(testIndexOfCharConst() , -1, "must be -1 (character not found)");
+        Asserts.assertEquals(testIndexOfCharArg(-2147483641) , -1, "must be -1 (character not found)");
+    }
+
+    static int testIndexOfCharConst() {
+        String s = new String(byArr);
+        return s.indexOf(-2147483641);
+    }
+
+    static int testIndexOfCharArg(int ch) {
+        String s = new String(byArr);
+        return s.indexOf(ch);
+    }
+}


### PR DESCRIPTION
I had to resolve library_call.cpp. 
STraight forward edits...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301491](https://bugs.openjdk.org/browse/JDK-8301491): C2: java.lang.StringUTF16::indexOfChar intrinsic called with negative character argument


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1927/head:pull/1927` \
`$ git checkout pull/1927`

Update a local copy of the PR: \
`$ git checkout pull/1927` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1927`

View PR using the GUI difftool: \
`$ git pr show -t 1927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1927.diff">https://git.openjdk.org/jdk11u-dev/pull/1927.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1927#issuecomment-1573970349)