### PR TITLE
8217395: Update langtools shell tests to use ${EXE_SUFFIX}

### DIFF
--- a/test/langtools/tools/javac/Paths/Util.sh
+++ b/test/langtools/tools/javac/Paths/Util.sh
@@ -24,10 +24,10 @@
 # Utilities for shell tests
 
 : ${TESTSRC=.} ${TESTCLASSES=.}
-  java="${TESTJAVA+${TESTJAVA}/bin/}java"
- javac="${TESTJAVA+${TESTJAVA}/bin/}javac"
-   jar="${TESTJAVA+${TESTJAVA}/bin/}jar"
-jimage="${TESTJAVA+${TESTJAVA}/bin/}jimage"
+  java="${TESTJAVA+${TESTJAVA}/bin/}java${EXE_SUFFIX}"
+ javac="${TESTJAVA+${TESTJAVA}/bin/}javac${EXE_SUFFIX}"
+   jar="${TESTJAVA+${TESTJAVA}/bin/}jar${EXE_SUFFIX}"
+jimage="${TESTJAVA+${TESTJAVA}/bin/}jimage${EXE_SUFFIX}"
 
 case `uname -s` in
   Windows*|CYGWIN*|MSYS*|MINGW*)


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.
No risk, only a test change.
Tests pass. SAP nightly testing passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8217395](https://bugs.openjdk.org/browse/JDK-8217395): Update langtools shell tests to use ${EXE_SUFFIX} (**Enhancement** - P3)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1928/head:pull/1928` \
`$ git checkout pull/1928`

Update a local copy of the PR: \
`$ git checkout pull/1928` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1928`

View PR using the GUI difftool: \
`$ git pr show -t 1928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1928.diff">https://git.openjdk.org/jdk11u-dev/pull/1928.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1928#issuecomment-1575983704)