### PR TITLE
8211343: nsk_jvmti_parseoptions should handle multiple suboptions

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetNativeMethodPrefix/SetNativeMethodPrefix001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetNativeMethodPrefix/SetNativeMethodPrefix001/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@
  *          /test/lib
  * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm/native
- *      -agentlib:SetNativeMethodPrefix001=
+ *      -agentlib:SetNativeMethodPrefix001
  *      nsk.jvmti.SetNativeMethodPrefix.SetNativeMethodPrefix001
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp
@@ -225,7 +225,7 @@ int nsk_jvmti_parseOptions(const char options[]) {
     char *str = NULL;
     char *name = NULL;
     char *value = NULL;
-    const char *delimiters = " ,";
+    const char *delimiters = " ,~";
     if (options == NULL)
         return success;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,6 @@ extern "C" {
 
 #define NSK_JVMTI_MAX_OPTIONS       10
 #define NSK_JVMTI_OPTION_START      '-'
-#define NSK_JVMTI_OPTION_VAL_SEP    '='
 
 #define NSK_JVMTI_OPT_PATH_TO_NEW_BYTE_CODE "pathToNewByteCode"
 #define PATH_FORMAT "%s%02d/%s"
@@ -191,23 +190,29 @@ static void nsk_jvmti_free() {
     }
 }
 
-int isOptSep(char c) {
-    return isspace(c) || c == '~';
+/*
+ * Tokenize a string based on a list of delimiters.
+ */
+static char* token(char **s, const char *delim) {
+  char *p;
+  char *start = *s;
+
+  if (s == NULL || *s == NULL) {
+    return NULL;
+  }
+
+  p = strpbrk(*s, delim);
+  if (p != NULL) {
+    /* Advance to next token. */
+    *p = '\0';
+    *s = p + 1;
+  } else {
+    /* End of tokens. */
+    *s = NULL;
+  }
+
+  return start;
 }
-
-
-/**
- *
- * The current option will not perform more than one
- * single option which given, this is due to places explained
- * in this question.
- *
- **/
-
- /*
-  * This whole play can be reduced with simple StringTokenizer (strtok).
-  *
-  */
 
 #if !defined(__clang_major__) && defined(__GNUC__) && (__GNUC__ >= 8)
 _Pragma("GCC diagnostic push")
@@ -215,82 +220,41 @@ _Pragma("GCC diagnostic ignored \"-Wstringop-truncation\"")
 #endif
 
 int nsk_jvmti_parseOptions(const char options[]) {
-    size_t len;
-    const char* opt;
     int success = NSK_TRUE;
 
-    context.options.string = NULL;
-    context.options.count = 0;
-    context.waittime = 2;
-
+    char *str = NULL;
+    char *name = NULL;
+    char *value = NULL;
+    const char *delimiters = " ,";
     if (options == NULL)
-        return NSK_TRUE;
+        return success;
 
-    len = strlen(options);
-    context.options.string = (char*)malloc(len + 2);
+    /*
+     * Save a copy of the full options string for
+     * ArgumentHandler.getAgentOptionsString().
+     */
+    context.options.string = strdup(options);
 
-    if (context.options.string == NULL) {
-            nsk_complain("nsk_jvmti_parseOptions(): out of memory\n");
-            return NSK_FALSE;
-    }
-    strncpy(context.options.string, options, len);
-    context.options.string[len] = '\0';
-    context.options.string[len+1] = '\0';
+    /* Create a temporary copy of the options string to be tokenized. */
+    str = strdup(options);
+    while ((name = token(&str, delimiters)) != NULL) {
+        value = strchr(name, '=');
 
-    for (opt = context.options.string; ; ) {
-        const char* opt_end;
-        const char* val_sep;
-        int opt_len=0;
-        int val_len=0;
-                int exit=1;
-
-        while (*opt != '\0' && isOptSep(*opt)) opt++;
-        if (*opt == '\0') break;
-
-        val_sep = NULL;
-        /*
-            This should break when the first option it encounters other wise
-        */
-        for (opt_end = opt, opt_len=0; !(*opt_end == '\0' || isOptSep(*opt_end)); opt_end++,opt_len++) {
-            if (*opt_end == NSK_JVMTI_OPTION_VAL_SEP) {
-                val_sep = opt_end;
-                exit=0;
-                break;
-            }
+        if (value != NULL) {
+            *value++ = '\0';
         }
-
-        if (exit == 1) break;
-
-        /* now scan for the search  for the option value end.
-
-        */
-        exit =1;
-        opt_end++;
-        val_sep++;
-        /**
-         * I was expecting this jvmti_parseOptions(),
-         * should be for multiple options as well.
-         * If this break is not there then It will expects
-         * to have. so a space should be sufficient as well.
-         */
-        for(val_len=0; !(*opt_end == '\0' || isOptSep(*opt_end)); opt_end++,val_len++) {
-            //if (*opt_end == NSK_JVMTI_OPTION_START) {
-            //    break;
-            //}
-        }
-
-        if (!add_option(opt, opt_len, val_sep, val_len)) {
+        if (!add_option(name, (int)strlen(name), value,
+                        value ? (int)strlen(value) : 0)) {
             success = NSK_FALSE;
             break;
         }
-        opt_end++;
-        opt = opt_end;
     }
-
     if (!success) {
         nsk_jvmti_free();
     }
-
+    if (str != NULL) {
+      free(str);
+    }
     return success;
 }
 


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.
No risk, only a test change. Support multiple agent options.
Tests pass. SAP nightly testing passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8211343](https://bugs.openjdk.org/browse/JDK-8211343): nsk_jvmti_parseoptions should handle multiple suboptions (**Bug** - P4)
 * [JDK-8216059](https://bugs.openjdk.org/browse/JDK-8216059): nsk_jvmti_parseoptions still has dependency on tilde separator (**Bug** - P4)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1929/head:pull/1929` \
`$ git checkout pull/1929`

Update a local copy of the PR: \
`$ git checkout pull/1929` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1929`

View PR using the GUI difftool: \
`$ git pr show -t 1929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1929.diff">https://git.openjdk.org/jdk11u-dev/pull/1929.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1929#issuecomment-1576090711)