### PR TITLE
8219628: [TESTBUG] javadoc/doclet/InheritDocForUserTags fails with -othervm

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/InheritDocForUserTags/DocTest.java
+++ b/test/langtools/jdk/javadoc/doclet/InheritDocForUserTags/DocTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,7 @@ public class DocTest extends JavadocTester {
     void test() {
         javadoc("-verbose",
                 "-d", "DocTest",
+                "-sourcepath", System.getProperty("test.src.path"),
                 "-tag", "apiNote:optcm:<em>API Note</em>",
                 "-tag", "implSpec:optcm:<em>Implementation Requirements</em>:",
                 "-tag", "implNote:optcm:<em>Implementation Note</em>:",

--- a/test/langtools/jdk/javadoc/doclet/lib/JavadocTester.java
+++ b/test/langtools/jdk/javadoc/doclet/lib/JavadocTester.java
@@ -112,7 +112,7 @@ import java.util.stream.Collectors;
  *      }
  *
  *      // test methods...
- *      @Test
+ *      {@literal @}Test
  *      void test() {
  *          javadoc(<i>args</i>);
  *          checkExit(Exit.OK);


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.
No risk, only a test change. ‘import javadoc.tester.JavadocTester;’ is removed because of package is different. 
Tests pass. SAP nightly testing passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8219628](https://bugs.openjdk.org/browse/JDK-8219628): [TESTBUG] javadoc/doclet/InheritDocForUserTags fails with -othervm (**Bug** - P4)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1930/head:pull/1930` \
`$ git checkout pull/1930`

Update a local copy of the PR: \
`$ git checkout pull/1930` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1930`

View PR using the GUI difftool: \
`$ git pr show -t 1930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1930.diff">https://git.openjdk.org/jdk11u-dev/pull/1930.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1930#issuecomment-1576148493)