### PR TITLE
8223856: Replace wildcard address with loopback or local host in tests - part 8

### DIFF
--- a/test/jdk/java/net/BindException/Test.java
+++ b/test/jdk/java/net/BindException/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,17 +45,23 @@ public class Test {
 
     static int count;
     static int failures;
+    static boolean retried;
 
     static void doTest(Object test[], InetAddress ia1, InetAddress ia2,
                        boolean silent) throws Exception {
-        String s1_type = (String)test[0];
-        String s2_type = (String)test[1];
-        int port = 0;
-
         /*
          * Increment test count
          */
         count++;
+
+        doTest(test, count, ia1, ia2, silent, !retried);
+    }
+
+    static void doTest(Object test[], int count, InetAddress ia1, InetAddress ia2,
+                       boolean silent, boolean retry) throws Exception {
+        String s1_type = (String)test[0];
+        String s2_type = (String)test[1];
+        int port = 0;
 
         /*
          * Do the test
@@ -68,6 +74,8 @@ public class Test {
         Socket sock1 = null;
         ServerSocket ss = null;
         DatagramSocket dsock1 = null;
+        boolean firstBound = false;
+
         try {
             /* bind the first socket */
 
@@ -89,6 +97,13 @@ public class Test {
 
             /* bind the second socket */
 
+            // The fact that the port was available for ia1 does not
+            // guarantee that it will also be available for ia2 as something
+            // else might already be bound to that port.
+            // For the sake of test stability we will retry once in
+            // case of unexpected bind exception.
+
+            firstBound = true;
             if (s2_type.equals("Socket")) {
                 try (Socket sock2 = new Socket()) {
                     sock2.bind( new InetSocketAddress(ia2, port));
@@ -138,6 +153,18 @@ public class Test {
          * If test passed and running in silent mode then exit
          */
         if (!failed && silent) {
+            return;
+        }
+
+        if (failed && retry && firstBound) {
+            // retry once at the first failure only
+            retried = true;
+            if (!silent) {
+                System.out.println("");
+                System.out.println("**************************");
+                System.out.println("Test " + count + ": Retrying...");
+            }
+            doTest(test, count, ia1, ia2, silent, false);
             return;
         }
 

--- a/test/jdk/java/net/PlainSocketImpl/SetOption.java
+++ b/test/jdk/java/net/PlainSocketImpl/SetOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,10 @@ public class SetOption {
 
     public static void main(String args[]) throws Exception {
 
-        ServerSocket ss = new ServerSocket(0);
-        Socket s1 = new Socket("localhost", ss.getLocalPort());
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        ServerSocket ss = new ServerSocket(0, 0, loopback);
+
+        Socket s1 = new Socket(loopback, ss.getLocalPort());
         Socket s2 = ss.accept();
 
         s1.close();

--- a/test/jdk/java/net/Socket/RST.java
+++ b/test/jdk/java/net/Socket/RST.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,10 @@ public class RST implements Runnable {
     }
 
     RST() throws Exception {
-        ServerSocket ss = new ServerSocket(0);
-        client = new Socket("localhost", ss.getLocalPort());
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        ServerSocket ss = new ServerSocket();
+        ss.bind(new InetSocketAddress(loopback, 0));
+        client = new Socket(loopback, ss.getLocalPort());
         Socket server = ss.accept();
 
         Thread thr = new Thread(this);

--- a/test/jdk/java/net/URLConnection/URLConnectionHeaders.java
+++ b/test/jdk/java/net/URLConnection/URLConnectionHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,14 @@
  * @summary URLConnection cannot enumerate request properties,
  *          and URLConnection can neither get nor set multiple
  *          request properties w/ same key
+ * @library /test/lib
  *
  */
 
 import java.net.*;
 import java.util.*;
 import java.io.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class URLConnectionHeaders {
 
@@ -77,15 +79,22 @@ public class URLConnectionHeaders {
         }
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         try {
-            ServerSocket serversocket = new ServerSocket (0);
-            int port = serversocket.getLocalPort ();
-            XServer server = new XServer (serversocket);
-            server.start ();
-            Thread.sleep (200);
-            URL url = new URL ("http://localhost:"+port+"/index.html");
-            URLConnection uc = url.openConnection ();
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            ServerSocket serversocket = new ServerSocket();
+            serversocket.bind(new InetSocketAddress(loopback, 0));
+            int port = serversocket.getLocalPort();
+            XServer server = new XServer(serversocket);
+            server.start();
+            Thread.sleep(200);
+            URL url = URIBuilder.newBuilder()
+                      .scheme("http")
+                      .loopback()
+                      .port(port)
+                      .path("/index.html")
+                      .toURL();
+            URLConnection uc = url.openConnection();
 
             // add request properties
             uc.addRequestProperty("Cookie", "cookie1");
@@ -106,6 +115,7 @@ public class URLConnectionHeaders {
 
         } catch (Exception e) {
             e.printStackTrace();
+            throw e;
         }
     }
 }

--- a/test/jdk/java/net/ipv6tests/UdpTest.java
+++ b/test/jdk/java/net/ipv6tests/UdpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,14 @@
 /*
  * @test
  * @bug 4868820
- * @summary IPv6 support for Windows XP and 2003 server
+ * @key intermittent
+ * @summary IPv6 support for Windows XP and 2003 server.
+ *          This test requires binding to the wildcard address and as such
+ *          may fail intermittently on some platforms.
  * @library /test/lib
  * @build jdk.test.lib.NetworkConfiguration
  *        jdk.test.lib.Platform
- * @run main UdpTest
+ * @run main UdpTest -d
  */
 
 import java.net.DatagramPacket;
@@ -88,6 +91,7 @@ public class UdpTest extends Tests {
     /* basic UDP connectivity test using IPv6 only and IPv4/IPv6 together */
 
     static void test1 () throws Exception {
+        System.out.println("Test1 starting");
         s1 = new DatagramSocket ();
         s2 = new DatagramSocket ();
         simpleDataExchange (s1, ia4addr, s2, ia4addr);
@@ -126,6 +130,7 @@ public class UdpTest extends Tests {
     /* check timeouts on receive */
 
     static void test2 () throws Exception {
+        System.out.println("Test2 starting");
         s1 = new DatagramSocket ();
         s2 = new DatagramSocket ();
         s1.setSoTimeout (4000);
@@ -176,6 +181,7 @@ public class UdpTest extends Tests {
     /* check connected sockets */
 
     static void test3 () throws Exception {
+        System.out.println("Test3 starting");
         s1 = new DatagramSocket ();
         s2 = new DatagramSocket ();
         s1.connect (ia6addr, s2.getLocalPort());
@@ -187,6 +193,7 @@ public class UdpTest extends Tests {
     /* check PortUnreachable */
 
     static void test4 () throws Exception {
+        System.out.println("Test4 starting");
         s1 = new DatagramSocket ();
         s1.connect (ia6addr, 5000);
         s1.setSoTimeout (3000);

--- a/test/jdk/sun/net/ftp/B6427768.java
+++ b/test/jdk/sun/net/ftp/B6427768.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,13 +105,14 @@ public class B6427768 {
     }
 
     public static void main(String[] args) throws IOException {
-        FtpServer server = new FtpServer(0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        FtpServer server = new FtpServer(loopback, 0);
         int port = server.getLocalPort();
         server.setFileSystemHandler(new MyFileSystemHandler("/"));
         server.setAuthHandler(new MyAuthHandler());
         server.start();
-        URL url = new URL("ftp://user:passwd@localhost:" + port + "/foo.txt");
-        URLConnection con = url.openConnection();
+        URL url = new URL("ftp://user:passwd@" + server.getAuthority() + "/foo.txt");
+        URLConnection con = url.openConnection(Proxy.NO_PROXY);
         // triggers the connection
         try {
             con.getInputStream();

--- a/test/jdk/sun/net/www/ftptest/FtpCommandHandler.java
+++ b/test/jdk/sun/net/www/ftptest/FtpCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -238,14 +238,14 @@ public class FtpCommandHandler extends Thread {
             return;
         }
         try {
-            if (pasv == null)
-                pasv = new ServerSocket(0);
-            int port = pasv.getLocalPort();
             InetAddress rAddress = cmd.getLocalAddress();
             if (rAddress instanceof Inet6Address) {
                 out.println("500 PASV illegal over IPv6 addresses, use EPSV.");
                 return;
             }
+            if (pasv == null)
+                pasv = new ServerSocket(0, 0, rAddress);
+            int port = pasv.getLocalPort();
             byte[] a = rAddress.getAddress();
             out.println("227 Entering Passive Mode " + a[0] + "," + a[1] + "," + a[2] + "," + a[3] + "," +
                         (port >> 8) + "," + (port & 0xff) );
@@ -266,7 +266,7 @@ public class FtpCommandHandler extends Thread {
         }
         try {
             if (pasv == null)
-                pasv = new ServerSocket(0);
+                pasv = new ServerSocket(0, 0, parent.getInetAddress());
             int port = pasv.getLocalPort();
             out.println("229 Entering Extended Passive Mode (|||" + port + "|)");
         } catch (IOException e) {

--- a/test/jdk/sun/net/www/ftptest/FtpServer.java
+++ b/test/jdk/sun/net/www/ftptest/FtpServer.java
@@ -110,8 +110,12 @@ public class FtpServer extends Thread implements AutoCloseable {
         return listener.getLocalPort();
     }
 
+    public InetAddress getInetAddress() {
+        return listener.getInetAddress();
+    }
+
     public String getAuthority() {
-        InetAddress address = listener.getInetAddress();
+        InetAddress address = getInetAddress();
         String hostaddr = address.isAnyLocalAddress()
             ? "localhost" : address.getHostAddress();
         if (hostaddr.indexOf(':') > -1) {

--- a/test/jdk/sun/net/www/http/HttpClient/RetryPost.java
+++ b/test/jdk/sun/net/www/http/HttpClient/RetryPost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 6427251 6382788
  * @modules jdk.httpserver
+ * @library /test/lib
  * @run main RetryPost
  * @run main/othervm -Dsun.net.http.retryPost=false RetryPost noRetry
  * @summary HttpURLConnection automatically retries non-idempotent method POST
@@ -36,12 +37,14 @@ import com.sun.net.httpserver.HttpHandler;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.SocketException;
 import java.net.URL;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
+import jdk.test.lib.net.URIBuilder;
 
 public class RetryPost
 {
@@ -66,7 +69,12 @@ public class RetryPost
     void doClient() throws Exception {
         try {
             InetSocketAddress address = httpServer.getAddress();
-            URL url = new URL("http://localhost:" + address.getPort() + "/test/");
+            URL url = URIBuilder.newBuilder()
+                      .scheme("http")
+                      .host(address.getAddress())
+                      .port(address.getPort())
+                      .path("/test/")
+                      .toURLUnchecked();
             HttpURLConnection uc = (HttpURLConnection)url.openConnection(Proxy.NO_PROXY);
             uc.setDoOutput(true);
             uc.setRequestMethod("POST");
@@ -93,7 +101,8 @@ public class RetryPost
      * Http Server
      */
     public void startHttpServer(boolean shouldRetry) throws IOException {
-        httpServer = com.sun.net.httpserver.HttpServer.create(new InetSocketAddress(0), 0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        httpServer = com.sun.net.httpserver.HttpServer.create(new InetSocketAddress(loopback, 0), 0);
         httpHandler = new MyHandler(shouldRetry);
 
         HttpContext ctx = httpServer.createContext("/test/", httpHandler);


### PR DESCRIPTION
I backport this to fix some issues we see in our CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8223856](https://bugs.openjdk.org/browse/JDK-8223856): Replace wildcard address with loopback or local host in tests - part 8 (**Sub-task** - `"3"`)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1932/head:pull/1932` \
`$ git checkout pull/1932`

Update a local copy of the PR: \
`$ git checkout pull/1932` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1932`

View PR using the GUI difftool: \
`$ git pr show -t 1932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1932.diff">https://git.openjdk.org/jdk11u-dev/pull/1932.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1932#issuecomment-1577132823)