### PR TITLE
8224617: (fs) java/nio/file/FileStore/Basic.java found filesystem twice

### DIFF
--- a/test/jdk/java/nio/file/FileStore/Basic.java
+++ b/test/jdk/java/nio/file/FileStore/Basic.java
@@ -124,7 +124,7 @@ public class Basic {
         /**
          * Test: Enumerate all FileStores
          */
-        if (FileUtils.areFileSystemsAccessible()) {
+        if (FileUtils.areAllMountPointsAccessible()) {
             FileStore prev = null;
             for (FileStore store: FileSystems.getDefault().getFileStores()) {
                 System.out.format("%s (name=%s type=%s)\n", store, store.name(),

--- a/test/lib/jdk/test/lib/util/FileUtils.java
+++ b/test/lib/jdk/test/lib/util/FileUtils.java
@@ -264,17 +264,17 @@ public final class FileUtils {
                 try {
                     Process proc = new ProcessBuilder("df").start();
                     BufferedReader reader = new BufferedReader
-                            (new InputStreamReader(proc.getInputStream()));
+                        (new InputStreamReader(proc.getInputStream()));
                     // Skip the first line as it is the "df" output header.
                     if (reader.readLine() != null ) {
                         String prevMountPoint = null, mountPoint = null;
                         while ((mountPoint = reader.readLine()) != null) {
                             if (prevMountPoint != null &&
-                                    mountPoint.equals(prevMountPoint)) {
+                                mountPoint.equals(prevMountPoint)) {
                                 throw new RuntimeException
-                                        ("System configuration error: " +
-                                                "duplicate mount point " + mountPoint +
-                                                " detected");
+                                    ("System configuration error: " +
+                                    "duplicate mount point " + mountPoint +
+                                    " detected");
                             }
                             prevMountPoint = mountPoint;
                         }
@@ -288,7 +288,7 @@ public final class FileUtils {
                         int exitValue = proc.exitValue();
                         if (exitValue != 0) {
                             System.err.printf("df process exited with %d != 0%n",
-                                    exitValue);
+                                exitValue);
                             areMountPointsOK.set(false);
                         }
                     } catch (IllegalThreadStateException ignored) {
@@ -301,13 +301,13 @@ public final class FileUtils {
             });
 
             final AtomicReference throwableReference =
-                    new AtomicReference<Throwable>();
+                new AtomicReference<Throwable>();
             thr.setUncaughtExceptionHandler(
-                    new Thread.UncaughtExceptionHandler() {
-                        public void uncaughtException(Thread t, Throwable e) {
-                            throwableReference.set(e);
-                        }
-                    });
+                 new Thread.UncaughtExceptionHandler() {
+                     public void uncaughtException(Thread t, Throwable e) {
+                        throwableReference.set(e);
+                     }
+                 });
 
             thr.start();
             try {

--- a/test/lib/jdk/test/lib/util/FileUtils.java
+++ b/test/lib/jdk/test/lib/util/FileUtils.java
@@ -304,10 +304,10 @@ public final class FileUtils {
                 new AtomicReference<Throwable>();
             thr.setUncaughtExceptionHandler(
                 new Thread.UncaughtExceptionHandler() {
-                     public void uncaughtException(Thread t, Throwable e) {
+                    public void uncaughtException(Thread t, Throwable e) {
                         throwableReference.set(e);
-                     }
-                 });
+                    }
+                });
 
             thr.start();
             try {

--- a/test/lib/jdk/test/lib/util/FileUtils.java
+++ b/test/lib/jdk/test/lib/util/FileUtils.java
@@ -303,7 +303,7 @@ public final class FileUtils {
             final AtomicReference throwableReference =
                 new AtomicReference<Throwable>();
             thr.setUncaughtExceptionHandler(
-                 new Thread.UncaughtExceptionHandler() {
+                new Thread.UncaughtExceptionHandler() {
                      public void uncaughtException(Thread t, Throwable e) {
                         throwableReference.set(e);
                      }

--- a/test/lib/jdk/test/lib/util/FileUtils.java
+++ b/test/lib/jdk/test/lib/util/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,8 @@
 
 package jdk.test.lib.util;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
@@ -41,6 +43,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.TimeUnit;
 
 import jdk.test.lib.Platform;
@@ -236,6 +240,93 @@ public final class FileUtils {
             }
         }
         return areFileSystemsAccessible;
+    }
+
+    /**
+     * Checks whether all file systems are accessible. This is performed
+     * by checking free disk space on all mounted file systems via a
+     * separate, spawned process. File systems are considered to be
+     * accessible if this process completes successfully before a given
+     * fixed duration has elapsed.
+     *
+     * @implNote On Unix this executes the {@code df} command in a separate
+     * process and on Windows always returns {@code true}.
+     *
+     * @return whether file systems appear to be accessible
+     *
+     * @throws RuntimeException if there are duplicate mount points or some
+     * other execution problem occurs
+     */
+    public static boolean areAllMountPointsAccessible() {
+        final AtomicBoolean areMountPointsOK = new AtomicBoolean(true);
+        if (!IS_WINDOWS) {
+            Thread thr = new Thread(() -> {
+                try {
+                    Process proc = new ProcessBuilder("df").start();
+                    BufferedReader reader = new BufferedReader
+                            (new InputStreamReader(proc.getInputStream()));
+                    // Skip the first line as it is the "df" output header.
+                    if (reader.readLine() != null ) {
+                        String prevMountPoint = null, mountPoint = null;
+                        while ((mountPoint = reader.readLine()) != null) {
+                            if (prevMountPoint != null &&
+                                    mountPoint.equals(prevMountPoint)) {
+                                throw new RuntimeException
+                                        ("System configuration error: " +
+                                                "duplicate mount point " + mountPoint +
+                                                " detected");
+                            }
+                            prevMountPoint = mountPoint;
+                        }
+                    }
+
+                    try {
+                        proc.waitFor(90, TimeUnit.SECONDS);
+                    } catch (InterruptedException ignored) {
+                    }
+                    try {
+                        int exitValue = proc.exitValue();
+                        if (exitValue != 0) {
+                            System.err.printf("df process exited with %d != 0%n",
+                                    exitValue);
+                            areMountPointsOK.set(false);
+                        }
+                    } catch (IllegalThreadStateException ignored) {
+                        System.err.println("df command apparently hung");
+                        areMountPointsOK.set(false);
+                    }
+                } catch (IOException ioe) {
+                    throw new RuntimeException(ioe);
+                };
+            });
+
+            final AtomicReference throwableReference =
+                    new AtomicReference<Throwable>();
+            thr.setUncaughtExceptionHandler(
+                    new Thread.UncaughtExceptionHandler() {
+                        public void uncaughtException(Thread t, Throwable e) {
+                            throwableReference.set(e);
+                        }
+                    });
+
+            thr.start();
+            try {
+                thr.join(120*1000L);
+            } catch (InterruptedException ie) {
+                throw new RuntimeException(ie);
+            }
+
+            Throwable uncaughtException = (Throwable)throwableReference.get();
+            if (uncaughtException != null) {
+                throw new RuntimeException(uncaughtException);
+            }
+
+            if (thr.isAlive()) {
+                throw new RuntimeException("df thread did not join in time");
+            }
+        }
+
+        return areMountPointsOK.get();
     }
 
     /**


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.
No risk, only a test change.
Tests pass. SAP nightly testing passed.

test/jdk/java/nio/file/FileStore/Basic.java  
Copyright
test/lib/jdk/test/lib/util/FileUtils.java
Resolved due to context

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8224617](https://bugs.openjdk.org/browse/JDK-8224617): (fs) java/nio/file/FileStore/Basic.java found filesystem twice (**Bug** - P4)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**) ⚠️ Review applies to [ec755845](https://git.openjdk.org/jdk11u-dev/pull/1933/files/ec7558458125910bc6c4377d20fac15f77b8908b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1933/head:pull/1933` \
`$ git checkout pull/1933`

Update a local copy of the PR: \
`$ git checkout pull/1933` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1933/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1933`

View PR using the GUI difftool: \
`$ git pr show -t 1933`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1933.diff">https://git.openjdk.org/jdk11u-dev/pull/1933.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1933#issuecomment-1578070570)