### PR TITLE
8283756: (zipfs) ZipFSOutputStreamTest.testOutputStream should only check inflated bytes

### DIFF
--- a/test/jdk/jdk/nio/zipfs/ZipFSOutputStreamTest.java
+++ b/test/jdk/jdk/nio/zipfs/ZipFSOutputStreamTest.java
@@ -120,7 +120,7 @@ public class ZipFSOutputStreamTest {
                     while ((numRead = is.read(buf)) != -1) {
                         totalRead += numRead;
                         // verify the content
-                        Assert.assertEquals(Arrays.mismatch(buf, chunk), -1,
+                        Assert.assertEquals(Arrays.mismatch(buf, 0, numRead, chunk, 0, numRead), -1,
                                 "Unexpected content in " + entryPath);
                     }
                     System.out.println("Read entry " + entryPath + " of bytes " + totalRead


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283756](https://bugs.openjdk.org/browse/JDK-8283756): (zipfs) ZipFSOutputStreamTest.testOutputStream should only check inflated bytes (**Bug** - `"4"`)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1937/head:pull/1937` \
`$ git checkout pull/1937`

Update a local copy of the PR: \
`$ git checkout pull/1937` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1937`

View PR using the GUI difftool: \
`$ git pr show -t 1937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1937.diff">https://git.openjdk.org/jdk11u-dev/pull/1937.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1937#issuecomment-1580143563)