### PR TITLE
8265980: Fix systemDictionary and loaderConstraints printing

### DIFF
--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -208,6 +208,7 @@ void DictionaryEntry::add_protection_domain(Dictionary* dict, Handle protection_
   if (lt.is_enabled()) {
     LogStream ls(lt);
     print_count(&ls);
+    ls.cr();
   }
 }
 

--- a/src/hotspot/share/classfile/dictionary.hpp
+++ b/src/hotspot/share/classfile/dictionary.hpp
@@ -195,7 +195,7 @@ class DictionaryEntry : public HashtableEntry<InstanceKlass*, mtClass> {
                                 current = current->_next) {
       count++;
     }
-    st->print_cr("pd set count = #%d", count);
+    st->print("pd set count = #%d", count);
   }
 
   void verify();

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -487,3 +487,5 @@ void LoaderConstraintTable::print_on(outputStream* st) const {
     }
   }
 }
+
+void LoaderConstraintTable::print() const { print_on(tty); }

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -242,9 +242,8 @@ bool LoaderConstraintTable::add_entry(Symbol* class_name,
     p->set_loaders(NEW_C_HEAP_ARRAY(ClassLoaderData*, 2, mtClass));
     p->set_loader(0, class_loader1());
     p->set_loader(1, class_loader2());
-    p->set_klass(klass);
-    p->set_next(bucket(index));
-    set_entry(index, p);
+    Hashtable<InstanceKlass*, mtClass>::add_entry(index, p);
+
     if (lt.is_enabled()) {
       ResourceMark rm;
       lt.print("adding new constraint for name: %s, loader[0]: %s,"
@@ -478,11 +477,11 @@ void LoaderConstraintTable::print_on(outputStream* st) const {
                                 probe != NULL;
                                 probe = probe->next()) {
       st->print("%4d: ", cindex);
-      probe->name()->print_on(st);
-      st->print(" , loaders:");
+      st->print("Symbol: %s loaders:", probe->name()->as_C_string());
       for (int n = 0; n < probe->num_loaders(); n++) {
+        st->cr();
+        st->print("    ");
         probe->loader_data(n)->print_value_on(st);
-        st->print(", ");
       }
       st->cr();
     }

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -189,6 +189,7 @@ void log_ldr_constraint_msg(Symbol* class_name, const char* reason,
 bool LoaderConstraintTable::add_entry(Symbol* class_name,
                                       InstanceKlass* klass1, Handle class_loader1,
                                       InstanceKlass* klass2, Handle class_loader2) {
+
   LogTarget(Info, class, loader, constraints) lt;
   if (klass1 != NULL && klass2 != NULL) {
     if (klass1 == klass2) {

--- a/src/hotspot/share/classfile/loaderConstraints.hpp
+++ b/src/hotspot/share/classfile/loaderConstraints.hpp
@@ -79,6 +79,7 @@ public:
   void purge_loader_constraints();
 
   void verify(PlaceholderTable* placeholders);
+  void print() const;
   void print_on(outputStream* st) const;
 };
 

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -1344,12 +1344,6 @@ void VM_PopulateDumpSharedSpace::doit() {
   FileMapInfo::check_nonempty_dir_in_shared_path_table();
 
   NOT_PRODUCT(SystemDictionary::verify();)
-  // The following guarantee is meant to ensure that no loader constraints
-  // exist yet, since the constraints table is not shared.  This becomes
-  // more important now that we don't re-initialize vtables/itables for
-  // shared classes at runtime, where constraints were previously created.
-  guarantee(SystemDictionary::constraints()->number_of_entries() == 0,
-            "loader constraints are not saved");
   guarantee(SystemDictionary::placeholders()->number_of_entries() == 0,
           "placeholders are not saved");
   // Revisit and implement this if we prelink method handle call sites:

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/DumpSymbolAndStringTable.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/DumpSymbolAndStringTable.java
@@ -73,7 +73,6 @@ public class DumpSymbolAndStringTable {
         try {
             output.shouldContain("Dictionary for loader data: 0x");
             output.shouldContain("^java.lang.String");
-            output.shouldNotContain("constraints=0");
         } catch (RuntimeException e) {
             output.shouldContain("Unknown diagnostic command");
         }

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/DumpSymbolAndStringTable.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/DumpSymbolAndStringTable.java
@@ -73,6 +73,7 @@ public class DumpSymbolAndStringTable {
         try {
             output.shouldContain("Dictionary for loader data: 0x");
             output.shouldContain("^java.lang.String");
+            output.shouldNotContain("constraints=0");
         } catch (RuntimeException e) {
             output.shouldContain("Unknown diagnostic command");
         }


### PR DESCRIPTION
I would like to backport
JDK-8265980 Fix systemDictionary and loaderConstraints printing
Because the systemDictionary infomation is important for develoers or users to maintain JVM.
I would appriciate if someone could review it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8265980](https://bugs.openjdk.org/browse/JDK-8265980): Fix systemDictionary and loaderConstraints printing (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1938/head:pull/1938` \
`$ git checkout pull/1938`

Update a local copy of the PR: \
`$ git checkout pull/1938` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1938`

View PR using the GUI difftool: \
`$ git pr show -t 1938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1938.diff">https://git.openjdk.org/jdk11u-dev/pull/1938.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1938#issuecomment-1583856961)