### PR TITLE
8229912: [TESTBUG] java/net/Socks/SocksIPv6Test fails without IPv6

### DIFF
--- a/test/jdk/java/net/Socks/SocksIPv6Test.java
+++ b/test/jdk/java/net/Socks/SocksIPv6Test.java
@@ -126,7 +126,6 @@ public class SocksIPv6Test {
 
     @Test(groups = "unit")
     public void testSocksOverIPv6() throws Exception {
-
         Proxy proxy = new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("::1",
                 socks.getPort()));
         URL url = new URL("http://[::1]:" + server.getAddress().getPort());
@@ -141,7 +140,6 @@ public class SocksIPv6Test {
 
     @Test(groups = "unit")
     public void testSocksOverIPv6Hostname() throws Exception {
-
         InetAddress ipv6Loopback = InetAddress.getByName("::1");
         String ipv6Hostname = ipv6Loopback.getHostName();
         String ipv6HostAddress = ipv6Loopback.getHostAddress();

--- a/test/jdk/java/net/Socks/SocksIPv6Test.java
+++ b/test/jdk/java/net/Socks/SocksIPv6Test.java
@@ -24,6 +24,7 @@
 /* @test
  * @bug 7100957
  * @modules jdk.httpserver
+ * @library /test/lib
  * @summary Java doesn't correctly handle the SOCKS protocol when used over IPv6.
  * @run testng SocksIPv6Test
  */
@@ -46,9 +47,12 @@ import java.util.Collections;
 import java.util.List;
 import com.sun.net.httpserver.*;
 import java.io.BufferedWriter;
+import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import jdk.test.lib.NetworkConfiguration;
 
 import static org.testng.Assert.*;
 
@@ -57,11 +61,13 @@ public class SocksIPv6Test {
     private HttpServer server;
     private SocksServer socks;
     private String response = "Hello.";
-    private static boolean shouldRun = false;
 
     @BeforeClass
     public void setUp() throws Exception {
-        shouldRun = ensureInet6AddressFamily() && ensureIPv6OnLoopback();
+        if (!ensureInet6AddressFamily() || !ensureIPv6OnLoopback()) {
+            NetworkConfiguration.printSystemConfiguration(System.out);
+            throw new SkipException("Host does not support IPv6");
+        }
 
         server = HttpServer.create(new InetSocketAddress("::1", 0), 0);
         server.createContext("/", ex -> {
@@ -120,7 +126,6 @@ public class SocksIPv6Test {
 
     @Test(groups = "unit")
     public void testSocksOverIPv6() throws Exception {
-        if (!shouldRun) return;
 
         Proxy proxy = new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("::1",
                 socks.getPort()));
@@ -136,7 +141,6 @@ public class SocksIPv6Test {
 
     @Test(groups = "unit")
     public void testSocksOverIPv6Hostname() throws Exception {
-        if (!shouldRun) return;
 
         InetAddress ipv6Loopback = InetAddress.getByName("::1");
         String ipv6Hostname = ipv6Loopback.getHostName();


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8229912](https://bugs.openjdk.org/browse/JDK-8229912): [TESTBUG] java/net/Socks/SocksIPv6Test fails without IPv6 (**Bug** - P5)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**) ⚠️ Review applies to [476b6802](https://git.openjdk.org/jdk11u-dev/pull/1939/files/476b680241b413860acd47ea9b9256f5a465d67a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1939/head:pull/1939` \
`$ git checkout pull/1939`

Update a local copy of the PR: \
`$ git checkout pull/1939` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1939/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1939`

View PR using the GUI difftool: \
`$ git pr show -t 1939`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1939.diff">https://git.openjdk.org/jdk11u-dev/pull/1939.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1939#issuecomment-1584010591)