### PR TITLE
8304291: [AIX] Broken build after JDK-8301998

### DIFF
--- a/src/java.desktop/share/native/libharfbuzz/hb-algs.hh
+++ b/src/java.desktop/share/native/libharfbuzz/hb-algs.hh
@@ -875,7 +875,8 @@ hb_in_ranges (T u, T lo1, T hi1, Ts... ds)
 static inline bool
 hb_unsigned_mul_overflows (unsigned int count, unsigned int size, unsigned *result = nullptr)
 {
-#if (defined(__GNUC__) && (__GNUC__ >= 4)) || (defined(__clang__) && (__clang_major__ >= 8))
+/* avoid with xlc16 clang on AIX; it sets the gcc macros */
+#if (defined(__GNUC__) && !defined(AIX) && (__GNUC__ >= 4)) || (defined(__clang__) && (__clang_major__ >= 8))
   unsigned stack_result;
   if (!result)
     result = &stack_result;

--- a/src/java.desktop/share/native/libharfbuzz/hb-subset.cc
+++ b/src/java.desktop/share/native/libharfbuzz/hb-subset.cc
@@ -43,7 +43,11 @@
 #include "OT/Color/sbix/sbix.hh"
 #include "hb-ot-os2-table.hh"
 #include "hb-ot-post-table.hh"
+
+#if !defined(AIX)
 #include "hb-ot-post-table-v2subset.hh"
+#endif
+
 #include "hb-ot-cff1-table.hh"
 #include "hb-ot-cff2-table.hh"
 #include "hb-ot-vorg-table.hh"


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [310aa934](https://github.com/openjdk/jdk/commit/310aa9347861922af5f0311e9e93a5f49dee6adc) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Matthias Baesken on 20 Apr 2023 and was reviewed by Martin Doerr, Tyler Steele and Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304291](https://bugs.openjdk.org/browse/JDK-8304291): [AIX] Broken build after JDK-8301998 (**Bug** - P3)


### Reviewers
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1940/head:pull/1940` \
`$ git checkout pull/1940`

Update a local copy of the PR: \
`$ git checkout pull/1940` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1940`

View PR using the GUI difftool: \
`$ git pr show -t 1940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1940.diff">https://git.openjdk.org/jdk11u-dev/pull/1940.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1940#issuecomment-1584493393)