### PR TITLE
8309550: jdk.jfr.internal.Utils::formatDataAmount method should gracefully handle amounts equal to Long.MIN_VALUE

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,6 @@ jobs:
           - 'hs/tier1 gc'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
-          - 'jdk/jfr'
 
         include:
           - test-name: 'jdk/tier1 part 1'
@@ -78,9 +77,6 @@ jobs:
 
           - test-name: 'langtools/tier1'
             test-suite: 'test/langtools/:tier1'
-          
-          - test-name: 'jdk/jfr'
-            test-suite: 'test/jdk/jdk/jfr'
 
           - test-name: 'hs/tier1 common'
             test-suite: 'test/hotspot/jtreg/:tier1_common'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
           - 'hs/tier1 gc'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
+          - 'jdk/jfr'
 
         include:
           - test-name: 'jdk/tier1 part 1'
@@ -77,6 +78,9 @@ jobs:
 
           - test-name: 'langtools/tier1'
             test-suite: 'test/langtools/:tier1'
+          
+          - test-name: 'jdk/jfr'
+            test-suite: 'test/jdk/jdk/jfr'
 
           - test-name: 'hs/tier1 common'
             test-suite: 'test/hotspot/jtreg/:tier1_common'

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -103,9 +103,9 @@ public final class Utils {
         }
     }
 
-    // Tjis method can't handle Long.MIN_VALUE because absolute value is negative
+    // handle Long.MIN_VALUE as a special case since its absolute value is negative
     private static String formatDataAmount(String formatter, long amount) {
-        int exp = (int) (Math.log(Math.abs(amount)) / Math.log(1024));
+        int exp = (amount == Long.MIN_VALUE) ? 6 : (int) (Math.log(Math.abs(amount)) / Math.log(1024));
         char unitPrefix = "kMGTPE".charAt(exp - 1);
         return String.format(formatter, amount / Math.pow(1024, exp), unitPrefix);
     }


### PR DESCRIPTION
Hi,

This is a backport of JDK-8309550: jdk.jfr.internal.Utils::formatDataAmount method should gracefully handle amounts equal to Long.MIN_VALUE

Original patch does not apply cleanly to 11u as one of the modified file `src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java` does not exit prior to 21. Changes to other files apply cleanly.

GHA tests are enabled and amended to include `test/jdk/jdk/jfr` in, addition to what's in the default configuration.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309550](https://bugs.openjdk.org/browse/JDK-8309550): jdk.jfr.internal.Utils::formatDataAmount method should gracefully handle amounts equal to Long.MIN_VALUE (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1942/head:pull/1942` \
`$ git checkout pull/1942`

Update a local copy of the PR: \
`$ git checkout pull/1942` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1942`

View PR using the GUI difftool: \
`$ git pr show -t 1942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1942.diff">https://git.openjdk.org/jdk11u-dev/pull/1942.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1942#issuecomment-1588786438)