### PR TITLE
8308156: VerifyCACerts.java misses blank in error output

### DIFF
--- a/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
+++ b/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
@@ -290,8 +290,8 @@ public class VerifyCACerts {
         String checksum = toHexString(md.digest(data));
         if (!checksum.equals(CHECKSUM)) {
             atLeastOneFailed = true;
-            System.err.println("ERROR: wrong checksum" + checksum);
-            System.err.println("Expected checksum" + CHECKSUM);
+            System.err.println("ERROR: wrong checksum " + checksum);
+            System.err.println("Expected checksum " + CHECKSUM);
         }
 
         KeyStore ks = KeyStore.getInstance("JKS");


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308156](https://bugs.openjdk.org/browse/JDK-8308156): VerifyCACerts.java misses blank in error output (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1943/head:pull/1943` \
`$ git checkout pull/1943`

Update a local copy of the PR: \
`$ git checkout pull/1943` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1943`

View PR using the GUI difftool: \
`$ git pr show -t 1943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1943.diff">https://git.openjdk.org/jdk11u-dev/pull/1943.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1943#issuecomment-1589264299)