### PR TITLE
8309138: Fix container tests for jdks with symlinked conf dir

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -36,6 +37,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import jdk.test.lib.Container;
 import jdk.test.lib.Utils;
@@ -164,7 +166,7 @@ public class DockerTestUtils {
         Path jdkSrcDir = Paths.get(JDK_UNDER_TEST);
         Path jdkDstDir = buildDir.resolve("jdk");
         Files.createDirectories(jdkDstDir);
-        Files.walkFileTree(jdkSrcDir, new CopyFileVisitor(jdkSrcDir, jdkDstDir));
+        Files.walkFileTree(jdkSrcDir, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, new CopyFileVisitor(jdkSrcDir, jdkDstDir));
 
         buildImage(imageName, buildDir);
     }


### PR DESCRIPTION
This backport fixing container tests for jdk with symlinked conf dir (such as fedora/rhel packages). Clean, only affects tests.

Testing:
tier1: OK
containers and jdk/internal/platform: [OK](https://github.com/zzambers/jdk-tester/actions/runs/5241547272/jobs/9463791131)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309138](https://bugs.openjdk.org/browse/JDK-8309138): Fix container tests for jdks with symlinked conf dir (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1944/head:pull/1944` \
`$ git checkout pull/1944`

Update a local copy of the PR: \
`$ git checkout pull/1944` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1944`

View PR using the GUI difftool: \
`$ git pr show -t 1944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1944.diff">https://git.openjdk.org/jdk11u-dev/pull/1944.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1944#issuecomment-1589499481)