### PR TITLE
8255348: NPE in PKIXCertPathValidator event logging code

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/certpath/PKIXCertPathValidator.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/PKIXCertPathValidator.java
@@ -228,13 +228,13 @@ public final class PKIXCertPathValidator extends CertPathValidatorSpi {
         X509ValidationEvent xve = new X509ValidationEvent();
         if (xve.shouldCommit() || EventHelper.isLoggingSecurity()) {
             int[] certIds = params.certificates().stream()
-                    .mapToInt(x -> x.hashCode())
+                    .mapToInt(Certificate::hashCode)
                     .toArray();
-            int anchorCertId =
-                    anchor.getTrustedCert().hashCode();
+            int anchorCertId = (anchorCert != null) ?
+                anchorCert.hashCode() : anchor.getCAPublicKey().hashCode();
             if (xve.shouldCommit()) {
                 xve.certificateId = anchorCertId;
-                int certificatePos = 1; //anchor cert
+                int certificatePos = 1; // most trusted CA
                 xve.certificatePosition = certificatePos;
                 xve.validationCounter = validationCounter.incrementAndGet();
                 xve.commit();

--- a/test/jdk/jdk/jfr/event/security/TestX509CertificateEvent.java
+++ b/test/jdk/jdk/jfr/event/security/TestX509CertificateEvent.java
@@ -48,12 +48,11 @@ public class TestX509CertificateEvent {
             recording.enable(EventNames.X509Certificate);
             recording.start();
 
-            CertificateFactory cf = CertificateFactory.getInstance("X.509");
-            TestCertificate.ONE.generate(cf);
-            TestCertificate.TWO.generate(cf);
+            TestCertificate.ONE.certificate();
+            TestCertificate.TWO.certificate();
             // Generate twice to make sure only one event per certificate is generated
-            TestCertificate.ONE.generate(cf);
-            TestCertificate.TWO.generate(cf);
+            TestCertificate.ONE.certificate();
+            TestCertificate.TWO.certificate();
 
             recording.stop();
 

--- a/test/jdk/jdk/jfr/event/security/TestX509ValidationEvent.java
+++ b/test/jdk/jdk/jfr/event/security/TestX509ValidationEvent.java
@@ -50,8 +50,8 @@ public class TestX509ValidationEvent {
         try (Recording recording = new Recording()) {
             recording.enable(EventNames.X509Validation);
             recording.start();
-            // intermeditate certificate test
-            TestCertificate.generateChain(false);
+            // intermediate certificate test
+            TestCertificate.generateChain(false, true);
             recording.stop();
             List<RecordedEvent> events = Events.fromRecording(recording);
             Asserts.assertEquals(events.size(), 3, "Incorrect number of events");
@@ -62,11 +62,22 @@ public class TestX509ValidationEvent {
             recording.enable(EventNames.X509Validation);
             recording.start();
             // self signed certificate test
-            TestCertificate.generateChain(true);
+            TestCertificate.generateChain(true, true);
             recording.stop();
             List<RecordedEvent> events = Events.fromRecording(recording);
             Asserts.assertEquals(events.size(), 2, "Incorrect number of events");
             assertEvent2(events);
+        }
+
+        try (Recording recording = new Recording()) {
+            recording.enable(EventNames.X509Validation);
+            recording.start();
+            // intermediate certificate test, with no Cert for trust anchor
+            TestCertificate.generateChain(true, false);
+            recording.stop();
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            Asserts.assertEquals(events.size(), 2, "Incorrect number of events");
+            assertEvent3(events);
         }
     }
 
@@ -101,6 +112,28 @@ public class TestX509ValidationEvent {
             int pos = e.getInt("certificatePosition");
             switch (pos) {
                 case 1:
+                case 2:
+                    Events.assertField(e, "certificateId")
+                            .equal(TestCertificate.ROOT_CA.certId);
+                    break;
+                default:
+                    System.out.println(events);
+                    throw new Exception("Unexpected position:" + pos);
+            }
+        }
+    }
+    /*
+     * Self signed certificate test
+     */
+    private static void assertEvent3(List<RecordedEvent> events) throws Exception {
+        for (RecordedEvent e : events) {
+            int pos = e.getInt("certificatePosition");
+            switch (pos) {
+                // use public key of cert provided in TrustAnchor
+                case 1:
+                    Asserts.assertEquals(e.getLong("certificateId"),
+                        Long.valueOf(TestCertificate.ROOT_CA.certificate().getPublicKey().hashCode()));
+                    break;
                 case 2:
                     Events.assertField(e, "certificateId")
                             .equal(TestCertificate.ROOT_CA.certId);

--- a/test/jdk/jdk/security/logging/TestX509CertificateLog.java
+++ b/test/jdk/jdk/security/logging/TestX509CertificateLog.java
@@ -58,9 +58,8 @@ public class TestX509CertificateLog {
 
     public static class GenerateX509Certicate {
         public static void main(String[] args) throws Exception {
-            CertificateFactory cf = CertificateFactory.getInstance("X.509");
-            TestCertificate.ONE.generate(cf);
-            TestCertificate.TWO.generate(cf);
+            TestCertificate.ONE.certificate();
+            TestCertificate.TWO.certificate();
         }
     }
 }

--- a/test/jdk/jdk/security/logging/TestX509ValidationLog.java
+++ b/test/jdk/jdk/security/logging/TestX509ValidationLog.java
@@ -43,14 +43,19 @@ public class TestX509ValidationLog {
         l.addExpected("FINE: ValidationChain: " +
                 TestCertificate.ROOT_CA.certId + ", " +
                 TestCertificate.ROOT_CA.certId);
+        l.addExpected("FINE: ValidationChain: " +
+                TestCertificate.ROOT_CA.certificate().getPublicKey().hashCode() +
+                ", " + TestCertificate.ROOT_CA.certId);
         l.testExpected();
     }
 
     public static class GenerateCertificateChain {
         public static void main(String[] args) throws Exception {
-            TestCertificate.generateChain(false);
+            TestCertificate.generateChain(false, true);
             // self signed test
-            TestCertificate.generateChain(true);
+            TestCertificate.generateChain(true, true);
+            // no cert for trust anchor
+            TestCertificate.generateChain(true, false);
         }
     }
 }

--- a/test/lib/jdk/test/lib/security/TestCertificate.java
+++ b/test/lib/jdk/test/lib/security/TestCertificate.java
@@ -122,6 +122,8 @@ public enum TestCertificate {
         "J2GyCaJINsyaI/I2\n" +
         "-----END CERTIFICATE-----");
 
+    private static final CertificateFactory CERTIFICATE_FACTORY = getCertificateFactory();
+
     public String serialNumber;
     public String algorithm;
     public String subject;
@@ -143,22 +145,35 @@ public enum TestCertificate {
         this.keyLength = 2048;
     }
 
-    public X509Certificate generate(CertificateFactory cf) throws CertificateException {
-        ByteArrayInputStream is = new ByteArrayInputStream(encoded.getBytes());
-        return (X509Certificate) cf.generateCertificate(is);
+    private static CertificateFactory getCertificateFactory() {
+        try {
+            return CertificateFactory.getInstance("X.509");
+        } catch (CertificateException e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    public static void generateChain(boolean selfSignedTest) throws Exception {
+    public X509Certificate certificate() throws CertificateException {
+        ByteArrayInputStream is = new ByteArrayInputStream(encoded.getBytes());
+        return (X509Certificate) CERTIFICATE_FACTORY.generateCertificate(is);
+    }
+
+    public static void generateChain(boolean selfSignedTest, boolean trustAnchorCert) throws Exception {
         // Do path validation as if it is always Tue, 06 Sep 2016 22:12:21 GMT
         // This value is within the lifetimes of all certificates.
         Date testDate = new Date(1473199941000L);
 
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        X509Certificate c1 = TestCertificate.ONE.generate(cf);
-        X509Certificate c2 = TestCertificate.TWO.generate(cf);
-        X509Certificate ca = TestCertificate.ROOT_CA.generate(cf);
+        X509Certificate c1 = TestCertificate.ONE.certificate();
+        X509Certificate c2 = TestCertificate.TWO.certificate();
+        X509Certificate ca = TestCertificate.ROOT_CA.certificate();
 
-        TrustAnchor ta = new TrustAnchor(ca, null);
+        TrustAnchor ta;
+        if (trustAnchorCert) {
+            ta = new TrustAnchor(ca, null);
+        } else {
+            ta = new TrustAnchor(ca.getIssuerX500Principal(), ca.getPublicKey(), null);
+        }
         CertPathValidator validator = CertPathValidator.getInstance("PKIX");
 
         PKIXParameters params = new PKIXParameters(Collections.singleton(ta));


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255348](https://bugs.openjdk.org/browse/JDK-8255348): NPE in PKIXCertPathValidator event logging code (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1947/head:pull/1947` \
`$ git checkout pull/1947`

Update a local copy of the PR: \
`$ git checkout pull/1947` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1947`

View PR using the GUI difftool: \
`$ git pr show -t 1947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1947.diff">https://git.openjdk.org/jdk11u-dev/pull/1947.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1947#issuecomment-1593067432)