### PR TITLE
8293858: Change PKCS7 code to use default SecureRandom impl instead of SHA1PRNG

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
@@ -36,6 +36,7 @@ import java.security.cert.CRLException;
 import java.security.cert.CertificateFactory;
 import java.security.*;
 
+import sun.security.jca.JCAUtil;
 import sun.security.timestamp.*;
 import sun.security.util.*;
 import sun.security.x509.AlgorithmId;
@@ -68,23 +69,6 @@ public class PKCS7 {
     private boolean oldStyle = false; // Is this JDK1.1.x-style?
 
     private Principal[] certIssuerNames;
-
-    /*
-     * Random number generator for creating nonce values
-     * (Lazy initialization)
-     */
-    private static class SecureRandomHolder {
-        static final SecureRandom RANDOM;
-        static {
-            SecureRandom tmp = null;
-            try {
-                tmp = SecureRandom.getInstance("SHA1PRNG");
-            } catch (NoSuchAlgorithmException e) {
-                // should not happen
-            }
-            RANDOM = tmp;
-        }
-    }
 
     /*
      * Object identifier for the timestamping key purpose.
@@ -885,11 +869,9 @@ public class PKCS7 {
         }
 
         // Generate a nonce
-        BigInteger nonce = null;
-        if (SecureRandomHolder.RANDOM != null) {
-            nonce = new BigInteger(64, SecureRandomHolder.RANDOM);
-            tsQuery.setNonce(nonce);
-        }
+        BigInteger nonce = new BigInteger(64, JCAUtil.getDefSecureRandom());
+        tsQuery.setNonce(nonce);
+
         tsQuery.requestCertificate(true);
 
         TSResponse tsReply = tsa.generateTimestamp(tsQuery);


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

Had to resolve import and removal of class SecureRandomHolder that is placed differently.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293858](https://bugs.openjdk.org/browse/JDK-8293858): Change PKCS7 code to use default SecureRandom impl instead of SHA1PRNG (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1949/head:pull/1949` \
`$ git checkout pull/1949`

Update a local copy of the PR: \
`$ git checkout pull/1949` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1949`

View PR using the GUI difftool: \
`$ git pr show -t 1949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1949.diff">https://git.openjdk.org/jdk11u-dev/pull/1949.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1949#issuecomment-1594565836)