### PR TITLE
8289748: C2 compiled code crashes with SIGFPE with -XX:+StressLCM and -XX:+StressGCM

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3240,7 +3240,12 @@ bool IdealLoopTree::do_remove_empty_loop(PhaseIdealLoop *phase) {
   // counted loop has limit check predicate.
   Node* phi = cl->phi();
   Node* exact_limit = phase->exact_limit(this);
-  Node* final_iv = new SubINode(exact_limit, cl->stride());
+
+  // We need to pin the exact limit to prevent it from floating above the zero trip guard.
+  Node * cast_ii = ConstraintCastNode::make_cast(Op_CastII, cl->in(LoopNode::EntryControl), exact_limit, phase->_igvn.type(exact_limit), true);
+  phase->register_new_node(cast_ii, cl->in(LoopNode::EntryControl));
+
+  Node* final_iv = new SubINode(cast_ii, cl->stride());
   phase->register_new_node(final_iv, cl->in(LoopNode::EntryControl));
   phase->_igvn.replace_node(phi, final_iv);
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyCountedLoop.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8289748
+ * @summary SIGFPE caused by C2 IdealLoopTree::do_remove_empty_loop
+ * @key stress randomness
+ *
+ * @run main/othervm -XX:-TieredCompilation -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestRemoveEmptyCountedLoop::test*
+ *                   compiler.loopopts.TestRemoveEmptyCountedLoop
+ */
+
+package compiler.loopopts;
+
+public class TestRemoveEmptyCountedLoop {
+
+    public static void test1() {
+        int k = 3;
+        for (int i=9; i>0; i--) {
+            for (int j=2; j<i; j++) {
+                k = k;
+                k = (1 % j);
+            }
+        }
+    }
+
+    public static void test2() {
+        int k = 3;
+        for (int i=9; i>0; i--) {
+            int j = 2;
+            do {
+                try {
+                    k = k;
+                    k = (1 % j);
+                } catch (Exception e) {}
+            } while (++j < i);
+        }
+    }
+
+    public static void main(String[] args) {
+        test1();
+        test2();
+        System.out.println("Test passed.");
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle form 17.

in loopTransform, I had to adapt the make_cast() call because
ConstraintCastNode::UnconditionalDependency is not in 11.
I think 'true" is the right thing here.

Also I removed a test case becasue  -XX:StressSeed is not in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8289748](https://bugs.openjdk.org/browse/JDK-8289748): C2 compiled code crashes with SIGFPE with -XX:+StressLCM and -XX:+StressGCM (**Bug** - P3)
 * [JDK-8301959](https://bugs.openjdk.org/browse/JDK-8301959): Compile command in compiler.loopopts.TestRemoveEmptyCountedLoop does not work (**Bug** - P5)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1951/head:pull/1951` \
`$ git checkout pull/1951`

Update a local copy of the PR: \
`$ git checkout pull/1951` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1951`

View PR using the GUI difftool: \
`$ git pr show -t 1951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1951.diff">https://git.openjdk.org/jdk11u-dev/pull/1951.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1951#issuecomment-1594637494)