### PR TITLE
Backport 1f87cb017ffb0a53c6a017b65b123ef568b8b2e7

### DIFF
--- a/test/jdk/java/net/NetworkInterface/NetworkInterfaceRetrievalTests.java
+++ b/test/jdk/java/net/NetworkInterface/NetworkInterfaceRetrievalTests.java
@@ -23,12 +23,14 @@
 
 /**
  * @test
+ * @library /test/lib
  * @bug 8179559
  */
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.util.Enumeration;
+import jdk.test.lib.Platform;
 
 public class NetworkInterfaceRetrievalTests {
     public static void main(String[] args) throws Exception {
@@ -39,6 +41,12 @@ public class NetworkInterfaceRetrievalTests {
                     .getNetworkInterfaces();
             while (en.hasMoreElements()) {
                 NetworkInterface ni = en.nextElement();
+
+                //JDK-8230132: Should not test on Windows with Teredo Tunneling Pseudo-Interface
+                String dName = ni.getDisplayName();
+                if (Platform.isWindows() && dName != null && dName.contains("Teredo"))
+                    continue;
+
                 Enumeration<InetAddress> addrs = ni.getInetAddresses();
                 System.out.println("############ Checking network interface + "
                         + ni + " #############");


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.