### PR TITLE
8226221: Update PKCS11 tests to use NSS 3.46 libs

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -988,21 +988,21 @@ public abstract class PKCS11Test {
     @Artifact(
             organization = "jpg.tests.jdk.nsslib",
             name = "nsslib-windows_x64",
-            revision = "3.41-VS2017",
+            revision = "3.46-VS2017",
             extension = "zip")
     private static class WINDOWS_X64 { }
 
     @Artifact(
             organization = "jpg.tests.jdk.nsslib",
             name = "nsslib-windows_x86",
-            revision = "3.41-VS2017",
+            revision = "3.46-VS2017",
             extension = "zip")
     private static class WINDOWS_X86 { }
 
     @Artifact(
             organization = "jpg.tests.jdk.nsslib",
             name = "nsslib-macosx_x64",
-            revision = "3.41",
+            revision = "3.46",
             extension = "zip")
     private static class MACOSX_X64 { }
 


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8226221](https://bugs.openjdk.org/browse/JDK-8226221): Update PKCS11 tests to use NSS 3.46 libs (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1954/head:pull/1954` \
`$ git checkout pull/1954`

Update a local copy of the PR: \
`$ git checkout pull/1954` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1954`

View PR using the GUI difftool: \
`$ git pr show -t 1954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1954.diff">https://git.openjdk.org/jdk11u-dev/pull/1954.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1954#issuecomment-1596236436)