### PR TITLE
8229338: clean up test/jdk/java/util/RandomAccess/Basic.java

### DIFF
--- a/test/jdk/java/util/RandomAccess/Basic.java
+++ b/test/jdk/java/util/RandomAccess/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,111 +21,148 @@
  * questions.
  */
 
-/*
+/**
  * @test
- * @bug 4327164
+ * @bug 4327164 8229338
  * @summary Basic test for new RandomAccess interface
+ * @run testng Basic
  */
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Random;
-import java.util.RandomAccess;
-import java.util.Vector;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class Basic {
-    public static void main(String[] args) throws Exception {
-        List a0 = Arrays.asList(new String[] { "a", "b", "c" });
-        List a[] = { a0, new ArrayList(a0), new LinkedList(a0),
-                new Vector(a0) };
 
-        if (!(a[0] instanceof RandomAccess))
-            throw new Exception("Arrays.asList doesn't implement RandomAccess");
-        if (!(a[1] instanceof RandomAccess))
-            throw new Exception("ArrayList doesn't implement RandomAccess");
-        if (a[2] instanceof RandomAccess)
-            throw new Exception("LinkedList implements RandomAccess");
-        if (!(a[3] instanceof RandomAccess))
-            throw new Exception("Vector doesn't implement RandomAccess");
-
-        for (int i = 0; i < a.length; i++) {
-            List t = a[i];
-            List ut = Collections.unmodifiableList(t);
-            List st = Collections.synchronizedList(t);
-
-            boolean random = t instanceof RandomAccess;
-            if ((ut instanceof RandomAccess) != random)
-                throw new Exception(
-                        "Unmodifiable fails to preserve RandomAccess: " + i);
-            if ((st instanceof RandomAccess) != random)
-                throw new Exception(
-                        "Synchronized fails to preserve RandomAccess: " + i);
-
-            while (t.size() > 0) {
-                t = t.subList(0, t.size() - 1);
-                if ((t instanceof RandomAccess) != random)
-                    throw new Exception(
-                            "SubList fails to preserve RandomAccess: " + i
-                                    + ", " + t.size());
-
-                ut = ut.subList(0, ut.size() - 1);
-                if ((ut instanceof RandomAccess) != random)
-                    throw new Exception(
-                            "SubList(unmodifiable) fails to preserve RandomAccess: "
-                                    + i + ", " + ut.size());
-
-                st = st.subList(0, st.size() - 1);
-                if ((st instanceof RandomAccess) != random)
-                    throw new Exception(
-                            "SubList(synchronized) fails to preserve RandomAccess: "
-                                    + i + ", " + st.size());
-            }
-        }
-
-        // Test that shuffle works the same on random and sequential access
-        List al = new ArrayList();
-        for (int j = 0; j < 100; j++)
-            al.add(Integer.valueOf(2 * j));
-        List ll = new LinkedList(al);
-        Random r1 = new Random(666), r2 = new Random(666);
+    /*
+     * Lists which implement Random Access interface
+     */
+    @DataProvider(name = "testLists")
+    public Object[][] testData() {
+        var intArray = new Integer[100];
+        var stack = new Stack<>();
+        var random = new Random();
         for (int i = 0; i < 100; i++) {
-            Collections.shuffle(al, r1);
-            Collections.shuffle(ll, r2);
-            if (!al.equals(ll))
-                throw new Exception("Shuffle failed: " + i);
+            var r = random.nextInt(100);
+            stack.push(r);
+            intArray[i] = r;
         }
+        List<Integer> list = Arrays.asList(intArray);
+        return new Object[][]{
+                {list, true, "Arrays.asList"},
+                {stack, true, "Stack"},
+                {new ArrayList<>(list), true, "ArrayList"},
+                {new LinkedList<>(list), false, "LinkedList"},
+                {new Vector<>(list), true, "Vector"},
+                {new CopyOnWriteArrayList<>(list), true, "CopyOnWriteArrayList"}
+        };
+    }
 
-        // Test that fill works on random & sequential access
-        List gumbyParade = Collections.nCopies(100, "gumby");
-        Collections.fill(al, "gumby");
-        if (!al.equals(gumbyParade))
-            throw new Exception("ArrayList fill failed");
-        Collections.fill(ll, "gumby");
-        if (!ll.equals(gumbyParade))
-            throw new Exception("LinkedList fill failed");
+    @Test(dataProvider = "testLists")
+    public void testRandomAccess(List<Integer> list, boolean expectedRA, String failMsg) {
 
+        var actualRA = list instanceof RandomAccess;
+        assertEquals(actualRA, expectedRA, failMsg);
+
+        List<Integer> unmodList = Collections.unmodifiableList(list);
+        List<Integer> syncList = Collections.synchronizedList(list);
+        assertEquals((unmodList instanceof RandomAccess), actualRA,
+                "Unmodifiable fails to preserve RandomAccess");
+        assertEquals((syncList instanceof RandomAccess), actualRA,
+                "Synchronized fails to preserve RandomAccess");
+
+        while (list.size() > 0) {
+            list = list.subList(0, list.size() - 1);
+            assertEquals((list instanceof RandomAccess), actualRA,
+                    "SubList fails to preserve RandomAccess: " + list.size());
+
+            unmodList = unmodList.subList(0, unmodList.size() - 1);
+            assertEquals((unmodList instanceof RandomAccess), actualRA,
+                    "SubList(unmodifiable) fails to preserve RandomAccess: "
+                            + unmodList.size());
+
+            syncList = syncList.subList(0, syncList.size() - 1);
+            assertEquals((syncList instanceof RandomAccess), actualRA,
+                    "SubList(synchronized) fails to preserve RandomAccess: "
+                            + syncList.size());
+        }
+    }
+
+    @Test(dataProvider = "testLists")
+    public void testListCopy(List<Integer> list, boolean expectedRA, String failMsg) {
+        ArrayList testCollection = new ArrayList<>(Collections.nCopies(100, 0));
         // Test that copy works on random & sequential access
-        List pokeyParade = Collections.nCopies(100, "pokey");
-        Collections.copy(al, pokeyParade);
-        if (!al.equals(pokeyParade))
-            throw new Exception("ArrayList copy failed");
-        Collections.copy(ll, pokeyParade);
-        if (!ll.equals(pokeyParade))
-            throw new Exception("LinkedList copy failed");
+        Collections.copy(list, testCollection);
+        assertEquals(list, testCollection, "Copy failed: " + failMsg);
+    }
 
-        // Test that binarySearch works the same on random & sequential access
-        al = new ArrayList();
-        for (int i = 0; i < 10000; i++)
-            al.add(Integer.valueOf(2 * i));
-        ll = new LinkedList(al);
+    @Test(dataProvider = "testLists")
+    public void testListFill(List<Integer> list, boolean expectedRA, String failMsg) {
+        ArrayList testCollection = new ArrayList<>(Collections.nCopies(100, 0));
+        // Test that copy works on random & sequential access
+        Collections.fill(list, 0);
+        assertEquals(list, testCollection, "Fill failed: " + failMsg);
+    }
+
+    /*
+     * Test that shuffle and binarySearch work the same on random and sequential access lists.
+     */
+    @DataProvider(name = "testFactoryLists")
+    public Object[][] testDataFactory() {
+        return new Object[][]{
+                {"ArrayList -> LinkedList", supplier(ArrayList::new), copyCtor(LinkedList::new)},
+                {"CopyOnWriteArrayList -> Stack", supplier(CopyOnWriteArrayList::new),
+                        copyCtor((list) -> { var s = new Stack();s.addAll(list);return s; })}
+        };
+    }
+
+    private Supplier<List<Integer>> supplier(Supplier<List<Integer>> supplier) {
+        return supplier;
+    }
+
+    private Function<List<Integer>, List<Integer>> copyCtor(Function<List<Integer>, List<Integer>> ctor) {
+        return ctor;
+    }
+
+    @Test(dataProvider = "testFactoryLists")
+    public void testListShuffle(String description, Supplier<List<Integer>> randomAccessListSupplier,
+                                Function<List<Integer>, List<Integer>> otherListFactory) {
+
+        //e.g: ArrayList<Integer> al = new ArrayList<>();
+        List<Integer> l1 = randomAccessListSupplier.get();
+        for (int j = 0; j < 100; j++) {
+            l1.add(Integer.valueOf(2 * j));
+        }
+        // e.g: List<Integer> ll = new LinkedList<>(al);
+        List<Integer> l2 = otherListFactory.apply(l1);
+        for (int i = 0; i < 100; i++) {
+            Collections.shuffle(l1, new Random(666));
+            Collections.shuffle(l2, new Random(666));
+            assertEquals(l1, l2, "Shuffle failed: " + description);
+        }
+    }
+
+    @Test(dataProvider = "testFactoryLists")
+    public void testListBinarySearch(String description, Supplier<List<Integer>> randomAccessListSupplier,
+                                     Function<List<Integer>, List<Integer>> otherListFactory) {
+
+        //e.g: ArrayList<Integer> al = new ArrayList<>();
+        List<Integer> l1 = randomAccessListSupplier.get();
+        for (int i = 0; i < 10000; i++) {
+            l1.add(Integer.valueOf(2 * i));
+        }
+        // e.g: List<Integer> ll = new LinkedList<>(al);
+        List<Integer> l2 = otherListFactory.apply(l1);
         for (int i = 0; i < 500; i++) {
-            Integer key = Integer.valueOf(r1.nextInt(20000));
-            if (Collections.binarySearch(al, key) != Collections
-                    .binarySearch(ll, key))
-                throw new Exception("Binary search failed: " + i);
+            Integer key = Integer.valueOf(new Random(666).nextInt(20000));
+            assertEquals(Collections.binarySearch(l1, key), Collections
+                    .binarySearch(l2, key), "Binary search failed: " + description);
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8229338](https://bugs.openjdk.org/browse/JDK-8229338): clean up test/jdk/java/util/RandomAccess/Basic.java (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1956/head:pull/1956` \
`$ git checkout pull/1956`

Update a local copy of the PR: \
`$ git checkout pull/1956` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1956`

View PR using the GUI difftool: \
`$ git pr show -t 1956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1956.diff">https://git.openjdk.org/jdk11u-dev/pull/1956.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1956#issuecomment-1596237962)