### PR TITLE
8231357: sun/security/pkcs11/Cipher/TestKATForGCM.java fails on SLES11 using mozilla-nss-3.14

### DIFF
--- a/test/jdk/sun/security/pkcs11/Cipher/TestKATForGCM.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestKATForGCM.java
@@ -30,12 +30,13 @@
  * @summary Known Answer Test for AES cipher with GCM mode support in
  * PKCS11 provider.
  */
-import java.security.*;
-import javax.crypto.*;
-import javax.crypto.spec.*;
-import java.math.*;
-
-import java.util.*;
+import java.security.GeneralSecurityException;
+import java.security.Provider;
+import java.util.Arrays;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 public class TestKATForGCM extends PKCS11Test {
 
@@ -307,15 +308,21 @@ public class TestKATForGCM extends PKCS11Test {
                 System.out.println("Test Passed!");
             }
         } catch (Exception e) {
-            double ver = getNSSInfo("nss");
-            if (ver < 3.251d && p.getName().contains("SunPKCS11-NSS") &&
-                System.getProperty("os.name").equals("SunOS")) {
-                // buggy behaviour from solaris on 11.2 OS (nss < 3.251)
-                System.out.println("Skipping: SunPKCS11-NSS: Old NSS: " + ver);
-                return; // OK
-            } else {
-                throw e;
+            System.out.println("Exception occured using " + p.getName() + " version " + p.getVersionStr());
+
+            if (isNSS(p)) {
+                double ver = getNSSInfo("nss");
+                String osName = System.getProperty("os.name");
+                if (ver < 3.251d && osName.equals("SunOS")) {
+                    // buggy behaviour from solaris on 11.2 OS (nss < 3.251)
+                    System.out.println("Skipping: SunPKCS11-NSS: Old NSS: " + ver);
+                    return; // OK
+                } else if (ver > 3.139 && ver < 3.15 && osName.equals("Linux")) {
+                    // warn about buggy behaviour on Linux with nss 3.14
+                    System.out.println("Warning: old NSS " + ver + " might be problematic, consider upgrading it");
+                }
             }
+            throw e;
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8231357](https://bugs.openjdk.org/browse/JDK-8231357): sun/security/pkcs11/Cipher/TestKATForGCM.java fails on SLES11 using mozilla-nss-3.14 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1957/head:pull/1957` \
`$ git checkout pull/1957`

Update a local copy of the PR: \
`$ git checkout pull/1957` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1957`

View PR using the GUI difftool: \
`$ git pr show -t 1957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1957.diff">https://git.openjdk.org/jdk11u-dev/pull/1957.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1957#issuecomment-1596240483)