### PR TITLE
8229333: java/io/File/SetLastModified.java timed out

### DIFF
--- a/test/jdk/java/io/File/SetLastModified.java
+++ b/test/jdk/java/io/File/SetLastModified.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
    @bug 4091757 6652379 8177809
+   @requires os.maxMemory >= 16G
    @summary Basic test for setLastModified method
  */
 


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8229333](https://bugs.openjdk.org/browse/JDK-8229333): java/io/File/SetLastModified.java timed out (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1958/head:pull/1958` \
`$ git checkout pull/1958`

Update a local copy of the PR: \
`$ git checkout pull/1958` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1958`

View PR using the GUI difftool: \
`$ git pr show -t 1958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1958.diff">https://git.openjdk.org/jdk11u-dev/pull/1958.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1958#issuecomment-1596241834)