### PR TITLE
8232195: Enable BigInteger tests: DivisionOverflow, SymmetricRangeTests and StringConstructorOverflow

### DIFF
--- a/test/jdk/java/math/BigInteger/largeMemory/StringConstructorOverflow.java
+++ b/test/jdk/java/math/BigInteger/largeMemory/StringConstructorOverflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,32 +23,39 @@
 
 /*
  * @test
- * @bug 8022780
- * @summary Test division of large values
- * @run main/othervm -Xshare:off DivisionOverflow
+ * @bug 8021204
+ * @summary Test constructor BigInteger(String val, int radix) on very long string
+ * @requires os.maxMemory > 8g
+ * @run main/othervm -Xshare:off -Xmx8g StringConstructorOverflow
  * @author Dmitry Nadezhin
  */
 import java.math.BigInteger;
 
-public class DivisionOverflow {
+public class StringConstructorOverflow {
+
+    // String with hexadecimal value pow(2,pow(2,34))+1
+    private static String makeLongHexString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append('1');
+        for (int i = 0; i < (1 << 30) - 1; i++) {
+            sb.append('0');
+        }
+        sb.append('1');
+        return sb.toString();
+    }
 
     public static void main(String[] args) {
         try {
-            BigInteger a = BigInteger.ONE.shiftLeft(2147483646);
-            BigInteger b = BigInteger.ONE.shiftLeft(1568);
-            BigInteger[] qr = a.divideAndRemainder(b);
-            BigInteger q = qr[0];
-            BigInteger r = qr[1];
-            if (!r.equals(BigInteger.ZERO)) {
-                throw new RuntimeException("Incorrect signum() of remainder " + r.signum());
+            BigInteger bi = new BigInteger(makeLongHexString(), 16);
+            if (bi.compareTo(BigInteger.ONE) <= 0) {
+                throw new RuntimeException("Incorrect result " + bi.toString());
             }
-            if (q.bitLength() != 2147482079) {
-                throw new RuntimeException("Incorrect bitLength() of quotient " + q.bitLength());
-            }
-            System.out.println("Division of large values passed without overflow.");
+        } catch (ArithmeticException e) {
+            // expected
+            System.out.println("Overflow is reported by ArithmeticException, as expected");
         } catch (OutOfMemoryError e) {
             // possible
-            System.err.println("DivisionOverflow skipped: OutOfMemoryError");
+            System.err.println("StringConstructorOverflow skipped: OutOfMemoryError");
             System.err.println("Run jtreg with -javaoption:-Xmx8g");
         }
     }

--- a/test/jdk/java/math/BigInteger/largeMemory/SymmetricRangeTests.java
+++ b/test/jdk/java/math/BigInteger/largeMemory/SymmetricRangeTests.java
@@ -23,11 +23,11 @@
 
 /*
  * @test
- * @library /test/lib
- * @ignore This test has huge memory requirements
- * @run main/timeout=180/othervm -Xmx8g SymmetricRangeTests
  * @bug 6910473 8021204 8021203 9005933 8074460 8078672
  * @summary Test range of BigInteger values (use -Dseed=X to set PRNG seed)
+ * @library /test/lib
+ * @requires os.maxMemory > 8g
+ * @run main/timeout=180/othervm -Xmx8g SymmetricRangeTests
  * @author Dmitry Nadezhin
  * @key randomness
  */


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

I omitted the removal of the directory from TEST.ROOT as it was not listed there.
Will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8232195](https://bugs.openjdk.org/browse/JDK-8232195): Enable BigInteger tests: DivisionOverflow, SymmetricRangeTests and StringConstructorOverflow (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1959/head:pull/1959` \
`$ git checkout pull/1959`

Update a local copy of the PR: \
`$ git checkout pull/1959` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1959/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1959`

View PR using the GUI difftool: \
`$ git pr show -t 1959`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1959.diff">https://git.openjdk.org/jdk11u-dev/pull/1959.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1959#issuecomment-1596244178)