### PR TITLE
8236045: [TESTBUG] MismatchedWhiteBox test fails with missing WhiteBox$WhiteBoxPermission.class

### DIFF
--- a/test/hotspot/jtreg/sanity/MismatchedWhiteBox/WhiteBox.java
+++ b/test/hotspot/jtreg/sanity/MismatchedWhiteBox/WhiteBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,15 @@
 package sun.hotspot;
 
 public class WhiteBox {
+    @SuppressWarnings("serial")
+    public static class WhiteBoxPermission extends java.security.BasicPermission {
+        // ClassFileInstaller is hard-coded to copy WhiteBox$WhiteBoxPermission, so let's
+        // make a fake one here as well.
+        public WhiteBoxPermission(String s) {
+            super(s);
+        }
+    }
+
     private static native void registerNatives();
     static { registerNatives(); }
     public native int notExistedMethod();


### PR DESCRIPTION
8236045: [TESTBUG] MismatchedWhiteBox test fails with missing WhiteBox$WhiteBoxPermission.class

Reviewed-by: Yi Yang

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8236045](https://bugs.openjdk.org/browse/JDK-8236045): [TESTBUG] MismatchedWhiteBox test fails with missing WhiteBox$WhiteBoxPermission.class (**Bug** - P3)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1963/head:pull/1963` \
`$ git checkout pull/1963`

Update a local copy of the PR: \
`$ git checkout pull/1963` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1963`

View PR using the GUI difftool: \
`$ git pr show -t 1963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1963.diff">https://git.openjdk.org/jdk11u-dev/pull/1963.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1963#issuecomment-1598018604)