### PR TITLE
8254350: CompletableFuture.get may swallow InterruptedException

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
+++ b/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
@@ -1807,6 +1807,8 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
      * interrupted.
      */
     private Object waitingGet(boolean interruptible) {
+        if (interruptible && Thread.interrupted())
+            return null;
         Signaller q = null;
         boolean queued = false;
         Object r;
@@ -1818,25 +1820,25 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
             }
             else if (!queued)
                 queued = tryPushStack(q);
+            else if (interruptible && q.interrupted) {
+                q.thread = null;
+                cleanStack();
+                return null;
+            }
             else {
                 try {
                     ForkJoinPool.managedBlock(q);
                 } catch (InterruptedException ie) { // currently cannot happen
                     q.interrupted = true;
                 }
-                if (q.interrupted && interruptible)
-                    break;
             }
         }
-        if (q != null && queued) {
+        if (q != null) {
             q.thread = null;
-            if (!interruptible && q.interrupted)
+            if (q.interrupted)
                 Thread.currentThread().interrupt();
-            if (r == null)
-                cleanStack();
         }
-        if (r != null || (r = result) != null)
-            postComplete();
+        postComplete();
         return r;
     }
 

--- a/test/jdk/java/util/concurrent/CompletableFuture/LostInterrupt.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/LostInterrupt.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadLocalRandom;
+import static java.util.concurrent.TimeUnit.DAYS;
+
+/*
+ * @test
+ * @bug 8254350
+ * @run main LostInterrupt
+ * @summary CompletableFuture.get may swallow interrupt status
+ * @key randomness
+ */
+
+// TODO: Rewrite as a CompletableFuture tck test ?
+
+/**
+ * Submits a task that completes immediately, then invokes CompletableFuture.get
+ * with the interrupt status set. CompletableFuture.get should either complete
+ * immediately with the interrupt status set, or else throw InterruptedException
+ * with the interrupt status cleared.
+ */
+public class LostInterrupt {
+    static final int ITERATIONS = 10_000;
+
+    public static void main(String[] args) throws Exception {
+        ThreadLocalRandom rnd = ThreadLocalRandom.current();
+        ForkJoinPool executor = new ForkJoinPool(1);
+        try {
+            for (int i = 0; i < ITERATIONS; i++) {
+                CompletableFuture<String> future = new CompletableFuture<>();
+                boolean timed = rnd.nextBoolean();
+                executor.execute(() -> future.complete("foo"));
+
+                Thread.currentThread().interrupt();
+                try {
+                    String result = timed ? future.get(1, DAYS) : future.get();
+
+                    if (!Thread.interrupted())
+                        throw new AssertionError("lost interrupt, run=" + i);
+                } catch (InterruptedException expected) {
+                    if (Thread.interrupted())
+                        throw new AssertionError(
+                            "interrupt status not cleared, run=" + i);
+                }
+            }
+        } finally {
+            executor.shutdown();
+        }
+    }
+}

--- a/test/jdk/java/util/concurrent/CompletableFuture/SwallowedInterruptedException.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/SwallowedInterruptedException.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
+
+/*
+ * @test
+ * @bug 8254350
+ * @run main SwallowedInterruptedException
+ * @key randomness
+ */
+
+public class SwallowedInterruptedException {
+    static final int ITERATIONS = 100;
+
+    public static void main(String[] args) throws Throwable {
+        for (int i = 1; i <= ITERATIONS; i++) {
+            System.out.format("Iteration %d%n", i);
+
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            CountDownLatch running = new CountDownLatch(1);
+            AtomicReference<String> failed = new AtomicReference<>();
+
+            Thread thread = new Thread(() -> {
+                // signal main thread that child is running
+                running.countDown();
+
+                // invoke Future.get, it complete with the interrupt status set or
+                // else throw InterruptedException with the interrupt status not set.
+                try {
+                    future.get();
+
+                    // interrupt status should be set
+                    if (!Thread.currentThread().isInterrupted()) {
+                        failed.set("Future.get completed with interrupt status not set");
+                    }
+                } catch (InterruptedException ex) {
+                    // interrupt status should be cleared
+                    if (Thread.currentThread().isInterrupted()) {
+                        failed.set("InterruptedException with interrupt status set");
+                    }
+                } catch (Throwable ex) {
+                    failed.set("Unexpected exception " + ex);
+                }
+            });
+            thread.setDaemon(true);
+            thread.start();
+
+            // wait for thread to run
+            running.await();
+
+            // interrupt thread and set result after an optional (random) delay
+            thread.interrupt();
+            long sleepMillis = ThreadLocalRandom.current().nextLong(10);
+            if (sleepMillis > 0)
+                Thread.sleep(sleepMillis);
+            future.complete(null);
+
+            // wait for thread to terminate and check for failure
+            thread.join();
+            String failedReason = failed.get();
+            if (failedReason != null) {
+                throw new RuntimeException("Test failed: " + failedReason);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.
src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
Resolved due to context
test/jdk/java/util/concurrent/CompletableFuture/LostInterrupt.java
Resolved due to context
test/jdk/java/util/concurrent/CompletableFuture/SwallowedInterruptedException.java
Resolved due to context

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8254350](https://bugs.openjdk.org/browse/JDK-8254350): CompletableFuture.get may swallow InterruptedException (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1964/head:pull/1964` \
`$ git checkout pull/1964`

Update a local copy of the PR: \
`$ git checkout pull/1964` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1964`

View PR using the GUI difftool: \
`$ git pr show -t 1964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1964.diff">https://git.openjdk.org/jdk11u-dev/pull/1964.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1964#issuecomment-1598041246)