### PR TITLE
8309959: JFR: Display N/A for missing data amount

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,6 @@ jobs:
           - 'hs/tier1 gc'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
-          - 'jdk/jfr'
 
         include:
           - test-name: 'jdk/tier1 part 1'
@@ -78,9 +77,6 @@ jobs:
 
           - test-name: 'langtools/tier1'
             test-suite: 'test/langtools/:tier1'
-          
-          - test-name: 'jdk/jfr'
-            test-suite: 'test/jdk/jdk/jfr'
 
           - test-name: 'hs/tier1 common'
             test-suite: 'test/hotspot/jtreg/:tier1_common'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
           - 'hs/tier1 gc'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
+          - 'jdk/jfr'
 
         include:
           - test-name: 'jdk/tier1 part 1'
@@ -77,6 +78,9 @@ jobs:
 
           - test-name: 'langtools/tier1'
             test-suite: 'test/langtools/:tier1'
+          
+          - test-name: 'jdk/jfr'
+            test-suite: 'test/jdk/jdk/jfr'
 
           - test-name: 'hs/tier1 common'
             test-suite: 'test/hotspot/jtreg/:tier1_common'

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -103,9 +103,9 @@ public final class Utils {
         }
     }
 
-    // Tjis method can't handle Long.MIN_VALUE because absolute value is negative
+    // handle Long.MIN_VALUE as a special case since its absolute value is negative
     private static String formatDataAmount(String formatter, long amount) {
-        int exp = (int) (Math.log(Math.abs(amount)) / Math.log(1024));
+        int exp = (amount == Long.MIN_VALUE) ? 6 : (int) (Math.log(Math.abs(amount)) / Math.log(1024));
         char unitPrefix = "kMGTPE".charAt(exp - 1);
         return String.format(formatter, amount / Math.pow(1024, exp), unitPrefix);
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -103,11 +103,13 @@ public final class Utils {
         }
     }
 
-    // handle Long.MIN_VALUE as a special case since its absolute value is negative
     private static String formatDataAmount(String formatter, long amount) {
-        int exp = (amount == Long.MIN_VALUE) ? 6 : (int) (Math.log(Math.abs(amount)) / Math.log(1024));
-        char unitPrefix = "kMGTPE".charAt(exp - 1);
-        return String.format(formatter, amount / Math.pow(1024, exp), unitPrefix);
+        if (amount == Long.MIN_VALUE) {
+            return "N/A";
+        }
+        int exp = (int) (Math.log(Math.abs(amount)) / Math.log(1024));
+        char unit = "kMGTPE".charAt(exp - 1);
+        return String.format(formatter, amount / Math.pow(1024, exp), unit);
     }
 
     public static String formatBytesCompact(long bytes) {


### PR DESCRIPTION
This is a backport of [JDK-8309959](https://bugs.openjdk.org/browse/JDK-8309959): JFR: Display N/A for missing data amount.

It is a follow up to the backport of [JDK-8309550](https://github.com/openjdk/jdk17u-dev/pull/1438): jdk.jfr.internal.Utils::formatDataAmount method should gracefully handle amounts equal to Long.MIN_VALUE

NB: [ValueFormatter.java](https://github.com/openjdk/jdk/commit/a1ab377d995dce4d636b908e96bd168dc3a9f3e5#diff-92129c25f421457539b76d9df74cdd34a12d8afd07e53612859e2edeee2c5758) that is changed in the original commit got introduced with [JDK-8306703](https://bugs.openjdk.org/browse/JDK-8306703). which is JDK 21+ only and shouldn't get backported.

A run of the Jdk_jfr test suite via GHA will be available here: https://github.com/fthevenet/jdk11u-dev/actions/runs/5324629652

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8309959](https://bugs.openjdk.org/browse/JDK-8309959) needs maintainer approval

### Issue
 * [JDK-8309959](https://bugs.openjdk.org/browse/JDK-8309959): JFR: Display N/A for missing data amount (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1969/head:pull/1969` \
`$ git checkout pull/1969`

Update a local copy of the PR: \
`$ git checkout pull/1969` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1969`

View PR using the GUI difftool: \
`$ git pr show -t 1969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1969.diff">https://git.openjdk.org/jdk11u-dev/pull/1969.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1969#issuecomment-1599100336)