### PR TITLE
8231516: network QuickAckTest.java failed due to "SocketException: maximum number of DatagramSockets reached"

### DIFF
--- a/test/jdk/jdk/net/Sockets/QuickAckTest.java
+++ b/test/jdk/jdk/net/Sockets/QuickAckTest.java
@@ -26,7 +26,7 @@
  * @bug 8145635
  * @summary Add TCP_QUICKACK socket option
  * @modules jdk.net
- * @run main QuickAckTest
+ * @run main/othervm QuickAckTest
  */
 import java.io.IOException;
 import java.net.DatagramSocket;


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8231516](https://bugs.openjdk.org/browse/JDK-8231516): network QuickAckTest.java failed due to "SocketException: maximum number of DatagramSockets reached" (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1977/head:pull/1977` \
`$ git checkout pull/1977`

Update a local copy of the PR: \
`$ git checkout pull/1977` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1977`

View PR using the GUI difftool: \
`$ git pr show -t 1977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1977.diff">https://git.openjdk.org/jdk11u-dev/pull/1977.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1977#issuecomment-1600969318)