### PR TITLE
8237183: Bug ID missing for test in patch which fixed JDK-8230665

### DIFF
--- a/test/jdk/java/nio/Buffer/Basic.java
+++ b/test/jdk/java/nio/Buffer/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 4413135 4414911 4416536 4416562 4418782 4471053 4472779 4490253 4523725
  *      4526177 4463011 4660660 4661219 4663521 4782970 4804304 4938424 6231529
  *      6221101 6234263 6535542 6591971 6593946 6795561 7190219 7199551 8065556
- *      8149469
+ *      8149469 8230665
  * @modules java.base/java.nio:open
  *          java.base/jdk.internal.misc
  * @author Mark Reinhold


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

I had to resolve, but it is trivial will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8237183](https://bugs.openjdk.org/browse/JDK-8237183): Bug ID missing for test in patch which fixed JDK-8230665 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1979/head:pull/1979` \
`$ git checkout pull/1979`

Update a local copy of the PR: \
`$ git checkout pull/1979` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1979`

View PR using the GUI difftool: \
`$ git pr show -t 1979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1979.diff">https://git.openjdk.org/jdk11u-dev/pull/1979.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1979#issuecomment-1602520942)