### PR TITLE
8239007: java/math/BigInteger/largeMemory/ tests should be disabled on 32-bit platforms

### DIFF
--- a/test/jdk/java/math/BigInteger/largeMemory/DivisionOverflow.java
+++ b/test/jdk/java/math/BigInteger/largeMemory/DivisionOverflow.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8022780
  * @summary Test division of large values
- * @requires os.maxMemory > 8g
+ * @requires (sun.arch.data.model == "64" & os.maxMemory > 8g)
  * @run main/othervm -Xshare:off -Xmx8g DivisionOverflow
  * @author Dmitry Nadezhin
  */

--- a/test/jdk/java/math/BigInteger/largeMemory/StringConstructorOverflow.java
+++ b/test/jdk/java/math/BigInteger/largeMemory/StringConstructorOverflow.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8021204
  * @summary Test constructor BigInteger(String val, int radix) on very long string
- * @requires os.maxMemory > 8g
+ * @requires (sun.arch.data.model == "64" & os.maxMemory > 8g)
  * @run main/othervm -Xshare:off -Xmx8g StringConstructorOverflow
  * @author Dmitry Nadezhin
  */

--- a/test/jdk/java/math/BigInteger/largeMemory/SymmetricRangeTests.java
+++ b/test/jdk/java/math/BigInteger/largeMemory/SymmetricRangeTests.java
@@ -26,7 +26,7 @@
  * @bug 6910473 8021204 8021203 9005933 8074460 8078672
  * @summary Test range of BigInteger values (use -Dseed=X to set PRNG seed)
  * @library /test/lib
- * @requires os.maxMemory > 8g
+ * @requires (sun.arch.data.model == "64" & os.maxMemory > 8g)
  * @run main/timeout=180/othervm -Xmx8g SymmetricRangeTests
  * @author Dmitry Nadezhin
  * @key randomness


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8239007](https://bugs.openjdk.org/browse/JDK-8239007): java/math/BigInteger/largeMemory/ tests should be disabled on 32-bit platforms (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1981/head:pull/1981` \
`$ git checkout pull/1981`

Update a local copy of the PR: \
`$ git checkout pull/1981` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1981`

View PR using the GUI difftool: \
`$ git pr show -t 1981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1981.diff">https://git.openjdk.org/jdk11u-dev/pull/1981.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1981#issuecomment-1602535320)