### PR TITLE
8247968: test/jdk/javax/crypto/SecretKeyFactory/security.properties has wrong header

### DIFF
--- a/test/jdk/javax/crypto/SecretKeyFactory/security.properties
+++ b/test/jdk/javax/crypto/SecretKeyFactory/security.properties
@@ -1,6 +1,3 @@
-# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
-# ORACLE PROPRIETARY/CONFIDENTIAL.  Use is subject to license terms.
-
 jdk.security.provider.preferred=
 jdk.jar.disabledAlgorithms=
 


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8247968](https://bugs.openjdk.org/browse/JDK-8247968): test/jdk/javax/crypto/SecretKeyFactory/security.properties has wrong header (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1982/head:pull/1982` \
`$ git checkout pull/1982`

Update a local copy of the PR: \
`$ git checkout pull/1982` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1982/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1982`

View PR using the GUI difftool: \
`$ git pr show -t 1982`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1982.diff">https://git.openjdk.org/jdk11u-dev/pull/1982.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1982#issuecomment-1602561884)