### PR TITLE
8251517: [TESTBUG] com/sun/net/httpserver/bugs/B6393710.java does not scale socket timeout

### DIFF
--- a/test/jdk/com/sun/net/httpserver/bugs/B6393710.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6393710.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 6393710
+ * @library /test/lib
  * @summary  Non authenticated call followed by authenticated call never returns
  */
 
@@ -33,6 +34,8 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.io.*;
 import java.net.*;
+
+import jdk.test.lib.Utils;
 
 /*
  * Test checks for following bug(s) when a POST containing a request body
@@ -77,7 +80,7 @@ public class B6393710 {
         server.start ();
 
         Socket s = new Socket ("localhost", server.getAddress().getPort());
-        s.setSoTimeout (5000);
+        s.setSoTimeout ((int) Utils.adjustTimeout(5000));
 
         OutputStream os = s.getOutputStream();
         os.write (cmd.getBytes());
@@ -124,8 +127,8 @@ public class B6393710 {
         return false;
     }
 
-    public static boolean ok = false;
-    static int requests = 0;
+    public static volatile boolean ok = false;
+    static volatile int requests = 0;
 
     static class Handler implements HttpHandler {
         int invocation = 1;


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

Resolve due to context differences.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8251517](https://bugs.openjdk.org/browse/JDK-8251517): [TESTBUG] com/sun/net/httpserver/bugs/B6393710.java does not scale socket timeout (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1983/head:pull/1983` \
`$ git checkout pull/1983`

Update a local copy of the PR: \
`$ git checkout pull/1983` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1983`

View PR using the GUI difftool: \
`$ git pr show -t 1983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1983.diff">https://git.openjdk.org/jdk11u-dev/pull/1983.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1983#issuecomment-1602561756)