### PR TITLE
8249699: java/io/ByteArrayOutputStream/MaxCapacity.java should use @requires instead of @ignore

### DIFF
--- a/test/jdk/java/io/ByteArrayOutputStream/MaxCapacity.java
+++ b/test/jdk/java/io/ByteArrayOutputStream/MaxCapacity.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2014 Google Inc. All rights reserved.
+ * Copyright (c) 2014, Google Inc. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +24,11 @@
 
 /*
  * @test
- * @ignore This test has huge memory requirements
- * @run main/timeout=1800/othervm -Xmx8g MaxCapacity
  * @bug 8055949
  * @summary Check that we can write (almost) Integer.MAX_VALUE bytes
  *          to a ByteArrayOutputStream.
+ * @requires (sun.arch.data.model == "64" & os.maxMemory >= 10g)
+ * @run main/timeout=1800/othervm -Xmx8g MaxCapacity
  * @author Martin Buchholz
  */
 import java.io.ByteArrayOutputStream;


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8249699](https://bugs.openjdk.org/browse/JDK-8249699): java/io/ByteArrayOutputStream/MaxCapacity.java should use @requires instead of @ignore (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1984/head:pull/1984` \
`$ git checkout pull/1984`

Update a local copy of the PR: \
`$ git checkout pull/1984` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1984`

View PR using the GUI difftool: \
`$ git pr show -t 1984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1984.diff">https://git.openjdk.org/jdk11u-dev/pull/1984.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1984#issuecomment-1602583732)