### PR TITLE
8260934: java/lang/StringBuilder/HugeCapacity.java fails without Compact Strings

### DIFF
--- a/test/jdk/java/lang/StringBuilder/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuilder/HugeCapacity.java
@@ -27,25 +27,32 @@
  * @summary Capacity should not get close to Integer.MAX_VALUE unless
  *          necessary
  * @requires (sun.arch.data.model == "64" & os.maxMemory >= 6G)
- * @run main/othervm -Xmx5G HugeCapacity
+ * @run main/othervm -Xms5G -Xmx5G -XX:+CompactStrings HugeCapacity true
+ * @run main/othervm -Xms5G -Xmx5G -XX:-CompactStrings HugeCapacity false
  */
 
 public class HugeCapacity {
     private static int failures = 0;
 
     public static void main(String[] args) {
-        testLatin1();
+        if (args.length == 0) {
+           throw new IllegalArgumentException("Need the argument");
+        }
+        boolean isCompact = Boolean.parseBoolean(args[0]);
+
+        testLatin1(isCompact);
         testUtf16();
         if (failures > 0) {
             throw new RuntimeException(failures + " tests failed");
         }
     }
 
-    private static void testLatin1() {
+    private static void testLatin1(boolean isCompact) {
         try {
+            int divisor = isCompact ? 2 : 4;
             StringBuilder sb = new StringBuilder();
-            sb.ensureCapacity(Integer.MAX_VALUE / 2);
-            sb.ensureCapacity(Integer.MAX_VALUE / 2 + 1);
+            sb.ensureCapacity(Integer.MAX_VALUE / divisor);
+            sb.ensureCapacity(Integer.MAX_VALUE / divisor + 1);
         } catch (OutOfMemoryError oom) {
             oom.printStackTrace();
             failures++;


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

I had to resolve because  "8218227: StringBuilder/StringBuffer constructor throws confusing NegativeArraySizeException"
is not in 11.
I took over the -Xms5g from that change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8260934](https://bugs.openjdk.org/browse/JDK-8260934): java/lang/StringBuilder/HugeCapacity.java fails without Compact Strings (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1985/head:pull/1985` \
`$ git checkout pull/1985`

Update a local copy of the PR: \
`$ git checkout pull/1985` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1985`

View PR using the GUI difftool: \
`$ git pr show -t 1985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1985.diff">https://git.openjdk.org/jdk11u-dev/pull/1985.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1985#issuecomment-1602606080)