### PR TITLE
8263970: Manual test javax/swing/JTextField/JapaneseReadingAttributes/JapaneseReadingAttributes.java failed

### DIFF
--- a/test/jdk/javax/swing/JTextField/JapaneseReadingAttributes/JapaneseReadingAttributes.java
+++ b/test/jdk/javax/swing/JTextField/JapaneseReadingAttributes/JapaneseReadingAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,7 +98,7 @@ public class JapaneseReadingAttributes {
     private static void setupUI() {
         String description = " 1. Go to \"Language Preferences -> Add a Language"
                             + "\" and add \"Japanese\"\n"
-                            + " 2. Set current IM to \"Japanese\" \n"
+                            + " 2. Set current IM to \"Japanese\" and IME option to \"Full width Katakana\" \n"
                             + " 3. Try typing in the text field to ensure"
                             + " that Japanese IME has been successfully"
                             + " selected \n"


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8263970](https://bugs.openjdk.org/browse/JDK-8263970): Manual test javax/swing/JTextField/JapaneseReadingAttributes/JapaneseReadingAttributes.java failed (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1988/head:pull/1988` \
`$ git checkout pull/1988`

Update a local copy of the PR: \
`$ git checkout pull/1988` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1988`

View PR using the GUI difftool: \
`$ git pr show -t 1988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1988.diff">https://git.openjdk.org/jdk11u-dev/pull/1988.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1988#issuecomment-1602747958)