### PR TITLE
8273807: Zero: Drop incorrect test block from compiler/startup/NumCompilerThreadsCheck.java

### DIFF
--- a/test/hotspot/jtreg/compiler/startup/NumCompilerThreadsCheck.java
+++ b/test/hotspot/jtreg/compiler/startup/NumCompilerThreadsCheck.java
@@ -46,11 +46,6 @@ public class NumCompilerThreadsCheck {
 
     String expectedOutput = "outside the allowed range";
     out.shouldContain(expectedOutput);
-
-    if (Platform.isZero()) {
-      String expectedLowWaterMarkText = "must be at least 0";
-      out.shouldContain(expectedLowWaterMarkText);
-    }
   }
 
 }


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273807](https://bugs.openjdk.org/browse/JDK-8273807): Zero: Drop incorrect test block from compiler/startup/NumCompilerThreadsCheck.java (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1990/head:pull/1990` \
`$ git checkout pull/1990`

Update a local copy of the PR: \
`$ git checkout pull/1990` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1990`

View PR using the GUI difftool: \
`$ git pr show -t 1990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1990.diff">https://git.openjdk.org/jdk11u-dev/pull/1990.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1990#issuecomment-1602767903)