### PR TITLE
8285635: javax/swing/JRootPane/DefaultButtonTest.java failed with Default Button not pressed for L&F: com.sun.java.swing.plaf.motif.MotifLookAndFeel

### DIFF
--- a/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
+++ b/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
@@ -89,6 +89,12 @@ public class DefaultButtonTest {
                 buttonPressed = false;
                 String lafName = laf.getClassName();
                 System.out.println("Testing L&F: " + lafName);
+
+                // Ignore obsolete/deprecated Motif
+                if (lafName.contains("Motif")) {
+                    System.out.println("Skipped Motif");
+                    continue;
+                }
                 SwingUtilities.invokeAndWait(() -> {
                     setLookAndFeel(lafName);
                     createUI();


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285635](https://bugs.openjdk.org/browse/JDK-8285635): javax/swing/JRootPane/DefaultButtonTest.java failed with Default Button not pressed for L&amp;F: com.sun.java.swing.plaf.motif.MotifLookAndFeel (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1994/head:pull/1994` \
`$ git checkout pull/1994`

Update a local copy of the PR: \
`$ git checkout pull/1994` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1994`

View PR using the GUI difftool: \
`$ git pr show -t 1994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1994.diff">https://git.openjdk.org/jdk11u-dev/pull/1994.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1994#issuecomment-1602839146)