### PR TITLE
8241097: java/math/BigInteger/largeMemory/SymmetricRangeTests.java requires -XX:+CompactStrings

### DIFF
--- a/test/jdk/java/math/BigInteger/largeMemory/SymmetricRangeTests.java
+++ b/test/jdk/java/math/BigInteger/largeMemory/SymmetricRangeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Test range of BigInteger values (use -Dseed=X to set PRNG seed)
  * @library /test/lib
  * @requires (sun.arch.data.model == "64" & os.maxMemory > 8g)
- * @run main/timeout=180/othervm -Xmx8g SymmetricRangeTests
+ * @run main/timeout=180/othervm -Xmx8g -XX:+CompactStrings SymmetricRangeTests
  * @author Dmitry Nadezhin
  * @key randomness
  */


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8241097](https://bugs.openjdk.org/browse/JDK-8241097): java/math/BigInteger/largeMemory/SymmetricRangeTests.java requires -XX:+CompactStrings (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/1999/head:pull/1999` \
`$ git checkout pull/1999`

Update a local copy of the PR: \
`$ git checkout pull/1999` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/1999/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1999`

View PR using the GUI difftool: \
`$ git pr show -t 1999`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/1999.diff">https://git.openjdk.org/jdk11u-dev/pull/1999.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/1999#issuecomment-1603936353)