### PR TITLE
8244078: ProcessTools executeTestJvm and createJavaProcessBuilder have inconsistent handling of test.*.opts

### DIFF
--- a/test/hotspot/jtreg/compiler/aot/verification/ClassAndLibraryNotMatchTest.java
+++ b/test/hotspot/jtreg/compiler/aot/verification/ClassAndLibraryNotMatchTest.java
@@ -92,7 +92,7 @@ public class ClassAndLibraryNotMatchTest {
     private void runAndCheckHelloWorld(String checkString) {
         ProcessBuilder pb;
         try {
-            pb = ProcessTools.createJavaProcessBuilder(true, "-cp", ".",
+            pb = ProcessTools.createTestJvm("-cp", ".",
                     "-XX:+UnlockExperimentalVMOptions", "-XX:+UseAOT",
                     "-XX:AOTLibrary=./" + LIB_NAME, HELLO_WORLD_CLASS_NAME);
         } catch (Exception e) {

--- a/test/hotspot/jtreg/compiler/aot/verification/vmflags/BasicFlagsChange.java
+++ b/test/hotspot/jtreg/compiler/aot/verification/vmflags/BasicFlagsChange.java
@@ -87,7 +87,7 @@ public class BasicFlagsChange {
                so, a message like "skipped $pathTolibrary aot library" or
                "loaded    $pathToLibrary  aot library" is present for cases of
                incompatible or compatible flags respectively */
-            pb = ProcessTools.createJavaProcessBuilder(true, "-XX:+UnlockExperimentalVMOptions",
+            pb = ProcessTools.createTestJvm("-XX:+UnlockExperimentalVMOptions",
                     "-XX:+UseAOT", "-XX:+PrintAOT", "-XX:AOTLibrary=./" + libName, option,
                     HelloWorldPrinter.class.getName());
         } catch (Exception ex) {

--- a/test/hotspot/jtreg/compiler/arraycopy/stress/TestStressArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/stress/TestStressArrayCopy.java
@@ -172,7 +172,7 @@ public class TestStressArrayCopy {
             for (String className : classNames) {
                 // Start a new job
                 {
-                    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, mix(c, "-Xmx256m", className).toArray(new String[0]));
+                    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(mix(c, "-Xmx256m", className).toArray(new String[0]));
                     Process p = pb.start();
                     OutputAnalyzer oa = new OutputAnalyzer(p);
                     forks.add(new Fork(p, oa));

--- a/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
@@ -137,11 +137,10 @@ public abstract class CiReplayBase {
             options.add(needCoreDump ? ENABLE_COREDUMP_ON_CRASH : DISABLE_COREDUMP_ON_CRASH);
             options.add(VERSION_OPTION);
             if (needCoreDump) {
-                crashOut = ProcessTools.executeProcess(getTestJavaCommandlineWithPrefix(
+                crashOut = ProcessTools.executeProcess(getTestJvmCommandlineWithPrefix(
                         RUN_SHELL_NO_LIMIT, options.toArray(new String[0])));
             } else {
-                crashOut = ProcessTools.executeProcess(ProcessTools.createJavaProcessBuilder(true,
-                        options));
+                crashOut = ProcessTools.executeProcess(ProcessTools.createTestJvm(options));
             }
             crashOutputString = crashOut.getOutput();
             Asserts.assertNotEquals(crashOut.getExitValue(), 0, "Crash JVM exits gracefully");
@@ -185,7 +184,7 @@ public abstract class CiReplayBase {
             List<String> allAdditionalOpts = new ArrayList<>();
             allAdditionalOpts.addAll(Arrays.asList(REPLAY_OPTIONS));
             allAdditionalOpts.addAll(Arrays.asList(additionalVmOpts));
-            OutputAnalyzer oa = ProcessTools.executeProcess(getTestJavaCommandlineWithPrefix(
+            OutputAnalyzer oa = ProcessTools.executeProcess(getTestJvmCommandlineWithPrefix(
                     RUN_SHELL_ZERO_LIMIT, allAdditionalOpts.toArray(new String[0])));
             return oa.getExitValue();
         } catch (Throwable t) {
@@ -285,9 +284,9 @@ public abstract class CiReplayBase {
         return null;
     }
 
-    private String[] getTestJavaCommandlineWithPrefix(String prefix, String... args) {
+    private String[] getTestJvmCommandlineWithPrefix(String prefix, String... args) {
         try {
-            String cmd = ProcessTools.getCommandLine(ProcessTools.createJavaProcessBuilder(true, args));
+            String cmd = ProcessTools.getCommandLine(ProcessTools.createTestJvm(args));
             return new String[]{"sh", "-c", prefix
                 + (Platform.isWindows() ? cmd.replace('\\', '/').replace(";", "\\;").replace("|", "\\|") : cmd)};
         } catch(Throwable t) {

--- a/test/hotspot/jtreg/compiler/ciReplay/SABase.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/SABase.java
@@ -57,7 +57,7 @@ public class SABase extends CiReplayBase {
         }
         ProcessBuilder pb;
         try {
-            pb = ProcessTools.createJavaProcessBuilder(true, "--add-modules", "jdk.hotspot.agent",
+            pb = ProcessTools.createTestJvm("--add-modules", "jdk.hotspot.agent",
                    "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED",
                     "sun.jvm.hotspot.CLHSDB", JDKToolFinder.getTestJDKTool("java"),
                     TEST_CORE_FILE_NAME);

--- a/test/hotspot/jtreg/compiler/graalunit/common/GraalUnitTestLauncher.java
+++ b/test/hotspot/jtreg/compiler/graalunit/common/GraalUnitTestLauncher.java
@@ -112,7 +112,7 @@ public class GraalUnitTestLauncher {
         String classPath = String.join(File.pathSeparator, System.getProperty("java.class.path"),
                 String.join(File.separator, libsDir, MXTOOL_JARFILE));
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(false,
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
                 "-cp",  classPath,
                 "com.oracle.mxtool.junit.FindClassesByAnnotatedMethods", graalUnitTestFilePath, testAnnotationName);
 
@@ -263,8 +263,7 @@ public class GraalUnitTestLauncher {
 
         javaFlags.add("@"+GENERATED_TESTCLASSES_FILENAME);
 
-        ProcessBuilder javaPB = ProcessTools.createJavaProcessBuilder(true,
-                javaFlags);
+        ProcessBuilder javaPB = ProcessTools.createTestJvm(javaFlags);
         System.out.println("INFO: run command: " + String.join(" ", javaPB.command()));
 
         OutputAnalyzer outputAnalyzer = new OutputAnalyzer(javaPB.start());

--- a/test/hotspot/jtreg/compiler/runtime/cr8015436/Driver8015436.java
+++ b/test/hotspot/jtreg/compiler/runtime/cr8015436/Driver8015436.java
@@ -30,8 +30,8 @@ public class Driver8015436 {
     public static void main(String args[]) {
         OutputAnalyzer oa;
         try {
-            oa = ProcessTools.executeProcess(ProcessTools.createJavaProcessBuilder(
-                    /* add test vm options */ true, Test8015436.class.getName()));
+            oa = ProcessTools.executeProcess(ProcessTools.createTestJvm(
+                    Test8015436.class.getName()));
         } catch (Exception ex) {
             throw new Error("TESTBUG: exception while running child process: " + ex, ex);
         }

--- a/test/hotspot/jtreg/compiler/types/correctness/OffTest.java
+++ b/test/hotspot/jtreg/compiler/types/correctness/OffTest.java
@@ -87,7 +87,7 @@ public class OffTest {
         OPTIONS[TYPE_PROFILE_INDEX] = typeProfileLevel;
         OPTIONS[USE_TYPE_SPECULATION_INDEX] = useTypeSpeculation;
         OPTIONS[PROFILING_TYPE_INDEX] = type.name();
-        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(/* addTestVmOptions= */ true, OPTIONS);
+        ProcessBuilder processBuilder = ProcessTools.createTestJvm(OPTIONS);
         OutputAnalyzer outputAnalyzer = new OutputAnalyzer(processBuilder.start());
         outputAnalyzer.shouldHaveExitValue(0);
     }

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAt.java
@@ -40,8 +40,7 @@ import java.util.Collections;
 
 public class TestAllocateHeapAt {
   public static void main(String args[]) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-        true,
+    ProcessBuilder pb = ProcessTools.createTestJvm(
         "-XX:AllocateHeapAt=" + System.getProperty("test.dir", "."),
         "-Xlog:gc+heap=info",
         "-Xmx32m",

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAtError.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAtError.java
@@ -46,8 +46,7 @@ public class TestAllocateHeapAtError {
       f = new File(test_dir, UUID.randomUUID().toString());
     } while(f.exists());
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-        true,
+    ProcessBuilder pb = ProcessTools.createTestJvm(
         "-XX:AllocateHeapAt=" + f.getName(),
         "-Xlog:gc+heap=info",
         "-Xmx32m",

--- a/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
+++ b/test/hotspot/jtreg/gc/TestAllocateHeapAtMultiple.java
@@ -62,7 +62,7 @@ public class TestAllocateHeapAtMultiple {
                                               "-Xlog:gc+heap=info",
                                               "-version"});
 
-      ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, flags);
+      ProcessBuilder pb = ProcessTools.createTestJvm(flags);
       OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
       System.out.println("Output:\n" + output.getOutput());

--- a/test/hotspot/jtreg/gc/TestVerifyDuringStartup.java
+++ b/test/hotspot/jtreg/gc/TestVerifyDuringStartup.java
@@ -38,8 +38,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class TestVerifyDuringStartup {
   public static void main(String args[]) throws Exception {
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-        true,
+    ProcessBuilder pb = ProcessTools.createTestJvm(
         "-XX:-UseTLAB",
         "-XX:+UnlockDiagnosticVMOptions",
         "-XX:+VerifyDuringStartup",

--- a/test/hotspot/jtreg/gc/arguments/GCArguments.java
+++ b/test/hotspot/jtreg/gc/arguments/GCArguments.java
@@ -67,22 +67,18 @@ public final class GCArguments {
     }
 
     static public ProcessBuilder createJavaProcessBuilder(List<String> arguments) {
-        return createJavaProcessBuilder(false, arguments);
-    }
-
-    static public ProcessBuilder createJavaProcessBuilder(boolean addTestVmAndJavaOptions,
-                                                          List<String> arguments) {
-        return createJavaProcessBuilder(addTestVmAndJavaOptions,
-                                        arguments.toArray(String[]::new));
+        return createJavaProcessBuilder(arguments.toArray(String[]::new));
     }
 
     static public ProcessBuilder createJavaProcessBuilder(String... arguments) {
-        return createJavaProcessBuilder(false, arguments);
+        return ProcessTools.createJavaProcessBuilder(withDefaults(arguments));
     }
 
-    static public ProcessBuilder createJavaProcessBuilder(boolean addTestVmAndJavaOptions,
-                                                          String... arguments) {
-        return ProcessTools.createJavaProcessBuilder(addTestVmAndJavaOptions,
-                                                     withDefaults(arguments));
+    static public ProcessBuilder createTestJvm(List<String> arguments) {
+        return createTestJvm(arguments.toArray(String[]::new));
+    }
+
+    static public ProcessBuilder createTestJvm(String... arguments) {
+        return ProcessTools.createTestJvm(withDefaults(arguments));
     }
 }

--- a/test/hotspot/jtreg/gc/arguments/TestUseNUMAInterleaving.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseNUMAInterleaving.java
@@ -41,8 +41,7 @@ import jdk.test.lib.process.ProcessTools;
 public class TestUseNUMAInterleaving {
 
     public static void main(String[] args) throws Exception {
-        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
-            true,
+        ProcessBuilder pb = GCArguments.createTestJvm(
             "-XX:+UseNUMA",
             "-XX:+PrintFlagsFinal",
             "-version");

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData.java
@@ -104,7 +104,7 @@ public class TestShrinkAuxiliaryData {
     }
 
     private void performTest(List<String> opts) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, opts);
+        ProcessBuilder pb = ProcessTools.createTestJvm(opts);
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         System.out.println(output.getStdout());

--- a/test/hotspot/jtreg/gc/g1/mixedgc/TestLogging.java
+++ b/test/hotspot/jtreg/gc/g1/mixedgc/TestLogging.java
@@ -95,8 +95,7 @@ public class TestLogging {
         Collections.addAll(testOpts, extraFlags);
         testOpts.add(MixedGCProvoker.class.getName());
         System.out.println(testOpts);
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(false,
-                testOpts);
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(testOpts);
         return new OutputAnalyzer(pb.start());
     }
 }

--- a/test/hotspot/jtreg/gc/whitebox/TestWBGC.java
+++ b/test/hotspot/jtreg/gc/whitebox/TestWBGC.java
@@ -43,8 +43,7 @@ import sun.hotspot.WhiteBox;
 public class TestWBGC {
 
     public static void main(String args[]) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-                true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-Xbootclasspath/a:.",
                 "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:+WhiteBoxAPI",

--- a/test/hotspot/jtreg/runtime/BootstrapMethod/BSMCalledTwice.java
+++ b/test/hotspot/jtreg/runtime/BootstrapMethod/BSMCalledTwice.java
@@ -107,7 +107,7 @@ public class BSMCalledTwice implements Opcodes {
         };
 
         cl.loadClass(classTestCName);
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, "-cp", ".",  classTestCName);
+        ProcessBuilder pb = ProcessTools.createTestJvm("-cp", ".",  classTestCName);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         String test_output = output.getOutput();
         if (test_output == null) {

--- a/test/hotspot/jtreg/runtime/ClassFile/UnsupportedClassFileVersion.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/UnsupportedClassFileVersion.java
@@ -42,7 +42,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class UnsupportedClassFileVersion implements Opcodes {
     public static void main(String... args) throws Exception {
         writeClassFile();
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, "-cp", ".",  "ClassFile");
+        ProcessBuilder pb = ProcessTools.createTestJvm("-cp", ".",  "ClassFile");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("ClassFile has been compiled by a more recent version of the " +
                             "Java Runtime (class file version 99.0), this version of " +

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedArchiveFile.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedArchiveFile.java
@@ -41,20 +41,20 @@ import jdk.test.lib.process.OutputAnalyzer;
 // methods to form command line to create/use shared archive.
 public class SharedArchiveFile {
     public static void main(String[] args) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                                 "-XX:SharedArchiveFile=./SharedArchiveFile.jsa",
                                 "-Xshare:dump");
         OutputAnalyzer out = CDSTestUtils.executeAndLog(pb, "SharedArchiveFile");
         CDSTestUtils.checkDump(out);
 
         // -XX:+DumpSharedSpaces should behave the same as -Xshare:dump
-        pb = ProcessTools.createJavaProcessBuilder(true,
+        pb = ProcessTools.createTestJvm(
                                 "-XX:SharedArchiveFile=./SharedArchiveFile.jsa",
                                 "-XX:+DumpSharedSpaces");
         out = CDSTestUtils.executeAndLog(pb, "SharedArchiveFile");
         CDSTestUtils.checkDump(out);
 
-        pb = ProcessTools.createJavaProcessBuilder(true,
+        pb = ProcessTools.createTestJvm(
                               "-XX:SharedArchiveFile=./SharedArchiveFile.jsa",
                               "-Xshare:on", "-version");
         out = CDSTestUtils.executeAndLog(pb, "SharedArchiveFile");

--- a/test/hotspot/jtreg/runtime/StackTrace/LargeClassTest.java
+++ b/test/hotspot/jtreg/runtime/StackTrace/LargeClassTest.java
@@ -46,7 +46,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class LargeClassTest implements Opcodes {
     public static void main(String... args) throws Exception {
         writeClassFile();
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, "-cp", ".",  "Large");
+        ProcessBuilder pb = ProcessTools.createTestJvm("-cp", ".",  "Large");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
     }

--- a/test/hotspot/jtreg/runtime/Unsafe/RangeCheck.java
+++ b/test/hotspot/jtreg/runtime/Unsafe/RangeCheck.java
@@ -44,8 +44,7 @@ public class RangeCheck {
             return;
         }
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-                true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-Xmx128m",
                 "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
                 "-XX:-TransmitErrorReport",

--- a/test/hotspot/jtreg/runtime/appcds/DumpClassList.java
+++ b/test/hotspot/jtreg/runtime/appcds/DumpClassList.java
@@ -76,8 +76,7 @@ public class DumpClassList {
         String appendJar = JarBuilder.build("bootappend", "boot/append/Foo");
 
         // dump class list
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-XX:DumpLoadedClassList=" + classList,
             "--patch-module=java.base=" + patchJar,
             "-Xbootclasspath/a:" + appendJar,

--- a/test/hotspot/jtreg/runtime/appcds/GraalWithLimitedMetaspace.java
+++ b/test/hotspot/jtreg/runtime/appcds/GraalWithLimitedMetaspace.java
@@ -86,7 +86,7 @@ public class GraalWithLimitedMetaspace {
     }
 
     static void dumpLoadedClasses(String[] expectedClasses) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
           TestCommon.makeCommandLineForAppCDS(
             "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
             // trigger JVMCI runtime init so that JVMCI classes will be
@@ -114,7 +114,7 @@ public class GraalWithLimitedMetaspace {
     }
 
     static void dumpArchive() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
           TestCommon.makeCommandLineForAppCDS(
             "-cp",
             TESTJAR,

--- a/test/hotspot/jtreg/runtime/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/appcds/TestCommon.java
@@ -147,7 +147,7 @@ public class TestCommon extends CDSTestUtils {
 
         for (String s : opts.suffix) cmd.add(s);
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, cmd);
+        ProcessBuilder pb = ProcessTools.createTestJvm(cmd);
         return executeAndLog(pb, "dump");
     }
 
@@ -197,7 +197,7 @@ public class TestCommon extends CDSTestUtils {
             }
         }
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, cmd);
+        ProcessBuilder pb = ProcessTools.createTestJvm(cmd);
         return executeAndLog(pb, "exec");
     }
 

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasic.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasic.java
@@ -46,7 +46,7 @@ public class SharedStringsBasic {
         String sharedArchiveConfigFile =
             TestCommon.getSourceFile("SharedStringsBasic.txt").toString();
 
-        ProcessBuilder dumpPb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder dumpPb = ProcessTools.createTestJvm(
           TestCommon.makeCommandLineForAppCDS(
             "-cp", appJar,
             "-XX:SharedArchiveConfigFile=" + sharedArchiveConfigFile,
@@ -58,7 +58,7 @@ public class SharedStringsBasic {
             .shouldContain("Shared string table stats")
             .shouldHaveExitValue(0);
 
-        ProcessBuilder runPb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder runPb = ProcessTools.createTestJvm(
           TestCommon.makeCommandLineForAppCDS(
             "-cp", appJar,
             "-XX:SharedArchiveFile=./SharedStringsBasic.jsa",

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SysDictCrash.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SysDictCrash.java
@@ -41,7 +41,7 @@ public class SysDictCrash {
     public static void main(String[] args) throws Exception {
         // SharedBaseAddress=0 puts the archive at a very high address on solaris,
         // which provokes the crash.
-        ProcessBuilder dumpPb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder dumpPb = ProcessTools.createTestJvm(
           TestCommon.makeCommandLineForAppCDS(
             "-XX:+UseG1GC", "-XX:MaxRAMPercentage=12.5",
             "-cp", ".",
@@ -51,7 +51,7 @@ public class SysDictCrash {
 
         TestCommon.checkDump(TestCommon.executeAndLog(dumpPb, "dump"));
 
-        ProcessBuilder runPb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder runPb = ProcessTools.createTestJvm(
           TestCommon.makeCommandLineForAppCDS(
             "-XX:+UseG1GC", "-XX:MaxRAMPercentage=12.5",
             "-XX:SharedArchiveFile=./SysDictCrash.jsa",

--- a/test/hotspot/jtreg/runtime/handshake/HandshakeTransitionTest.java
+++ b/test/hotspot/jtreg/runtime/handshake/HandshakeTransitionTest.java
@@ -53,8 +53,7 @@ public class HandshakeTransitionTest {
             useJVMCICompilerStr = "-XX:+UnlockExperimentalVMOptions";
         }
         ProcessBuilder pb =
-            ProcessTools.createJavaProcessBuilder(
-                    true,
+            ProcessTools.createTestJvm(
                     "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
                     "-XX:+SafepointALot",
                     "-XX:GuaranteedSafepointInterval=20",

--- a/test/hotspot/jtreg/runtime/modules/ModuleOptionsTest.java
+++ b/test/hotspot/jtreg/runtime/modules/ModuleOptionsTest.java
@@ -28,6 +28,7 @@
  *          options but accumulates --add-module values.
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
+ * @run driver ModuleOptionsTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleClassList.java
+++ b/test/hotspot/jtreg/runtime/modules/PatchModule/PatchModuleClassList.java
@@ -63,8 +63,7 @@ public class PatchModuleClassList {
         String moduleJar = BasicJarBuilder.getTestJar("javanaming.jar");
 
         String classList = "javanaming.list";
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-XX:DumpLoadedClassList=" + classList,
             "--patch-module=java.naming=" + moduleJar,
             "PatchModuleMain", BOOT_CLASS.replace('/', '.'));
@@ -98,8 +97,7 @@ public class PatchModuleClassList {
         moduleJar = BasicJarBuilder.getTestJar("javasql.jar");
 
         classList = "javasql.list";
-        pb = ProcessTools.createJavaProcessBuilder(
-            true,
+        pb = ProcessTools.createTestJvm(
             "-XX:DumpLoadedClassList=" + classList,
             "--patch-module=java.sql=" + moduleJar,
             "PatchModuleMain", PLATFORM_CLASS.replace('/', '.'));
@@ -131,8 +129,7 @@ public class PatchModuleClassList {
         moduleJar = BasicJarBuilder.getTestJar("hello.jar");
 
         classList = "hello.list";
-        pb = ProcessTools.createJavaProcessBuilder(
-            true,
+        pb = ProcessTools.createTestJvm(
             "-XX:DumpLoadedClassList=" + classList,
             "-Xbootclasspath/a:" + moduleJar,
             "Hello");

--- a/test/hotspot/jtreg/runtime/os/AvailableProcessors.java
+++ b/test/hotspot/jtreg/runtime/os/AvailableProcessors.java
@@ -68,8 +68,7 @@ public class AvailableProcessors {
             // Get the java command we want to execute
             // Enable logging for easier failure diagnosis
             ProcessBuilder master =
-                    ProcessTools.createJavaProcessBuilder(false,
-                                                          "-Xlog:os=trace",
+                    ProcessTools.createJavaProcessBuilder("-Xlog:os=trace",
                                                           "AvailableProcessors");
 
             int[] expected = new int[] { 1, available/2, available-1, available };

--- a/test/hotspot/jtreg/runtime/os/TestUseCpuAllocPath.java
+++ b/test/hotspot/jtreg/runtime/os/TestUseCpuAllocPath.java
@@ -41,8 +41,7 @@ public class TestUseCpuAllocPath {
 
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb =
-            ProcessTools.createJavaProcessBuilder(false,
-                                                  "-Xlog:os=trace",
+            ProcessTools.createJavaProcessBuilder("-Xlog:os=trace",
                                                   "-XX:+UnlockDiagnosticVMOptions",
                                                   "-XX:+UseCpuAllocPath",
                                                   "-version");

--- a/test/hotspot/jtreg/runtime/verifier/OverriderMsg.java
+++ b/test/hotspot/jtreg/runtime/verifier/OverriderMsg.java
@@ -125,7 +125,7 @@ public class OverriderMsg {
     public static void main(String... args) throws Exception {
         dump_HasFinal();
         dump_Overrider();
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, "-cp", ".",  "Overrider");
+        ProcessBuilder pb = ProcessTools.createTestJvm("-cp", ".",  "Overrider");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain(
             "java.lang.VerifyError: class Overrider overrides final method HasFinal.m(Ljava/lang/String;)V");

--- a/test/hotspot/jtreg/runtime/verifier/TestANewArray.java
+++ b/test/hotspot/jtreg/runtime/verifier/TestANewArray.java
@@ -69,7 +69,7 @@ public class TestANewArray {
         byte[] classFile_254 = dumpClassFile(cfv, test_Dimension_254, array_Dimension_254);
         writeClassFileFromByteArray(classFile_254);
         System.err.println("Running with cfv: " + cfv + ", test_Dimension_254");
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, "-verify", "-cp", ".",  classCName);
+        ProcessBuilder pb = ProcessTools.createTestJvm("-verify", "-cp", ".",  classCName);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("java.lang.VerifyError");
         output.shouldHaveExitValue(0);
@@ -78,7 +78,7 @@ public class TestANewArray {
         byte[] classFile_255 = dumpClassFile(cfv, test_Dimension_255, array_Dimension_255);
         writeClassFileFromByteArray(classFile_255);
         System.err.println("Running with cfv: " + cfv + ", test_Dimension_255");
-        pb = ProcessTools.createJavaProcessBuilder(true, "-verify", "-cp", ".",  classCName);
+        pb = ProcessTools.createTestJvm("-verify", "-cp", ".",  classCName);
         output = new OutputAnalyzer(pb.start());
         // If anewarray has an operand with 255 array dimensions then VerifyError should
         // be thrown because the resulting array would have 256 dimensions.
@@ -95,7 +95,7 @@ public class TestANewArray {
         byte[] classFile_264 = dumpClassFile(cfv, test_Dimension_264, array_Dimension_264);
         writeClassFileFromByteArray(classFile_264);
         System.err.println("Running with cfv: " + cfv + ", test_Dimension_264");
-        pb = ProcessTools.createJavaProcessBuilder(true, "-verify", "-cp", ".",  classCName);
+        pb = ProcessTools.createTestJvm("-verify", "-cp", ".",  classCName);
         output = new OutputAnalyzer(pb.start());
         output.shouldContain("java.lang.ClassFormatError");
         output.shouldHaveExitValue(1);

--- a/test/hotspot/jtreg/runtime/verifier/TestMultiANewArray.java
+++ b/test/hotspot/jtreg/runtime/verifier/TestMultiANewArray.java
@@ -48,7 +48,7 @@ public class TestMultiANewArray {
         int cfv = Integer.parseInt(args[0]);
         writeClassFile(cfv);
         System.err.println("Running with cfv: " + cfv);
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, "-cp", ".",  "ClassFile");
+        ProcessBuilder pb = ProcessTools.createTestJvm("-cp", ".",  "ClassFile");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("VerifyError");
         output.shouldHaveExitValue(1);

--- a/test/hotspot/jtreg/serviceability/jvmti/GetObjectSizeClass.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetObjectSizeClass.java
@@ -50,7 +50,7 @@ public class GetObjectSizeClass {
         pb.command(new String[] { JDKToolFinder.getJDKTool("jar"), "cmf", "MANIFEST.MF", "agent.jar", "GetObjectSizeClassAgent.class"});
         pb.start().waitFor();
 
-        ProcessBuilder pt = ProcessTools.createJavaProcessBuilder(true, "-javaagent:agent.jar",  "GetObjectSizeClassAgent");
+        ProcessBuilder pt = ProcessTools.createTestJvm("-javaagent:agent.jar",  "GetObjectSizeClassAgent");
         OutputAnalyzer output = new OutputAnalyzer(pt.start());
 
         output.stdoutShouldContain("GetObjectSizeClass passed");

--- a/test/hotspot/jtreg/serviceability/jvmti/GetObjectSizeOverflow.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetObjectSizeOverflow.java
@@ -57,7 +57,7 @@ public class GetObjectSizeOverflow {
         pb.command(new String[] { JDKToolFinder.getJDKTool("jar"), "cmf", "MANIFEST.MF", "agent.jar", "GetObjectSizeOverflowAgent.class"});
         pb.start().waitFor();
 
-        ProcessBuilder pt = ProcessTools.createJavaProcessBuilder(true, "-Xmx4000m", "-javaagent:agent.jar",  "GetObjectSizeOverflowAgent");
+        ProcessBuilder pt = ProcessTools.createTestJvm("-Xmx4000m", "-javaagent:agent.jar",  "GetObjectSizeOverflowAgent");
         OutputAnalyzer output = new OutputAnalyzer(pt.start());
 
         if (output.getStdout().contains("Could not reserve enough space") || output.getStderr().contains("java.lang.OutOfMemoryError")) {

--- a/test/hotspot/jtreg/serviceability/logging/TestLogRotation.java
+++ b/test/hotspot/jtreg/serviceability/logging/TestLogRotation.java
@@ -72,8 +72,7 @@ public class TestLogRotation {
 
     public static void runTest(int numberOfFiles) throws Exception {
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-                true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-cp", System.getProperty("java.class.path"),
                 "-Xlog:gc=debug:" + logFileName
                         + "::filesize=" + logFileSizeK + "k"

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
@@ -95,7 +95,7 @@ public class ClhsdbCDSCore {
                List<String> options = new ArrayList<>();
                options.addAll(Arrays.asList(jArgs));
                crashOut =
-                   ProcessTools.executeProcess(getTestJavaCommandlineWithPrefix(
+                   ProcessTools.executeProcess(getTestJvmCommandlineWithPrefix(
                    RUN_SHELL_NO_LIMIT, options.toArray(new String[0])));
             } catch (Throwable t) {
                throw new Error("Can't execute the java cds process.", t);
@@ -258,9 +258,9 @@ public class ClhsdbCDSCore {
         return null;
     }
 
-    private static String[] getTestJavaCommandlineWithPrefix(String prefix, String... args) {
+    private static String[] getTestJvmCommandlineWithPrefix(String prefix, String... args) {
         try {
-            String cmd = ProcessTools.getCommandLine(ProcessTools.createJavaProcessBuilder(true, args));
+            String cmd = ProcessTools.getCommandLine(ProcessTools.createTestJvm(args));
             return new String[]{"sh", "-c", prefix + cmd};
         } catch (Throwable t) {
             throw new Error("Can't create process builder: " + t, t);

--- a/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
@@ -86,7 +86,7 @@ public class TestJmapCore {
     }
 
     static void test(String type) throws Throwable {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, "-XX:+CreateCoredumpOnCrash",
+        ProcessBuilder pb = ProcessTools.createTestJvm("-XX:+CreateCoredumpOnCrash",
                 "-Xmx512m", "-XX:MaxMetaspaceSize=64m", "-XX:+CrashOnOutOfMemoryError", "-XX:-TransmitErrorReport",
                 TestJmapCore.class.getName(), type);
 

--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -174,9 +174,7 @@ public class CtwRunner {
         while (!done) {
             String[] cmd = cmd(classStart, classStop);
             try {
-                ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-                        /* addTestVmAndJavaOptions = */ true,
-                        cmd);
+                ProcessBuilder pb = ProcessTools.createTestJvm(cmd);
                 String commandLine = pb.command()
                         .stream()
                         .collect(Collectors.joining(" "));

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/jtreg/JitTesterDriver.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/jtreg/JitTesterDriver.java
@@ -47,7 +47,7 @@ public class JitTesterDriver {
         }
         OutputAnalyzer oa;
         try {
-            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, args);
+            ProcessBuilder pb = ProcessTools.createTestJvm(args);
             oa = new OutputAnalyzer(pb.start());
         } catch (Exception e) {
             throw new Error("Unexpected exception on test jvm start :" + e, e);

--- a/test/hotspot/jtreg/testlibrary_tests/ctw/CtwTest.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ctw/CtwTest.java
@@ -102,7 +102,7 @@ public abstract class CtwTest {
                 }
             }
         }
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, cmd);
+        ProcessBuilder pb = ProcessTools.createTestJvm(cmd);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         dump(output, "compile");
         output.shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/vmTestbase/gc/huge/quicklook/largeheap/MemOptions/MemOptionsTest.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/huge/quicklook/largeheap/MemOptions/MemOptionsTest.java
@@ -94,7 +94,7 @@ public class MemOptionsTest {
         var cmd = new ArrayList<String>();
         Collections.addAll(cmd, opts);
         cmd.add(MemStat.class.getName());
-        var pb = ProcessTools.createJavaProcessBuilder(true, cmd);
+        var pb = ProcessTools.createTestJvm(cmd);
         var output = new OutputAnalyzer(pb.start());
         if (output.getExitValue() != 0) {
             output.reportDiagnosticSummary();
@@ -107,7 +107,7 @@ public class MemOptionsTest {
         var cmd = new ArrayList<String>();
         Collections.addAll(cmd, opts);
         cmd.add(MemStat.class.getName());
-        var pb = ProcessTools.createJavaProcessBuilder(true, cmd);
+        var pb = ProcessTools.createTestJvm(cmd);
         var output = new OutputAnalyzer(pb.start());
         if (output.getExitValue() == 0) {
             output.reportDiagnosticSummary();

--- a/test/hotspot/jtreg/vmTestbase/jit/tiered/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/tiered/Test.java
@@ -51,7 +51,7 @@ public class Test {
     public static void main(String[] args) throws Exception {
         {
             System.out.println("TieredCompilation is enabled");
-            var pb = ProcessTools.createJavaProcessBuilder(true,
+            var pb = ProcessTools.createTestJvm(
                     "-XX:+TieredCompilation",
                     "-XX:+PrintTieredEvents",
                     "-version");
@@ -64,7 +64,7 @@ public class Test {
         }
         {
             System.out.println("TieredCompilation is disabled");
-            var pb = ProcessTools.createJavaProcessBuilder(true,
+            var pb = ProcessTools.createTestJvm(
                     "-XX:-TieredCompilation",
                     "-XX:+PrintTieredEvents",
                     "-version");

--- a/test/hotspot/jtreg/vmTestbase/metaspace/flags/maxMetaspaceSize/TestMaxMetaspaceSize.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/flags/maxMetaspaceSize/TestMaxMetaspaceSize.java
@@ -39,8 +39,8 @@ import jdk.test.lib.process.ProcessTools;
 public class TestMaxMetaspaceSize {
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb =
-            ProcessTools.createJavaProcessBuilder(true, "-XX:MaxMetaspaceSize=100m",
-                                                  maxMetaspaceSize.class.getName());
+            ProcessTools.createTestJvm("-XX:MaxMetaspaceSize=100m",
+                                       maxMetaspaceSize.class.getName());
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
 
         if (out.getExitValue() == 0) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform003/TestDriver.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses/retransform003/TestDriver.java
@@ -69,8 +69,7 @@ import java.util.Arrays;
 
 public class TestDriver {
     public static void main(String[] args) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-                true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-agentlib:retransform003-01=id=1 can_retransform_classes=1",
                 "-agentlib:retransform003-02=id=2 can_retransform_classes=0",
                 "-agentlib:retransform003-03=id=3 can_retransform_classes=1",

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetNativeMethodPrefix/SetNativeMethodPrefix002/TestDriver.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetNativeMethodPrefix/SetNativeMethodPrefix002/TestDriver.java
@@ -58,8 +58,7 @@ import java.util.Arrays;
 
 public class TestDriver {
     public static void main(String[] args) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-                true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-agentlib:SetNativeMethodPrefix001=trace=all",
                 "-agentlib:SetNativeMethodPrefix002-01=trace=all prefix=wa_",
                 "-agentlib:SetNativeMethodPrefix002-02=trace=all prefix=wb_",

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/CodeCacheInfo/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/CodeCacheInfo/Test.java
@@ -53,7 +53,7 @@ public class Test {
     public static void main(String[] args) throws Exception {
         {
             System.out.println("SegmentedCodeCache is enabled");
-            var pb = ProcessTools.createJavaProcessBuilder(true,
+            var pb = ProcessTools.createTestJvm(
                     "-XX:+SegmentedCodeCache",
                     "-XX:+PrintCodeCache",
                     "-version");
@@ -63,7 +63,7 @@ public class Test {
         }
         {
             System.out.println("SegmentedCodeCache is disabled");
-            var pb = ProcessTools.createJavaProcessBuilder(true,
+            var pb = ProcessTools.createTestJvm(
                     "-XX:-SegmentedCodeCache",
                     "-XX:+PrintCodeCache",
                     "-version");

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/CodeCacheInfoOnCompilation/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/CodeCacheInfoOnCompilation/Test.java
@@ -46,7 +46,7 @@ public class Test {
     private static String REGEXP = "^(CodeCache|(CodeHeap.*)): size=\\d+Kb used=\\d+Kb max_used=\\d+Kb free=\\d+Kb";
 
     public static void main(String[] args) throws Exception {
-        var pb = ProcessTools.createJavaProcessBuilder(true,
+        var pb = ProcessTools.createTestJvm(
                 "-XX:-PrintCodeCache",
                 "-XX:+PrintCodeCacheOnCompilation",
                 "-XX:-Inline",

--- a/test/jdk/com/sun/jdi/JITDebug.java
+++ b/test/jdk/com/sun/jdi/JITDebug.java
@@ -104,7 +104,7 @@ public class JITDebug {
     }
 
     void testLaunch() {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true);
+        ProcessBuilder pb = ProcessTools.createTestJvm();
         List largs = pb.command();
         largs.add("-classpath");
         largs.add(Utils.TEST_CLASSES);

--- a/test/jdk/com/sun/jdi/PrivateTransportTest.java
+++ b/test/jdk/com/sun/jdi/PrivateTransportTest.java
@@ -82,7 +82,7 @@ public class PrivateTransportTest {
         String libName = transportLib.getFileName().toString().replace("dt_socket", "private_dt_socket");
         Files.copy(transportLib, Paths.get(Utils.TEST_CLASSES).resolve(libName));
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-agentlib:jdwp=transport=private_dt_socket,server=y,suspend=n",
                 "-classpath", Utils.TEST_CLASSES,
                 "HelloWorld");

--- a/test/jdk/com/sun/jdi/cds/CDSJDITest.java
+++ b/test/jdk/com/sun/jdi/cds/CDSJDITest.java
@@ -81,7 +81,7 @@ public class CDSJDITest {
         outputDump.shouldHaveExitValue(0);
 
         // Run the test specified JDI test
-        pb = ProcessTools.createJavaProcessBuilder(true, testArgs);
+        pb = ProcessTools.createTestJvm(testArgs);
         OutputAnalyzer outputRun = executeAndLog(pb, "exec");
         try {
             outputRun.shouldContain("sharing");

--- a/test/jdk/com/sun/jdi/lib/jdb/Debuggee.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/Debuggee.java
@@ -68,7 +68,6 @@ public class Debuggee implements Closeable {
         private String transport = "dt_socket";
         private String address = null;
         private boolean suspended = true;
-        private boolean addTestVmAndJavaOptions = true;
 
         private Launcher(String mainClass) {
             this.mainClass = mainClass;
@@ -96,11 +95,6 @@ public class Debuggee implements Closeable {
             suspended = value;
             return this;
         }
-        // default is "true"
-        public Launcher addTestVmAndJavaOptions(boolean value) {
-            addTestVmAndJavaOptions = value;
-            return this;
-        }
 
         public ProcessBuilder prepare() {
             List<String> debuggeeArgs = new LinkedList<>();
@@ -109,8 +103,7 @@ public class Debuggee implements Closeable {
                     + ",server=y,suspend=" + (suspended ? "y" : "n"));
             debuggeeArgs.addAll(options);
             debuggeeArgs.add(mainClass);
-            return ProcessTools.createJavaProcessBuilder(addTestVmAndJavaOptions,
-                    debuggeeArgs.toArray(new String[0]));
+            return ProcessTools.createTestJvm(debuggeeArgs);
         }
 
         public Debuggee launch(String name) {

--- a/test/jdk/java/io/File/MacPath.java
+++ b/test/jdk/java/io/File/MacPath.java
@@ -38,7 +38,7 @@ import jdk.test.lib.process.ProcessTools;
 public class MacPath {
     public static void main(String args[]) throws Exception {
         final ProcessBuilder pb =
-                ProcessTools.createJavaProcessBuilder(true, MacPathTest.class.getName());
+                ProcessTools.createTestJvm(MacPathTest.class.getName());
         final Map<String, String> env = pb.environment();
         env.put("LC_ALL", "en_US.UTF-8");
         Process p = ProcessTools.startProcess("Mac Path Test", pb);

--- a/test/jdk/java/io/Serializable/evolution/RenamePackage/RenamePackageTest.java
+++ b/test/jdk/java/io/Serializable/evolution/RenamePackage/RenamePackageTest.java
@@ -81,7 +81,7 @@ public class RenamePackageTest {
     }
 
     private static void runTestSerialDriver() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-classpath",
                 SHARE.toString()
                     + File.pathSeparator
@@ -93,7 +93,7 @@ public class RenamePackageTest {
     }
 
     private static void runInstallSerialDriver() throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-classpath",
                 SHARE.toString()
                     + File.pathSeparator

--- a/test/jdk/java/lang/Runtime/shutdown/ShutdownInterruptedMain.java
+++ b/test/jdk/java/lang/Runtime/shutdown/ShutdownInterruptedMain.java
@@ -38,7 +38,7 @@ public class ShutdownInterruptedMain {
 
     public static void main(String[] args) throws Exception {
         if (args.length > 0) {
-            ProcessBuilder pb = createJavaProcessBuilder(true, "ShutdownInterruptedMain");
+            ProcessBuilder pb = createTestJvm("ShutdownInterruptedMain");
             OutputAnalyzer output = executeProcess(pb);
             output.shouldContain("Shutdown Hook");
             output.shouldHaveExitValue(0);

--- a/test/jdk/java/lang/Runtime/shutdown/ShutdownInterruptedMain.java
+++ b/test/jdk/java/lang/Runtime/shutdown/ShutdownInterruptedMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  */
 
 import jdk.test.lib.process.OutputAnalyzer;
-import static jdk.test.lib.process.ProcessTools.createJavaProcessBuilder;
+import static jdk.test.lib.process.ProcessTools.createTestJvm;
 import static jdk.test.lib.process.ProcessTools.executeProcess;
 
 public class ShutdownInterruptedMain {

--- a/test/jdk/java/lang/StackWalker/CallerFromMain.java
+++ b/test/jdk/java/lang/StackWalker/CallerFromMain.java
@@ -37,7 +37,7 @@ public class CallerFromMain {
     private static final StackWalker sw = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
     public static void main(String[] args) throws Exception {
         if (args.length > 0) {
-            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, "CallerFromMain");
+            ProcessBuilder pb = ProcessTools.createTestJvm("CallerFromMain");
             OutputAnalyzer output = ProcessTools.executeProcess(pb);
             System.out.println(output.getOutput());
             output.shouldHaveExitValue(0);

--- a/test/jdk/java/lang/System/MacEncoding/MacJNUEncoding.java
+++ b/test/jdk/java/lang/System/MacEncoding/MacJNUEncoding.java
@@ -49,7 +49,7 @@ public class MacJNUEncoding {
 
         final String locale = args[2];
         System.out.println("Running test for locale: " + locale);
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 ExpectedEncoding.class.getName(), args[0], args[1]);
         Map<String, String> env = pb.environment();
         env.put("LANG", locale);

--- a/test/jdk/java/lang/instrument/DaemonThread/TestDaemonThreadLauncher.java
+++ b/test/jdk/java/lang/instrument/DaemonThread/TestDaemonThreadLauncher.java
@@ -29,7 +29,7 @@ import jdk.test.lib.process.ProcessTools;
 public class TestDaemonThreadLauncher {
     public static void main(String args[]) throws Exception {
         for(int i=0; i<50; i++) {
-            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, "-javaagent:DummyAgent.jar", "TestDaemonThread", ".");
+            ProcessBuilder pb = ProcessTools.createTestJvm("-javaagent:DummyAgent.jar", "TestDaemonThread", ".");
             OutputAnalyzer analyzer = ProcessTools.executeProcess(pb);
             analyzer.shouldNotContain("ASSERTION FAILED");
             analyzer.shouldHaveExitValue(0);

--- a/test/jdk/java/nio/charset/Charset/DefaultCharsetTest.java
+++ b/test/jdk/java/nio/charset/Charset/DefaultCharsetTest.java
@@ -54,7 +54,7 @@ import static org.testng.Assert.assertTrue;
 public class DefaultCharsetTest {
 
     private static final ProcessBuilder pb
-            = ProcessTools.createJavaProcessBuilder(true, Default.class.getName());
+            = ProcessTools.createTestJvm(Default.class.getName());
     private static final Map<String, String> env = pb.environment();
     private static String UNSUPPORTED = null;
 

--- a/test/jdk/java/nio/charset/coders/SJISMappingPropTest.java
+++ b/test/jdk/java/nio/charset/coders/SJISMappingPropTest.java
@@ -81,7 +81,7 @@ public class SJISMappingPropTest {
     }
 
     private void runTest(String locale, String... cmd) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, cmd);
+        ProcessBuilder pb = ProcessTools.createTestJvm(cmd);
         Map<String, String> env = pb.environment();
         env.put("LC_ALL", locale);
         OutputAnalyzer out = ProcessTools.executeProcess(pb)

--- a/test/jdk/java/nio/file/Path/MacPathTest.java
+++ b/test/jdk/java/nio/file/Path/MacPathTest.java
@@ -41,7 +41,7 @@ import jdk.test.lib.process.ProcessTools;
 public class MacPathTest {
 
     public static void main(String args[]) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, MacPath.class.getName());
+        ProcessBuilder pb = ProcessTools.createTestJvm(MacPath.class.getName());
         pb.environment().put("LC_ALL", "en_US.UTF-8");
         ProcessTools.executeProcess(pb)
                     .outputTo(System.out)

--- a/test/jdk/jdk/jfr/event/sampling/TestNative.java
+++ b/test/jdk/jdk/jfr/event/sampling/TestNative.java
@@ -57,7 +57,7 @@ public class TestNative {
 
     public static void main(String[] args) throws Exception {
         String lib = System.getProperty("test.nativepath");
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, "-Djava.library.path=" + lib, "jdk.jfr.event.sampling.TestNative$Test");
+        ProcessBuilder pb = ProcessTools.createTestJvm("-Djava.library.path=" + lib, "jdk.jfr.event.sampling.TestNative$Test");
 
         OutputAnalyzer output = ProcessTools.executeProcess(pb);
         output.shouldHaveExitValue(0);

--- a/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
+++ b/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
@@ -91,7 +91,7 @@ public class TestDumpOnCrash {
     private static long runProcess(String crasher, String signal, boolean disk) throws Exception {
         System.out.println("Test case for crasher " + crasher);
         final String flightRecordingOptions = "dumponexit=true,disk=" + Boolean.toString(disk);
-        Process p = ProcessTools.createJavaProcessBuilder(true,
+        Process p = ProcessTools.createTestJvm(
                 "-Xmx64m",
                 "-XX:-TransmitErrorReport",
                 "-XX:-CreateCoredumpOnCrash",

--- a/test/jdk/jdk/jfr/jvm/TestJfrJavaBase.java
+++ b/test/jdk/jdk/jfr/jvm/TestJfrJavaBase.java
@@ -51,7 +51,7 @@ public class TestJfrJavaBase {
     public static void main(String[] args) throws Exception {
         OutputAnalyzer output;
         if (args.length == 0) {
-            output = ProcessTools.executeProcess(ProcessTools.createJavaProcessBuilder(false,
+            output = ProcessTools.executeProcess(ProcessTools.createJavaProcessBuilder(
                 "-Dtest.jdk=" + System.getProperty("test.jdk"),
                 "--limit-modules", "java.base", "-cp", System.getProperty("java.class.path"),
                 TestJfrJavaBase.class.getName(), "runtest"));

--- a/test/jdk/jdk/jfr/startupargs/TestDumpOnExit.java
+++ b/test/jdk/jdk/jfr/startupargs/TestDumpOnExit.java
@@ -94,7 +94,7 @@ public class TestDumpOnExit {
     }
 
     private static void testDumponExit(Supplier<Path> p,String... args) throws Exception, IOException {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, args);
+        ProcessBuilder pb = ProcessTools.createTestJvm(args);
         OutputAnalyzer output = ProcessTools.executeProcess(pb);
         System.out.println(output.getOutput());
         output.shouldHaveExitValue(0);

--- a/test/jdk/jdk/jfr/startupargs/TestMemoryOptions.java
+++ b/test/jdk/jdk/jfr/startupargs/TestMemoryOptions.java
@@ -485,21 +485,19 @@ public class TestMemoryOptions {
             final String flightRecorderOptions = tc.getTestString();
             ProcessBuilder pb;
             if (flightRecorderOptions != null) {
-                pb = ProcessTools.createJavaProcessBuilder(true,
-                                                           "--add-exports=jdk.jfr/jdk.jfr.internal=ALL-UNNAMED",
-                                                           "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
-                                                           flightRecorderOptions,
-                                                           "-XX:StartFlightRecording",
-                                                           SUT.class.getName(),
-                                                           tc.getTestName());
+                pb = ProcessTools.createTestJvm("--add-exports=jdk.jfr/jdk.jfr.internal=ALL-UNNAMED",
+                                                "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                                                flightRecorderOptions,
+                                                "-XX:StartFlightRecording",
+                                                SUT.class.getName(),
+                                                tc.getTestName());
             } else {
                 // default, no FlightRecorderOptions passed
-                pb = ProcessTools.createJavaProcessBuilder(true,
-                                                           "--add-exports=jdk.jfr/jdk.jfr.internal=ALL-UNNAMED",
-                                                           "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
-                                                           "-XX:StartFlightRecording",
-                                                           SUT.class.getName(),
-                                                           tc.getTestName());
+                pb = ProcessTools.createTestJvm("--add-exports=jdk.jfr/jdk.jfr.internal=ALL-UNNAMED",
+                                                "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                                                "-XX:StartFlightRecording",
+                                                SUT.class.getName(),
+                                                tc.getTestName());
             }
 
             System.out.println("Driver launching SUT with string: " + flightRecorderOptions != null ? flightRecorderOptions : "default");

--- a/test/jdk/jdk/jfr/startupargs/TestMultipleStartupRecordings.java
+++ b/test/jdk/jdk/jfr/startupargs/TestMultipleStartupRecordings.java
@@ -57,14 +57,14 @@ public class TestMultipleStartupRecordings {
 
     private static void launchUnary(String options) throws Exception {
         String recording1 = START_FLIGHT_RECORDING + (options != null ? options : "");
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, recording1, MainClass.class.getName());
+        ProcessBuilder pb = ProcessTools.createTestJvm(recording1, MainClass.class.getName());
         test(pb, "Started recording 1");
     }
 
     private static void launchBinary(String options1, String options2) throws Exception {
         String recording1 = START_FLIGHT_RECORDING + (options1 != null ? options1 : "");
         String recording2 = START_FLIGHT_RECORDING + (options2 != null ? options2 : "");
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, recording1, recording2, MainClass.class.getName());
+        ProcessBuilder pb = ProcessTools.createTestJvm(recording1, recording2, MainClass.class.getName());
         test(pb, "Started recording 1", "Started recording 2");
     }
 
@@ -72,7 +72,7 @@ public class TestMultipleStartupRecordings {
         String recording1 = START_FLIGHT_RECORDING + (options1 != null ? options1 : "");
         String recording2 = START_FLIGHT_RECORDING + (options2 != null ? options2 : "");
         String recording3 = START_FLIGHT_RECORDING + (options3 != null ? options3 : "");
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, recording1, recording2, recording3, MainClass.class.getName());
+        ProcessBuilder pb = ProcessTools.createTestJvm(recording1, recording2, recording3, MainClass.class.getName());
         test(pb, "Started recording 1", "Started recording 2", "Started recording 3");
     }
 
@@ -96,7 +96,7 @@ public class TestMultipleStartupRecordings {
         String flightRecorderOptions = FLIGHT_RECORDER_OPTIONS + "=maxchunksize=8m";
         String recording1 = START_FLIGHT_RECORDING + "=filename=recording1.jfr";
         String recording2 = START_FLIGHT_RECORDING + "=name=myrecording,filename=recording2.jfr";
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, flightRecorderOptions, recording1, recording2, MainClass.class.getName());
+        ProcessBuilder pb = ProcessTools.createTestJvm(flightRecorderOptions, recording1, recording2, MainClass.class.getName());
         test(pb, "Started recording 1", "Started recording 2");
     }
 

--- a/test/jdk/jdk/jfr/startupargs/TestRetransformUsingLog.java
+++ b/test/jdk/jdk/jfr/startupargs/TestRetransformUsingLog.java
@@ -106,7 +106,7 @@ public class TestRetransformUsingLog {
         }
         System.out.println();
         System.out.println();
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, args.toArray(new String[0]));
+        ProcessBuilder pb = ProcessTools.createTestJvm(args);
         OutputAnalyzer out = ProcessTools.executeProcess(pb);
         System.out.println(out.getOutput());
         verifier.accept(out);

--- a/test/jdk/jdk/jfr/startupargs/TestStartDuration.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartDuration.java
@@ -55,7 +55,7 @@ public class TestStartDuration {
     }
 
     private static void testDurationInRange(String duration, Duration durationString, boolean wait) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-XX:StartFlightRecording=name=TestStartDuration,duration=" + duration, TestValues.class.getName(),
             durationString.toString(), wait ? "wait" : "");
         OutputAnalyzer out = ProcessTools.executeProcess(pb);
@@ -65,7 +65,7 @@ public class TestStartDuration {
 
 
     private static void testDurationJavaVersion(String duration, boolean inRange) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-XX:StartFlightRecording=name=TestStartDuration,duration=" + duration, "-version");
         OutputAnalyzer out = ProcessTools.executeProcess(pb);
 

--- a/test/jdk/jdk/jfr/startupargs/TestStartName.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartName.java
@@ -47,7 +47,7 @@ public class TestStartName {
     }
 
     private static void testName(String recordingName, boolean validName) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-XX:StartFlightRecording=name=" + recordingName, TestName.class.getName(), recordingName);
         OutputAnalyzer out = ProcessTools.executeProcess(pb);
 

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineKeyLimit.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineKeyLimit.java
@@ -119,7 +119,7 @@ public class SSLEngineKeyLimit {
             System.out.println("test.java.opts: " +
                     System.getProperty("test.java.opts"));
 
-            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+            ProcessBuilder pb = ProcessTools.createTestJvm(
                     Utils.addTestJavaOpts("SSLEngineKeyLimit", "p", args[1]));
 
             OutputAnalyzer output = ProcessTools.executeProcess(pb);

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketKeyLimit.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketKeyLimit.java
@@ -124,7 +124,7 @@ public class SSLSocketKeyLimit {
             System.out.println("test.java.opts: " +
                     System.getProperty("test.java.opts"));
 
-            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+            ProcessBuilder pb = ProcessTools.createTestJvm(
                     Utils.addTestJavaOpts("SSLSocketKeyLimit", "p", args[1]));
 
             OutputAnalyzer output = ProcessTools.executeProcess(pb);

--- a/test/lib/jdk/test/lib/Utils.java
+++ b/test/lib/jdk/test/lib/Utils.java
@@ -194,6 +194,18 @@ public final class Utils {
     }
 
     /**
+     * Combines given arguments with default JTReg arguments for a jvm running a test.
+     * This is the combination of JTReg arguments test.vm.opts and test.java.opts
+     * @return The combination of JTReg test java options and user args.
+     */
+    public static String[] prependTestJavaOpts(String... userArgs) {
+        List<String> opts = new ArrayList<String>();
+        Collections.addAll(opts, getTestJavaOpts());
+        Collections.addAll(opts, userArgs);
+        return opts.toArray(new String[0]);
+    }
+
+    /**
      * Removes any options specifying which GC to use, for example "-XX:+UseG1GC".
      * Removes any options matching: -XX:(+/-)Use*GC
      * Used when a test need to set its own GC version. Then any

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -261,7 +261,7 @@ public class CDSTestUtils {
         for (String s : opts.suffix) cmd.add(s);
 
         String[] cmdLine = cmd.toArray(new String[cmd.size()]);
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, cmdLine);
+        ProcessBuilder pb = ProcessTools.createTestJvm(cmdLine);
         return executeAndLog(pb, "dump");
     }
 
@@ -409,7 +409,7 @@ public class CDSTestUtils {
         for (String s : opts.suffix) cmd.add(s);
 
         String[] cmdLine = cmd.toArray(new String[cmd.size()]);
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, cmdLine);
+        ProcessBuilder pb = ProcessTools.createTestJvm(cmdLine);
         return executeAndLog(pb, "exec");
     }
 

--- a/test/lib/jdk/test/lib/jfr/AppExecutorHelper.java
+++ b/test/lib/jdk/test/lib/jfr/AppExecutorHelper.java
@@ -74,7 +74,7 @@ public class AppExecutorHelper {
             Collections.addAll(arguments, classArguments);
         }
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true, arguments.toArray(new String[0]));
+        ProcessBuilder pb = ProcessTools.createTestJvm(arguments);
         return ProcessTools.executeProcess(pb);
     }
 }

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -277,19 +277,7 @@ public final class ProcessTools {
      * @return The ProcessBuilder instance representing the java command.
      */
     public static ProcessBuilder createJavaProcessBuilder(List<String> command) {
-        return createJavaProcessBuilder(false, command);
-    }
-
-    /**
-     * Create ProcessBuilder using the java launcher from the jdk to be tested.
-     * <p>
-     * @param addTestVmAndJavaOptions If true, adds test.vm.opts and test.java.opts
-     *        to the java arguments.
-     * @param command Arguments to pass to the java command.
-     * @return The ProcessBuilder instance representing the java command.
-     */
-    public static ProcessBuilder createJavaProcessBuilder(boolean addTestVmAndJavaOptions, List<String> command) {
-        return createJavaProcessBuilder(addTestVmAndJavaOptions, command.toArray(String[]::new));
+        return createJavaProcessBuilder(command.toArray(String[]::new));
     }
 
     /**
@@ -299,18 +287,6 @@ public final class ProcessTools {
      * @return The ProcessBuilder instance representing the java command.
      */
     public static ProcessBuilder createJavaProcessBuilder(String... command) {
-        return createJavaProcessBuilder(false, command);
-    }
-
-    /**
-     * Create ProcessBuilder using the java launcher from the jdk to be tested.
-     *
-     * @param addTestVmAndJavaOptions If true, adds test.vm.opts and test.java.opts
-     *        to the java arguments.
-     * @param command Arguments to pass to the java command.
-     * @return The ProcessBuilder instance representing the java command.
-     */
-    public static ProcessBuilder createJavaProcessBuilder(boolean addTestVmAndJavaOptions, String... command) {
         String javapath = JDKToolFinder.getJDKTool("java");
 
         ArrayList<String> args = new ArrayList<>();
@@ -318,10 +294,6 @@ public final class ProcessTools {
 
         args.add("-cp");
         args.add(System.getProperty("java.class.path"));
-
-        if (addTestVmAndJavaOptions) {
-            Collections.addAll(args, Utils.getTestJavaOpts());
-        }
 
         Collections.addAll(args, command);
 
@@ -342,6 +314,36 @@ public final class ProcessTools {
             }
             System.out.println();
         }
+    }
+
+    /**
+     * Create ProcessBuilder using the java launcher from the jdk to be tested.
+     * The default jvm options from jtreg, test.vm.opts and test.java.opts, are added.
+     *
+     * The command line will be like:
+     * {test.jdk}/bin/java {test.vm.opts} {test.java.opts} cmds
+     * Create ProcessBuilder using the java launcher from the jdk to be tested.
+     *
+     * @param command Arguments to pass to the java command.
+     * @return The ProcessBuilder instance representing the java command.
+     */
+    public static ProcessBuilder createTestJvm(List<String> command) {
+        return createTestJvm(command.toArray(String[]::new));
+    }
+
+    /**
+     * Create ProcessBuilder using the java launcher from the jdk to be tested.
+     * The default jvm options from jtreg, test.vm.opts and test.java.opts, are added.
+     *
+     * The command line will be like:
+     * {test.jdk}/bin/java {test.vm.opts} {test.java.opts} cmds
+     * Create ProcessBuilder using the java launcher from the jdk to be tested.
+     *
+     * @param command Arguments to pass to the java command.
+     * @return The ProcessBuilder instance representing the java command.
+     */
+    public static ProcessBuilder createTestJvm(String... command) {
+        return createJavaProcessBuilder(Utils.prependTestJavaOpts(command));
     }
 
     /**
@@ -375,7 +377,7 @@ public final class ProcessTools {
      * @return The output from the process.
      */
     public static OutputAnalyzer executeTestJvm(String... cmds) throws Exception {
-        ProcessBuilder pb = createJavaProcessBuilder(true, cmds);
+        ProcessBuilder pb = createTestJvm(cmds);
         return executeProcess(pb);
     }
 


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

A row of files are not in 11 or have been moved. 
Some trivial resolves were necessary.
An extra commit fixes the remaining occurances.

test/hotspot/jtreg/compiler/graalunit/common/GraalUnitTestLauncher.java
Context

not in 11: test/hotspot/jtreg/gc/logging/TestMetaSpaceLog.java
not in 11: test/hotspot/jtreg/gc/nvdimm/TestAllocateOldGenAt.java
not in 11: test/hotspot/jtreg/gc/nvdimm/TestAllocateOldGenAtError.java
not in 11: test/hotspot/jtreg/gc/nvdimm/TestAllocateOldGenAtMultiple.java
not in 11: test/hotspot/jtreg/gc/nvdimm/TestHumongousObjectsOnNvdimm.java
not in 11: test/hotspot/jtreg/gc/nvdimm/TestOldObjectsOnNvdimm.java
not in 11: test/hotspot/jtreg/gc/nvdimm/TestYoungObjectsOnDram.java

test/hotspot/jtreg/runtime/7162488/TestUnrecognizedVmOption.java
Later change undoes this, and is already backported (8247741). Skipped.

not in 11: test/hotspot/jtreg/runtime/InvocationTests/invocationC1Tests.java
not in 11: test/hotspot/jtreg/runtime/InvocationTests/invocationGraalTests.java
not in 11: test/hotspot/jtreg/runtime/InvocationTests/invokeinterfaceTests.java
not in 11: test/hotspot/jtreg/runtime/InvocationTests/invokespecialTests.java
not in 11: test/hotspot/jtreg/runtime/InvocationTests/invokevirtualTests.java

not in 11: test/hotspot/jtreg/runtime/cds/SharedArchiveFile.java
not in 11: test/hotspot/jtreg/runtime/cds/appcds/DumpClassList.java
not in 11: test/hotspot/jtreg/runtime/cds/appcds/GraalWithLimitedMetaspace.java
not in 11: test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
not in 11: test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicArchiveTestBase.java
not in 11: test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/NoClassToArchive.java
not in 11: test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsBasic.java
not in 11: test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SysDictCrash.java

test/hotspot/jtreg/runtime/handshake/HandshakeTransitionTest.java
Context

test/hotspot/jtreg/serviceability/logging/TestLogRotation.java
Extra empty line.

test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
Context.

not in 11: test/jdk/java/lang/RuntimeTests/shutdown/ShutdownInterruptedMain.java
not in 11: test/jdk/jdk/jfr/api/consumer/streaming/TestCrossProcessStreaming.java
not in 11: test/jdk/jdk/jfr/api/consumer/streaming/TestProcess.java
not in 11: test/jdk/jdk/jfr/event/runtime/TestDumpReason.java
not in 11: test/jdk/jdk/jfr/event/runtime/TestShutdownEvent.java
not in 11: test/jdk/sun/security/ssl/SSLSessionImpl/ResumptionUpdateBoundValues.java

test/lib/jdk/test/lib/process/ProcessTools.java
Context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8244078](https://bugs.openjdk.org/browse/JDK-8244078): ProcessTools executeTestJvm and createJavaProcessBuilder have inconsistent handling of test.*.opts (**Enhancement** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2000/head:pull/2000` \
`$ git checkout pull/2000`

Update a local copy of the PR: \
`$ git checkout pull/2000` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2000`

View PR using the GUI difftool: \
`$ git pr show -t 2000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2000.diff">https://git.openjdk.org/jdk11u-dev/pull/2000.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2000#issuecomment-1606101851)