### PR TITLE
8168261: Use server cipher suites preference by default

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLContextSpi.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLContextSpi.java
@@ -210,10 +210,9 @@ public abstract class SSLContextSpi {
      */
     protected SSLParameters engineGetSupportedSSLParameters() {
         SSLSocket socket = getDefaultSocket();
-        SSLParameters params = new SSLParameters();
+        SSLParameters params = socket.getSSLParameters();
         params.setCipherSuites(socket.getSupportedCipherSuites());
         params.setProtocols(socket.getSupportedProtocols());
         return params;
     }
-
 }

--- a/src/java.base/share/classes/sun/security/ssl/SSLConfiguration.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLConfiguration.java
@@ -143,7 +143,7 @@ final class SSLConfiguration implements Cloneable {
         this.identificationProtocol = null;
         this.serverNames = Collections.<SNIServerName>emptyList();
         this.sniMatchers = Collections.<SNIMatcher>emptyList();
-        this.preferLocalCipherSuites = false;
+        this.preferLocalCipherSuites = true;
 
         this.applicationProtocols = new String[0];
         this.enableRetransmissions = sslContext.isDTLS();

--- a/test/jdk/sun/security/ssl/SSLContextImpl/DefaultCipherSuitePreference.java
+++ b/test/jdk/sun/security/ssl/SSLContextImpl/DefaultCipherSuitePreference.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// SunJSSE does not support dynamic system properties, no way to re-use
+// system properties in samevm/agentvm mode.
+
+/*
+ * @test
+ * @bug 8168261
+ * @summary Use server cipher suites preference by default
+ * @run main/othervm DefaultCipherSuitePreference
+ */
+
+import javax.net.SocketFactory;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.TrustManager;
+
+public class DefaultCipherSuitePreference {
+    private static final String[] contextAlgorithms = {
+            "Default", "SSL", "TLS", "SSLv3", "TLSv1",
+            "TLSv1.1", "TLSv1.2", "TLSv1.3"
+        };
+
+    public static void main(String[] args) throws Exception {
+        for (String algorithm : contextAlgorithms) {
+            System.out.println("Checking SSLContext of " + algorithm);
+            SSLContext sslContext = SSLContext.getInstance(algorithm);
+
+            // Default SSLContext is initialized automatically.
+            if (!algorithm.equals("Default")) {
+                // Use default TK, KM and random.
+                sslContext.init((KeyManager[])null, (TrustManager[])null, null);
+            }
+
+            //
+            // Check SSLContext
+            //
+            // Check default SSLParameters of SSLContext
+            checkDefaultCipherSuitePreference(
+                    sslContext.getDefaultSSLParameters(),
+                    "SSLContext.getDefaultSSLParameters()");
+
+            // Check supported SSLParameters of SSLContext
+            checkDefaultCipherSuitePreference(
+                    sslContext.getSupportedSSLParameters(),
+                    "SSLContext.getSupportedSSLParameters()");
+
+            //
+            // Check SSLEngine
+            //
+            // Check SSLParameters of SSLEngine
+            SSLEngine engine = sslContext.createSSLEngine();
+            engine.setUseClientMode(true);
+            checkDefaultCipherSuitePreference(
+                    engine.getSSLParameters(),
+                    "client mode SSLEngine.getSSLParameters()");
+
+            engine.setUseClientMode(false);
+            checkDefaultCipherSuitePreference(
+                    engine.getSSLParameters(),
+                    "server mode SSLEngine.getSSLParameters()");
+
+            //
+            // Check SSLSocket
+            //
+            // Check SSLParameters of SSLSocket
+            SocketFactory fac = sslContext.getSocketFactory();
+            SSLSocket socket = (SSLSocket)fac.createSocket();
+            checkDefaultCipherSuitePreference(
+                    socket.getSSLParameters(),
+                    "SSLSocket.getSSLParameters()");
+
+            //
+            // Check SSLServerSocket
+            //
+            // Check SSLParameters of SSLServerSocket
+            SSLServerSocketFactory sf = sslContext.getServerSocketFactory();
+            SSLServerSocket ssocket = (SSLServerSocket)sf.createServerSocket();
+            checkDefaultCipherSuitePreference(
+                    ssocket.getSSLParameters(),
+                    "SSLServerSocket.getSSLParameters()");
+        }
+    }
+
+    private static void checkDefaultCipherSuitePreference(
+            SSLParameters parameters, String context) throws Exception {
+        if (!parameters.getUseCipherSuitesOrder()) {
+            throw new Exception(
+                    "The local cipher suite preference is not honored " +
+                    "in the connection populated SSLParameters object (" +
+                    context + ")");
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

Resolved copyright, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8168261](https://bugs.openjdk.org/browse/JDK-8168261): Use server cipher suites preference by default (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2004/head:pull/2004` \
`$ git checkout pull/2004`

Update a local copy of the PR: \
`$ git checkout pull/2004` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2004`

View PR using the GUI difftool: \
`$ git pr show -t 2004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2004.diff">https://git.openjdk.org/jdk11u-dev/pull/2004.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2004#issuecomment-1613211562)