### PR TITLE
8228403: SignTwice.java failed with java.io.FileNotFoundException: File name too long

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/compatibility/JdkUtils.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/JdkUtils.java
@@ -36,12 +36,18 @@ public class JdkUtils {
         KEY, SIG, DIGEST;
     }
 
+    static final String M_JAVA_VERSION = "javaVersion";
     static final String M_JAVA_RUNTIME_VERSION = "javaRuntimeVersion";
     static final String M_IS_SUPPORTED_KEYALG = "isSupportedKeyalg";
     static final String M_IS_SUPPORTED_SIGALG = "isSupportedSigalg";
     static final String M_IS_SUPPORTED_DIGESTALG = "isSupportedDigestalg";
 
     // Returns the JDK build version.
+    static String javaVersion() {
+        return System.getProperty("java.version");
+    }
+
+    // Returns the JDK build runtime version.
     static String javaRuntimeVersion() {
         return System.getProperty("java.runtime.version");
     }
@@ -63,7 +69,9 @@ public class JdkUtils {
     }
 
     public static void main(String[] args) {
-        if (M_JAVA_RUNTIME_VERSION.equals(args[0])) {
+        if (M_JAVA_VERSION.equals(args[0])) {
+            System.out.print(javaVersion());
+        } else if (M_JAVA_RUNTIME_VERSION.equals(args[0])) {
             System.out.print(javaRuntimeVersion());
         } else if (M_IS_SUPPORTED_KEYALG.equals(args[0])) {
             System.out.print(isSupportedAlg(Alg.KEY, args[1]));


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8228403](https://bugs.openjdk.org/browse/JDK-8228403): SignTwice.java failed with java.io.FileNotFoundException: File name too long (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2005/head:pull/2005` \
`$ git checkout pull/2005`

Update a local copy of the PR: \
`$ git checkout pull/2005` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2005`

View PR using the GUI difftool: \
`$ git pr show -t 2005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2005.diff">https://git.openjdk.org/jdk11u-dev/pull/2005.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2005#issuecomment-1613259003)