### PR TITLE
8306484: Open source several AWT Choice jtreg tests

### DIFF
--- a/test/jdk/java/awt/Choice/ChoiceConsumeMouseEvents.java
+++ b/test/jdk/java/awt/Choice/ChoiceConsumeMouseEvents.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6251988
+  @summary PIT: Choice consumes MouseReleased, MouseClicked events when clicking it with left button,
+  @key headful
+*/
+
+import java.awt.Choice;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+public class ChoiceConsumeMouseEvents {
+
+    static volatile Frame frame;
+    static volatile Robot robot;
+    static volatile Choice choice1 = new Choice();
+    static volatile boolean mousePressed = false;
+    static volatile boolean mouseReleased = false;
+    static volatile boolean mouseClicked = false;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> createUI());
+            runTest();
+        } finally {
+           if (frame != null) {
+               EventQueue.invokeAndWait(() -> frame.dispose());
+           }
+        }
+    }
+
+    static void createUI() {
+        for (int i = 1; i<10; i++){
+            choice1.add("item-0"+i);
+        }
+        choice1.addMouseListener(new MouseAdapter() {
+            public void mousePressed(MouseEvent me) {
+                mousePressed = true;
+                System.out.println(me);
+            }
+            public void mouseReleased(MouseEvent me) {
+                mouseReleased = true;
+                System.out.println(me);
+            }
+            public void mouseClicked(MouseEvent me) {
+                mouseClicked = true;
+                System.out.println(me);
+            }
+        });
+
+        frame = new Frame("ChoiceConsumeMouseEvents");
+        frame.add(choice1);
+        frame.setSize(400, 400);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        frame.validate();
+    }
+
+    static void runTest() {
+        try {
+            robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(50);
+            robot.delay(100);
+            testMouseClick(InputEvent.BUTTON1_DOWN_MASK, 0);
+            robot.delay(100);
+            testMouseClick(InputEvent.BUTTON1_DOWN_MASK, 100);
+        } catch (Throwable e) {
+            throw new RuntimeException("Test failed. Exception thrown: "+e);
+        }
+    }
+
+    static void testMouseClick(int button, int delay) {
+        Point pt = choice1.getLocationOnScreen();
+        robot.mouseMove(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2);
+        robot.delay(100);
+        robot.mousePress(button);
+        robot.delay(delay);
+        robot.mouseRelease(button);
+        robot.delay(200);
+        if (!(mousePressed &&
+              mouseReleased &&
+              mouseClicked))
+        {
+            throw new RuntimeException("Test failed. Choice should generate PRESSED, RELEASED, CLICKED events");
+        } else {
+            System.out.println("Test passed. Choice generated MouseDragged PRESSED, RELEASED, CLICKED events");
+        }
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+        robot.delay(200);
+        mousePressed = false;
+        mouseReleased = false;
+        mouseClicked = false;
+    }
+}

--- a/test/jdk/java/awt/Choice/ChoiceFocusLostTest.java
+++ b/test/jdk/java/awt/Choice/ChoiceFocusLostTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4338368
+  @summary Tests that choice doesn't throw spurious mouse events when losing focus
+  @key headful
+*/
+
+import java.awt.Button;
+import java.awt.Choice;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Robot;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+public class ChoiceFocusLostTest {
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> createUI());
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.delay(50);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            robot.waitForIdle();
+            robot.delay(1000);
+            if (!client.isPassed()) {
+                throw new RuntimeException("Test failed: choice fires spurious events");
+            } else {
+                System.out.println("Test passed.");
+            }
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+        }
+    }
+
+    static volatile Frame frame;
+    static volatile ChoiceBug client;
+
+    static void createUI() {
+        frame = new Frame("ChoiceFocusLostTest");
+        client = new ChoiceBug();
+        frame.add(client);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+}
+
+class ChoiceBug extends Panel {
+
+    volatile boolean passed = true;
+
+    public ChoiceBug() {
+        Choice choice = new Choice();
+        choice.add("item-1");
+        choice.add("item-2");
+        Button button = new Button("Button");
+        add(choice);
+        add(button);
+        choice.addMouseListener(new MouseAdapter() {
+            public void mouseReleased(MouseEvent me) {
+                passed = false;
+            }
+            public void mouseClicked(MouseEvent me) {
+                passed = false;
+            }
+        });
+        choice.addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent fe) {
+                System.out.println("Focus Gained");
+                System.out.println(fe);
+            }
+            public void focusLost(FocusEvent fe) {
+                System.out.println("Got expected FocusLost event.");
+                System.out.println(fe);
+            }
+        });
+        setSize(400, 400);
+        choice.requestFocus();
+    }
+
+    public boolean isPassed() {
+        return passed;
+    }
+}

--- a/test/jdk/java/awt/Choice/ChoiceFreezeTest.java
+++ b/test/jdk/java/awt/Choice/ChoiceFreezeTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4303064
+  @summary Tests that choice doesn't freeze display when its container is
+           disabled and enabled after.
+  @key headful
+*/
+
+import java.awt.Button;
+import java.awt.Choice;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+public class ChoiceFreezeTest {
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> createUI());
+            runTest();
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+        }
+    }
+
+    static volatile Frame frame;
+    static volatile ChoiceFreezeBug client;
+
+    static void createUI() {
+        frame = new Frame("ChoiceFreezeTest");
+        client = new ChoiceFreezeBug();
+        frame.add(client);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        client.init();
+     }
+
+     static void runTest() throws Exception {
+         Robot robot = new Robot();
+         robot.waitForIdle();
+         robot.delay(2000);
+         robot.mouseMove(client.choice.getLocationOnScreen().x + 1, client.choice.getLocationOnScreen().y + 1);
+         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+         robot.delay(1000);
+         robot.mouseMove(client.button.getLocationOnScreen().x + 3, client.button.getLocationOnScreen().y + 3);
+         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+         robot.delay(1000);
+         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+         robot.delay(6000);
+
+         if (!client.isPassed()) {
+             throw new RuntimeException("Test failed: display is frozen.");
+         }
+    }
+}
+
+class ChoiceFreezeBug extends Panel {
+
+    volatile Button button;
+    volatile Choice choice;
+    volatile ChoiceMouseListener listener = new ChoiceMouseListener();
+
+    public ChoiceFreezeBug() {
+        choice = new Choice();
+        choice.addItem("Item 1");
+        choice.addItem("Item 2");
+        button = new Button("Button");
+        add(choice);
+        add(button);
+        button.addMouseListener(listener);
+        setEnabled(false);
+    }
+
+    void init() {
+        setEnabled(true);
+        choice.requestFocus();
+    }
+
+    public boolean isPassed() {
+        return listener.isPassed();
+    }
+}
+
+class ChoiceMouseListener extends MouseAdapter {
+
+    volatile boolean passed = false;
+
+    public void mouseReleased(MouseEvent e) {
+        passed = true;
+    }
+
+    public void mousePressed(MouseEvent e) {
+        passed = true;
+    }
+
+    public boolean isPassed() {
+        return passed;
+    }
+}

--- a/test/jdk/java/awt/Choice/ChoiceGeneratesItemEvents.java
+++ b/test/jdk/java/awt/Choice/ChoiceGeneratesItemEvents.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6239941
+  @summary Choice triggers ItemEvent when selecting an item with right mouse button, Xtoolkit
+  @key headful
+  @requires (os.family == "linux")
+*/
+
+import java.awt.Choice;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.KeyEvent;
+
+public class ChoiceGeneratesItemEvents implements ItemListener {
+
+    public static void main(String[] args) throws Exception {
+        if (!System.getProperty("os.name").toLowerCase().startsWith("linux")) {
+            System.out.println("This test is for Linux only");
+            return;
+        }
+        try {
+            EventQueue.invokeAndWait(() -> createUI());
+            runTest();
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(() -> frame.dispose());
+
+            }
+        }
+    }
+
+    static volatile Frame frame;
+    static volatile Robot robot;
+    static volatile Choice choice1;
+    static volatile boolean passed = true;
+
+    static void createUI() {
+        choice1 = new Choice();
+        for (int i = 1; i<10; i++){
+            choice1.add("item-0"+i);
+        }
+        choice1.setForeground(Color.red);
+        choice1.setBackground(Color.red);
+        choice1.addItemListener(new ChoiceGeneratesItemEvents());
+        frame = new Frame("ChoiceGeneratesItemEvents");
+        frame.add(choice1);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.validate();
+        frame.setVisible(true);
+    }
+
+    static void runTest() throws Exception {
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(50);
+        robot.delay(100);
+        testMousePressOnChoice(InputEvent.BUTTON2_DOWN_MASK);
+        testMousePressOnChoice(InputEvent.BUTTON3_DOWN_MASK);
+        if (!passed) {
+            throw new RuntimeException("Test failed.");
+        } else {
+            System.out.println("Test passed. ");
+        }
+    }
+
+    static void testMousePressOnChoice(int button) {
+        Point pt = choice1.getLocationOnScreen();
+        robot.mouseMove(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2);
+        robot.delay(100);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(2000);
+
+        int px = pt.x + choice1.getWidth()/2;
+        int py = pt.y + 2 * choice1.getHeight();
+        Color color = robot.getPixelColor(px, py);
+        //we should take a color on the point on the choice's menu
+        System.out.println("Got color " + color + " at (" + px + "," + py + ")");
+        if (!color.equals(Color.red)) {
+            throw new RuntimeException("Test failed. Choice wasn't open with LEFTMOUSE button." +button);
+        }
+        robot.mouseMove(pt.x + choice1.getWidth()/2,
+                        pt.y + 5*choice1.getHeight());
+        robot.delay(200);
+        robot.mousePress(button);
+        robot.mouseRelease(button);
+        robot.delay(200);
+
+        //close opened choice
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+        robot.delay(200);
+    }
+
+    public void itemStateChanged(ItemEvent ie) {
+        System.err.println("Opened Choice generated ItemEvent on RIGHT/MIDDLE mouse press." +ie);
+        passed = false;
+    }
+}

--- a/test/jdk/java/awt/Choice/ChoiceHandleMouseEvent.java
+++ b/test/jdk/java/awt/Choice/ChoiceHandleMouseEvent.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 5003166
+  @summary REG:Mouse button not validated before bringing up the drop-down menu for choice
+  @key headful
+  @requires (os.family == "linux" | os.family == "windows")
+*/
+
+import java.awt.Choice;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+public class ChoiceHandleMouseEvent {
+    static Robot robot;
+    static volatile Choice choice1;
+    static volatile Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (!os.startsWith("windows") && !os.startsWith("linux")) {
+            System.out.println("This test is only for Windows and Linux");
+            return;
+        }
+        try {
+            EventQueue.invokeAndWait(() -> createUI());
+            runTest();
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+       }
+    }
+
+    static void createUI() {
+        choice1 = new Choice();
+        choice1.add("item-01");
+        choice1.add("item-02");
+        choice1.add("item-03");
+        choice1.add("item-04");
+        choice1.setForeground(Color.red);
+        choice1.setBackground(Color.red);
+        frame = new Frame("ChoiceHandleMouseEvent");
+        frame.add(choice1);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.validate();
+        frame.setVisible(true);
+    }
+
+    static void runTest() throws Exception {
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(50);
+
+        /*
+         * Stage 1: Choice should only opens with LEFTMOUSE click.
+         * Should only pass on Windows or XAWT.
+         * Choice on motif might be opened only by click on small box
+         * in the right side.
+         */
+        testPressMouseButton(InputEvent.BUTTON2_DOWN_MASK);
+        testPressMouseButton(InputEvent.BUTTON3_DOWN_MASK);
+        System.out.println("Passed Stage 1: Choice should only opens with LEFT BUTTON.");
+
+        /*
+         * Stage 2: Choice should only change its value if pressed
+         * mouse button is LEFTMOUSE.
+         */
+        // first parameter is for opening choice. The second is for
+        // selecting item inside the menu
+        testPressMouseButton_2(InputEvent.BUTTON1_DOWN_MASK, InputEvent.BUTTON2_DOWN_MASK);
+        testPressMouseButton_2(InputEvent.BUTTON1_DOWN_MASK, InputEvent.BUTTON3_DOWN_MASK);
+        System.out.println("Passed Stage 2: Choice should not change its value if pressed mouse buttonis  not left.");
+
+        /*
+         * Stage 3: Choice should only react on drags with LEFTMOUSE button.
+         */
+        // first parameter is for opening choice. The second is for
+        // selecting item inside the menu
+        testDragMouseButton(InputEvent.BUTTON1_DOWN_MASK, InputEvent.BUTTON2_DOWN_MASK);
+        testDragMouseButton(InputEvent.BUTTON1_DOWN_MASK, InputEvent.BUTTON3_DOWN_MASK);
+        System.out.println("Passed Stage 3: Choice should only react on drags with LEFTMOUSE button.");
+    }
+
+    static void testPressMouseButton(int button) {
+        Point pt = choice1.getLocationOnScreen();
+        robot.mouseMove(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2);
+        robot.delay(100);
+        robot.mousePress(button);
+        robot.mouseRelease(button);
+        robot.delay(200);
+
+        int px = pt.x + choice1.getWidth()/2;
+        int py = pt.y + 3 * choice1.getHeight();
+        Color color = robot.getPixelColor(px, py);
+        //we should take a color on the point on the choice's menu
+        System.out.println("Got color " + color + " at (" + px + "," + py + ")");
+        System.out.println("RED="+Color.red);
+        if (color.equals(Color.red)) {
+            throw new RuntimeException("Test failed. Choice opens with "+button);
+        } else {
+            System.out.println("Stage 1 passed."+ button);
+        }
+
+        //close opened choice
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+    }
+
+    static void testPressMouseButton_2(int openButton, int button) {
+        Point pt = choice1.getLocationOnScreen();
+        robot.mouseMove(pt.x + choice1.getWidth()/2,
+                        pt.y + choice1.getHeight()/2);
+        robot.delay(100);
+        robot.mousePress(openButton);
+        robot.mouseRelease(openButton);
+        robot.delay(200);
+        robot.mouseMove(pt.x + choice1.getWidth()/2,
+                        pt.y + 2 * choice1.getHeight());
+        robot.mousePress(button);
+        robot.mouseRelease(button);
+
+        System.out.println();
+
+        if (choice1.getSelectedIndex() == 0) {
+            System.out.println("Stage 2 passed." + openButton +":"+button);
+        } else {
+            throw new RuntimeException("Stage 2 failed." + openButton +":"+button);
+        }
+
+        //close opened choice
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+    }
+
+    static void testDragMouseButton(int openButton, int button) {
+        Point pt = choice1.getLocationOnScreen();
+        robot.mouseMove(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2);
+        robot.delay(100);
+        robot.mousePress(openButton);
+        robot.mouseRelease(openButton);
+        robot.delay(200);
+
+        robot.mousePress(button);
+        dragMouse(pt.x + choice1.getWidth()/2, pt.y +
+                  choice1.getHeight()/2,
+                  pt.x + choice1.getWidth()/2,
+                  pt.y + 2 * choice1.getHeight());
+        robot.mouseRelease(button);
+
+        if (choice1.getSelectedIndex() == 0 ){
+            System.out.println("Stage 3 passed." + openButton +":"+button);
+            //            System.out.println("choice1.getSelectedIndex()" + choice1.getSelectedIndex());
+        } else {
+            throw new RuntimeException("Stage 3 failed." + openButton +":"+button);
+        }
+
+        //close opened choice
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+    }
+
+    static void dragMouse(int x0, int y0, int x1, int y1) {
+        int curX = x0;
+        int curY = y0;
+        int dx = x0 < x1 ? 1 : -1;
+        int dy = y0 < y1 ? 1 : -1;
+
+        while (curX != x1){
+            curX += dx;
+            robot.mouseMove(curX, curY);
+        }
+        while (curY != y1 ){
+            curY += dy;
+            robot.mouseMove(curX, curY);
+        }
+    }
+}

--- a/test/jdk/java/awt/Choice/ChoiceHandleMouseEvent_2.java
+++ b/test/jdk/java/awt/Choice/ChoiceHandleMouseEvent_2.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6239944
+  @summary PIT: Right clicking on the scrollbar of the choice's dropdown disposes the drop-down, on XToolkit
+  @key headful
+  @requires (os.family == "linux" | os.family == "windows")
+*/
+
+import java.awt.Choice;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+public class ChoiceHandleMouseEvent_2 {
+
+    static Robot robot;
+    static volatile Choice choice1;
+    static volatile Frame frame;
+    static boolean isWindows;
+
+    public static void main(String[] args) throws Exception {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (!os.startsWith("windows") && !os.startsWith("linux")) {
+            System.out.println("This test is only for Windows and Linux");
+            return;
+        }
+        isWindows = os.startsWith("windows");
+        try {
+            EventQueue.invokeAndWait(() -> createUI());
+            runTest();
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+       }
+    }
+
+    static void createUI() {
+        choice1 = new Choice();
+        for (int i = 1; i<50; i++) {
+            choice1.add("item-0"+i);
+        }
+        choice1.setForeground(Color.red);
+        choice1.setBackground(Color.red);
+        frame = new Frame("ChoiceHandleMouseEvent_2");
+        frame.setBackground(Color.green);
+        Panel panel = new Panel();
+        panel.setBackground(Color.green);
+        panel.add(choice1);
+        frame.add(panel);
+        frame.setSize(300,300);
+        frame.setLocationRelativeTo(null);
+        frame.validate();
+        frame.setVisible(true);
+    }
+
+    static void runTest() throws Exception {
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(50);
+        robot.delay(100);
+
+        /*
+         * Stage 1. Choice should be closed if user dragged mouse
+         * outside of Choice after opening it.
+         * Should only pass on Windows or XAWT.
+         * Choice on motif might be opened only by click on small box
+         * in the right side.
+         */
+         testDragMouseButtonOut(InputEvent.BUTTON1_DOWN_MASK);
+         System.out.println("Passed Stage 1: Choice should be closed if mouse dragged out.");
+
+        /*
+         * Stage 2: Choice should be closed if LeftMouse drag finished
+         * on Scrollbar. This involeves only one
+         * MousePress and one MouseRelease event
+         */
+         // first parameter is for opening choice. The second is for
+         // selecting item inside the menu
+         testDragMouseButtonOnSB(InputEvent.BUTTON1_DOWN_MASK);
+         System.out.println("Passed Stage 2: Choice should be closed if " +
+                            "LeftMouse drag finished on Scrollbar.");
+
+        /*
+         * Stage 3: Pressing RIGHT/MIDDLE MouseButton on Scrollbar
+         * shouldn't close Choice's pop-down menu.
+         * Pressing LEFT MouseButton shouldn't close it too. It should
+         * scroll it.
+         * This is an unstable test because we doesn't have an API to
+         * get Scrollbar from Choice. There is a possibility not to
+         * hit the scrollbar that couldn't been predicted.
+         */
+         // first parameter is for opening choice. The second is for
+         // selecting item inside the menu
+         testPressOnScrollbar(InputEvent.BUTTON1_DOWN_MASK, InputEvent.BUTTON2_DOWN_MASK);
+         testPressOnScrollbar(InputEvent.BUTTON1_DOWN_MASK, InputEvent.BUTTON3_DOWN_MASK);
+         System.out.println("Passed Stage 3: Choice correctly reacts on mouse click on its Scrollbar.");
+
+         /*
+          * Stage 4: Choice should close its popdown menu if user opened a Choice then
+          * releases Mouse and then presses Mouse again and dragged it on Choice's Scrollbar
+          * This involves only one MousePress and one MouseRelease
+          * event, so it differs from Stage 2.
+          */
+          // first parameter is for opening choice. The second is for
+          // selecting item inside the menu or scrollbar
+          testDragMouseOnScrollbar(InputEvent.BUTTON1_DOWN_MASK, InputEvent.BUTTON1_DOWN_MASK);
+          System.out.println("Passed Stage 4: Choice should close if user opened a " +
+                             "Choice then releases Mouse and then presses Mouse again " +
+                             "and drag it on Choice's Scrollbar .");
+    }
+
+
+    //Stage 4
+    static void testDragMouseOnScrollbar(int openButton, int button) {
+        Point pt = choice1.getLocationOnScreen();
+        robot.mouseMove(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2);
+        robot.delay(100);
+        robot.mousePress(openButton);
+        robot.mouseRelease(openButton);
+        robot.delay(200);
+
+        robot.mouseMove(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2);
+        robot.mousePress(button);
+        /*X-coordinate should be closer to right edge of Choice, so
+          divider 4 is used. */
+        dragMouse(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2,
+                  pt.x + choice1.getWidth() - choice1.getHeight()/4, pt.y + 5*choice1.getHeight());
+        robot.mouseRelease(button);
+        robot.delay(200);
+
+        int px = pt.x + choice1.getWidth()/2;
+        int py = pt.y + 3 * choice1.getHeight();
+        Color color = robot.getPixelColor(px, py);
+        //should take a color on the point on the choice's menu
+        System.out.println("Got color " + color + " at (" + px + "," + py + ")");
+        if (color.equals(Color.red)) {
+            throw new RuntimeException(
+               "Test failed. Choice didn't close after drag without firstPress on ScrollBar " + button);
+        } else {
+            System.out.println("Stage 4 passed."+ button);
+        }
+
+        //close opened choice
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+        robot.delay(200);
+    }
+
+    //stage 3
+    static void testPressOnScrollbar(int openButton, int button) {
+        if (!isWindows) {
+            return; // Windows-only tests.
+        }
+        Point pt = choice1.getLocationOnScreen();
+        robot.mouseMove(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2);
+        robot.delay(100);
+        robot.mousePress(openButton);
+        robot.mouseRelease(openButton);
+        robot.delay(200);
+        /*X-coordinate should be closer to right edge of Choice, so
+          divide by 4 is used. */
+        int px = pt.x + choice1.getWidth() - choice1.getHeight()/4;
+        int py = pt.y + 5*choice1.getHeight();
+        robot.mouseMove(px, py);
+        robot.delay(200);
+        robot.mousePress(button);
+        robot.mouseRelease(button);
+        robot.delay(200);
+
+        System.out.println("x= "+px);
+        System.out.println("y= "+py);
+
+        /*
+          This is for Windows only.
+          On XP theme choice become closed on RightMouseClick over a scrollbar.
+          A system menu is opened after that. On Classic theme Choice doesn't react on it at all.
+        */
+        boolean isXPTheme = false;
+        Object themeObject = Toolkit.getDefaultToolkit().getDesktopProperty("win.xpstyle.themeActive");
+        // it returns null when Classic theme is active but we should
+        // check it's boolean value anyway if event it's not null.
+        if (themeObject != null) {
+            isXPTheme = ((Boolean)themeObject).booleanValue();
+        }
+        System.out.println("isXPTheme="+isXPTheme);
+        px = pt.x + choice1.getWidth()/2;
+        py = pt.y + 3 * choice1.getHeight();
+        Color color = robot.getPixelColor(px, py);
+        //we should take a color on the point on the choice's menu
+        System.out.println("Got color " + color + " at (" + px + "," + py + ")");
+        System.out.println("RED="+Color.red);
+        System.out.println("GREEN="+Color.green);
+        if (isXPTheme && button == InputEvent.BUTTON3_DOWN_MASK) {
+            if (!color.equals(Color.green)) {
+                throw new RuntimeException("Stage 3 failed(XP theme). " +
+                  "Choice wasn't closed with pressing button on its Scrollbar" + openButton +":"+button);
+            } else {
+                System.out.println("Stage 3 passed(XP theme)." + openButton +":"+button);
+            }
+        } else {
+            if (!color.equals(Color.red)) {
+                throw new RuntimeException("Stage 3 failed(classic theme). " +
+                   "Choice is being closed with pressing button on its Scrollbar" + openButton +":"+button);
+            } else {
+                System.out.println("Stage 3 passed(classic theme)." + openButton +":"+button);
+            }
+        }
+
+        //close opened choice
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+        robot.delay(200);
+    }
+
+    // Stage 1
+    static void testDragMouseButtonOut(int button) {
+        Point pt = choice1.getLocationOnScreen();
+
+        robot.mouseMove(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2);
+        robot.mousePress(button);
+        dragMouse(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2,
+                  pt.x + choice1.getWidth()*2, pt.y + choice1.getHeight()/2);
+        robot.mouseRelease(button);
+        robot.delay(200);
+        int px = pt.x + choice1.getWidth()/2;
+        int py = pt.y + 3 * choice1.getHeight();
+        Color color = robot.getPixelColor(px, py);
+        //should take a color on the point on the choice's menu
+        System.out.println("Got color " + color + " at (" + px + "," + py + ")");
+        System.out.println("RED="+Color.red);
+        // fix 6268989: On Windows Choice shouldn't been closed if
+        //  Mouse dragged outside of Choice after one mouse press.
+        if (isWindows) {
+            if (color.equals(Color.red)) {
+                System.out.println("Stage 1 passed. On Windows Choice shouldn't be " +
+                      "closed if Mouse dragged outside of Choice after one mouse press "+button);
+            } else {
+                throw new RuntimeException("Test failed. Choice on Windows shouldn't be " +
+                   "closed after drag outside of Choice after one mouse press "+button);
+            }
+        } else {
+            if (color.equals(Color.red)) {
+                throw new RuntimeException("Test failed. Choice didn't close " +
+                                           "after drag outside of Choice "+button);
+            } else {
+                System.out.println("Stage 1 passed."+ button);
+            }
+        }
+
+        //close opened choice
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+        robot.delay(200);
+    }
+
+    //stage 2
+    static void testDragMouseButtonOnSB(int button) {
+        Point pt = choice1.getLocationOnScreen();
+
+        robot.mouseMove(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2);
+        robot.mousePress(button);
+        /*X-coordinate should be closer to right edge of Choice, so
+          divider 4 is used. */
+        dragMouse(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2,
+                  pt.x + choice1.getWidth() - choice1.getHeight()/4, pt.y + 5*choice1.getHeight());
+        robot.mouseRelease(button);
+        robot.delay(200);
+        int px = pt.x + choice1.getWidth()/2;
+        int py = pt.y + 3 * choice1.getHeight();
+        Color color = robot.getPixelColor(px, py);
+        //should take a color on the point on the choice's menu
+        System.out.println("Got color " + color + " at (" + px + "," + py + ")");
+        if (isWindows) {
+            if (color.equals(Color.red)) {
+                System.out.println("Stage 2 passed. On Windows Choice shouldn't be " +
+                                   " closed if Mouse dragged on its scrollbar "+button);
+            } else {
+                throw new RuntimeException("Test failed. On Windows Choice shouldn't be " +
+                                           " closed if Mouse dragged on its scrollbar  "+button);
+            }
+        } else {
+            if (color.equals(Color.red)) {
+                throw new RuntimeException("Test failed. Choice didn't close after drag on ScrollBar "+button);
+            } else {
+                System.out.println("Stage 2 passed."+ button);
+            }
+        }
+
+        //close opened choice
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+        robot.delay(200);
+    }
+
+    static void dragMouse(int x0, int y0, int x1, int y1) {
+        int curX = x0;
+        int curY = y0;
+        int dx = x0 < x1 ? 1 : -1;
+        int dy = y0 < y1 ? 1 : -1;
+
+        while (curX != x1) {
+            curX += dx;
+            robot.mouseMove(curX, curY);
+        }
+        while (curY != y1) {
+            curY += dy;
+            robot.mouseMove(curX, curY);
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306484](https://bugs.openjdk.org/browse/JDK-8306484): Open source several AWT Choice jtreg tests (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2009/head:pull/2009` \
`$ git checkout pull/2009`

Update a local copy of the PR: \
`$ git checkout pull/2009` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2009`

View PR using the GUI difftool: \
`$ git pr show -t 2009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2009.diff">https://git.openjdk.org/jdk11u-dev/pull/2009.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2009#issuecomment-1613639396)