### PR TITLE
8307569: Build with gcc8 is broken after JDK-8307301

### DIFF
--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -561,8 +561,9 @@ else
 
   HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing
   # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
+  # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
-       maybe-uninitialized class-memaccess unused-result extra noexcept-type
+       maybe-uninitialized class-memaccess unused-result extra noexcept-type expansion-to-defined
   HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
        tautological-constant-out-of-range-compare int-to-pointer-cast \
        undef missing-field-initializers deprecated-declarations c++11-narrowing range-loop-analysis


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

I had to resolve, also the file location is different.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307569](https://bugs.openjdk.org/browse/JDK-8307569): Build with gcc8 is broken after JDK-8307301 (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2011/head:pull/2011` \
`$ git checkout pull/2011`

Update a local copy of the PR: \
`$ git checkout pull/2011` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2011`

View PR using the GUI difftool: \
`$ git pr show -t 2011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2011.diff">https://git.openjdk.org/jdk11u-dev/pull/2011.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2011#issuecomment-1614210377)