### PR TITLE
8307604: gcc12 based Alpine build broken build after JDK-8307301

### DIFF
--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -561,8 +561,9 @@ else
 
   HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing
   # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
+  # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
-       maybe-uninitialized class-memaccess unused-result extra noexcept-type
+       maybe-uninitialized class-memaccess unused-result extra noexcept-type expansion-to-defined
   HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
        tautological-constant-out-of-range-compare int-to-pointer-cast \
        undef missing-field-initializers deprecated-declarations c++11-narrowing range-loop-analysis

--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -559,7 +559,8 @@ else
   # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
   LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-ft.cc
 
-  HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing
+  HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing \
+       array-bounds
   # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
   # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

I had to resolve, also the file location is different.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307604](https://bugs.openjdk.org/browse/JDK-8307604): gcc12 based Alpine build broken build after JDK-8307301 (**Bug** - P3)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2012/head:pull/2012` \
`$ git checkout pull/2012`

Update a local copy of the PR: \
`$ git checkout pull/2012` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2012`

View PR using the GUI difftool: \
`$ git pr show -t 2012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2012.diff">https://git.openjdk.org/jdk11u-dev/pull/2012.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2012#issuecomment-1614302640)