### PR TITLE
8232840: java/math/BigInteger/largeMemory/SymmetricRangeTests.java fails due to "OutOfMemoryError: Requested array size exceeds VM limit"

### DIFF
--- a/test/jdk/java/math/BigInteger/largeMemory/SymmetricRangeTests.java
+++ b/test/jdk/java/math/BigInteger/largeMemory/SymmetricRangeTests.java
@@ -26,7 +26,7 @@
  * @bug 6910473 8021204 8021203 9005933 8074460 8078672
  * @summary Test range of BigInteger values (use -Dseed=X to set PRNG seed)
  * @library /test/lib
- * @requires (sun.arch.data.model == "64" & os.maxMemory > 8g)
+ * @requires (sun.arch.data.model == "64" & os.maxMemory >= 10g)
  * @run main/timeout=180/othervm -Xmx8g -XX:+CompactStrings SymmetricRangeTests
  * @author Dmitry Nadezhin
  * @key randomness


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

I had to resolve the ProblemList, as the test was not problem listed. (JDK-8232922)
Will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8232840](https://bugs.openjdk.org/browse/JDK-8232840): java/math/BigInteger/largeMemory/SymmetricRangeTests.java fails due to "OutOfMemoryError: Requested array size exceeds VM limit" (**Bug** - P4)
 * [JDK-8232922](https://bugs.openjdk.org/browse/JDK-8232922): Add java/math/BigInteger/largeMemory/SymmetricRangeTests.java to ProblemList-Xcomp (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2014/head:pull/2014` \
`$ git checkout pull/2014`

Update a local copy of the PR: \
`$ git checkout pull/2014` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2014`

View PR using the GUI difftool: \
`$ git pr show -t 2014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2014.diff">https://git.openjdk.org/jdk11u-dev/pull/2014.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2014#issuecomment-1614252761)