### PR TITLE
8286620: Create regression test for verifying setMargin() of JRadioButton

### DIFF
--- a/test/jdk/javax/swing/JRadioButton/bug4380543.java
+++ b/test/jdk/javax/swing/JRadioButton/bug4380543.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/* @test
+ * @bug 4380543
+ * @key headful
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary setMargin() does not work for AbstractButton
+ * @run main/manual bug4380543
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.Insets;
+
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+public class bug4380543 {
+    static TestFrame testObj;
+    static String instructions
+            =
+            "INSTRUCTIONS:\n" +
+            "   1. Check if the Left inset(margin) is set visually\n" +
+            "      similar to other three sides around the Radio Button\n" +
+            "      and CheckBox (insets set to 20 on all 4 sides).\n" +
+            "   2. Rendering depends on OS and supported Look and Feels.\n" +
+            "      Verify only with those L&F where margins are visible.\n" +
+            "   3. If the Left inset(margin) appears too small, press Fail,\n" +
+            "      else press Pass."
+            ;
+    static PassFailJFrame passFailJFrame;
+
+    public static void main(String[] args) throws Exception {
+
+        SwingUtilities.invokeAndWait(new Runnable() {
+            public void run() {
+                try {
+                    passFailJFrame = new PassFailJFrame(instructions);
+                    testObj = new TestFrame();
+                    //Adding the Test Frame to handle dispose
+                    PassFailJFrame.addTestFrame(testObj);
+                    PassFailJFrame.positionTestFrame(testObj, PassFailJFrame.Position.HORIZONTAL);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+        passFailJFrame.awaitAndCheck();
+    }
+}
+
+class TestFrame extends JFrame implements ActionListener {
+    public TestFrame() {
+        initComponents();
+    }
+
+    public void initComponents() {
+        JPanel p = new JPanel();
+        JPanel buttonsPanel = new JPanel();
+        buttonsPanel.setLayout(new BoxLayout(buttonsPanel, BoxLayout.Y_AXIS));
+
+        JRadioButton rb  = new JRadioButton("JRadioButton");
+        rb.setMargin(new Insets(20, 20, 20, 20));
+        rb.setBackground(Color.GREEN);
+        rb.setAlignmentX(0.5f);
+        buttonsPanel.add(rb);
+
+        JCheckBox cb  = new JCheckBox("JCheckBox");
+        cb.setMargin(new Insets(20, 20, 20, 20));
+        cb.setBackground(Color.YELLOW);
+        cb.setAlignmentX(0.5f);
+        buttonsPanel.add(cb);
+
+        getContentPane().add(buttonsPanel);
+        UIManager.LookAndFeelInfo[] lookAndFeel = UIManager.getInstalledLookAndFeels();
+        for (UIManager.LookAndFeelInfo look : lookAndFeel) {
+            JButton btn = new JButton(look.getName());
+            btn.setActionCommand(look.getClassName());
+            btn.addActionListener(this);
+            p.add(btn);
+        }
+
+        getContentPane().add(p,BorderLayout.SOUTH);
+
+        setSize(500, 300);
+        setVisible(true);
+    }
+
+    private static void setLookAndFeel(String laf) {
+        try {
+            UIManager.setLookAndFeel(laf);
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported L&F: " + laf);
+        } catch (ClassNotFoundException | InstantiationException
+                | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //Changing the Look and Feel on user selection
+    public void actionPerformed(ActionEvent e) {
+        setLookAndFeel(e.getActionCommand());
+        SwingUtilities.updateComponentTreeUI(this);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

I had to replace the """ string.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286620](https://bugs.openjdk.org/browse/JDK-8286620): Create regression test for verifying setMargin() of JRadioButton (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2015/head:pull/2015` \
`$ git checkout pull/2015`

Update a local copy of the PR: \
`$ git checkout pull/2015` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2015`

View PR using the GUI difftool: \
`$ git pr show -t 2015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2015.diff">https://git.openjdk.org/jdk11u-dev/pull/2015.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2015#issuecomment-1614262745)