### PR TITLE
8304867: Explicitly disable dtrace for ppc builds

### DIFF
--- a/make/autoconf/hotspot.m4
+++ b/make/autoconf/hotspot.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -165,8 +165,11 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_DTRACE],
 
   DTRACE_DEP_MISSING=false
 
-  AC_MSG_CHECKING([for dtrace tool])
-  if test "x$DTRACE" != "x" && test -x "$DTRACE"; then
+  AC_MSG_CHECKING([for dtrace tool and platform support])
+  if test "x$OPENJDK_TARGET_CPU_ARCH" = "xppc"; then
+    AC_MSG_RESULT([no, $OPENJDK_TARGET_CPU_ARCH])
+    DTRACE_DEP_MISSING=true
+  elif test "x$DTRACE" != "x" && test -x "$DTRACE"; then
     AC_MSG_RESULT([$DTRACE])
   else
     AC_MSG_RESULT([not found, cannot build dtrace])


### PR DESCRIPTION
Backport of 8304867

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304867](https://bugs.openjdk.org/browse/JDK-8304867): Explicitly disable dtrace for ppc builds (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2017/head:pull/2017` \
`$ git checkout pull/2017`

Update a local copy of the PR: \
`$ git checkout pull/2017` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2017`

View PR using the GUI difftool: \
`$ git pr show -t 2017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2017.diff">https://git.openjdk.org/jdk11u-dev/pull/2017.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2017#issuecomment-1617683375)