### PR TITLE
8293657: sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1 failed with "SSLHandshakeException: Remote host terminated the handshake"

### DIFF
--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -902,9 +902,6 @@ public final class ConnectorBootstrap {
     private static class HostAwareSslSocketFactory extends SslRMIServerSocketFactory {
 
         private final String bindAddress;
-        private final String[] enabledCipherSuites;
-        private final String[] enabledProtocols;
-        private final boolean needClientAuth;
         private final SSLContext context;
 
         private HostAwareSslSocketFactory(String[] enabledCipherSuites,
@@ -919,11 +916,9 @@ public final class ConnectorBootstrap {
                                           String[] enabledProtocols,
                                           boolean sslNeedClientAuth,
                                           String bindAddress) throws IllegalArgumentException {
-            this.context = ctx;
+            super(ctx, enabledCipherSuites, enabledProtocols, sslNeedClientAuth);
             this.bindAddress = bindAddress;
-            this.enabledProtocols = enabledProtocols;
-            this.enabledCipherSuites = enabledCipherSuites;
-            this.needClientAuth = sslNeedClientAuth;
+            this.context = ctx;
             checkValues(ctx, enabledCipherSuites, enabledProtocols);
         }
 
@@ -933,14 +928,15 @@ public final class ConnectorBootstrap {
                 try {
                     InetAddress addr = InetAddress.getByName(bindAddress);
                     return new SslServerSocket(port, 0, addr, context,
-                                               enabledCipherSuites, enabledProtocols, needClientAuth);
+                            this.getEnabledCipherSuites(), this.getEnabledProtocols(),
+                            this.getNeedClientAuth());
                 } catch (UnknownHostException e) {
                     return new SslServerSocket(port, context,
-                                               enabledCipherSuites, enabledProtocols, needClientAuth);
+                            this.getEnabledCipherSuites(), this.getEnabledProtocols(), this.getNeedClientAuth());
                 }
             } else {
                 return new SslServerSocket(port, context,
-                                           enabledCipherSuites, enabledProtocols, needClientAuth);
+                        this.getEnabledCipherSuites(), this.getEnabledProtocols(), this.getNeedClientAuth());
             }
         }
 

--- a/test/jdk/sun/management/jmxremote/bootstrap/management_ssltest07_ok.properties.in
+++ b/test/jdk/sun/management/jmxremote/bootstrap/management_ssltest07_ok.properties.in
@@ -1,5 +1,5 @@
-com.sun.management.jmxremote.ssl.enabled.cipher.suites=TLS_DHE_DSS_WITH_AES_128_GCM_SHA256
+com.sun.management.jmxremote.ssl.enabled.cipher.suites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
 com.sun.management.jmxremote.ssl.enabled.protocols=SSLv2Hello,SSLv3,TLSv1
 com.sun.management.jmxremote.ssl.need.client.auth=true
 com.sun.management.jmxremote.authenticate=false
-javax.rmi.ssl.client.enabledCipherSuites=TLS_DHE_DSS_WITH_AES_128_GCM_SHA256
+javax.rmi.ssl.client.enabledCipherSuites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA


### PR DESCRIPTION
This backport is for parity with 11.0.21-oracle. 
Small risk, simple change. The change applies clean with these exceptions: 
 - Copyright year mismatch 
 - Test was problem-listed in 17, but not in 11. 
 - missing "import java.io.BufferedInputStream;" 

Test passes before and after the fix is applied. 
SAP nightly tests did not reveal any issue related to this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293657](https://bugs.openjdk.org/browse/JDK-8293657): sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1 failed with "SSLHandshakeException: Remote host terminated the handshake" (**Bug** - P3)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2018/head:pull/2018` \
`$ git checkout pull/2018`

Update a local copy of the PR: \
`$ git checkout pull/2018` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2018`

View PR using the GUI difftool: \
`$ git pr show -t 2018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2018.diff">https://git.openjdk.org/jdk11u-dev/pull/2018.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2018#issuecomment-1618094244)