### PR TITLE
8291830: jvmti/RedefineClasses/StressRedefine failed: assert(!is_null(v)) failed: narrow klass value can never be zero

### DIFF
--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -25,7 +25,7 @@
 #include "precompiled.hpp"
 #include "classfile/classLoaderData.inline.hpp"
 #include "classfile/dictionary.hpp"
-#include "classfile/javaClasses.hpp"
+#include "classfile/javaClasses.inline.hpp"
 #include "classfile/systemDictionary.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
@@ -735,7 +735,7 @@ void Klass::verify_on(outputStream* st) {
   }
 
   if (java_mirror_no_keepalive() != NULL) {
-    guarantee(oopDesc::is_oop(java_mirror_no_keepalive()), "should be instance");
+    guarantee(java_lang_Class::is_instance(java_mirror_no_keepalive()), "should be instance");
   }
 }
 

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -269,9 +269,8 @@ protected:
   // Both mirrors are on the ClassLoaderData::_handles list already so no
   // barriers are needed.
   void set_java_mirror_handle(OopHandle mirror) { _java_mirror = mirror; }
-  OopHandle java_mirror_handle() const          {
-    return _java_mirror;
-  }
+  OopHandle java_mirror_handle() const          { return _java_mirror;   }
+  void swap_java_mirror_handle(OopHandle& mirror) { _java_mirror.swap(mirror); }
 
   // modifier flags
   jint modifier_flags() const          { return _modifier_flags; }

--- a/src/hotspot/share/oops/oopHandle.hpp
+++ b/src/hotspot/share/oops/oopHandle.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,10 @@ private:
 public:
   OopHandle() : _obj(NULL) {}
   OopHandle(oop* w) : _obj(w) {}
+
+  void swap(OopHandle& copy) {
+    ::swap(_obj, copy._obj);
+  }
 
   inline oop resolve() const;
   inline oop peek() const;

--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -411,14 +411,14 @@ class RedefineVerifyMark : public StackObj {
                      JvmtiThreadState *state) : _state(state), _scratch_class(scratch_class)
   {
     _state->set_class_versions_map(the_class, scratch_class);
-    _scratch_mirror = _scratch_class->java_mirror_handle();
-    _scratch_class->set_java_mirror_handle(the_class->java_mirror_handle());
+    _scratch_mirror = the_class->java_mirror_handle();  // this is a copy that is swapped
+    _scratch_class->swap_java_mirror_handle(_scratch_mirror);
   }
 
   ~RedefineVerifyMark() {
     // Restore the scratch class's mirror, so when scratch_class is removed
     // the correct mirror pointing to it can be cleared.
-    _scratch_class->set_java_mirror_handle(_scratch_mirror);
+    _scratch_class->swap_java_mirror_handle(_scratch_mirror);
     _state->clear_class_versions_map();
   }
 };


### PR DESCRIPTION
Fix request [11u] 

I backport this for parity with 11.0.21-oracle. The change does not at all apply cleanly.

- ResourceMark not added in classLoaderData.cpp (logging code which would need it is not present).
- Deleted method Klass::replace_java_mirror() did not exist in jdk11.
- class RedefineVerifyMark exists in share/prims/jvmtiThreadState.hpp, not in share/prims/jvmtiRedefineClasses.cpp

SAP nightly tests did not reveal any issue related to this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291830](https://bugs.openjdk.org/browse/JDK-8291830): jvmti/RedefineClasses/StressRedefine failed: assert(!is_null(v)) failed: narrow klass value can never be zero (**Bug** - P2)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2019/head:pull/2019` \
`$ git checkout pull/2019`

Update a local copy of the PR: \
`$ git checkout pull/2019` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2019`

View PR using the GUI difftool: \
`$ git pr show -t 2019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2019.diff">https://git.openjdk.org/jdk11u-dev/pull/2019.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2019#issuecomment-1618736989)