### PR TITLE
8305074: ProblemList javax/net/ssl/DTLS/RespondToRetransmit.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -617,7 +617,7 @@ sun/security/tools/jarsigner/compatibility/SignTwice.java       8217375 windows-
 sun/security/tools/jarsigner/warnings/BadKeyUsageTest.java      8026393 generic-all
 
 javax/net/ssl/DTLS/PacketLossRetransmission.java                8169086 macosx-x64
-javax/net/ssl/DTLS/RespondToRetransmit.java                     8169086 macosx-x64
+javax/net/ssl/DTLS/RespondToRetransmit.java                     8169086 macosx-all
 javax/net/ssl/DTLS/CipherSuite.java                             8202059 macosx-x64
 
 sun/security/provider/KeyStore/DKSTest.sh                       8180266 windows-all


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.
We see this failing on mac aarch in our CI.
This corresponds to JDK-8174887.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305074](https://bugs.openjdk.org/browse/JDK-8305074): ProblemList javax/net/ssl/DTLS/RespondToRetransmit.java (**Sub-task** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2020/head:pull/2020` \
`$ git checkout pull/2020`

Update a local copy of the PR: \
`$ git checkout pull/2020` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2020/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2020`

View PR using the GUI difftool: \
`$ git pr show -t 2020`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2020.diff">https://git.openjdk.org/jdk11u-dev/pull/2020.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2020#issuecomment-1619791343)