### PR TITLE
8304054: Linux: NullPointerException from FontConfiguration.getVersion in case no fonts are installed

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -1252,15 +1252,24 @@ public abstract class FontConfiguration {
         return filenamesMap.get(platformName);
     }
 
+    private static final String fontconfigErrorMessage =
+            "Fontconfig head is null, check your fonts or fonts configuration";
+
     /**
      * Returns a configuration specific path to be appended to the font
      * search path.
      */
     public String getExtraFontPath() {
+        if (head == null) {
+            throw new RuntimeException(fontconfigErrorMessage);
+        }
         return getString(head[INDEX_appendedfontpath]);
     }
 
     public String getVersion() {
+        if (head == null) {
+            throw new RuntimeException(fontconfigErrorMessage);
+        }
         return getString(head[INDEX_version]);
     }
 


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304054](https://bugs.openjdk.org/browse/JDK-8304054): Linux: NullPointerException from FontConfiguration.getVersion in case no fonts are installed (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2023/head:pull/2023` \
`$ git checkout pull/2023`

Update a local copy of the PR: \
`$ git checkout pull/2023` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2023`

View PR using the GUI difftool: \
`$ git pr show -t 2023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2023.diff">https://git.openjdk.org/jdk11u-dev/pull/2023.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2023#issuecomment-1620086608)