### PR TITLE
8291444: GHA builds/tests won't run manually if disabled from automatic running

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,19 +71,17 @@ jobs:
           # 'false' otherwise.
           # arg $1: platform name or names to look for
           function check_platform() {
-            if [[ '${{ !secrets.JDK_SUBMIT_FILTER || startsWith(github.ref, 'refs/heads/submit/') }}' == 'false' ]]; then
-              # If JDK_SUBMIT_FILTER is set, and this is not a "submit/" branch, don't run anything
-              echo 'false'
-              return
-            fi
-
             if [[ $GITHUB_EVENT_NAME == workflow_dispatch ]]; then
               input='${{ github.event.inputs.platforms }}'
             elif [[ $GITHUB_EVENT_NAME == push ]]; then
-              input='${{ secrets.JDK_SUBMIT_PLATFORMS }}'
-            else
-              echo 'Internal error in GHA'
-              exit 1
+              if [[ '${{ !secrets.JDK_SUBMIT_FILTER || startsWith(github.ref, 'refs/heads/submit/') }}' == 'false' ]]; then
+                # If JDK_SUBMIT_FILTER is set, and this is not a "submit/" branch, don't run anything
+                >&2 echo 'JDK_SUBMIT_FILTER is set and not a "submit/" branch'
+                echo 'false'
+                return
+              else
+                input='${{ secrets.JDK_SUBMIT_PLATFORMS }}'
+              fi
             fi
 
             normalized_input="$(echo ,$input, | tr -d ' ')"


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8291444](https://bugs.openjdk.org/browse/JDK-8291444), commit [17744caa](https://github.com/openjdk/jdk17u-dev/commit/17744caa87ac313e924deb92af37c491cf7c97bc) from the [openjdk/jdk17u-dev](https://git.openjdk.org/jdk17u-dev) repository.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291444](https://bugs.openjdk.org/browse/JDK-8291444): GHA builds/tests won't run manually if disabled from automatic running (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2024/head:pull/2024` \
`$ git checkout pull/2024`

Update a local copy of the PR: \
`$ git checkout pull/2024` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2024`

View PR using the GUI difftool: \
`$ git pr show -t 2024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2024.diff">https://git.openjdk.org/jdk11u-dev/pull/2024.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2024#issuecomment-1620205240)