### PR TITLE
8306636: Disable compiler/c2/Test6905845.java with -XX:TieredStopAtLevel=3

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/Test6905845.java
+++ b/test/hotspot/jtreg/compiler/c2/Test6905845.java
@@ -26,6 +26,7 @@
  * @bug 6905845
  * @summary Server VM improperly optimizing away loop.
  *
+ * @requires vm.opt.TieredStopAtLevel != 3
  * @run main/timeout=480 compiler.c2.Test6905845
  */
 


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306636](https://bugs.openjdk.org/browse/JDK-8306636): Disable compiler/c2/Test6905845.java with -XX:TieredStopAtLevel=3 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2028/head:pull/2028` \
`$ git checkout pull/2028`

Update a local copy of the PR: \
`$ git checkout pull/2028` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2028`

View PR using the GUI difftool: \
`$ git pr show -t 2028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2028.diff">https://git.openjdk.org/jdk11u-dev/pull/2028.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2028#issuecomment-1621392535)