### PR TITLE
8305421: Work around JDK-8305420 in CDSJDITest.java

### DIFF
--- a/test/jdk/com/sun/jdi/cds/CDSJDITest.java
+++ b/test/jdk/com/sun/jdi/cds/CDSJDITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ public class CDSJDITest {
             "-XX:+UnlockDiagnosticVMOptions", "-XX:SharedArchiveFile=./SharedArchiveFile.jsa",
             "-XX:ExtraSharedClassListFile=" + jarClasslistFile.getPath(),
             "-Xshare:dump");
-        OutputAnalyzer outputDump = executeAndLog(pb, "exec");
+        OutputAnalyzer outputDump = executeAndLog(pb, "dump");
         for (String jarClass : jarClasses) {
             outputDump.shouldNotContain("Cannot find " + jarClass);
         }


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

test/jdk/com/sun/jdi/cds/CDSJDITest.java
Copyright
“-Xlog:class+path=info” is not in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305421](https://bugs.openjdk.org/browse/JDK-8305421): Work around JDK-8305420 in CDSJDITest.java (**Sub-task** - P4)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2029/head:pull/2029` \
`$ git checkout pull/2029`

Update a local copy of the PR: \
`$ git checkout pull/2029` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2029`

View PR using the GUI difftool: \
`$ git pr show -t 2029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2029.diff">https://git.openjdk.org/jdk11u-dev/pull/2029.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2029#issuecomment-1621433479)