### PR TITLE
8306137: Open source several AWT ScrollPane related tests

### DIFF
--- a/test/jdk/java/awt/ScrollPane/ComponentScrollTest.java
+++ b/test/jdk/java/awt/ScrollPane/ComponentScrollTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+  @test
+  @bug 4342129
+  @summary Unable to scroll in scrollpane for canvas
+  @key headful
+*/
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.ScrollPane;
+
+import java.awt.event.AdjustmentEvent;
+import java.awt.event.AdjustmentListener;
+
+public class ComponentScrollTest {
+    public ScrollPane scrollpane;
+    public Frame frame;
+    public volatile int count = 0;
+
+    public static void main(String[] args) throws Exception {
+        ComponentScrollTest cst = new ComponentScrollTest();
+        cst.init();
+        cst.start();
+    }
+
+    public void init() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            scrollpane = new ScrollPane();
+            frame = new Frame("Component Scroll Test");
+            scrollpane.add(new Component() {
+                public Dimension getPreferredSize() {
+                    return new Dimension(500, 500);
+                }
+
+                public void paint(Graphics g) {
+                    g.drawLine(0, 0, 500, 500);
+                }
+            });
+            frame.add(scrollpane);
+            scrollpane.getVAdjustable().addAdjustmentListener(new AdjustmentListener() {
+                @Override
+                public void adjustmentValueChanged(AdjustmentEvent adjustmentEvent) {
+                    count++;
+                    scrollpane.getVAdjustable().setValue(20);
+                }
+            });
+            frame.pack();
+            frame.setVisible(true);
+        });
+    }
+
+    public void start() throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                scrollpane.getVAdjustable().setValue(20);
+            });
+
+            Thread.sleep(1000);
+
+            System.out.println("Count = " + count);
+            if (count > 50) {
+                throw new RuntimeException();
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneExtraScrollBar.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneExtraScrollBar.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4152524
+  @requires os.family=="windows"
+  @summary Test that scroll pane doesn't have scroll bars visible when it is
+  shown for the first time with SCROLLBARS_AS_NEEDED style
+  @key headful
+*/
+
+import java.awt.Button;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.ScrollPane;
+
+import java.awt.event.InputEvent;
+
+public class ScrollPaneExtraScrollBar {
+    ScrollPane sp;
+    Frame f;
+    volatile Rectangle r;
+
+    public static void main(String[] args) throws Exception {
+        ScrollPaneExtraScrollBar scrollTest = new ScrollPaneExtraScrollBar();
+        scrollTest.init();
+        scrollTest.start();
+    }
+
+    public void init() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            f = new Frame("ScrollPaneExtraScrollBar");
+            sp = new ScrollPane(ScrollPane.SCROLLBARS_AS_NEEDED);
+            sp.add(new Button("TEST"));
+            f.add("Center", sp);
+            f.pack();
+            f.setLocationRelativeTo(null);
+            f.setVisible(true);
+        });
+    }
+
+    public void start() throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(100);
+            EventQueue.invokeAndWait(() -> {
+                r = f.getBounds();
+            });
+            robot.mouseMove(r.x + r.width - 1, r.y + r.height - 1);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseMove(r.x + r.width + 50, r.y + r.height + 50);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> {
+                Insets insets = sp.getInsets();
+                if (insets.left != insets.right || insets.top != insets.bottom) {
+                    throw new RuntimeException("ScrollPane has scroll bars visible" +
+                            " when it shouldn't");
+                }
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneLimitation.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneLimitation.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4046446
+  @requires os.family=="windows"
+  @summary Tests 16-bit limitations of scroll pane, child's position and size
+  and mouse coordinates
+  @key headful
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.ScrollPane;
+
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseAdapter;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class ScrollPaneLimitation {
+    static final int SCROLL_POS = 50000;
+    public static Component child = null;
+    static final CountDownLatch go = new CountDownLatch(1);
+    public Frame frame;
+    volatile Point point;
+    ScrollPane pane;
+
+    public static void main(String[] args) throws Exception {
+        ScrollPaneLimitation scrollTest = new ScrollPaneLimitation();
+        scrollTest.init();
+        scrollTest.start();
+    }
+
+    public void init() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            frame = new Frame("Scroll Pane Limitation");
+            frame.setLayout(new BorderLayout());
+            pane = new ScrollPane();
+            frame.add(pane);
+            child = new MyPanel();
+            child.addMouseListener(new MouseAdapter() {
+                public void mousePressed(MouseEvent e) {
+                    if (e.getID() == MouseEvent.MOUSE_PRESSED
+                            && e.getSource() == ScrollPaneLimitation.child
+                            && e.getY() > SCROLL_POS) {
+                        go.countDown();
+                    }
+                }
+            });
+            pane.add(child);
+            frame.setSize(200, 200);
+            frame.pack();
+            frame.setLocationRelativeTo(null);
+            frame.setAlwaysOnTop(true);
+            frame.setVisible(true);
+            pane.doLayout();
+        });
+    }
+
+    public void start() throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> {
+                Point p = child.getLocation();
+                System.out.println("Child's initial location " + p);
+                System.out.println("Pane's insets " + pane.getInsets());
+                pane.setScrollPosition(0, SCROLL_POS);
+                p = pane.getScrollPosition();
+                System.out.println("Scroll pos = " + p);
+                if (p.y != SCROLL_POS) {
+                    throw new RuntimeException("wrong scroll position");
+                }
+                p = child.getLocation();
+                System.out.println("Child pos = " + p);
+                if (p.y != -SCROLL_POS) {
+                    if (child.isLightweight()) {
+                        // If it is lightweight it will always have (0, 0) location.
+                        // Check location of its parent - it is Panel and it should
+                        // be at (inset left, inset top + position)
+                        Container cp = child.getParent();
+                        p = cp.getLocation();
+                        System.out.println("Child's parent pos = " + p);
+                        if (p.y != -SCROLL_POS) {
+                            throw new RuntimeException("wrong child location");
+                        }
+                    } else {
+                        throw new RuntimeException("wrong child location");
+                    }
+                }
+
+                p = pane.getLocationOnScreen();
+                Dimension d = pane.getSize();
+                point = new Point(p.x + d.width / 2, p.y + d.height / 2);
+            });
+            robot.mouseMove(point.x, point.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            if (!go.await(3, TimeUnit.SECONDS)) {
+                throw new RuntimeException("mouse was not pressed");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static class MyPanel extends Component {
+        public Dimension getPreferredSize() {
+            return new Dimension(100, 100000);
+        }
+    }
+}

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneRemoveAdd.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneRemoveAdd.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4100671
+  @summary Tests that after removing/adding a component can be still access.
+  @key headful
+*/
+
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.ScrollPane;
+
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class ScrollPaneRemoveAdd {
+    Button button;
+    ScrollPane pane;
+    Frame frame;
+    volatile Point buttonLoc;
+    volatile Dimension buttonSize;
+    volatile CountDownLatch latch;
+
+    public static void main(String[] args) throws Exception {
+        ScrollPaneRemoveAdd scrollTest = new ScrollPaneRemoveAdd();
+        scrollTest.init();
+        scrollTest.start();
+    }
+
+    public void init() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            frame = new Frame("Scroll pane Add/Remove");
+            pane = new ScrollPane(ScrollPane.SCROLLBARS_ALWAYS);
+            button = new Button("press");
+            latch = new CountDownLatch(1);
+
+            pane.add(button);
+            frame.add(pane);
+
+            button.addActionListener(new ActionListener() {
+                public void actionPerformed(ActionEvent e) {
+                    latch.countDown();
+                }
+            });
+            frame.pack();
+            frame.setLocationRelativeTo(null);
+            frame.setAlwaysOnTop(true);
+            frame.setVisible(true);
+        });
+    }
+
+    public void start() throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                pane.remove(0);
+                pane.add(button);
+                buttonLoc = button.getLocationOnScreen();
+                buttonSize = button.getSize();
+            });
+
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            robot.mouseMove(buttonLoc.x + buttonSize.width / 2,
+                    buttonLoc.y + buttonSize.height / 2);
+            robot.delay(50);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(50);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            if (!latch.await(1, TimeUnit.SECONDS)) {
+                throw new RuntimeException("ScrollPane doesn't handle " +
+                        "correctly add after remove");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneWindowsTest.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneWindowsTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4452612
+  @requires os.family=="windows"
+  @summary The popup menu of the scroll bar doesn't work properly in Window2000.
+  @key headful
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Insets;
+import java.awt.Panel;
+import java.awt.Robot;
+import java.awt.ScrollPane;
+import java.awt.ScrollPaneAdjustable;
+
+import java.awt.event.AdjustmentListener;
+import java.awt.event.AdjustmentEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+public class ScrollPaneWindowsTest implements AdjustmentListener {
+    ScrollPane sp;
+    Panel p;
+    Robot robot;
+    Frame frame;
+    Insets paneInsets;
+    public static final Object LOCK = new Object();
+    ScrollPaneAdjustable vScroll;
+    ScrollPaneAdjustable hScroll;
+    boolean notifyReceived = false;
+    volatile int xPos = 0;
+    volatile int yPos = 0;
+
+    public static void main(String[] args) throws Exception {
+        ScrollPaneWindowsTest scrollTest = new ScrollPaneWindowsTest();
+        scrollTest.init();
+        scrollTest.start();
+    }
+
+    public void init() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            frame = new Frame("ScrollPaneWindowsTest");
+            frame.setLayout(new BorderLayout(1, 1));
+            p = new Panel();
+            p.setLayout(null);
+            p.setSize(new Dimension(800, 800));
+            sp = new ScrollPane(ScrollPane.SCROLLBARS_ALWAYS);
+            vScroll = (ScrollPaneAdjustable) sp.getVAdjustable();
+            hScroll = (ScrollPaneAdjustable) sp.getHAdjustable();
+            vScroll.addAdjustmentListener(ScrollPaneWindowsTest.this);
+            hScroll.addAdjustmentListener(ScrollPaneWindowsTest.this);
+            sp.add(p);
+            frame.add(sp);
+            frame.pack();
+            frame.setSize(400, 400);
+            frame.setLocationRelativeTo(null);
+            frame.setAlwaysOnTop(true);
+            frame.setVisible(true);
+        });
+    }
+
+    public void start() throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                paneInsets = sp.getInsets();
+                System.out.println("Insets: right = " + paneInsets.right + " bottom =  " + paneInsets.bottom);
+            });
+
+            robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(100);
+
+            EventQueue.invokeAndWait(() -> {
+                xPos = sp.getLocationOnScreen().x + sp.getWidth() - paneInsets.right / 2;
+                yPos = sp.getLocationOnScreen().y + sp.getHeight() / 2;
+            });
+
+            robot.mouseMove(xPos, yPos);
+            testOneScrollbar(vScroll);
+
+            robot.waitForIdle();
+            robot.delay(100);
+
+            EventQueue.invokeAndWait(() -> {
+                xPos = sp.getLocationOnScreen().x + sp.getWidth() / 2;
+                yPos = sp.getLocationOnScreen().y + sp.getHeight() - paneInsets.bottom / 2;
+            });
+
+            robot.mouseMove(xPos, yPos);
+            testOneScrollbar(hScroll);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+        System.out.println("Test passed. ");
+    }
+
+    public void testOneScrollbar(ScrollPaneAdjustable scroll) throws Exception {
+        //to Bottom  - right
+        robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+        robot.waitForIdle();
+        robot.delay(2000);
+
+        synchronized (LOCK) {
+            notifyReceived = false;
+            for (int i = 0; i < 3; i++) {
+                robot.keyPress(KeyEvent.VK_DOWN);
+                robot.keyRelease(KeyEvent.VK_DOWN);
+            }
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+            if (!notifyReceived) {
+                System.out.println("we are waiting 1");
+                LOCK.wait(2000);
+            }
+            if (scroll.getValue() + scroll.getVisibleAmount() != scroll.getMaximum()) {
+                System.out.println("scroll.getValue() = " + scroll.getValue());
+                System.out.println("scroll.getVisibleAmount() = " + scroll.getVisibleAmount());
+                System.out.println("scroll.getMaximum() = " + scroll.getMaximum());
+                throw new RuntimeException("Test Failed. Position of scrollbar is incorrect.");
+            } else {
+                System.out.println("Test stage 1 passed.");
+            }
+            notifyReceived = false;
+        }
+
+        //to top-left
+        robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+        robot.waitForIdle();
+        robot.delay(2000);
+
+        synchronized (LOCK) {
+            for (int i = 0; i < 2; i++) {
+                robot.keyPress(KeyEvent.VK_DOWN);
+                robot.keyRelease(KeyEvent.VK_DOWN);
+            }
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+            if (!notifyReceived) {
+                System.out.println("we are waiting 2");
+                LOCK.wait(2000);
+            }
+            if (scroll.getValue() != 0) {
+                System.out.println("scroll.getValue() = " + scroll.getValue());
+                throw new RuntimeException("Test Failed. Position of scrollbar is incorrect.");
+            } else {
+                System.out.println("Test stage 2 passed.");
+            }
+        }
+    }
+
+    @Override
+    public void adjustmentValueChanged(AdjustmentEvent adjustmentEvent) {
+        synchronized (ScrollPaneWindowsTest.LOCK) {
+            notifyReceived = true;
+            ScrollPaneWindowsTest.LOCK.notify();
+        }
+        System.out.println("Adjustment Event called ");
+    }
+}

--- a/test/jdk/java/awt/ScrollPane/ScrollPositionIntact.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPositionIntact.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ @test
+ @bug 6404832
+ @summary Tests that scroll position is not changed by validate() for mode SCROLLBARS_NEVER
+ @key headful
+ @run main ScrollPositionIntact
+*/
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Label;
+import java.awt.Panel;
+import java.awt.Robot;
+import java.awt.ScrollPane;
+
+public class ScrollPositionIntact {
+    Frame frame;
+    ScrollPane sp;
+    Panel pa;
+    public static final int X_POS = 100;
+
+    public static void main(String[] args) throws Exception {
+        ScrollPositionIntact test = new ScrollPositionIntact();
+        test.init();
+        test.start();
+    }
+
+    public void init() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            pa = new Panel();
+            pa.setSize(600, 50);
+            pa.setPreferredSize(new Dimension(600, 50));
+            pa.setBackground(Color.red);
+            sp = new ScrollPane(ScrollPane.SCROLLBARS_NEVER);
+            sp.setSize(200, 50);
+            pa.setLayout(new GridLayout(1, 3));
+            pa.add("West", new Label("west", Label.LEFT));
+            pa.add("West", new Label());
+            pa.add("East", new Label("East", Label.RIGHT));
+            sp.add(pa);
+            frame = new Frame("ScrollPositionIntact");
+            frame.setSize(200, 100);
+            frame.add(sp);
+            frame.setVisible(true);
+        });
+    }
+
+    public void start() throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> {
+                frame.toFront();
+                frame.requestFocus();
+
+                sp.setScrollPosition(X_POS, sp.getScrollPosition().y);
+                pa.validate();
+                // Now, before the fix, in Windows XP, Windows XP theme and on Vista,
+                // scrollposition would be reset to zero..
+                sp.validate();
+
+                int i = (int) (sp.getScrollPosition().getX());
+                if (i <= 0) {
+                    // actual position MAY be not equal to X_POS; still, it must be > 0.
+                    throw new RuntimeException("Test failure: zero scroll position.\n\n");
+                }
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306137](https://bugs.openjdk.org/browse/JDK-8306137): Open source several AWT ScrollPane related tests (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2030/head:pull/2030` \
`$ git checkout pull/2030`

Update a local copy of the PR: \
`$ git checkout pull/2030` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2030`

View PR using the GUI difftool: \
`$ git pr show -t 2030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2030.diff">https://git.openjdk.org/jdk11u-dev/pull/2030.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2030#issuecomment-1621654626)