### PR TITLE
8225012: sanity/client/SwingSet/src/ToolTipDemoTest.java fails on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -742,7 +742,7 @@ java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 
-sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
+sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 linux-all
 
 javax/swing/SwingWorker/6432565/bug6432565.java 8199077 generic-all
 javax/swing/SwingWorker/6880336/NestedWorkers.java 8199049 windows-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -742,7 +742,7 @@ java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
 
-sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 linux-all
+sanity/client/SwingSet/src/ToolTipDemoTest.java 8293001 linux-all
 
 javax/swing/SwingWorker/6432565/bug6432565.java 8199077 generic-all
 javax/swing/SwingWorker/6880336/NestedWorkers.java 8199049 windows-all

--- a/test/jdk/com/sun/jdi/cds/CDSJDITest.java
+++ b/test/jdk/com/sun/jdi/cds/CDSJDITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ public class CDSJDITest {
             "-XX:+UnlockDiagnosticVMOptions", "-XX:SharedArchiveFile=./SharedArchiveFile.jsa",
             "-XX:ExtraSharedClassListFile=" + jarClasslistFile.getPath(),
             "-Xshare:dump");
-        OutputAnalyzer outputDump = executeAndLog(pb, "exec");
+        OutputAnalyzer outputDump = executeAndLog(pb, "dump");
         for (String jarClass : jarClasses) {
             outputDump.shouldNotContain("Cannot find " + jarClass);
         }

--- a/test/jdk/com/sun/jdi/cds/CDSJDITest.java
+++ b/test/jdk/com/sun/jdi/cds/CDSJDITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ public class CDSJDITest {
             "-XX:+UnlockDiagnosticVMOptions", "-XX:SharedArchiveFile=./SharedArchiveFile.jsa",
             "-XX:ExtraSharedClassListFile=" + jarClasslistFile.getPath(),
             "-Xshare:dump");
-        OutputAnalyzer outputDump = executeAndLog(pb, "dump");
+        OutputAnalyzer outputDump = executeAndLog(pb, "exec");
         for (String jarClass : jarClasses) {
             outputDump.shouldNotContain("Cannot find " + jarClass);
         }

--- a/test/jdk/sanity/client/SwingSet/src/ToolTipDemoTest.java
+++ b/test/jdk/sanity/client/SwingSet/src/ToolTipDemoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import javax.swing.UIManager;
 
 import org.jtregext.GuiTestListener;
 import org.netbeans.jemmy.ClassReference;
+import org.netbeans.jemmy.JemmyProperties;
 import org.netbeans.jemmy.operators.JComponentOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JLabelOperator;
@@ -79,11 +80,19 @@ public class ToolTipDemoTest {
     @Test(dataProvider = "availableLookAndFeels", dataProviderClass = TestHelpers.class)
     public void test(String lookAndFeel) throws Exception {
         UIManager.setLookAndFeel(lookAndFeel);
+
+        JemmyProperties.setCurrentDispatchingModel(JemmyProperties.ROBOT_MODEL_MASK |
+                JemmyProperties.SMOOTH_ROBOT_MODEL_MASK);
+
         new ClassReference(ToolTipDemo.class.getCanonicalName()).startApplication();
         JFrameOperator frameOperator = new JFrameOperator(DEMO_TITLE);
         frameOperator.setComparator(EXACT_STRING_COMPARATOR);
         // Setting the tooltip dismiss delay
         ToolTipManager.sharedInstance().setDismissDelay(TOOLTIP_DISMISS_DELAY);
+
+        //activate window
+        frameOperator.clickMouse();
+        frameOperator.moveMouse(-1, -1);
 
         // Verifying the plain tooltip properties
         checkToolTip(frameOperator, PLAIN_TOOLTIP_COMP_TITLE,
@@ -116,18 +125,15 @@ public class ToolTipDemoTest {
      */
     private void checkToolTip(JFrameOperator frameOperator, String compTitle,
             String toolTipText) {
-
         JLabelOperator toolTipHostComp =
                 new JLabelOperator(frameOperator, compTitle);
         JToolTipOperator toolTipOperator =
                 new JToolTipOperator(toolTipHostComp.showToolTip());
         toolTipOperator.waitTipText(toolTipText);
         checkToolTipLocation(toolTipHostComp, toolTipOperator);
-
-        // Dismissing the tooltip by mouse click
-        toolTipHostComp.clickMouse();
+        // Dismissing the tooltip by moving the mouse out
+        toolTipHostComp.moveMouse(-1, -1);
         toolTipOperator.waitComponentShowing(false);
-
     }
 
     private void checkToolTipLocation(JComponentOperator componentOpertor,


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

I had to resolve the ProblemList, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8225012](https://bugs.openjdk.org/browse/JDK-8225012): sanity/client/SwingSet/src/ToolTipDemoTest.java fails on Windows (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2033/head:pull/2033` \
`$ git checkout pull/2033`

Update a local copy of the PR: \
`$ git checkout pull/2033` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2033/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2033`

View PR using the GUI difftool: \
`$ git pr show -t 2033`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2033.diff">https://git.openjdk.org/jdk11u-dev/pull/2033.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2033#issuecomment-1629197451)