### PR TITLE
8220410: sun/security/tools/jarsigner/warnings/NoTimestampTest.java failed with missing expected output

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/warnings/NoTimestampTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/warnings/NoTimestampTest.java
@@ -27,6 +27,7 @@ import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.util.JarUtils;
@@ -46,6 +47,7 @@ public class NoTimestampTest extends Test {
      * and checks that proper warnings are shown.
      */
     public static void main(String[] args) throws Throwable {
+
         Locale reservedLocale = Locale.getDefault();
         Locale.setDefault(Locale.US);
 
@@ -61,6 +63,9 @@ public class NoTimestampTest extends Test {
     private void start() throws Throwable {
         String timezone = System.getProperty("user.timezone");
         System.out.println(String.format("Timezone = %s", timezone));
+        if (timezone != null) {
+            TimeZone.setDefault(TimeZone.getTimeZone(timezone));
+        }
 
         // create a jar file that contains one class file
         Utils.createFiles(FIRST_FILE);
@@ -73,10 +78,11 @@ public class NoTimestampTest extends Test {
                 "-validity", Integer.toString(VALIDITY));
 
         Date expirationDate = getCertExpirationDate();
+        System.out.println("Cert expiration: " + expirationDate);
 
         // sign jar file
         OutputAnalyzer analyzer = jarsigner(
-                "-J-Duser.timezone=" + timezone,
+                userTimezoneOpt(timezone),
                 "-keystore", KEYSTORE,
                 "-storepass", PASSWORD,
                 "-keypass", PASSWORD,
@@ -90,7 +96,7 @@ public class NoTimestampTest extends Test {
 
         // verify signed jar
         analyzer = jarsigner(
-                "-J-Duser.timezone=" + timezone,
+                userTimezoneOpt(timezone),
                 "-verify",
                 "-keystore", KEYSTORE,
                 "-storepass", PASSWORD,
@@ -103,7 +109,7 @@ public class NoTimestampTest extends Test {
 
         // verify signed jar in strict mode
         analyzer = jarsigner(
-                "-J-Duser.timezone=" + timezone,
+                userTimezoneOpt(timezone),
                 "-verify",
                 "-strict",
                 "-keystore", KEYSTORE,
@@ -115,6 +121,10 @@ public class NoTimestampTest extends Test {
         checkVerifying(analyzer, 0, warning);
 
         System.out.println("Test passed");
+    }
+
+    private static String userTimezoneOpt(String timezone) {
+        return timezone == null ? null : "-J-Duser.timezone=" + timezone;
     }
 
     private static Date getCertExpirationDate() throws Exception {

--- a/test/jdk/sun/security/tools/jarsigner/warnings/Test.java
+++ b/test/jdk/sun/security/tools/jarsigner/warnings/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,13 @@
  * questions.
  */
 
-import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 /**
  * Base class.
@@ -263,7 +264,9 @@ public abstract class Test {
         cmd.add(tool);
         cmd.add("-J-Duser.language=en");
         cmd.add("-J-Duser.country=US");
-        cmd.addAll(Arrays.asList(args));
+        cmd.addAll(Arrays.asList(args).stream().filter(arg -> {
+            return arg != null && !arg.isEmpty();
+        }).collect(Collectors.toList()));
         return ProcessTools.executeCommand(cmd.toArray(new String[cmd.size()]));
     }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.
test/jdk/sun/security/tools/jarsigner/warnings/NoTimestampTest.java
Resolved due to context
test/jdk/sun/security/tools/jarsigner/warnings/Test.java
Copyright

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8220410](https://bugs.openjdk.org/browse/JDK-8220410): sun/security/tools/jarsigner/warnings/NoTimestampTest.java failed with missing expected output (**Bug** - P3)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2036/head:pull/2036` \
`$ git checkout pull/2036`

Update a local copy of the PR: \
`$ git checkout pull/2036` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2036`

View PR using the GUI difftool: \
`$ git pr show -t 2036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2036.diff">https://git.openjdk.org/jdk11u-dev/pull/2036.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2036#issuecomment-1630345052)