### PR TITLE
8229481: sun/net/www/protocol/https/ChunkedOutputStream.java failed with a SSLException

### DIFF
--- a/test/jdk/sun/net/www/protocol/https/ChunkedOutputStream.java
+++ b/test/jdk/sun/net/www/protocol/https/ChunkedOutputStream.java
@@ -322,7 +322,6 @@ public class ChunkedOutputStream implements HttpCallback {
                 server = new TestHttpsServer(
                         new ChunkedOutputStream(), 1, 10, 0);
                 System.out.println ("Server started: listening on port: " + server.getLocalPort());
-                testPlainText(server.getAuthority());
                 // the test server doesn't support keep-alive yet
                 // test1("http://localhost:"+server.getLocalPort()+"/d0");
                 test1("https://localhost:"+server.getLocalPort()+"/d01");

--- a/test/jdk/sun/net/www/protocol/https/ChunkedOutputStream.java
+++ b/test/jdk/sun/net/www/protocol/https/ChunkedOutputStream.java
@@ -133,11 +133,11 @@ public class ChunkedOutputStream implements HttpCallback {
                 req.sendResponse (200, "OK");
                 req.orderlyClose();
                 break;
-            }
             default:
                 req.sendResponse(404, "Not Found");
                 req.orderlyClose();
                 break;
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/test/jdk/sun/net/www/protocol/https/ChunkedOutputStream.java
+++ b/test/jdk/sun/net/www/protocol/https/ChunkedOutputStream.java
@@ -333,6 +333,7 @@ public class ChunkedOutputStream implements HttpCallback {
                 server = new TestHttpsServer(
                         new ChunkedOutputStream(), 1, 10, 0);
                 System.out.println ("Server started: listening on port: " + server.getLocalPort());
+                testPlainText(server.getAuthority());
                 // the test server doesn't support keep-alive yet
                 // test1("http://localhost:"+server.getLocalPort()+"/d0");
                 test1("https://localhost:"+server.getLocalPort()+"/d01");

--- a/test/jdk/sun/net/www/protocol/https/ChunkedOutputStream.java
+++ b/test/jdk/sun/net/www/protocol/https/ChunkedOutputStream.java
@@ -36,6 +36,7 @@
 import java.io.*;
 import java.net.*;
 import javax.net.ssl.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ChunkedOutputStream implements HttpCallback {
     /*
@@ -46,6 +47,7 @@ public class ChunkedOutputStream implements HttpCallback {
     static String trustStoreFile = "truststore";
     static String passwd = "passphrase";
     static int count = 0;
+    static final AtomicInteger rogueCount = new AtomicInteger();
 
     static final String str1 = "Helloworld1234567890abcdefghijklmnopqrstuvwxyz"+
                                 "1234567890abcdefkjsdlkjflkjsldkfjlsdkjflkj"+
@@ -149,6 +151,26 @@ public class ChunkedOutputStream implements HttpCallback {
         String s1 = new String (buf, 0, off, "ISO8859_1");
         if (!cmp.equals(s1)) {
             throw new IOException ("strings not same");
+        }
+    }
+
+    /* basic smoke test: verify that server drops plain connections */
+    static void testPlainText(String authority) throws Exception {
+        URL url = new URL("http://" + authority + "/Donauschiffsgesellschaftskapitaenskajuete");
+        System.out.println("client opening connection to: " + url);
+        HttpURLConnection urlc = (HttpURLConnection)url.openConnection(Proxy.NO_PROXY);
+        int rogue = rogueCount.get();
+        try {
+            int code  = urlc.getResponseCode();
+            System.out.println("Unexpected response: " + code);
+            throw new AssertionError("Unexpected response: " + code);
+        } catch (SocketException x) {
+            // we expect that the server will drop the connection and
+            // close the accepted socket, so we should get a SocketException
+            // on the client side, and confirm that this::dropPlainTextConnections
+            // has ben called.
+            if (rogueCount.get() == rogue) throw x;
+            System.out.println("Got expected exception: " + x);
         }
     }
 
@@ -300,6 +322,7 @@ public class ChunkedOutputStream implements HttpCallback {
                 server = new TestHttpsServer(
                         new ChunkedOutputStream(), 1, 10, 0);
                 System.out.println ("Server started: listening on port: " + server.getLocalPort());
+                testPlainText(server.getAuthority());
                 // the test server doesn't support keep-alive yet
                 // test1("http://localhost:"+server.getLocalPort()+"/d0");
                 test1("https://localhost:"+server.getLocalPort()+"/d01");

--- a/test/jdk/sun/net/www/protocol/https/ChunkedOutputStream.java
+++ b/test/jdk/sun/net/www/protocol/https/ChunkedOutputStream.java
@@ -134,9 +134,20 @@ public class ChunkedOutputStream implements HttpCallback {
                 req.orderlyClose();
                 break;
             }
+            default:
+                req.sendResponse(404, "Not Found");
+                req.orderlyClose();
+                break;
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    public boolean dropPlainTextConnections() {
+        System.out.println("Unrecognized SSL message, plaintext connection?");
+        System.out.println("TestHttpsServer receveived rogue connection: ignoring it.");
+        rogueCount.incrementAndGet();
+        return true;
     }
 
     static void readAndCompare (InputStream is, String cmp) throws IOException {

--- a/test/jdk/sun/net/www/protocol/https/HttpCallback.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,4 +36,15 @@ public interface HttpCallback {
      *        client and used to send the response
      */
     void request (HttpTransaction msg);
+
+    /**
+     * Tells whether the server should simply close the
+     * connection and ignore the request when the first
+     * byte received by the server looks like a plain
+     * text connection.
+     * @return true if the request should be ignored.
+     **/
+    default boolean dropPlainTextConnections() {
+        return false;
+    }
 }

--- a/test/jdk/sun/net/www/protocol/https/TestHttpsServer.java
+++ b/test/jdk/sun/net/www/protocol/https/TestHttpsServer.java
@@ -286,6 +286,7 @@ public class TestHttpsServer {
         HttpCallback cb;
         HandshakeStatus currentHSStatus;
         boolean initialHSComplete;
+        boolean handshakeStarted;
         /*
          * All inbound data goes through this buffer.
          *
@@ -334,6 +335,25 @@ public class TestHttpsServer {
 
                     case NEED_UNWRAP:
                         int bytes = schan.read(inNetBB);
+                        if (!handshakeStarted && bytes > 0) {
+                            handshakeStarted = true;
+                            int byte0 = inNetBB.get(0);
+                            if (byte0 != 0x16) {
+                                // first byte of a TLS connection is supposed to be
+                                // 0x16. If not it may be a plain text connection.
+                                //
+                                // Sometime a rogue client may try to open a plain
+                                // connection with our server. Calling this method
+                                // gives a chance to the test logic to ignore such
+                                // rogue connections.
+                                //
+                                if (cb.dropPlainTextConnections()) {
+                                    try { schan.close(); } catch (IOException x) { };
+                                    return;
+                                }
+                                // else sslEng.unwrap will throw later on...
+                            }
+                        }
 
 needIO:
                         while (currentHSStatus == HandshakeStatus.NEED_UNWRAP) {

--- a/test/jdk/sun/net/www/protocol/https/TestHttpsServer.java
+++ b/test/jdk/sun/net/www/protocol/https/TestHttpsServer.java
@@ -165,6 +165,14 @@ public class TestHttpsServer {
         return schan.socket().getLocalPort ();
     }
 
+    public String getAuthority() {
+        InetAddress address = schan.socket().getInetAddress();
+        String hostaddr = address.getHostAddress();
+        if (address.isAnyLocalAddress()) hostaddr = "localhost";
+        if (hostaddr.indexOf(':') > -1) hostaddr = "[" + hostaddr + "]";
+        return hostaddr + ":" + getLocalPort();
+    }
+
     static class Server extends Thread {
 
         ServerSocketChannel schan;


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.
test/jdk/sun/net/www/protocol/https/TestHttpsServer.java
'getAuthority()' is added because of TestHttpsServer does not have it, and later [JDK-8268464](https://bugs.openjdk.org/browse/JDK-8268464) will remove this class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8229481](https://bugs.openjdk.org/browse/JDK-8229481): sun/net/www/protocol/https/ChunkedOutputStream.java failed with a SSLException (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2037/head:pull/2037` \
`$ git checkout pull/2037`

Update a local copy of the PR: \
`$ git checkout pull/2037` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2037`

View PR using the GUI difftool: \
`$ git pr show -t 2037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2037.diff">https://git.openjdk.org/jdk11u-dev/pull/2037.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2037#issuecomment-1631985831)