### PR TITLE
8228341: SignTwice.java fails intermittently on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -613,7 +613,6 @@ sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8161536 generic-
 
 sun/security/tools/keytool/ListKeychainStore.sh                 8156889 macosx-all
 
-sun/security/tools/jarsigner/compatibility/SignTwice.java       8217375 windows-all
 sun/security/tools/jarsigner/warnings/BadKeyUsageTest.java      8026393 generic-all
 
 javax/net/ssl/DTLS/PacketLossRetransmission.java                8169086 macosx-x64

--- a/test/jdk/sun/security/tools/jarsigner/compatibility/SignTwice.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/SignTwice.java
@@ -36,7 +36,7 @@
  * @test
  * @library /test/lib ../warnings
  * @compile Compatibility.java
- * @run main/othervm/timeout=2500
+ * @run main/othervm/timeout=600
  *  -Djava.security.properties=./java.security
  *  -Duser.language=en
  *  -Duser.country=US
@@ -46,8 +46,8 @@
  *  -DtestComprehensiveJarContents=true
  *  -DtestJarUpdate=true
  *  -Dstrict=true
- *  -DkeyAlgs=EC;#RSA;#DSA;
- *  -DdigestAlgs=SHA-512
+ *  -DkeyAlgs=EC;0
+ *  -DdigestAlgs=SHA-256
  *  SignTwice
  */
 public class SignTwice {


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.
test/jdk/ProblemList.txt
Resolved due to context

test/jdk/sun/security/tools/jarsigner/compatibility/SignTwice.java
Resolved due to context

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8228341](https://bugs.openjdk.org/browse/JDK-8228341): SignTwice.java fails intermittently on Windows (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2039/head:pull/2039` \
`$ git checkout pull/2039`

Update a local copy of the PR: \
`$ git checkout pull/2039` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2039`

View PR using the GUI difftool: \
`$ git pr show -t 2039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2039.diff">https://git.openjdk.org/jdk11u-dev/pull/2039.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2039#issuecomment-1632154199)