### PR TITLE
8222323: ChildAlwaysOnTopTest.java fails with "RuntimeException: Failed to unset alwaysOnTop"

### DIFF
--- a/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
+++ b/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
+++ b/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,142 +21,236 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @key headful
- * @summary setAlwaysOnTop doesn't behave correctly in Linux/Solaris under
- *          certain scenarios
  * @bug 8021961
- * @author Semyon Sadetsky
+ * @summary To test setAlwaysOnTop functionality.
  * @run main/othervm -Dsun.java2d.uiScale=1 ChildAlwaysOnTopTest
  */
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.Window;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
+
+import java.io.File;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
 
 public class ChildAlwaysOnTopTest {
 
     private static Window win1;
     private static Window win2;
     private static Point point;
+    private static Robot robot;
+    private static int caseNo = 0;
+    private static StringBuffer errorLog = new StringBuffer();
+    private static String[] errorMsg= new String[] {
+            " Scenario 1 Failed: alwaysOnTop window is sent back by another" +
+                    " child window with setVisible().",
+            " Scenario 2 Failed: alwaysOnTop window is" +
+                    " sent back by another child window with toFront().",
+            " Scenario 3 Failed: Failed to unset alwaysOnTop ",
+    };
 
     public static void main(String[] args) throws Exception {
-        if( Toolkit.getDefaultToolkit().isAlwaysOnTopSupported() ) {
 
-
-            test(null);
-
-            Window f = new Frame();
-            f.setBackground(Color.darkGray);
-            f.setSize(500, 500);
-            try {
-                test(f);
-            } finally {
-                f.dispose();
-            }
-
-            f = new Frame();
-            f.setBackground(Color.darkGray);
-            f.setSize(500, 500);
-            f.setVisible(true);
-            f = new Dialog((Frame)f);
-            try {
-                test(f);
-            } finally {
-                ((Frame)f.getParent()).dispose();
-            }
+        if (!Toolkit.getDefaultToolkit().isAlwaysOnTopSupported()) {
+            System.out.println("alwaysOnTop not supported by: "+
+                    Toolkit.getDefaultToolkit().getClass().getName());
+            return;
         }
-        System.out.println("ok");
+
+        // CASE 1 - JDialog without parent/owner
+        System.out.println("Testing CASE 1: JDialog without parent/owner");
+        caseNo = 1;
+        test(null);
+        System.out.println("CASE 1 Completed");
+        System.out.println();
+
+        // CASE 2 - JDialog with JFrame as owner
+        System.out.println("Testing CASE 2: JDialog with JFrame as owner");
+        caseNo = 2;
+        Window f = new Frame();
+        f.setBackground(Color.darkGray);
+        f.setSize(500, 500);
+        try {
+            test(f);
+        } finally {
+            f.dispose();
+        }
+        System.out.println("CASE 2 Completed");
+        System.out.println();
+
+        // CASE 3 - JDialog within another JDialog as owner
+        System.out.println("Testing CASE 3:Dialog within another"+
+                " JDialog as owner");
+        caseNo = 3;
+        f = new Frame();
+        f.setBackground(Color.darkGray);
+        f.setSize(500, 500);
+        f.setVisible(true);
+        f = new Dialog((Frame)f);
+        try {
+            test(f);
+        } finally {
+            ((Frame)f.getParent()).dispose();
+        }
+        System.out.println("CASE 3 Completed");
+        System.out.println();
+
+        if (errorLog.length() == 0)
+            System.out.println("All three cases passed !!");
+        }
+        else {
+            throw new RuntimeException("Following cases and scenarios failed."+
+                    " Please check the saved screenshots.\n"+ errorLog);
+        }
     }
 
     public static void test(Window parent) throws Exception {
-        SwingUtilities.invokeAndWait(new Runnable() {
-            @Override
-            public void run() {
-                win1 = parent == null ? new JDialog() : new JDialog(parent);
-                win1.setName("top");
-                win2 = parent == null ? new JDialog() : new JDialog(parent);
-                win2.setName("behind");
-                win1.setSize(200, 200);
-                Panel panel = new Panel();
-                panel.setBackground(Color.GREEN);
-                win1.add(panel);
-                panel = new Panel();
-                panel.setBackground(Color.RED);
-                win2.add(panel);
-                win1.setAlwaysOnTop(true);
-                win2.setAlwaysOnTop(false);
-                win1.setVisible(true);
-            }
-        });
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
+                @Override
+                public void run() {
+                    win1 = parent == null ? new JDialog() : new JDialog(parent);
+                    win1.setName("Top");
 
-        Robot robot = new Robot();
-        robot.delay(500);
-        robot.waitForIdle();
+                    win2 = parent == null ? new JDialog() : new JDialog(parent);
+                    win2.setName("Behind");
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            @Override
-            public void run() {
+                    JLabel label = new JLabel("TOP WINDOW");
+                    // top window - green and smaller
+                    win1.setSize(200, 200);
+                    Panel panel = new Panel();
+                    panel.setBackground(Color.GREEN);
+                    panel.add(label);
+                    win1.add(panel);
+                    win1.setAlwaysOnTop(true);
+
+                    // behind window - red and bigger
+                    label = new JLabel("BEHIND WINDOW");
+                    win2.setSize(300, 300);
+                    panel = new Panel();
+                    panel.setBackground(Color.RED);
+                    panel.add(label);
+                    win2.add(panel);
+
+                    win1.setVisible(true);
+                    win2.setVisible(true);
+                }
+            });
+
+            robot = new Robot();
+            robot.setAutoDelay(300);
+            robot.waitForIdle();
+
+            // Scenario 1: Trying to unset the alwaysOnTop (green window)
+            // by setting the setVisible to true for behind (red) window
+            System.out.println(" >> Testing Scenario 1 ...");
+            SwingUtilities.invokeAndWait(()-> {
                 point = win1.getLocationOnScreen();
-                win2.setBounds(win1.getBounds());
                 win2.setVisible(true);
-            }
-        });
+            });
 
-        robot.delay(500);
-        robot.waitForIdle();
+            checkTopWindow(caseNo, 1, Color.GREEN);
 
-        Color color = robot.getPixelColor(point.x + 100, point.y + 100);
-        if(!color.equals(Color.GREEN)) {
-            win1.dispose();
-            win2.dispose();
-            throw new RuntimeException("alawaysOnTop window is sent back by " +
-                    "another child window setVisible(). " + color);
-        }
+            /*---------------------------------------------------------------*/
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            @Override
-            public void run() {
+            // Scenario 2: Trying to unset the alwaysOnTop (green window)
+            // by setting toFront() to true for behind (red) window
+            System.out.println(" >> Testing Scenario 2 ...");
+            SwingUtilities.invokeAndWait(()-> {
                 win2.toFront();
                 if (parent != null) {
                     parent.setLocation(win1.getLocation());
                     parent.toFront();
                 }
-            }
-        });
+            });
 
-        robot.delay(500);
-        robot.waitForIdle();
+            checkTopWindow(caseNo, 2, Color.GREEN);
 
-        color = robot.getPixelColor(point.x + 100, point.y + 100);
-        if(!color.equals(Color.GREEN)) {
-            win1.dispose();
-            win2.dispose();
-            throw new RuntimeException("alawaysOnTop window is sent back by " +
-                    "another child window toFront(). " + color);
-        }
+            /*----------------------------------------------------------------*/
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            @Override
-            public void run() {
-                win1.setAlwaysOnTop(false);
-                if (parent != null) {
-                    parent.setVisible(false);
-                    parent.setVisible(true);
+            // Scenario 3: Trying to unset the alwaysOnTop (green window)
+            // by setting alwaysOnTop to false. The unsetting should work
+            // in this case and bring the red window to the top.
+            System.out.println(" >> Testing Scenario 3 ...");
+            SwingUtilities.invokeAndWait(new Runnable() {
+                @Override
+                public void run() {
+                    win1.setAlwaysOnTop(false);
+                    if (parent != null) {
+                        parent.setVisible(false);
+                        parent.setVisible(true);
+                    }
                 }
-                win2.toFront();
+            });
+
+            robot.delay(300);
+            robot.waitForIdle();
+
+            SwingUtilities.invokeAndWait(new Runnable() {
+                @Override
+                public void run() {
+                    win2.toFront();
+                }
+            });
+
+            checkTopWindow(caseNo, 3, Color.RED);
+
+        } finally {
+            if (win1 != null) {
+                SwingUtilities.invokeAndWait(()-> win1.dispose());
             }
-        });
+            if (win2 != null) {
+                SwingUtilities.invokeAndWait(()-> win2.dispose());
+            }
+        }
+    }
+    // to check if the current top window background color
+    // matches the expected color
+    private static void checkTopWindow(int caseNo, int scenarioNo,
+                                       Color expectedColor) {
 
         robot.delay(500);
         robot.waitForIdle();
+        Color actualColor = robot.getPixelColor(point.x + 100, point.y + 100);
 
-        color = robot.getPixelColor(point.x + 100, point.y + 100);
-        if(!color.equals(Color.RED)) {
-            throw new RuntimeException("Failed to unset alawaysOnTop " + color);
+        saveScreenCapture(caseNo , scenarioNo);
+
+        if (!actualColor.equals(expectedColor)) {
+            System.out.println(" >> Scenario "+ scenarioNo +" FAILED !!");
+            errorLog.append("Case "+ caseNo + errorMsg[scenarioNo - 1]
+                    +" Expected Color: "+ expectedColor +" vs Actual Color: "
+                    + actualColor +"\n");
         }
+        else {
+            System.out.println(" >> Scenario "+ scenarioNo +" Passed");
+        }
+    }
 
-        win1.dispose();
-        win2.dispose();
+    // For Debugging purpose - method used to save the screen capture as
+    // BufferedImage in the event the test fails
+    private static void saveScreenCapture(int caseNo, int scenarioNo) {
+        String filename = "img_"+ caseNo +"_"+ scenarioNo;
+        BufferedImage image = robot.createScreenCapture(
+                new Rectangle(0, 0, 500, 500));
+        try {
+            ImageIO.write(image, "png", new File(filename));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
+++ b/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi,

This is a backport of JDK-8222323: ChildAlwaysOnTopTest.java fails with "RuntimeException: Failed to unset alwaysOnTop"

ChildAlwaysOnTopTest.java is not excluded by ProblemList in 11u. But I detected the test failed on Windows Server 2016.

Also original patch does not apply cleanly to 11u, because the fix uses "StringBuffer.isEmpty()" published in JDK15. I fixed the test so as not to use "StringBuffer.isEmpty()".

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8222323](https://bugs.openjdk.org/browse/JDK-8222323): ChildAlwaysOnTopTest.java fails with "RuntimeException: Failed to unset alwaysOnTop" (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2040/head:pull/2040` \
`$ git checkout pull/2040`

Update a local copy of the PR: \
`$ git checkout pull/2040` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2040`

View PR using the GUI difftool: \
`$ git pr show -t 2040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2040.diff">https://git.openjdk.org/jdk11u-dev/pull/2040.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2040#issuecomment-1633811874)