### PR TITLE
8270331: [TESTBUG] Error: Not a test or directory containing tests: java/awt/print/PrinterJob/InitToBlack.java

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/InitToBlack.java
+++ b/test/jdk/java/awt/print/PrinterJob/InitToBlack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,21 +22,57 @@
  */
 
 /**
+ * @test
  * @bug 4184565
  * @summary Confirm that the default foreground color on a printer
  *          graphics object is black so that rendering will appear
  *          without having to execute setColor first.
- * @run applet/manual=yesno InitToBlack.html
+ * @run main/manual InitToBlack
  */
 
-import java.awt.*;
-import java.awt.print.*;
-import java.applet.Applet;
+import java.awt.BorderLayout;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.print.Book;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
 
-public class InitToBlack extends Applet implements Printable {
+public class InitToBlack implements Printable {
 
-    public void init() {
+    private static volatile JFrame frame;
+    private static volatile boolean testResult = false;
+    private static volatile CountDownLatch printButtonCountDownLatch =
+            new CountDownLatch(1);
+    private static volatile CountDownLatch CountDownLatch =
+            new CountDownLatch(1);
+    private static volatile String failureReason;
+
+    @Override
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
+        Graphics2D g2d = (Graphics2D) graphics;
+        g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
+        graphics.drawString("Test Passes", 200, 200);
+        return PAGE_EXISTS;
+    }
+
+    private void test() {
         PrinterJob pjob = PrinterJob.getPrinterJob();
+        if (pjob.getPrintService() == null) {
+            System.out.println("There is no printer configured on this system");
+            return;
+        }
 
         Book book = new Book();
         book.append(this, pjob.defaultPage());
@@ -49,17 +85,97 @@ public class InitToBlack extends Applet implements Printable {
         }
     }
 
-    public int print(Graphics g, PageFormat pf, int pageIndex) {
-        Graphics2D g2d = (Graphics2D) g;
-        g2d.translate(pf.getImageableX(), pf.getImageableY());
+    private static void createTestUI() {
+        frame = new JFrame("Test InitToBlack");
+        String INSTRUCTION = """
+                Aim: This test checks whether the default foreground color on a printer
+                graphics object is black so that rendering will appear without having
+                to execute setColor.
+                Step:
+                1) Click on the "Print" button. Check whether page is printed on the printer.
+                2) Check whether "Test Passes" is printed on the page and it should be in
+                black color. If yes then press "Pass" button else press "Fail" button.
+                """;
+        JTextArea instructionTextArea = new JTextArea(INSTRUCTION, 4, 40);
+        instructionTextArea.setEditable(false);
 
-        g.drawString("Test Passes", 200, 200);
+        JPanel buttonPanel = new JPanel();
+        JButton printButton = new JButton("Print");
+        printButton.addActionListener((ae) -> {
+            InitToBlack initToBlack = new InitToBlack();
+            initToBlack.test();
+            printButtonCountDownLatch.countDown();
+        });
 
-        return PAGE_EXISTS;
+        JButton passButton = new JButton("Pass");
+        passButton.addActionListener((ae) -> {
+            testResult = true;
+            CountDownLatch.countDown();
+            frame.dispose();
+        });
+        JButton failButton = new JButton("Fail");
+        failButton.addActionListener((ae) -> {
+            getFailureReason();
+            frame.dispose();
+        });
+        buttonPanel.add(printButton);
+        buttonPanel.add(passButton);
+        buttonPanel.add(failButton);
+
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.add(instructionTextArea, BorderLayout.CENTER);
+        panel.add(buttonPanel, BorderLayout.SOUTH);
+
+        frame.add(panel);
+        frame.setLocationRelativeTo(null);
+        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        frame.pack();
+        frame.setVisible(true);
     }
 
-    public static void main(String[] args) {
-        new InitToBlack().init();
-        System.exit(0);
+    public static void getFailureReason() {
+        final JDialog dialog = new JDialog();
+        dialog.setTitle("Read testcase failure reason");
+        JPanel jPanel = new JPanel(new BorderLayout());
+        JTextArea jTextArea = new JTextArea(5, 20);
+
+        JButton okButton = new JButton("Ok");
+        okButton.addActionListener((ae) -> {
+            failureReason = jTextArea.getText();
+            testResult = false;
+            CountDownLatch.countDown();
+            dialog.dispose();
+        });
+
+        jPanel.add(new JLabel("Enter the testcase failed reason below and " +
+                "click OK button", JLabel.CENTER), BorderLayout.NORTH);
+        jPanel.add(jTextArea, BorderLayout.CENTER);
+
+        JPanel okayBtnPanel = new JPanel();
+        okayBtnPanel.add(okButton);
+
+        jPanel.add(okayBtnPanel, BorderLayout.SOUTH);
+        dialog.add(jPanel);
+        dialog.setLocationRelativeTo(null);
+        dialog.pack();
+        dialog.setVisible(true);
+    }
+
+    public static void main(String[] args) throws InterruptedException, InvocationTargetException {
+        SwingUtilities.invokeAndWait(InitToBlack::createTestUI);
+        if (!printButtonCountDownLatch.await(2, TimeUnit.MINUTES)) {
+            throw new RuntimeException("Timeout: User did not perform action " +
+                    "on Print button.");
+        }
+        if (!CountDownLatch.await(2, TimeUnit.MINUTES)) {
+            throw new RuntimeException("Timeout : User did not decide " +
+                    "whether test passed or failed");
+        }
+
+        if (!testResult) {
+            throw new RuntimeException("Test failed : " + failureReason);
+        } else {
+            System.out.println("Test Passed");
+        }
     }
 }

--- a/test/jdk/java/awt/print/PrinterJob/InitToBlack.java
+++ b/test/jdk/java/awt/print/PrinterJob/InitToBlack.java
@@ -87,15 +87,13 @@ public class InitToBlack implements Printable {
 
     private static void createTestUI() {
         frame = new JFrame("Test InitToBlack");
-        String INSTRUCTION = """
-                Aim: This test checks whether the default foreground color on a printer
-                graphics object is black so that rendering will appear without having
-                to execute setColor.
-                Step:
-                1) Click on the "Print" button. Check whether page is printed on the printer.
-                2) Check whether "Test Passes" is printed on the page and it should be in
-                black color. If yes then press "Pass" button else press "Fail" button.
-                """;
+        String INSTRUCTION = "Aim: This test checks whether the default foreground color on a printer\n" +
+                "graphics object is black so that rendering will appear without having\n" +
+                "to execute setColor.\n" +
+                "Step:\n" +
+                "1) Click on the \"Print\" button. Check whether page is printed on the printer.\n" +
+                "2) Check whether \"Test Passes\" is printed on the page and it should be in\n" +
+                "black color. If yes then press \"Pass\" button else press \"Fail\" button.\n";
         JTextArea instructionTextArea = new JTextArea(INSTRUCTION, 4, 40);
         instructionTextArea.setEditable(false);
 


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.
'String INSTRUCTION' is modified because of text block is not supported in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270331](https://bugs.openjdk.org/browse/JDK-8270331): [TESTBUG] Error: Not a test or directory containing tests: java/awt/print/PrinterJob/InitToBlack.java (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2042/head:pull/2042` \
`$ git checkout pull/2042`

Update a local copy of the PR: \
`$ git checkout pull/2042` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2042`

View PR using the GUI difftool: \
`$ git pr show -t 2042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2042.diff">https://git.openjdk.org/jdk11u-dev/pull/2042.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2042#issuecomment-1637317923)