### PR TITLE
8312138: jcmd VM.metaspace vslist has no newline character before the Class: label.

### DIFF
--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -758,6 +758,7 @@ void MetaspaceUtils::print_report(outputStream* out, size_t scale, int flags) {
       out->print_cr("   Non-Class:");
     }
     Metaspace::space_list()->print_on(out, scale);
+    out->cr();
     if (Metaspace::using_class_space()) {
       out->print_cr("       Class:");
       Metaspace::class_space_list()->print_on(out, scale);


### PR DESCRIPTION
I would like to fix this issue because the logs are not easy to read and users can misread the useful logs.
Could anyone review the fix please?

There is a test to verify VM.metaspace vslist in hotspot/jtreg/runtime/Metaspace/PrintMetaspaceDcmd.java,
but it does not check this issue.
I think we do not need to add a new test to the jtreg test sets, once we verified that the logs are output correctly.

The issue has been fixed since jdk17 as one of the fixes for JDK-8251158.
The fix I propose is not a backport of JDK-8251158.
I imported the fix from https://github.com/openjdk/jdk/blob/7ba6a6bf003b810e9f48cb755abe39b1376ad3fe/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp#L254

I verified that a newline character is added before the "Class:" label and the logs are easier to read before fix: 

Virtual space lists:
   Non-Class:
1 nodes, current node: 0x00007f3b5c09a650

node @0x00007f3b5c09a650: reserved=8.00 MB, committed=4.25 MB ( 53%), used=4.19 MB ( 52%)
   [0x00007f3b2f800000, 0x00007f3b2fc30000, 0x00007f3b2fc40000, 0x00007f3b30000000)
       Class:
1 nodes, current node: 0x00007f3b5c09a450

node @0x00007f3b5c09a450: reserved=1.00 GB, committed=512.00 KB ( <1%), used=398.00 KB ( <1%)
   [0x0000000100000000, 0x0000000100063800, 0x0000000100080000, 0x0000000140000000)

I also verifyed  hotspot_all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312138](https://bugs.openjdk.org/browse/JDK-8312138): jcmd VM.metaspace vslist has no newline character before the Class: label. (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2043/head:pull/2043` \
`$ git checkout pull/2043`

Update a local copy of the PR: \
`$ git checkout pull/2043` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2043`

View PR using the GUI difftool: \
`$ git pr show -t 2043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2043.diff">https://git.openjdk.org/jdk11u-dev/pull/2043.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2043#issuecomment-1637431111)