### PR TITLE
8275303: sun/java2d/pipe/InterpolationQualityTest.java fails with D3D basic render driver

### DIFF
--- a/src/java.desktop/windows/native/libawt/java2d/d3d/D3DBadHardware.h
+++ b/src/java.desktop/windows/native/libawt/java2d/d3d/D3DBadHardware.h
@@ -54,6 +54,9 @@ static const ADAPTER_INFO badHardware[] = {
     // All Intel Chips.
     { 0x8086, ALL_DEVICEIDS, NO_VERSION, OS_ALL },
 
+    // Microsoft Basic Render Driver (as maybe used in VMs such as VirtualBox)
+    { 0x1414, 0x008c, NO_VERSION, OS_ALL },
+
     // ATI Mobility Radeon X1600, X1400, X1450, X1300, X1350
     // Reason: workaround for 6613066, 6687166
     // X1300 (four sub ids)


### PR DESCRIPTION
I backport this for parity with 17.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275303](https://bugs.openjdk.org/browse/JDK-8275303): sun/java2d/pipe/InterpolationQualityTest.java fails with D3D basic render driver (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2044/head:pull/2044` \
`$ git checkout pull/2044`

Update a local copy of the PR: \
`$ git checkout pull/2044` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2044`

View PR using the GUI difftool: \
`$ git pr show -t 2044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2044.diff">https://git.openjdk.org/jdk11u-dev/pull/2044.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2044#issuecomment-1637530119)