### PR TITLE
8297681: Unnecessary color conversion during 4BYTE_ABGR_PRE to INT_ARGB_PRE blit

### DIFF
--- a/src/java.desktop/share/native/libawt/java2d/loops/FourByteAbgrPre.c
+++ b/src/java.desktop/share/native/libawt/java2d/loops/FourByteAbgrPre.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,6 +69,8 @@ DECLARE_SRCOVER_MASKBLIT(IntArgb, FourByteAbgrPre);
 DECLARE_ALPHA_MASKBLIT(IntArgb, FourByteAbgrPre);
 DECLARE_SRCOVER_MASKBLIT(IntArgbPre, FourByteAbgrPre);
 DECLARE_ALPHA_MASKBLIT(IntArgbPre, FourByteAbgrPre);
+DECLARE_SRCOVER_MASKBLIT(FourByteAbgrPre, IntArgbPre);
+DECLARE_ALPHA_MASKBLIT(FourByteAbgrPre, IntArgbPre);
 DECLARE_ALPHA_MASKBLIT(IntRgb, FourByteAbgrPre);
 DECLARE_SOLID_DRAWGLYPHLISTAA(FourByteAbgrPre);
 DECLARE_SOLID_DRAWGLYPHLISTLCD(FourByteAbgrPre);
@@ -103,6 +105,8 @@ NativePrimitive FourByteAbgrPrePrimitives[] = {
     REGISTER_ALPHA_MASKBLIT(IntArgb, FourByteAbgrPre),
     REGISTER_SRCOVER_MASKBLIT(IntArgbPre, FourByteAbgrPre),
     REGISTER_ALPHA_MASKBLIT(IntArgbPre, FourByteAbgrPre),
+    REGISTER_SRCOVER_MASKBLIT(FourByteAbgrPre, IntArgbPre),
+    REGISTER_ALPHA_MASKBLIT(FourByteAbgrPre, IntArgbPre),
     REGISTER_ALPHA_MASKBLIT(IntRgb, FourByteAbgrPre),
     REGISTER_SOLID_DRAWGLYPHLISTAA(FourByteAbgrPre),
     REGISTER_SOLID_DRAWGLYPHLISTLCD(FourByteAbgrPre),
@@ -176,6 +180,10 @@ DEFINE_ALPHA_MASKBLIT(IntArgb, FourByteAbgrPre, 4ByteArgb)
 DEFINE_SRCOVER_MASKBLIT(IntArgbPre, FourByteAbgrPre, 4ByteArgb)
 
 DEFINE_ALPHA_MASKBLIT(IntArgbPre, FourByteAbgrPre, 4ByteArgb)
+
+DEFINE_SRCOVER_MASKBLIT(FourByteAbgrPre, IntArgbPre, 4ByteArgb)
+
+DEFINE_ALPHA_MASKBLIT(FourByteAbgrPre, IntArgbPre, 4ByteArgb)
 
 DEFINE_ALPHA_MASKBLIT(IntRgb, FourByteAbgrPre, 4ByteArgb)
 

--- a/test/jdk/sun/java2d/loops/SkipConversionIfPossible.java
+++ b/test/jdk/sun/java2d/loops/SkipConversionIfPossible.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AlphaComposite;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.util.Arrays;
+
+import static java.awt.image.BufferedImage.TYPE_3BYTE_BGR;
+import static java.awt.image.BufferedImage.TYPE_4BYTE_ABGR;
+import static java.awt.image.BufferedImage.TYPE_4BYTE_ABGR_PRE;
+import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
+import static java.awt.image.BufferedImage.TYPE_INT_ARGB_PRE;
+import static java.awt.image.BufferedImage.TYPE_INT_BGR;
+import static java.awt.image.BufferedImage.TYPE_INT_RGB;
+
+/**
+ * @test
+ * @bug 8297681
+ * @summary The blit TYPE_4BYTE_ABGR_PRE to TYPE_INT_ARGB_PRE should be "direct"
+ */
+public final class SkipConversionIfPossible {
+
+    private static final int SIZE = 256;
+
+    public static void main(String[] args) {
+        // Initial bug was in the TYPE_4BYTE_ABGR_PRE to TYPE_INT_ARGB_PRE blit.
+        // But I checked other blits just in case.
+        test(new int[]{TYPE_INT_ARGB_PRE, TYPE_4BYTE_ABGR_PRE});
+        test(new int[]{TYPE_INT_RGB, TYPE_INT_BGR, TYPE_3BYTE_BGR});
+        test(new int[]{TYPE_INT_ARGB, TYPE_4BYTE_ABGR});
+    }
+
+    private static void test(int[] types) {
+        for (int src : types) {
+            for (int dst : types) {
+                render(src, dst);
+            }
+        }
+    }
+
+    private static void render(int src, int dst) {
+        BufferedImage from = new BufferedImage(SIZE, SIZE, src);
+        for (int a = 0; a < SIZE; ++a) {
+            for (int c = 0; c < SIZE; ++c) {
+                // The data is intentionally broken for the argb_pre format, but
+                // it should be stored as is in dst if no conversion was done.
+                from.getRaster().setPixel(c, a, new int[]{c, c << 24, -c, a});
+            }
+        }
+        BufferedImage to = new BufferedImage(SIZE, SIZE, dst);
+        Graphics2D g = to.createGraphics();
+        g.setComposite(AlphaComposite.Src);
+        g.drawImage(from, 0, 0, null);
+        g.dispose();
+
+        for (int a = 0; a < SIZE; ++a) {
+            for (int c = 0; c < SIZE; ++c) {
+                int[] pixel1 = from.getRaster().getPixel(c, a, (int[]) null);
+                int[] pixel2 = to.getRaster().getPixel(c, a, (int[]) null);
+                if (!Arrays.equals(pixel1, pixel2)) {
+                    System.err.println(Arrays.toString(pixel1));
+                    System.err.println(Arrays.toString(pixel2));
+                    throw new RuntimeException();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [8ffed34e](https://github.com/openjdk/jdk/commit/8ffed34e1da0ad2b9b6503f13831843dadfed319) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 30 Nov 2022 and was reviewed by Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297681](https://bugs.openjdk.org/browse/JDK-8297681): Unnecessary color conversion during 4BYTE_ABGR_PRE to INT_ARGB_PRE blit (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2045/head:pull/2045` \
`$ git checkout pull/2045`

Update a local copy of the PR: \
`$ git checkout pull/2045` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2045`

View PR using the GUI difftool: \
`$ git pr show -t 2045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2045.diff">https://git.openjdk.org/jdk11u-dev/pull/2045.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2045#issuecomment-1638918952)