### PR TITLE
8277353: java/security/MessageDigest/ThreadSafetyTest.java test times out

### DIFF
--- a/test/jdk/java/security/MessageDigest/ThreadSafetyTest.java
+++ b/test/jdk/java/security/MessageDigest/ThreadSafetyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Azul Systems, Inc. All rights reserved.
+ * Copyright (c) 2020, 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,9 @@
 
 /*
  * @test
- * @bug 8241960
+ * @bug 8241960 8277353
  * @summary Confirm that java.security.MessageDigest is thread-safe after clone.
- * @run main/othervm ThreadSafetyTest 5 4
+ * @run main ThreadSafetyTest 4 2
  */
 
 import java.security.MessageDigest;
@@ -56,7 +56,7 @@ public class ThreadSafetyTest {
             duration = Integer.parseInt(args[1]);
         }
         int nProcessors = Runtime.getRuntime().availableProcessors();
-        int nTasks = nProcessors * threadsFactor;
+        int nTasks = Math.min(nProcessors, 4) * threadsFactor;
 
         System.out.println("Testing with " + nTasks + " threads on " +
                            nProcessors + " processors for " + duration +


### PR DESCRIPTION
I backport this for parity with 17.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277353](https://bugs.openjdk.org/browse/JDK-8277353): java/security/MessageDigest/ThreadSafetyTest.java test times out (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2048/head:pull/2048` \
`$ git checkout pull/2048`

Update a local copy of the PR: \
`$ git checkout pull/2048` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2048`

View PR using the GUI difftool: \
`$ git pr show -t 2048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2048.diff">https://git.openjdk.org/jdk11u-dev/pull/2048.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2048#issuecomment-1640122688)