### PR TITLE
8257993: vmTestbase/nsk/jvmti/RedefineClasses/StressRedefine/TestDescription.java crash intermittently

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -854,24 +854,18 @@ void InterpreterRuntime::resolve_invoke(JavaThread* thread, Bytecodes::Code byte
   CallInfo info;
   constantPoolHandle pool(thread, last_frame.method()->constants());
 
+  methodHandle resolved_method;
+
   {
     JvmtiHideSingleStepping jhss(thread);
     LinkResolver::resolve_invoke(info, receiver, pool,
                                  last_frame.get_index_u2_cpcache(bytecode), bytecode,
                                  CHECK);
-    if (JvmtiExport::can_hotswap_or_post_breakpoint()) {
-      int retry_count = 0;
-      while (info.resolved_method()->is_old()) {
-        // It is very unlikely that method is redefined more than 100 times
-        // in the middle of resolve. If it is looping here more than 100 times
-        // means then there could be a bug here.
-        guarantee((retry_count++ < 100),
-                  "Could not resolve to latest version of redefined method");
-        // method is redefined in the middle of resolve so re-try.
-        LinkResolver::resolve_invoke(info, receiver, pool,
-                                     last_frame.get_index_u2_cpcache(bytecode), bytecode,
-                                     CHECK);
-      }
+
+    if (JvmtiExport::can_hotswap_or_post_breakpoint() && info.resolved_method()->is_old()) {
+      resolved_method = methodHandle(thread, info.resolved_method()->get_new_method());
+    } else {
+      resolved_method = info.resolved_method();
     }
   } // end JvmtiHideSingleStepping
 
@@ -881,22 +875,20 @@ void InterpreterRuntime::resolve_invoke(JavaThread* thread, Bytecodes::Code byte
 
 #ifdef ASSERT
   if (bytecode == Bytecodes::_invokeinterface) {
-    if (info.resolved_method()->method_holder() ==
-                                            SystemDictionary::Object_klass()) {
+    if (resolved_method->method_holder() == SystemDictionary::Object_klass()) {
       // NOTE: THIS IS A FIX FOR A CORNER CASE in the JVM spec
       // (see also CallInfo::set_interface for details)
       assert(info.call_kind() == CallInfo::vtable_call ||
              info.call_kind() == CallInfo::direct_call, "");
-      methodHandle rm = info.resolved_method();
-      assert(rm->is_final() || info.has_vtable_index(),
+      assert(resolved_method->is_final() || info.has_vtable_index(),
              "should have been set already");
-    } else if (!info.resolved_method()->has_itable_index()) {
+    } else if (!resolved_method->has_itable_index()) {
       // Resolved something like CharSequence.toString.  Use vtable not itable.
       assert(info.call_kind() != CallInfo::itable_call, "");
     } else {
       // Setup itable entry
       assert(info.call_kind() == CallInfo::itable_call, "");
-      int index = info.resolved_method()->itable_index();
+      int index = resolved_method->itable_index();
       assert(info.itable_index() == index, "");
     }
   } else if (bytecode == Bytecodes::_invokespecial) {
@@ -916,20 +908,20 @@ void InterpreterRuntime::resolve_invoke(JavaThread* thread, Bytecodes::Code byte
   case CallInfo::direct_call:
     cp_cache_entry->set_direct_call(
       bytecode,
-      info.resolved_method(),
+      resolved_method,
       sender->is_interface());
     break;
   case CallInfo::vtable_call:
     cp_cache_entry->set_vtable_call(
       bytecode,
-      info.resolved_method(),
+      resolved_method,
       info.vtable_index());
     break;
   case CallInfo::itable_call:
     cp_cache_entry->set_itable_call(
       bytecode,
       info.resolved_klass(),
-      info.resolved_method(),
+      resolved_method,
       info.itable_index());
     break;
   default:  ShouldNotReachHere();

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -861,7 +861,6 @@ void InterpreterRuntime::resolve_invoke(JavaThread* thread, Bytecodes::Code byte
     LinkResolver::resolve_invoke(info, receiver, pool,
                                  last_frame.get_index_u2_cpcache(bytecode), bytecode,
                                  CHECK);
-
     if (JvmtiExport::can_hotswap_or_post_breakpoint() && info.resolved_method()->is_old()) {
       resolved_method = methodHandle(thread, info.resolved_method()->get_new_method());
     } else {

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -984,6 +984,15 @@ class Method : public Metadata {
   // Deallocation function for redefine classes or if an error occurs
   void deallocate_contents(ClassLoaderData* loader_data);
 
+  Method* get_new_method() const {
+    InstanceKlass* holder = method_holder();
+    Method* new_method = holder->method_with_idnum(orig_method_idnum());
+
+    assert(new_method != NULL, "method_with_idnum() should not be null");
+    assert(this != new_method, "sanity check");
+    return new_method;
+  }
+
   // Printing
 #ifndef PRODUCT
   void print_on(outputStream* st) const;


### PR DESCRIPTION
This backport is for parity with 11.0.21-oracle

Patch (from jdk16) did not apply at all. Basically, it is a fresh implementation, guided by the original fix. Had to introduce new method "Method* get_new_method() const;" in method.hpp. Did not exist in 11.

Local testing successful.
SAP internal nightly build and test did not show any issues.
Reviewed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8257993](https://bugs.openjdk.org/browse/JDK-8257993): vmTestbase/nsk/jvmti/RedefineClasses/StressRedefine/TestDescription.java crash intermittently (**Bug** - P3)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [25c47887](https://git.openjdk.org/jdk11u-dev/pull/2051/files/25c478875973774cc10ad85fe472d449f2feb2cc)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2051/head:pull/2051` \
`$ git checkout pull/2051`

Update a local copy of the PR: \
`$ git checkout pull/2051` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2051`

View PR using the GUI difftool: \
`$ git pr show -t 2051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2051.diff">https://git.openjdk.org/jdk11u-dev/pull/2051.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2051#issuecomment-1644046509)