### PR TITLE
8286481: Exception printed to stdout on Windows when storing transparent image in clipboard

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WClipboard.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WClipboard.java
@@ -83,13 +83,7 @@ final class WClipboard extends SunClipboard {
                         translateTransferable(contents, flavor, format);
                     publishClipboardData(format, bytes);
                 } catch (IOException e) {
-                    // Fix 4696186: don't print exception if data with
-                    // javaJVMLocalObjectMimeType failed to serialize.
-                    // May remove this if-check when 5078787 is fixed.
-                    if (!(flavor.isMimeTypeEqual(DataFlavor.javaJVMLocalObjectMimeType) &&
-                          e instanceof java.io.NotSerializableException)) {
-                        e.printStackTrace();
-                    }
+                    // Cannot be translated in this format, skip
                 }
             }
         } finally {


### PR DESCRIPTION
This backport is for parity with 11.0.21-oracle

Patch applies cleanly. Nightly tests run without related issues..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286481](https://bugs.openjdk.org/browse/JDK-8286481): Exception printed to stdout on Windows when storing transparent image in clipboard (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2054/head:pull/2054` \
`$ git checkout pull/2054`

Update a local copy of the PR: \
`$ git checkout pull/2054` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2054`

View PR using the GUI difftool: \
`$ git pr show -t 2054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2054.diff">https://git.openjdk.org/jdk11u-dev/pull/2054.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2054#issuecomment-1645370211)