### PR TITLE
8313159: [11u] Fix test SSLEngineKeyLimit.java after Merge error

### DIFF
--- a/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineKeyLimit.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineKeyLimit.java
@@ -126,14 +126,9 @@ public class SSLEngineKeyLimit {
             System.out.println("test.java.opts: " +
                     System.getProperty("test.java.opts"));
 
-<<<<<<< HEAD
             ProcessBuilder pb = ProcessTools.createTestJvm(
-                    Utils.addTestJavaOpts("SSLEngineKeyLimit", "p", args[1]));
-=======
-            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
                     Utils.addTestJavaOpts("SSLEngineKeyLimit", "p", args[1],
                             args[2]));
->>>>>>> a829804de566fb89ad0fe45d242a09db24a5867c
 
             OutputAnalyzer output = ProcessTools.executeProcess(pb);
             try {


### PR DESCRIPTION
Remove resolve comments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313159](https://bugs.openjdk.org/browse/JDK-8313159): [11u] Fix test SSLEngineKeyLimit.java after Merge error (**Enhancement** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2057/head:pull/2057` \
`$ git checkout pull/2057`

Update a local copy of the PR: \
`$ git checkout pull/2057` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2057`

View PR using the GUI difftool: \
`$ git pr show -t 2057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2057.diff">https://git.openjdk.org/jdk11u-dev/pull/2057.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2057#issuecomment-1651202342)