### PR TITLE
8305733: Pattern.CASE_INSENSITIVE does not take effect in jdk11

### DIFF
--- a/src/java.base/share/classes/java/util/regex/CharPredicates.java
+++ b/src/java.base/share/classes/java/util/regex/CharPredicates.java
@@ -169,11 +169,15 @@ class CharPredicates {
 
     /////////////////////////////////////////////////////////////////////////////
 
-    private static CharPredicate getPosixPredicate(String name) {
+    private static CharPredicate getPosixPredicate(String name, boolean caseIns) {
         switch (name) {
             case "ALPHA": return ALPHABETIC();
-            case "LOWER": return LOWERCASE();
-            case "UPPER": return UPPERCASE();
+            case "LOWER": return caseIns
+                              ? LOWERCASE().union(UPPERCASE(), TITLECASE())
+                              : LOWERCASE();
+            case "UPPER": return caseIns
+                              ? UPPERCASE().union(LOWERCASE(), TITLECASE())
+                              : UPPERCASE();
             case "SPACE": return WHITE_SPACE();
             case "PUNCT": return PUNCTUATION();
             case "XDIGIT": return HEX_DIGIT();
@@ -187,7 +191,7 @@ class CharPredicates {
         }
     }
 
-    private static CharPredicate getUnicodePredicate(String name) {
+    private static CharPredicate getUnicodePredicate(String name, boolean caseIns) {
         switch (name) {
             case "ALPHABETIC": return ALPHABETIC();
             case "ASSIGNED": return ASSIGNED();
@@ -196,11 +200,17 @@ class CharPredicates {
             case "IDEOGRAPHIC": return IDEOGRAPHIC();
             case "JOINCONTROL": return JOIN_CONTROL();
             case "LETTER": return LETTER();
-            case "LOWERCASE": return LOWERCASE();
+            case "LOWERCASE": return caseIns
+                                  ? LOWERCASE().union(UPPERCASE(), TITLECASE())
+                                  : LOWERCASE();
             case "NONCHARACTERCODEPOINT": return NONCHARACTER_CODE_POINT();
-            case "TITLECASE": return TITLECASE();
+            case "TITLECASE": return caseIns
+                                  ? TITLECASE().union(LOWERCASE(), UPPERCASE())
+                                  : TITLECASE();
             case "PUNCTUATION": return PUNCTUATION();
-            case "UPPERCASE": return UPPERCASE();
+            case "UPPERCASE": return caseIns
+                                  ? UPPERCASE().union(LOWERCASE(), TITLECASE())
+                                  : UPPERCASE();
             case "WHITESPACE": return WHITE_SPACE();
             case "WORD": return WORD();
             case "WHITE_SPACE": return WHITE_SPACE();
@@ -211,16 +221,16 @@ class CharPredicates {
         }
     }
 
-    public static CharPredicate forUnicodeProperty(String propName) {
+    public static CharPredicate forUnicodeProperty(String propName, boolean caseIns) {
         propName = propName.toUpperCase(Locale.ROOT);
-        CharPredicate p = getUnicodePredicate(propName);
+        CharPredicate p = getUnicodePredicate(propName, caseIns);
         if (p != null)
             return p;
-        return getPosixPredicate(propName);
+        return getPosixPredicate(propName, caseIns);
     }
 
-    public static CharPredicate forPOSIXName(String propName) {
-        return getPosixPredicate(propName.toUpperCase(Locale.ENGLISH));
+    public static CharPredicate forPOSIXName(String propName, boolean caseIns) {
+        return getPosixPredicate(propName.toUpperCase(Locale.ENGLISH), caseIns);
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -254,14 +264,23 @@ class CharPredicates {
 
     // unicode categories, aliases, properties, java methods ...
 
-    static CharPredicate forProperty(String name) {
+    static CharPredicate forProperty(String name, boolean caseIns) {
         // Unicode character property aliases, defined in
         // http://www.unicode.org/Public/UNIDATA/PropertyValueAliases.txt
         switch (name) {
             case "Cn": return category(1<<Character.UNASSIGNED);
-            case "Lu": return category(1<<Character.UPPERCASE_LETTER);
-            case "Ll": return category(1<<Character.LOWERCASE_LETTER);
-            case "Lt": return category(1<<Character.TITLECASE_LETTER);
+            case "Lu": return category(caseIns ? (1 << Character.LOWERCASE_LETTER) |
+                                                 (1 << Character.UPPERCASE_LETTER) |
+                                                 (1 << Character.TITLECASE_LETTER)
+                                               : (1 << Character.UPPERCASE_LETTER));
+            case "Ll": return category(caseIns ? (1 << Character.LOWERCASE_LETTER) |
+                                                 (1 << Character.UPPERCASE_LETTER) |
+                                                 (1 << Character.TITLECASE_LETTER)
+                                               : (1 << Character.LOWERCASE_LETTER));
+            case "Lt": return category(caseIns ? (1 << Character.LOWERCASE_LETTER) |
+                                                 (1 << Character.UPPERCASE_LETTER) |
+                                                 (1 << Character.TITLECASE_LETTER)
+                                               : (1 << Character.TITLECASE_LETTER));
             case "Lm": return category(1<<Character.MODIFIER_LETTER);
             case "Lo": return category(1<<Character.OTHER_LETTER);
             case "Mn": return category(1<<Character.NON_SPACING_MARK);
@@ -338,32 +357,43 @@ class CharPredicates {
             case "Cntrl": return ctype(ASCII.CNTRL);  // Control characters
             case "Digit": return range('0', '9');     // Numeric characters
             case "Graph": return ctype(ASCII.GRAPH);  // printable and visible
-            case "Lower": return range('a', 'z');     // Lower-case alphabetic
+            case "Lower": return caseIns ? ctype(ASCII.ALPHA)
+                                         : range('a', 'z');     // Lower-case alphabetic
             case "Print": return range(0x20, 0x7E);   // Printable characters
             case "Punct": return ctype(ASCII.PUNCT);  // Punctuation characters
             case "Space": return ctype(ASCII.SPACE);  // Space characters
-            case "Upper": return range('A', 'Z');     // Upper-case alphabetic
+            case "Upper": return caseIns ? ctype(ASCII.ALPHA)
+                                         : range('A', 'Z');     // Upper-case alphabetic
             case "XDigit": return ctype(ASCII.XDIGIT); // hexadecimal digits
 
             // Java character properties, defined by methods in Character.java
-            case "javaLowerCase": return java.lang.Character::isLowerCase;
-            case "javaUpperCase": return  Character::isUpperCase;
-            case "javaAlphabetic": return java.lang.Character::isAlphabetic;
-            case "javaIdeographic": return java.lang.Character::isIdeographic;
-            case "javaTitleCase": return java.lang.Character::isTitleCase;
-            case "javaDigit": return java.lang.Character::isDigit;
-            case "javaDefined": return java.lang.Character::isDefined;
-            case "javaLetter": return java.lang.Character::isLetter;
-            case "javaLetterOrDigit": return java.lang.Character::isLetterOrDigit;
-            case "javaJavaIdentifierStart": return java.lang.Character::isJavaIdentifierStart;
-            case "javaJavaIdentifierPart": return java.lang.Character::isJavaIdentifierPart;
-            case "javaUnicodeIdentifierStart": return java.lang.Character::isUnicodeIdentifierStart;
-            case "javaUnicodeIdentifierPart": return java.lang.Character::isUnicodeIdentifierPart;
-            case "javaIdentifierIgnorable": return java.lang.Character::isIdentifierIgnorable;
-            case "javaSpaceChar": return java.lang.Character::isSpaceChar;
-            case "javaWhitespace": return java.lang.Character::isWhitespace;
-            case "javaISOControl": return java.lang.Character::isISOControl;
-            case "javaMirrored": return java.lang.Character::isMirrored;
+            case "javaLowerCase": return caseIns ? c -> Character.isLowerCase(c) ||
+                                                        Character.isUpperCase(c) ||
+                                                        Character.isTitleCase(c)
+                                                 : Character::isLowerCase;
+            case "javaUpperCase": return caseIns ? c -> Character.isUpperCase(c) ||
+                                                        Character.isLowerCase(c) ||
+                                                        Character.isTitleCase(c)
+                                                 : Character::isUpperCase;
+            case "javaAlphabetic": return Character::isAlphabetic;
+            case "javaIdeographic": return Character::isIdeographic;
+            case "javaTitleCase": return caseIns ? c -> Character.isTitleCase(c) ||
+                                                   Character.isLowerCase(c) ||
+                                                   Character.isUpperCase(c)
+                                            : Character::isTitleCase;
+            case "javaDigit": return Character::isDigit;
+            case "javaDefined": return Character::isDefined;
+            case "javaLetter": return Character::isLetter;
+            case "javaLetterOrDigit": return Character::isLetterOrDigit;
+            case "javaJavaIdentifierStart": return Character::isJavaIdentifierStart;
+            case "javaJavaIdentifierPart": return Character::isJavaIdentifierPart;
+            case "javaUnicodeIdentifierStart": return Character::isUnicodeIdentifierStart;
+            case "javaUnicodeIdentifierPart": return Character::isUnicodeIdentifierPart;
+            case "javaIdentifierIgnorable": return Character::isIdentifierIgnorable;
+            case "javaSpaceChar": return Character::isSpaceChar;
+            case "javaWhitespace": return Character::isWhitespace;
+            case "javaISOControl": return Character::isISOControl;
+            case "javaMirrored": return Character::isMirrored;
             default: return null;
         }
     }

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -2885,7 +2885,7 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
                     break;
                 case "gc":
                 case "general_category":
-                    p = CharPredicates.forProperty(value);
+                    p = CharPredicates.forProperty(value, has(CASE_INSENSITIVE));
                     break;
                 default:
                     break;
@@ -2901,17 +2901,17 @@ loop:   for(int x=0, offset=0; x<nCodePoints; x++, offset+=len) {
             } else if (name.startsWith("Is")) {
                 // \p{IsGeneralCategory} and \p{IsScriptName}
                 name = name.substring(2);
-                p = CharPredicates.forUnicodeProperty(name);
+                p = CharPredicates.forUnicodeProperty(name, has(CASE_INSENSITIVE));
                 if (p == null)
-                    p = CharPredicates.forProperty(name);
+                    p = CharPredicates.forProperty(name, has(CASE_INSENSITIVE));
                 if (p == null)
                     p = CharPredicates.forUnicodeScript(name);
             } else {
                 if (has(UNICODE_CHARACTER_CLASS)) {
-                    p = CharPredicates.forPOSIXName(name);
+                    p = CharPredicates.forPOSIXName(name, has(CASE_INSENSITIVE));
                 }
                 if (p == null)
-                    p = CharPredicates.forProperty(name);
+                    p = CharPredicates.forProperty(name, has(CASE_INSENSITIVE));
             }
             if (p == null)
                 throw error("Unknown character property name {In/Is" + name + "}");


### PR DESCRIPTION
fix [JDK-8305733](https://bugs.openjdk.org/browse/JDK-8305733)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305733](https://bugs.openjdk.org/browse/JDK-8305733): Pattern.CASE_INSENSITIVE does not take effect in jdk11 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2061/head:pull/2061` \
`$ git checkout pull/2061`

Update a local copy of the PR: \
`$ git checkout pull/2061` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2061`

View PR using the GUI difftool: \
`$ git pr show -t 2061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2061.diff">https://git.openjdk.org/jdk11u-dev/pull/2061.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2061#issuecomment-1653786408)