### PR TITLE
8243210: ClhsdbScanOops fails with NullPointerException in FileMapHeader.inCopiedVtableSpace

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/FileMapInfo.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/FileMapInfo.java
@@ -121,6 +121,9 @@ public class FileMapInfo {
     }
 
     public boolean inCopiedVtableSpace(Address vptrAddress) {
+      if (vptrAddress == null) {
+        return false;
+      }
       if (vptrAddress.greaterThan(mdRegionBaseAddress) &&
           vptrAddress.lessThanOrEqual(mdRegionEndAddress)) {
         return true;


### PR DESCRIPTION
We see this exact problem at customers, and the fix is trivial and no-risk, so lets get this fixed.

Unclean backport.

Differences:

- `src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/FileMapInfo.java` had been rewritten for `8263002: Remove CDS MiscCode region` but it does not affect the effectiveness of this patch.

- `test/hotspot/jtreg/ProblemList.txt`: the original patch re-includes the formerly excluded test `serviceability/sa/ClhsdbScanOops.java` for macos. That exclusion did not exist in 11, so I left the hunk out.

Tests:

I manually tested `serviceability/sa/ClhsdbScanOops.java` on Linux x64, seems fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8243210](https://bugs.openjdk.org/browse/JDK-8243210): ClhsdbScanOops fails with NullPointerException in FileMapHeader.inCopiedVtableSpace (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2066/head:pull/2066` \
`$ git checkout pull/2066`

Update a local copy of the PR: \
`$ git checkout pull/2066` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2066`

View PR using the GUI difftool: \
`$ git pr show -t 2066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2066.diff">https://git.openjdk.org/jdk11u-dev/pull/2066.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2066#issuecomment-1666026236)