### PR TITLE
8313803: [11u] Exclude jdk/jfr/event/sampling/TestStackFrameLineNumbers.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -859,9 +859,10 @@ javax/rmi/ssl/SSLSocketParametersTest.sh                        8162906 generic-
 # jdk_jfr
 
 jdk/jfr/event/sampling/TestNative.java                          8202142    generic-all
+jdk/jfr/event/sampling/TestStackFrameLineNumbers.java           8313802    linux-all,windows-all
 jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java          8228990,8229370    generic-all
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209    generic-all
 jdk/jfr/event/oldobject/TestLargeRootSet.java                   8205651    generic-all
- 
+
 ############################################################################
 


### PR DESCRIPTION
The test jdk/jfr/event/sampling/TestStackFrameLineNumbers.java is shaky, ever since it was brought to 11u with 11.0.12. Unless this can be improved we should exclude it to avoid noise in the CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313803](https://bugs.openjdk.org/browse/JDK-8313803): [11u] Exclude jdk/jfr/event/sampling/TestStackFrameLineNumbers.java (**Sub-task** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2067/head:pull/2067` \
`$ git checkout pull/2067`

Update a local copy of the PR: \
`$ git checkout pull/2067` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2067/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2067`

View PR using the GUI difftool: \
`$ git pr show -t 2067`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2067.diff">https://git.openjdk.org/jdk11u-dev/pull/2067.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2067#issuecomment-1666251100)