### PR TITLE
8181383: com/sun/jdi/OptionTest.java fails intermittently with bind failed: Address already in use

### DIFF
--- a/test/jdk/com/sun/jdi/OptionTest.java
+++ b/test/jdk/com/sun/jdi/OptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,6 @@
  * @run driver OptionTest
  */
 
-import java.net.ServerSocket;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class OptionTest extends Object {
@@ -127,18 +125,12 @@ public class OptionTest extends Object {
     }
 
     public static void main(String[] args) throws Exception {
-        // find a free port
-        ServerSocket ss = new ServerSocket(0);
-        int port = ss.getLocalPort();
-        ss.close();
-        String address = String.valueOf(port);
-
         String javaExe = System.getProperty("java.home") +
             java.io.File.separator + "bin" +
             java.io.File.separator + "java";
         String targetClass = "HelloWorld";
         String baseOptions = "transport=dt_socket" +
-                              ",address=" + address +
+                              ",address=0" +
                               ",server=y" +
                               ",suspend=n";
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of JDK-8181383, commit [f16ddb2c](https://github.com/openjdk/jdk17u-dev/commit/f16ddb2c3d0edb60ce0521fc0e3920f831dbb3bf) from the [openjdk/jdk17u-dev](https://git.openjdk.org/jdk17u-dev) repository.

The commit being backported was authored by Alex Menkov on 26 Feb 2019 and was reviewed by Serguei Spitsyn and Chris Plummer.

We see this error occasionally in our CI, so this backport will help to reduce noise.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8181383](https://bugs.openjdk.org/browse/JDK-8181383): com/sun/jdi/OptionTest.java fails intermittently with bind failed: Address already in use (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2068/head:pull/2068` \
`$ git checkout pull/2068`

Update a local copy of the PR: \
`$ git checkout pull/2068` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2068`

View PR using the GUI difftool: \
`$ git pr show -t 2068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2068.diff">https://git.openjdk.org/jdk11u-dev/pull/2068.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2068#issuecomment-1666252443)