### PR TITLE
8269091: javax/sound/sampled/Clip/SetPositionHang.java failed with ArrayIndexOutOfBoundsException: Array index out of range: -4

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
@@ -1377,8 +1377,9 @@ final class DirectAudioDevice extends AbstractMixer {
                     }
                 }
                 while (doIO && thread == curThread) {
-                    if (newFramePosition >= 0) {
-                        clipBytePosition = newFramePosition * frameSize;
+                    int npf = newFramePosition; // copy into local variable
+                    if (npf >= 0) {
+                        clipBytePosition = npf * frameSize;
                         newFramePosition = -1;
                     }
                     int endFrame = getFrameLength() - 1;

--- a/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
+++ b/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
@@ -28,7 +28,7 @@ import javax.sound.sampled.LineUnavailableException;
 
 /**
  * @test
- * @bug 8266421
+ * @bug 8266421 8269091
  * @summary Tests that Clip.setFramePosition/setMicrosecondPosition do not hang.
  */
 public final class SetPositionHang implements Runnable {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8269091](https://bugs.openjdk.org/browse/JDK-8269091), commit [b6a5d208](https://github.com/openjdk/jdk17u-dev/commit/b6a5d2082832c9d70051df8d4a5190f6a6faec58) from the [openjdk/jdk17u-dev](https://git.openjdk.org/jdk17u-dev) repository.

The commit being backported was authored by Matthias Baesken on 13 Jun 2023 and had no reviewers.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269091](https://bugs.openjdk.org/browse/JDK-8269091): javax/sound/sampled/Clip/SetPositionHang.java failed with ArrayIndexOutOfBoundsException: Array index out of range: -4 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2069/head:pull/2069` \
`$ git checkout pull/2069`

Update a local copy of the PR: \
`$ git checkout pull/2069` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2069`

View PR using the GUI difftool: \
`$ git pr show -t 2069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2069.diff">https://git.openjdk.org/jdk11u-dev/pull/2069.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2069#issuecomment-1667412067)