### PR TITLE
8314086: A typo in the fix for JDK-8312462 is causing test failure in ChildAlwaysOnTopTest.java

### DIFF
--- a/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
+++ b/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
@@ -110,7 +110,7 @@ public class ChildAlwaysOnTopTest {
         System.out.println("CASE 3 Completed");
         System.out.println();
 
-        if (errorLog.length() == 0)
+        if (errorLog.length() == 0) {
             System.out.println("All three cases passed !!");
         }
         else {


### PR DESCRIPTION
I\`d like to fix the bug reported in JDK-8314086.  
\`{\` is missing in ChildAlwaysOnTopTest.java as suggested in the issue.
This is causing compilation failure in ChildAlwaysOnTopTest.java. 
After fixing this typo, the test successfully passed.
