### PR TITLE
8306718: Optimize and opensource some old AWT tests

### DIFF
--- a/test/jdk/java/awt/EventDispatchThread/StoppingEdtOnPushPopTest.java
+++ b/test/jdk/java/awt/EventDispatchThread/StoppingEdtOnPushPopTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4848555
+  @summary Popping an event queue could cause its thread to restart inadvertently
+  @run main StoppingEdtOnPushPopTest
+*/
+
+import java.awt.AWTEvent;
+import java.awt.ActiveEvent;
+import java.awt.EventQueue;
+import java.awt.Toolkit;
+
+public class StoppingEdtOnPushPopTest implements Runnable {
+    public void start() {
+        int before = countEventQueues();
+        try {
+            for (int i = 0; i < 10; i++) {
+                EventQueue.invokeAndWait(this);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Test was interrupted");
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            e.printStackTrace();
+            throw new RuntimeException("InvocationTargetException occurred");
+        }
+        pause(1000);
+        int after = countEventQueues();
+        if (before < after && after > 1) {
+            throw new RuntimeException("Test failed (before=" + before
+                    + "; after=" + after + ")");
+        }
+        System.out.println("Test passed");
+    }
+
+    public void run() {
+        System.out.println("push/pop");
+        MyEventQueue queue = new MyEventQueue();
+        Toolkit.getDefaultToolkit().getSystemEventQueue().push(queue);
+        Toolkit.getDefaultToolkit().getSystemEventQueue()
+                .postEvent(new EmptyEvent());
+        queue.pop();
+    }
+
+    public int countEventQueues() {
+        int count = 0;
+        System.out.println("All threads currently running in the system");
+        Thread threads[] = new Thread[Thread.activeCount()];
+        Thread.enumerate(threads);
+        for (int i = 0; i < threads.length; ++i) {
+            Thread thread = threads[i];
+            if (thread != null) {
+                System.out.println(thread.getName());
+                if (thread.getName().startsWith("AWT-EventQueue")) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    public void pause(long aMillis) {
+        try {
+            Thread.sleep(aMillis);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Test was interrupted");
+        }
+    }
+
+    public static void main(String[] args) {
+        StoppingEdtOnPushPopTest test = new StoppingEdtOnPushPopTest();
+        test.start();
+    }
+}
+
+class MyEventQueue extends EventQueue {
+    public MyEventQueue() {
+        super();
+    }
+
+    public void pop() {
+        super.pop();
+    }
+}
+
+class EmptyEvent extends AWTEvent implements ActiveEvent {
+    public EmptyEvent() {
+        super(new Object(), 0);
+    }
+
+    public void dispatch() {
+        System.out.println("one more EmptyEvent");
+    }
+}

--- a/test/jdk/java/awt/FileDialog/ExceptionAfterSetDirectory.java
+++ b/test/jdk/java/awt/FileDialog/ExceptionAfterSetDirectory.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6308332
+  @summary FileDialog.setDirectory() throws exception on Linux & Solaris
+  @key headful
+  @run main ExceptionAfterSetDirectory
+*/
+
+import java.awt.AWTException;
+import java.awt.EventQueue;
+import java.awt.FileDialog;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.lang.reflect.InvocationTargetException;
+
+public class ExceptionAfterSetDirectory {
+    FileDialog fd = null;
+    Frame frame;
+
+    public void start() throws InterruptedException,
+            InvocationTargetException {
+        EventQueue.invokeAndWait(() -> {
+            frame = new Frame("ExceptionAfterSetDirectory");
+            frame.setLayout(new FlowLayout());
+            frame.setBounds(100, 100, 100, 100);
+            frame.setVisible(true);
+            fd = new FileDialog(frame, "file dialog", FileDialog.LOAD);
+        });
+
+        try {
+            test();
+        } catch (Exception e) {
+            throw new RuntimeException("Test failed.", e);
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(frame::dispose);
+            }
+            if (fd != null) {
+                EventQueue.invokeAndWait(fd::dispose);;
+            }
+        }
+    }
+
+    private void test() throws InterruptedException, InvocationTargetException {
+        final Robot r;
+
+        try {
+            r = new Robot();
+        } catch (AWTException e) {
+            throw new RuntimeException("Can not initialize Robot.", e);
+        }
+
+        r.setAutoDelay(200);
+        r.delay(500);
+
+        EventQueue.invokeLater(() -> {
+            fd.setVisible(true);
+        });
+        r.delay(2000);
+        r.waitForIdle();
+
+        if (System.getProperty("os.name").contains("OS X")) {
+            // Workaround for JDK-7186009 - try to close file dialog pressing escape
+            r.keyPress(KeyEvent.VK_ESCAPE);
+            r.keyRelease(KeyEvent.VK_ESCAPE);
+            r.delay(2000);
+            r.waitForIdle();
+        }
+
+        if (fd.isVisible()) {
+            EventQueue.invokeAndWait(() -> {
+                fd.setVisible(false);
+            });
+            r.delay(2000);
+            r.waitForIdle();
+        }
+
+        // Changing directory on hidden file dialog should not cause an exception
+        EventQueue.invokeAndWait(() -> {
+            fd.setDirectory("/");
+        });
+        r.delay(2000);
+        r.waitForIdle();
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        ExceptionAfterSetDirectory test = new ExceptionAfterSetDirectory();
+        test.start();
+    }
+}

--- a/test/jdk/java/awt/FlowLayout/MinimumLayoutSize.java
+++ b/test/jdk/java/awt/FlowLayout/MinimumLayoutSize.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6257219
+  @summary FlowLayout gives a wrong minimum size if the first component is hidden.
+  @key headful
+  @run main MinimumLayoutSize
+*/
+
+
+import java.awt.AWTException;
+import java.awt.Button;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.LayoutManager;
+import java.awt.Panel;
+import java.awt.Robot;
+import java.lang.reflect.InvocationTargetException;
+
+public class MinimumLayoutSize {
+    Frame frame;
+    Button b1;
+    Button b2;
+    Panel panel;
+
+    public void start() throws AWTException,
+            InterruptedException, InvocationTargetException {
+        try {
+            Robot robot = new Robot();
+            LayoutManager layout = new FlowLayout(FlowLayout.LEFT, 100, 0);
+            final int[] widths = new int[2];
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("MinimumLayoutSize");
+                b1 = new Button("B1");
+                b2 = new Button("B2");
+                panel = new Panel();
+                panel.add(b2);
+                frame.add(panel);
+                frame.pack();
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            //add hidden component b1
+            EventQueue.invokeAndWait(() -> {
+                widths[0] = layout.minimumLayoutSize(panel).width;
+                b1.setVisible(false);
+                panel.add(b1, 0);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            EventQueue.invokeAndWait(() -> {
+                widths[1] = layout.minimumLayoutSize(panel).width;
+                frame.setVisible(false);
+            });
+            System.out.println("TRACE: w1 = " + widths[0] + " w2 = " + widths[1]);
+
+            if (widths[0] != widths[1]) {
+                throw new RuntimeException("Test FAILED. Minimum sizes are not equal."
+                        + " w1 = " + widths[0] + " w2 = " + widths[1]);
+            }
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+            }
+        }
+        System.out.println("Test passed");
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        MinimumLayoutSize test = new MinimumLayoutSize();
+        test.start();
+    }
+}

--- a/test/jdk/java/awt/FlowLayout/PreferredLayoutSize.java
+++ b/test/jdk/java/awt/FlowLayout/PreferredLayoutSize.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4284124
+  @summary FlowLayout gives a wrong size if the first component is hidden.
+  @key headful
+  @run main PreferredLayoutSize
+*/
+
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.lang.reflect.InvocationTargetException;
+
+public class PreferredLayoutSize {
+    public void start() {
+        Frame f = new Frame("PreferredLayoutSize");
+        int[] widths = new int[2];
+
+        try {
+            f.setLocationRelativeTo(null);
+            Button b1 = new Button("button 1");
+            Button b2 = new Button("button 2");
+            f.setLayout(new FlowLayout(FlowLayout.LEFT, 50, 5));
+            f.add(b1);
+            f.add(b2);
+            f.pack();
+            f.setVisible(true);
+            b1.setVisible(false);
+            b2.setVisible(true);
+            Dimension d1 = f.getPreferredSize();
+            Dimension d2 = b2.getPreferredSize();
+            widths[0] = d1.width - d2.width;
+            b1.setVisible(true);
+            b2.setVisible(false);
+            d1 = f.getPreferredSize();
+            d2 = b1.getPreferredSize();
+            widths[1] = d1.width - d2.width;
+            f.setVisible(false);
+        } finally {
+            f.dispose();
+        }
+
+        if (widths[0] != widths[1]) {
+            throw new RuntimeException("Test FAILED");
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PreferredLayoutSize test = new PreferredLayoutSize();
+        EventQueue.invokeAndWait(test::start);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306718](https://bugs.openjdk.org/browse/JDK-8306718): Optimize and opensource some old AWT tests (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2085/head:pull/2085` \
`$ git checkout pull/2085`

Update a local copy of the PR: \
`$ git checkout pull/2085` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2085/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2085`

View PR using the GUI difftool: \
`$ git pr show -t 2085`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2085.diff">https://git.openjdk.org/jdk11u-dev/pull/2085.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2085#issuecomment-1681899653)