### PR TITLE
8284772: GHA: Use GCC Major Version Dependencies Only

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -32,14 +32,6 @@ on:
         required: false
         type: string
         default: '10'
-      apt-gcc-version:
-        required: false
-        type: string
-        default: '10.3.0-1ubuntu1~20.04'
-      apt-gcc-cross-suffix:
-        required: false
-        type: string
-        default: 'cross1'
 
 jobs:
   build-cross-compile:
@@ -93,10 +85,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install --only-upgrade apt
           sudo apt-get install \
-              gcc-${{ inputs.gcc-major-version }}=${{ inputs.apt-gcc-version }} \
-              g++-${{ inputs.gcc-major-version }}=${{ inputs.apt-gcc-version }} \
-              gcc-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}=${{ inputs.apt-gcc-version }}${{ inputs.apt-gcc-cross-suffix }} \
-              g++-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}=${{ inputs.apt-gcc-version }}${{ inputs.apt-gcc-cross-suffix }} \
+              gcc-${{ inputs.gcc-major-version }} \
+              g++-${{ inputs.gcc-major-version }} \
+              gcc-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}} \
+              g++-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}} \
               libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc-major-version }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc-major-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x64
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      apt-gcc-version: '10'
     # The linux-x64 jdk bundle is used as buildjdk for the cross-compile job
     if: needs.select.outputs.linux-x64 == 'true' || needs.select.outputs.linux-cross-compile == 'true'
 
@@ -147,7 +147,7 @@ jobs:
       platform: linux-x64
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      apt-gcc-version: '10'
       extra-conf-options: '--disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -159,7 +159,7 @@ jobs:
       platform: linux-x64
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      apt-gcc-version: '10'
       extra-conf-options: '--with-jvm-variants=zero --disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -171,7 +171,7 @@ jobs:
       platform: linux-x64
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      apt-gcc-version: '10'
       extra-conf-options: '--with-jvm-variants=minimal --disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -184,7 +184,7 @@ jobs:
       make-target: 'hotspot'
       # Technically this is not the "debug" level, but we can't inject a new matrix state for just this job
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      apt-gcc-version: '10'
       extra-conf-options: '--with-debug-level=optimized --disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 


### PR DESCRIPTION
GHA is currently broken in 11u-dev as the referenced Ubuntu gcc package, `10.3.0-1ubuntu1~20.04`, is no longer available.

Rather than bumping this yet again, this PR suggests dropping the specific version as we did some time ago in 8u. The requirement still specifies a specific major version of GCC. It just means the dependency isn't broken every time Ubuntu bumps to a new minor release or even just makes a minor change to the package alone.

Note that the current setup does not guarantee sticking with an exact version of GCC anyway, because - as seen by the current GHA breakage - older versions get removed from the package repository. All we get from this exact version requirement is sporadic breakage. If we truly want a static version of GCC, we need to provide our own as we do with the JDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284772](https://bugs.openjdk.org/browse/JDK-8284772): GHA: Use GCC Major Version Dependencies Only (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**) ⚠️ Review applies to [5ab54a0f](https://git.openjdk.org/jdk11u-dev/pull/2087/files/5ab54a0f9f8c79c704e788a60c6871163d8923c7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2087/head:pull/2087` \
`$ git checkout pull/2087`

Update a local copy of the PR: \
`$ git checkout pull/2087` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2087`

View PR using the GUI difftool: \
`$ git pr show -t 2087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2087.diff">https://git.openjdk.org/jdk11u-dev/pull/2087.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2087#issuecomment-1682871785)