### PR TITLE
8314950: CMS may miss NMT tag after mark stack expansion

### DIFF
--- a/src/hotspot/share/gc/cms/concurrentMarkSweepGeneration.cpp
+++ b/src/hotspot/share/gc/cms/concurrentMarkSweepGeneration.cpp
@@ -5788,6 +5788,9 @@ void CMSMarkStack::expand() {
     if (!_virtual_space.initialize(rs, rs.size())) {
       fatal("Not enough swap for expanded marking stack");
     }
+    // Record NMT memory type
+    MemTracker::record_virtual_memory_type(rs.base(), mtGC);
+
     _base = (oop*)(_virtual_space.low());
     _index = 0;
     _capacity = new_capacity;


### PR DESCRIPTION
Please review this small fix that tags new mark stack after expansion.

Thanks @MBaesken for reporting this bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314950](https://bugs.openjdk.org/browse/JDK-8314950): CMS may miss NMT tag after mark stack expansion (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2097/head:pull/2097` \
`$ git checkout pull/2097`

Update a local copy of the PR: \
`$ git checkout pull/2097` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2097`

View PR using the GUI difftool: \
`$ git pr show -t 2097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2097.diff">https://git.openjdk.org/jdk11u-dev/pull/2097.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2097#issuecomment-1691826385)