### PR TITLE
8315135: Memory leak in the native implementation of Pack200.Unpacker.unpack()

### DIFF
--- a/src/java.base/share/classes/com/sun/java/util/jar/pack/NativeUnpack.java
+++ b/src/java.base/share/classes/com/sun/java/util/jar/pack/NativeUnpack.java
@@ -61,7 +61,7 @@ class NativeUnpack {
 
     // Resets the engine and frees all resources.
     // Returns total number of bytes consumed by the engine.
-    private synchronized native long finish();
+    synchronized native long finish();
 
     // Setting state in the unpacker.
     protected  synchronized native boolean setOption(String opt, String value);

--- a/src/java.base/share/classes/com/sun/java/util/jar/pack/UnpackerImpl.java
+++ b/src/java.base/share/classes/com/sun/java/util/jar/pack/UnpackerImpl.java
@@ -116,6 +116,11 @@ public class UnpackerImpl extends TLGlobals implements Pack200.Unpacker {
                 } catch (UnsatisfiedLinkError | NoClassDefFoundError ex) {
                     // failover to java implementation
                     (new DoUnpack()).run(in0, out);
+                } finally {
+                    if (_nunp != null) {
+                       // Free up native memory and JNI handles to prevent leaks
+                       ((NativeUnpack) _nunp).finish();
+                    }
                 }
                 in0.close();
                 Utils.markJarFile(out);

--- a/test/jdk/tools/pack200/UnpackMalformed.java
+++ b/test/jdk/tools/pack200/UnpackMalformed.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8315135
+ * @run main/othervm/timeout=300 -Dcom.sun.java.util.jar.pack.disable.native=false -Xmx8m UnpackMalformed
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Pack200;
+
+@SuppressWarnings("removal")
+public class UnpackMalformed {
+  public static void main(String[] args) {
+    try {
+      ByteArrayInputStream in = new ByteArrayInputStream("foobar".getBytes());
+      for(int i=0; i < 1_000; i++) {
+        try {
+          JarOutputStream out = new JarOutputStream(new ByteArrayOutputStream());
+          Pack200.Unpacker unpacker = Pack200.newUnpacker();
+          unpacker.unpack(in, out);
+        } catch (IOException e) {
+        }
+      }
+    } catch (OutOfMemoryError e) {
+      System.out.println(e);
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
This issue was found by Yakov Shafranovich (yakovsh@amazon.com) who also provided the reproducer and proposed a fix.

The native implementation of the `Pack200.Unpacker` class included in OpenJDK 8 and 11 has a native and heap memory leak that gets triggered when corrupted files are processed. If the native `NativeUnpack::start()` method throws an exception (because of a corrupted input file) its caller `NativeUnpack::run()` fails to call the native `NativeUnpack::finish()` method which is responsible for freeing the allocated native memory and releasing the created ﻿global JNI handles﻿. A Java application processing large number of malformed Pack200 files will eventually run either out of native memory or out of heap space and exit with an `OutOfMemoryError`.

The problem can be demonstrated with the following short test program which will exit with an `OutOfMemoryError` quite quickly if run with `java -Xmx32m NativePack200POC`:

```java
import java.io.*;
import java.util.jar.*;

@SuppressWarnings("removal")
public class NativePack200POC {
  public static void main(String[] args) {
    try {
      ByteArrayInputStream in = new ByteArrayInputStream("foobar".getBytes());
      for(int i=0; i < 1_000_000; i++) {
        try {
          JarOutputStream out = new JarOutputStream(new ByteArrayOutputStream());
          Pack200.Unpacker unpacker = Pack200.newUnpacker();
          unpacker.unpack(in, out);
        } catch (IOException e) {
        }
      }
    } catch (OutOfMemoryError e) {
      System.out.println(e);
      throw e;
    }
  }
}
```

The problem can be worked around by disabling the native Pack200 implementation with `-Dcom.sun.java.util.jar.pack.disable.native=true` but the default setting is `-Dcom.sun.java.util.jar.pack.disable.native=false`.

Notice that this bug can not be fixed in HEAD because the Pack200 functionality has been removed in JDK 14 (https://openjdk.org/jeps/367). I therefore propose to fix this in jdk11u-dev first and then downport the fix to jdk8u-dev as well.
﻿
