### PR TITLE
8294941: GHA: Cut down cross-compilation sysroots

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -128,7 +128,9 @@ jobs:
           # Prepare sysroot and remove unused files to minimize cache
           sudo chroot sysroot symlinks -cr .
           sudo chown ${USER} -R sysroot
-          rm -rf sysroot/{dev,proc,run,sys}
+          rm -rf sysroot/{dev,proc,run,sys,var}
+          rm -rf sysroot/usr/{sbin,bin,share}
+          rm -rf sysroot/usr/lib/{apt,udev,systemd}
         if: steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Configure'


### PR DESCRIPTION
Clean backport to improve 11u GHA overheads. It would be followed by another backport that would cut stuff even deeper: [JDK-8314262](https://bugs.openjdk.org/browse/JDK-8314262).

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294941](https://bugs.openjdk.org/browse/JDK-8294941): GHA: Cut down cross-compilation sysroots (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2105/head:pull/2105` \
`$ git checkout pull/2105`

Update a local copy of the PR: \
`$ git checkout pull/2105` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2105`

View PR using the GUI difftool: \
`$ git pr show -t 2105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2105.diff">https://git.openjdk.org/jdk11u-dev/pull/2105.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2105#issuecomment-1698869488)