### PR TITLE
8294956: GHA: qemu-debootstrap is deprecated, use the regular one

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: 'Create sysroot'
         run: >
-          sudo qemu-debootstrap
+          sudo debootstrap
           --arch=${{ matrix.debian-arch }}
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev


### PR DESCRIPTION
Clean backport to further improve 11u GHA reliability.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294956](https://bugs.openjdk.org/browse/JDK-8294956): GHA: qemu-debootstrap is deprecated, use the regular one (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2106/head:pull/2106` \
`$ git checkout pull/2106`

Update a local copy of the PR: \
`$ git checkout pull/2106` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2106`

View PR using the GUI difftool: \
`$ git pr show -t 2106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2106.diff">https://git.openjdk.org/jdk11u-dev/pull/2106.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2106#issuecomment-1698872306)