### PR TITLE
8313576: GCC 7 reports compiler warning in bundled freetype 2.13.0

### DIFF
--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -516,6 +516,7 @@ else
     LIBFREETYPE_LIBS := -lfreetype
   endif
 
+  # gcc_ftobjs.c := maybe-uninitialized required for GCC 7 builds.
   $(eval $(call SetupJdkLibrary, BUILD_LIBFREETYPE, \
       NAME := freetype, \
       OPTIMIZATION := HIGHEST, \
@@ -528,6 +529,7 @@ else
       DISABLED_WARNINGS_microsoft := 4018 4267 4244 4312 4819, \
       DISABLED_WARNINGS_gcc := implicit-fallthrough cast-function-type bad-function-cast, \
       DISABLED_WARNINGS_clang := missing-declarations, \
+      DISABLED_WARNINGS_gcc_ftobjs.c := maybe-uninitialized, \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \
   ))


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [8248e351](https://github.com/openjdk/jdk/commit/8248e351d0bed263fb68d8468004a4286e6391af) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 2 Aug 2023 and was reviewed by Aleksey Shipilev and Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313576](https://bugs.openjdk.org/browse/JDK-8313576): GCC 7 reports compiler warning in bundled freetype 2.13.0 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2108/head:pull/2108` \
`$ git checkout pull/2108`

Update a local copy of the PR: \
`$ git checkout pull/2108` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2108`

View PR using the GUI difftool: \
`$ git pr show -t 2108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2108.diff">https://git.openjdk.org/jdk11u-dev/pull/2108.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2108#issuecomment-1701425789)