### PR TITLE
Backport e45f3d5176e4affaa08480b560ca983fdbcb2846

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -359,10 +359,15 @@ define SetupCompileNativeFileBody
       endif
     endif
 
+    ifneq ($(DISABLE_WARNING_PREFIX), )
+      $1_WARNINGS_FLAGS := $$(addprefix $(DISABLE_WARNING_PREFIX), \
+        $$($$($1_BASE)_DISABLED_WARNINGS_$(TOOLCHAIN_TYPE)_$$($1_FILENAME)))
+    endif
+
     $1_BASE_CFLAGS :=  $$($$($1_BASE)_CFLAGS) $$($$($1_BASE)_EXTRA_CFLAGS) \
-        $$($$($1_BASE)_SYSROOT_CFLAGS)
+        $$($$($1_BASE)_SYSROOT_CFLAGS) $$($1_WARNINGS_FLAGS)
     $1_BASE_CXXFLAGS := $$($$($1_BASE)_CXXFLAGS) $$($$($1_BASE)_EXTRA_CXXFLAGS) \
-        $$($$($1_BASE)_SYSROOT_CFLAGS) $$($1_EXTRA_CXXFLAGS)
+        $$($$($1_BASE)_SYSROOT_CFLAGS) $$($1_EXTRA_CXXFLAGS) $$($1_WARNINGS_FLAGS)
     $1_BASE_ASFLAGS := $$($$($1_BASE)_ASFLAGS) $$($$($1_BASE)_EXTRA_ASFLAGS)
 
     ifneq ($$(filter %.c, $$($1_FILENAME)), )


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e45f3d51](https://github.com/openjdk/jdk/commit/e45f3d5176e4affaa08480b560ca983fdbcb2846) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Magnus Ihse Bursie on 23 Sep 2022 and was reviewed by Erik Joelsson.

Thanks!