### PR TITLE
8315480: [11u] Harmonize GHA cross-compilation block with mainline

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -56,18 +56,26 @@ jobs:
           - ppc64le
         include:
           - target-cpu: aarch64
-            debian-arch: arm64
             gnu-arch: aarch64
+            debian-arch: arm64
+            debian-repository: https://httpredir.debian.org/debian/
+            debian-version: bullseye
           - target-cpu: arm
-            debian-arch: armhf
             gnu-arch: arm
+            debian-arch: armhf
+            debian-repository: https://httpredir.debian.org/debian/
+            debian-version: bullseye
             gnu-abi: eabihf
           - target-cpu: s390x
-            debian-arch: s390x
             gnu-arch: s390x
+            debian-arch: s390x
+            debian-repository: https://httpredir.debian.org/debian/
+            debian-version: bullseye
           - target-cpu: ppc64le
-            debian-arch: ppc64el
             gnu-arch: powerpc64le
+            debian-arch: ppc64el
+            debian-repository: https://httpredir.debian.org/debian/
+            debian-version: bullseye
 
     steps:
       - name: 'Checkout the JDK source'
@@ -118,9 +126,9 @@ jobs:
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev
           --resolve-deps
-          bullseye
+          ${{ matrix.debian-version }}
           sysroot
-          https://httpredir.debian.org/debian/
+          ${{ matrix.debian-repository }}
         if: steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Prepare sysroot'


### PR DESCRIPTION
Parts of this block were rewritten with RISC-V GHA integration ([JDK-8283929](https://bugs.openjdk.org/browse/JDK-8283929)). Since we don't expect RISC-V to integrate any time soon, we could just roll in the rewrite without RISC-V parts to 11u, and this minimize the difference to mainline.

This would allow other clean backports.

Additional testing:
 - [x] GHA (cross-compilation still works)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315480](https://bugs.openjdk.org/browse/JDK-8315480): [11u] Harmonize GHA cross-compilation block with mainline (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2111/head:pull/2111` \
`$ git checkout pull/2111`

Update a local copy of the PR: \
`$ git checkout pull/2111` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2111`

View PR using the GUI difftool: \
`$ git pr show -t 2111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2111.diff">https://git.openjdk.org/jdk11u-dev/pull/2111.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2111#issuecomment-1701472361)