### PR TITLE
8306372: Open source AWT CardLayout and Checkbox tests

### DIFF
--- a/test/jdk/java/awt/CardLayout/CardsOrderTest.java
+++ b/test/jdk/java/awt/CardLayout/CardsOrderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4689398
+  @summary Inserting items in a Container with CardLayout does not work since Merlin
+*/
+
+import java.awt.CardLayout;
+import java.awt.Component;
+import java.awt.Container;
+
+public class CardsOrderTest {
+
+    public static void main(String[] args) throws Exception {
+
+        CardLayout layout = new CardLayout();
+        Container cont = new Container();
+        Component comp1 = new Component() {};
+        Component comp2 = new Component() {};
+        Component comp3 = new Component() {};
+        cont.setLayout(layout);
+        cont.add(comp1, "1", 0);
+        cont.add(comp2, "2", 0);
+        cont.add(comp3, "3", 0);
+
+        // Testing visibility "state" - not actually if its visible on screen
+        // since this test does not require a UI.
+        System.out.println("comp1.isVisible() = " + comp1.isVisible());
+        System.out.println("comp2.isVisible() = " + comp2.isVisible());
+        System.out.println("comp3.isVisible() = " + comp3.isVisible());
+
+        if (!comp1.isVisible() || comp2.isVisible() || comp3.isVisible()) {
+            throw new RuntimeException("first added component must be visible");
+        }
+
+        System.out.println("CardLayout.next()");
+        layout.next(cont);
+
+        System.out.println("comp1.isVisible() = " + comp1.isVisible());
+        System.out.println("comp2.isVisible() = " + comp2.isVisible());
+        System.out.println("comp3.isVisible() = " + comp3.isVisible());
+
+        if (!comp3.isVisible() ||comp1.isVisible() || comp2.isVisible()) {
+            throw new RuntimeException("the wrong component is visible after CardLayout.next() (must be comp3)");
+        }
+    }
+}

--- a/test/jdk/java/awt/CardLayout/ObedienceTest.java
+++ b/test/jdk/java/awt/CardLayout/ObedienceTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4690266
+  @summary REGRESSION: Wizard Page does not move to the next page
+*/
+
+import java.awt.CardLayout;
+import java.awt.Component;
+import java.awt.Container;
+
+public class ObedienceTest {
+
+    public static void main(String[] args) {
+        Container cont = new Container();
+        Component comp1 = new Component() {};
+        Component comp2 = new Component() {};
+        CardLayout layout = new CardLayout();
+        cont.setLayout(layout);
+        cont.add(comp1, "first");
+        cont.add(comp2, "second");
+
+        if (!comp1.isVisible()) {
+            throw new RuntimeException("first component must be visible");
+        }
+
+        comp1.setVisible(false);
+        comp2.setVisible(true);
+        layout.layoutContainer(cont);
+
+        if (!comp2.isVisible() || comp1.isVisible()) {
+            System.out.println("comp1.isVisible() = " + comp1.isVisible());
+            System.out.println("comp2.isVisible() = " + comp2.isVisible());
+            throw new RuntimeException("manually shown component must be visible after layoutContainer()");
+        }
+    }
+}

--- a/test/jdk/java/awt/Checkbox/CheckboxCrashTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxCrashTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4378378
+  @summary Tests that checkbox.setLabel(null) doesn't crash the VM.
+  @key headful
+*/
+
+import java.awt.Checkbox;
+import java.awt.EventQueue;
+import java.awt.Frame;
+
+public class CheckboxCrashTest  {
+
+    static Frame f;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> runTest());
+            Thread.sleep(1000);
+        } finally {
+           f.dispose();
+        }
+    }
+
+    static void runTest() {
+        f = new Frame("CheckboxCrashTest");
+        Checkbox cb = new Checkbox();
+        f.add(cb);
+        f.pack();
+        cb.setLabel(null);
+        f.setVisible(true);
+    }
+}

--- a/test/jdk/java/awt/Checkbox/MultiCheckedCheckboxGroupTest.java
+++ b/test/jdk/java/awt/Checkbox/MultiCheckedCheckboxGroupTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4136496
+  @key headful
+  @summary Checkbox.setCheckboxGroup(CheckboxGroup) works wrong on some Checkbox states
+*/
+
+import java.awt.Checkbox;
+import java.awt.CheckboxGroup;
+
+public class MultiCheckedCheckboxGroupTest {
+
+    public static void main(String[] args) throws Exception {
+
+        CheckboxGroup gr = new CheckboxGroup();
+        Checkbox chb1 = new Checkbox("Box 1", true, gr);
+        Checkbox chb2 = new Checkbox("Box 2", true, null);
+
+        chb2.setCheckboxGroup(gr);
+
+        System.out.println("chb1="+chb1);
+        System.out.println("chb2="+chb2);
+        System.out.println("gr.getSelectedCheckbox="+gr.getSelectedCheckbox());
+
+        if(chb1.getState()
+          && !chb2.getState()
+          && chb1.getCheckboxGroup() == gr
+          && chb2.getCheckboxGroup() == gr
+          && gr.getSelectedCheckbox() == chb1) {
+            System.out.println("PASSED");
+        } else {
+            System.out.println("FAILED");
+            throw new RuntimeException("Test FAILED");
+        }
+    }
+}

--- a/test/jdk/java/awt/Checkbox/NullCheckboxGroupTest.java
+++ b/test/jdk/java/awt/Checkbox/NullCheckboxGroupTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4114268
+  @key headful
+  @summary Checkbox.setCheckboxGroup(null) alters selection for CB's previous CBGroup
+*/
+
+import java.awt.Checkbox;
+import java.awt.CheckboxGroup;
+
+public class NullCheckboxGroupTest {
+
+
+    public static void main(String[] args) {
+        CheckboxGroup cbg = new CheckboxGroup();
+        Checkbox chbox1 = new Checkbox("First", cbg, true);
+        Checkbox chbox2 = new Checkbox("Second", cbg, false);
+
+        chbox2.setCheckboxGroup(null);
+
+        System.out.println("chbox1="+chbox1);
+        System.out.println("chbox2="+chbox2);
+        System.out.println("cbg="+cbg);
+
+        if (cbg.getSelectedCheckbox() != chbox1) {
+            System.out.println("FAILED");
+            throw new RuntimeException("Test FAILED");
+        } else {
+            System.out.println("PASSED");
+        }
+    }
+ }

--- a/test/jdk/java/awt/Checkbox/SetCheckboxGroupNull.java
+++ b/test/jdk/java/awt/Checkbox/SetCheckboxGroupNull.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4726853
+  @key headful
+  @summary Checkbox is changing it's state after removing from CheckboxGroup
+*/
+
+import java.awt.Checkbox;
+import java.awt.CheckboxGroup;
+
+public class SetCheckboxGroupNull {
+
+    public static void main(String[] args) {
+        boolean passed = true;
+
+        // 1 step
+        {
+            CheckboxGroup g = new CheckboxGroup();
+            Checkbox cb1 = new Checkbox("Label", true, g);
+            System.out.println("1. (should be true) "+cb1.getState());
+            passed = passed && (cb1.getState() == true);
+            cb1.setCheckboxGroup(null);
+            System.out.println("2. (should be true) "+cb1.getState());
+            passed = passed && (cb1.getState() == true);
+        }
+
+        // 2 step
+        {
+            CheckboxGroup g = new CheckboxGroup();
+            Checkbox cb1 = new Checkbox("CB1", true, g);
+            System.out.println("3. (should be true) " + cb1.getState());
+            passed = passed && (cb1.getState() == true);
+            g.setSelectedCheckbox(null);
+            System.out.println("4. (should be false) " + cb1.getState());
+            passed = passed && (cb1.getState() == false);
+        }
+
+        if (!passed) {
+            throw new RuntimeException("SetCheckboxGroupNull FAILED");
+        }
+        System.out.println("SetCheckboxGroupNull PASSED");
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306372](https://bugs.openjdk.org/browse/JDK-8306372): Open source AWT CardLayout and Checkbox tests (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2112/head:pull/2112` \
`$ git checkout pull/2112`

Update a local copy of the PR: \
`$ git checkout pull/2112` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2112`

View PR using the GUI difftool: \
`$ git pr show -t 2112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2112.diff">https://git.openjdk.org/jdk11u-dev/pull/2112.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2112#issuecomment-1702297367)