### PR TITLE
8233847: (sctp) Flx link-local IPv6 scope handling and test cleanup.

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -240,8 +240,9 @@ module java.base {
         jdk.naming.dns;
     exports sun.net.util to
         java.desktop,
+        java.net.http,
         jdk.jconsole,
-        java.net.http;
+        jdk.sctp;
     exports sun.net.www to
         java.desktop,
         java.net.http,

--- a/src/jdk.sctp/share/classes/com/sun/nio/sctp/HandlerResult.java
+++ b/src/jdk.sctp/share/classes/com/sun/nio/sctp/HandlerResult.java
@@ -29,7 +29,7 @@ package com.sun.nio.sctp;
  *
  * <P> The {@code HandlerResult} is used to determine the behavior of the
  * channel after it handles a notification from the SCTP stack. Essentially its
- * value determines if the channel should try to receive another notificaiton or
+ * value determines if the channel should try to receive another notification or
  * a message before returning.
  *
  * @since 1.7

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
@@ -53,6 +53,7 @@ import com.sun.nio.sctp.MessageInfo;
 import com.sun.nio.sctp.NotificationHandler;
 import com.sun.nio.sctp.SctpChannel;
 import com.sun.nio.sctp.SctpSocketOption;
+import sun.net.util.IPAddressUtil;
 import sun.nio.ch.DirectBuffer;
 import sun.nio.ch.IOStatus;
 import sun.nio.ch.IOUtil;
@@ -1033,6 +1034,9 @@ public class SctpChannelImpl extends SctpChannel
         if (target != null) {
             InetSocketAddress isa = Net.checkAddress(target);
             addr = isa.getAddress();
+            if (addr.isLinkLocalAddress()) {
+                addr = IPAddressUtil.toScopedAddress(addr);
+            }
             port = isa.getPort();
         }
 

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
@@ -53,6 +53,7 @@ import com.sun.nio.sctp.MessageInfo;
 import com.sun.nio.sctp.SctpChannel;
 import com.sun.nio.sctp.SctpMultiChannel;
 import com.sun.nio.sctp.SctpSocketOption;
+import sun.net.util.IPAddressUtil;
 import sun.nio.ch.DirectBuffer;
 import sun.nio.ch.NativeThread;
 import sun.nio.ch.IOStatus;
@@ -892,6 +893,9 @@ public class SctpMultiChannelImpl extends SctpMultiChannel
         if (target != null) {
             InetSocketAddress isa = Net.checkAddress(target);
             addr = isa.getAddress();
+            if (addr.isLinkLocalAddress()) {
+                addr = IPAddressUtil.toScopedAddress(addr);
+            }
             port = isa.getPort();
         }
         int pos = bb.position();

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpNet.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpNet.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.HashSet;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import sun.net.util.IPAddressUtil;
 import sun.nio.ch.IOUtil;
 import sun.nio.ch.Net;
 import com.sun.nio.sctp.SctpSocketOption;
@@ -169,9 +170,13 @@ public class SctpNet {
             InetSocketAddress netAddr = (InetSocketAddress)addr;
 
             if (name.equals(SCTP_PRIMARY_ADDR)) {
+                InetAddress inetAddress = netAddr.getAddress();
+                if (inetAddress.isLinkLocalAddress()) {
+                    inetAddress = IPAddressUtil.toScopedAddress(inetAddress);
+                }
                 setPrimAddrOption0(fd,
                                    assocId,
-                                   netAddr.getAddress(),
+                                   inetAddress,
                                    netAddr.getPort());
             } else {
                 setPeerPrimAddrOption0(fd,

--- a/test/jdk/com/sun/nio/sctp/SctpChannel/Bind.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/Bind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,9 +110,10 @@ public class Bind {
             try {
                 channel.close();  /* open a new unbound channel for test */
                 channel = SctpChannel.open();
-                connectChannel(channel);
-                channel.bind(null);
-                fail("AlreadyConnectedException expected");
+                try (var peer = connectChannel(channel)) {
+                    channel.bind(null);
+                    fail("AlreadyConnectedException expected");
+                }
             } catch (AlreadyConnectedException unused) { pass();
             } catch (IOException ioe) { unexpected(ioe); }
 
@@ -264,7 +265,9 @@ public class Bind {
         } finally {
             try { if (channel != null) channel.close(); }
             catch (IOException ioe) { unexpected(ioe); }
-        }
+            try { if (peerChannel != null) peerChannel.close(); }
+            catch (IOException ioe) { unexpected(ioe); }
+         }
     }
 
     boolean boundAddress(SctpChannel channel, InetAddress addr)

--- a/test/jdk/com/sun/nio/sctp/SctpChannel/CommUp.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/CommUp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -190,6 +190,9 @@ public class CommUp {
                     server.thread().interrupt();
                 }
             } //for
+
+            try { sc.close(); }
+            catch (IOException ioe) { unexpected(ioe); }
 
         } catch (IOException ioe) {
             unexpected(ioe);

--- a/test/jdk/com/sun/nio/sctp/SctpChannel/Connect.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/Connect.java
@@ -61,11 +61,10 @@ public class Connect {
 
     void doTest() {
         SctpChannel channel = null;
-        SctpServerChannel ssc = null;
 
-        try {
+        try (SctpServerChannel ssc = SctpServerChannel.open()) {
             /* Create a server channel to connect to */
-            ssc = SctpServerChannel.open().bind(null);
+            ssc.bind(null);
             Set<SocketAddress> addrs = ssc.getAllLocalAddresses();
             if (addrs.isEmpty())
                 debug("addrs should not be empty");
@@ -208,8 +207,6 @@ public class Connect {
             unexpected(ioe);
         } finally {
             try { if (channel != null) channel.close(); }
-            catch (IOException unused) {}
-            try { if (ssc != null) ssc.close(); }
             catch (IOException unused) {}
         }
     }

--- a/test/jdk/com/sun/nio/sctp/SctpChannel/SocketOptionTests.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/SocketOptionTests.java
@@ -72,8 +72,7 @@ public class SocketOptionTests {
             return;
         }
 
-        try {
-            SctpChannel sc = SctpChannel.open();
+        try (SctpChannel sc = SctpChannel.open()) {
 
             /* check supported options */
             Set<SctpSocketOption<?>> options = sc.supportedOptions();
@@ -143,8 +142,6 @@ public class SocketOptionTests {
 
     /* SCTP_PRIMARY_ADDR */
     void sctpPrimaryAddr() throws IOException {
-        SocketAddress addrToSet = null;;
-
         System.out.println("TESTING SCTP_PRIMARY_ADDR");
         SctpChannel sc = SctpChannel.open();
         SctpServerChannel ssc = SctpServerChannel.open().bind(null);
@@ -158,12 +155,11 @@ public class SocketOptionTests {
         sc.connect(serverAddr);
         SctpChannel peerChannel = ssc.accept();
         ssc.close();
-        Set<SocketAddress> peerAddrs = peerChannel.getAllLocalAddresses();
-        debug("Peer local Addresses: ");
-        for (Iterator<SocketAddress> it = peerAddrs.iterator(); it.hasNext(); ) {
+        Set<SocketAddress> remoteAddresses = sc.getRemoteAddresses();
+        debug("Remote Addresses: ");
+        for (Iterator<SocketAddress> it = remoteAddresses.iterator(); it.hasNext(); ) {
             InetSocketAddress addr = (InetSocketAddress)it.next();
             debug("\t" + addr);
-            addrToSet = addr;   // any of the peer addresses will do!
         }
 
         /* retrieval of SCTP_PRIMARY_ADDR is not supported on Solaris */
@@ -176,25 +172,21 @@ public class SocketOptionTests {
         } else { /* Linux */
             SocketAddress primaryAddr = sc.getOption(SCTP_PRIMARY_ADDR);
             System.out.println("SCTP_PRIMARY_ADDR returned: " + primaryAddr);
-            /* Verify that this is one of the peer addresses */
-            boolean found = false;
-            addrToSet = primaryAddr; // may not have more than one addr
-            for (Iterator<SocketAddress> it = peerAddrs.iterator(); it.hasNext(); ) {
-                InetSocketAddress addr = (InetSocketAddress)it.next();
-                if (addr.equals(primaryAddr)) {
-                    found = true;
-                }
-                addrToSet = addr;
-            }
-            check(found, "SCTP_PRIMARY_ADDR returned bogus address!");
+            /* Verify that this is one of the remote addresses */
+            check(remoteAddresses.contains(primaryAddr), "SCTP_PRIMARY_ADDR returned bogus address!");
 
-            System.out.println("SCTP_PRIMARY_ADDR try set to: " + addrToSet);
-            sc.setOption(SCTP_PRIMARY_ADDR, addrToSet);
-            System.out.println("SCTP_PRIMARY_ADDR set to: " + addrToSet);
-            primaryAddr = sc.getOption(SCTP_PRIMARY_ADDR);
-            System.out.println("SCTP_PRIMARY_ADDR returned: " + primaryAddr);
-            check(addrToSet.equals(primaryAddr),"SCTP_PRIMARY_ADDR not set correctly");
+            for (Iterator<SocketAddress> it = remoteAddresses.iterator(); it.hasNext(); ) {
+                InetSocketAddress addrToSet = (InetSocketAddress) it.next();
+                System.out.println("SCTP_PRIMARY_ADDR try set to: " + addrToSet);
+                sc.setOption(SCTP_PRIMARY_ADDR, addrToSet);
+                System.out.println("SCTP_PRIMARY_ADDR set to    : " + addrToSet);
+                primaryAddr = sc.getOption(SCTP_PRIMARY_ADDR);
+                System.out.println("SCTP_PRIMARY_ADDR returned  : " + primaryAddr);
+                check(addrToSet.equals(primaryAddr), "SCTP_PRIMARY_ADDR not set correctly");
+            }
         }
+        sc.close();
+        peerChannel.close();
     }
             //--------------------- Infrastructure ---------------------------
     boolean debug = true;

--- a/test/jdk/com/sun/nio/sctp/SctpMultiChannel/Branch.java
+++ b/test/jdk/com/sun/nio/sctp/SctpMultiChannel/Branch.java
@@ -210,7 +210,8 @@ public class Branch {
                 /* echo the message */
                 debug("Server: echoing first message");
                 buffer.flip();
-                int bytes = serverChannel.send(buffer, info);
+                MessageInfo sendInfo = MessageInfo.createOutgoing(info.association(), null, 0);
+                int bytes = serverChannel.send(buffer, sendInfo);
                 debug("Server: sent " + bytes + "bytes");
 
                 clientFinishedLatch.await(10L, TimeUnit.SECONDS);

--- a/test/jdk/com/sun/nio/sctp/SctpMultiChannel/Send.java
+++ b/test/jdk/com/sun/nio/sctp/SctpMultiChannel/Send.java
@@ -276,7 +276,8 @@ public class Send {
                 /* echo the message */
                 debug("Server: echoing first message");
                 buffer.flip();
-                int bytes = serverChannel.send(buffer, info);
+                MessageInfo sendInfo = MessageInfo.createOutgoing(assoc, null, info.streamNumber());
+                int bytes = serverChannel.send(buffer, sendInfo);
                 debug("Server: sent " + bytes + "bytes");
 
                 /* receive a large message */
@@ -302,7 +303,8 @@ public class Send {
                 /* echo the message */
                 debug("Server: echoing second message");
                 buffer.flip();
-                bytes = serverChannel.send(buffer, info);
+                sendInfo = MessageInfo.createOutgoing(assoc, null, info.streamNumber());
+                bytes = serverChannel.send(buffer, sendInfo);
                 debug("Server: sent " + bytes + "bytes");
 
                 /* TEST 6 */

--- a/test/jdk/com/sun/nio/sctp/SctpMultiChannel/SendFailed.java
+++ b/test/jdk/com/sun/nio/sctp/SctpMultiChannel/SendFailed.java
@@ -97,14 +97,19 @@ public class SendFailed {
                     new SendFailedNotificationHandler();
             ByteBuffer recvBuffer = direct ? allocateDirect(recvBufferSize)
                                            : allocate((recvBufferSize));
-            channel.receive(recvBuffer, null, handler);
+            MessageInfo info = channel.receive(recvBuffer, null, handler);
+            debug("receive returned info:" + info);
 
-            // verify sent buffer received by send failed notification
-            ByteBuffer buffer = handler.getSendFailedByteBuffer();
-            check(buffer.remaining() == sent);
-            check(buffer.position() == 0);
-            check(buffer.limit() == sent);
-            assertSameContent(sendBuffer, handler.getSendFailedByteBuffer());
+            if (handler.receivedSendFailed) {
+                // verify sent buffer received by send failed notification
+                ByteBuffer buffer = handler.getSendFailedByteBuffer();
+                check(buffer.remaining() == sent);
+                check(buffer.position() == 0);
+                check(buffer.limit() == sent);
+                assertSameContent(sendBuffer, handler.getSendFailedByteBuffer());
+            } else {
+                debug("Unexpected event or received data. Check output.");
+            }
         }
     }
 
@@ -112,6 +117,7 @@ public class SendFailed {
     {
         /** Reference to the buffer captured in send failed notification */
         private ByteBuffer sentBuffer;
+        boolean receivedSendFailed;
 
         @Override
         public HandlerResult handleNotification(
@@ -134,6 +140,7 @@ public class SendFailed {
         public HandlerResult handleNotification(
                 SendFailedNotification notification, Object attachment) {
             debug("%nSendFailedNotification: %s. ", notification);
+            receivedSendFailed = true;
             sentBuffer = notification.buffer();
             return HandlerResult.RETURN;
         }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [76e5a32c](https://github.com/openjdk/jdk17u-dev/commit/76e5a32c52c670173ded80eb10f5afd715f472cd) from the [openjdk/jdk17u-dev](https://git.openjdk.org/jdk17u-dev) repository.

The commit being backported was authored by Chris Hegarty on 21 Nov 2019 and was reviewed by Alan Bateman.

I'm trying to backport this to see if this fixes some recurring CI test errors we're seeing.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233847](https://bugs.openjdk.org/browse/JDK-8233847): (sctp) Flx link-local IPv6 scope handling and test cleanup. (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2114/head:pull/2114` \
`$ git checkout pull/2114`

Update a local copy of the PR: \
`$ git checkout pull/2114` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2114`

View PR using the GUI difftool: \
`$ git pr show -t 2114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2114.diff">https://git.openjdk.org/jdk11u-dev/pull/2114.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2114#issuecomment-1702678629)