### PR TITLE
8313707: GHA: Bootstrap sysroots with --variant=minbase

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -126,6 +126,7 @@ jobs:
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev
           --resolve-deps
+          --variant=minbase
           ${{ matrix.debian-version }}
           sysroot
           ${{ matrix.debian-repository }}


### PR DESCRIPTION
Improves GHA stability and matches what mainline GHA is doing. Semi-clean due to contextual differences.

Additional testing:
 - [x] GHA (cross-builds are still working)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313707](https://bugs.openjdk.org/browse/JDK-8313707): GHA: Bootstrap sysroots with --variant=minbase (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2115/head:pull/2115` \
`$ git checkout pull/2115`

Update a local copy of the PR: \
`$ git checkout pull/2115` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2115`

View PR using the GUI difftool: \
`$ git pr show -t 2115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2115.diff">https://git.openjdk.org/jdk11u-dev/pull/2115.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2115#issuecomment-1702738455)