### PR TITLE
8312489: Increase jdk.jar.maxSignatureFileSize default which is too low for JARs such as WhiteSource/Mend unified agent jar

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -809,7 +809,9 @@ class JarFile extends ZipFile {
                 throw new IOException("Unsupported size: " + uncompressedSize +
                         " for JarEntry " + ze.getName() +
                         ". Allowed max size: " +
-                        SignatureFileVerifier.MAX_SIG_FILE_SIZE + " bytes");
+                        SignatureFileVerifier.MAX_SIG_FILE_SIZE + " bytes. " +
+                        "You can use the jdk.jar.maxSignatureFileSize " +
+                        "system property to increase the default value.");
             }
             int len = (int)uncompressedSize;
             int bytesRead;

--- a/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -852,16 +852,16 @@ public class SignatureFileVerifier {
          * the maximum allowed number of bytes for the signature-related files
          * in a JAR file.
          */
-        Integer tmp = GetIntegerAction.privilegedGetProperty(
-                "jdk.jar.maxSignatureFileSize", 8000000);
+        int tmp = GetIntegerAction.privilegedGetProperty(
+                "jdk.jar.maxSignatureFileSize", 16000000);
         if (tmp < 0 || tmp > MAX_ARRAY_SIZE) {
             if (debug != null) {
-                debug.println("Default signature file size 8000000 bytes " +
-                        "is used as the specified size for the " +
-                        "jdk.jar.maxSignatureFileSize system property " +
+                debug.println("The default signature file size of 16000000 bytes " +
+                        "will be used for the jdk.jar.maxSignatureFileSize " +
+                        "system property since the specified value " +
                         "is out of range: " + tmp);
             }
-            tmp = 8000000;
+            tmp = 16000000;
         }
         return tmp;
     }


### PR DESCRIPTION
The security fix, JDK-8300596, introduced a maximum size for signature-related files in JAR files, via the `jdk.jar.maxSignatureFileSize` property. The default value of 8MB has since proven to be too low for some JARs in general use. This change doubles it to 16MB, while still being much lower than the previous `MAX_ARRAY_SIZE` value of `Integer.MAX_VALUE - 8`

This pull request contains a clean backport of commit [e47a84f2](https://github.com/openjdk/jdk/commit/e47a84f23dd2608c6f5748093eefe301fb5bf750) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Hai-May Chao on 31 Jul 2023 and was reviewed by Sean Mullan and Matthias Baesken.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change requires CSR request [JDK-8313216](https://bugs.openjdk.org/browse/JDK-8313216) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8312489](https://bugs.openjdk.org/browse/JDK-8312489): Increase jdk.jar.maxSignatureFileSize default which is too low for JARs such as WhiteSource/Mend unified agent jar (**Enhancement** - P3)
 * [JDK-8313216](https://bugs.openjdk.org/browse/JDK-8313216): Increase jdk.jar.maxSignatureFileSize default which is too low for JARs such as WhiteSource/Mend unified agent jar (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2116/head:pull/2116` \
`$ git checkout pull/2116`

Update a local copy of the PR: \
`$ git checkout pull/2116` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2116`

View PR using the GUI difftool: \
`$ git pr show -t 2116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2116.diff">https://git.openjdk.org/jdk11u-dev/pull/2116.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2116#issuecomment-1703903990)