### PR TITLE
8315862: [11u] Backport 8227337: javax/management/remote/mandatory/connection/ReconnectTest.java NoSuchObjectException no such object in table

### DIFF
--- a/test/jdk/javax/management/remote/mandatory/connection/MultiThreadDeadLockTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/MultiThreadDeadLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,11 +40,14 @@ import javax.management.remote.JMXConnectorServerFactory;
 import javax.management.remote.JMXServiceURL;
 import javax.management.remote.rmi.RMIConnectorServer;
 
+import jdk.test.lib.Utils;
+
 /*
  * @test
  * @bug 6697180
  * @summary test on a client notification deadlock.
  * @author Shanliang JIANG
+ * @library /test/lib
  *
  * @run clean MultiThreadDeadLockTest
  * @run build MultiThreadDeadLockTest
@@ -53,7 +56,7 @@ import javax.management.remote.rmi.RMIConnectorServer;
 
 public class MultiThreadDeadLockTest {
 
-    private static long serverTimeout = 500L;
+    private static long serverTimeout = Utils.adjustTimeout(500);
 
     public static void main(String[] args) throws Exception {
         print("Create the MBean server");

--- a/test/jdk/javax/management/remote/mandatory/connection/ReconnectTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/ReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,15 +26,16 @@
  * @bug 4927217
  * @summary test to reconnect
  * @author Shanliang JIANG
- *
+ * @library /test/lib
  * @run clean ReconnectTest
  * @run build ReconnectTest
  * @run main ReconnectTest
  */
 
+import jdk.test.lib.Utils;
+
 import java.util.*;
 import java.net.MalformedURLException;
-import java.io.IOException;
 
 import javax.management.*;
 import javax.management.remote.*;
@@ -46,7 +47,7 @@ public class ReconnectTest {
     private static HashMap env = new HashMap(2);
 
     static {
-        String timeout = "1000";
+        String timeout = Long.toString(Utils.adjustTimeout(1000));
         env.put("jmx.remote.x.server.connection.timeout", timeout);
         env.put("jmx.remote.x.client.connection.check.period", timeout);
     }
@@ -104,7 +105,7 @@ public class ReconnectTest {
 
         for (int i=0; i<3; i++) {
             System.out.println("************** Sleeping ...... "+i);
-            Thread.sleep(2000);
+            Thread.sleep(Utils.adjustTimeout(2000));
             System.out.println("Sleep done.");
 
             System.out.println("The default domain is "


### PR DESCRIPTION
Backport of JDK-8227337 which is not public.
Original commit: https://github.com/openjdk/jdk/commit/50e18e29e334e0cc52729e70731e5204ac479306
Patch applies clean but problemlist entry did not exist in 11.

Needs to go together with / as prerequisite of #2119 to fix the test and to even avoid compile errors in building test/jdk/javax/management/remote/mandatory/connection/MultiThreadDeadLockTest.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315862](https://bugs.openjdk.org/browse/JDK-8315862): [11u] Backport 8227337: javax/management/remote/mandatory/connection/ReconnectTest.java NoSuchObjectException no such object in table (**Bug** - P3)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2120/head:pull/2120` \
`$ git checkout pull/2120`

Update a local copy of the PR: \
`$ git checkout pull/2120` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2120`

View PR using the GUI difftool: \
`$ git pr show -t 2120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2120.diff">https://git.openjdk.org/jdk11u-dev/pull/2120.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2120#issuecomment-1710319363)