### PR TITLE
8244508: JFR: FlightRecorderOptions reset date format

### DIFF
--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -556,7 +556,8 @@ JfrConfigureFlightRecorderDCmd::JfrConfigureFlightRecorderDCmd(outputStream* out
   _thread_buffer_size("thread_buffer_size", "Size of a thread buffer", "MEMORY SIZE", false, "8k"),
   _memory_size("memorysize", "Overall memory size, ", "MEMORY SIZE", false, "10m"),
   _max_chunk_size("maxchunksize", "Size of an individual disk chunk", "MEMORY SIZE", false, "12m"),
-  _sample_threads("samplethreads", "Activate Thread sampling", "BOOLEAN", false, "true") {
+  _sample_threads("samplethreads", "Activate Thread sampling", "BOOLEAN", false, "true"),
+  _verbose(true) {
   _dcmdparser.add_dcmd_option(&_repository_path);
   _dcmdparser.add_dcmd_option(&_dump_path);
   _dcmdparser.add_dcmd_option(&_stack_depth);
@@ -643,7 +644,7 @@ void JfrConfigureFlightRecorderDCmd::execute(DCmdSource source, TRAPS) {
 
   static const char klass[] = "jdk/jfr/internal/dcmd/DCmdConfigure";
   static const char method[] = "execute";
-  static const char signature[] = "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;"
+  static const char signature[] = "(ZLjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;"
     "Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;"
     "Ljava/lang/Long;Ljava/lang/Boolean;)Ljava/lang/String;";
 
@@ -651,6 +652,7 @@ void JfrConfigureFlightRecorderDCmd::execute(DCmdSource source, TRAPS) {
   execute_args.set_receiver(h_dcmd_instance);
 
   // params
+  execute_args.push_int(_verbose ? 1 : 0);
   execute_args.push_jobject(repository_path);
   execute_args.push_jobject(dump_path);
   execute_args.push_jobject(stack_depth);

--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.hpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.hpp
@@ -150,9 +150,13 @@ class JfrConfigureFlightRecorderDCmd : public DCmdWithParser {
   DCmdArgument<MemorySizeArgument> _memory_size;
   DCmdArgument<MemorySizeArgument> _max_chunk_size;
   DCmdArgument<bool>  _sample_threads;
+  bool _verbose;
 
  public:
   JfrConfigureFlightRecorderDCmd(outputStream* output, bool heap);
+  void set_verbose(bool verbose) {
+    _verbose = verbose;
+  }
   static const char* name() {
     return "JFR.configure";
   }

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
@@ -366,6 +366,7 @@ bool JfrOptionSet::configure(TRAPS) {
   configure._sample_threads.set_is_set(_dcmd_sample_threads.is_set());
   configure._sample_threads.set_value(_dcmd_sample_threads.value());
 
+  configure.set_verbose(false);
   configure.execute(DCmd_Source_Internal, THREAD);
 
   if (HAS_PENDING_EXCEPTION) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdConfigure.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdConfigure.java
@@ -59,6 +59,7 @@ final class DCmdConfigure extends AbstractDCmd {
      */
     public String execute
     (
+            boolean verbose,
             String repositoryPath,
             String dumpPath,
             Integer stackDepth,
@@ -92,66 +93,86 @@ final class DCmdConfigure extends AbstractDCmd {
             } catch (Exception e) {
                 throw new DCmdException("Could not use " + repositoryPath + " as repository. " + e.getMessage(), e);
             }
-            printRepositoryPath();
+            if (verbose) {
+                printRepositoryPath();
+            }
             updated = true;
         }
 
         if (dumpPath != null)  {
             Options.setDumpPath(new SafePath(dumpPath));
             Logger.log(LogTag.JFR, LogLevel.INFO, "Emergency dump path set to " + dumpPath);
-            printDumpPath();
+           if (verbose) {
+               printDumpPath();
+           }
             updated = true;
         }
 
         if (stackDepth != null)  {
             Options.setStackDepth(stackDepth);
             Logger.log(LogTag.JFR, LogLevel.INFO, "Stack depth set to " + stackDepth);
-            printStackDepth();
+            if (verbose) {
+                printStackDepth();
+            }
             updated = true;
         }
 
         if (globalBufferCount != null)  {
             Options.setGlobalBufferCount(globalBufferCount);
             Logger.log(LogTag.JFR, LogLevel.INFO, "Global buffer count set to " + globalBufferCount);
-            printGlobalBufferCount();
+            if (verbose) {
+                printGlobalBufferCount();
+            }
             updated = true;
         }
 
         if (globalBufferSize != null)  {
             Options.setGlobalBufferSize(globalBufferSize);
             Logger.log(LogTag.JFR, LogLevel.INFO, "Global buffer size set to " + globalBufferSize);
-            printGlobalBufferSize();
+            if (verbose) {
+                printGlobalBufferSize();
+            }
             updated = true;
         }
 
         if (threadBufferSize != null)  {
             Options.setThreadBufferSize(threadBufferSize);
             Logger.log(LogTag.JFR, LogLevel.INFO, "Thread buffer size set to " + threadBufferSize);
-            printThreadBufferSize();
+            if (verbose) {
+                printThreadBufferSize();
+            }
             updated = true;
         }
 
         if (memorySize != null) {
             Options.setMemorySize(memorySize);
             Logger.log(LogTag.JFR, LogLevel.INFO, "Memory size set to " + memorySize);
-            printMemorySize();
+            if (verbose) {
+                printMemorySize();
+            }
             updated = true;
         }
 
         if (maxChunkSize != null)  {
             Options.setMaxChunkSize(maxChunkSize);
             Logger.log(LogTag.JFR, LogLevel.INFO, "Max chunk size set to " + maxChunkSize);
-            printMaxChunkSize();
+            if (verbose) {
+                printMaxChunkSize();
+            }
             updated = true;
         }
 
         if (sampleThreads != null)  {
             Options.setSampleThreads(sampleThreads);
             Logger.log(LogTag.JFR, LogLevel.INFO, "Sample threads set to " + sampleThreads);
-            printSampleThreads();
+            if (verbose) {
+                printSampleThreads();
+            }
             updated = true;
         }
-
+        if (!verbose) {
+            return "";
+        }
         if (!updated) {
             println("Current configuration:");
             println();

--- a/test/jdk/jdk/jfr/startupargs/TestOptionsWithLocale.java
+++ b/test/jdk/jdk/jfr/startupargs/TestOptionsWithLocale.java
@@ -1,0 +1,40 @@
+package jdk.jfr.startupargs;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+/**
+ * @test
+ * @summary Checks that locale is respected when using -XX:FlightRecorderOptions
+ *          See JDK-8244508
+ * @key jfr
+ * @requires vm.hasJFR
+ * @modules jdk.jfr
+ * @library /test/lib
+ * @run main jdk.jfr.startupargs.TestOptionsWithLocale
+ */
+public class TestOptionsWithLocale {
+
+    public static class PrintDate {
+        public static void main(String... args) {
+            GregorianCalendar date = new GregorianCalendar(2020, Calendar.JANUARY, 1);
+            DateFormat formatter = DateFormat.getDateTimeInstance();
+            System.out.println(formatter.format(date.getTime()));
+        }
+    }
+
+    public static void main(String... args) throws IOException {
+        ProcessBuilder pb = ProcessTools.createTestJvm(
+                "-Duser.country=DE",
+                "-Duser.language=de",
+                "-XX:FlightRecorderOptions:stackdepth=128",
+                PrintDate.class.getName());
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldContain("01.01.2020, 00:00:00");
+    }
+}


### PR DESCRIPTION
Hello all,

This backport request is related to JDK-8244508 [1]. When using JFR (`-XX:StartFlightRecording`), the configured default Locale is not honored, with FormatData or TimezoneNames(for example), because the relevant ResourceBundles do not get loaded when an attempt is made to locate and load them during VM startup (i.e when  `-XX:StartFlightRecording` triggers JFR initialiazation). Though [1] quotes a mailing-list post [2] mentioning this issue was not seen with jdk11 then, the testcase in [1] does fail with 11.0.20 (as well as 11.0.22/master branch) as of today:

```
$ java --show-version -Duser.country=DE -Duser.language=de -XX:FlightRecorderOptions=stackdepth=128 Main
openjdk 11.0.22-internal 2024-01-16
OpenJDK Runtime Environment (build 11.0.22-internal+0-adhoc.pushkarnk.jdk11u-dev)
OpenJDK 64-Bit Server VM (build 11.0.22-internal+0-adhoc.pushkarnk.jdk11u-dev, mixed mode)
expected: 01.01.2020, 00:00:00
actual:   2020 Jan 1 00:00:00 
```
Testing: Linux x86-64 build, tier1 tests with `release` and `fastdebug` builds.

[1] https://bugs.openjdk.org/browse/JDK-8244508
[2] https://mail.openjdk.org/pipermail/hotspot-jfr-dev/2020-March/001313.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8244508](https://bugs.openjdk.org/browse/JDK-8244508) needs maintainer approval

### Issue
 * [JDK-8244508](https://bugs.openjdk.org/browse/JDK-8244508): JFR: FlightRecorderOptions reset date format (**Bug** - P3 - Approved)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2121/head:pull/2121` \
`$ git checkout pull/2121`

Update a local copy of the PR: \
`$ git checkout pull/2121` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2121`

View PR using the GUI difftool: \
`$ git pr show -t 2121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2121.diff">https://git.openjdk.org/jdk11u-dev/pull/2121.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2121#issuecomment-1710321578)