### PR TITLE
8311813: C1: Uninitialized PhiResolver::_loop field

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -81,7 +81,7 @@ void PhiResolverState::reset(int max_vregs) {
 PhiResolver::PhiResolver(LIRGenerator* gen, int max_vregs)
  : _gen(gen)
  , _state(gen->resolver_state())
- , _loop(nullptr)
+ , _loop(NULL)
  , _temp(LIR_OprFact::illegalOpr)
 {
   // reinitialize the shared state arrays

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -81,6 +81,7 @@ void PhiResolverState::reset(int max_vregs) {
 PhiResolver::PhiResolver(LIRGenerator* gen, int max_vregs)
  : _gen(gen)
  , _state(gen->resolver_state())
+ , _loop(nullptr)
  , _temp(LIR_OprFact::illegalOpr)
 {
   // reinitialize the shared state arrays


### PR DESCRIPTION
[JDK-8311813](https://bugs.openjdk.org/browse/JDK-8311813)

Initialize `PhiResolver::_loop` field to `nullptr`

Clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311813](https://bugs.openjdk.org/browse/JDK-8311813): C1: Uninitialized PhiResolver::_loop field (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2123/head:pull/2123` \
`$ git checkout pull/2123`

Update a local copy of the PR: \
`$ git checkout pull/2123` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2123`

View PR using the GUI difftool: \
`$ git pr show -t 2123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2123.diff">https://git.openjdk.org/jdk11u-dev/pull/2123.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2123#issuecomment-1709173154)