### PR TITLE
8292713: Unsafe.allocateInstance should be intrinsified without UseUnalignedAccesses

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.cpp
+++ b/src/hotspot/share/classfile/vmSymbols.cpp
@@ -716,6 +716,7 @@ bool vmIntrinsics::is_disabled_by_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_compareAndExchangeObject:
   case vmIntrinsics::_compareAndExchangeObjectAcquire:
   case vmIntrinsics::_compareAndExchangeObjectRelease:
+  case vmIntrinsics::_allocateInstance:
     if (!InlineUnsafeOps) return true;
     break;
   case vmIntrinsics::_getShortUnaligned:
@@ -726,7 +727,6 @@ bool vmIntrinsics::is_disabled_by_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_putCharUnaligned:
   case vmIntrinsics::_putIntUnaligned:
   case vmIntrinsics::_putLongUnaligned:
-  case vmIntrinsics::_allocateInstance:
     if (!InlineUnsafeOps || !UseUnalignedAccesses) return true;
     break;
   case vmIntrinsics::_hashCode:


### PR DESCRIPTION
Backport to improve arm32 performance in 11u and riscv-port in: https://github.com/openjdk/riscv-port-jdk11u/pull/3.
This is not a clean backport as the function has been moved to new file and renamed. 

I checked the 11u related code and I think the following analysis on the JBS description is still true for 11u:
"The intrinsic is currently only implemented in C2. I see no reason for this intrinsic to depend on `UseUnalignedAccesses`: what `LibraryCallKit::inline_unsafe_allocate()` does seems similar to what the regular `Parse::do_new()` does, namely doing the clinit barrier and then delegating into `GraphKit::new_instance`."

Tested with the initial riscv-port in: https://github.com/openjdk/riscv-port-jdk11u/pull/3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292713](https://bugs.openjdk.org/browse/JDK-8292713): Unsafe.allocateInstance should be intrinsified without UseUnalignedAccesses (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2125/head:pull/2125` \
`$ git checkout pull/2125`

Update a local copy of the PR: \
`$ git checkout pull/2125` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2125`

View PR using the GUI difftool: \
`$ git pr show -t 2125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2125.diff">https://git.openjdk.org/jdk11u-dev/pull/2125.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2125#issuecomment-1711226976)