### PR TITLE
8195589: T6587786.java failed after JDK-8189997

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -60,7 +60,6 @@ tools/javac/importscope/T8193717.java                                           
 # javap
 
 tools/javap/output/RepeatingTypeAnnotations.java                                8057687    generic-all    emit correct byte code an attributes for type annotations
-tools/javap/T6587786.java                                                       8195589    generic-all    T6587786.java failed after JDK-8189997
 
 ###########################################################################
 #

--- a/test/langtools/tools/javap/T6587786.java
+++ b/test/langtools/tools/javap/T6587786.java
@@ -36,18 +36,21 @@ public class T6587786 {
     }
 
     public void run() throws IOException {
-        javap("com.sun.javadoc.Doc", "com.sun.crypto.provider.ai");
-        javap("com.sun.crypto.provider.ai", "com.sun.javadoc.ClassDoc");
+        javap("jdk.javadoc.doclet.Doclet", "java.util.List");
+        javap("java.util.List", "jdk.javadoc.doclet.StandardDoclet");
     }
 
     void javap(String... args) {
         StringWriter sw = new StringWriter();
         PrintWriter out = new PrintWriter(sw);
         //sun.tools.javap.Main.entry(args);
-        int rc = com.sun.tools.javap.Main.run(args, out);
-        if (rc != 0)
-            throw new Error("javap failed. rc=" + rc);
-        out.close();
-        System.out.println(sw.toString());
+        try {
+            int rc = com.sun.tools.javap.Main.run(args, out);
+            if (rc != 0)
+                throw new Error("javap failed. rc=" + rc);
+        } finally {
+            out.close();
+            System.out.println(sw.toString());
+        }
     }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8195589](https://bugs.openjdk.org/browse/JDK-8195589): T6587786.java failed after JDK-8189997 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2126/head:pull/2126` \
`$ git checkout pull/2126`

Update a local copy of the PR: \
`$ git checkout pull/2126` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2126`

View PR using the GUI difftool: \
`$ git pr show -t 2126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2126.diff">https://git.openjdk.org/jdk11u-dev/pull/2126.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2126#issuecomment-1711272734)