### PR TITLE
8233000: Mark vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize test as stress test

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
@@ -24,6 +24,8 @@
 
 /*
  * @test
+ * @key stress
+ * @key stress
  *
  * @summary converted from VM Testbase vm/mlvm/meth/stress/compiler/deoptimize.
  * VM Testbase keywords: [feature_mlvm, nonconcurrent, quarantine]


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233000](https://bugs.openjdk.org/browse/JDK-8233000): Mark vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize test as stress test (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2127/head:pull/2127` \
`$ git checkout pull/2127`

Update a local copy of the PR: \
`$ git checkout pull/2127` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2127`

View PR using the GUI difftool: \
`$ git pr show -t 2127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2127.diff">https://git.openjdk.org/jdk11u-dev/pull/2127.diff</a>

</details>
