### PR TITLE
8307079: Update test java/awt/Choice/DragOffNoSelect.java

### DIFF
--- a/test/jdk/java/awt/Choice/DragOffNoSelectTest.java
+++ b/test/jdk/java/awt/Choice/DragOffNoSelectTest.java
@@ -71,7 +71,7 @@ public class DragOffNoSelectTest implements WindowListener, Runnable {
         }
         frame.add(theChoice);
         frame.addWindowListener(testInstance);
-        frame.setSize(400, 400);
+        frame.pack();
         frame.setLocationRelativeTo(null);
 
         frame.setVisible(true);


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307079](https://bugs.openjdk.org/browse/JDK-8307079): Update test java/awt/Choice/DragOffNoSelect.java (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2131/head:pull/2131` \
`$ git checkout pull/2131`

Update a local copy of the PR: \
`$ git checkout pull/2131` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2131`

View PR using the GUI difftool: \
`$ git pr show -t 2131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2131.diff">https://git.openjdk.org/jdk11u-dev/pull/2131.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2131#issuecomment-1718911721)