### PR TITLE
8316380: [11u] Backport 8170089: nsk/jdi/EventSet/resume/resume008: ERROR: suspendCounts don't match for : Common-Cleaner

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume001.java
@@ -50,9 +50,9 @@ import static nsk.share.Consts.TEST_FAILED;
  * To check up on the method, a debugger,
  * upon getting new set for ClassPrepareEvent,
  * suspends VM with the method VirtualMachine.suspend(),
- * gets the List of geduggee's threads calling VM.allThreads(),
+ * gets the List of debuggee's threads calling VM.allThreads(),
  * invokes the method EventSet.resume(), and
- * gets another List of geduggee's threads.
+ * gets another List of debuggee's threads.
  * The debugger then compares values of
  * each thread's suspendCount from first and second Lists.
  *
@@ -63,6 +63,13 @@ import static nsk.share.Consts.TEST_FAILED;
  *   making special clases loaded and prepared to create the Events
  * - Upon getting the Events,
  *   the debugger performs the check required.
+ * - The debugger informs the debuggee when it completes
+ *   each test case, so it will wait before hitting
+ *   communication breakpoints.
+ *   This prevents the breakpoint SUSPEND_ALL policy
+ *   disrupting the first test case check for
+ *   SUSPEND_NONE, if the debuggee gets ahead of
+ *   the debugger processing.
  */
 
 public class resume001 extends TestDebuggerType1 {
@@ -233,6 +240,7 @@ public class resume001 extends TestDebuggerType1 {
 
                      default: throw new Failure("** default case 1 **");
                 }
+                informDebuggeeTestCase(i);
             }
 
             display("......--> vm.resume()");
@@ -261,5 +269,22 @@ public class resume001 extends TestDebuggerType1 {
             throw new Failure("** FAILURE to set up ClassPrepareRequest **");
         }
     }
-
+    /**
+     * Inform debuggee which thread test the debugger has completed.
+     * Used for synchronization, so the debuggee does not move too quickly.
+     * @param testCase index of just completed test
+     */
+    void informDebuggeeTestCase(int testCase) {
+        try {
+            ((ClassType)debuggeeClass)
+                .setValue(debuggeeClass.fieldByName("testCase"),
+                          vm.mirrorOf(testCase));
+        } catch (InvalidTypeException ite) {
+            throw new Failure("** FAILURE setting testCase  **");
+        } catch (ClassNotLoadedException cnle) {
+            throw new Failure("** FAILURE notifying debuggee  **");
+        } catch (VMDisconnectedException e) {
+            throw new Failure("** FAILURE debuggee connection **");
+        }
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume001a.java
@@ -33,7 +33,7 @@ import nsk.share.jdi.*;
 
 public class resume001a {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
 
     static final int PASSED = 0;
     static final int FAILED = 2;
@@ -57,6 +57,7 @@ public class resume001a {
 
     static int exitCode = PASSED;
 
+    static int testCase    = -1;
     static int instruction = 1;
     static int end         = 0;
                                    //    static int quit        = 0;
@@ -100,6 +101,10 @@ public class resume001a {
 
                 case 0:
                 TestClass2 obj2 = new TestClass2();
+                // Wait for debugger to complete the first test case
+                // before advancing to the first breakpoint
+                waitForTestCase(0);
+
                 break;
 
                 case 1:
@@ -118,6 +123,16 @@ public class resume001a {
 
         log1("debuggee exits");
         System.exit(exitCode + PASS_BASE);
+    }
+    // Synchronize with debugger progression.
+    static void waitForTestCase(int t) {
+        while (testCase < t) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                // ignored
+            }
+        }
     }
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume002.java
@@ -48,9 +48,9 @@ import java.io.*;
  * To check up on the method, a debugger,                       <BR>
  * upon getting new set for the EventSet,                       <BR>
  * suspends VM with the method VirtualMachine.suspend(),        <BR>
- * gets the List of geduggee's threads calling VM.allThreads(), <BR>
+ * gets the List of debuggee's threads calling VM.allThreads(), <BR>
  * invokes the method EventSet.resume(), and                    <BR>
- * gets another List of geduggee's threads.                     <BR>
+ * gets another List of debuggee's threads.                     <BR>
  * The debugger then compares values of                         <BR>
  * each thread's suspendCount from first and second Lists.      <BR>
  * <BR>
@@ -87,12 +87,12 @@ import java.io.*;
 
 public class resume002 {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
     static final int PASSED = 0;
     static final int FAILED = 2;
     static final int PASS_BASE = 95;
 
-    //----------------------------------------------------- templete parameters
+    //----------------------------------------------------- template parameters
     static final String
     sHeader1 = "\n==> nsk/jdi/EventSet/resume/resume002 ",
     sHeader2 = "--> debugger: ",
@@ -503,6 +503,7 @@ public class resume002 {
 
             log2("......--> vm.resume()");
             vm.resume();
+            informDebuggeeTestCase(i);
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
         log1("    TESTING ENDS");
@@ -642,5 +643,22 @@ public class resume002 {
             throw new JDITestRuntimeException("** FAILURE to set up AccessWatchpointRequest **");
         }
     }
-
+    /**
+     * Inform debuggee which thread test the debugger has completed.
+     * Used for synchronization, so the debuggee does not move too quickly.
+     * @param testCase index of just completed test
+     */
+    void informDebuggeeTestCase(int testCase) {
+        try {
+            ((ClassType)debuggeeClass)
+                .setValue(debuggeeClass.fieldByName("testCase"),
+                          vm.mirrorOf(testCase));
+        } catch (InvalidTypeException ite) {
+            throw new Failure("** FAILURE setting testCase  **");
+        } catch (ClassNotLoadedException cnle) {
+            throw new Failure("** FAILURE notifying debuggee  **");
+        } catch (VMDisconnectedException e) {
+            throw new Failure("** FAILURE debuggee connection **");
+        }
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume002a.java
@@ -33,7 +33,7 @@ import nsk.share.jdi.*;
 
 public class resume002a {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
 
     static final int PASSED = 0;
     static final int FAILED = 2;
@@ -41,6 +41,7 @@ public class resume002a {
 
     static ArgumentHandler argHandler;
     static Log log;
+    static int testCase    = -1;
 
     //--------------------------------------------------   log procedures
 
@@ -98,8 +99,12 @@ public class resume002a {
 
     //------------------------------------------------------  section tested
 
-                    case 0: resume002aTestClass.method();
-                            break;
+                    case 0:
+                        resume002aTestClass.method();
+                        // Wait for debugger to complete the first test case
+                        // before advancing to the first breakpoint
+                        waitForTestCase(0);
+                        break;
 
                     case 1: resume002aTestClass.method();
                             break;
@@ -118,6 +123,17 @@ public class resume002a {
         log1("debuggee exits");
         System.exit(exitCode + PASS_BASE);
     }
+    // Synchronize with debugger progression.
+    static void waitForTestCase(int t) {
+        while (testCase < t) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                // ignored
+            }
+        }
+    }
+
 }
 
 class resume002aTestClass {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume003.java
@@ -48,9 +48,9 @@ import java.io.*;
  * To check up on the method, a debugger,                       <BR>
  * upon getting new set for the EventSet,                       <BR>
  * suspends VM with the method VirtualMachine.suspend(),        <BR>
- * gets the List of geduggee's threads calling VM.allThreads(), <BR>
+ * gets the List of debuggee's threads calling VM.allThreads(), <BR>
  * invokes the method EventSet.resume(), and                    <BR>
- * gets another List of geduggee's threads.                     <BR>
+ * gets another List of debuggee's threads.                     <BR>
  * The debugger then compares values of                         <BR>
  * each thread's suspendCount from first and second Lists.      <BR>
  * <BR>
@@ -87,12 +87,12 @@ import java.io.*;
 
 public class resume003 {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
     static final int PASSED = 0;
     static final int FAILED = 2;
     static final int PASS_BASE = 95;
 
-    //----------------------------------------------------- templete parameters
+    //----------------------------------------------------- template parameters
     static final String
     sHeader1 = "\n==> nsk/jdi/EventSet/resume/resume003 ",
     sHeader2 = "--> debugger: ",
@@ -503,6 +503,8 @@ public class resume003 {
 
             log2("......--> vm.resume()");
             vm.resume();
+            informDebuggeeTestCase(i);
+
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
         log1("    TESTING ENDS");
@@ -642,5 +644,22 @@ public class resume003 {
             throw new JDITestRuntimeException("** FAILURE to set up ModificationWatchpointRequest **");
         }
     }
-
+    /**
+     * Inform debuggee which thread test the debugger has completed.
+     * Used for synchronization, so the debuggee does not move too quickly.
+     * @param testCase index of just completed test
+     */
+    void informDebuggeeTestCase(int testCase) {
+        try {
+            ((ClassType)debuggeeClass)
+                .setValue(debuggeeClass.fieldByName("testCase"),
+                          vm.mirrorOf(testCase));
+        } catch (InvalidTypeException ite) {
+            throw new Failure("** FAILURE setting testCase  **");
+        } catch (ClassNotLoadedException cnle) {
+            throw new Failure("** FAILURE notifying debuggee  **");
+        } catch (VMDisconnectedException e) {
+            throw new Failure("** FAILURE debuggee connection **");
+        }
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume003a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume003a.java
@@ -33,7 +33,8 @@ import nsk.share.jdi.*;
 
 public class resume003a {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
+    static int testCase    = -1;
 
     static final int PASSED = 0;
     static final int FAILED = 2;
@@ -98,8 +99,12 @@ public class resume003a {
 
     //------------------------------------------------------  section tested
 
-                    case 0: resume003aTestClass.method();
-                            break;
+                    case 0:
+                        resume003aTestClass.method();
+                        // Wait for debugger to complete the first test case
+                        // before advancing to the first breakpoint
+                        waitForTestCase(0);
+                        break;
 
                     case 1: resume003aTestClass.method();
                             break;
@@ -117,6 +122,16 @@ public class resume003a {
 
         log1("debuggee exits");
         System.exit(exitCode + PASS_BASE);
+    }
+    // Synchronize with debugger progression.
+    static void waitForTestCase(int t) {
+        while (testCase < t) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                // ignored
+            }
+        }
     }
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume004.java
@@ -48,9 +48,9 @@ import java.io.*;
  * To check up on the method, a debugger,                       <BR>
  * upon getting new set for the EventSet,                       <BR>
  * suspends VM with the method VirtualMachine.suspend(),        <BR>
- * gets the List of geduggee's threads calling VM.allThreads(), <BR>
+ * gets the List of debuggee's threads calling VM.allThreads(), <BR>
  * invokes the method EventSet.resume(), and                    <BR>
- * gets another List of geduggee's threads.                     <BR>
+ * gets another List of debuggee's threads.                     <BR>
  * The debugger then compares values of                         <BR>
  * each thread's suspendCount from first and second Lists.      <BR>
  * <BR>
@@ -87,12 +87,12 @@ import java.io.*;
 
 public class resume004 {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
     static final int PASSED = 0;
     static final int FAILED = 2;
     static final int PASS_BASE = 95;
 
-    //----------------------------------------------------- templete parameters
+    //----------------------------------------------------- template parameters
     static final String
     sHeader1 = "\n==> nsk/jdi/EventSet/resume/resume004 ",
     sHeader2 = "--> debugger: ",
@@ -493,6 +493,7 @@ public class resume004 {
 
                   default: throw new JDITestRuntimeException("** default case 1 **");
                 }
+                informDebuggeeTestCase(i);
             }
 
             log2("......--> vm.resume()");
@@ -638,5 +639,22 @@ public class resume004 {
             throw new JDITestRuntimeException("** FAILURE to set up BreakpointRequest **");
         }
     }
-
+    /**
+     * Inform debuggee which thread test the debugger has completed.
+     * Used for synchronization, so the debuggee does not move too quickly.
+     * @param testCase index of just completed test
+     */
+    void informDebuggeeTestCase(int testCase) {
+        try {
+            ((ClassType)debuggeeClass)
+                .setValue(debuggeeClass.fieldByName("testCase"),
+                          vm.mirrorOf(testCase));
+        } catch (InvalidTypeException ite) {
+            throw new Failure("** FAILURE setting testCase  **");
+        } catch (ClassNotLoadedException cnle) {
+            throw new Failure("** FAILURE notifying debuggee  **");
+        } catch (VMDisconnectedException e) {
+            throw new Failure("** FAILURE debuggee connection **");
+        }
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume004a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume004a.java
@@ -33,7 +33,8 @@ import nsk.share.jdi.*;
 
 public class resume004a {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
+    static int testCase    = -1;
 
     static final int PASSED = 0;
     static final int FAILED = 2;
@@ -98,8 +99,10 @@ public class resume004a {
 
     //------------------------------------------------------  section tested
 
-                    case 0: resume004aTestClass.method();
-                            break;
+                    case 0:
+                        resume004aTestClass.method();
+                        waitForTestCase(0);
+                        break;
 
                     case 1: resume004aTestClass.method();
                             break;
@@ -117,6 +120,16 @@ public class resume004a {
 
         log1("debuggee exits");
         System.exit(exitCode + PASS_BASE);
+    }
+    // Synchronize with debugger progression.
+    static void waitForTestCase(int t) {
+        while (testCase < t) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                // ignored
+            }
+        }
     }
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume005.java
@@ -48,9 +48,9 @@ import java.io.*;
  * To check up on the method, a debugger,                       <BR>
  * upon getting new set for the EventSet,                       <BR>
  * suspends VM with the method VirtualMachine.suspend(),        <BR>
- * gets the List of geduggee's threads calling VM.allThreads(), <BR>
+ * gets the List of debuggee's threads calling VM.allThreads(), <BR>
  * invokes the method EventSet.resume(), and                    <BR>
- * gets another List of geduggee's threads.                     <BR>
+ * gets another List of debuggee's threads.                     <BR>
  * The debugger then compares values of                         <BR>
  * each thread's suspendCount from first and second Lists.      <BR>
  * <BR>
@@ -87,12 +87,12 @@ import java.io.*;
 
 public class resume005 {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
     static final int PASSED = 0;
     static final int FAILED = 2;
     static final int PASS_BASE = 95;
 
-    //----------------------------------------------------- templete parameters
+    //----------------------------------------------------- template parameters
     static final String
     sHeader1 = "\n==> nsk/jdi/EventSet/resume/resume005 ",
     sHeader2 = "--> debugger: ",
@@ -493,6 +493,7 @@ public class resume005 {
 
                   default: throw new JDITestRuntimeException("** default case 1 **");
                 }
+                informDebuggeeTestCase(i);
             }
 
             log2("......--> vm.resume()");
@@ -634,5 +635,22 @@ public class resume005 {
             throw new JDITestRuntimeException("** FAILURE to set up ExceptionRequest **");
         }
     }
-
+    /**
+     * Inform debuggee which thread test the debugger has completed.
+     * Used for synchronization, so the debuggee does not move too quickly.
+     * @param testCase index of just completed test
+     */
+    void informDebuggeeTestCase(int testCase) {
+        try {
+            ((ClassType)debuggeeClass)
+                .setValue(debuggeeClass.fieldByName("testCase"),
+                          vm.mirrorOf(testCase));
+        } catch (InvalidTypeException ite) {
+            throw new Failure("** FAILURE setting testCase  **");
+        } catch (ClassNotLoadedException cnle) {
+            throw new Failure("** FAILURE notifying debuggee  **");
+        } catch (VMDisconnectedException e) {
+            throw new Failure("** FAILURE debuggee connection **");
+        }
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume005a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume005a.java
@@ -33,7 +33,8 @@ import nsk.share.jdi.*;
 
 public class resume005a {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
+    static int testCase    = -1;
 
     static final int PASSED = 0;
     static final int FAILED = 2;
@@ -98,8 +99,10 @@ public class resume005a {
 
     //------------------------------------------------------  section tested
 
-                    case 0: resume005aTestClass.method();
-                            break;
+                    case 0:
+                        resume005aTestClass.method();
+                        waitForTestCase(0);
+                        break;
 
                     case 1: resume005aTestClass.method();
                             break;
@@ -122,7 +125,16 @@ public class resume005a {
     public static void nullMethod() {
         throw new NullPointerException("test");
     }
-
+    // Synchronize with debugger progression.
+    static void waitForTestCase(int t) {
+        while (testCase < t) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                // ignored
+            }
+        }
+    }
 }
 
 class resume005aTestClass {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume006.java
@@ -48,9 +48,9 @@ import java.io.*;
  * To check up on the method, a debugger,                       <BR>
  * upon getting new set for the EventSet,                       <BR>
  * suspends VM with the method VirtualMachine.suspend(),        <BR>
- * gets the List of geduggee's threads calling VM.allThreads(), <BR>
+ * gets the List of debuggee's threads calling VM.allThreads(), <BR>
  * invokes the method EventSet.resume(), and                    <BR>
- * gets another List of geduggee's threads.                     <BR>
+ * gets another List of debuggee's threads.                     <BR>
  * The debugger then compares values of                         <BR>
  * each thread's suspendCount from first and second Lists.      <BR>
  * <BR>
@@ -87,12 +87,12 @@ import java.io.*;
 
 public class resume006 {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
     static final int PASSED = 0;
     static final int FAILED = 2;
     static final int PASS_BASE = 95;
 
-    //----------------------------------------------------- templete parameters
+    //----------------------------------------------------- template parameters
     static final String
     sHeader1 = "\n==> nsk/jdi/EventSet/resume/resume006 ",
     sHeader2 = "--> debugger: ",
@@ -495,6 +495,7 @@ public class resume006 {
 
             log2("......--> vm.resume()");
             vm.resume();
+            informDebuggeeTestCase(i);
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
         log1("    TESTING ENDS");
@@ -632,5 +633,22 @@ public class resume006 {
             throw new JDITestRuntimeException("** FAILURE to set up MethodEntryRequest **");
         }
     }
-
+    /**
+     * Inform debuggee which thread test the debugger has completed.
+     * Used for synchronization, so the debuggee does not move too quickly.
+     * @param testCase index of just completed test
+     */
+    void informDebuggeeTestCase(int testCase) {
+        try {
+            ((ClassType)debuggeeClass)
+                .setValue(debuggeeClass.fieldByName("testCase"),
+                          vm.mirrorOf(testCase));
+        } catch (InvalidTypeException ite) {
+            throw new Failure("** FAILURE setting testCase  **");
+        } catch (ClassNotLoadedException cnle) {
+            throw new Failure("** FAILURE notifying debuggee  **");
+        } catch (VMDisconnectedException e) {
+            throw new Failure("** FAILURE debuggee connection **");
+        }
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume006a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume006a.java
@@ -33,7 +33,7 @@ import nsk.share.jdi.*;
 
 public class resume006a {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
 
     static final int PASSED = 0;
     static final int FAILED = 2;
@@ -41,6 +41,7 @@ public class resume006a {
 
     static ArgumentHandler argHandler;
     static Log log;
+    static int testCase    = -1;
 
     //--------------------------------------------------   log procedures
 
@@ -98,8 +99,12 @@ public class resume006a {
 
     //------------------------------------------------------  section tested
 
-                    case 0: resume006aTestClass.method();
-                            break;
+                    case 0:
+                        resume006aTestClass.method();
+                        // Wait for debugger to complete the first test case
+                        // before advancing to the next breakpoint
+                        waitForTestCase(0);
+                        break;
 
                     case 1: resume006aTestClass.method();
                             break;
@@ -118,7 +123,16 @@ public class resume006a {
         log1("debuggee exits");
         System.exit(exitCode + PASS_BASE);
     }
-
+    // Synchronize with debugger progression.
+    static void waitForTestCase(int t) {
+        while (testCase < t) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                // ignored
+            }
+        }
+    }
 }
 
 class resume006aTestClass {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume007.java
@@ -48,9 +48,9 @@ import java.io.*;
  * To check up on the method, a debugger,                       <BR>
  * upon getting new set for the EventSet,                       <BR>
  * suspends VM with the method VirtualMachine.suspend(),        <BR>
- * gets the List of geduggee's threads calling VM.allThreads(), <BR>
+ * gets the List of debuggee's threads calling VM.allThreads(), <BR>
  * invokes the method EventSet.resume(), and                    <BR>
- * gets another List of geduggee's threads.                     <BR>
+ * gets another List of debuggee's threads.                     <BR>
  * The debugger then compares values of                         <BR>
  * each thread's suspendCount from first and second Lists.      <BR>
  * <BR>
@@ -87,12 +87,12 @@ import java.io.*;
 
 public class resume007 {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
     static final int PASSED = Consts.TEST_PASSED;
     static final int FAILED = Consts.TEST_FAILED;
     static final int PASS_BASE = Consts.JCK_STATUS_BASE;
 
-    //----------------------------------------------------- templete parameters
+    //----------------------------------------------------- template parameters
     static final String
     sHeader1 = "\n==> nsk/jdi/EventSet/resume/resume007 ",
     sHeader2 = "--> debugger: ",
@@ -490,6 +490,7 @@ public class resume007 {
 
                   default: throw new JDITestRuntimeException("** default case 1 **");
                 }
+                informDebuggeeTestCase(i);
             }
 
             log2("......--> vm.resume()");
@@ -631,5 +632,22 @@ public class resume007 {
             throw new JDITestRuntimeException("** FAILURE to set up MethodExitRequest **");
         }
     }
-
+    /**
+     * Inform debuggee which thread test the debugger has completed.
+     * Used for synchronization, so the debuggee does not move too quickly.
+     * @param testCase index of just completed test
+     */
+    void informDebuggeeTestCase(int testCase) {
+        try {
+            ((ClassType)debuggeeClass)
+                .setValue(debuggeeClass.fieldByName("testCase"),
+                          vm.mirrorOf(testCase));
+        } catch (InvalidTypeException ite) {
+            throw new Failure("** FAILURE setting testCase  **");
+        } catch (ClassNotLoadedException cnle) {
+            throw new Failure("** FAILURE notifying debuggee  **");
+        } catch (VMDisconnectedException e) {
+            throw new Failure("** FAILURE debuggee connection **");
+        }
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume007a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume007a.java
@@ -33,7 +33,8 @@ import nsk.share.jdi.*;
 
 public class resume007a {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
+    static int testCase    = -1;
 
     static final int PASSED = 0;
     static final int FAILED = 2;
@@ -98,8 +99,10 @@ public class resume007a {
 
     //------------------------------------------------------  section tested
 
-                    case 0: resume007aTestClass.method();
-                            break;
+                    case 0:
+                        resume007aTestClass.method();
+                        waitForTestCase(0);
+                        break;
 
                     case 1: resume007aTestClass.method();
                             break;
@@ -118,7 +121,16 @@ public class resume007a {
         log1("debuggee exits");
         System.exit(exitCode + PASS_BASE);
     }
-
+    // Synchronize with debugger progression.
+    static void waitForTestCase(int t) {
+        while (testCase < t) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                // ignored
+            }
+        }
+    }
 }
 
 class resume007aTestClass {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume009a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume009a.java
@@ -33,7 +33,7 @@ import nsk.share.jdi.*;
 
 public class resume009a {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
 
     static final int PASSED = 0;
     static final int FAILED = 2;
@@ -62,6 +62,7 @@ public class resume009a {
 
     static int exitCode = PASSED;
 
+    static int testCase    = -1;
     static int instruction = 1;
     static int end         = 0;
                                    //    static int quit        = 0;
@@ -104,6 +105,9 @@ public class resume009a {
                             threadRun(thread0);
 
                             thread1 = new Threadresume009a("thread1");
+                            // Wait for debugger to complete the first test case
+                            // before advancing to the first breakpoint
+                            waitForTestCase(0);
                             methodForCommunication();
                             break;
 
@@ -151,6 +155,16 @@ public class resume009a {
             return FAILED;
         }
         return PASSED;
+    }
+    // Synchronize with debugger progression.
+    static void waitForTestCase(int t) {
+        while (testCase < t) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                // ignored
+            }
+        }
     }
 
     static class Threadresume009a extends Thread {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume010.java
@@ -48,9 +48,9 @@ import java.io.*;
  * To check up on the method, a debugger,                       <BR>
  * upon getting new set for the EventSet,                       <BR>
  * suspends VM with the method VirtualMachine.suspend(),        <BR>
- * gets the List of geduggee's threads calling VM.allThreads(), <BR>
+ * gets the List of debuggee's threads calling VM.allThreads(), <BR>
  * invokes the method EventSet.resume(), and                    <BR>
- * gets another List of geduggee's threads.                     <BR>
+ * gets another List of debuggee's threads.                     <BR>
  * The debugger then compares values of                         <BR>
  * each thread's suspendCount from first and second Lists.      <BR>
  * <BR>
@@ -87,12 +87,12 @@ import java.io.*;
 
 public class resume010 {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
     static final int PASSED = 0;
     static final int FAILED = 2;
     static final int PASS_BASE = 95;
 
-    //----------------------------------------------------- templete parameters
+    //----------------------------------------------------- template parameters
     static final String
     sHeader1 = "\n==> nsk/jdi/EventSet/resume/resume010 ",
     sHeader2 = "--> debugger: ",
@@ -488,6 +488,7 @@ public class resume010 {
                     default:
                         throw new JDITestRuntimeException("** default case 1 **");
                 }
+                informDebuggeeTestCase(i);
             }
 
             log2("......--> vm.resume()");
@@ -627,5 +628,22 @@ public class resume010 {
             throw new JDITestRuntimeException("** FAILURE to set up StepRequest **");
         }
     }
-
+    /**
+     * Inform debuggee which thread test the debugger has completed.
+     * Used for synchronization, so the debuggee does not move too quickly.
+     * @param testCase index of just completed test
+     */
+    void informDebuggeeTestCase(int testCase) {
+        try {
+            ((ClassType)debuggeeClass)
+                .setValue(debuggeeClass.fieldByName("testCase"),
+                          vm.mirrorOf(testCase));
+        } catch (InvalidTypeException ite) {
+            throw new Failure("** FAILURE setting testCase  **");
+        } catch (ClassNotLoadedException cnle) {
+            throw new Failure("** FAILURE notifying debuggee  **");
+        } catch (VMDisconnectedException e) {
+            throw new Failure("** FAILURE debuggee connection **");
+        }
+    }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume010a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/resume/resume010a.java
@@ -33,7 +33,7 @@ import nsk.share.jdi.*;
 
 public class resume010a {
 
-    //----------------------------------------------------- templete section
+    //----------------------------------------------------- template section
 
     static final int PASSED = 0;
     static final int FAILED = 2;
@@ -60,6 +60,7 @@ public class resume010a {
 
     static int exitCode = PASSED;
 
+    static int testCase    = -1;
     static int instruction = 1;
     static int end         = 0;
                                    //    static int quit        = 0;
@@ -98,8 +99,12 @@ public class resume010a {
 
     //------------------------------------------------------  section tested
 
-                    case 0: resume010aTestClass.method();
-                            break;
+                    case 0:
+                        resume010aTestClass.method();
+                        // Wait for debugger to complete the first test case
+                        // before advancing to the first breakpoint
+                        waitForTestCase(0);
+                        break;
 
                     case 1: resume010aTestClass.method();
                             break;
@@ -117,7 +122,16 @@ public class resume010a {
 
         System.exit(exitCode + PASS_BASE);
     }
-
+    // Synchronize with debugger progression.
+    static void waitForTestCase(int t) {
+        while (testCase < t) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                // ignored
+            }
+        }
+    }
 }
 class resume010aTestClass {
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of the closed bug JDK-8170089, commit [b984ecc4](https://github.com/openjdk/jdk17u-dev/commit/b984ecc4389adf186a446d8fabaa1819de9962b0) from the [openjdk/jdk17u-dev](https://git.openjdk.org/jdk17u-dev) repository.

The commit being backported was authored by Gary Adams on 28 Aug 2018 and was reviewed by Chris Plummer and Serguei Spitsyn.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316380](https://bugs.openjdk.org/browse/JDK-8316380): [11u] Backport 8170089: nsk/jdi/EventSet/resume/resume008: ERROR: suspendCounts don't match for : Common-Cleaner (**Bug** - P3)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2133/head:pull/2133` \
`$ git checkout pull/2133`

Update a local copy of the PR: \
`$ git checkout pull/2133` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2133`

View PR using the GUI difftool: \
`$ git pr show -t 2133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2133.diff">https://git.openjdk.org/jdk11u-dev/pull/2133.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2133#issuecomment-1721756204)