### PR TITLE
8313815: The exception messages printed by jcmd ManagementAgent.start are corrupted on Japanese Windows

### DIFF
--- a/src/jdk.attach/share/classes/sun/tools/attach/HotSpotVirtualMachine.java
+++ b/src/jdk.attach/share/classes/sun/tools/attach/HotSpotVirtualMachine.java
@@ -355,7 +355,7 @@ public abstract class HotSpotVirtualMachine extends VirtualMachine {
     String readErrorMessage(InputStream in) throws IOException {
         String s;
         StringBuilder message = new StringBuilder();
-        BufferedReader br = new BufferedReader(new InputStreamReader(in));
+        BufferedReader br = new BufferedReader(new InputStreamReader(in,"UTF-8"));
         while ((s = br.readLine()) != null) {
             message.append(s);
         }


### PR DESCRIPTION
I would like to backport this fix to 11u.
The original patch applies cleanly to 11u.
There is no risk, because the logic around the changes is same as jdk17
Testing:
all serviceability area tests jdk_svc, and a specific test to verify the fix.

Could anyone review the fix please?

Thanks,
Kimura Yukihiro

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313815](https://bugs.openjdk.org/browse/JDK-8313815): The exception messages printed by jcmd ManagementAgent.start are corrupted on Japanese Windows (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2134/head:pull/2134` \
`$ git checkout pull/2134`

Update a local copy of the PR: \
`$ git checkout pull/2134` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2134`

View PR using the GUI difftool: \
`$ git pr show -t 2134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2134.diff">https://git.openjdk.org/jdk11u-dev/pull/2134.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2134#issuecomment-1726749399)