### PR TITLE
8316178: Better diagnostic header for CodeBlobs

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -185,7 +185,8 @@ void RuntimeBlob::trace_new_stub(RuntimeBlob* stub, const char* name1, const cha
     jio_snprintf(stub_id, sizeof(stub_id), "%s%s", name1, name2);
     if (PrintStubCode) {
       ttyLocker ttyl;
-      tty->print_cr("Decoding %s " INTPTR_FORMAT, stub_id, (intptr_t) stub);
+      tty->print_cr("Decoding %s " PTR_FORMAT " [" PTR_FORMAT ", " PTR_FORMAT "] (%d bytes)",
+                    stub_id, p2i(stub), p2i(stub->code_begin()), p2i(stub->code_end()), stub->code_size());
       Disassembler::decode(stub->code_begin(), stub->code_end());
       tty->cr();
     }


### PR DESCRIPTION
Semi-clean backport to improve JVM diagnostics. Does not apply cleanly because context is quite a bit different in JDK 11.

Additional testing:
 - [x] Eyeballing the VM output

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316178](https://bugs.openjdk.org/browse/JDK-8316178): Better diagnostic header for CodeBlobs (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2137/head:pull/2137` \
`$ git checkout pull/2137`

Update a local copy of the PR: \
`$ git checkout pull/2137` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2137`

View PR using the GUI difftool: \
`$ git pr show -t 2137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2137.diff">https://git.openjdk.org/jdk11u-dev/pull/2137.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2137#issuecomment-1728957489)