### PR TITLE
8265586: [windows] last button is not shown in AWT Frame with BorderLayout and MenuBar set.

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -24,7 +24,6 @@
  */
 
 #include "awt.h"
-
 #include <jlong.h>
 
 #include "awt_Component.h"
@@ -1396,6 +1395,9 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
     RECT inside;
     int extraBottomInsets = 0;
 
+    // extra padded border for captioned windows
+    int extraPaddedBorderInsets = ::GetSystemMetrics(SM_CXPADDEDBORDER);
+
     ::GetClientRect(GetHWnd(), &inside);
     ::GetWindowRect(GetHWnd(), &outside);
 
@@ -1419,17 +1421,15 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
             LONG style = GetStyle();
             if (style & WS_THICKFRAME) {
                 m_insets.left = m_insets.right =
-                    ::GetSystemMetrics(SM_CXSIZEFRAME);
+                    ::GetSystemMetrics(SM_CXSIZEFRAME) + extraPaddedBorderInsets;
                 m_insets.top = m_insets.bottom =
-                    ::GetSystemMetrics(SM_CYSIZEFRAME);
+                    ::GetSystemMetrics(SM_CYSIZEFRAME) + extraPaddedBorderInsets;
             } else {
                 m_insets.left = m_insets.right =
-                    ::GetSystemMetrics(SM_CXDLGFRAME);
+                    ::GetSystemMetrics(SM_CXDLGFRAME) + extraPaddedBorderInsets;
                 m_insets.top = m_insets.bottom =
-                    ::GetSystemMetrics(SM_CYDLGFRAME);
+                    ::GetSystemMetrics(SM_CYDLGFRAME) + extraPaddedBorderInsets;
             }
-
-
             /* Add in title. */
             m_insets.top += ::GetSystemMetrics(SM_CYCAPTION);
         }

--- a/test/jdk/java/awt/Frame/AwtFramePackTest.java
+++ b/test/jdk/java/awt/Frame/AwtFramePackTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.Panel;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+
+/*
+ * @test
+ * @bug 8265586
+ * @key headful
+ * @summary Tests whether insets are calculated correctly on Windows
+ * for AWT Frame by checking the actual and expected/preferred frame sizes.
+ * @run main AwtFramePackTest
+ */
+
+public class AwtFramePackTest {
+
+    private static Frame frame;
+    private static Robot robot;
+
+    public static void main(String[] args) throws AWTException {
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(300);
+
+            frame = new Frame();
+            frame.setLayout(new BorderLayout());
+
+            Panel panel = new Panel();
+            panel.add(new Button("Panel Button B1"));
+            panel.add(new Button("Panel Button B2"));
+            frame.add(panel, BorderLayout.CENTER);
+
+            MenuBar mb = new MenuBar();
+            Menu m = new Menu("Menu");
+            mb.add(m);
+            frame.setMenuBar(mb);
+
+            frame.pack();
+            frame.setVisible(true);
+
+            robot.delay(500);
+            robot.waitForIdle();
+
+            Dimension actualFrameSize = frame.getSize();
+            Dimension expectedFrameSize = frame.getPreferredSize();
+
+            if (!actualFrameSize.equals(expectedFrameSize)) {
+                System.out.println("Expected frame size: "+ expectedFrameSize);
+                System.out.println("Actual frame size: "+ actualFrameSize);
+                saveScreenCapture();
+                throw new RuntimeException("Expected and Actual frame size" +
+                        " are different. frame.pack() does not work!!");
+            }
+        } finally {
+            frame.dispose();
+        }
+    }
+
+    // for debugging purpose, saves screen capture when test fails.
+    private static void saveScreenCapture() {
+        BufferedImage image = robot.createScreenCapture(frame.getBounds());
+        try {
+            ImageIO.write(image,"png", new File("Frame.png"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8265586](https://bugs.openjdk.org/browse/JDK-8265586): [windows] last button is not shown in AWT Frame with BorderLayout and MenuBar set. (**Bug** - P4)
 * [JDK-8288993](https://bugs.openjdk.org/browse/JDK-8288993): Make AwtFramePackTest generic by removing @<!---->requires tag (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2138/head:pull/2138` \
`$ git checkout pull/2138`

Update a local copy of the PR: \
`$ git checkout pull/2138` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2138`

View PR using the GUI difftool: \
`$ git pr show -t 2138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2138.diff">https://git.openjdk.org/jdk11u-dev/pull/2138.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2138#issuecomment-1729343399)