### PR TITLE
8288325: [windows] Actual and Preferred Size of AWT Non-resizable frame are different

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -1393,7 +1393,6 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
      */
     RECT outside;
     RECT inside;
-    int extraBottomInsets = 0;
 
     // extra padded border for captioned windows
     int extraPaddedBorderInsets = ::GetSystemMetrics(SM_CXPADDEDBORDER);
@@ -1405,12 +1404,13 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
     if (outside.right - outside.left > 0 && outside.bottom - outside.top > 0) {
         ::MapWindowPoints(GetHWnd(), 0, (LPPOINT)&inside, 2);
         m_insets.top = inside.top - outside.top;
-        m_insets.bottom = outside.bottom - inside.bottom + extraBottomInsets;
+        m_insets.bottom = outside.bottom - inside.bottom;
         m_insets.left = inside.left - outside.left;
         m_insets.right = outside.right - inside.right;
     } else {
         m_insets.top = -1;
     }
+
     if (m_insets.left < 0 || m_insets.top < 0 ||
         m_insets.right < 0 || m_insets.bottom < 0)
     {
@@ -1418,18 +1418,11 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
         jobject target = GetTarget(env);
         if (IsUndecorated() == FALSE) {
             /* Get outer frame sizes. */
-            LONG style = GetStyle();
-            if (style & WS_THICKFRAME) {
-                m_insets.left = m_insets.right =
-                    ::GetSystemMetrics(SM_CXSIZEFRAME) + extraPaddedBorderInsets;
-                m_insets.top = m_insets.bottom =
-                    ::GetSystemMetrics(SM_CYSIZEFRAME) + extraPaddedBorderInsets;
-            } else {
-                m_insets.left = m_insets.right =
-                    ::GetSystemMetrics(SM_CXDLGFRAME) + extraPaddedBorderInsets;
-                m_insets.top = m_insets.bottom =
-                    ::GetSystemMetrics(SM_CYDLGFRAME) + extraPaddedBorderInsets;
-            }
+            // System metrics are same for resizable & non-resizable frame.
+            m_insets.left = m_insets.right =
+                ::GetSystemMetrics(SM_CXFRAME) + extraPaddedBorderInsets;
+            m_insets.top = m_insets.bottom =
+                ::GetSystemMetrics(SM_CYFRAME) + extraPaddedBorderInsets;
             /* Add in title. */
             m_insets.top += ::GetSystemMetrics(SM_CYCAPTION);
         }
@@ -1437,7 +1430,7 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
             /* fix for 4418125: Undecorated frames are off by one */
             /* undo the -1 set above */
             /* Additional fix for 5059656 */
-                /* Also, 5089312: Window insets should be 0. */
+            /* Also, 5089312: Window insets should be 0. */
             ::memset(&m_insets, 0, sizeof(m_insets));
         }
 
@@ -1450,7 +1443,6 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
             env->DeleteLocalRef(target);
             return FALSE;
         }
-        m_insets.bottom += extraBottomInsets;
         env->DeleteLocalRef(target);
     }
 

--- a/test/jdk/java/awt/Frame/AwtFramePackTest.java
+++ b/test/jdk/java/awt/Frame/AwtFramePackTest.java
@@ -39,21 +39,37 @@ import javax.imageio.ImageIO;
  * @test
  * @bug 8265586
  * @key headful
- * @summary Tests whether insets are calculated correctly on Windows
- * for AWT Frame by checking the actual and expected/preferred frame sizes.
+ * @summary Tests whether correct native frame insets are obtained
+ * for Resizable & Non-Resizable AWT Frame by checking the actual
+ * and expected/preferred frame sizes.
  * @run main AwtFramePackTest
  */
-
 public class AwtFramePackTest {
-
     private static Frame frame;
     private static Robot robot;
+    private static StringBuffer errorLog = new StringBuffer();
 
     public static void main(String[] args) throws AWTException {
-        try {
-            robot = new Robot();
-            robot.setAutoDelay(300);
+        robot = new Robot();
+        robot.setAutoDelay(300);
 
+        // Resizable frame
+        createAWTFrame(true);
+
+        robot.waitForIdle();
+        robot.delay(500);
+
+        // Non-Resizable frame
+        createAWTFrame(false);
+
+        if (errorLog != null && errorLog.length() > 0) {
+            throw new RuntimeException("Test failed due to the following" +
+                    " one or more errors: \n" + errorLog);
+        }
+    }
+
+    private static void createAWTFrame(boolean isResizable) {
+        try {
             frame = new Frame();
             frame.setLayout(new BorderLayout());
 
@@ -67,32 +83,36 @@ public class AwtFramePackTest {
             mb.add(m);
             frame.setMenuBar(mb);
 
+            frame.setResizable(isResizable);
             frame.pack();
             frame.setVisible(true);
 
-            robot.delay(500);
             robot.waitForIdle();
+            robot.delay(500);
 
             Dimension actualFrameSize = frame.getSize();
             Dimension expectedFrameSize = frame.getPreferredSize();
 
             if (!actualFrameSize.equals(expectedFrameSize)) {
-                System.out.println("Expected frame size: "+ expectedFrameSize);
-                System.out.println("Actual frame size: "+ actualFrameSize);
-                saveScreenCapture();
-                throw new RuntimeException("Expected and Actual frame size" +
-                        " are different. frame.pack() does not work!!");
+                String frameType = isResizable ? "ResizableFrame" : "NonResizableFrame";
+                System.out.println("Expected frame size: " + expectedFrameSize);
+                System.out.println("Actual frame size: " + actualFrameSize);
+                saveScreenCapture(frameType + ".png");
+                errorLog.append(frameType + ": Expected and Actual frame size" +
+                        " are different. frame.pack() does not work!! \n");
             }
         } finally {
-            frame.dispose();
+            if (frame != null) {
+                frame.dispose();
+            }
         }
     }
 
     // for debugging purpose, saves screen capture when test fails.
-    private static void saveScreenCapture() {
+    private static void saveScreenCapture(String filename) {
         BufferedImage image = robot.createScreenCapture(frame.getBounds());
         try {
-            ImageIO.write(image,"png", new File("Frame.png"));
+            ImageIO.write(image,"png", new File(filename));
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

I had to fix the syntac of the test, as isEmtpy() is not availabe in 11. 
Replaced by errorLog != null && errorLog.length() > 0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8288325](https://bugs.openjdk.org/browse/JDK-8288325) needs maintainer approval

### Issue
 * [JDK-8288325](https://bugs.openjdk.org/browse/JDK-8288325): [windows] Actual and Preferred Size of AWT Non-resizable frame are different (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2139/head:pull/2139` \
`$ git checkout pull/2139`

Update a local copy of the PR: \
`$ git checkout pull/2139` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2139`

View PR using the GUI difftool: \
`$ git pr show -t 2139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2139.diff">https://git.openjdk.org/jdk11u-dev/pull/2139.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2139#issuecomment-1730950140)