### PR TITLE
8301065: Handle control characters in java_lang_String::print

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -730,8 +730,13 @@ void java_lang_String::print(oop java_string, outputStream* st) {
 
   st->print("\"");
   for (int index = 0; index < length; index++) {
-    st->print("%c", (!is_latin1) ?  value->char_at(index) :
-                           ((jchar) value->byte_at(index)) & 0xff );
+    jchar c = (!is_latin1) ?  value->char_at(index) :
+                             ((jchar) value->byte_at(index)) & 0xff;
+    if (c < ' ') {
+      st->print("\\x%02X", c); // print control characters e.g. \x0A
+    } else {
+      st->print("%c", c);
+    }
   }
   st->print("\"");
 }


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8301065](https://bugs.openjdk.org/browse/JDK-8301065) needs maintainer approval

### Issue
 * [JDK-8301065](https://bugs.openjdk.org/browse/JDK-8301065): Handle control characters in java_lang_String::print (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2142/head:pull/2142` \
`$ git checkout pull/2142`

Update a local copy of the PR: \
`$ git checkout pull/2142` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2142`

View PR using the GUI difftool: \
`$ git pr show -t 2142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2142.diff">https://git.openjdk.org/jdk11u-dev/pull/2142.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2142#issuecomment-1731131757)