### PR TITLE
8316206: Test StretchedFontTest.java fails for Baekmuk font

### DIFF
--- a/test/jdk/java/awt/font/FontScaling/StretchedFontTest.java
+++ b/test/jdk/java/awt/font/FontScaling/StretchedFontTest.java
@@ -26,6 +26,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.font.FontRenderContext;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -62,15 +63,19 @@ public final class StretchedFontTest {
             new Color(0x7F000000, true)
     };
 
+    /** Locale for getting font names. */
+    private static final Locale ENGLISH_LOCALE = Locale.ENGLISH;
+
     private static final AffineTransform STRETCH_TRANSFORM =
             AffineTransform.getScaleInstance(2.0, 1.0);
 
     public static void main(String[] args) {
         List<String> errors =
                 Arrays.stream(getLocalGraphicsEnvironment()
-                              .getAvailableFontFamilyNames(Locale.ENGLISH))
+                              .getAvailableFontFamilyNames(ENGLISH_LOCALE))
                       .map(family -> new Font(family, Font.PLAIN, FONT_SIZE))
                       .filter(font -> font.canDisplay(TEXT.codePointAt(0)))
+                      .filter(font -> !isBrokenFont(font))
                       .map(font -> font.deriveFont(STRETCH_TRANSFORM))
                       .flatMap(StretchedFontTest::testFont)
                       .filter(Objects::nonNull)
@@ -81,6 +86,26 @@ public final class StretchedFontTest {
             throw new Error(errors.size() + " failure(s) found;"
                             + " the first one: " + errors.get(0));
         }
+    }
+
+    /**
+     * Checks whether the font renders the glyph in {@code TEXT} and
+     * returns {@code true} if the glyph isn't rendered.
+     *
+     * @param font the font to test
+     * @return {@code true} if the visual bounds of {@code TEXT} are empty, and
+     *         {@code false} otherwise
+     */
+    private static boolean isBrokenFont(final Font font) {
+        final boolean empty =
+                font.createGlyphVector(new FontRenderContext(null, false, false),
+                                       TEXT)
+                    .getVisualBounds()
+                    .isEmpty();
+        if (empty) {
+            System.err.println("Broken font: " + font.getFontName(ENGLISH_LOCALE));
+        }
+        return empty;
     }
 
     /**
@@ -146,7 +171,7 @@ public final class StretchedFontTest {
         if (verifyImage(image)) {
             return null;
         }
-        String fontName = font.getFontName(Locale.ENGLISH);
+        String fontName = font.getFontName(ENGLISH_LOCALE);
         String hintValue = getHintString(hint);
         String hexColor = String.format("0x%08x", foreground.getRGB());
         saveImage(image, fontName + "-" + hintValue + "-" + hexColor);


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8316206](https://bugs.openjdk.org/browse/JDK-8316206) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316206](https://bugs.openjdk.org/browse/JDK-8316206): Test StretchedFontTest.java fails for Baekmuk font (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2147/head:pull/2147` \
`$ git checkout pull/2147`

Update a local copy of the PR: \
`$ git checkout pull/2147` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2147`

View PR using the GUI difftool: \
`$ git pr show -t 2147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2147.diff">https://git.openjdk.org/jdk11u-dev/pull/2147.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2147#issuecomment-1734960720)