### PR TITLE
8221396: Clean up serviceability/sa/TestUniverse.java

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestUniverse.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestUniverse.java
@@ -29,99 +29,107 @@ import java.util.Map;
 import java.util.HashMap;
 import jdk.test.lib.apps.LingeredApp;
 import jtreg.SkippedException;
+import sun.hotspot.gc.GC;
 
 /**
  * @test
  * @summary Test the 'universe' command of jhsdb clhsdb.
- * @requires vm.hasSA & vm.gc != "Z"
+ * @requires vm.hasSA
  * @bug 8190307
  * @library /test/lib
  * @build jdk.test.lib.apps.*
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. TestUniverse withoutZ
- */
-
-/**
- * @test
- * @summary Test the 'universe' command of jhsdb clhsdb.
- * @requires vm.hasSA & vm.gc == "Z"
- * @bug 8190307
- * @library /test/lib
- * @build jdk.test.lib.apps.*
- * @build sun.hotspot.WhiteBox
- * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. TestUniverse withZ
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. TestUniverse
  */
 
 public class TestUniverse {
 
-    private static void testClhsdbForUniverse(long lingeredAppPid,
-                                              String gc) throws Exception {
-
+    private static void testClhsdbForUniverse(long lingeredAppPid, GC gc) throws Exception {
         ClhsdbLauncher launcher = new ClhsdbLauncher();
         List<String> cmds = List.of("universe");
         Map<String, List<String>> expStrMap = new HashMap<>();
         List<String> expStrings = new ArrayList<String>();
         expStrings.add("Heap Parameters");
 
-        if (gc.contains("UseZGC")) {
-            expStrings.add("ZHeap");
-        }
-        if (gc.contains("G1GC")) {
+        switch (gc) {
+        case Serial:
+            expStrings.add("Gen 1:   old");
+            break;
+
+        case Parallel:
+            expStrings.add("ParallelScavengeHeap");
+            expStrings.add("PSYoungGen");
+            expStrings.add("eden");
+            break;
+
+        case ConcMarkSweep:
+            expStrings.add("Gen 1: concurrent mark-sweep generation");
+            break;
+
+        case G1:
             expStrings.add("garbage-first heap");
             expStrings.add("region size");
             expStrings.add("G1 Young Generation:");
             expStrings.add("regions  =");
-        }
-        if (gc.contains("UseConcMarkSweepGC")) {
-            expStrings.add("Gen 1: concurrent mark-sweep generation");
-        }
-        if (gc.contains("UseSerialGC")) {
-            expStrings.add("Gen 1:   old");
-        }
-        if (gc.contains("UseParallelGC")) {
-            expStrings.add("ParallelScavengeHeap");
-            expStrings.add("PSYoungGen");
-            expStrings.add("eden");
-        }
-        if (gc.contains("UseEpsilonGC")) {
+            break;
+
+        case Epsilon:
             expStrings.add("Epsilon heap");
             expStrings.add("reserved");
             expStrings.add("committed");
             expStrings.add("used");
+            break;
+
+        case Z:
+            expStrings.add("ZHeap");
+            break;
+
+        case Shenandoah:
+            expStrings.add("Shenandoah Heap");
+            break;
         }
+
         expStrMap.put("universe", expStrings);
         launcher.run(lingeredAppPid, cmds, expStrMap, null);
     }
 
-    public static void test(String gc) throws Exception {
+    private static void test(GC gc) throws Exception {
         LingeredApp app = null;
         try {
-            List<String> vmArgs = new ArrayList<String>();
-            vmArgs.add("-XX:+UnlockExperimentalVMOptions"); // unlock experimental GCs
-            vmArgs.add(gc);
-            app = LingeredApp.startApp(vmArgs);
-            System.out.println ("Started LingeredApp with the GC option " + gc +
-                                " and pid " + app.getPid());
+            app = LingeredApp.startApp(List.of("-XX:+UnlockExperimentalVMOptions", "-XX:+Use" + gc + "GC"));
+            System.out.println ("Started LingeredApp with " + gc + "GC and pid " + app.getPid());
             testClhsdbForUniverse(app.getPid(), gc);
         } finally {
             LingeredApp.stopApp(app);
         }
     }
 
+    private static boolean isSelectedAndSupported(GC gc) {
+        if (!gc.isSelected()) {
+            // Not selected
+            return false;
+        }
+
+        if (Compiler.isGraalEnabled()) {
+            if (gc == GC.ConcMarkSweep || gc == GC.Epsilon || gc == GC.Z || gc == GC.Shenandoah) {
+                // Not supported
+                System.out.println ("Skipped testing of " + gc + "GC, not supported by Graal");
+                return false;
+            }
+        }
+
+        // Selected and supported
+        return true;
+    }
+
     public static void main (String... args) throws Exception {
-        System.out.println("Starting TestUniverse test");
+        System.out.println("Starting TestUniverse");
         try {
-            test("-XX:+UseG1GC");
-            test("-XX:+UseParallelGC");
-            test("-XX:+UseSerialGC");
-            if (!Compiler.isGraalEnabled()) { // Graal does not support all GCs
-                test("-XX:+UseConcMarkSweepGC");
-                if (args[0].equals("withZ")) {
-                    test("-XX:+UseZGC");
+            for (GC gc: GC.values()) {
+                if (isSelectedAndSupported(gc)) {
+                    test(gc);
                 }
-                test("-XX:+UseEpsilonGC");
             }
         } catch (SkippedException se) {
             throw se;


### PR DESCRIPTION
Hi all,

This is a backport of JDK-8221396: Clean up serviceability/sa/TestUniverse.java  
I would like to backport this enhancement to jdk11u for test maintainability.

The original patch does not apply cleanly to jdk11u, because JDK-8238268 was backported ahead. As for TestUniverse.java, JDK-8238268 simply changes `@requires vm.hasSAandCanAttach` to `@requires vm.hasSA`, and the identical change can be safely applied to this patch.

The risk is low as this fix only affects testing.  
There is a related Issue: JDK-8231931, and I submit the corresponding PR https://github.com/openjdk/jdk11u-dev/pull/2149. Testing was done after applying this related patch.  
Testing: the affected test under all available GCs.

Thank you.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8221396](https://bugs.openjdk.org/browse/JDK-8221396) needs maintainer approval

### Issue
 * [JDK-8221396](https://bugs.openjdk.org/browse/JDK-8221396): Clean up serviceability/sa/TestUniverse.java (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2148/head:pull/2148` \
`$ git checkout pull/2148`

Update a local copy of the PR: \
`$ git checkout pull/2148` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2148`

View PR using the GUI difftool: \
`$ git pr show -t 2148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2148.diff">https://git.openjdk.org/jdk11u-dev/pull/2148.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2148#issuecomment-1734975555)