### PR TITLE
8315770: serviceability/sa/TestJmapCoreMetaspace.java should run with -XX:-VerifyDependencies

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
@@ -88,6 +88,9 @@ public class TestJmapCore {
     static void test(String type) throws Throwable {
         ProcessBuilder pb = ProcessTools.createTestJvm("-XX:+CreateCoredumpOnCrash",
                 "-Xmx512m", "-XX:MaxMetaspaceSize=64m", "-XX:+CrashOnOutOfMemoryError", "-XX:-TransmitErrorReport",
+                // The test loads lots of small classes to exhaust Metaspace, skip method
+                // dependency verification to improve performance in debug builds.
+                Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "--show-version",
                 TestJmapCore.class.getName(), type);
 
         boolean useDefaultUlimit = useDefaultUlimit();


### PR DESCRIPTION
Backporting the fix for https://bugs.openjdk.org/browse/JDK-8315770 merged as part of openjdk/jdk#15631. https://github.com/openjdk/jdk/commit/877731d2a20249ce4724a071ba2da1faa56daca4.patch apply failed due to differences in the file and the changes have been performed selectively.

Below are the test results:
* after_release: **123.62s user 10.26s system 160% cpu 1:23.59 total**
* after_fastdebug: **197.42s user 15.07s system 195% cpu 1:48.49 total**
* before_release: **123.65s user 9.56s system 159% cpu 1:23.38 total**
* before_fastdebug: **232.70s user 15.29s system 170% cpu 2:25.70 total**

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8315770](https://bugs.openjdk.org/browse/JDK-8315770) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315770](https://bugs.openjdk.org/browse/JDK-8315770): serviceability/sa/TestJmapCoreMetaspace.java should run with -XX:-VerifyDependencies (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2150/head:pull/2150` \
`$ git checkout pull/2150`

Update a local copy of the PR: \
`$ git checkout pull/2150` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2150`

View PR using the GUI difftool: \
`$ git pr show -t 2150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2150.diff">https://git.openjdk.org/jdk11u-dev/pull/2150.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2150#issuecomment-1737271496)