### PR TITLE
8315683: Parallelize java/util/concurrent/tck/JSR166TestCase.java

### DIFF
--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -35,18 +35,19 @@
  */
 
 /*
- * @test
- * @summary JSR-166 tck tests, in a number of variations.
- *          The first is the conformance testing variant,
- *          while others also test implementation details.
+ * @test id=default
+ * @summary Conformance testing variant of JSR-166 tck tests.
  * @build *
  * @modules java.management
  * @run junit/othervm/timeout=1000 JSR166TestCase
- * @run junit/othervm/timeout=1000
- *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
- *      --add-opens java.base/java.lang=ALL-UNNAMED
- *      -Djsr166.testImplementationDetails=true
- *      JSR166TestCase
+ */
+
+/*
+ * @test id=forkjoinpool-common-parallelism
+ * @summary Test implementation details variant of JSR-166
+ *          tck tests with ForkJoinPool common parallelism.
+ * @build *
+ * @modules java.management
  * @run junit/othervm/timeout=1000
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
  *      --add-opens java.base/java.lang=ALL-UNNAMED
@@ -59,6 +60,20 @@
  *      -Djsr166.testImplementationDetails=true
  *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
  *      -Djava.util.secureRandomSeed=true
+ *      JSR166TestCase
+ */
+
+/*
+ * @test id=others
+ * @summary Remaining test implementation details variant of
+ *          JSR-166 tck tests apart from ForkJoinPool common
+ *          parallelism.
+ * @build *
+ * @modules java.management
+ * @run junit/othervm/timeout=1000
+ *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+ *      --add-opens java.base/java.lang=ALL-UNNAMED
+ *      -Djsr166.testImplementationDetails=true
  *      JSR166TestCase
  * @run junit/othervm/timeout=1000/policy=tck.policy
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED


### PR DESCRIPTION
Backporting the fix for https://bugs.openjdk.org/browse/JDK-8315683 merged as part of openjdk/jdk#15619. https://github.com/openjdk/jdk/commit/4415261688dc258b6d254668bcf8818c61cc65ea.patch could not be cleanly applied as `@run junit/othervm/timeout=1000 -Djava.security.manager=allow` JSR166TestCase is not applicable for JDK11.

The tests passed in release mode in linux_x86_64 with time: **462.54s user 21.92s system 1099% cpu 44.077 total**
Before it was: **325.80s user 21.64s system 534% cpu 1:05.04 total**

```
Passed: java/util/concurrent/tck/JSR166TestCase.java#default
Passed: java/util/concurrent/tck/JSR166TestCase.java#others
Passed:
java/util/concurrent/tck/JSR166TestCase.java#forkjoinpool-common-parallelism
Test results: passed: 3
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315683](https://bugs.openjdk.org/browse/JDK-8315683) needs maintainer approval

### Issue
 * [JDK-8315683](https://bugs.openjdk.org/browse/JDK-8315683): Parallelize java/util/concurrent/tck/JSR166TestCase.java (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2151/head:pull/2151` \
`$ git checkout pull/2151`

Update a local copy of the PR: \
`$ git checkout pull/2151` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2151`

View PR using the GUI difftool: \
`$ git pr show -t 2151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2151.diff">https://git.openjdk.org/jdk11u-dev/pull/2151.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2151#issuecomment-1737572104)