### PR TITLE
8280004: DCmdArgument<jlong>::parse_value() should handle NULL input

### DIFF
--- a/src/hotspot/share/services/diagnosticArgument.cpp
+++ b/src/hotspot/share/services/diagnosticArgument.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
 #include "memory/resourceArea.hpp"
 #include "runtime/thread.hpp"
 #include "services/diagnosticArgument.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 StringArrayArgument::StringArrayArgument() {
   _array = new(ResourceObj::C_HEAP, mtInternal)GrowableArray<char *>(32, true);
@@ -116,13 +117,12 @@ template <> void DCmdArgument<jlong>::parse_value(const char* str,
       || sscanf(str, JLONG_FORMAT "%n", &_value, &scanned) != 1
       || (size_t)scanned != len)
   {
-    ResourceMark rm;
-
-    char* buf = NEW_RESOURCE_ARRAY(char, len + 1);
-    strncpy(buf, str, len);
-    buf[len] = '\0';
+    const int maxprint = 64;
     Exceptions::fthrow(THREAD_AND_LOCATION, vmSymbols::java_lang_IllegalArgumentException(),
-      "Integer parsing error in command argument '%s'. Could not parse: %s.\n", _name, buf);
+      "Integer parsing error in command argument '%s'. Could not parse: %.*s%s.\n", _name,
+      MIN2((int)len, maxprint),
+      (str == NULL ? "<null>" : str),
+      (len > maxprint ? "..." : ""));
   }
 }
 


### PR DESCRIPTION
A low risk fix for diagnostics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8280004](https://bugs.openjdk.org/browse/JDK-8280004) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280004](https://bugs.openjdk.org/browse/JDK-8280004): DCmdArgument&lt;jlong&gt;::parse_value() should handle NULL input (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2153/head:pull/2153` \
`$ git checkout pull/2153`

Update a local copy of the PR: \
`$ git checkout pull/2153` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2153`

View PR using the GUI difftool: \
`$ git pr show -t 2153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2153.diff">https://git.openjdk.org/jdk11u-dev/pull/2153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2153#issuecomment-1738770177)