### PR TITLE
8242330: Arrays should be cloned in several JAAS Callback classes

### DIFF
--- a/src/java.base/share/classes/javax/security/auth/callback/ChoiceCallback.java
+++ b/src/java.base/share/classes/javax/security/auth/callback/ChoiceCallback.java
@@ -74,8 +74,7 @@ public class ChoiceCallback implements Callback, java.io.Serializable {
      *
      * @param prompt the prompt used to describe the list of choices.
      *
-     * @param choices the list of choices. The array is cloned to protect
-     *                  against subsequent modification.
+     * @param choices the list of choices.
      *
      * @param defaultChoice the choice to be used as the default choice
      *                  when the list of choices are displayed.  This value
@@ -127,7 +126,7 @@ public class ChoiceCallback implements Callback, java.io.Serializable {
     /**
      * Get the list of choices.
      *
-     * @return a copy of the list of choices.
+     * @return the list of choices.
      */
     public String[] getChoices() {
         return choices.clone();
@@ -170,8 +169,7 @@ public class ChoiceCallback implements Callback, java.io.Serializable {
      * Set the selected choices.
      *
      * @param selections the selections represented as indexes into the
-     *          {@code choices} list. The array is cloned to protect
-     *          against subsequent modification.
+     *          {@code choices} list.
      *
      * @exception UnsupportedOperationException if multiple selections are
      *          not allowed, as determined by
@@ -188,7 +186,7 @@ public class ChoiceCallback implements Callback, java.io.Serializable {
     /**
      * Get the selected choices.
      *
-     * @return a copy of the selected choices, represented as indexes into the
+     * @return the selected choices, represented as indexes into the
      *          {@code choices} list.
      *
      * @see #setSelectedIndexes

--- a/src/java.base/share/classes/javax/security/auth/callback/ChoiceCallback.java
+++ b/src/java.base/share/classes/javax/security/auth/callback/ChoiceCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,23 +42,23 @@ public class ChoiceCallback implements Callback, java.io.Serializable {
      * @serial
      * @since 1.4
      */
-    private String prompt;
+    private final String prompt;
     /**
      * @serial the list of choices
      * @since 1.4
      */
-    private String[] choices;
+    private final String[] choices;
     /**
      * @serial the choice to be used as the default choice
      * @since 1.4
      */
-    private int defaultChoice;
+    private final int defaultChoice;
     /**
      * @serial whether multiple selections are allowed from the list of
      * choices
      * @since 1.4
      */
-    private boolean multipleSelectionsAllowed;
+    private final boolean multipleSelectionsAllowed;
     /**
      * @serial the selected choices, represented as indexes into the
      *          {@code choices} list.
@@ -74,7 +74,8 @@ public class ChoiceCallback implements Callback, java.io.Serializable {
      *
      * @param prompt the prompt used to describe the list of choices.
      *
-     * @param choices the list of choices.
+     * @param choices the list of choices. The array is cloned to protect
+     *                  against subsequent modification.
      *
      * @param defaultChoice the choice to be used as the default choice
      *                  when the list of choices are displayed.  This value
@@ -109,7 +110,7 @@ public class ChoiceCallback implements Callback, java.io.Serializable {
         }
 
         this.prompt = prompt;
-        this.choices = choices;
+        this.choices = choices.clone();
         this.defaultChoice = defaultChoice;
         this.multipleSelectionsAllowed = multipleSelectionsAllowed;
     }
@@ -126,10 +127,10 @@ public class ChoiceCallback implements Callback, java.io.Serializable {
     /**
      * Get the list of choices.
      *
-     * @return the list of choices.
+     * @return a copy of the list of choices.
      */
     public String[] getChoices() {
-        return choices;
+        return choices.clone();
     }
 
     /**
@@ -169,7 +170,8 @@ public class ChoiceCallback implements Callback, java.io.Serializable {
      * Set the selected choices.
      *
      * @param selections the selections represented as indexes into the
-     *          {@code choices} list.
+     *          {@code choices} list. The array is cloned to protect
+     *          against subsequent modification.
      *
      * @exception UnsupportedOperationException if multiple selections are
      *          not allowed, as determined by
@@ -180,18 +182,18 @@ public class ChoiceCallback implements Callback, java.io.Serializable {
     public void setSelectedIndexes(int[] selections) {
         if (!multipleSelectionsAllowed)
             throw new UnsupportedOperationException();
-        this.selections = selections;
+        this.selections = selections == null ? null : selections.clone();
     }
 
     /**
      * Get the selected choices.
      *
-     * @return the selected choices, represented as indexes into the
+     * @return a copy of the selected choices, represented as indexes into the
      *          {@code choices} list.
      *
      * @see #setSelectedIndexes
      */
     public int[] getSelectedIndexes() {
-        return selections;
+        return selections == null ? null : selections.clone();
     }
 }

--- a/src/java.base/share/classes/javax/security/auth/callback/ConfirmationCallback.java
+++ b/src/java.base/share/classes/javax/security/auth/callback/ConfirmationCallback.java
@@ -227,8 +227,7 @@ public class ConfirmationCallback implements Callback, java.io.Serializable {
      * @param messageType the message type ({@code INFORMATION},
      *                  {@code WARNING} or {@code ERROR}).
      *
-     * @param options the list of confirmation options. The array is cloned
-     *                  to protect against subsequent modification.
+     * @param options the list of confirmation options.
      *
      * @param defaultOption the default option, represented as an index
      *                  into the {@code options} array.
@@ -344,8 +343,7 @@ public class ConfirmationCallback implements Callback, java.io.Serializable {
      * @param messageType the message type ({@code INFORMATION},
      *                  {@code WARNING} or {@code ERROR}).
      *
-     * @param options the list of confirmation options. The array is cloned
-     *                  to protect against subsequent modification.
+     * @param options the list of confirmation options.
      *
      * @param defaultOption the default option, represented as an index
      *                  into the {@code options} array.
@@ -426,7 +424,7 @@ public class ConfirmationCallback implements Callback, java.io.Serializable {
     /**
      * Get the confirmation options.
      *
-     * @return a copy of the list of confirmation options, or null if this
+     * @return the list of confirmation options, or null if this
      *          {@code ConfirmationCallback} was instantiated with
      *          an {@code optionType} instead of {@code options}.
      */

--- a/src/java.base/share/classes/javax/security/auth/callback/ConfirmationCallback.java
+++ b/src/java.base/share/classes/javax/security/auth/callback/ConfirmationCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,31 +121,32 @@ public class ConfirmationCallback implements Callback, java.io.Serializable {
 
     /** ERROR message type. */
     public static final int ERROR                       = 2;
+
     /**
      * @serial
      * @since 1.4
      */
-    private String prompt;
+    private final String prompt;
     /**
      * @serial
      * @since 1.4
      */
-    private int messageType;
+    private final int messageType;
     /**
      * @serial
      * @since 1.4
      */
-    private int optionType = UNSPECIFIED_OPTION;
+    private final int optionType;
     /**
      * @serial
      * @since 1.4
      */
-    private int defaultOption;
+    private final int defaultOption;
     /**
      * @serial
      * @since 1.4
      */
-    private String[] options;
+    private final String[] options;
     /**
      * @serial
      * @since 1.4
@@ -205,8 +206,10 @@ public class ConfirmationCallback implements Callback, java.io.Serializable {
             break;
         }
 
+        this.prompt = null;
         this.messageType = messageType;
         this.optionType = optionType;
+        this.options = null;
         this.defaultOption = defaultOption;
     }
 
@@ -224,7 +227,8 @@ public class ConfirmationCallback implements Callback, java.io.Serializable {
      * @param messageType the message type ({@code INFORMATION},
      *                  {@code WARNING} or {@code ERROR}).
      *
-     * @param options the list of confirmation options.
+     * @param options the list of confirmation options. The array is cloned
+     *                  to protect against subsequent modification.
      *
      * @param defaultOption the default option, represented as an index
      *                  into the {@code options} array.
@@ -252,8 +256,10 @@ public class ConfirmationCallback implements Callback, java.io.Serializable {
                 throw new IllegalArgumentException();
         }
 
+        this.prompt = null;
         this.messageType = messageType;
-        this.options = options;
+        this.optionType = UNSPECIFIED_OPTION;
+        this.options = options.clone();
         this.defaultOption = defaultOption;
     }
 
@@ -318,6 +324,7 @@ public class ConfirmationCallback implements Callback, java.io.Serializable {
         this.prompt = prompt;
         this.messageType = messageType;
         this.optionType = optionType;
+        this.options = null;
         this.defaultOption = defaultOption;
     }
 
@@ -337,7 +344,8 @@ public class ConfirmationCallback implements Callback, java.io.Serializable {
      * @param messageType the message type ({@code INFORMATION},
      *                  {@code WARNING} or {@code ERROR}).
      *
-     * @param options the list of confirmation options.
+     * @param options the list of confirmation options. The array is cloned
+     *                  to protect against subsequent modification.
      *
      * @param defaultOption the default option, represented as an index
      *                  into the {@code options} array.
@@ -370,7 +378,8 @@ public class ConfirmationCallback implements Callback, java.io.Serializable {
 
         this.prompt = prompt;
         this.messageType = messageType;
-        this.options = options;
+        this.optionType = UNSPECIFIED_OPTION;
+        this.options = options.clone();
         this.defaultOption = defaultOption;
     }
 
@@ -417,12 +426,12 @@ public class ConfirmationCallback implements Callback, java.io.Serializable {
     /**
      * Get the confirmation options.
      *
-     * @return the list of confirmation options, or null if this
+     * @return a copy of the list of confirmation options, or null if this
      *          {@code ConfirmationCallback} was instantiated with
      *          an {@code optionType} instead of {@code options}.
      */
     public String[] getOptions() {
-        return options;
+        return options == null ? null : options.clone();
     }
 
     /**

--- a/test/jdk/javax/security/auth/callback/Mutability.java
+++ b/test/jdk/javax/security/auth/callback/Mutability.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8242330
+ * @library /test/lib
+ * @summary Arrays should be cloned in several JAAS Callback classes
+ */
+
+import javax.security.auth.callback.ChoiceCallback;
+import javax.security.auth.callback.ConfirmationCallback;
+
+import static jdk.test.lib.Asserts.assertEQ;
+
+public class Mutability {
+    public static void main(String[] args) {
+
+        // #1. ConfirmationCallback.new(3)
+        String[] i11 = {"1", "2"};
+        ConfirmationCallback c1 = new ConfirmationCallback(
+                ConfirmationCallback.INFORMATION,
+                i11,
+                0);
+
+        // Modify argument of constructor
+        i11[0] = "x";
+        String[] o11 = c1.getOptions();
+        assertEQ(o11[0], "1");
+        // Modify output
+        o11[0] = "y";
+        String[] o12 = c1.getOptions();
+        assertEQ(o12[0], "1");
+
+        // #2. ConfirmationCallback.new(4)
+        String[] i21 = {"1", "2"};
+        ConfirmationCallback c2 = new ConfirmationCallback(
+                "Hi",
+                ConfirmationCallback.INFORMATION,
+                i21,
+                0);
+
+        // Modify argument of constructor
+        i21[0] = "x";
+        assertEQ(c2.getOptions()[0], "1");
+
+        // #3. ChoiceCallback.new
+        String[] i31 = {"1", "2"};
+        ChoiceCallback c3 = new ChoiceCallback(
+                "Hi",
+                i31,
+                0,
+                true);
+
+        // Modify argument of constructor
+        i31[0] = "x";
+        String[] o31 = c3.getChoices();
+        assertEQ(o31[0], "1");
+        // Modify output of getChoices
+        o31[0] = "y";
+        String[] o32 = c3.getChoices();
+        assertEQ(o32[0], "1");
+
+        int[] s31 = {0, 1};
+        c3.setSelectedIndexes(s31);
+
+        // Modify argument of setSelectedIndexes
+        s31[0] = 1;
+        int[] s32 = c3.getSelectedIndexes();
+        assertEQ(s32[0], 0);
+        // Modify output of getSelectedIndexes
+        s32[1] = 0;
+        int[] s33 = c3.getSelectedIndexes();
+        assertEQ(s33[1], 1);
+    }
+}


### PR DESCRIPTION
Backport of the fix is clean for 11u in everything but copyright dates.
CSR copy is filed as [JDK-8317297](https://bugs.openjdk.org/browse/JDK-8317297).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8242330](https://bugs.openjdk.org/browse/JDK-8242330) needs maintainer approval

### Issues
 * [JDK-8242330](https://bugs.openjdk.org/browse/JDK-8242330): Arrays should be cloned in several JAAS Callback classes (**Bug** - P3 - Approved)
 * [JDK-8317297](https://bugs.openjdk.org/browse/JDK-8317297): Arrays should be cloned in several JAAS Callback classes (**CSR**) (Withdrawn)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2157/head:pull/2157` \
`$ git checkout pull/2157`

Update a local copy of the PR: \
`$ git checkout pull/2157` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2157`

View PR using the GUI difftool: \
`$ git pr show -t 2157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2157.diff">https://git.openjdk.org/jdk11u-dev/pull/2157.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2157#issuecomment-1741189268)