### PR TITLE
8293466: libjsig should ignore non-modifying sigaction calls

### DIFF
--- a/src/java.base/unix/native/libjsig/jsig.c
+++ b/src/java.base/unix/native/libjsig/jsig.c
@@ -278,16 +278,27 @@ int sigaction(int sig, const struct sigaction *act, struct sigaction *oact) {
     signal_unlock();
     return 0;
   } else if (jvm_signal_installing) {
-    /* jvm is installing its signal handlers. Install the new
-     * handlers and save the old ones. */
+    /* jvm is installing its signal handlers.
+     * - if this is a modifying sigaction call, we install a new signal handler and store the old one
+     *   as chained signal handler.
+     * - if this is a non-modifying sigaction call, we don't change any state; we just return the existing
+     *   signal handler in the system (not the stored one).
+     * This works under the assumption that there is only one modifying sigaction call for a specific signal
+     * within the JVM_begin_signal_setting-JVM_end_signal_setting-window. There can be any number of non-modifying
+     * calls, but they will only return the expected preexisting handler if executed before the modifying call.
+     */
     res = call_os_sigaction(sig, act, &oldAct);
-    sact[sig] = oldAct;
-    if (oact != NULL) {
-      *oact = oldAct;
+    if (res == 0) {
+      if (act != NULL) {
+        /* store pre-existing handler as chained handler */
+        sact[sig] = oldAct;
+        /* Record the signals used by jvm. */
+        sigaddset(&jvmsigs, sig);
+      }
+      if (oact != NULL) {
+        *oact = oldAct;
+      }
     }
-
-    /* Record the signals used by jvm. */
-    sigaddset(&jvmsigs, sig);
 
     signal_unlock();
     return res;


### PR DESCRIPTION
A small fix for 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8293466](https://bugs.openjdk.org/browse/JDK-8293466) needs maintainer approval

### Issue
 * [JDK-8293466](https://bugs.openjdk.org/browse/JDK-8293466): libjsig should ignore non-modifying sigaction calls (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2158/head:pull/2158` \
`$ git checkout pull/2158`

Update a local copy of the PR: \
`$ git checkout pull/2158` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2158`

View PR using the GUI difftool: \
`$ git pr show -t 2158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2158.diff">https://git.openjdk.org/jdk11u-dev/pull/2158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2158#issuecomment-1742616993)