### PR TITLE
8041447: Test javax/swing/dnd/7171812/bug7171812.java fails with java.lang.RuntimeException: Test failed, scroll on drag doesn't work

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -128,7 +128,6 @@ java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion.java 8060176 
 java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion_1.java 8060176 windows-all,macosx-all
 java/awt/dnd/MissingEventsOnModalDialog/MissingEventsOnModalDialogTest.java 8164464 linux-all,macosx-all
 java/awt/dnd/URIListBetweenJVMsTest/URIListBetweenJVMsTest.java 8171510 macosx-all
-javax/swing/dnd/7171812/bug7171812.java 8041447 macosx-all
 java/awt/Focus/ChoiceFocus/ChoiceFocus.java 8169103 windows-all,macosx-all
 java/awt/Focus/ClearLwQueueBreakTest/ClearLwQueueBreakTest.java 8198618 macosx-all
 java/awt/Focus/ConsumeNextKeyTypedOnModalShowTest/ConsumeNextKeyTypedOnModalShowTest.java 6986252 macosx-all

--- a/test/jdk/javax/swing/dnd/7171812/bug7171812.java
+++ b/test/jdk/javax/swing/dnd/7171812/bug7171812.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,25 +26,39 @@
  * @key headful
  * @bug 7171812
  * @summary [macosx] Views keep scrolling back to the drag position after DnD
- * @author Alexander Zuev
  * @run main bug7171812
  */
 
-import java.awt.*;
-import java.awt.dnd.*;
+import java.awt.BorderLayout;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
 import java.awt.event.InputEvent;
-import javax.swing.*;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
 
 public class bug7171812 {
     static JFrame mainFrame;
     static String listData[];
     static JListWithScroll<String> list;
     static JScrollPane scrollPane;
+    static volatile Point pt;
+    static volatile int height;
 
     /**
      * @param args the command line arguments
      */
     public static void main(String[] args) throws Exception{
+
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        robot.setAutoWaitForIdle(true);
 
         SwingUtilities.invokeAndWait(new Runnable() {
             @Override
@@ -53,18 +67,21 @@ public class bug7171812 {
             }
         });
 
-        Robot robot = new Robot();
-        robot.setAutoDelay(10);
         robot.waitForIdle();
-        robot.mouseMove(scrollPane.getLocationOnScreen().x + 5, scrollPane.getLocationOnScreen().y + 5);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        for(int offset = 5; offset < scrollPane.getHeight()-20; offset++) {
-            robot.mouseMove(scrollPane.getLocationOnScreen().x+5, scrollPane.getLocationOnScreen().y+offset);
+        robot.delay(1000);
+        SwingUtilities.invokeAndWait(() -> {
+            pt = scrollPane.getLocationOnScreen();
+            height = scrollPane.getHeight();
+        });
+        robot.mouseMove(pt.x + 5, pt.y + 5);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        for(int offset = 5; offset < height - 20; offset++) {
+            robot.mouseMove(pt.x + 5, pt.y + offset);
         }
         for(int offset = 5; offset < 195; offset++) {
-            robot.mouseMove(scrollPane.getLocationOnScreen().x+offset, scrollPane.getLocationOnScreen().y+scrollPane.getHeight()-20);
+            robot.mouseMove(pt.x + offset, pt.y + height - 20);
         }
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         try {
             SwingUtilities.invokeAndWait(new Runnable() {
                 @Override


### PR DESCRIPTION
- Backport for [JDK-8041447](https://bugs.openjdk.org/browse/JDK-8041447)
- Tested pass in local

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8041447](https://bugs.openjdk.org/browse/JDK-8041447) needs maintainer approval

### Issue
 * [JDK-8041447](https://bugs.openjdk.org/browse/JDK-8041447): Test javax/swing/dnd/7171812/bug7171812.java fails with java.lang.RuntimeException: Test failed, scroll on drag doesn't work (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2159/head:pull/2159` \
`$ git checkout pull/2159`

Update a local copy of the PR: \
`$ git checkout pull/2159` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2159`

View PR using the GUI difftool: \
`$ git pr show -t 2159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2159.diff">https://git.openjdk.org/jdk11u-dev/pull/2159.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2159#issuecomment-1744345804)