### PR TITLE
8233000: Mark vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize test as stress test

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
@@ -24,6 +24,8 @@
 
 /*
  * @test
+ * @key stress
+ * @key stress
  *
  * @summary converted from VM Testbase vm/mlvm/meth/stress/compiler/deoptimize.
  * VM Testbase keywords: [feature_mlvm, nonconcurrent, quarantine]

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
@@ -25,7 +25,6 @@
 /*
  * @test
  * @key stress
- * @key stress
  *
  * @summary converted from VM Testbase vm/mlvm/meth/stress/compiler/deoptimize.
  * VM Testbase keywords: [feature_mlvm, nonconcurrent, quarantine]


### PR DESCRIPTION
- Backport of [JDK-8233000](https://bugs.openjdk.org/browse/JDK-8233000)
- Verified good in local

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8233000](https://bugs.openjdk.org/browse/JDK-8233000) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233000](https://bugs.openjdk.org/browse/JDK-8233000): Mark vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize test as stress test (**Bug** - P4 - Approved)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2160/head:pull/2160` \
`$ git checkout pull/2160`

Update a local copy of the PR: \
`$ git checkout pull/2160` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2160`

View PR using the GUI difftool: \
`$ git pr show -t 2160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2160.diff">https://git.openjdk.org/jdk11u-dev/pull/2160.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2160#issuecomment-1744345475)