### PR TITLE
8197825: [Test] Intermittent timeout with javax/swing JColorChooser Test

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -685,7 +685,6 @@ javax/swing/JWindow/ShapedAndTranslucentWindows/SetShapeAndClickSwing.java 80134
 javax/swing/JWindow/ShapedAndTranslucentWindows/TranslucentJComboBox.java 8024627 macosx-all
 # The next test below is an intermittent failure
 javax/swing/JComboBox/8033069/bug8033069ScrollBar.java 8163367 generic-all
-javax/swing/JColorChooser/Test6827032.java 8197825 windows-all
 javax/swing/JSplitPane/4201995/bug4201995.java 8079127 generic-all
 javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all


### PR DESCRIPTION
- Backport for [JDK-8197825](https://bugs.openjdk.org/browse/JDK-8197825)
- Verified good in local (MacOS M1)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8197825](https://bugs.openjdk.org/browse/JDK-8197825) needs maintainer approval

### Issue
 * [JDK-8197825](https://bugs.openjdk.org/browse/JDK-8197825): [Test] Intermittent timeout with javax/swing JColorChooser Test (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2162/head:pull/2162` \
`$ git checkout pull/2162`

Update a local copy of the PR: \
`$ git checkout pull/2162` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2162`

View PR using the GUI difftool: \
`$ git pr show -t 2162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2162.diff">https://git.openjdk.org/jdk11u-dev/pull/2162.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2162#issuecomment-1754595133)