### PR TITLE
8278456: Define jtreg jdk_desktop test group time-based sub-tasks for use by headful testing.

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -383,14 +383,33 @@ jdk_editpad = \
      jdk/editpad
 
 jdk_desktop = \
-    :jdk_awt \
-    :jdk_2d \
-    :jdk_beans \
+    :jdk_desktop_part1 \
+    :jdk_desktop_part2 \
+    :jdk_desktop_part3
+
+jdk_desktop_part1 = \
+    :jdk_client_sanity \
     :jdk_swing \
+    :jdk_2d \
     :jdk_sound \
     :jdk_imageio \
+    :jdk_editpad \
     :jfc_demo \
-    :jdk_editpad
+    :jdk_accessibility \
+    :jdk_beans
+
+jdk_desktop_part2 = \
+    :jdk_awt \
+    -java/awt/Component \
+    -java/awt/Modal \
+    -java/awt/datatransfer \
+    -java/awt/Window
+
+jdk_desktop_part3 = \
+    java/awt/Component \
+    java/awt/Modal \
+    java/awt/datatransfer \
+    java/awt/Window
 
 # SwingSet3 tests.
 jdk_client_sanity = \

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -376,6 +376,8 @@ jdk_sound = \
 jdk_imageio = \
     javax/imageio
 
+jdk_accessibility =
+
 jfc_demo = \
      demo/jfc
 


### PR DESCRIPTION
- Backport for [JDK-8278456](https://bugs.openjdk.org/browse/JDK-8278456)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8278456](https://bugs.openjdk.org/browse/JDK-8278456) needs maintainer approval

### Issue
 * [JDK-8278456](https://bugs.openjdk.org/browse/JDK-8278456): Define jtreg jdk_desktop test group time-based sub-tasks for use by headful testing. (**Bug** - P4 - Approved)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2164/head:pull/2164` \
`$ git checkout pull/2164`

Update a local copy of the PR: \
`$ git checkout pull/2164` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2164`

View PR using the GUI difftool: \
`$ git pr show -t 2164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2164.diff">https://git.openjdk.org/jdk11u-dev/pull/2164.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2164#issuecomment-1745771001)