### PR TITLE
8300405: Screen capture for test JFileChooserSetLocationTest.java, failure case

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/JFileChooserSetLocationTest.java
+++ b/test/jdk/javax/swing/JFileChooser/JFileChooserSetLocationTest.java
@@ -23,17 +23,23 @@
 
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import javax.imageio.ImageIO;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
@@ -175,12 +181,18 @@ public class JFileChooserSetLocationTest {
         return pt.get();
     }
 
-    public static void verify(int x1, int x2, int y1, int y2) {
+    public static void verify(int x1, int x2, int y1, int y2) throws Exception {
         System.out.println("verify " + x1 + "==" + x2 + "; " + y1 + "==" + y2);
         if ((Math.abs(x1 - x2) < TOLERANCE_LEVEL) &&
             (Math.abs(y1 - y2) < TOLERANCE_LEVEL)) {
             System.out.println("Test passed");
         } else {
+            GraphicsConfiguration gc = GraphicsEnvironment.
+                    getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
+            Rectangle gcBounds = gc.getBounds();
+            BufferedImage bufferedImage = robot.createScreenCapture(
+                    new Rectangle(gcBounds));
+            ImageIO.write(bufferedImage, "png",new File("FailureImage.png"));
             throw new RuntimeException(
                     "Test Failed, setLocation() is not working properly");
         }


### PR DESCRIPTION
- [JDK-8300405](https://bugs.openjdk.org/browse/JDK-8300405)
- Verified good in local

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8300405](https://bugs.openjdk.org/browse/JDK-8300405) needs maintainer approval

### Issue
 * [JDK-8300405](https://bugs.openjdk.org/browse/JDK-8300405): Screen capture for test JFileChooserSetLocationTest.java, failure case (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2166/head:pull/2166` \
`$ git checkout pull/2166`

Update a local copy of the PR: \
`$ git checkout pull/2166` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2166`

View PR using the GUI difftool: \
`$ git pr show -t 2166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2166.diff">https://git.openjdk.org/jdk11u-dev/pull/2166.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2166#issuecomment-1745853252)