### PR TITLE
8316710: Exclude java/awt/font/Rotate/RotatedTextTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -441,6 +441,7 @@ java/awt/Modal/OnTop/OnTopTKModal6Test.java 8198666 macosx-all
 java/awt/List/SingleModeDeselect/SingleModeDeselect.java 8196367 windows-all
 java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java 8061235 macosx-all
 javax/print/PrintSEUmlauts/PrintSEUmlauts.java 8135174 generic-all
+java/awt/font/Rotate/RotatedTextTest.java 8219641 linux-all
 java/awt/font/TextLayout/LigatureCaretTest.java 8197821 generic-all
 java/awt/Graphics2D/DrawString/RotTransText.java 8197797 generic-all
 java/awt/image/VolatileImage/CustomCompositeTest.java 8199002 windows-all,linux-all


### PR DESCRIPTION
Backport of the test exclusion. I had to resolve the problemlist but will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316710](https://bugs.openjdk.org/browse/JDK-8316710) needs maintainer approval

### Issue
 * [JDK-8316710](https://bugs.openjdk.org/browse/JDK-8316710): Exclude java/awt/font/Rotate/RotatedTextTest.java (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2167/head:pull/2167` \
`$ git checkout pull/2167`

Update a local copy of the PR: \
`$ git checkout pull/2167` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2167`

View PR using the GUI difftool: \
`$ git pr show -t 2167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2167.diff">https://git.openjdk.org/jdk11u-dev/pull/2167.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2167#issuecomment-1749187895)