### PR TITLE
8232933: Javac inferred type does not conform to equality constraint

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/InferenceContext.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/InferenceContext.java
@@ -337,6 +337,17 @@ public class InferenceContext {
         if (roots.length() == inferencevars.length()) {
             return this;
         }
+        /* if any of the inference vars is a captured variable bail out, this is because
+         * we could end up generating more than necessary captured variables in an outer
+         * inference context and then when we need to propagate back to an inner inference
+         * context that has been minimized it could be that some bounds constraints doesn't
+         * hold like subtyping constraints between bonds etc.
+         */
+        for (Type iv : inferencevars) {
+            if (iv.hasTag(TypeTag.TYPEVAR) && ((TypeVar)iv).isCaptured()) {
+                return this;
+            }
+        }
         ReachabilityVisitor rv = new ReachabilityVisitor();
         rv.scan(roots);
         if (rv.min.size() == inferencevars.length()) {

--- a/test/langtools/tools/javac/inference_context_min/DontMinimizeInfContextTest.java
+++ b/test/langtools/tools/javac/inference_context_min/DontMinimizeInfContextTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8232933
+ * @summary Javac inferred type does not conform to equality constraint
+ * @compile DontMinimizeInfContextTest.java
+ */
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+class DontMinimizeInfContextTest {
+    void m() {
+        List<? extends A<?, ?>> a = new LinkedList<>();
+        Map<String, List<A<?, ?>>> b = a.stream().collect(
+                Collectors.groupingBy(A::getval, Collectors.toList())
+        );
+    }
+
+    class A<K, V> {
+        String getval() {
+            return "s";
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8232933](https://bugs.openjdk.org/browse/JDK-8232933) needs maintainer approval

### Issue
 * [JDK-8232933](https://bugs.openjdk.org/browse/JDK-8232933): Javac inferred type does not conform to equality constraint (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2170/head:pull/2170` \
`$ git checkout pull/2170`

Update a local copy of the PR: \
`$ git checkout pull/2170` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2170`

View PR using the GUI difftool: \
`$ git pr show -t 2170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2170.diff">https://git.openjdk.org/jdk11u-dev/pull/2170.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2170#issuecomment-1754541977)