### PR TITLE
8303607: SunMSCAPI provider leaks memory and keys

### DIFF
--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -502,7 +502,11 @@ JNIEXPORT void JNICALL Java_sun_security_mscapi_CKeyStore_loadKeysOrCertificateC
             else
             {
                 if (bCallerFreeProv == TRUE) {
-                    ::CryptReleaseContext(hCryptProv, NULL); // deprecated
+                    if ((dwKeySpec & CERT_NCRYPT_KEY_SPEC) == CERT_NCRYPT_KEY_SPEC) {
+                        NCryptFreeObject(hCryptProv);
+                    } else {
+                        ::CryptReleaseContext(hCryptProv, NULL); // deprecated
+                    }
                     bCallerFreeProv = FALSE;
                 }
 


### PR DESCRIPTION
Backport a393f2581740f854518a3ef7caccd6d3c2d8e4a0

Backporting this to 11 as the issue is still relevant; passes tier1 tests and the fix has been verified in 11/windows

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8303607](https://bugs.openjdk.org/browse/JDK-8303607) needs maintainer approval

### Issue
 * [JDK-8303607](https://bugs.openjdk.org/browse/JDK-8303607): SunMSCAPI provider leaks memory and keys (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2174/head:pull/2174` \
`$ git checkout pull/2174`

Update a local copy of the PR: \
`$ git checkout pull/2174` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2174`

View PR using the GUI difftool: \
`$ git pr show -t 2174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2174.diff">https://git.openjdk.org/jdk11u-dev/pull/2174.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2174#issuecomment-1756456111)