### PR TITLE
8315062: [GHA] get-bootjdk action should return the abolute path

### DIFF
--- a/.github/actions/get-bootjdk/action.yml
+++ b/.github/actions/get-bootjdk/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -104,6 +104,6 @@ runs:
     - name: 'Export path to where BootJDK is installed'
       id: path-name
       run: |
-        # Export the path
-        echo 'path=bootjdk/jdk' >> $GITHUB_OUTPUT
+        # Export the absolute path
+        echo "path=`pwd`/bootjdk/jdk" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
Clean backport to improve GHA reliability and keep testing pipelines in sync.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315062](https://bugs.openjdk.org/browse/JDK-8315062) needs maintainer approval

### Issue
 * [JDK-8315062](https://bugs.openjdk.org/browse/JDK-8315062): [GHA] get-bootjdk action should return the abolute path (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2176/head:pull/2176` \
`$ git checkout pull/2176`

Update a local copy of the PR: \
`$ git checkout pull/2176` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2176`

View PR using the GUI difftool: \
`$ git pr show -t 2176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2176.diff">https://git.openjdk.org/jdk11u-dev/pull/2176.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2176#issuecomment-1759112279)