### PR TITLE
8255548: Missing coverage for javax.xml.crypto.dom.DOMCryptoContext

### DIFF
--- a/test/jdk/javax/xml/crypto/dsig/GenerationTests.java
+++ b/test/jdk/javax/xml/crypto/dsig/GenerationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  *          java.base/sun.security.x509
  *          java.xml.crypto/org.jcp.xml.dsig.internal.dom
  *          jdk.httpserver/com.sun.net.httpserver
+ * @build jdk.test.lib.Asserts
  * @compile -XDignore.symbol.file KeySelectors.java SignatureValidator.java
  *     X509KeySelector.java GenerationTests.java
  * @run main/othervm/timeout=300 -Dsun.net.httpserver.nodelay=true GenerationTests
@@ -91,6 +92,8 @@ import javax.xml.transform.*;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.*;
+
+import jdk.test.lib.Asserts;
 
 /**
  * Test that recreates merlin-xmldsig-twenty-three test vectors (and more)
@@ -286,6 +289,7 @@ public class GenerationTests {
 
     public static void main(String args[]) throws Exception {
         setup();
+        test_context_iterator();
         test_create_signature_enveloped_dsa(1024);
         test_create_signature_enveloped_dsa(2048);
         test_create_signature_enveloping_b64_dsa();
@@ -1860,6 +1864,48 @@ public class GenerationTests {
             return false;
         }
 
+        return true;
+    }
+
+    static boolean test_context_iterator() throws Exception {
+        System.out.println("Testing context iterator() method.");
+
+        Reference ref = fac.newReference("#object",
+                fac.newDigestMethod(DigestMethod.SHA512, null));
+        SignedInfo si = fac.newSignedInfo(withoutComments, rsaSha512,
+                Collections.singletonList(ref));
+
+        Document doc = db.newDocument();
+        XMLObject obj = fac.newXMLObject(Collections.singletonList(
+                new DOMStructure(doc.createTextNode("test text"))), "object",
+                null, null);
+
+        DOMSignContext dsc = new DOMSignContext(signingKey, doc);
+        Asserts.assertNotNull(dsc.iterator());
+        Asserts.assertFalse(dsc.iterator().hasNext());
+
+        String namespaceURI = "https://example.com/ns";
+        String idAttrValue = "id1";
+        String elementQualifiedName = "test:data";
+
+        Element elm = doc.createElementNS(namespaceURI, elementQualifiedName);
+        elm.setAttributeNS(namespaceURI, "test:id", idAttrValue);
+        dsc.setIdAttributeNS(elm, namespaceURI, "id");
+
+        Iterator<Map.Entry<String, Element>> iter = dsc.iterator();
+        Asserts.assertTrue(dsc.iterator().hasNext());
+
+        Map.Entry<String, Element> element = iter.next();
+        Asserts.assertEquals(element.getKey(), idAttrValue);
+        Asserts.assertEquals(element.getValue().getNodeName(), elementQualifiedName);
+
+        try {
+            iter.remove();
+            throw new RuntimeException(
+                    "The expected UnsupportedOperationException was not thrown.");
+        } catch (UnsupportedOperationException exc) {
+            // this is expected
+        }
         return true;
     }
 

--- a/test/jdk/javax/xml/crypto/dsig/GenerationTests.java
+++ b/test/jdk/javax/xml/crypto/dsig/GenerationTests.java
@@ -30,6 +30,7 @@
  *          java.base/sun.security.x509
  *          java.xml.crypto/org.jcp.xml.dsig.internal.dom
  *          jdk.httpserver/com.sun.net.httpserver
+ * @library /test/lib
  * @build jdk.test.lib.Asserts
  * @compile -XDignore.symbol.file KeySelectors.java SignatureValidator.java
  *     X509KeySelector.java GenerationTests.java


### PR DESCRIPTION
- Backport for [JDK-8255548](https://bugs.openjdk.org/browse/JDK-8255548)
- Test succeeded in local dev box

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8255548](https://bugs.openjdk.org/browse/JDK-8255548) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255548](https://bugs.openjdk.org/browse/JDK-8255548): Missing coverage for javax.xml.crypto.dom.DOMCryptoContext (**Bug** - P4 - Approved)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2177/head:pull/2177` \
`$ git checkout pull/2177`

Update a local copy of the PR: \
`$ git checkout pull/2177` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2177`

View PR using the GUI difftool: \
`$ git pr show -t 2177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2177.diff">https://git.openjdk.org/jdk11u-dev/pull/2177.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2177#issuecomment-1760520985)