### PR TITLE
8296275: Write a test to verify setAccelerator  method of JMenuItem

### DIFF
--- a/test/jdk/javax/swing/JMenuItem/JMenuItemSetAcceleratorTest.java
+++ b/test/jdk/javax/swing/JMenuItem/JMenuItemSetAcceleratorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @key headful
+ * @bug 8296275
+ * @summary To verify the setAccelerator method of JMenuItem.
+ * @requires (os.family=="mac")
+ * @run main JMenuItemSetAcceleratorTest
+ */
+
+public class JMenuItemSetAcceleratorTest {
+    private static JFrame frame;
+    private static final CountDownLatch actionLatch = new CountDownLatch(1);
+    private volatile static Point frameAt;
+    private volatile static Dimension frameSize;
+
+    private static void createAndShow() {
+        frame = new JFrame("JMenuItem.setAccelerator");
+        frame.setLayout(new FlowLayout());
+
+        JMenuBar bar = new JMenuBar();
+        JMenu menu = new JMenu("File");
+        JMenuItem menuItem = new JMenuItem("Menu Item");
+
+        menuItem.setAccelerator(
+            KeyStroke.getKeyStroke(KeyEvent.VK_M, InputEvent.META_DOWN_MASK));
+        menuItem.addActionListener(e -> {
+            System.out.println("menu item action.");
+            actionLatch.countDown();
+        });
+
+        menu.add(menuItem);
+        bar.add(menu);
+
+        frame.setJMenuBar(bar);
+        frame.setSize(200, 200);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(JMenuItemSetAcceleratorTest::createAndShow);
+
+            Robot robot = new Robot();
+            robot.setAutoDelay(50);
+            robot.setAutoWaitForIdle(true);
+
+            EventQueue.invokeAndWait(() -> {
+                frameAt = frame.getLocationOnScreen();
+                frameSize = frame.getSize();
+            });
+
+            robot.mouseMove(frameAt.x + frameSize.width / 2,
+                frameAt.y + frameSize.height / 2);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+
+            robot.keyPress(KeyEvent.VK_META);
+            robot.keyPress(KeyEvent.VK_M);
+            robot.keyRelease(KeyEvent.VK_M);
+            robot.keyRelease(KeyEvent.VK_META);
+
+            if (!actionLatch.await(5, TimeUnit.SECONDS)) {
+                throw new RuntimeException(
+                    "Hasn't received the JMenuItem action event by pressing "
+                        + "accelerator keys, test fails.");
+            }
+            System.out.println("Test passed, received action event on menu item.");
+        } finally {
+            SwingUtilities.invokeAndWait(JMenuItemSetAcceleratorTest::disposeFrame);
+        }
+    }
+
+    public static void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+        }
+    }
+}


### PR DESCRIPTION
- Backport of [JDK-8296275](https://bugs.openjdk.org/browse/JDK-8296275)
- Test succeeded in local dev box

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8296275](https://bugs.openjdk.org/browse/JDK-8296275) needs maintainer approval

### Issue
 * [JDK-8296275](https://bugs.openjdk.org/browse/JDK-8296275): Write a test to verify setAccelerator  method of JMenuItem (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2179/head:pull/2179` \
`$ git checkout pull/2179`

Update a local copy of the PR: \
`$ git checkout pull/2179` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2179`

View PR using the GUI difftool: \
`$ git pr show -t 2179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2179.diff">https://git.openjdk.org/jdk11u-dev/pull/2179.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2179#issuecomment-1760964195)