### PR TITLE
8297296: java/awt/Mouse/EnterExitEvents/DragWindowTest.java fails with "No MouseReleased event on label!"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -370,7 +370,6 @@ java/awt/Modal/MultipleDialogs/MultipleDialogs3Test.java 8198665 macosx-all
 java/awt/Modal/MultipleDialogs/MultipleDialogs4Test.java 8198665 macosx-all
 java/awt/Modal/MultipleDialogs/MultipleDialogs5Test.java 8198665 macosx-all
 java/awt/Mouse/EnterExitEvents/DragWindowOutOfFrameTest.java 8177326 macosx-all
-java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8023562 macosx-all
 java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8005021 macosx-all
 java/awt/Mouse/EnterExitEvents/FullscreenEnterEventTest.java 8051455 macosx-all
 java/awt/Mouse/MouseModifiersUnitTest/MouseModifiersUnitTest_Standard.java 7124407 macosx-all

--- a/test/jdk/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
+++ b/test/jdk/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
@@ -34,11 +34,23 @@
  * @run main DragWindowTest
  */
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Window;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
 
 import test.java.awt.regtesthelpers.Util;
 
@@ -55,7 +67,7 @@ public class DragWindowTest {
     public static void main(String[] args) throws Exception {
 
         Robot robot = new Robot();
-        robot.setAutoDelay(50);
+        robot.setAutoDelay(100);
 
         SwingUtilities.invokeAndWait(new Runnable() {
 
@@ -65,6 +77,7 @@ public class DragWindowTest {
             }
         });
 
+        robot.delay(250);
         robot.waitForIdle();
 
         Point pointToClick = Util.invokeOnEDT(new Callable<Point>() {
@@ -134,6 +147,7 @@ public class DragWindowTest {
         panel.add(button, BorderLayout.CENTER);
 
         frame.getContentPane().add(panel);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
 
     }


### PR DESCRIPTION
- Backport of [JDK-8297296](https://bugs.openjdk.org/browse/JDK-8297296)
- Test succeeded in local dev box

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8297296](https://bugs.openjdk.org/browse/JDK-8297296) needs maintainer approval

### Issue
 * [JDK-8297296](https://bugs.openjdk.org/browse/JDK-8297296): java/awt/Mouse/EnterExitEvents/DragWindowTest.java fails with "No MouseReleased event on label!" (**Bug** - P4 - Approved)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2180/head:pull/2180` \
`$ git checkout pull/2180`

Update a local copy of the PR: \
`$ git checkout pull/2180` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2180`

View PR using the GUI difftool: \
`$ git pr show -t 2180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2180.diff">https://git.openjdk.org/jdk11u-dev/pull/2180.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2180#issuecomment-1760976711)