### PR TITLE
8301570: Test  runtime/jni/nativeStack/ needs to detach the native thread

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/nativeStack/libnativeStack.c
+++ b/test/hotspot/jtreg/runtime/jni/nativeStack/libnativeStack.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,6 +85,13 @@ static void * thread_start(void* unused) {
     (*env)->ExceptionDescribe(env);
     exit(1);
   }
+
+  res = (*jvm)->DetachCurrentThread(jvm);
+  if (res != JNI_OK) {
+    fprintf(stderr, "Test ERROR. Can't detach current thread: %d\n", res);
+    exit(1);
+  }
+
   printf("Native thread terminating\n");
 
   return NULL;


### PR DESCRIPTION
- Backport of [JDK-8301570](https://bugs.openjdk.org/browse/JDK-8301570)
- Test succeeded in local dev box

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8301570](https://bugs.openjdk.org/browse/JDK-8301570) needs maintainer approval

### Issue
 * [JDK-8301570](https://bugs.openjdk.org/browse/JDK-8301570): Test  runtime/jni/nativeStack/ needs to detach the native thread (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2183/head:pull/2183` \
`$ git checkout pull/2183`

Update a local copy of the PR: \
`$ git checkout pull/2183` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2183`

View PR using the GUI difftool: \
`$ git pr show -t 2183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2183.diff">https://git.openjdk.org/jdk11u-dev/pull/2183.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2183#issuecomment-1761036260)