### PR TITLE
8207214: Broken links in JDK API serialized-form page

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -889,7 +889,7 @@ public class HtmlDocletWriter {
         return getDocLink(context, typeElement, element, label, strong, false);
     }
 
-   /**
+    /**
      * Return the link for the given member.
      *
      * @param context the id of the context where the link will be printed.
@@ -909,22 +909,26 @@ public class HtmlDocletWriter {
 
     public Content getDocLink(LinkInfoImpl.Kind context, TypeElement typeElement, Element element,
             Content label, boolean strong, boolean isProperty) {
-        if (! (utils.isIncluded(element) || utils.isLinkable(typeElement))) {
+        if (!utils.isLinkable(typeElement, element)) {
             return label;
-        } else if (utils.isExecutableElement(element)) {
+        }
+
+        if (utils.isExecutableElement(element)) {
             ExecutableElement ee = (ExecutableElement)element;
             return getLink(new LinkInfoImpl(configuration, context, typeElement)
                 .label(label)
                 .where(links.getName(getAnchor(ee, isProperty)))
                 .strong(strong));
-        } else if (utils.isVariableElement(element) || utils.isTypeElement(element)) {
+        }
+
+        if (utils.isVariableElement(element) || utils.isTypeElement(element)) {
             return getLink(new LinkInfoImpl(configuration, context, typeElement)
                 .label(label)
                 .where(links.getName(element.getSimpleName().toString()))
                 .strong(strong));
-        } else {
-            return label;
         }
+
+        return label;
     }
 
     /**
@@ -978,7 +982,6 @@ public class HtmlDocletWriter {
     }
 
     public Content seeTagToContent(Element element, DocTree see) {
-
         Kind kind = see.getKind();
         if (!(kind == LINK || kind == SEE || kind == LINK_PLAIN)) {
             return new ContentBuilder();

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -273,11 +273,9 @@ public class TagletWriterImpl extends TagletWriter {
      */
     public Content seeTagOutput(Element holder, List<? extends DocTree> seeTags) {
         ContentBuilder body = new ContentBuilder();
-        if (!seeTags.isEmpty()) {
-            for (DocTree dt : seeTags) {
-                appendSeparatorIfNotEmpty(body);
-                body.addContent(htmlWriter.seeTagToContent(holder, dt));
-            }
+        for (DocTree dt : seeTags) {
+            appendSeparatorIfNotEmpty(body);
+            body.addContent(htmlWriter.seeTagToContent(holder, dt));
         }
         if (utils.isVariableElement(holder) && ((VariableElement)holder).getConstantValue() != null &&
                 htmlWriter instanceof ClassWriterImpl) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
@@ -223,7 +223,6 @@ doclet.Annotation_Type_Optional_Member=Optional Element
 doclet.Annotation_Type_Required_Member=Required Element
 doclet.Annotation_Type_Member=Annotation Type Element
 doclet.Enum_Constant=Enum Constant
-doclet.Class=Class
 doclet.Description=Description
 doclet.ConstantField=Constant Field
 doclet.Value=Value

--- a/test/langtools/jdk/javadoc/doclet/testSerializedFormWithSee/TestSerializedFormWithSee.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedFormWithSee/TestSerializedFormWithSee.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8207214
+ * @summary Test serialized forms, with at-see to other members
+ * @library /tools/lib ../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build JavadocTester toolbox.ToolBox
+ * @run main TestSerializedFormWithSee
+ */
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import toolbox.ToolBox;
+
+/**
+ * Test the links generated in source files with combinations
+ * of modules, Serializable, and @see for public and private methods.
+ *
+ * In the various test cases, in addition to the explicit call
+ * to {@code checkExit}, the primary check is the implicit call
+ * to {@code checkLinks}, to verify that there are no broken
+ * links in the generated files.
+ */
+public class TestSerializedFormWithSee extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestSerializedFormWithSee tester = new TestSerializedFormWithSee();
+        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    private final ToolBox tb;
+
+    TestSerializedFormWithSee() {
+        tb = new ToolBox();
+    }
+
+    @Test
+    public void test_noModule_notSerializable(Path base) throws IOException {
+        Path srcDir = generateSource(base, false, false);
+
+        Path outDir = base.resolve("out");
+        javadoc("-d", outDir.toString(),
+                "-sourcepath", srcDir.toString(),
+                "p");
+        checkExit(Exit.OK);
+    }
+
+    @Test
+    public void test_noModule_serializable(Path base) throws IOException {
+        Path srcDir = generateSource(base, false, true);
+
+        Path outDir = base.resolve("out");
+        javadoc("-d", outDir.toString(),
+                "-sourcepath", srcDir.toString(),
+                "p");
+        checkExit(Exit.OK);
+    }
+
+    @Test
+    public void test_module_notSerializable(Path base) throws IOException {
+        Path srcDir = generateSource(base, true, false);
+
+        Path outDir = base.resolve("out");
+        javadoc("-d", outDir.toString(),
+                "-sourcepath", srcDir.toString(),
+                "m/p");
+        checkExit(Exit.OK);
+    }
+
+    @Test
+    public void test_module_serializable(Path base) throws IOException {
+        Path srcDir = generateSource(base, true, true);
+
+        Path outDir = base.resolve("out");
+        javadoc("-d", outDir.toString(),
+                "-sourcepath", srcDir.toString(),
+                "m/p");
+        checkExit(Exit.OK);
+    }
+
+    Path generateSource(Path base, boolean module, boolean serializable) throws IOException {
+        Path dir = base.resolve("src");
+        if (module) {
+            tb.writeJavaFiles(dir, "module m { }");
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("package p;\n");
+        sb.append("public class C " + (serializable ? "implements java.io.Serializable " : "") + "{\n");
+        for (String access : new String[] { "public", "private" }) {
+            sb.append("    /**\n");
+            sb.append("     * This is a " + access + " " + (serializable ? "serializable " : "") + "field.\n");
+            sb.append("     * More description.\n");
+            sb.append("     * " + (serializable ? "@serial This is the serial description." : "") + "\n");
+            sb.append("     * @see #publicMethod()\n");
+            sb.append("     * @see #privateMethod()\n");
+            sb.append("     */\n");
+            sb.append("    " + access + " int " + access + "Field;\n");
+        }
+        for (String access : new String[] { "public", "private" }) {
+            sb.append("    /**\n");
+            sb.append("     * This is a " + access + " method.\n");
+            sb.append("     * More description.\n");
+            sb.append("     * @return zero.\n");
+            sb.append("     */\n");
+            sb.append("    " + access + " int " + access + "Method() { return 0; }\n");
+        }
+        sb.append("    }\n");
+        tb.writeJavaFiles(dir, sb.toString());
+        return dir;
+    }
+}


### PR DESCRIPTION
OpenJDK commit https://github.com/openjdk/jdk/commit/955ce37d602d9456f5b665d0ccd90d51a6fe4637

OpenJDK issue https://bugs.openjdk.org/browse/JDK-8207214

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8207214](https://bugs.openjdk.org/browse/JDK-8207214) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8207214](https://bugs.openjdk.org/browse/JDK-8207214): Broken links in JDK API serialized-form page (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2187/head:pull/2187` \
`$ git checkout pull/2187`

Update a local copy of the PR: \
`$ git checkout pull/2187` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2187`

View PR using the GUI difftool: \
`$ git pr show -t 2187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2187.diff">https://git.openjdk.org/jdk11u-dev/pull/2187.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2187#issuecomment-1763795116)