### PR TITLE
8299255: Unexpected round errors in FreetypeFontScaler

### DIFF
--- a/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
+++ b/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
@@ -443,10 +443,10 @@ Java_sun_font_FreetypeFontScaler_createScalerContextNative(
         ptsz = 1.0;
     }
     context->ptsz = (int)(ptsz * 64);
-    context->transform.xx =  FloatToFTFixed((float)dmat[0]/ptsz);
-    context->transform.yx = -FloatToFTFixed((float)dmat[1]/ptsz);
-    context->transform.xy = -FloatToFTFixed((float)dmat[2]/ptsz);
-    context->transform.yy =  FloatToFTFixed((float)dmat[3]/ptsz);
+    context->transform.xx =  FloatToFTFixed((float)(dmat[0]/ptsz));
+    context->transform.yx = -FloatToFTFixed((float)(dmat[1]/ptsz));
+    context->transform.xy = -FloatToFTFixed((float)(dmat[2]/ptsz));
+    context->transform.yy =  FloatToFTFixed((float)(dmat[3]/ptsz));
     context->aaType = aa;
     context->fmType = fm;
 

--- a/test/jdk/java/awt/FontClass/FontScalerRoundTest.java
+++ b/test/jdk/java/awt/FontClass/FontScalerRoundTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8299255
+ * @summary Verify no round error in Font scaling
+ */
+
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.font.FontRenderContext;
+import java.awt.font.LineMetrics;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+
+public class FontScalerRoundTest {
+    public static void main(String[] args) {
+        final double SCALE = 4096.0;
+        final double STEP = 0.0001;
+        final double LIMIT = STEP * 100.0;
+
+        BufferedImage img = new BufferedImage(100, 100,
+                                    BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = img.createGraphics();
+        FontRenderContext frc = g2d.getFontRenderContext();
+
+        Font font = new Font(Font.DIALOG, Font.PLAIN, 1);
+        float h1 = getScaledHeight(font, frc, SCALE);
+        float h2 = getScaledHeight(font, frc, SCALE + STEP);
+        float diff = Math.abs(h1 - h2);
+
+        if (diff > LIMIT) {
+            throw new RuntimeException("Font metrix had round error " +
+                                       h1 + "," + h2);
+        }
+    }
+
+    private static float getScaledHeight(Font font,
+                                         FontRenderContext frc,
+                                         double scale) {
+        AffineTransform at = new AffineTransform(scale, 0.0, 0.0, scale,
+                                                 0.0, 0.0);
+        Font transFont = font.deriveFont(at);
+        LineMetrics m = transFont.getLineMetrics("0", frc);
+        return m.getHeight();
+    }
+}
+


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8299255](https://bugs.openjdk.org/browse/JDK-8299255) needs maintainer approval

### Issue
 * [JDK-8299255](https://bugs.openjdk.org/browse/JDK-8299255): Unexpected round errors in FreetypeFontScaler (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2191/head:pull/2191` \
`$ git checkout pull/2191`

Update a local copy of the PR: \
`$ git checkout pull/2191` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2191`

View PR using the GUI difftool: \
`$ git pr show -t 2191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2191.diff">https://git.openjdk.org/jdk11u-dev/pull/2191.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2191#issuecomment-1764184115)