### PR TITLE
8311285: report some fontconfig related environment variables in hs_err file

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -83,6 +83,8 @@ const char *env_list[] = {
   "JAVA_HOME", "JRE_HOME", "JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "CLASSPATH",
   "JAVA_COMPILER", "PATH", "USERNAME",
 
+  "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "FC_LANG", "FONTCONFIG_USE_MMAP",
+
   // Env variables that are defined on Solaris/Linux/BSD
   "LD_LIBRARY_PATH", "LD_PRELOAD", "SHELL", "DISPLAY",
   "HOSTTYPE", "OSTYPE", "ARCH", "MACHTYPE",


### PR DESCRIPTION
Backport of 8311285

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8311285](https://bugs.openjdk.org/browse/JDK-8311285) needs maintainer approval

### Issue
 * [JDK-8311285](https://bugs.openjdk.org/browse/JDK-8311285): report some fontconfig related environment variables in hs_err file (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2193/head:pull/2193` \
`$ git checkout pull/2193`

Update a local copy of the PR: \
`$ git checkout pull/2193` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2193`

View PR using the GUI difftool: \
`$ git pr show -t 2193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2193.diff">https://git.openjdk.org/jdk11u-dev/pull/2193.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2193#issuecomment-1764341138)