### PR TITLE
8153090: TAB key cannot change input focus after the radio button in the Color Selection dialog

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaSpinnerUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaSpinnerUI.java
@@ -556,6 +556,7 @@ public class AquaSpinnerUI extends SpinnerUI {
             if (bottom != null) {
                 fBottomModel = bottom.getModel();
             }
+            setFocusable(false);
         }
 
         @Override

--- a/src/java.desktop/share/classes/javax/swing/colorchooser/ColorPanel.java
+++ b/src/java.desktop/share/classes/javax/swing/colorchooser/ColorPanel.java
@@ -99,8 +99,6 @@ final class ColorPanel extends JPanel implements ActionListener {
             add(spinner.getSpinner(), gbc);
             gbc.insets.top = 5;
         }
-        setFocusTraversalPolicy(new ContainerOrderFocusTraversalPolicy());
-        setFocusTraversalPolicyProvider(true);
         setFocusable(false);
 
         this.model = model;

--- a/test/jdk/javax/swing/JSpinner/8223788/JSpinnerButtonFocusTest.java
+++ b/test/jdk/javax/swing/JSpinner/8223788/JSpinnerButtonFocusTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 8223788
+ * @summary JSpinner buttons in JColorChooser dialog may capture focus
+ *          using TAB Key
+ * @run main JSpinnerButtonFocusTest
+ */
+
+import java.awt.Robot;
+import java.awt.BorderLayout;
+import java.awt.ContainerOrderFocusTraversalPolicy;
+import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JSpinner;
+import javax.swing.JSpinner.DefaultEditor;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class JSpinnerButtonFocusTest {
+    static JFrame frame;
+    static Robot robot;
+    static JSpinner spinner1, spinner2;
+    static DefaultEditor editor2;
+    static boolean jTextFieldFocusStatus;
+
+    public static void main(String args[]) throws Exception {
+
+        for (UIManager.LookAndFeelInfo LF : UIManager.getInstalledLookAndFeels()) {
+            try {
+                UIManager.setLookAndFeel(LF.getClassName());
+                robot = new Robot();
+                robot.setAutoDelay(50);
+                robot.setAutoWaitForIdle(true);
+
+                SwingUtilities.invokeAndWait(() -> {
+                    frame = new JFrame();
+                    spinner1 = new JSpinner();
+                    spinner2 = new JSpinner();
+
+                    frame.setLayout(new BorderLayout());
+                    frame.getContentPane().add(spinner1, BorderLayout.NORTH);
+                    frame.getContentPane().add(spinner2, BorderLayout.SOUTH);
+
+                    ((DefaultEditor)spinner1.getEditor()).setFocusable(false);
+                    spinner1.setFocusable(false);
+
+                    editor2 = (DefaultEditor) spinner2.getEditor();
+                    editor2.setFocusable(false);
+                    spinner2.setFocusable(false);
+
+                    frame.setFocusTraversalPolicy(
+                            new ContainerOrderFocusTraversalPolicy());
+                    frame.setFocusTraversalPolicyProvider(true);
+
+                    frame.pack();
+                    frame.setVisible(true);
+                });
+
+                robot.waitForIdle();
+                pressTab(5);
+                robot.waitForIdle();
+
+                SwingUtilities.invokeAndWait(() -> {
+                    jTextFieldFocusStatus = editor2.getTextField().isFocusOwner();
+                });
+
+                if (!jTextFieldFocusStatus) {
+                    throw new RuntimeException(
+                            "Spinner's Text Field doesn't have focus ");
+                }
+            } finally {
+                if(frame != null){
+                    SwingUtilities.invokeAndWait(frame::dispose);
+                }
+            }
+        }
+    }
+
+    public static void pressTab(int n) {
+        for (int i = 0; i < n; i++) {
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8223788](https://bugs.openjdk.org/browse/JDK-8223788) needs maintainer approval
- [ ] [JDK-8153090](https://bugs.openjdk.org/browse/JDK-8153090) needs maintainer approval

### Issues
 * [JDK-8153090](https://bugs.openjdk.org/browse/JDK-8153090): TAB key cannot change input focus after the radio button in the Color Selection dialog (**Bug** - P3)
 * [JDK-8223788](https://bugs.openjdk.org/browse/JDK-8223788): [macos] JSpinner buttons in JColorChooser dialog may capture focus using TAB Key. (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2196/head:pull/2196` \
`$ git checkout pull/2196`

Update a local copy of the PR: \
`$ git checkout pull/2196` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2196`

View PR using the GUI difftool: \
`$ git pr show -t 2196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2196.diff">https://git.openjdk.org/jdk11u-dev/pull/2196.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2196#issuecomment-1772175609)