### PR TITLE
8273804: Platform.isTieredSupported should handle the no-compiler case

### DIFF
--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -82,7 +82,7 @@ public class Platform {
     }
 
     public static boolean isTieredSupported() {
-        return compiler.contains("Tiered Compilers");
+        return (compiler != null) && compiler.contains("Tiered Compilers");
     }
 
     public static boolean isInt() {


### PR DESCRIPTION
a clean backport of [JDK-8273804](https://bugs.openjdk.org/browse/JDK-8273804).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8273804](https://bugs.openjdk.org/browse/JDK-8273804) needs maintainer approval

### Issue
 * [JDK-8273804](https://bugs.openjdk.org/browse/JDK-8273804): Platform.isTieredSupported should handle the no-compiler case (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2201/head:pull/2201` \
`$ git checkout pull/2201`

Update a local copy of the PR: \
`$ git checkout pull/2201` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2201`

View PR using the GUI difftool: \
`$ git pr show -t 2201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2201.diff">https://git.openjdk.org/jdk11u-dev/pull/2201.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2201#issuecomment-1772741251)