### PR TITLE
8294673: JFR: Add SecurityProviderService#threshold to TestActiveSettingEvent.java

### DIFF
--- a/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
@@ -206,6 +206,7 @@ public final class TestActiveSettingEvent {
         settingValues.put(EventNames.X509Certificate + "#threshold", "0 ns");
         settingValues.put(EventNames.X509Validation + "#threshold", "0 ns");
         settingValues.put(EventNames.Deserialization + "#threshold", "0 ns");
+        settingValues.put(EventNames.SecurityProviderService + "#threshold", "0 ns");
 
         try (Recording recording = new Recording(c)) {
             Map<Long, EventType> eventTypes = new HashMap<>();


### PR DESCRIPTION
Follow-up to JDK-8254711.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8294673](https://bugs.openjdk.org/browse/JDK-8294673) needs maintainer approval

### Issue
 * [JDK-8294673](https://bugs.openjdk.org/browse/JDK-8294673): JFR: Add SecurityProviderService#threshold to TestActiveSettingEvent.java (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2203/head:pull/2203` \
`$ git checkout pull/2203`

Update a local copy of the PR: \
`$ git checkout pull/2203` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2203`

View PR using the GUI difftool: \
`$ git pr show -t 2203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2203.diff">https://git.openjdk.org/jdk11u-dev/pull/2203.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2203#issuecomment-1772872993)