### PR TITLE
8213898: CDS dumping of springboot asserts in G1ArchiveAllocator::alloc_new_region

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.cpp
@@ -286,7 +286,7 @@ uint HeapRegionManager::find_highest_free(bool* expanded) {
   uint curr = max_length() - 1;
   while (true) {
     HeapRegion *hr = _regions.get_by_index(curr);
-    if (hr == NULL) {
+    if (hr == NULL || !is_available(curr)) {
       uint res = expand_at(curr, 1, NULL);
       if (res == 1) {
         *expanded = true;


### PR DESCRIPTION
runtime/appcds/javaldr/GCDuringDump.java can trigger exception occasionally when the default value of `MaxGCPauseMillis` is set  to 100ms on jdk11u, so need backport this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8213898](https://bugs.openjdk.org/browse/JDK-8213898) needs maintainer approval

### Issue
 * [JDK-8213898](https://bugs.openjdk.org/browse/JDK-8213898): CDS dumping of springboot asserts in G1ArchiveAllocator::alloc_new_region (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2204/head:pull/2204` \
`$ git checkout pull/2204`

Update a local copy of the PR: \
`$ git checkout pull/2204` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2204`

View PR using the GUI difftool: \
`$ git pr show -t 2204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2204.diff">https://git.openjdk.org/jdk11u-dev/pull/2204.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2204#issuecomment-1773688941)