### PR TITLE
8312182: THPs cause huge RSS due to thread start timing issue

### DIFF
--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -82,7 +82,17 @@
           "be dumped into the corefile.")                               \
                                                                         \
   diagnostic(bool, UseCpuAllocPath, false,                              \
-             "Use CPU_ALLOC code path in os::active_processor_count ")
+             "Use CPU_ALLOC code path in os::active_processor_count ")  \
+                                                                        \
+  diagnostic(bool, DisableTHPStackMitigation, false,                    \
+          "If THPs are unconditionally enabled on the system (mode "    \
+          "\"always\"), the JVM will prevent THP from forming in "      \
+          "thread stacks. This switch disables that mitigation and "    \
+          "allows THPs to form in thread stacks.")                      \
+                                                                        \
+  develop(bool, DelayThreadStartALot, false,                            \
+          "Artificially delay thread starts randomly for testing.")     \
+                                                                        \
 
 //
 // Defines Linux-specific default values. The flags are available on all

--- a/src/hotspot/os/linux/hugepages.cpp
+++ b/src/hotspot/os/linux/hugepages.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "hugepages.hpp"
+#include "runtime/os.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+bool HugePages::_is_thp_always_mode = false;
+size_t HugePages::_thp_pagesize = 0;
+
+// Given a file that contains a single (integral) number, return that number in (*out) and true;
+// in case of an error, return false.
+static bool read_number_file(const char* file, size_t* out) {
+  FILE* f = ::fopen(file, "r");
+  bool rc = false;
+  if (f != NULL) {
+    uint64_t i = 0;
+    if (::fscanf(f, SIZE_FORMAT, out) == 1) {
+      rc = true;
+    }
+    ::fclose(f);
+  }
+  return rc;
+}
+
+void HugePages::initialize() {
+  // Scan /sys/kernel/mm/transparent_hugepage/enabled
+  // see mm/huge_memory.c
+  const char* filename = "/sys/kernel/mm/transparent_hugepage/enabled";
+  FILE* f = ::fopen(filename, "r");
+  if (f != NULL) {
+    char buf[64];
+    char* s = fgets(buf, sizeof(buf), f);
+    if (s == buf) {
+      _is_thp_always_mode = (::strstr(buf, "[always]") != NULL);
+    }
+    fclose(f);
+  }
+
+  // Scan large page size for THP from hpage_pmd_size
+  _thp_pagesize = 0;
+  if (!read_number_file("/sys/kernel/mm/transparent_hugepage/hpage_pmd_size", &_thp_pagesize)) {
+    _thp_pagesize = 2 * M; // default to the most common page size
+  }
+}

--- a/src/hotspot/os/linux/hugepages.hpp
+++ b/src/hotspot/os/linux/hugepages.hpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_LINUX_HUGEPAGES_HPP
+#define OS_LINUX_HUGEPAGES_HPP
+
+#include "memory/allocation.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+// Please note that this is a stubbed out variant of the full HugePages
+// class from later versions. To keep changes minimal, only the absolutely
+// necessary parts have been downported.
+
+// Umbrella static interface
+class HugePages : public AllStatic {
+
+  // See /sys/kernel/mm/transparent_hugepages/enabled
+  static bool _is_thp_always_mode;
+
+  // Contains the THP page size
+  static size_t _thp_pagesize;
+
+public:
+
+  static bool is_thp_always_mode()              { return _is_thp_always_mode; }
+  static size_t thp_pagesize()                  { return _thp_pagesize; }
+
+  static void initialize();
+
+};
+
+#endif // OS_LINUX_HUGEPAGES_HPP

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -32,6 +32,7 @@
 #include "code/vtableStubs.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/disassembler.hpp"
+#include "hugepages.hpp"
 #include "interpreter/interpreter.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"
@@ -822,6 +823,10 @@ static void *thread_native_entry(Thread *thread) {
     }
   }
 
+  if (DelayThreadStartALot) {
+    os::naked_short_sleep(100);
+  }
+
   // call one more level start routine
   thread->call_run();
 
@@ -961,6 +966,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   // Calculate stack size if it's not specified by caller.
   size_t stack_size = os::Posix::get_initial_stack_size(thr_type, req_stack_size);
   size_t guard_size = os::Linux::default_guard_size(thr_type);
+
   // Configure glibc guard page. Must happen before calling
   // get_static_tls_area_size(), which uses the guard_size.
   pthread_attr_setguardsize(&attr, guard_size);
@@ -980,6 +986,18 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
     stack_size += stack_adjust_size;
   }
   assert(is_aligned(stack_size, os::vm_page_size()), "stack_size not aligned");
+
+  if (!DisableTHPStackMitigation) {
+    // In addition to the glibc guard page that prevents inter-thread-stack hugepage
+    // coalescing (see comment in os::Linux::default_guard_size()), we also make
+    // sure the stack size itself is not huge-page-size aligned; that makes it much
+    // more likely for thread stack boundaries to be unaligned as well and hence
+    // protects thread stacks from being targeted by khugepaged.
+    if (HugePages::thp_pagesize() > 0 &&
+        is_aligned(stack_size, HugePages::thp_pagesize())) {
+      stack_size += os::vm_page_size();
+    }
+  }
 
   int status = pthread_attr_setstacksize(&attr, stack_size);
   assert_status(status == 0, status, "pthread_attr_setstacksize");
@@ -3506,6 +3524,27 @@ bool os::Linux::libnuma_init() {
 }
 
 size_t os::Linux::default_guard_size(os::ThreadType thr_type) {
+
+  if (!DisableTHPStackMitigation) {
+    // If THPs are unconditionally enabled, the following scenario can lead to huge RSS
+    // - parent thread spawns, in quick succession, multiple child threads
+    // - child threads are slow to start
+    // - thread stacks of future child threads are adjacent and get merged into one large VMA
+    //   by the kernel, and subsequently transformed into huge pages by khugepaged
+    // - child threads come up, place JVM guard pages, thus splinter the large VMA, splinter
+    //   the huge pages into many (still paged-in) small pages.
+    // The result of that sequence are thread stacks that are fully paged-in even though the
+    // threads did not even start yet.
+    // We prevent that by letting the glibc allocate a guard page, which causes a VMA with different
+    // permission bits to separate two ajacent thread stacks and therefore prevent merging stacks
+    // into one VMA.
+    //
+    // Yes, this means we have two guard sections - the glibc and the JVM one - per thread. But the
+    // cost for that one extra protected page is dwarfed from a large win in performance and memory
+    // that avoiding interference by khugepaged buys us.
+    return os::vm_page_size();
+  }
+
   // Creating guard page is very expensive. Java thread has HotSpot
   // guard pages, only enable glibc guard page for non-Java threads.
   // (Remember: compiler thread is a Java thread, too!)
@@ -4159,6 +4198,25 @@ bool os::Linux::setup_large_page_type(size_t page_size) {
 }
 
 void os::large_page_init() {
+
+  // Query OS information first.
+  HugePages::initialize();
+
+  // If THPs are unconditionally enabled (THP mode "always"), khugepaged may attempt to
+  // coalesce small pages in thread stacks to huge pages. That costs a lot of memory and
+  // is usually unwanted for thread stacks. Therefore we attempt to prevent THP formation in
+  // thread stacks unless the user explicitly allowed THP formation by manually disabling
+  // -XX:+DisableTHPStackMitigation.
+  if (HugePages::is_thp_always_mode()) {
+    if (DisableTHPStackMitigation) {
+      log_info(pagesize)("JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
+    } else {
+      log_info(pagesize)("JVM will attempt to prevent THPs in thread stacks.");
+    }
+  } else {
+    FLAG_SET_ERGO(bool, DisableTHPStackMitigation, true); // Mitigation not needed
+  }
+
   if (!UseLargePages &&
       !UseTransparentHugePages &&
       !UseHugeTLBFS &&

--- a/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Red Hat Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=ENABLED
+ * @bug 8303215 8312182
+ * @summary On THP=always systems, we prevent THPs from forming within thread stacks
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @requires vm.debug
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver THPsInThreadStackPreventionTest PATCH-ENABLED
+ */
+
+/*
+ * @test id=DISABLED
+ * @bug 8303215 8312182
+ * @summary On THP=always systems, we prevent THPs from forming within thread stacks (negative test)
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @requires vm.debug
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run main/manual THPsInThreadStackPreventionTest  PATCH-DISABLED
+ */
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+
+public class THPsInThreadStackPreventionTest {
+
+    // We test the mitigation for "huge rss for THP=always" introduced with JDK-8312182 and JDK-8302015:
+    //
+    // We start a program that spawns a ton of threads with a stack size close to THP page size. The threads
+    // are idle and should not build up a lot of stack. The threads are started with an artificial delay
+    // between thread start and stack guardpage creation, which exacerbates the RSS bloat (for explanation
+    // please see 8312182).
+    //
+    // We then observe RSS of that program. We expect it to stay below a reasonable maximum. The unpatched
+    // version should show an RSS of ~2 GB (paying for the fully paged in thread stacks). The fixed variant should
+    // cost only ~200-400 MB.
+
+    static final int numThreads = 1000;
+    static final long threadStackSizeMB = 2; // must be 2M
+    static final long heapSizeMB = 64;
+    static final long basicRSSOverheadMB = heapSizeMB + 150;
+    // A successful completion of this test would show not more than X KB per thread stack.
+    static final long acceptableRSSPerThreadStack = 128 * 1024;
+    static final long acceptableRSSForAllThreadStacks = numThreads * acceptableRSSPerThreadStack;
+    static final long acceptableRSSLimitMB = (acceptableRSSForAllThreadStacks / (1024 * 1024)) + basicRSSOverheadMB;
+
+    private static class TestMain {
+
+        static class Sleeper extends Thread {
+            CyclicBarrier barrier;
+            public Sleeper(CyclicBarrier barrier) {
+                this.barrier = barrier;
+            }
+            @Override
+            public void run() {
+                try {
+                    barrier.await(); // wait for all siblings
+                    barrier.await(); // wait main thread to print status
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        public static void main(String[] args) throws BrokenBarrierException, InterruptedException {
+
+            // Fire up 1000 threads with 2M stack size each.
+            Sleeper[] threads = new Sleeper[numThreads];
+            CyclicBarrier barrier = new CyclicBarrier(numThreads + 1);
+
+            for (int i = 0; i < numThreads; i++) {
+                threads[i] = new Sleeper(barrier);
+                threads[i].start();
+            }
+
+            // Wait for all threads to come up
+            barrier.await();
+
+            // print status
+            String file = "/proc/self/status";
+            try (FileReader fr = new FileReader(file);
+                 BufferedReader reader = new BufferedReader(fr)) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    System.out.println(line);
+                }
+            } catch (IOException | NumberFormatException e) { /* ignored */ }
+
+            // Signal threads to stop
+            barrier.await();
+
+        }
+    }
+
+    static class ProcSelfStatus {
+
+        public long rssMB;
+        public long swapMB;
+        public int numLifeThreads;
+
+        // Parse output from /proc/self/status
+        public static ProcSelfStatus parse(OutputAnalyzer o) {
+            ProcSelfStatus status = new ProcSelfStatus();
+            String s = o.firstMatch("Threads:\\s*(\\d+)", 1);
+            Objects.requireNonNull(s);
+            status.numLifeThreads = Integer.parseInt(s);
+            s = o.firstMatch("VmRSS:\\s*(\\d+) kB", 1);
+            Objects.requireNonNull(s);
+            status.rssMB = Long.parseLong(s) / 1024;
+            s = o.firstMatch("VmSwap:\\s*(\\d+) kB", 1);
+            Objects.requireNonNull(s);
+            status.swapMB = Long.parseLong(s) / 1024;
+            return status;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        HugePageConfiguration config = HugePageConfiguration.readFromOS();
+        // This issue is bound to THP=always
+        if (config.getThpMode() != HugePageConfiguration.THPMode.always) {
+            throw new SkippedException("Test only makes sense in THP \"always\" mode");
+        }
+
+        String[] defaultArgs = {
+            "-Xlog:pagesize",
+            "-Xmx" + heapSizeMB + "m", "-Xms" + heapSizeMB + "m", "-XX:+AlwaysPreTouch", // stabilize RSS
+            "-Xss" + threadStackSizeMB + "m",
+            "-XX:-CreateCoredumpOnCrash",
+            // This will delay the child threads before they create guard pages, thereby greatly increasing the
+            // chance of large VMA formation + hugepage coalescation; see JDK-8312182
+            "-XX:+DelayThreadStartALot"
+        };
+        ArrayList<String> finalargs = new ArrayList<>(Arrays.asList(defaultArgs));
+
+        switch (args[0]) {
+            case "PATCH-ENABLED": {
+                finalargs.add(TestMain.class.getName());
+                ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);
+
+                OutputAnalyzer output = new OutputAnalyzer(pb.start());
+                output.shouldHaveExitValue(0);
+
+                // this line indicates the mitigation is active:
+                output.shouldContain("[pagesize] JVM will attempt to prevent THPs in thread stacks.");
+
+                ProcSelfStatus status = ProcSelfStatus.parse(output);
+                if (status.numLifeThreads < numThreads) {
+                    throw new RuntimeException("Number of live threads lower than expected: " + status.numLifeThreads + ", expected " + numThreads);
+                } else {
+                    System.out.println("Found " + status.numLifeThreads + " to be alive. Ok.");
+                }
+
+                long rssPlusSwapMB = status.swapMB + status.rssMB;
+
+                if (rssPlusSwapMB > acceptableRSSLimitMB) {
+                    throw new RuntimeException("RSS+Swap larger than expected: " + rssPlusSwapMB + "m, expected at most " + acceptableRSSLimitMB + "m");
+                } else {
+                    if (rssPlusSwapMB < heapSizeMB) { // we pretouch the java heap, so we expect to see at least that:
+                        throw new RuntimeException("RSS+Swap suspiciously low: " + rssPlusSwapMB + "m, expected at least " + heapSizeMB + "m");
+                    }
+                    System.out.println("Okay: RSS+Swap=" + rssPlusSwapMB + ", within acceptable limit of " + acceptableRSSLimitMB);
+                }
+            }
+            break;
+
+            case "PATCH-DISABLED": {
+
+                // Only execute manually! this will allocate ~2gb of memory!
+
+                // explicitly disable the no-THP-workaround:
+                finalargs.add("-XX:+UnlockDiagnosticVMOptions");
+                finalargs.add("-XX:+DisableTHPStackMitigation");
+
+                finalargs.add(TestMain.class.getName());
+                ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);
+                OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+                output.shouldHaveExitValue(0);
+
+                // We deliberately switched off mitigation, VM should tell us:
+                output.shouldContain("[pagesize] JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
+
+                // Parse output from self/status
+                ProcSelfStatus status = ProcSelfStatus.parse(output);
+                if (status.numLifeThreads < numThreads) {
+                    throw new RuntimeException("Number of live threads lower than expected (" + status.numLifeThreads + ", expected " + numThreads +")");
+                } else {
+                    System.out.println("Found " + status.numLifeThreads + " to be alive. Ok.");
+                }
+
+                long rssPlusSwapMB = status.swapMB + status.rssMB;
+
+                if (rssPlusSwapMB < acceptableRSSLimitMB) {
+                    throw new RuntimeException("RSS+Swap lower than expected: " + rssPlusSwapMB + "m, expected more than " + acceptableRSSLimitMB + "m");
+                }
+                break;
+            }
+
+            default: throw new RuntimeException("Bad argument: " + args[0]);
+        }
+    }
+}


### PR DESCRIPTION
This is an unclean backport.

If fixes a footprint- and performance issue one gets when running with THP always enabled and a lot of threads, especially if the thread stack size is close to the THP page size (typically 2M).

It can be reproduced easily by e.g. starting a test program spawning 10000 threads with -Xss2m. If the machine has THP set to "madvise" or "never", this would cost 300-600MB RSS. With THP set to "always," it costs 2-3GB RSS, possibly a lot more since the problem depends on timing.

For details and explanations, please see the JBS description.

The patch: Large page support has evolved over the years. The surrounding infrastructure has changed a lot since JDK 11. 

To cleanly downport the patch, I would have to downport at least 8 patches and a CSR (*).

This would be an unacceptable risk as well as completely unnecessary. The patch only uses a tiny portion of the new infrastructure and can be implanted easily into earlier VM versions with a little bit of stub work.

The patch does
- on startup, it queries the OS for its THP state (whether it is "always", so unconditional) and the THP page size. That part lives in hugepages.cpp/hpp and has been dumbed down a lot from mainline.
- If THP are unconditionally enabled:
  - On Thread creation, we change the stack size to some size that is not THP-size aligned.
  - On Thread creation, we always let libc create a guard page to prevent VMA folding (see JBS description)

That's it. With this patch, the 10000 thread test RSS is back to baseline, ~600MB.

(*)

Patches that would have to be dowported for a clean patch:
- JDK-8257588 - Make os::page_sizes a bitmask (https://bugs.openjdk.org/browse/JDK-8257588)
- JDK-8257989 - Error in gtest os_page_size_for_region_unaligned after 8257588 (https://bugs.openjdk.org/browse/JDK-8257989)
- JDK-8256155 - Allow multiple large page sizes to be used on Linux (https://bugs.openjdk.org/browse/JDK-8256155)
- needs CSR JDK-8265517 - Change definition of LargePageSizeInBytes (https://bugs.openjdk.org/browse/JDK-8265517)
- JDK-8261401 - Add sanity check for UseSHM large pages similar to the one used with hugetlb large pages -(https://bugs.openjdk.org/browse/JDK-8261401)
- JDK-8303215 - Make thread stacks not use huge pages https://bugs.openjdk.org/browse/JDK-8303215
- JDK-8310233 - Fix THP detection on Linux (https://bugs.openjdk.org/browse/JDK-8310233)
- JDK-8312394 [linux] SIGSEGV if kernel was built without hugepage support (https://bugs.openjdk.org/browse/JDK-8312394)
- JDK-8312620 WSL Linux build crashes after JDK-8310233 (https://bugs.openjdk.org/browse/JDK-8312620)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8310687](https://bugs.openjdk.org/browse/JDK-8310687) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8312182](https://bugs.openjdk.org/browse/JDK-8312182) needs maintainer approval

### Issues
 * [JDK-8312182](https://bugs.openjdk.org/browse/JDK-8312182): THPs cause huge RSS due to thread start timing issue (**Bug** - P3)
 * [JDK-8310687](https://bugs.openjdk.org/browse/JDK-8310687): JDK-8303215 is incomplete (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2205/head:pull/2205` \
`$ git checkout pull/2205`

Update a local copy of the PR: \
`$ git checkout pull/2205` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2205`

View PR using the GUI difftool: \
`$ git pr show -t 2205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2205.diff">https://git.openjdk.org/jdk11u-dev/pull/2205.diff</a>

</details>
