### PR TITLE
8303215: Make thread stacks not use huge pages

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -981,6 +981,15 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   }
   assert(is_aligned(stack_size, os::vm_page_size()), "stack_size not aligned");
 
+  // Add an additional page to the stack size to reduce its chances of getting large page aligned
+  // so that the stack does not get backed by a transparent huge page.
+  size_t default_large_page_size = os::large_page_size();
+  if (default_large_page_size != 0 &&
+      stack_size >= default_large_page_size &&
+      is_aligned(stack_size, default_large_page_size)) {
+    stack_size += os::vm_page_size();
+  }
+
   int status = pthread_attr_setstacksize(&attr, stack_size);
   assert_status(status == 0, status, "pthread_attr_setstacksize");
 
@@ -4159,6 +4168,10 @@ bool os::Linux::setup_large_page_type(size_t page_size) {
 }
 
 void os::large_page_init() {
+
+  // Always initialize the default large page size even if large pages are not being used.
+  size_t large_page_size = Linux::setup_large_page_size();
+
   if (!UseLargePages &&
       !UseTransparentHugePages &&
       !UseHugeTLBFS &&
@@ -4176,7 +4189,6 @@ void os::large_page_init() {
     return;
   }
 
-  size_t large_page_size = Linux::setup_large_page_size();
   UseLargePages          = Linux::setup_large_page_type(large_page_size);
 
   set_coredump_filter(LARGEPAGES_BIT);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4168,7 +4168,6 @@ bool os::Linux::setup_large_page_type(size_t page_size) {
 }
 
 void os::large_page_init() {
-
   // Always initialize the default large page size even if large pages are not being used.
   size_t large_page_size = Linux::setup_large_page_size();
 

--- a/src/hotspot/os_cpu/linux_aarch64/globals_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/globals_linux_aarch64.hpp
@@ -30,10 +30,18 @@
 // (see globals.hpp)
 
 define_pd_global(bool, DontYieldALot,            false);
-define_pd_global(intx, ThreadStackSize,          2048); // 0 => use system default
-define_pd_global(intx, VMThreadStackSize,        2048);
 
-define_pd_global(intx, CompilerThreadStackSize,  2048);
+// Set default stack sizes < 2MB so as to prevent stacks from getting
+// large-page aligned and backed by THPs on systems where 2MB is the
+// default huge page size. For non-JavaThreads, glibc may add an additional
+// guard page to the total stack size, so to keep the default sizes same
+// for all the following flags, we set them to 2 pages less than 2MB. On
+// systems where 2MB is the default large page size, 4KB is most commonly
+// the regular page size.
+define_pd_global(intx, ThreadStackSize,          2040); // 0 => use system default
+define_pd_global(intx, VMThreadStackSize,        2040);
+
+define_pd_global(intx, CompilerThreadStackSize,  2040);
 
 define_pd_global(uintx,JVMInvokeMethodSlack,     8192);
 


### PR DESCRIPTION
Backported for parity with Oracle and as preparation to fix https://bugs.openjdk.org/browse/JDK-8312182.

Backport is unclean, but the difference is minor. I had to adjust hunks in `os::large_page_init()` since the surrounding coding changed a lot since JDK 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8303215](https://bugs.openjdk.org/browse/JDK-8303215) needs maintainer approval

### Issue
 * [JDK-8303215](https://bugs.openjdk.org/browse/JDK-8303215): Make thread stacks not use huge pages (**Enhancement** - P3)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2208/head:pull/2208` \
`$ git checkout pull/2208`

Update a local copy of the PR: \
`$ git checkout pull/2208` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2208`

View PR using the GUI difftool: \
`$ git pr show -t 2208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2208.diff">https://git.openjdk.org/jdk11u-dev/pull/2208.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2208#issuecomment-1776653062)