### PR TITLE
8282143: Objects.requireNonNull should be ForceInline

### DIFF
--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -216,6 +216,7 @@ public final class Objects {
      * @return {@code obj} if not {@code null}
      * @throws NullPointerException if {@code obj} is {@code null}
      */
+    @ForceInline
     public static <T> T requireNonNull(T obj) {
         if (obj == null)
             throw new NullPointerException();
@@ -241,6 +242,7 @@ public final class Objects {
      * @return {@code obj} if not {@code null}
      * @throws NullPointerException if {@code obj} is {@code null}
      */
+    @ForceInline
     public static <T> T requireNonNull(T obj, String message) {
         if (obj == null)
             throw new NullPointerException(message);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [fc52a218](https://github.com/openjdk/jdk/commit/fc52a2182a9debc04b2ac302801b3d61989f54ec) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Quan Anh Mai on 2 Mar 2022 and was reviewed by Paul Sandoz.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8282143](https://bugs.openjdk.org/browse/JDK-8282143) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282143](https://bugs.openjdk.org/browse/JDK-8282143): Objects.requireNonNull should be ForceInline (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2213/head:pull/2213` \
`$ git checkout pull/2213`

Update a local copy of the PR: \
`$ git checkout pull/2213` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2213`

View PR using the GUI difftool: \
`$ git pr show -t 2213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2213.diff">https://git.openjdk.org/jdk11u-dev/pull/2213.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2213#issuecomment-1777394149)