### PR TITLE
8217329: JTREG: Clean up, remove unused imports in gc folder

### DIFF
--- a/test/hotspot/jtreg/gc/TestAgeOutput.java
+++ b/test/hotspot/jtreg/gc/TestAgeOutput.java
@@ -66,11 +66,8 @@ import sun.hotspot.WhiteBox;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-
-import static jdk.test.lib.Asserts.*;
 
 public class TestAgeOutput {
 

--- a/test/hotspot/jtreg/gc/TestCardTablePageCommits.java
+++ b/test/hotspot/jtreg/gc/TestCardTablePageCommits.java
@@ -23,7 +23,6 @@
 
 package gc;
 
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Platform;

--- a/test/hotspot/jtreg/gc/TestGenerationPerfCounter.java
+++ b/test/hotspot/jtreg/gc/TestGenerationPerfCounter.java
@@ -24,7 +24,6 @@
 package gc;
 
 import static jdk.test.lib.Asserts.*;
-import gc.testlibrary.PerfCounter;
 import gc.testlibrary.PerfCounters;
 
 

--- a/test/hotspot/jtreg/gc/TestMemoryMXBeansAndPoolsPresence.java
+++ b/test/hotspot/jtreg/gc/TestMemoryMXBeansAndPoolsPresence.java
@@ -24,7 +24,6 @@
 package gc;
 
 import java.util.List;
-import java.util.ArrayList;
 import java.lang.management.*;
 import static jdk.test.lib.Asserts.*;
 import java.util.stream.*;

--- a/test/hotspot/jtreg/gc/TestNumWorkerOutput.java
+++ b/test/hotspot/jtreg/gc/TestNumWorkerOutput.java
@@ -54,11 +54,8 @@ import sun.hotspot.WhiteBox;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-
-import static jdk.test.lib.Asserts.*;
 
 public class TestNumWorkerOutput {
 

--- a/test/hotspot/jtreg/gc/TestObjectAlignment.java
+++ b/test/hotspot/jtreg/gc/TestObjectAlignment.java
@@ -44,9 +44,6 @@ package gc;
  * @run main/othervm gc.TestObjectAlignment -Xmx20M -XX:-ExplicitGCInvokesConcurrent -XX:+IgnoreUnrecognizedVMOptions -XX:ObjectAlignmentInBytes=256
  */
 
-import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.process.OutputAnalyzer;
-
 public class TestObjectAlignment {
 
   public static byte[] garbage;

--- a/test/hotspot/jtreg/gc/TestPolicyNamePerfCounter.java
+++ b/test/hotspot/jtreg/gc/TestPolicyNamePerfCounter.java
@@ -24,7 +24,6 @@
 package gc;
 
 import static jdk.test.lib.Asserts.*;
-import gc.testlibrary.PerfCounter;
 import gc.testlibrary.PerfCounters;
 
 

--- a/test/hotspot/jtreg/gc/arguments/AllocationHelper.java
+++ b/test/hotspot/jtreg/gc/arguments/AllocationHelper.java
@@ -23,7 +23,6 @@
 
 package gc.arguments;
 
-import java.util.LinkedList;
 import java.util.concurrent.Callable;
 
 /**

--- a/test/hotspot/jtreg/gc/arguments/TestSelectDefaultGC.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSelectDefaultGC.java
@@ -36,11 +36,8 @@ package gc.arguments;
  * @run driver gc.arguments.TestSelectDefaultGC
  */
 
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-
-import java.util.regex.*;
 
 public class TestSelectDefaultGC {
     public static void assertVMOption(OutputAnalyzer output, String option, boolean value) {

--- a/test/hotspot/jtreg/gc/arguments/TestShrinkHeapInSteps.java
+++ b/test/hotspot/jtreg/gc/arguments/TestShrinkHeapInSteps.java
@@ -37,7 +37,6 @@ package gc.arguments;
 
 import java.util.LinkedList;
 import java.util.Arrays;
-import java.util.Collections;
 import jdk.test.lib.Utils;
 
 public class TestShrinkHeapInSteps {

--- a/test/hotspot/jtreg/gc/class_unloading/TestCMSClassUnloadingEnabledHWM.java
+++ b/test/hotspot/jtreg/gc/class_unloading/TestCMSClassUnloadingEnabledHWM.java
@@ -42,8 +42,6 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
-import java.util.ArrayList;
-import java.util.Arrays;
 import sun.hotspot.WhiteBox;
 
 public class TestCMSClassUnloadingEnabledHWM {

--- a/test/hotspot/jtreg/gc/class_unloading/TestG1ClassUnloadingHWM.java
+++ b/test/hotspot/jtreg/gc/class_unloading/TestG1ClassUnloadingHWM.java
@@ -40,8 +40,6 @@ package gc.class_unloading;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-import java.util.ArrayList;
-import java.util.Arrays;
 import sun.hotspot.WhiteBox;
 
 public class TestG1ClassUnloadingHWM {

--- a/test/hotspot/jtreg/gc/concurrent_phase_control/CheckControl.java
+++ b/test/hotspot/jtreg/gc/concurrent_phase_control/CheckControl.java
@@ -51,7 +51,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 

--- a/test/hotspot/jtreg/gc/epsilon/TestArraycopyCheckcast.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestArraycopyCheckcast.java
@@ -51,8 +51,6 @@ package gc.epsilon;
  *                   gc.epsilon.TestArraycopyCheckcast
  */
 
-import java.util.Random;
-
 public class TestArraycopyCheckcast {
 
   static int COUNT = Integer.getInteger("count", 1000);

--- a/test/hotspot/jtreg/gc/epsilon/TestEpsilonEnabled.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestEpsilonEnabled.java
@@ -35,7 +35,6 @@ package gc.epsilon;
  *                   gc.epsilon.TestEpsilonEnabled
  */
 
-import jdk.test.lib.Platform;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 

--- a/test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java
@@ -49,7 +49,6 @@ package gc.epsilon;
  */
 
 import java.lang.management.*;
-import java.util.*;
 
 public class TestMemoryMXBeans {
 

--- a/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsLog.java
+++ b/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsLog.java
@@ -39,12 +39,8 @@ package gc.g1;
 import sun.hotspot.WhiteBox;
 
 import java.util.Arrays;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import jdk.test.lib.Asserts;
 
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 

--- a/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
+++ b/test/hotspot/jtreg/gc/g1/TestLargePageUseForAuxMemory.java
@@ -38,9 +38,6 @@ package gc.g1;
  */
 
 import java.lang.Math;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.Asserts;

--- a/test/hotspot/jtreg/gc/g1/TestPLABOutput.java
+++ b/test/hotspot/jtreg/gc/g1/TestPLABOutput.java
@@ -41,7 +41,6 @@ import sun.hotspot.WhiteBox;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 

--- a/test/hotspot/jtreg/gc/g1/TestRemsetLoggingTools.java
+++ b/test/hotspot/jtreg/gc/g1/TestRemsetLoggingTools.java
@@ -27,13 +27,10 @@ package gc.g1;
  * Common helpers for TestRemsetLogging* tests
  */
 
-import com.sun.management.HotSpotDiagnosticMXBean;
-import com.sun.management.VMOption;
 import sun.hotspot.WhiteBox;
 
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
-import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 

--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData.java
@@ -28,7 +28,6 @@ import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.Utils;
 import jtreg.SkippedException;
 
 import java.io.IOException;
@@ -37,7 +36,6 @@ import java.lang.management.MemoryUsage;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;

--- a/test/hotspot/jtreg/gc/g1/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/g1/TestStringDeduplicationTools.java
@@ -27,9 +27,7 @@ package gc.g1;
  * Common code for string deduplication tests
  */
 
-import java.lang.management.*;
 import java.lang.reflect.*;
-import java.security.*;
 import java.util.*;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
+++ b/test/hotspot/jtreg/gc/g1/TestVerifyGCType.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 import jdk.test.lib.Asserts;
-import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import sun.hotspot.WhiteBox;

--- a/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
+++ b/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
@@ -42,8 +42,6 @@ import sun.hotspot.WhiteBox;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Collections;
-
 import java.lang.management.*;
 
 // 8195115 says that for the "G1 Old Gen" MemoryPool, CollectionUsage.used

--- a/test/hotspot/jtreg/gc/logging/TestDeprecatedPrintFlags.java
+++ b/test/hotspot/jtreg/gc/logging/TestDeprecatedPrintFlags.java
@@ -36,10 +36,8 @@ package gc.logging;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.stream.Collectors;
 
 public class TestDeprecatedPrintFlags {

--- a/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
+++ b/test/hotspot/jtreg/gc/logging/TestPrintReferences.java
@@ -37,8 +37,6 @@ package gc.logging;
 
 import java.lang.ref.SoftReference;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import java.util.regex.Pattern;

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspaceMemoryPool.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspaceMemoryPool.java
@@ -26,8 +26,6 @@ package gc.metaspace;
 import java.util.List;
 import java.lang.management.*;
 import jdk.test.lib.Platform;
-import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.process.OutputAnalyzer;
 import static jdk.test.lib.Asserts.*;
 
 /* @test TestMetaspaceMemoryPool

--- a/test/hotspot/jtreg/gc/metaspace/TestPerfCountersAndMemoryPools.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestPerfCountersAndMemoryPools.java
@@ -28,7 +28,6 @@ import java.lang.management.*;
 
 import jdk.test.lib.Platform;
 import static jdk.test.lib.Asserts.*;
-import gc.testlibrary.PerfCounter;
 import gc.testlibrary.PerfCounters;
 
 /* @test TestPerfCountersAndMemoryPools

--- a/test/hotspot/jtreg/gc/stress/gclocker/TestGCLocker.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestGCLocker.java
@@ -30,7 +30,6 @@ package gc.stress.gclocker;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryUsage;
-import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.List;

--- a/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGC.java
@@ -26,7 +26,6 @@ package gc.stress.systemgc;
 // A test that stresses a full GC by allocating objects of different lifetimes
 // and concurrently calling System.gc().
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;

--- a/test/hotspot/jtreg/gc/whitebox/TestConcMarkCycleWB.java
+++ b/test/hotspot/jtreg/gc/whitebox/TestConcMarkCycleWB.java
@@ -38,7 +38,6 @@ package gc.whitebox;
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseG1GC gc.whitebox.TestConcMarkCycleWB
  * @summary Verifies that ConcurrentMarking-related WB works properly
  */
-import static jdk.test.lib.Asserts.assertFalse;
 import static jdk.test.lib.Asserts.assertTrue;
 import sun.hotspot.WhiteBox;
 


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

I dropped a row of files as they are not in 11. 
The rest applied clean. 
All modified tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8217329](https://bugs.openjdk.org/browse/JDK-8217329) needs maintainer approval

### Issue
 * [JDK-8217329](https://bugs.openjdk.org/browse/JDK-8217329): JTREG: Clean up, remove unused imports in gc folder (**Enhancement** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2214/head:pull/2214` \
`$ git checkout pull/2214`

Update a local copy of the PR: \
`$ git checkout pull/2214` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2214`

View PR using the GUI difftool: \
`$ git pr show -t 2214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2214.diff">https://git.openjdk.org/jdk11u-dev/pull/2214.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2214#issuecomment-1777400406)