### PR TITLE
8286707: JFR: Don't commit JFR internal jdk.JavaMonitorWait events

### DIFF
--- a/src/hotspot/share/jfr/recorder/repository/jfrChunkRotation.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrChunkRotation.cpp
@@ -36,7 +36,7 @@ static jobject install_chunk_monitor(Thread* thread) {
   // read static field
   HandleMark hm(thread);
   static const char klass[] = "jdk/jfr/internal/JVM";
-  static const char field[] = "FILE_DELTA_CHANGE";
+  static const char field[] = "CHUNK_ROTATION_MONITOR";
   static const char signature[] = "Ljava/lang/Object;";
   JavaValue result(T_OBJECT);
   JfrJavaArguments field_args(&result, klass, field, signature, thread);

--- a/src/hotspot/share/jfr/support/jfrIntrinsics.hpp
+++ b/src/hotspot/share/jfr/support/jfrIntrinsics.hpp
@@ -34,7 +34,8 @@
 #include "jfr/recorder/checkpoint/types/traceid/jfrTraceIdMacros.hpp"
 
 #define JFR_TEMPLATES(template) \
-  template(jdk_jfr_internal_JVM,          "jdk/jfr/internal/JVM")
+  template(jdk_jfr_internal_JVM,          "jdk/jfr/internal/JVM")                                                    \
+  template(jfr_chunk_rotation_monitor,                                "jdk/jfr/internal/JVM$ChunkRotationMonitor")   \
 
 #define JFR_INTRINSICS(do_intrinsic, do_class, do_name, do_signature, do_alias)                              \
   do_intrinsic(_counterTime,        jdk_jfr_internal_JVM, counterTime_name, void_long_signature, F_SN)       \

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1393,6 +1393,12 @@ static int Adjust(volatile int * adr, int dx) {
   return v;
 }
 
+static inline bool is_excluded(const Klass* monitor_klass) {
+  assert(monitor_klass != NULL, "invariant");
+  NOT_JFR_RETURN_(false);
+  JFR_ONLY(return vmSymbols::jfr_chunk_rotation_monitor() == monitor_klass->name());
+}
+
 static void post_monitor_wait_event(EventJavaMonitorWait* event,
                                     ObjectMonitor* monitor,
                                     jlong notifier_tid,
@@ -1400,7 +1406,11 @@ static void post_monitor_wait_event(EventJavaMonitorWait* event,
                                     bool timedout) {
   assert(event != NULL, "invariant");
   assert(monitor != NULL, "invariant");
-  event->set_monitorClass(((oop)monitor->object())->klass());
+  const Klass* monitor_klass = ((oop)monitor->object())->klass();
+  if (is_excluded(monitor_klass)) {
+    return;
+  }
+  event->set_monitorClass(monitor_klass);
   event->set_timeout(timeout);
   event->set_address((uintptr_t)monitor->object_addr());
   event->set_notifier(notifier_tid);

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -279,8 +279,12 @@
 
 #if INCLUDE_JFR
 #define JFR_ONLY(code) code
+#define NOT_JFR_RETURN()      /* next token must be ; */
+#define NOT_JFR_RETURN_(code) /* next token must be ; */
 #else
 #define JFR_ONLY(code)
+#define NOT_JFR_RETURN()      {}
+#define NOT_JFR_RETURN_(code) { return code; }
 #endif
 
 #ifndef INCLUDE_JVMCI

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -38,10 +38,16 @@ import jdk.jfr.Event;
 public final class JVM {
     private static final JVM jvm = new JVM();
 
-    // JVM signals file changes by doing Object#notifu on this object
-    static final Object FILE_DELTA_CHANGE = new Object();
-
     static final long RESERVED_CLASS_ID_LIMIT = 400;
+
+    private static class ChunkRotationMonitor {}
+
+    /*
+     * The JVM uses the chunk rotation monitor to notify Java that a rotation is warranted.
+     * The monitor type is used to exclude jdk.JavaMonitorWait events from being generated
+     * when Object.wait() is called on this monitor.
+     */
+    static final Object CHUNK_ROTATION_MONITOR = new ChunkRotationMonitor();
 
     private volatile boolean recording;
     private volatile boolean nativeOK;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -444,8 +444,8 @@ public final class PlatformRecorder {
 
     private void takeNap(long duration) {
         try {
-            synchronized (JVM.FILE_DELTA_CHANGE) {
-                JVM.FILE_DELTA_CHANGE.wait(duration < 10 ? 10 : duration);
+            synchronized (JVM.CHUNK_ROTATION_MONITOR) {
+                JVM.CHUNK_ROTATION_MONITOR.wait(duration < 10 ? 10 : duration);
             }
         } catch (InterruptedException e) {
             e.printStackTrace();


### PR DESCRIPTION
I backport this for parity with 11.0.20-oracle.

Trivial resolves in 
src/hotspot/share/jfr/support/jfrIntrinsics.hpp
src/hotspot/share/runtime/objectMonitor.cpp
src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java

src/jdk.jfr/share/classes/jdk/jfr/internal/RequestEngine.java
Skipped change to setFlushInterval() as method is not in 11.
That was added by "8226511: Implement JFR Event Streaming".

I had to define NOT_JFR_RETURN_ and change a nullptr occurance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8286707](https://bugs.openjdk.org/browse/JDK-8286707) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286707](https://bugs.openjdk.org/browse/JDK-8286707): JFR: Don't commit JFR internal jdk.JavaMonitorWait events (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2218/head:pull/2218` \
`$ git checkout pull/2218`

Update a local copy of the PR: \
`$ git checkout pull/2218` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2218`

View PR using the GUI difftool: \
`$ git pr show -t 2218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2218.diff">https://git.openjdk.org/jdk11u-dev/pull/2218.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2218#issuecomment-1780591931)