### PR TITLE
8220083: Remove hard-coded 127.0.0.1 loopback address in JDK networking tests

### DIFF
--- a/test/jdk/com/sun/net/httpserver/TestLogging.java
+++ b/test/jdk/com/sun/net/httpserver/TestLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,7 @@ public class TestLogging extends Test {
                 System.out.println ("caught expected exception");
             }
 
-            Socket s = new Socket ("127.0.0.1", p1);
+            Socket s = new Socket (InetAddress.getLoopbackAddress(), p1);
             OutputStream os = s.getOutputStream();
             //os.write ("GET xxx HTTP/1.1\r\n".getBytes());
             os.write ("HELLO WORLD\r\n".getBytes());

--- a/test/jdk/com/sun/net/httpserver/bugs/6725892/Test.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/6725892/Test.java
@@ -105,7 +105,7 @@ public class Test {
 
     static void test1() throws IOException {
         failed = false;
-        Socket s = new Socket ("127.0.0.1", port);
+        Socket s = new Socket (InetAddress.getLoopbackAddress(), port);
         InputStream is = s.getInputStream();
         // server should close connection after 2 seconds. We wait up to 10
         s.setSoTimeout (10000);

--- a/test/jdk/com/sun/net/httpserver/bugs/B6361557.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6361557.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ public class B6361557 {
         server.start ();
 
         InetSocketAddress destaddr = new InetSocketAddress (
-                "127.0.0.1", server.getAddress().getPort()
+                InetAddress.getLoopbackAddress(), server.getAddress().getPort()
         );
         System.out.println ("destaddr " + destaddr);
 

--- a/test/jdk/com/sun/net/httpserver/bugs/TruncatedRequestBody.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/TruncatedRequestBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
@@ -100,7 +101,7 @@ public class TruncatedRequestBody {
 
         // Test 1: fixed length
 
-        Socket sock = new Socket("127.0.0.1", port);
+        Socket sock = new Socket(InetAddress.getLoopbackAddress(), port);
         String s1 = "POST /foo HTTP/1.1\r\nContent-length: 200000\r\n"
                 + "\r\nfoo bar99";
 
@@ -114,7 +115,7 @@ public class TruncatedRequestBody {
 
         String s2 = "POST /foo HTTP/1.1\r\nTransfer-encoding: chunked\r\n\r\n" +
                 "100\r\nFoo bar";
-        sock = new Socket("127.0.0.1", port);
+        sock = new Socket(InetAddress.getLoopbackAddress(), port);
         os = sock.getOutputStream();
         os.write(s2.getBytes(StandardCharsets.ISO_8859_1));
         Thread.sleep(500);

--- a/test/jdk/com/sun/nio/sctp/SctpMultiChannel/SendFailed.java
+++ b/test/jdk/com/sun/nio/sctp/SctpMultiChannel/SendFailed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
 
 import com.sun.nio.sctp.*;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -36,7 +37,7 @@ import static java.nio.ByteBuffer.*;
 
 public class SendFailed {
 
-    static final SocketAddress remoteAddress = new InetSocketAddress("127.0.0.1", 3000);
+    static final SocketAddress remoteAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 3000);
 
     static final int[] bufferSizes =
             { 20, 49, 50, 51, 100, 101, 1024, 1025, 4095, 4096, 4097, 8191, 8192, 8193};

--- a/test/jdk/java/net/Authenticator/B6870935.java
+++ b/test/jdk/java/net/Authenticator/B6870935.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -240,7 +240,7 @@ public class B6870935 {
         try  {
 
             Authenticator.setDefault (new MyAuthenticator ());
-            SocketAddress addr = new InetSocketAddress ("127.0.0.1", port);
+            SocketAddress addr = new InetSocketAddress (InetAddress.getLoopbackAddress(), port);
             Proxy proxy = new Proxy (Proxy.Type.HTTP, addr);
             String s = "http://www.ibm.com";
             URL url = new URL(s);

--- a/test/jdk/java/net/DatagramSocket/SendDatagramToBadAddress.java
+++ b/test/jdk/java/net/DatagramSocket/SendDatagramToBadAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,8 +114,7 @@ public class SendDatagramToBadAddress {
         if (OSsupportsFeature()) {
             print ("running on OS that supports ICMP port unreachable");
         }
-        String host = "127.0.0.1";
-        InetAddress addr = InetAddress.getByName(host);
+        InetAddress addr = InetAddress.getLoopbackAddress();
         DatagramSocket sock = new DatagramSocket();
         DatagramSocket serversock = new DatagramSocket(0);
         DatagramPacket p;

--- a/test/jdk/java/net/HttpURLConnection/SetAuthenticator/HTTPTestServer.java
+++ b/test/jdk/java/net/HttpURLConnection/SetAuthenticator/HTTPTestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -218,7 +218,8 @@ public class HTTPTestServer extends HTTPTest {
 
         @Override
         protected ServerSocket createBindable() throws IOException {
-            return new ServerSocket(0, 0, InetAddress.getByName("127.0.0.1"));
+            InetAddress address = InetAddress.getLoopbackAddress();
+            return new ServerSocket(0, 0, address);
         }
 
         @Override
@@ -240,7 +241,8 @@ public class HTTPTestServer extends HTTPTest {
         @Override
         protected S createBindable() throws IOException {
             S server = newHttpServer();
-            server.bind(new InetSocketAddress("127.0.0.1", 0), 0);
+            InetAddress address = InetAddress.getLoopbackAddress();
+            server.bind(new InetSocketAddress(address, 0), 0);
             return server;
         }
 

--- a/test/jdk/java/net/Socket/UrgentDataTest.java
+++ b/test/jdk/java/net/Socket/UrgentDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public class UrgentDataTest {
                 test.listener = new ServerSocket (0);
                 test.isClient = true;
                 test.isServer = true;
-                test.clHost = "127.0.0.1";
+                test.clHost = InetAddress.getLoopbackAddress().getHostAddress();
                 test.clPort = test.listener.getLocalPort();
                 test.run();
             } else if (args[0].equals ("-server")) {

--- a/test/jdk/java/net/SocketOption/OptionsTest.java
+++ b/test/jdk/java/net/SocketOption/OptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,7 @@ public class OptionsTest {
     static void doSocketTests() throws Exception {
         try (
             ServerSocket srv = new ServerSocket(0);
-            Socket c = new Socket("127.0.0.1", srv.getLocalPort());
+            Socket c = new Socket(InetAddress.getLoopbackAddress(), srv.getLocalPort());
             Socket s = srv.accept();
         ) {
             Set<SocketOption<?>> options = c.supportedOptions();

--- a/test/jdk/java/net/httpclient/UnknownBodyLengthTest.java
+++ b/test/jdk/java/net/httpclient/UnknownBodyLengthTest.java
@@ -22,6 +22,7 @@
  */
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -72,7 +73,7 @@ public class UnknownBodyLengthTest {
                          : ServerSocketFactory.getDefault();
         ss = factory.createServerSocket();
         ss.setReuseAddress(true);
-        ss.bind(new InetSocketAddress("127.0.0.1", 0));
+        ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         System.out.println("ServerSocket = " + ss.getClass() + " " + ss);
         port = ss.getLocalPort();
         clientURL = (useSSL ? "https" : "http") + "://localhost:"

--- a/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
+++ b/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,7 +182,7 @@ public class AsyncCloseAndInterrupt {
         = new ChannelFactory("DatagramChannel") {
                 InterruptibleChannel create() throws IOException {
                     DatagramChannel dc = DatagramChannel.open();
-                    InetAddress lb = InetAddress.getByName("127.0.0.1");
+                    InetAddress lb = InetAddress.getLoopbackAddress();
                     dc.bind(new InetSocketAddress(lb, 0));
                     dc.connect(new InetSocketAddress(lb, 80));
                     return dc;

--- a/test/jdk/java/nio/channels/AsynchronousChannelGroup/bootlib/Attack.java
+++ b/test/jdk/java/nio/channels/AsynchronousChannelGroup/bootlib/Attack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.Socket;
 import java.util.concurrent.CountDownLatch;
 
@@ -42,7 +43,7 @@ public class Attack implements Runnable {
     @Override
     public void run() {
         try {
-            new Socket("127.0.0.1", 9999).close();
+            new Socket(InetAddress.getLoopbackAddress(), 9999).close();
             throw new RuntimeException("Connected (not expected)");
         } catch (IOException e) {
             throw new RuntimeException("IOException (not expected)");

--- a/test/jdk/java/nio/channels/Selector/LotsOfCancels.java
+++ b/test/jdk/java/nio/channels/Selector/LotsOfCancels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 Google Inc.  All Rights Reserved.
+ * Copyright 2009, 2019, Google Inc.  All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.SelectionKey;
@@ -87,7 +88,7 @@ public class LotsOfCancels {
             throws Exception {
         testStartTime = System.nanoTime();
 
-        InetSocketAddress address = new InetSocketAddress("127.0.0.1", 7359);
+        InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress(), 7359);
 
         // Create server channel, add it to selector and run epoll_ctl.
         log("Setting up server");

--- a/test/jdk/java/nio/channels/SocketChannel/AsyncCloseChannel.java
+++ b/test/jdk/java/nio/channels/SocketChannel/AsyncCloseChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  */
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -39,7 +40,6 @@ public class AsyncCloseChannel {
     static volatile boolean keepGoing = true;
     static int maxAcceptCount = 100;
     static volatile int acceptCount = 0;
-    static String host = "127.0.0.1";
     static int sensorPort;
     static int targetPort;
 
@@ -149,7 +149,7 @@ public class AsyncCloseChannel {
                         }
                         wake = false;
                     }
-                    s.connect(new InetSocketAddress(host, sensorPort));
+                    s.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(), sensorPort));
                     try {
                         Thread.sleep(10);
                     } catch (InterruptedException ex) { }
@@ -183,7 +183,7 @@ public class AsyncCloseChannel {
             while(keepGoing) {
                 try {
                     final SocketChannel s = SocketChannel.open(
-                        new InetSocketAddress(host, targetPort));
+                        new InetSocketAddress(InetAddress.getLoopbackAddress(), targetPort));
                     s.finishConnect();
                     s.socket().setSoLinger(false, 0);
                     ready = false;

--- a/test/jdk/java/nio/channels/SocketChannel/CloseRegisteredChannel.java
+++ b/test/jdk/java/nio/channels/SocketChannel/CloseRegisteredChannel.java
@@ -41,7 +41,7 @@ public class CloseRegisteredChannel {
         //System.out.println ("listening on port " + port);
 
         SocketChannel client = SocketChannel.open ();
-        client.connect (new InetSocketAddress ("127.0.0.1", port));
+        client.connect (new InetSocketAddress (InetAddress.getLoopbackAddress(), port));
         SocketChannel peer = server.accept ();
         peer.configureBlocking (true);
 

--- a/test/jdk/java/nio/channels/SocketChannel/CloseTimeoutChannel.java
+++ b/test/jdk/java/nio/channels/SocketChannel/CloseTimeoutChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class CloseTimeoutChannel {
         try {
             System.out.println("Establishing connection");
             Socket socket=SocketChannel.open(
-                new InetSocketAddress("127.0.0.1", port)).socket();
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), port)).socket();
             OutputStream out=socket.getOutputStream();
             InputStream in=socket.getInputStream();
 

--- a/test/jdk/java/nio/channels/SocketChannel/SocketInheritance.java
+++ b/test/jdk/java/nio/channels/SocketChannel/SocketInheritance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class SocketInheritance {
 
     // connect to the given port
     static SocketChannel connect(int port) throws IOException {
-        InetAddress lh = InetAddress.getByName("127.0.0.1");
+        InetAddress lh = InetAddress.getLoopbackAddress();
         InetSocketAddress isa = new InetSocketAddress(lh, port);
         return SocketChannel.open(isa);
     }

--- a/test/jdk/java/nio/channels/etc/AdaptorCloseAndInterrupt.java
+++ b/test/jdk/java/nio/channels/etc/AdaptorCloseAndInterrupt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,7 @@ public class AdaptorCloseAndInterrupt {
     void scReadAsyncClose() throws IOException {
         try {
             SocketChannel sc = SocketChannel.open(new InetSocketAddress(
-                "127.0.0.1", port));
+                InetAddress.getLoopbackAddress(), port));
             sc.socket().setSoTimeout(30*1000);
 
             doAsyncClose(sc);
@@ -115,7 +115,7 @@ public class AdaptorCloseAndInterrupt {
     void scReadAsyncInterrupt() throws IOException {
         try {
             final SocketChannel sc = SocketChannel.open(new InetSocketAddress(
-                "127.0.0.1", port));
+                InetAddress.getLoopbackAddress(), port));
             sc.socket().setSoTimeout(30*1000);
 
             doAsyncInterrupt();
@@ -141,7 +141,7 @@ public class AdaptorCloseAndInterrupt {
     void dcReceiveAsyncClose() throws IOException {
         DatagramChannel dc = DatagramChannel.open();
         dc.connect(new InetSocketAddress(
-            "127.0.0.1", port));
+            InetAddress.getLoopbackAddress(), port));
         dc.socket().setSoTimeout(30*1000);
 
         doAsyncClose(dc);
@@ -159,7 +159,7 @@ public class AdaptorCloseAndInterrupt {
     void dcReceiveAsyncInterrupt() throws IOException {
         DatagramChannel dc = DatagramChannel.open();
         dc.connect(new InetSocketAddress(
-            "127.0.0.1", port));
+            InetAddress.getLoopbackAddress(), port));
         dc.socket().setSoTimeout(30*1000);
 
         doAsyncInterrupt();

--- a/test/jdk/java/nio/channels/etc/Shadow.java
+++ b/test/jdk/java/nio/channels/etc/Shadow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ public class Shadow {
 
         // connect client socket to port
         SocketAddress connectAddr =
-            new InetSocketAddress("127.0.0.1",
+            new InetSocketAddress(InetAddress.getLoopbackAddress(),
                                   serverSocket.getLocalPort());
         socket.connect(connectAddr);
         log.println("connected Socket: " + socket);

--- a/test/jdk/java/nio/charset/coders/StreamTimeout.java
+++ b/test/jdk/java/nio/charset/coders/StreamTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 
@@ -47,7 +48,7 @@ public class StreamTimeout {
         private final Socket so;
 
         Client(int port) throws IOException {
-            so = new Socket("127.0.0.1", port);
+            so = new Socket(InetAddress.getLoopbackAddress(), port);
         }
 
         @Override

--- a/test/jdk/java/rmi/transport/readTimeout/ReadTimeoutTest.java
+++ b/test/jdk/java/rmi/transport/readTimeout/ReadTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,9 +82,9 @@ public class ReadTimeoutTest
 
             // Now, connect to that port
             //Thread.sleep(2000);
-            System.err.println("(connecting to listening port on 127.0.0.1:" +
+            System.err.println("(connecting to listening port on localhost:" +
                                port + ")");
-            DoS = new Socket("127.0.0.1", port);
+            DoS = new Socket(InetAddress.getLoopbackAddress(), port);
             InputStream stream = DoS.getInputStream();
 
             // Read on the socket in the background

--- a/test/jdk/jdk/net/Sockets/QuickAckTest.java
+++ b/test/jdk/jdk/net/Sockets/QuickAckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  */
 import java.io.IOException;
 import java.net.DatagramSocket;
+import java.net.InetAddress;
 import java.net.MulticastSocket;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -38,12 +39,10 @@ import jdk.net.Sockets;
 
 public class QuickAckTest {
 
-    private static final String LOCAL_HOST = "127.0.0.1";
-
     public static void main(String args[]) throws IOException {
 
         try (ServerSocket ss = new ServerSocket(0);
-                Socket s = new Socket(LOCAL_HOST, ss.getLocalPort());
+                Socket s = new Socket(InetAddress.getLoopbackAddress(), ss.getLocalPort());
                 DatagramSocket ds = new DatagramSocket(0);
                 MulticastSocket mc = new MulticastSocket(0)) {
 

--- a/test/jdk/jdk/net/Sockets/Test.java
+++ b/test/jdk/jdk/net/Sockets/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,14 +79,14 @@ public class Test {
              DatagramSocket dg = new DatagramSocket(0)) {
 
             int tcp_port = ss.getLocalPort();
-            final InetAddress loop = InetAddress.getByName("127.0.0.1");
+            final InetAddress loop = InetAddress.getLoopbackAddress();
             final InetSocketAddress loopad = new InetSocketAddress(loop, tcp_port);
 
             final int udp_port = dg.getLocalPort();
 
-            final Socket s = new Socket("127.0.0.1", tcp_port);
+            final Socket s = new Socket(loop, tcp_port);
             final SocketChannel sc = SocketChannel.open();
-            sc.connect(new InetSocketAddress("127.0.0.1", tcp_port));
+            sc.connect(new InetSocketAddress(loop, tcp_port));
 
             doTest("Sockets.setOption Socket", () -> {
                 out.println(flowIn);

--- a/test/jdk/sun/net/www/protocol/http/TunnelThroughProxy.java
+++ b/test/jdk/sun/net/www/protocol/http/TunnelThroughProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
I backport this test improvement as prereq of 8223145 Replace wildcard address with loopback or local host in tests - part 1

I had to resolve the following files:

test/jdk/com/sun/net/httpserver/bugs/6725892/Test.java
Copyright

test/jdk/java/net/SocketOption/TcpKeepAliveTest.java
Changes already backported. Skipped.

test/jdk/java/nio/channels/SocketChannel/CloseRegisteredChannel.java
Resolved due to context.

test/jdk/sun/net/www/protocol/http/TunnelThroughProxy.java
Patch skipped because "8216986: Remove unused code from SocksSocketImpl" not in 11.

SendFailed.java
I had to add import for InetAddress to make it work.

Tests all pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8220083](https://bugs.openjdk.org/browse/JDK-8220083) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8220083](https://bugs.openjdk.org/browse/JDK-8220083): Remove hard-coded 127.0.0.1 loopback address in JDK networking tests (**Sub-task** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2222/head:pull/2222` \
`$ git checkout pull/2222`

Update a local copy of the PR: \
`$ git checkout pull/2222` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2222`

View PR using the GUI difftool: \
`$ git pr show -t 2222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2222.diff">https://git.openjdk.org/jdk11u-dev/pull/2222.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2222#issuecomment-1781216533)