### PR TITLE
8183374: Refactor java/lang/Runtime shell tests to java

### DIFF
--- a/test/jdk/java/lang/RuntimeTests/exec/SetCwd.java
+++ b/test/jdk/java/lang/RuntimeTests/exec/SetCwd.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4156278
+ * @summary Basic functional test for
+ *          Runtime.exec(String[] command, String[] env, File path) and
+ *          Runtime.exec(String command, String[] env, File path).
+ *
+ * @library /test/lib
+ * @run testng/othervm SetCwd
+ */
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.*;
+
+import static jdk.test.lib.Asserts.assertTrue;
+
+public class SetCwd {
+
+    private static final String TEST_CLASSES = System.getProperty(
+            "test.classes", ".");
+
+    private static final String[] CMD_ARRAY = new String[2];
+
+    @BeforeTest
+    public static void setUp() throws Exception {
+        CMD_ARRAY[0] = System.getProperty("java.home") + File.separator +
+                "bin" + File.separator + "java";
+        CMD_ARRAY[1] = SimpleProcess.class.getName();
+    }
+
+    @Test
+    public void testRuntimeExecWithArray() throws Exception {
+        Process process = Runtime.getRuntime().exec(CMD_ARRAY, null,
+                new File(TEST_CLASSES));
+        verifyProcessOutput(process);
+    }
+
+    @Test
+    public void testRuntimeExecWithString() throws Exception {
+        String cmd = String.join(" ", CMD_ARRAY);
+        Process process = Runtime.getRuntime().exec(cmd, null,
+                new File(TEST_CLASSES));
+        verifyProcessOutput(process);
+    }
+
+    // Verify the process has executed by comparing its output with the expected
+    private void verifyProcessOutput(Process process) throws Exception {
+        process.waitFor();
+        assertTrue(process.exitValue() == 0);
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getInputStream()))) {
+            String line = reader.readLine();
+            if (!line.startsWith(TEST_CLASSES)) {
+                String error = String.format("Expected process output first line: " +
+                        "'%s' Actual: '%s'", TEST_CLASSES, line);
+                throw new Exception(error);
+            }
+        }
+    }
+
+    // This class main will be the entry point for test subprocesses
+    static class SimpleProcess {
+        public static void main (String[] args) throws Exception {
+            File dir = new File(".");
+            System.out.println(dir.getCanonicalPath());
+        }
+    }
+}

--- a/test/jdk/java/lang/RuntimeTests/shutdown/ShutdownHooks.java
+++ b/test/jdk/java/lang/RuntimeTests/shutdown/ShutdownHooks.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6829503
+ * @summary  1) Test Console and DeleteOnExitHook can be initialized
+ *              while shutdown is in progress
+ *           2) Test if files that are added by the application shutdown
+ *              hook are deleted on exit during shutdown
+ * @library /test/lib
+ * @run testng/othervm ShutdownHooks
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.*;
+import java.nio.file.Files;
+
+import static jdk.test.lib.Asserts.assertFalse;
+
+public class ShutdownHooks {
+
+    private static final String TEST_FILE_NAME = "fileToBeDeleted";
+
+    private static final File TEST_FILE = new File(TEST_FILE_NAME);
+
+    private static final String TEST_CLASSES = System.getProperty(
+            "test.classes", ".");
+
+    @BeforeTest
+    public static void setUp() throws Exception {
+        // Make sure file does not exist before test
+        Files.deleteIfExists(TEST_FILE.toPath());
+    }
+
+    @Test
+    public void testShutdownHooks() throws Exception {
+        // Run in a new process in order to evaluate shutdown hook results
+        String[] testCommand = new String[] {"-classpath", TEST_CLASSES,
+                ShutdownHooksProcess.class.getName()};
+        ProcessTools.executeTestJvm(testCommand).shouldHaveExitValue(0);
+
+        String errorMsg = "File exists despite shutdown hook has been run";
+        assertFalse(Files.exists(TEST_FILE.toPath()), errorMsg);
+    }
+
+    // This class main will be the entry point for test subprocesses
+    static class ShutdownHooksProcess {
+        public static void main(String[] args) throws Exception {
+            Runtime.getRuntime().addShutdownHook(new Cleaner());
+
+            System.out.println("Writing to "+ TEST_FILE);
+            try (PrintWriter pw = new PrintWriter(TEST_FILE)) {
+                pw.println("Shutdown begins");
+            }
+        }
+
+        static class Cleaner extends Thread {
+            public void run() {
+                // register the Console's shutdown hook while the application
+                // shutdown hook is running
+                Console cons = System.console();
+                // register the DeleteOnExitHook while the application
+                // shutdown hook is running
+                TEST_FILE.deleteOnExit();
+                try (PrintWriter pw = new PrintWriter(TEST_FILE)) {
+                    pw.println("File is being deleted");
+                } catch (FileNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.


The tests were added by "8225054: Compiler implementation for records " after 11
Thus they are not in 11 yet and patching failed.
I include the full tests as in 17 after this change. I think they are useful for 11, too. 
Both pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8183374](https://bugs.openjdk.org/browse/JDK-8183374) needs maintainer approval

### Issue
 * [JDK-8183374](https://bugs.openjdk.org/browse/JDK-8183374): Refactor java/lang/Runtime shell tests to java (**Enhancement** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2225/head:pull/2225` \
`$ git checkout pull/2225`

Update a local copy of the PR: \
`$ git checkout pull/2225` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2225`

View PR using the GUI difftool: \
`$ git pr show -t 2225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2225.diff">https://git.openjdk.org/jdk11u-dev/pull/2225.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2225#issuecomment-1782463023)