### PR TITLE
8308910: Allow executeAndLog to accept running process

### DIFF
--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -558,8 +558,12 @@ public class CDSTestUtils {
 
     // ============================= Logging
     public static OutputAnalyzer executeAndLog(ProcessBuilder pb, String logName) throws Exception {
+        return executeAndLog(pb.start(), logName);
+    }
+
+    public static OutputAnalyzer executeAndLog(Process process, String logName) throws Exception {
         long started = System.currentTimeMillis();
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        OutputAnalyzer output = new OutputAnalyzer(process);
 
         writeFile(getOutputFile(logName + ".stdout"), output.getStdout());
         writeFile(getOutputFile(logName + ".stderr"), output.getStderr());


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle from 17.

Trivial resolves were needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8308910](https://bugs.openjdk.org/browse/JDK-8308910) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308910](https://bugs.openjdk.org/browse/JDK-8308910): Allow executeAndLog to accept running process (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2227/head:pull/2227` \
`$ git checkout pull/2227`

Update a local copy of the PR: \
`$ git checkout pull/2227` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2227`

View PR using the GUI difftool: \
`$ git pr show -t 2227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2227.diff">https://git.openjdk.org/jdk11u-dev/pull/2227.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2227#issuecomment-1782494880)