### PR TITLE
8318669: Target OS detection in 'test-prebuilt' makefile target is incorrect when running on MSYS2

### DIFF
--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -157,6 +157,10 @@ ifeq ($(UNAME_OS), CYGWIN)
   OPENJDK_TARGET_OS := windows
   OPENJDK_TARGET_OS_TYPE := windows
   OPENJDK_TARGET_OS_ENV := windows.cygwin
+else ifeq ($(UNAME_OS), MINGW64)
+  OPENJDK_TARGET_OS := windows
+  OPENJDK_TARGET_OS_TYPE := windows
+  OPENJDK_TARGET_OS_ENV := windows.msys2
 else
   OPENJDK_TARGET_OS_TYPE:=unix
   ifeq ($(UNAME_OS), Linux)
@@ -170,6 +174,9 @@ else
   endif
   OPENJDK_TARGET_OS_ENV := $(OPENJDK_TARGET_OS)
 endif
+
+# Sanity check env detection
+$(info Detected target OS, type and env: [$(OPENJDK_TARGET_OS)] [$(OPENJDK_TARGET_OS_TYPE)] [$(OPENJDK_TARGET_OS_ENV)])
 
 # Assume little endian unless otherwise specified
 OPENJDK_TARGET_CPU_ENDIAN := little


### PR DESCRIPTION
Backport of  [8318669: Target OS detection in 'test-prebuilt' makefile target is incorrect when running on MSYS2](https://bugs.openjdk.org/browse/JDK-8318669)

This is low risk as this only affects testing on Windows with MSYS2, when run using the "run-prebuilt" makefile target.
Without this patch, however, Windows-specific patches may fail or otherwise misbehave when run under such conditions (which is notably the case in Github actions).

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318669](https://bugs.openjdk.org/browse/JDK-8318669) needs maintainer approval

### Issue
 * [JDK-8318669](https://bugs.openjdk.org/browse/JDK-8318669): Target OS detection in 'test-prebuilt' makefile target is incorrect when running on MSYS2 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2229/head:pull/2229` \
`$ git checkout pull/2229`

Update a local copy of the PR: \
`$ git checkout pull/2229` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2229`

View PR using the GUI difftool: \
`$ git pr show -t 2229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2229.diff">https://git.openjdk.org/jdk11u-dev/pull/2229.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2229#issuecomment-1783771974)