### PR TITLE
8306280: Open source several choice AWT tests

### DIFF
--- a/test/jdk/java/awt/Choice/EmptyChoiceTest.java
+++ b/test/jdk/java/awt/Choice/EmptyChoiceTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ @test
+ @bug 4908468
+ @summary Linux Empty Choice throws NPE
+ @key headful
+ @run main EmptyChoiceTest
+*/
+import java.awt.BorderLayout;
+import java.awt.Choice;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Image;
+import java.lang.reflect.InvocationTargetException;
+
+public class EmptyChoiceTest
+{
+    Frame frame;
+    Choice choice = null;
+
+    public static void main(String[] args) throws
+            InterruptedException,
+            InvocationTargetException {
+        EventQueue.invokeAndWait(() -> {
+            EmptyChoiceTest emptyChoiceTest = new EmptyChoiceTest();
+            emptyChoiceTest.init();
+            emptyChoiceTest.test();
+        });
+    }
+
+    public void init() {
+        frame = new Frame();
+        frame.setLayout(new BorderLayout());
+        choice = new Choice();
+        frame.add(choice, BorderLayout.NORTH);
+        frame.setSize(200, 200);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        frame.validate();
+    }
+
+    public void test () {
+        try {
+            int iWidth = choice.getWidth();
+            int iHeight = choice.getHeight();
+            Image componentImage =
+                choice.createImage(iWidth, iHeight);
+            Graphics graphics =
+                componentImage.getGraphics();
+            graphics.setClip(0, 0, iWidth, iHeight);
+            choice.printAll(graphics);
+            System.out.println("PrintAll successful!");
+        } catch (NullPointerException exp) {
+            throw new RuntimeException("Test failed. " +
+                    "Empty Choice printAll throws NullPointerException");
+        } catch (Exception exc){
+            throw new RuntimeException("Test failed.", exc);
+        } finally {
+            frame.dispose();
+        }
+    }
+}

--- a/test/jdk/java/awt/Choice/InsertRemoveTest.java
+++ b/test/jdk/java/awt/Choice/InsertRemoveTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ @test
+ @bug 4115130
+ @summary Tests Inserting/Removing items doesn't cause crash.
+ @key headful
+ @run main InsertRemoveTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Choice;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.lang.reflect.InvocationTargetException;
+
+public class InsertRemoveTest {
+    Choice choice1;
+    Choice choice2;
+    Choice choice3;
+    Frame f;
+    int itemCount = 0;
+    int iterCount = 0;
+
+    public static void main(String[] args)
+            throws InterruptedException, InvocationTargetException {
+        EventQueue.invokeAndWait(() -> new InsertRemoveTest().start());
+    }
+
+    public void start() {
+        f = new Frame("Check Choice");
+        f.setLayout(new BorderLayout());
+
+        choice1 = new Choice();
+        choice2 = new Choice();
+        choice3 = new Choice();
+
+        f.add(choice1, BorderLayout.NORTH);
+        f.add(choice3, BorderLayout.CENTER);
+        f.add(choice2, BorderLayout.SOUTH);
+
+        f.pack();
+        f.setLocationRelativeTo(null);
+        f.setVisible(true);
+
+        try {
+            for (int i = 0; i < 50; i++) {
+                if (choice1 != null && itemCount < 40) {
+                    choice1.insert("I am Choice, yes I am : " + iterCount,
+                            0);
+                    choice2.add("I am the same, yes I am : " + iterCount);
+                    choice3.insert("I am the same, yes I am : " + iterCount,
+                            10);
+                    itemCount++;
+                    iterCount++;
+                }
+                if (itemCount >= 20 && choice1 != null
+                        && choice1.getItemCount() > 0) {
+                    choice1.remove(0);
+                    choice2.remove(10);
+                    choice3.remove(19);
+                    itemCount--;
+                }
+                f.validate();
+            }
+        } finally {
+            f.dispose();
+        }
+    }
+
+}

--- a/test/jdk/java/awt/Choice/OpenedChoiceHangs.java
+++ b/test/jdk/java/awt/Choice/OpenedChoiceHangs.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6246503
+  @summary Disabling a choice after selection locks keyboard, \
+           mouse and makes the system unusable
+  @key headful
+  @run main OpenedChoiceHangs
+*/
+
+import java.awt.AWTException;
+import java.awt.Button;
+import java.awt.Choice;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.KeyEvent;
+import java.lang.reflect.InvocationTargetException;
+
+public class OpenedChoiceHangs implements ItemListener {
+    static final Object FOCUS_LOCK = new Object();
+
+    Frame frame;
+    Choice ch = new Choice();
+    Button b = new Button("A button");
+    Robot robot;
+
+    public static void main(String[] args)
+            throws InterruptedException, InvocationTargetException {
+        OpenedChoiceHangs openedChoiceHangs = new OpenedChoiceHangs();
+        EventQueue.invokeAndWait(openedChoiceHangs::init);
+        openedChoiceHangs.test();
+    }
+
+    public void init() {
+        frame = new Frame();
+
+        frame.setLayout(new FlowLayout());
+        for (int i = 1; i < 10; i++) {
+            ch.add("item " + i);
+        }
+        frame.add(ch);
+        frame.add(b);
+        ch.setBackground(new Color(255, 0, 0));
+        ch.setForeground(new Color(255, 0, 0));
+        ch.addItemListener(this);
+
+        frame.setSize(200, 200);
+        frame.setVisible(true);
+        frame.setLocationRelativeTo(null);
+        frame.validate();
+    }
+
+    public void test() {
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.setAutoWaitForIdle(true);
+            robot.delay(1000);
+            robot.mouseMove(ch.getLocationOnScreen().x + ch.getWidth() / 2,
+                    ch.getLocationOnScreen().y + ch.getHeight() / 2);
+
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(1000);
+            if (!ch.isFocusOwner()) {
+                synchronized (FOCUS_LOCK) {
+                    FOCUS_LOCK.wait(3000);
+                }
+            }
+            if (!ch.isFocusOwner()){
+                throw new RuntimeException(
+                        "Test failed. Choice has no focus after mouse press.");
+            }
+            robot.keyPress(KeyEvent.VK_DOWN);
+            robot.keyRelease(KeyEvent.VK_DOWN);
+            robot.delay(1000);
+
+            robot.keyPress(KeyEvent.VK_UP);
+            robot.keyRelease(KeyEvent.VK_UP);
+            robot.delay(1000);
+
+            Color color = robot.getPixelColor(
+                    ch.getLocationOnScreen().x + ch.getWidth() / 2,
+                    ch.getLocationOnScreen().y + ch.getHeight() * 4);
+            System.out.println("Color is " + color);
+            if (color.equals(new Color(255, 0,0))){
+                throw new RuntimeException(
+                        "Test failed. Choice is disabled and still opened. ");
+            }
+        } catch (AWTException e) {
+            throw new RuntimeException(
+                    "Test interrupted due to AWTException. Robot=" + robot, e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Test interrupted. Robot=" + robot, e);
+        } finally {
+            EventQueue.invokeLater(frame::dispose);
+        }
+
+        System.out.println("Test passed: Choice became closed after disabling.");
+    }
+
+    public void itemStateChanged (ItemEvent ie) {
+        System.out.println("Choice Item has changed: "+ie);
+        ch.setEnabled(false);
+    }
+    public void focusGained(FocusEvent fEvent){
+        System.out.println("focusGained"+fEvent);
+        synchronized(FOCUS_LOCK){
+            FOCUS_LOCK.notify();
+        }
+    }
+
+    public void focusLost(FocusEvent fEvent){
+        System.out.println("focusLost"+fEvent);
+    }
+}

--- a/test/jdk/java/awt/Choice/PressOutsideOpenedChoice.java
+++ b/test/jdk/java/awt/Choice/PressOutsideOpenedChoice.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6259328
+  @summary Choice scrolls when dragging the parent frame while drop-down \
+            is active
+  @key headful
+  @run main PressOutsideOpenedChoice
+*/
+
+
+import java.awt.Choice;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.lang.reflect.InvocationTargetException;
+
+public class PressOutsideOpenedChoice extends Frame {
+    Robot robot;
+    Choice choice1 = new Choice();
+    Point pt;
+
+    public static void main(String[] args)
+            throws InterruptedException, InvocationTargetException {
+        PressOutsideOpenedChoice pressOutsideOpenedChoice =
+                new PressOutsideOpenedChoice();
+        EventQueue.invokeAndWait(pressOutsideOpenedChoice::init);
+        pressOutsideOpenedChoice.start();
+    }
+
+    public void init() {
+        for (int i = 1; i < 50; i++) {
+            choice1.add("item-" + i);
+        }
+        choice1.setForeground(Color.red);
+        choice1.setBackground(Color.red);
+        add(choice1);
+        setLayout(new FlowLayout());
+        setSize (200,200);
+        setLocationRelativeTo(null);
+        setVisible(true);
+        validate();
+    }
+
+    public void start() {
+        try {
+            robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(50);
+            robot.delay(1000);
+            testPressOutsideOpenedChoice(InputEvent.BUTTON1_DOWN_MASK);
+        } catch (Throwable e) {
+            throw new RuntimeException("Test failed. Exception thrown: " + e);
+        } finally {
+            EventQueue.invokeLater(this::dispose);
+        }
+    }
+
+    public void testPressOutsideOpenedChoice(int button) {
+        pt = choice1.getLocationOnScreen();
+        robot.mouseMove(pt.x + choice1.getWidth() - choice1.getHeight() / 4,
+                pt.y + choice1.getHeight() / 2);
+        robot.delay(100);
+        robot.mousePress(button);
+        robot.mouseRelease(button);
+        robot.delay(200);
+        //move mouse outside of the choice
+        robot.mouseMove(pt.x - choice1.getWidth() / 2,
+                pt.y + choice1.getHeight() / 2);
+        robot.delay(400);
+        robot.mousePress(button);
+        robot.mouseRelease(button);
+        robot.delay(200);
+        Color color = robot.getPixelColor(pt.x + choice1.getWidth() / 2,
+                pt.y + 3 * choice1.getHeight());
+        System.out.println("color got " +
+                robot.getPixelColor(pt.x + choice1.getWidth() / 2,
+                        pt.y + 3 * choice1.getHeight()));
+        if (color.equals(Color.red)) {
+            throw new RuntimeException("Test failed. Choice didn't close " +
+                    "after mouse press outside of Choice " + button);
+        } else {
+            System.out.println("Test passed. " +
+                    "Choice closed with MousePress outside");
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d03128d0](https://github.com/openjdk/jdk/commit/d03128d0e5158ea967e714341c019b9af00ac4a1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alexander Zvegintsev on 19 Apr 2023 and was reviewed by Jayathirth D V, Phil Race and Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8306280](https://bugs.openjdk.org/browse/JDK-8306280) needs maintainer approval

### Issue
 * [JDK-8306280](https://bugs.openjdk.org/browse/JDK-8306280): Open source several choice AWT tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2233/head:pull/2233` \
`$ git checkout pull/2233`

Update a local copy of the PR: \
`$ git checkout pull/2233` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2233`

View PR using the GUI difftool: \
`$ git pr show -t 2233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2233.diff">https://git.openjdk.org/jdk11u-dev/pull/2233.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2233#issuecomment-1783215466)