### PR TITLE
8315606: Open source few swing text/html tests

### DIFF
--- a/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4357975.java
+++ b/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4357975.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4357975
+ * @summary  Tests if InsertUnorderedListItem generates the proper tag sequence
+ * @run main bug4357975
+ */
+
+import java.awt.event.ActionEvent;
+
+import javax.swing.Action;
+import javax.swing.JEditorPane;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.Element;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.HTMLDocument;
+
+public class bug4357975 {
+
+    public static void main(String[] args) throws Exception {
+        JEditorPane jep = new JEditorPane();
+        HTMLEditorKit kit = new HTMLEditorKit();
+        jep.setEditorKit(kit);
+        jep.setDocument(kit.createDefaultDocument());
+
+        HTMLDocument doc = (HTMLDocument) jep.getDocument();
+
+        DocumentListener l = new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                int offset = e.getOffset();
+                HTMLDocument doc = (HTMLDocument)e.getDocument();
+
+                Element el = doc.getCharacterElement(offset + 1);
+                AttributeSet attrs = el.getAttributes();
+                Object name = attrs.getAttribute(StyleConstants.NameAttribute);
+                boolean passed = (name == HTML.Tag.CONTENT);
+
+                el = el.getParentElement();
+                attrs = el.getAttributes();
+                name = attrs.getAttribute(StyleConstants.NameAttribute);
+                passed = (passed && (name == HTML.Tag.IMPLIED));
+
+                el = el.getParentElement();
+                attrs = el.getAttributes();
+                name = attrs.getAttribute(StyleConstants.NameAttribute);
+                passed = (passed && (name == HTML.Tag.LI));
+
+                el = el.getParentElement();
+                attrs = el.getAttributes();
+                name = attrs.getAttribute(StyleConstants.NameAttribute);
+                passed = (passed && (name == HTML.Tag.UL));
+                if (!passed) {
+                    throw new RuntimeException("Test failed");
+                }
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {}
+            @Override
+            public void removeUpdate(DocumentEvent e) {}
+        };
+        doc.addDocumentListener(l);
+
+        Action[] actions = kit.getActions();
+        for (int i = 0; i < actions.length; i++){
+            Action a = actions[i];
+            if (a.getValue(Action.NAME) == "InsertUnorderedListItem") {
+                a.actionPerformed(new ActionEvent(jep,
+                                                  ActionEvent.ACTION_PERFORMED,
+                                                  (String) a.getValue(Action.ACTION_COMMAND_KEY)));
+                break;
+            }
+        }
+
+    }
+}

--- a/test/jdk/javax/swing/text/html/HTMLWriter/bug4841760.java
+++ b/test/jdk/javax/swing/text/html/HTMLWriter/bug4841760.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4841760
+ * @summary  Tests if HTML tags are correctly shown for
+             StyleEditorKit.ForegroundAction() in JTextPane output.
+ * @run main bug4841760
+ */
+
+import javax.swing.JTextPane;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.html.HTMLEditorKit;
+
+public class bug4841760 {
+
+    public static void main(String[] args) throws Exception {
+        JTextPane jep = new JTextPane();
+        jep.setEditorKit(new HTMLEditorKit());
+        jep.setText("<html><head></head><body><font size=3>hellojavaworld</font></body></html>");
+
+        SimpleAttributeSet set = new SimpleAttributeSet();
+        StyleConstants.setForeground(set, java.awt.Color.BLUE);
+        jep.getStyledDocument().setCharacterAttributes(3, 5, set, false);
+
+        String gotText = jep.getText();
+        System.out.println("gotText: " + gotText);
+        // there should be color attribute set
+        // and 3 font tags
+        int i = gotText.indexOf("color");
+        if (i > 0) {
+            i = gotText.indexOf("<font");
+            if (i > 0) {
+                i = gotText.indexOf("<font", i + 1);
+                if (i > 0) {
+                    i = gotText.indexOf("<font", i + 1);
+                    if (i <= 0) {
+                        throw new RuntimeException("Test failed.");
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/test/jdk/javax/swing/text/html/ImageView/bug4329185.java
+++ b/test/jdk/javax/swing/text/html/ImageView/bug4329185.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4329185
+ * @summary  Tests if vertical image alignment is working
+ * @key headful
+ * @run main bug4329185
+ */
+
+import java.awt.Robot;
+
+import javax.swing.JFrame;
+import javax.swing.JEditorPane;
+import javax.swing.SwingUtilities;
+import javax.swing.text.Element;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.View;
+import javax.swing.text.ViewFactory;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLEditorKit;
+
+public class bug4329185 {
+
+    private static final View[] views = new View[3];
+    private static JFrame f;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                 bug4329185 test = new bug4329185();
+                 test.start();
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            boolean passed = ((views[0].getAlignment(View.Y_AXIS) == 0.0)
+                             && (views[1].getAlignment(View.Y_AXIS) == 0.5)
+                             && (views[2].getAlignment(View.Y_AXIS) == 1.0));
+            if (!passed) {
+                throw new RuntimeException("Test failed.");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    public void start() {
+        String text = "aaa<IMG align=top><IMG align=middle><IMG align=bottom>";
+        f = new JFrame("bug4329185");
+        JEditorPane jep = new JEditorPane();
+        jep.setEditorKit(new MyHTMLEditorKit());
+        jep.setEditable(false);
+
+        jep.setText(text);
+
+        f.getContentPane().add(jep);
+        f.setSize(500, 500);
+        f.setLocationRelativeTo(null);
+        f.setVisible(true);
+    }
+
+
+    static class MyHTMLEditorKit extends HTMLEditorKit {
+
+        private final ViewFactory defaultFactory = new MyHTMLFactory();
+
+        @Override
+        public ViewFactory getViewFactory() {
+            return defaultFactory;
+        }
+
+        static class MyHTMLFactory extends HTMLEditorKit.HTMLFactory {
+            private int i = 0;
+
+            @Override
+            public View create(Element elem) {
+                Object o = elem.getAttributes()
+                               .getAttribute(StyleConstants.NameAttribute);
+                if (o instanceof HTML.Tag) {
+                    HTML.Tag kind = (HTML.Tag) o;
+                    if (kind == HTML.Tag.IMG) {
+                        View v = super.create(elem);
+                        views[i++] = v;
+                        return v;
+                    }
+                }
+                return super.create(elem);
+            }
+        }
+    }
+
+}

--- a/test/jdk/javax/swing/text/html/InlineView/bug4623342.java
+++ b/test/jdk/javax/swing/text/html/InlineView/bug4623342.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4623342
+ * @summary  Tests if InlineView causes extra spacing around images in JTable
+ * @key headful
+ * @run main bug4623342
+ */
+
+import java.awt.Robot;
+import java.awt.Shape;
+
+import javax.swing.JFrame;
+import javax.swing.JEditorPane;
+import javax.swing.SwingUtilities;
+import javax.swing.text.View;
+import javax.swing.text.html.HTMLEditorKit;
+
+public class bug4623342 {
+
+    private static volatile boolean passed;
+
+    private JEditorPane jep;
+    private static JFrame f;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            bug4623342 test = new bug4623342();
+            SwingUtilities.invokeAndWait(test::init);
+            robot.waitForIdle();
+            robot.delay(100);
+            SwingUtilities.invokeAndWait(test::start);
+            if (!passed) {
+                throw new RuntimeException("Test failed.");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    public void init() {
+
+        String text =
+            "<table border=\"0\" cellpadding=\"0\" cellspacing=\"0\">" +
+             "<tr><td width=\"10\" height=\"23\">" +
+               "<img src=\"file:/a.jpg\" width=65 height=23 border=\"0\"></td></tr>" +
+             "<tr><td width=\"10\" height=\"23\">" +
+               "<img src=\"file:/a.jpg\" width=65 height=23 border=\"0\"></td></tr></table>";
+
+        f = new JFrame();
+        jep = new JEditorPane();
+        jep.setEditorKit(new HTMLEditorKit());
+        jep.setEditable(false);
+
+        jep.setText(text);
+
+        f.getContentPane().add(jep);
+        f.setSize(500, 500);
+        f.setLocationRelativeTo(null);
+        f.setVisible(true);
+    }
+
+    private void start() {
+        Shape r = jep.getBounds();
+        View v = jep.getUI().getRootView(jep);
+        int tableHeight = 0;
+        while (!(v instanceof javax.swing.text.html.ParagraphView)) {
+            int n = v.getViewCount();
+            Shape sh = v.getChildAllocation(n - 1, r);
+            String viewName = v.getClass().getName();
+            if (viewName.endsWith("TableView")) {
+                tableHeight = r.getBounds().height;
+            }
+            v = v.getView(n - 1);
+            if (sh != null) {
+                r = sh;
+            }
+        }
+        // tableHeight should be the sum of TD's heights (46)
+        passed = (tableHeight == 46);
+    }
+}


### PR DESCRIPTION
Hi all, 
This pull request contains a backport of commit [4127fbb9ed6ca3c3e82da599dbf9cee54de5da31](https://github.com/openjdk/jdk/commit/4127fbb9ed6ca3c3e82da599dbf9cee54de5da31).

Patch doesn't apply cleanly. There are some slight changes in test/jdk/javax/swing/text/html/ImageView/bug4329185.java regarding pattern matching for instanceof. Pattern matching was introduced in Java 14, so it raises a compilation error. I resolved by adding some casting.

```
diff --git a/test/jdk/javax/swing/text/html/ImageView/bug4329185.java b/test/jdk/javax/swing/text/html/ImageView/bug4329185.java
index 6338e395d45..da43b8b80dc 100644
--- a/test/jdk/javax/swing/text/html/ImageView/bug4329185.java
+++ b/test/jdk/javax/swing/text/html/ImageView/bug4329185.java
@@ -103,8 +103,7 @@ public class bug4329185 {
             public View create(Element elem) {
                 Object o = elem.getAttributes()
                                .getAttribute(StyleConstants.NameAttribute);
-                if (o instanceof HTML.Tag) {
-                    HTML.Tag kind = (HTML.Tag) o;
+                if (o instanceof HTML.Tag kind) {
                     if (kind == HTML.Tag.IMG) {
                         View v = super.create(elem);
                         views[i++] = v;
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315606](https://bugs.openjdk.org/browse/JDK-8315606) needs maintainer approval

### Issue
 * [JDK-8315606](https://bugs.openjdk.org/browse/JDK-8315606): Open source few swing text/html tests (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2234/head:pull/2234` \
`$ git checkout pull/2234`

Update a local copy of the PR: \
`$ git checkout pull/2234` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2234`

View PR using the GUI difftool: \
`$ git pr show -t 2234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2234.diff">https://git.openjdk.org/jdk11u-dev/pull/2234.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2234#issuecomment-1783420136)