### PR TITLE
8318705: [macos] ProblemList java/rmi/registry/multipleRegistries/MultipleRegistries.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -588,6 +588,7 @@ java/rmi/activation/ActivationGroup/downloadActivationGroup/DownloadActivationGr
 java/rmi/activation/rmidViaInheritedChannel/InheritedChannelNotServerSocket.java 8170562 generic-all
 
 java/rmi/registry/readTest/CodebaseTest.java                    8173324 windows-all
+java/rmi/registry/multipleRegistries/MultipleRegistries.java    8268182 macosx-all
 
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64
 


### PR DESCRIPTION
This is excluded in upper releases, and we see this in 11, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318705](https://bugs.openjdk.org/browse/JDK-8318705) needs maintainer approval

### Issue
 * [JDK-8318705](https://bugs.openjdk.org/browse/JDK-8318705): [macos] ProblemList java/rmi/registry/multipleRegistries/MultipleRegistries.java (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2235/head:pull/2235` \
`$ git checkout pull/2235`

Update a local copy of the PR: \
`$ git checkout pull/2235` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2235`

View PR using the GUI difftool: \
`$ git pr show -t 2235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2235.diff">https://git.openjdk.org/jdk11u-dev/pull/2235.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2235#issuecomment-1784225657)