### PR TITLE
8289745: JfrStructCopyFailed uses heap words instead of bytes for object sizes

### DIFF
--- a/src/hotspot/share/gc/shared/gcTraceSend.cpp
+++ b/src/hotspot/share/gc/shared/gcTraceSend.cpp
@@ -161,9 +161,9 @@ void OldGCTracer::send_old_gc_event() const {
 static JfrStructCopyFailed to_struct(const CopyFailedInfo& cf_info) {
   JfrStructCopyFailed failed_info;
   failed_info.set_objectCount(cf_info.failed_count());
-  failed_info.set_firstSize(cf_info.first_size());
-  failed_info.set_smallestSize(cf_info.smallest_size());
-  failed_info.set_totalSize(cf_info.total_size());
+  failed_info.set_firstSize(cf_info.first_size() * HeapWordSize);
+  failed_info.set_smallestSize(cf_info.smallest_size() * HeapWordSize);
+  failed_info.set_totalSize(cf_info.total_size() * HeapWordSize);
   return failed_info;
 }
 

--- a/test/jdk/jdk/jfr/event/gc/detailed/PromotionFailedEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/PromotionFailedEvent.java
@@ -51,12 +51,16 @@ public class PromotionFailedEvent {
         // This test can not always trigger the expected event.
         // Test is ok even if no events found.
         List<RecordedEvent> events = RecordingFile.readAllEvents(Paths.get(jfr_file));
+        int minObjectAlignment = 8;
         for (RecordedEvent event : events) {
             System.out.println("Event: " + event);
             long smallestSize = Events.assertField(event, "promotionFailed.smallestSize").atLeast(1L).getValue();
+            Asserts.assertTrue((smallestSize % minObjectAlignment) == 0, "smallestSize " + smallestSize + " is not a valid size.");
             long firstSize = Events.assertField(event, "promotionFailed.firstSize").atLeast(smallestSize).getValue();
+            Asserts.assertTrue((firstSize % minObjectAlignment) == 0, "firstSize " + firstSize + " is not a valid size.");
             long totalSize = Events.assertField(event, "promotionFailed.totalSize").atLeast(firstSize).getValue();
             long objectCount = Events.assertField(event, "promotionFailed.objectCount").atLeast(1L).getValue();
+            Asserts.assertTrue((totalSize % minObjectAlignment) == 0, "totalSize " + totalSize + " is not a valid size.");
             Asserts.assertLessThanOrEqual(smallestSize * objectCount, totalSize, "smallestSize * objectCount <= totalSize");
         }
     }

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java
@@ -62,13 +62,17 @@ public class TestEvacuationFailedEvent {
         }
 
         List<RecordedEvent> events = RecordingFile.readAllEvents(Paths.get(JFR_FILE));
+        int minObjectAlignment = 8;
 
         Events.hasEvents(events);
         for (RecordedEvent event : events) {
             long objectCount = Events.assertField(event, "evacuationFailed.objectCount").atLeast(1L).getValue();
             long smallestSize = Events.assertField(event, "evacuationFailed.smallestSize").atLeast(1L).getValue();
+            Asserts.assertTrue((smallestSize % minObjectAlignment) == 0, "smallestSize " + smallestSize + " is not a valid size.");
             long firstSize = Events.assertField(event, "evacuationFailed.firstSize").atLeast(smallestSize).getValue();
+            Asserts.assertTrue((firstSize % minObjectAlignment) == 0, "firstSize " + firstSize + " is not a valid size.");
             long totalSize = Events.assertField(event, "evacuationFailed.totalSize").atLeast(firstSize).getValue();
+            Asserts.assertTrue((totalSize % minObjectAlignment) == 0, "totalSize " + totalSize + " is not a valid size.");
             Asserts.assertLessThanOrEqual(smallestSize * objectCount, totalSize, "smallestSize * objectCount <= totalSize");
         }
     }


### PR DESCRIPTION
Hi,
 
This is a backport of JDK-8289745: JfrStructCopyFailed uses heap words instead of bytes for object sizes
 
Original patch does not apply cleanly to 11u, because the adaption to the G1 event is not
needed, since it is present in JDK 11.

Tested tier1-4 for all platforms without any issues.
 
Thanks,
-Ralf

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8289745](https://bugs.openjdk.org/browse/JDK-8289745) needs maintainer approval

### Issue
 * [JDK-8289745](https://bugs.openjdk.org/browse/JDK-8289745): JfrStructCopyFailed uses heap words instead of bytes for object sizes (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2237/head:pull/2237` \
`$ git checkout pull/2237`

Update a local copy of the PR: \
`$ git checkout pull/2237` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2237`

View PR using the GUI difftool: \
`$ git pr show -t 2237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2237.diff">https://git.openjdk.org/jdk11u-dev/pull/2237.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2237#issuecomment-1784774536)