### PR TITLE
8293166: jdk/jfr/jvm/TestDumpOnCrash.java fails on Linux ppc64le and Linux aarch64

### DIFF
--- a/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
+++ b/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,6 +95,7 @@ public class TestDumpOnCrash {
                 "-Xmx64m",
                 "-XX:-TransmitErrorReport",
                 "-XX:-CreateCoredumpOnCrash",
+                "-XX:-TieredCompilation", // Avoid secondary crashes (see JDK-8293166)
                 "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
                 "-XX:StartFlightRecording=" + flightRecordingOptions,
                 crasher,


### PR DESCRIPTION
Hi,
 
This is a backport of JDK-8293166: jdk/jfr/jvm/TestDumpOnCrash.java fails on Linux ppc64le and Linux aarch64
 
Original patch does not apply cleanly to 11u, because the parameters were added
via a List in the original code, but via an array in the JDK 11 code.
 
Testing: tier1-4 on all platforms with no problems.
 
Thanks,
-Ralf

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8293166](https://bugs.openjdk.org/browse/JDK-8293166) needs maintainer approval

### Issue
 * [JDK-8293166](https://bugs.openjdk.org/browse/JDK-8293166): jdk/jfr/jvm/TestDumpOnCrash.java fails on Linux ppc64le and Linux aarch64 (**Bug** - P3 - Approved)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2238/head:pull/2238` \
`$ git checkout pull/2238`

Update a local copy of the PR: \
`$ git checkout pull/2238` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2238`

View PR using the GUI difftool: \
`$ git pr show -t 2238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2238.diff">https://git.openjdk.org/jdk11u-dev/pull/2238.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2238#issuecomment-1785052573)