### PR TITLE
8299254: Support dealing with standard assert macro

### DIFF
--- a/make/hotspot/lib/JvmFlags.gmk
+++ b/make/hotspot/lib/JvmFlags.gmk
@@ -67,10 +67,12 @@ JVM_CFLAGS_TARGET_DEFINES += \
     #
 
 ifeq ($(DEBUG_LEVEL), release)
+  # release builds disable uses of assert macro from <assert.h>.
+  JVM_CFLAGS_DEBUGLEVEL := -DNDEBUG
   # For hotspot, release builds differ internally between "optimized" and "product"
   # in that "optimize" does not define PRODUCT.
   ifneq ($(HOTSPOT_DEBUG_LEVEL), optimized)
-    JVM_CFLAGS_DEBUGLEVEL := -DPRODUCT
+    JVM_CFLAGS_DEBUGLEVEL += -DPRODUCT
   endif
 else ifeq ($(DEBUG_LEVEL), fastdebug)
   JVM_CFLAGS_DEBUGLEVEL := -DASSERT

--- a/src/hotspot/share/utilities/vmassert_reinstall.hpp
+++ b/src/hotspot/share/utilities/vmassert_reinstall.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// Intentionally no #include guard.  May be included multiple times for effect.
+
+// See vmassert_uninstall.hpp for usage.
+
+// Remove possible stdlib assert macro (or any others, for that matter).
+#undef assert
+
+// Reinstall HotSpot's assert macro, if previously defined.
+#ifdef vmassert
+#define assert(p, ...) vmassert(p, __VA_ARGS__)
+#endif
+

--- a/src/hotspot/share/utilities/vmassert_uninstall.hpp
+++ b/src/hotspot/share/utilities/vmassert_uninstall.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// Intentionally no #include guard.  May be included multiple times for effect.
+
+// The files vmassert_uninstall.hpp and vmassert_reinstall.hpp provide a
+// workaround for the name collision between HotSpot's assert macro and the
+// Standard Library's assert macro.  When including a 3rd-party header that
+// uses (and so includes) the standard assert macro, wrap that inclusion with
+// includes of these two files, e.g.
+//
+// #include "utilities/vmassert_uninstall.hpp"
+// #include <header including standard assert macro>
+// #include "utilities/vmassert_reinstall.hpp"
+//
+// This removes the HotSpot macro definition while pre-processing the
+// 3rd-party header, then reinstates the HotSpot macro (if previously defined)
+// for following code.
+
+// Remove HotSpot's assert macro, if present.
+#ifdef vmassert
+#undef assert
+#endif // vmassert
+

--- a/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp
+++ b/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,13 @@
 #include "precompiled.hpp"
 #include "gc/shared/memset_with_concurrent_readers.hpp"
 #include "utilities/globalDefinitions.hpp"
-#include "unittest.hpp"
 
+#include "utilities/vmassert_uninstall.hpp"
 #include <string.h>
 #include <sstream>
+#include "utilities/vmassert_reinstall.hpp"
+
+#include "unittest.hpp"
 
 static unsigned line_byte(const char* line, size_t i) {
   return unsigned(line[i]) & 0xFF;

--- a/test/hotspot/gtest/jfr/test_networkUtilization.cpp
+++ b/test/hotspot/gtest/jfr/test_networkUtilization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,11 +42,13 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
 
-#include "unittest.hpp"
-
+#include "utilities/vmassert_uninstall.hpp"
 #include <vector>
 #include <list>
 #include <map>
+#include "utilities/vmassert_reinstall.hpp"
+
+#include "unittest.hpp"
 
 namespace {
 

--- a/test/hotspot/gtest/unittest.hpp
+++ b/test/hotspot/gtest/unittest.hpp
@@ -28,38 +28,9 @@
 #include <stdio.h>
 
 #define GTEST_DONT_DEFINE_TEST 1
-
-// googlemock has ::testing::internal::Log function, so we need to temporary
-// undefine 'Log' from logging/log.hpp and define it back after gmock header
-// file is included. As SS compiler doesn't have push_/pop_macro pragmas and
-// log.hpp might have been already included, we have to copy-paste macro definition.
-#ifdef Log
-  #define UNDEFINED_Log
-  #undef Log
-#endif
-
-// R macro is defined by src/hotspot/cpu/arm/register_arm.hpp, F$n are defined
-// in ppc/register_ppc.hpp, these macros conflict with typenames used in
-// internal googlemock templates. As the macros are not expected to be used by
-// any of tests directly, and this header file is supposed to be the last
-// include, we just undefine it; if/when it changes, we will need to re-define
-// the macros after the following includes.
-#undef R
-#undef F1
-#undef F2
-
 #include "utilities/vmassert_uninstall.hpp"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "utilities/vmassert_reinstall.hpp"
-
-#ifdef UNDEFINED_Log
-  #define Log(...)  LogImpl<LOG_TAGS(__VA_ARGS__)> // copied from logging/log.hpp
-  #undef UNDEFINED_Log
-#endif
-
-// Wrapper around os::exit so we don't need to include os.hpp here.
-extern void gtest_exit_from_child_vm(int num);
 
 #define CONCAT(a, b) a ## b
 

--- a/test/hotspot/gtest/unittest.hpp
+++ b/test/hotspot/gtest/unittest.hpp
@@ -28,19 +28,38 @@
 #include <stdio.h>
 
 #define GTEST_DONT_DEFINE_TEST 1
-#include "gtest/gtest.h"
 
-// gtest/gtest.h includes assert.h which will define the assert macro, but hotspot has its
-// own standards incompatible assert macro that takes two parameters.
-// The workaround is to undef assert and then re-define it. The re-definition
-// must unfortunately be copied since debug.hpp might already have been
-// included and a second include wouldn't work due to the header guards in debug.hpp.
-#ifdef assert
-  #undef assert
-  #ifdef vmassert
-    #define assert(p, ...) vmassert(p, __VA_ARGS__)
-  #endif
+// googlemock has ::testing::internal::Log function, so we need to temporary
+// undefine 'Log' from logging/log.hpp and define it back after gmock header
+// file is included. As SS compiler doesn't have push_/pop_macro pragmas and
+// log.hpp might have been already included, we have to copy-paste macro definition.
+#ifdef Log
+  #define UNDEFINED_Log
+  #undef Log
 #endif
+
+// R macro is defined by src/hotspot/cpu/arm/register_arm.hpp, F$n are defined
+// in ppc/register_ppc.hpp, these macros conflict with typenames used in
+// internal googlemock templates. As the macros are not expected to be used by
+// any of tests directly, and this header file is supposed to be the last
+// include, we just undefine it; if/when it changes, we will need to re-define
+// the macros after the following includes.
+#undef R
+#undef F1
+#undef F2
+
+#include "utilities/vmassert_uninstall.hpp"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "utilities/vmassert_reinstall.hpp"
+
+#ifdef UNDEFINED_Log
+  #define Log(...)  LogImpl<LOG_TAGS(__VA_ARGS__)> // copied from logging/log.hpp
+  #undef UNDEFINED_Log
+#endif
+
+// Wrapper around os::exit so we don't need to include os.hpp here.
+extern void gtest_exit_from_child_vm(int num);
 
 #define CONCAT(a, b) a ## b
 


### PR DESCRIPTION
Not a clean backport of  [c61bd4e1d5e58a0129c7](https://git.openjdk.org/jdk/commit/3e2314d08218dc8a4f4fc61bd4e1d5e58a0129c7) .
Context and whitespace conflicts only, plus shenandoah gc tests don't exist in 11u.
Resolved JBS issue is [JDK-8299254](https://bugs.openjdk.org/browse/JDK-8299254)

GHA tested.
Tier1/tier2 and jck tests passed on windows, linux

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8299254](https://bugs.openjdk.org/browse/JDK-8299254) needs maintainer approval

### Issue
 * [JDK-8299254](https://bugs.openjdk.org/browse/JDK-8299254): Support dealing with standard assert macro (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2239/head:pull/2239` \
`$ git checkout pull/2239`

Update a local copy of the PR: \
`$ git checkout pull/2239` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2239`

View PR using the GUI difftool: \
`$ git pr show -t 2239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2239.diff">https://git.openjdk.org/jdk11u-dev/pull/2239.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2239#issuecomment-1785525262)