### PR TITLE
8315214: Do not run sun/tools/jhsdb tests concurrently

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -30,7 +30,7 @@ javax/management com/sun/awt sun/awt sun/java2d javax/xml/jaxp/testng/validation
 exclusiveAccess.dirs=java/rmi/Naming java/util/prefs sun/management/jmxremote sun/tools/jstatd \
 sun/security/mscapi java/util/stream java/util/Arrays/largeMemory \
 java/util/BitSet/stream javax/rmi java/net/httpclient/websocket \
-sanity/client
+sanity/client sun/tools/jhsdb
 
 # Group definitions
 groups=TEST.groups


### PR DESCRIPTION
Backport 8315214

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315214](https://bugs.openjdk.org/browse/JDK-8315214) needs maintainer approval

### Issue
 * [JDK-8315214](https://bugs.openjdk.org/browse/JDK-8315214): Do not run sun/tools/jhsdb tests concurrently (**Sub-task** - P4 - Approved)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2244/head:pull/2244` \
`$ git checkout pull/2244`

Update a local copy of the PR: \
`$ git checkout pull/2244` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2244`

View PR using the GUI difftool: \
`$ git pr show -t 2244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2244.diff">https://git.openjdk.org/jdk11u-dev/pull/2244.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2244#issuecomment-1786773076)