### PR TITLE
8223145: Replace wildcard address with loopback or local host in tests - part 1

### DIFF
--- a/test/jdk/com/sun/net/httpserver/TestLogging.java
+++ b/test/jdk/com/sun/net/httpserver/TestLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,7 @@ public class TestLogging extends Test {
                 System.out.println ("caught expected exception");
             }
 
-            Socket s = new Socket ("127.0.0.1", p1);
+            Socket s = new Socket (InetAddress.getLoopbackAddress(), p1);
             OutputStream os = s.getOutputStream();
             //os.write ("GET xxx HTTP/1.1\r\n".getBytes());
             os.write ("HELLO WORLD\r\n".getBytes());

--- a/test/jdk/com/sun/net/httpserver/bugs/6725892/Test.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/6725892/Test.java
@@ -105,7 +105,7 @@ public class Test {
 
     static void test1() throws IOException {
         failed = false;
-        Socket s = new Socket ("127.0.0.1", port);
+        Socket s = new Socket (InetAddress.getLoopbackAddress(), port);
         InputStream is = s.getInputStream();
         // server should close connection after 2 seconds. We wait up to 10
         s.setSoTimeout (10000);

--- a/test/jdk/com/sun/net/httpserver/bugs/B6361557.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6361557.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ public class B6361557 {
         server.start ();
 
         InetSocketAddress destaddr = new InetSocketAddress (
-                "127.0.0.1", server.getAddress().getPort()
+                InetAddress.getLoopbackAddress(), server.getAddress().getPort()
         );
         System.out.println ("destaddr " + destaddr);
 

--- a/test/jdk/com/sun/net/httpserver/bugs/B6361557.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6361557.java
@@ -69,7 +69,8 @@ public class B6361557 {
 
     public static void main (String[] args) throws Exception {
         Handler handler = new Handler();
-        InetSocketAddress addr = new InetSocketAddress (0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        InetSocketAddress addr = new InetSocketAddress (loopback, 0);
         HttpServer server = HttpServer.create (addr, 0);
         HttpContext ctx = server.createContext ("/test", handler);
 
@@ -78,7 +79,7 @@ public class B6361557 {
         server.start ();
 
         InetSocketAddress destaddr = new InetSocketAddress (
-                InetAddress.getLoopbackAddress(), server.getAddress().getPort()
+                loopback, server.getAddress().getPort()
         );
         System.out.println ("destaddr " + destaddr);
 
@@ -86,7 +87,10 @@ public class B6361557 {
         int requests = 0;
         int responses = 0;
         while (true) {
-            int selres = selector.select (1);
+            // we need to read responses from time to time: slightly
+            // increase the timeout with the amount of pending responses
+            // to give a chance to the server to reply.
+            int selres = selector.select (requests - responses + 1);
             Set<SelectionKey> selkeys = selector.selectedKeys();
             for (SelectionKey key : selkeys) {
                 if (key.isReadable()) {
@@ -95,14 +99,18 @@ public class B6361557 {
                     try {
                         int x = chan.read(buf);
                         if (x == -1 || responseComplete(buf)) {
+                            System.out.print("_");
                             key.attach(null);
                             chan.close();
                             responses++;
                         }
-                    } catch (IOException e) {}
+                    } catch (IOException e) {
+                        System.out.println(e);
+                    }
                 }
             }
             if (requests < NUM) {
+                System.out.print(".");
                 SocketChannel schan = SocketChannel.open(destaddr);
                 requestBuf.rewind();
                 int c = 0;

--- a/test/jdk/com/sun/net/httpserver/bugs/TruncatedRequestBody.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/TruncatedRequestBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
@@ -100,7 +101,7 @@ public class TruncatedRequestBody {
 
         // Test 1: fixed length
 
-        Socket sock = new Socket("127.0.0.1", port);
+        Socket sock = new Socket(InetAddress.getLoopbackAddress(), port);
         String s1 = "POST /foo HTTP/1.1\r\nContent-length: 200000\r\n"
                 + "\r\nfoo bar99";
 
@@ -114,7 +115,7 @@ public class TruncatedRequestBody {
 
         String s2 = "POST /foo HTTP/1.1\r\nTransfer-encoding: chunked\r\n\r\n" +
                 "100\r\nFoo bar";
-        sock = new Socket("127.0.0.1", port);
+        sock = new Socket(InetAddress.getLoopbackAddress(), port);
         os = sock.getOutputStream();
         os.write(s2.getBytes(StandardCharsets.ISO_8859_1));
         Thread.sleep(500);

--- a/test/jdk/com/sun/nio/sctp/SctpMultiChannel/SendFailed.java
+++ b/test/jdk/com/sun/nio/sctp/SctpMultiChannel/SendFailed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
 
 import com.sun.nio.sctp.*;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -36,7 +37,7 @@ import static java.nio.ByteBuffer.*;
 
 public class SendFailed {
 
-    static final SocketAddress remoteAddress = new InetSocketAddress("127.0.0.1", 3000);
+    static final SocketAddress remoteAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 3000);
 
     static final int[] bufferSizes =
             { 20, 49, 50, 51, 100, 101, 1024, 1025, 4095, 4096, 4097, 8191, 8192, 8193};

--- a/test/jdk/java/net/Authenticator/B4722333.java
+++ b/test/jdk/java/net/Authenticator/B4722333.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,13 +121,14 @@ public class B4722333 implements HttpCallback {
         MyAuthenticator auth = new MyAuthenticator ();
         Authenticator.setDefault (auth);
         try {
-            server = new TestHttpServer (new B4722333(), 1, 10, 0);
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            server = new TestHttpServer (new B4722333(), 1, 10, loopback, 0);
             System.out.println ("Server started: listening on port: " + server.getLocalPort());
-            client ("http://localhost:"+server.getLocalPort()+"/d1/d2/d3/foo.html");
-            client ("http://localhost:"+server.getLocalPort()+"/ASD/d3/x.html");
-            client ("http://localhost:"+server.getLocalPort()+"/biz/d3/x.html");
-            client ("http://localhost:"+server.getLocalPort()+"/bar/d3/x.html");
-            client ("http://localhost:"+server.getLocalPort()+"/fuzz/d3/x.html");
+            client ("http://" + server.getAuthority() + "/d1/d2/d3/foo.html");
+            client ("http://" + server.getAuthority() + "/ASD/d3/x.html");
+            client ("http://" + server.getAuthority() + "/biz/d3/x.html");
+            client ("http://" + server.getAuthority() + "/bar/d3/x.html");
+            client ("http://" + server.getAuthority() + "/fuzz/d3/x.html");
         } catch (Exception e) {
             if (server != null) {
                 server.terminate();

--- a/test/jdk/java/net/Authenticator/B6870935.java
+++ b/test/jdk/java/net/Authenticator/B6870935.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -240,7 +240,7 @@ public class B6870935 {
         try  {
 
             Authenticator.setDefault (new MyAuthenticator ());
-            SocketAddress addr = new InetSocketAddress ("127.0.0.1", port);
+            SocketAddress addr = new InetSocketAddress (InetAddress.getLoopbackAddress(), port);
             Proxy proxy = new Proxy (Proxy.Type.HTTP, addr);
             String s = "http://www.ibm.com";
             URL url = new URL(s);

--- a/test/jdk/java/net/DatagramSocket/SendDatagramToBadAddress.java
+++ b/test/jdk/java/net/DatagramSocket/SendDatagramToBadAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,8 +114,7 @@ public class SendDatagramToBadAddress {
         if (OSsupportsFeature()) {
             print ("running on OS that supports ICMP port unreachable");
         }
-        String host = "127.0.0.1";
-        InetAddress addr = InetAddress.getByName(host);
+        InetAddress addr = InetAddress.getLoopbackAddress();
         DatagramSocket sock = new DatagramSocket();
         DatagramSocket serversock = new DatagramSocket(0);
         DatagramPacket p;

--- a/test/jdk/java/net/HttpURLConnection/SetAuthenticator/HTTPTestServer.java
+++ b/test/jdk/java/net/HttpURLConnection/SetAuthenticator/HTTPTestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -218,7 +218,8 @@ public class HTTPTestServer extends HTTPTest {
 
         @Override
         protected ServerSocket createBindable() throws IOException {
-            return new ServerSocket(0, 0, InetAddress.getByName("127.0.0.1"));
+            InetAddress address = InetAddress.getLoopbackAddress();
+            return new ServerSocket(0, 0, address);
         }
 
         @Override
@@ -240,7 +241,8 @@ public class HTTPTestServer extends HTTPTest {
         @Override
         protected S createBindable() throws IOException {
             S server = newHttpServer();
-            server.bind(new InetSocketAddress("127.0.0.1", 0), 0);
+            InetAddress address = InetAddress.getLoopbackAddress();
+            server.bind(new InetSocketAddress(address, 0), 0);
             return server;
         }
 

--- a/test/jdk/java/net/HttpURLConnection/UnmodifiableMaps.java
+++ b/test/jdk/java/net/HttpURLConnection/UnmodifiableMaps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,13 @@
 /**
  * @test
  * @bug 7128648
+ * @library /test/lib
  * @modules jdk.httpserver
  * @summary HttpURLConnection.getHeaderFields should return an unmodifiable Map
  */
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.HttpURLConnection;
@@ -41,6 +43,7 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.Headers;
 import static java.net.Proxy.NO_PROXY;
+import jdk.test.lib.net.URIBuilder;
 
 public class UnmodifiableMaps {
 
@@ -48,7 +51,12 @@ public class UnmodifiableMaps {
         HttpServer server = startHttpServer();
         try {
             InetSocketAddress address = server.getAddress();
-            URI uri = new URI("http://localhost:" + address.getPort() + "/foo");
+            URI uri = URIBuilder.newBuilder()
+                .scheme("http")
+                .host(address.getAddress())
+                .port(address.getPort())
+                .path("/foo")
+                .build();
             doClient(uri);
         } finally {
             server.stop(0);
@@ -78,7 +86,8 @@ public class UnmodifiableMaps {
 
     // HTTP Server
     HttpServer startHttpServer() throws IOException {
-        HttpServer httpServer = HttpServer.create(new InetSocketAddress(0), 0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress(loopback, 0), 0);
         httpServer.createContext("/foo", new SimpleHandler());
         httpServer.start();
         return httpServer;
@@ -146,4 +155,3 @@ public class UnmodifiableMaps {
         System.out.printf("%nPassed = %d, failed = %d%n%n", passed, failed);
         if (failed > 0) throw new AssertionError("Some tests failed");}
 }
-

--- a/test/jdk/java/net/Socket/GetLocalAddress.java
+++ b/test/jdk/java/net/Socket/GetLocalAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,8 @@ public class GetLocalAddress implements Runnable {
         int          linger = 65546;
         int          value = 0;
         addr = InetAddress.getLocalHost();
-        ss = new ServerSocket(0);
+        ss = new ServerSocket();
+        ss.bind(new InetSocketAddress(addr, 0));
         port = ss.getLocalPort();
 
         Thread t = new Thread(new GetLocalAddress());

--- a/test/jdk/java/net/Socket/SetReceiveBufferSize.java
+++ b/test/jdk/java/net/Socket/SetReceiveBufferSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@
  *
  */
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.ServerSocket;
 
@@ -37,8 +39,10 @@ public class SetReceiveBufferSize {
     }
 
     public SetReceiveBufferSize() throws Exception {
-        ServerSocket ss = new ServerSocket(0);
-        Socket s = new Socket("localhost", ss.getLocalPort());
+        ServerSocket ss = new ServerSocket();
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        ss.bind(new InetSocketAddress(loopback, 0));
+        Socket s = new Socket(loopback, ss.getLocalPort());
         Socket accepted = ss.accept();
         try {
             s.setReceiveBufferSize(0);

--- a/test/jdk/java/net/Socket/SoTimeout.java
+++ b/test/jdk/java/net/Socket/SoTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,8 @@ public class SoTimeout implements Runnable {
 
     public static void main(String[] args) throws Exception {
         addr = InetAddress.getLocalHost();
-        serverSocket = new ServerSocket(0);
+        serverSocket = new ServerSocket();
+        serverSocket.bind(new InetSocketAddress(addr, 0));
         port = serverSocket.getLocalPort();
 
         byte[] b = new byte[12];

--- a/test/jdk/java/net/Socket/TestAfterClose.java
+++ b/test/jdk/java/net/Socket/TestAfterClose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,9 @@ public class TestAfterClose
 
     public static void main(String[] args) {
         try {
-            ServerSocket ss = new ServerSocket(0, 0, null);
-            Socket socket = new Socket("localhost", ss.getLocalPort());
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            ServerSocket ss = new ServerSocket(0, 0, loopback);
+            Socket socket = new Socket(loopback, ss.getLocalPort());
             ss.accept();
             ss.close();
             test(socket);

--- a/test/jdk/java/net/Socket/UrgentDataTest.java
+++ b/test/jdk/java/net/Socket/UrgentDataTest.java
@@ -54,10 +54,12 @@ public class UrgentDataTest {
         try {
             UrgentDataTest test = new UrgentDataTest ();
             if (args.length == 0) {
-                test.listener = new ServerSocket (0);
+                InetAddress loopback = InetAddress.getLoopbackAddress();
+                test.listener = new ServerSocket ();
+                test.listener.bind(new InetSocketAddress(loopback, 0));
                 test.isClient = true;
                 test.isServer = true;
-                test.clHost = InetAddress.getLoopbackAddress().getHostAddress();
+                test.clHost = loopback.getHostAddress();
                 test.clPort = test.listener.getLocalPort();
                 test.run();
             } else if (args[0].equals ("-server")) {

--- a/test/jdk/java/net/Socket/UrgentDataTest.java
+++ b/test/jdk/java/net/Socket/UrgentDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public class UrgentDataTest {
                 test.listener = new ServerSocket (0);
                 test.isClient = true;
                 test.isServer = true;
-                test.clHost = "127.0.0.1";
+                test.clHost = InetAddress.getLoopbackAddress().getHostAddress();
                 test.clPort = test.listener.getLocalPort();
                 test.run();
             } else if (args[0].equals ("-server")) {

--- a/test/jdk/java/net/SocketOption/OptionsTest.java
+++ b/test/jdk/java/net/SocketOption/OptionsTest.java
@@ -99,7 +99,7 @@ public class OptionsTest {
 
     static void doSocketTests() throws Exception {
         try (
-            ServerSocket srv = new ServerSocket(0);
+            ServerSocket srv = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
             Socket c = new Socket(InetAddress.getLoopbackAddress(), srv.getLocalPort());
             Socket s = srv.accept();
         ) {

--- a/test/jdk/java/net/SocketOption/OptionsTest.java
+++ b/test/jdk/java/net/SocketOption/OptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,7 @@ public class OptionsTest {
     static void doSocketTests() throws Exception {
         try (
             ServerSocket srv = new ServerSocket(0);
-            Socket c = new Socket("127.0.0.1", srv.getLocalPort());
+            Socket c = new Socket(InetAddress.getLoopbackAddress(), srv.getLocalPort());
             Socket s = srv.accept();
         ) {
             Set<SocketOption<?>> options = c.supportedOptions();

--- a/test/jdk/java/net/URL/GetContent.java
+++ b/test/jdk/java/net/URL/GetContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,13 @@
 /**
  * @test
  * @bug 4145315
+ * @library /test/lib
  * @summary Test a read from nonexistant URL
  */
 
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class GetContent implements Runnable {
 
@@ -71,10 +73,12 @@ public class GetContent implements Runnable {
 
          boolean error = true;
          try {
-             String name = "http://localhost:" + ss.getLocalPort() +
-                           "/no-such-name";
-             java.net.URL url = null;
-             url = new java.net.URL(name);
+             java.net.URL url = URIBuilder.newBuilder()
+                 .scheme("http")
+                 .host(ss.getInetAddress())
+                 .port(ss.getLocalPort())
+                 .path("/no-such-name")
+                 .toURL();
              Object obj = url.getContent();
              InputStream in = (InputStream) obj;
              byte buff[] = new byte[200];

--- a/test/jdk/java/net/URLConnection/B5052093.java
+++ b/test/jdk/java/net/URLConnection/B5052093.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,9 +64,10 @@ public class B5052093 implements HttpCallback {
     }
 
     public static void main(String[] args) throws Exception {
-        server = new TestHttpServer(new B5052093(), 1, 10, 0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        server = new TestHttpServer(new B5052093(), 1, 10, loopback, 0);
         try {
-            URL url = new URL("http://localhost:"+server.getLocalPort()+"/foo");
+            URL url = new URL("http://" + server.getAuthority() + "/foo");
             URLConnection conn = url.openConnection();
             int i = conn.getContentLength();
             long l = conn.getContentLengthLong();

--- a/test/jdk/java/net/URLPermission/nstest/LookupTest.java
+++ b/test/jdk/java/net/URLPermission/nstest/LookupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.NetPermission;
 import java.net.ProxySelector;
 import java.net.ServerSocket;
@@ -104,7 +106,7 @@ public class LookupTest {
         String hostsFileName = CWD + "/LookupTestHosts";
         System.setProperty("jdk.net.hosts.file", hostsFileName);
         addMappingToHostsFile("allowedAndFound.com",
-                              "127.0.0.1",
+                              InetAddress.getLoopbackAddress().getHostAddress(),
                               hostsFileName,
                               false);
         addMappingToHostsFile("notAllowedButFound.com",
@@ -131,7 +133,9 @@ public class LookupTest {
         private volatile boolean done;
 
         public Server() throws IOException {
-            serverSocket = new ServerSocket(0);
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            serverSocket = new ServerSocket();
+            serverSocket.bind(new InetSocketAddress(loopback, 0));
             port = serverSocket.getLocalPort();
         }
 

--- a/test/jdk/java/net/httpclient/UnknownBodyLengthTest.java
+++ b/test/jdk/java/net/httpclient/UnknownBodyLengthTest.java
@@ -22,6 +22,7 @@
  */
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -72,7 +73,7 @@ public class UnknownBodyLengthTest {
                          : ServerSocketFactory.getDefault();
         ss = factory.createServerSocket();
         ss.setReuseAddress(true);
-        ss.bind(new InetSocketAddress("127.0.0.1", 0));
+        ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         System.out.println("ServerSocket = " + ss.getClass() + " " + ss);
         port = ss.getLocalPort();
         clientURL = (useSSL ? "https" : "http") + "://localhost:"

--- a/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
+++ b/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,7 +182,7 @@ public class AsyncCloseAndInterrupt {
         = new ChannelFactory("DatagramChannel") {
                 InterruptibleChannel create() throws IOException {
                     DatagramChannel dc = DatagramChannel.open();
-                    InetAddress lb = InetAddress.getByName("127.0.0.1");
+                    InetAddress lb = InetAddress.getLoopbackAddress();
                     dc.bind(new InetSocketAddress(lb, 0));
                     dc.connect(new InetSocketAddress(lb, 80));
                     return dc;

--- a/test/jdk/java/nio/channels/AsynchronousChannelGroup/bootlib/Attack.java
+++ b/test/jdk/java/nio/channels/AsynchronousChannelGroup/bootlib/Attack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.Socket;
 import java.util.concurrent.CountDownLatch;
 
@@ -42,7 +43,7 @@ public class Attack implements Runnable {
     @Override
     public void run() {
         try {
-            new Socket("127.0.0.1", 9999).close();
+            new Socket(InetAddress.getLoopbackAddress(), 9999).close();
             throw new RuntimeException("Connected (not expected)");
         } catch (IOException e) {
             throw new RuntimeException("IOException (not expected)");

--- a/test/jdk/java/nio/channels/Selector/LotsOfCancels.java
+++ b/test/jdk/java/nio/channels/Selector/LotsOfCancels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009 Google Inc.  All Rights Reserved.
+ * Copyright 2009, 2019, Google Inc.  All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.SelectionKey;
@@ -87,7 +88,7 @@ public class LotsOfCancels {
             throws Exception {
         testStartTime = System.nanoTime();
 
-        InetSocketAddress address = new InetSocketAddress("127.0.0.1", 7359);
+        InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress(), 7359);
 
         // Create server channel, add it to selector and run epoll_ctl.
         log("Setting up server");

--- a/test/jdk/java/nio/channels/SocketChannel/AsyncCloseChannel.java
+++ b/test/jdk/java/nio/channels/SocketChannel/AsyncCloseChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  */
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -39,7 +40,6 @@ public class AsyncCloseChannel {
     static volatile boolean keepGoing = true;
     static int maxAcceptCount = 100;
     static volatile int acceptCount = 0;
-    static String host = "127.0.0.1";
     static int sensorPort;
     static int targetPort;
 
@@ -149,7 +149,7 @@ public class AsyncCloseChannel {
                         }
                         wake = false;
                     }
-                    s.connect(new InetSocketAddress(host, sensorPort));
+                    s.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(), sensorPort));
                     try {
                         Thread.sleep(10);
                     } catch (InterruptedException ex) { }
@@ -183,7 +183,7 @@ public class AsyncCloseChannel {
             while(keepGoing) {
                 try {
                     final SocketChannel s = SocketChannel.open(
-                        new InetSocketAddress(host, targetPort));
+                        new InetSocketAddress(InetAddress.getLoopbackAddress(), targetPort));
                     s.finishConnect();
                     s.socket().setSoLinger(false, 0);
                     ready = false;

--- a/test/jdk/java/nio/channels/SocketChannel/CloseRegisteredChannel.java
+++ b/test/jdk/java/nio/channels/SocketChannel/CloseRegisteredChannel.java
@@ -41,7 +41,7 @@ public class CloseRegisteredChannel {
         //System.out.println ("listening on port " + port);
 
         SocketChannel client = SocketChannel.open ();
-        client.connect (new InetSocketAddress ("127.0.0.1", port));
+        client.connect (new InetSocketAddress (InetAddress.getLoopbackAddress(), port));
         SocketChannel peer = server.accept ();
         peer.configureBlocking (true);
 

--- a/test/jdk/java/nio/channels/SocketChannel/CloseTimeoutChannel.java
+++ b/test/jdk/java/nio/channels/SocketChannel/CloseTimeoutChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class CloseTimeoutChannel {
         try {
             System.out.println("Establishing connection");
             Socket socket=SocketChannel.open(
-                new InetSocketAddress("127.0.0.1", port)).socket();
+                new InetSocketAddress(InetAddress.getLoopbackAddress(), port)).socket();
             OutputStream out=socket.getOutputStream();
             InputStream in=socket.getInputStream();
 

--- a/test/jdk/java/nio/channels/SocketChannel/SocketInheritance.java
+++ b/test/jdk/java/nio/channels/SocketChannel/SocketInheritance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class SocketInheritance {
 
     // connect to the given port
     static SocketChannel connect(int port) throws IOException {
-        InetAddress lh = InetAddress.getByName("127.0.0.1");
+        InetAddress lh = InetAddress.getLoopbackAddress();
         InetSocketAddress isa = new InetSocketAddress(lh, port);
         return SocketChannel.open(isa);
     }

--- a/test/jdk/java/nio/channels/etc/AdaptorCloseAndInterrupt.java
+++ b/test/jdk/java/nio/channels/etc/AdaptorCloseAndInterrupt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,7 @@ public class AdaptorCloseAndInterrupt {
     void scReadAsyncClose() throws IOException {
         try {
             SocketChannel sc = SocketChannel.open(new InetSocketAddress(
-                "127.0.0.1", port));
+                InetAddress.getLoopbackAddress(), port));
             sc.socket().setSoTimeout(30*1000);
 
             doAsyncClose(sc);
@@ -115,7 +115,7 @@ public class AdaptorCloseAndInterrupt {
     void scReadAsyncInterrupt() throws IOException {
         try {
             final SocketChannel sc = SocketChannel.open(new InetSocketAddress(
-                "127.0.0.1", port));
+                InetAddress.getLoopbackAddress(), port));
             sc.socket().setSoTimeout(30*1000);
 
             doAsyncInterrupt();
@@ -141,7 +141,7 @@ public class AdaptorCloseAndInterrupt {
     void dcReceiveAsyncClose() throws IOException {
         DatagramChannel dc = DatagramChannel.open();
         dc.connect(new InetSocketAddress(
-            "127.0.0.1", port));
+            InetAddress.getLoopbackAddress(), port));
         dc.socket().setSoTimeout(30*1000);
 
         doAsyncClose(dc);
@@ -159,7 +159,7 @@ public class AdaptorCloseAndInterrupt {
     void dcReceiveAsyncInterrupt() throws IOException {
         DatagramChannel dc = DatagramChannel.open();
         dc.connect(new InetSocketAddress(
-            "127.0.0.1", port));
+            InetAddress.getLoopbackAddress(), port));
         dc.socket().setSoTimeout(30*1000);
 
         doAsyncInterrupt();

--- a/test/jdk/java/nio/channels/etc/Shadow.java
+++ b/test/jdk/java/nio/channels/etc/Shadow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ public class Shadow {
 
         // connect client socket to port
         SocketAddress connectAddr =
-            new InetSocketAddress("127.0.0.1",
+            new InetSocketAddress(InetAddress.getLoopbackAddress(),
                                   serverSocket.getLocalPort());
         socket.connect(connectAddr);
         log.println("connected Socket: " + socket);

--- a/test/jdk/java/nio/charset/coders/StreamTimeout.java
+++ b/test/jdk/java/nio/charset/coders/StreamTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 
@@ -47,7 +48,7 @@ public class StreamTimeout {
         private final Socket so;
 
         Client(int port) throws IOException {
-            so = new Socket("127.0.0.1", port);
+            so = new Socket(InetAddress.getLoopbackAddress(), port);
         }
 
         @Override

--- a/test/jdk/java/rmi/transport/readTimeout/ReadTimeoutTest.java
+++ b/test/jdk/java/rmi/transport/readTimeout/ReadTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,9 +82,9 @@ public class ReadTimeoutTest
 
             // Now, connect to that port
             //Thread.sleep(2000);
-            System.err.println("(connecting to listening port on 127.0.0.1:" +
+            System.err.println("(connecting to listening port on localhost:" +
                                port + ")");
-            DoS = new Socket("127.0.0.1", port);
+            DoS = new Socket(InetAddress.getLoopbackAddress(), port);
             InputStream stream = DoS.getInputStream();
 
             // Read on the socket in the background

--- a/test/jdk/jdk/net/Sockets/QuickAckTest.java
+++ b/test/jdk/jdk/net/Sockets/QuickAckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
  */
 import java.io.IOException;
 import java.net.DatagramSocket;
+import java.net.InetAddress;
 import java.net.MulticastSocket;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -38,12 +39,10 @@ import jdk.net.Sockets;
 
 public class QuickAckTest {
 
-    private static final String LOCAL_HOST = "127.0.0.1";
-
     public static void main(String args[]) throws IOException {
 
         try (ServerSocket ss = new ServerSocket(0);
-                Socket s = new Socket(LOCAL_HOST, ss.getLocalPort());
+                Socket s = new Socket(InetAddress.getLoopbackAddress(), ss.getLocalPort());
                 DatagramSocket ds = new DatagramSocket(0);
                 MulticastSocket mc = new MulticastSocket(0)) {
 

--- a/test/jdk/jdk/net/Sockets/Test.java
+++ b/test/jdk/jdk/net/Sockets/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,14 +79,14 @@ public class Test {
              DatagramSocket dg = new DatagramSocket(0)) {
 
             int tcp_port = ss.getLocalPort();
-            final InetAddress loop = InetAddress.getByName("127.0.0.1");
+            final InetAddress loop = InetAddress.getLoopbackAddress();
             final InetSocketAddress loopad = new InetSocketAddress(loop, tcp_port);
 
             final int udp_port = dg.getLocalPort();
 
-            final Socket s = new Socket("127.0.0.1", tcp_port);
+            final Socket s = new Socket(loop, tcp_port);
             final SocketChannel sc = SocketChannel.open();
-            sc.connect(new InetSocketAddress("127.0.0.1", tcp_port));
+            sc.connect(new InetSocketAddress(loop, tcp_port));
 
             doTest("Sockets.setOption Socket", () -> {
                 out.println(flowIn);

--- a/test/jdk/sun/net/ftp/TestFtpClientNameListWithNull.java
+++ b/test/jdk/sun/net/ftp/TestFtpClientNameListWithNull.java
@@ -37,6 +37,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -52,7 +53,8 @@ public class TestFtpClientNameListWithNull {
              FtpClient client = FtpClient.create()) {
             (new Thread(server)).start();
             int port = server.getPort();
-            client.connect(new InetSocketAddress("localhost", port));
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            client.connect(new InetSocketAddress(loopback, port));
             client.nameList(null);
         } finally {
             if (commandHasArgs) {
@@ -66,7 +68,9 @@ public class TestFtpClientNameListWithNull {
         private final ServerSocket serverSocket;
 
         FtpServer() throws IOException {
-            serverSocket = new ServerSocket(0);
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            serverSocket = new ServerSocket();
+            serverSocket.bind(new InetSocketAddress(loopback, 0));
         }
 
         public void handleClient(Socket client) throws IOException {

--- a/test/jdk/sun/net/www/http/HttpClient/ProxyTest.java
+++ b/test/jdk/sun/net/www/http/HttpClient/ProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,7 +126,9 @@ public class ProxyTest {
         }
 
         public HttpProxyServer() throws IOException {
-            server = new ServerSocket(0);
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            server = new ServerSocket();
+            server.bind(new InetSocketAddress(loopback, 0));
         }
 
         public int getPort() {
@@ -183,7 +185,8 @@ public class ProxyTest {
             server.start();
             int port = server.getPort();
 
-            Proxy ftpProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", port));
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            Proxy ftpProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(loopback, port));
             URL url = new URL(testURL);
             InputStream ins = (url.openConnection(ftpProxy)).getInputStream();
             in = new BufferedReader(new InputStreamReader(ins));

--- a/test/jdk/sun/net/www/http/HttpURLConnection/NTLMAuthWithSM.java
+++ b/test/jdk/sun/net/www/http/HttpURLConnection/NTLMAuthWithSM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Authenticator;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
 import java.net.URL;
@@ -62,8 +63,8 @@ public class NTLMAuthWithSM {
             // set authenticator
             Authenticator.setDefault(new AuthenticatorImpl());
 
-            String url = String.format("http://localhost:%d/test/",
-                    server.getPort());
+            String url = String.format("http://%s/test/",
+                    server.getAuthority());
 
             // load a document which is protected with NTML authentication
             System.out.println("load() called: " + url);
@@ -107,8 +108,9 @@ public class NTLMAuthWithSM {
         }
 
         static LocalHttpServer startServer() throws IOException {
+            InetAddress loopback = InetAddress.getLoopbackAddress();
             HttpServer httpServer = HttpServer.create(
-                    new InetSocketAddress(0), 0);
+                    new InetSocketAddress(loopback, 0), 0);
             LocalHttpServer localHttpServer = new LocalHttpServer(httpServer);
             localHttpServer.start();
 
@@ -124,6 +126,14 @@ public class NTLMAuthWithSM {
         void stop() {
             server.stop(0);
             System.out.println("HttpServer: stopped");
+        }
+
+        String getAuthority() {
+            InetAddress address = server.getAddress().getAddress();
+            String hostaddr = address.isAnyLocalAddress()
+                   ? "localhost" : address.getHostAddress();
+            if (hostaddr.indexOf(':') > -1) hostaddr = "[" + hostaddr + "]";
+            return hostaddr + ":" + getPort();
         }
 
         int getPort() {

--- a/test/jdk/sun/net/www/http/HttpURLConnection/PostOnDelete.java
+++ b/test/jdk/sun/net/www/http/HttpURLConnection/PostOnDelete.java
@@ -83,9 +83,10 @@ public class PostOnDelete {
         }
 
         public String getAuthority() {
-            String address = server.getAddress().getHostString();
-            address =  (address.indexOf(':') >= 0) ? ("[" + address + "]") : address;
-            return address + ":" + getPort();
+            InetAddress address = server.getAddress().getAddress();
+            String hostaddr = address.isAnyLocalAddress() ? "localhost" : address.getHostAddress();
+            hostaddr =  (hostaddr.indexOf(':') >= 0) ? ("[" + hostaddr + "]") : hostaddr;
+            return hostaddr + ":" + getPort();
         }
 
         public int getPort() {

--- a/test/jdk/sun/net/www/http/KeepAliveStream/KeepAliveStreamClose.java
+++ b/test/jdk/sun/net/www/http/KeepAliveStream/KeepAliveStreamClose.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,13 @@
  * @test
  * @bug 4392195
  * @summary Infinite loop in sun.net.www.http.KeepAliveStream [due to skip()]
+ * @library /test/lib
  * @run main/othervm/timeout=30 KeepAliveStreamClose
  */
 
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class KeepAliveStreamClose {
     static class XServer extends Thread {
@@ -78,11 +80,16 @@ public class KeepAliveStreamClose {
 
     public static void main (String[] args) {
         try {
-            ServerSocket serversocket = new ServerSocket (0);
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            ServerSocket serversocket = new ServerSocket (0, 50, loopback);
             int port = serversocket.getLocalPort ();
             XServer server = new XServer (serversocket);
             server.start ();
-            URL url = new URL ("http://localhost:"+port);
+            URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(port)
+                .toURL();
             URLConnection urlc = url.openConnection ();
             InputStream is = urlc.getInputStream ();
             int i=0, c;

--- a/test/jdk/sun/net/www/protocol/http/B8012625.java
+++ b/test/jdk/sun/net/www/protocol/http/B8012625.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,8 @@ public class B8012625 implements HttpHandler {
     ExecutorService ex;
 
     public B8012625 () throws Exception {
-        server = HttpServer.create(new InetSocketAddress(0), 10);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        server = HttpServer.create(new InetSocketAddress(loopback, 0), 10);
         HttpContext ctx = server.createContext("/", this);
         ex = Executors.newFixedThreadPool(5);
         server.setExecutor(ex);

--- a/test/jdk/sun/net/www/protocol/http/Finalizer.java
+++ b/test/jdk/sun/net/www/protocol/http/Finalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,8 +80,11 @@ class XServer extends Thread {
 
 public class Finalizer {
     public static void main (String args[]) {
+        ServerSocket serversocket = null;
         try {
-            ServerSocket serversocket = new ServerSocket (0);
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            serversocket = new ServerSocket();
+            serversocket.bind(new InetSocketAddress(loopback, 0));
             int port = serversocket.getLocalPort ();
             XServer server = new XServer (serversocket);
             server.start ();
@@ -107,6 +110,10 @@ public class Finalizer {
         } catch (IOException e) {
             throw new RuntimeException("finalize method failure."+e);
         } catch (InterruptedException ie) {
+        } finally {
+            if (serversocket != null) {
+                try {serversocket.close();} catch (IOException io) {}
+            }
         }
     }
 

--- a/test/jdk/sun/net/www/protocol/http/ResponseCacheStream.java
+++ b/test/jdk/sun/net/www/protocol/http/ResponseCacheStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,8 +99,9 @@ public class ResponseCacheStream implements HttpCallback {
     public static void main(String[] args) throws Exception {
         MyResponseCache cache = new MyResponseCache();
         try {
+            InetAddress loopback = InetAddress.getLoopbackAddress();
             ResponseCache.setDefault(cache);
-            server = new TestHttpServer (new ResponseCacheStream());
+            server = new TestHttpServer (new ResponseCacheStream(), loopback, 0);
             System.out.println ("Server: listening on port: " + server.getLocalPort());
             URL url = URIBuilder.newBuilder()
                 .scheme("http")

--- a/test/jdk/sun/net/www/protocol/http/TunnelThroughProxy.java
+++ b/test/jdk/sun/net/www/protocol/http/TunnelThroughProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/CookieHandlerTest.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/CookieHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /* @test
  * @bug 4696506 4942650
  * @summary Unit test for java.net.CookieHandler
+ * @library /test/lib
  * @run main/othervm CookieHandlerTest
  *
  *     SunJSSE does not support dynamic system properties, no way to re-use
@@ -35,6 +36,7 @@ import java.net.*;
 import java.util.*;
 import java.io.*;
 import javax.net.ssl.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class CookieHandlerTest {
     static Map<String,String> cookies;
@@ -78,10 +80,12 @@ public class CookieHandlerTest {
      * to avoid infinite hangs.
      */
     void doServerSide() throws Exception {
+        InetAddress loopback = InetAddress.getLoopbackAddress();
         SSLServerSocketFactory sslssf =
             (SSLServerSocketFactory) SSLServerSocketFactory.getDefault();
         SSLServerSocket sslServerSocket =
-            (SSLServerSocket) sslssf.createServerSocket(serverPort);
+            (SSLServerSocket) sslssf.createServerSocket();
+        sslServerSocket.bind(new InetSocketAddress(loopback, serverPort));
         serverPort = sslServerSocket.getLocalPort();
 
         /*
@@ -151,8 +155,11 @@ public class CookieHandlerTest {
         }
         HttpsURLConnection http = null;
         /* establish http connection to server */
-        String uri = "https://localhost:" + +serverPort ;
-        URL url = new URL(uri);
+        URL url = URIBuilder.newBuilder()
+                  .scheme("https")
+                  .loopback()
+                  .port(serverPort)
+                  .toURL();
         HttpsURLConnection.setDefaultHostnameVerifier(new NameVerifier());
         http = (HttpsURLConnection)url.openConnection();
 


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

Omitted changes to TestHttpServer.java, URIBuilder.java. They are already in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8223145](https://bugs.openjdk.org/browse/JDK-8223145) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8223145](https://bugs.openjdk.org/browse/JDK-8223145): Replace wildcard address with loopback or local host in tests - part 1 (**Sub-task** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2245/head:pull/2245` \
`$ git checkout pull/2245`

Update a local copy of the PR: \
`$ git checkout pull/2245` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2245`

View PR using the GUI difftool: \
`$ git pr show -t 2245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2245.diff">https://git.openjdk.org/jdk11u-dev/pull/2245.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2245#issuecomment-1787202065)