### PR TITLE
8226825: Replace wildcard address with loopback or local host in tests - part 19

### DIFF
--- a/test/jdk/java/net/Socket/SetSoLinger.java
+++ b/test/jdk/java/net/Socket/SetSoLinger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary Test Socket.setSoLinger
  * @run main SetSoLinger
  * @run main/othervm -Djava.net.preferIPv4Stack=true SetSoLinger
+ * @run main/othervm -Djava.net.preferIPv6Addresses=true SetSoLinger
  */
 
 import java.net.*;
@@ -37,7 +38,10 @@ public class SetSoLinger {
     public static void main(String args[]) throws Exception {
         int value;
         InetAddress addr = InetAddress.getLocalHost();
-        ServerSocket ss = new ServerSocket(0);
+        ServerSocket ss = new ServerSocket();
+
+        InetSocketAddress socketAddress = new InetSocketAddress(addr, 0);
+        ss.bind(socketAddress);
         int port = ss.getLocalPort();
 
         Socket s = new Socket(addr, port);

--- a/test/jdk/sun/net/www/protocol/http/B6641309.java
+++ b/test/jdk/sun/net/www/protocol/http/B6641309.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,10 @@
  * @test
  * @bug 6641309
  * @modules jdk.httpserver
- * @summary Wrong Cookie separator used in HttpURLConnection
+ * @library /test/lib
+ * @run main/othervm B6641309
+ * @run main/othervm -Djava.net.preferIPv6Addresses=true B6641309
+ * @summary Wrong Cookie separator used in HttpURLConnection B6641309
  */
 
 import java.net.*;
@@ -35,65 +38,65 @@ import com.sun.net.httpserver.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 
+import jdk.test.lib.net.URIBuilder;
+
 public class B6641309
 {
     com.sun.net.httpserver.HttpServer httpServer;
     ExecutorService executorService;
 
-    public static void main(String[] args)
-    {
+    public static void main(String[] args) throws Exception {
         new B6641309();
     }
 
-    public B6641309()
-    {
-        try {
-            startHttpServer();
-            doClient();
-        } catch (IOException ioe) {
-            System.err.println(ioe);
-        }
+    public B6641309() throws Exception {
+        startHttpServer();
+        doClient();
     }
 
-    void doClient() {
+    void doClient() throws Exception {
         CookieHandler.setDefault(new CookieManager(null, CookiePolicy.ACCEPT_ALL));
-        try {
-            InetSocketAddress address = httpServer.getAddress();
+        ProxySelector.setDefault(ProxySelector.of(null));
 
-            // GET Request
-            URL url = new URL("http://localhost:" + address.getPort() + "/test/");
-            CookieHandler ch = CookieHandler.getDefault();
-            Map<String,List<String>> header = new HashMap<String,List<String>>();
-            List<String> values = new LinkedList<String>();
-            values.add("Test1Cookie=TEST1; path=/test/");
-            values.add("Test2Cookie=TEST2; path=/test/");
-            header.put("Set-Cookie", values);
+        InetSocketAddress address = httpServer.getAddress();
 
-            // preload the CookieHandler with a cookie for our URL
-            // so that it will be sent during the first request
-            ch.put(url.toURI(), header);
-            HttpURLConnection uc = (HttpURLConnection)url.openConnection();
-            int resp = uc.getResponseCode();
-            if (resp != 200)
-                throw new RuntimeException("Failed: Response code from GET is not 200");
+        // GET Request
+        URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .host(address.getAddress())
+                .port(address.getPort())
+                .path("/test/")
+                .toURL();
 
-            System.out.println("Response code from GET = 200 OK");
+        CookieHandler ch = CookieHandler.getDefault();
+        Map<String,List<String>> header = new HashMap<String,List<String>>();
+        List<String> values = new LinkedList<String>();
+        values.add("Test1Cookie=TEST1; path=/test/");
+        values.add("Test2Cookie=TEST2; path=/test/");
+        header.put("Set-Cookie", values);
 
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (URISyntaxException e) {
-            e.printStackTrace();
-        } finally {
-            httpServer.stop(1);
-            executorService.shutdown();
+        // preload the CookieHandler with a cookie for our URL
+        // so that it will be sent during the first request
+        ch.put(url.toURI(), header);
+        HttpURLConnection uc = (HttpURLConnection)url.openConnection();
+        int resp = uc.getResponseCode();
+        if (resp != 200) {
+            throw new RuntimeException("Failed: Response code from GET is not 200: "
+                    + resp);
         }
+        System.out.println("Response code from GET = 200 OK");
+
+        httpServer.stop(1);
+        executorService.shutdown();
     }
 
     /**
      * Http Server
      */
     public void startHttpServer() throws IOException {
-        httpServer = com.sun.net.httpserver.HttpServer.create(new InetSocketAddress(0), 0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        InetSocketAddress address = new InetSocketAddress(loopback, 0);
+        httpServer = com.sun.net.httpserver.HttpServer.create(address, 0);
 
         // create HttpServer context
         HttpContext ctx = httpServer.createContext("/test/", new MyHandler());

--- a/test/jdk/sun/net/www/protocol/http/B6890349.java
+++ b/test/jdk/sun/net/www/protocol/http/B6890349.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,9 @@
 /**
  * @test
  * @bug 6890349
+ * @library /test/lib
  * @run main/othervm B6890349
+ * @run main/othervm -Djava.net.preferIPv6Addresses=true B6890349
  * @summary  Light weight HTTP server
  */
 
@@ -34,7 +36,11 @@ public class B6890349 extends Thread {
     public static final void main(String[] args) throws Exception {
 
         try {
-            ServerSocket server = new ServerSocket (0);
+            ServerSocket server = new ServerSocket();
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            InetSocketAddress address = new InetSocketAddress(loopback, 0);
+            server.bind(address);
+
             int port = server.getLocalPort();
             System.out.println ("listening on "  + port);
             B6890349 t = new B6890349 (server);
@@ -44,11 +50,11 @@ public class B6890349 extends Thread {
                 port,
                 "/foo\nbar");
             System.out.println("URL: " + u);
-            HttpURLConnection urlc = (HttpURLConnection)u.openConnection ();
+            HttpURLConnection urlc = (HttpURLConnection)u.openConnection(Proxy.NO_PROXY);
             InputStream is = urlc.getInputStream();
             throw new RuntimeException ("Test failed");
         } catch (IOException e) {
-            System.out.println ("OK");
+            System.out.println ("Caught expected exception: " + e);
         }
     }
 

--- a/test/jdk/sun/net/www/protocol/http/Modified.java
+++ b/test/jdk/sun/net/www/protocol/http/Modified.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,16 @@
 /*
  * @test
  * @bug 4092605
+ * @library /test/lib
+ * @run main/othervm Modified
+ * @run main/othervm -Djava.net.preferIPv6Addresses=true Modified
  * @summary Test HttpURLConnection setIfModifiedSince
  *
  */
 
 import java.net.*;
 import java.io.*;
+import jdk.test.lib.net.URIBuilder;
 
 public class Modified implements Runnable {
 
@@ -78,13 +82,22 @@ public class Modified implements Runnable {
 
     Modified() throws Exception {
 
-        ss = new ServerSocket(0);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        InetSocketAddress address = new InetSocketAddress(loopback, 0);
+        ss = new ServerSocket();
+        ss.bind(address);
+        int port = ss.getLocalPort();
+
         Thread thr = new Thread(this);
         thr.start();
 
-        URL testURL = new URL("http://localhost:" + ss.getLocalPort() +
-                              "/index.html");
-        URLConnection URLConn = testURL.openConnection();
+        URL testURL = URIBuilder.newBuilder()
+                .scheme("http")
+                .host(loopback)
+                .port(port)
+                .path("/index.html")
+                .toURL();
+        URLConnection URLConn = testURL.openConnection(Proxy.NO_PROXY);
         HttpURLConnection httpConn;
 
         if (URLConn instanceof HttpURLConnection) {


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8226825](https://bugs.openjdk.org/browse/JDK-8226825) needs maintainer approval

### Issue
 * [JDK-8226825](https://bugs.openjdk.org/browse/JDK-8226825): Replace wildcard address with loopback or local host in tests - part 19 (**Sub-task** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2246/head:pull/2246` \
`$ git checkout pull/2246`

Update a local copy of the PR: \
`$ git checkout pull/2246` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2246`

View PR using the GUI difftool: \
`$ git pr show -t 2246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2246.diff">https://git.openjdk.org/jdk11u-dev/pull/2246.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2246#issuecomment-1787278544)