### PR TITLE
8224204: Replace wildcard address with loopback or local host in tests - part 10

### DIFF
--- a/test/jdk/sun/net/InetAddress/nameservice/simple/DefaultCaching.java
+++ b/test/jdk/sun/net/InetAddress/nameservice/simple/DefaultCaching.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,98 +33,112 @@ import java.security.Security;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.io.BufferedWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public class DefaultCaching {
 
     public static void main(String args[]) throws Exception {
 
-        String hostsFileName = System.getProperty("test.src", ".") + "/DefaultCachingHosts";
+        String hostsFileNameSrc = System.getProperty("test.src", ".") + "/DefaultCachingHosts";
+        String hostsFileName = System.getProperty("user.dir", ".") + "/DefaultCachingHosts";
+        if (!hostsFileNameSrc.equals(hostsFileName)) {
+            Files.copy(Path.of(hostsFileNameSrc), Path.of(hostsFileName), REPLACE_EXISTING);
+            System.out.println("Host file created: " + hostsFileName);
+        }
         System.setProperty("jdk.net.hosts.file", hostsFileName);
         // initial mapping
         // name service needs to resolve this.
         addMappingToHostsFile("theclub", "129.156.220.219", hostsFileName, false);
 
-        test ("theclub", "129.156.220.219", true);      // lk: 1
-        test ("luster", "1.16.20.2", false);            // lk: 2
+        test("theclub", "129.156.220.219", true);      // lk: 1
+        test("luster", "1.16.20.2", false);            // lk: 2
 
         // name service now needs to know about luster
         addMappingToHostsFile("luster", "10.5.18.21", hostsFileName, true);
 
-        test ("luster", "1.16.20.2", false);            // lk: 2
-        sleep (10+1);
+        test("luster", "1.16.20.2", false);            // lk: 2
+        sleep(10+1);
         test("luster", "10.5.18.21", true, 3);          // lk: 3
-        sleep (5);
+        sleep(5);
 
         // new mapping for theclub and rewrite existing foo and luster mappings
         addMappingToHostsFile("theclub", "129.156.220.1", hostsFileName, false);
         addMappingToHostsFile("foo", "10.5.18.22", hostsFileName, true);
         addMappingToHostsFile("luster", "10.5.18.21", hostsFileName, true);
 
-        test ("theclub", "129.156.220.219", true, 3);
-        test ("luster", "10.5.18.21", true, 3);
-        test ("bar", "10.5.18.22", false, 4);
-        test ("foo", "10.5.18.22", true, 5);
+        test("theclub", "129.156.220.219", true, 3);
+        test("luster", "10.5.18.21", true, 3);
+        test("bar", "10.5.18.22", false, 4);
+        test("foo", "10.5.18.22", true, 5);
 
         // now delay to see if theclub has expired
-        sleep (5);
+        sleep(5);
 
-        test ("foo", "10.5.18.22", true, 5);
-        test ("theclub", "129.156.220.1", true, 6);
+        test("foo", "10.5.18.22", true, 5);
+        test("theclub", "129.156.220.1", true, 6);
 
-        sleep (11);
+        sleep(11);
         // now see if luster has expired
-        test ("luster", "10.5.18.21", true, 7);
-        test ("theclub", "129.156.220.1", true, 7);
+        test("luster", "10.5.18.21", true, 7);
+        test("theclub", "129.156.220.1", true, 7);
 
         // now delay to see if 3rd has expired
-        sleep (10+6);
+        sleep(10+6);
 
-        test ("theclub", "129.156.220.1", true, 8);
-        test ("luster", "10.5.18.21", true, 8);
-        test ("foo", "10.5.18.22", true, 9);
+        test("theclub", "129.156.220.1", true, 8);
+        test("luster", "10.5.18.21", true, 8);
+        test("foo", "10.5.18.22", true, 9);
     }
 
     /* throws RuntimeException if it fails */
 
-    static void test (String host, String address,
-                        boolean shouldSucceed, int count) {
-        test (host, address, shouldSucceed);
+    static void test(String host, String address,
+                     boolean shouldSucceed, int count) {
+        test(host, address, shouldSucceed);
     }
 
-    static void sleep (int seconds) {
+    static void sleep(int seconds) {
         try {
-            Thread.sleep (seconds * 1000);
+            Thread.sleep(seconds * 1000);
         } catch (InterruptedException e) {}
     }
 
-    static void test (String host, String address, boolean shouldSucceed) {
+    static void test(String host, String address, boolean shouldSucceed) {
         InetAddress addr = null;
         try {
-            addr = InetAddress.getByName (host);
+            addr = InetAddress.getByName(host);
             if (!shouldSucceed) {
-                throw new RuntimeException (host+":"+address+": should fail");
-
+                throw new RuntimeException(host+":"+address+": should fail (got "
+                                           + addr + ")");
             }
             if (!address.equals(addr.getHostAddress())) {
-                throw new RuntimeException(host+":"+address+": compare failed");
+                throw new RuntimeException(host+":"+address+": compare failed (found "
+                                           + addr + ")");
             }
+            System.out.println("test: " + host + "/" + address
+                               + " succeeded - got " + addr);
         } catch (UnknownHostException e) {
             if (shouldSucceed) {
                 throw new RuntimeException(host+":"+address+": should succeed");
+            } else {
+                System.out.println("test: " + host + "/" + address
+                                   + " succeeded - got expected " + e);
             }
         }
     }
 
 
-    private static void addMappingToHostsFile (String host,
-                                               String addr,
-                                               String hostsFileName,
-                                               boolean append)
+    private static void addMappingToHostsFile(String host,
+                                              String addr,
+                                              String hostsFileName,
+                                              boolean append)
                                              throws Exception {
         String mapping = addr + " " + host;
         try (PrintWriter hfPWriter = new PrintWriter(new BufferedWriter(
                 new FileWriter(hostsFileName, append)))) {
             hfPWriter.println(mapping);
-}
+        }
     }
 }

--- a/test/jdk/sun/net/www/http/KeepAliveCache/KeepAliveTimerThread.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/KeepAliveTimerThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
  * @library /test/lib
  * @bug 4701299
  * @summary Keep-Alive-Timer thread management in KeepAliveCache causes memory leak
+ * @run main KeepAliveTimerThread
+ * @run main/othervm -Djava.net.preferIPv6Addresses=true KeepAliveTimerThread
  */
 
 import java.net.*;
@@ -103,8 +105,10 @@ public class KeepAliveTimerThread {
 
 
     public static void main(String args[]) throws Exception {
-        ServerSocket ss = new ServerSocket(0);
-        Server s = new Server (ss);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        ServerSocket ss = new ServerSocket();
+        ss.bind(new InetSocketAddress(loopback, 0));
+        Server s = new Server(ss);
         s.start();
 
         URL url = URIBuilder.newBuilder()

--- a/test/jdk/sun/net/www/http/KeepAliveStream/InfiniteLoop.java
+++ b/test/jdk/sun/net/www/http/KeepAliveStream/InfiniteLoop.java
@@ -26,6 +26,9 @@
  * @bug 8004863
  * @modules jdk.httpserver
  * @summary Checks for proper close code in KeepAliveStream
+ * @library /test/lib
+ * @run main InfiniteLoop
+ * @run main/othervm -Djava.net.preferIPv6Addresses=true InfiniteLoop
  */
 
 import com.sun.net.httpserver.HttpExchange;
@@ -35,9 +38,13 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URL;
 import java.util.concurrent.Phaser;
+
+import jdk.test.lib.net.URIBuilder;
 
 // Racey test, will not always fail, but if it does then we have a problem.
 
@@ -49,11 +56,16 @@ public class InfiniteLoop {
         server.start();
         try {
             InetSocketAddress address = server.getAddress();
-            URL url = new URL("http://localhost:" + address.getPort()
-                              + "/test/InfiniteLoop");
+            URL url = URIBuilder.newBuilder()
+                      .scheme("http")
+                      .host(server.getAddress().getAddress())
+                      .port(server.getAddress().getPort())
+                      .path("/test/InfiniteLoop")
+                      .toURL();
             final Phaser phaser = new Phaser(2);
             for (int i=0; i<10; i++) {
-                HttpURLConnection uc = (HttpURLConnection)url.openConnection();
+                HttpURLConnection uc = (HttpURLConnection)
+                    url.openConnection(Proxy.NO_PROXY);
                 final InputStream is = uc.getInputStream();
                 final Thread thread = new Thread() {
                     public void run() {

--- a/test/jdk/sun/net/www/protocol/http/B6369510.java
+++ b/test/jdk/sun/net/www/protocol/http/B6369510.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,11 +59,12 @@ public class B6369510
     void doClient() {
         try {
             InetSocketAddress address = httpServer.getAddress();
-            String urlString = "http://" + InetAddress.getLocalHost().getHostName() + ":" + address.getPort() + "/test/";
+            String urlString = "http://" + InetAddress.getLocalHost().getHostName()
+                               + ":" + address.getPort() + "/test/";
             System.out.println("URL == " + urlString);
 
             // GET Request
-            URL url = new URL("http://" + InetAddress.getLocalHost().getHostName() + ":" + address.getPort() + "/test/");
+            URL url = new URL(urlString);
             HttpURLConnection uc = (HttpURLConnection)url.openConnection(Proxy.NO_PROXY);
             int resp = uc.getResponseCode();
             if (resp != 200)
@@ -95,7 +96,8 @@ public class B6369510
      * Http Server
      */
     public void startHttpServer() throws IOException {
-        httpServer = com.sun.net.httpserver.HttpServer.create(new InetSocketAddress(0), 0);
+        InetAddress localhost = InetAddress.getLocalHost();
+        httpServer = HttpServer.create(new InetSocketAddress(localhost, 0), 0);
 
         // create HttpServer context
         HttpContext ctx = httpServer.createContext("/test/", new MyHandler());


### PR DESCRIPTION
I backport this to simplify later backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8224204](https://bugs.openjdk.org/browse/JDK-8224204) needs maintainer approval

### Issue
 * [JDK-8224204](https://bugs.openjdk.org/browse/JDK-8224204): Replace wildcard address with loopback or local host in tests - part 10 (**Sub-task** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2248/head:pull/2248` \
`$ git checkout pull/2248`

Update a local copy of the PR: \
`$ git checkout pull/2248` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2248`

View PR using the GUI difftool: \
`$ git pr show -t 2248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2248.diff">https://git.openjdk.org/jdk11u-dev/pull/2248.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2248#issuecomment-1787526895)