### PR TITLE
8290469: Add new positioning options to PassFailJFrame test framework

### DIFF
--- a/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
@@ -81,6 +81,10 @@ public class TrayIconScalingTest {
         PassFailJFrame passFailJFrame = new PassFailJFrame("TrayIcon " +
                 "Test Instructions", INSTRUCTIONS, 8, 18, 85);
         createAndShowGUI();
+        // does not have a test window,
+        // hence only the instruction frame is positioned
+        PassFailJFrame.positionTestWindow(null,
+                PassFailJFrame.Position.HORIZONTAL);
         try {
             passFailJFrame.awaitAndCheck();
         } finally {

--- a/test/jdk/java/awt/print/PrinterJob/ImagePrinting/ClippedImages.java
+++ b/test/jdk/java/awt/print/PrinterJob/ImagePrinting/ClippedImages.java
@@ -59,6 +59,7 @@ import static java.awt.EventQueue.invokeAndWait;
 public class ClippedImages {
 
     private static ClippedImageCanvas c;
+    private static Frame frame;
 
     public static void main(String[] args) throws InterruptedException,
             InvocationTargetException {
@@ -100,7 +101,7 @@ public class ClippedImages {
     }
 
     public static void createTestUI() {
-        Frame frame = new Frame("Clipped Src Area Image Printing Test");
+        frame = new Frame("Clipped Src Area Image Printing Test");
         c = new ClippedImageCanvas();
         frame.add(c, BorderLayout.CENTER);
 
@@ -123,10 +124,10 @@ public class ClippedImages {
         frame.add(p, BorderLayout.SOUTH);
         frame.setLocationRelativeTo(null);
         frame.pack();
-        frame.setVisible(true);
 
         PassFailJFrame.addTestWindow(frame);
         PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
+        frame.setVisible(true);
     }
 
     private static void printOne() {

--- a/test/jdk/java/awt/print/PrinterJob/PrintGlyphVectorTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintGlyphVectorTest.java
@@ -34,13 +34,11 @@ import java.awt.BorderLayout;
 import java.awt.Button;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Dialog;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.Label;
 import java.awt.font.FontRenderContext;
 import java.awt.font.GlyphVector;
 import java.awt.geom.Point2D;
@@ -51,6 +49,7 @@ import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 
 public class PrintGlyphVectorTest extends Component implements Printable {
+    private static Frame f;
 
     private static final String INSTRUCTIONS =
             "Note: You must have a printer installed for this test.\n" +
@@ -127,7 +126,7 @@ public class PrintGlyphVectorTest extends Component implements Printable {
             PassFailJFrame.forcePass();
         }
 
-        Frame f = new Frame("Test PrintGlyphVector");
+        f = new Frame("Test PrintGlyphVector");
         PrintGlyphVectorTest pvt = new PrintGlyphVectorTest();
         f.add(pvt, BorderLayout.CENTER);
 
@@ -148,13 +147,13 @@ public class PrintGlyphVectorTest extends Component implements Printable {
 
         f.add(printButton, BorderLayout.SOUTH);
         f.pack();
-        f.setVisible(true);
 
         // add the test frame to dispose
         PassFailJFrame.addTestWindow(f);
 
         // Arrange the test instruction frame and test frame side by side
         PassFailJFrame.positionTestWindow(f, PassFailJFrame.Position.HORIZONTAL);
+        f.setVisible(true);
     }
 
     public static void main(String[] arg) throws Exception {

--- a/test/jdk/java/awt/print/PrinterJob/PrintLatinCJKTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintLatinCJKTest.java
@@ -73,8 +73,6 @@ public class PrintLatinCJKTest implements Printable {
             });
             frame.getContentPane().add(b, BorderLayout.SOUTH);
             frame.pack();
-            frame.setLocationRelativeTo(null);
-            frame.setVisible(true);
 
             // add the test frame to dispose
             PassFailJFrame.addTestWindow(frame);
@@ -82,6 +80,7 @@ public class PrintLatinCJKTest implements Printable {
             // Arrange the test instruction frame and test frame side by side
             PassFailJFrame.positionTestWindow(frame,
                     PassFailJFrame.Position.HORIZONTAL);
+            frame.setVisible(true);
         });
     }
 
@@ -99,7 +98,7 @@ public class PrintLatinCJKTest implements Printable {
 
     public static void main(String[] args) throws InterruptedException, InvocationTargetException {
         PassFailJFrame passFailJFrame = new PassFailJFrame("Test Instruction" +
-                "Frame", info, 10, 40, 5);
+                "Frame", info, 10, 10, 45);
         showFrame();
         passFailJFrame.awaitAndCheck();
     }

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -23,6 +23,10 @@
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
+import java.awt.Insets;
+import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.WindowAdapter;
@@ -40,6 +44,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.Timer;
+
 
 import static javax.swing.SwingUtilities.invokeAndWait;
 import static javax.swing.SwingUtilities.isEventDispatchThread;
@@ -65,7 +70,7 @@ public class PassFailJFrame {
     private static volatile String testFailedReason;
     private static JFrame frame;
 
-    public enum Position {HORIZONTAL, VERTICAL}
+    public enum Position {HORIZONTAL, VERTICAL, TOP_LEFT_CORNER}
 
     public PassFailJFrame(String instructions) throws InterruptedException,
             InvocationTargetException {
@@ -176,7 +181,6 @@ public class PassFailJFrame {
         frame.add(buttonsPanel, BorderLayout.SOUTH);
         frame.pack();
         frame.setLocationRelativeTo(null);
-        frame.setVisible(true);
         windowList.add(frame);
     }
 
@@ -262,31 +266,116 @@ public class PassFailJFrame {
     }
 
     /**
-     * Position the instruction frame with testWindow (testcase created
-     * window) by the specified position.
-     * Note: This method should be invoked from the method that creates
-     * testWindow.
+     * Approximately positions the instruction frame relative to the test
+     * window as specified by the {@code position} parameter. If {@code testWindow}
+     * is {@code null}, only the instruction frame is positioned according to
+     * {@code position} parameter.
+     * <p>This method should be called before making the test window visible
+     * to avoid flickering.</p>
      *
-     * @param testWindow test window that the test is created
-     * @param position  position can be either HORIZONTAL (both test
-     *                  instruction frame and test window as arranged
-     *                  side by side) or VERTICAL (both test instruction
-     *                  frame and test window as arranged up and down)
+     * @param testWindow test window that the test created.
+     *                   May be {@code null}.
+     *
+     * @param position  position must be one of:
+     *                  <ul>
+     *                  <li>{@code HORIZONTAL} - the test instruction frame is positioned
+     *                  such that its right edge aligns with screen's horizontal center
+     *                  and the test window (if not {@code null}) is placed to the right
+     *                  of the instruction frame.</li>
+     *
+     *                  <li>{@code VERTICAL} - the test instruction frame is positioned
+     *                  such that its bottom edge aligns with the screen's vertical center
+     *                  and the test window (if not {@code null}) is placed below the
+     *                  instruction frame.</li>
+     *
+     *                  <li>{@code TOP_LEFT_CORNER} - the test instruction frame is positioned
+     *                  such that its top left corner is at the top left corner of the screen
+     *                  and the test window (if not {@code null}) is placed to the right of
+     *                  the instruction frame.</li>
+     *                  </ul>
      */
     public static void positionTestWindow(Window testWindow, Position position) {
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+
+        // Get the screen insets to position the frame by taking into
+        // account the location of taskbar/menubars on screen.
+        GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment()
+                .getDefaultScreenDevice().getDefaultConfiguration();
+        Insets screenInsets = Toolkit.getDefaultToolkit().getScreenInsets(gc);
+
         if (position.equals(Position.HORIZONTAL)) {
             int newX = ((screenSize.width / 2) - frame.getWidth());
-            frame.setLocation(newX, frame.getY());
-
-            testWindow.setLocation((frame.getLocation().x + frame.getWidth() + 5), frame.getY());
+            frame.setLocation((newX + screenInsets.left),
+                    (frame.getY() + screenInsets.top));
+            syncLocationToWindowManager();
+            if (testWindow != null) {
+                testWindow.setLocation((frame.getX() + frame.getWidth() + 5),
+                        frame.getY());
+            }
         } else if (position.equals(Position.VERTICAL)) {
             int newY = ((screenSize.height / 2) - frame.getHeight());
-            frame.setLocation(frame.getX(), newY);
-
-            testWindow.setLocation(frame.getX(),
-                    (frame.getLocation().y + frame.getHeight() + 5));
+            frame.setLocation((frame.getX() + screenInsets.left),
+                    (newY + screenInsets.top));
+            syncLocationToWindowManager();
+            if (testWindow != null) {
+                testWindow.setLocation(frame.getX(),
+                        (frame.getY() + frame.getHeight() + 5));
+            }
+        } else if (position.equals(Position.TOP_LEFT_CORNER)) {
+            frame.setLocation(screenInsets.left, screenInsets.top);
+            syncLocationToWindowManager();
+            if (testWindow != null) {
+                testWindow.setLocation((frame.getX() + frame.getWidth() + 5),
+                        frame.getY());
+            }
         }
+        // make instruction frame visible after updating
+        // frame & window positions
+        frame.setVisible(true);
+    }
+
+    /**
+     * Ensures the frame location is updated by the window manager
+     * if it adjusts the frame location after {@code setLocation}.
+     *
+     * @see #positionTestWindow
+     */
+    private static void syncLocationToWindowManager() {
+        Toolkit.getDefaultToolkit().sync();
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Returns the current position and size of the test instruction frame.
+     * This method can be used in scenarios when custom positioning of
+     * multiple test windows w.r.t test instruction frame is necessary,
+     * at test-case level and the desired configuration is not available
+     * as a {@code Position} option.
+     *
+     * @return Rectangle bounds of test instruction frame
+     * @see #positionTestWindow
+     *
+     * @throws InterruptedException      exception thrown when thread is
+     *                                   interrupted
+     * @throws InvocationTargetException if an exception is thrown while
+     *                                   obtaining frame bounds on EDT
+     */
+    public static Rectangle getInstructionFrameBounds()
+            throws InterruptedException, InvocationTargetException {
+        final Rectangle[] bounds = {null};
+
+        if (isEventDispatchThread()) {
+            bounds[0] = frame != null ? frame.getBounds() : null;
+        } else {
+            invokeAndWait(() -> {
+                bounds[0] = frame != null ? frame.getBounds() : null;
+            });
+        }
+        return bounds[0];
     }
 
     /**

--- a/test/jdk/javax/swing/JRadioButton/bug4380543.java
+++ b/test/jdk/javax/swing/JRadioButton/bug4380543.java
@@ -20,15 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
- * @bug 4380543
- * @key headful
- * @library /java/awt/regtesthelpers
- * @build PassFailJFrame
- * @summary setMargin() does not work for AbstractButton
- * @run main/manual bug4380543
-*/
-
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
@@ -45,6 +36,14 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
+/* @test
+ * @bug 4380543
+ * @key headful
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary setMargin() does not work for AbstractButton
+ * @run main/manual bug4380543
+ */
 public class bug4380543 {
     static TestFrame testObj;
     static String instructions
@@ -62,17 +61,16 @@ public class bug4380543 {
 
     public static void main(String[] args) throws Exception {
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                try {
-                    passFailJFrame = new PassFailJFrame(instructions);
-                    testObj = new TestFrame();
-                    //Adding the Test Frame to handle dispose
-                    PassFailJFrame.addTestWindow(testObj);
-                    PassFailJFrame.positionTestWindow(testObj, PassFailJFrame.Position.HORIZONTAL);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                passFailJFrame = new PassFailJFrame(instructions);
+                testObj = new TestFrame();
+                //Adding the Test Frame to handle dispose
+                PassFailJFrame.addTestWindow(testObj);
+                PassFailJFrame.positionTestWindow(testObj, PassFailJFrame.Position.HORIZONTAL);
+                testObj.setVisible(true);
+            } catch (Exception e) {
+                e.printStackTrace();
             }
         });
         passFailJFrame.awaitAndCheck();
@@ -111,9 +109,7 @@ class TestFrame extends JFrame implements ActionListener {
         }
 
         getContentPane().add(p,BorderLayout.SOUTH);
-
         setSize(500, 300);
-        setVisible(true);
     }
 
     private static void setLookAndFeel(String laf) {

--- a/test/jdk/javax/swing/JTabbedPane/4209065/bug4209065.java
+++ b/test/jdk/javax/swing/JTabbedPane/4209065/bug4209065.java
@@ -21,6 +21,13 @@
  * questions.
  */
 
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+
 /*
  * @test
  * @bug 4209065
@@ -29,14 +36,6 @@
  * @summary To test if the style of the text on the tab matches the description.
  * @run main/manual bug4209065
  */
-
-import java.lang.reflect.InvocationTargetException;
-
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JTabbedPane;
-import javax.swing.SwingUtilities;
-
 
 public final class bug4209065 {
 
@@ -47,37 +46,32 @@ public final class bug4209065 {
                     " text may be larger\nthan the tab height but this is OK" +
                     " and NOT a failure.";
 
-    public static void createAndShowGUI() throws InterruptedException,
-            InvocationTargetException {
-        SwingUtilities.invokeAndWait(() -> {
-            frame = new JFrame("JTabbedPane");
+    public static void createAndShowGUI() {
 
-            JTabbedPane tp = new JTabbedPane();
+        frame = new JFrame("JTabbedPane");
+        JTabbedPane tp = new JTabbedPane();
 
-            tp.addTab("<html><center><font size=+3>big</font></center></html>",
-                    new JLabel());
-            tp.addTab("<html><center><font color=red>red</font></center></html>",
-                    new JLabel());
-            tp.addTab("<html><center><em><b>Bold Italic!</b></em></center></html>",
-                    new JLabel());
+        tp.addTab("<html><center><font size=+3>big</font></center></html>",
+                new JLabel());
+        tp.addTab("<html><center><font color=red>red</font></center></html>",
+                new JLabel());
+        tp.addTab("<html><center><em><b>Bold Italic!</b></em></center></html>",
+                new JLabel());
 
-            frame.getContentPane().add(tp);
-            frame.setSize(400, 400);
-            frame.setLocationRelativeTo(null);
-            frame.setVisible(true);
+        frame.getContentPane().add(tp);
+        frame.setSize(400, 400);
 
-
-            PassFailJFrame.addTestWindow(frame);
-            PassFailJFrame.positionTestWindow(frame,
-                    PassFailJFrame.Position.HORIZONTAL);
-        });
+        PassFailJFrame.addTestWindow(frame);
+        PassFailJFrame.positionTestWindow(frame,
+                PassFailJFrame.Position.HORIZONTAL);
+        frame.setVisible(true);
     }
 
     public static void main(String[] args) throws InterruptedException,
             InvocationTargetException {
         PassFailJFrame passFailJFrame = new PassFailJFrame("JTabbedPane " +
                 "Test Instructions", text, 5, 19, 35);
-        createAndShowGUI();
+        SwingUtilities.invokeAndWait(bug4209065::createAndShowGUI);
         passFailJFrame.awaitAndCheck();
     }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8290469](https://bugs.openjdk.org/browse/JDK-8290469) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290469](https://bugs.openjdk.org/browse/JDK-8290469): Add new positioning options to PassFailJFrame test framework (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2250/head:pull/2250` \
`$ git checkout pull/2250`

Update a local copy of the PR: \
`$ git checkout pull/2250` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2250`

View PR using the GUI difftool: \
`$ git pr show -t 2250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2250.diff">https://git.openjdk.org/jdk11u-dev/pull/2250.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2250#issuecomment-1794647049)