### PR TITLE
8285687: Remove jtreg tag manual=yesno for java/awt/print/PrinterJob/PageRangesDlgTest.java

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/PageRangesDlgTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageRangesDlgTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,56 +21,72 @@
  * questions.
  */
 
-/**
+import java.awt.Graphics;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.print.attribute.standard.DialogTypeSelection;
+import javax.print.attribute.standard.PageRanges;
+import jtreg.SkippedException;
+
+/*
  * @test
  * @bug 8061267
+ * @key printer
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @summary The specified page range should be displayed in the dialog
- * @run main/manual=yesno PageRangesDlgTest
+ * @run main/manual PageRangesDlgTest
  */
-
-import javax.print.*;
-import javax.print.attribute.*;
-import javax.print.attribute.standard.*;
-import java.awt.*;
-import java.awt.print.*;
 
 public class PageRangesDlgTest implements Printable {
 
-    static String[] instr = {
-     "This test is to check that the print dialog displays the specified",
-     "page ranges. You must have a printer installed for this test.",
-     "It is valid only on dialogs which support page ranges",
-     "In each dialog, check that a page range of 2 to 3 is requested",
-     "Optionally press Print instead of Cancel, and verify that the",
-     "correct number/set of pages is printed",
-    };
-
-    public static void main(String args[]) throws Exception {
-        for (int i=0;i<instr.length;i++) {
-            System.out.println(instr[i]);
-        }
+    private static void showPrintDialogs() throws PrinterException {
         PrinterJob job = PrinterJob.getPrinterJob();
-        if (job.getPrintService() == null) {
-           System.out.println("No printers. Test cannot continue.");
-           return;
-        }
         job.setPrintable(new PageRangesDlgTest());
         PrintRequestAttributeSet aset = new HashPrintRequestAttributeSet();
-        aset.add(new PageRanges(2,3));
+        aset.add(new PageRanges(2, 3));
         if (job.printDialog(aset)) {
-           job.print(aset);
+            job.print(aset);
         }
 
         job = PrinterJob.getPrinterJob();
         job.setPrintable(new PageRangesDlgTest());
         aset.add(DialogTypeSelection.NATIVE);
-        if (job.printDialog()) {
+        if (job.printDialog(aset)) {
             job.print();
         }
     }
 
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
+
+        String instruction =
+                "Note: You must have a printer installed for this test.\n" +
+                "If printer is not installed then the test passes automatically.\n" +
+                "\n" +
+                "This test is to check that the print dialog displays the specified,\n" +
+                "page ranges. It is valid only on dialogs which support page ranges,\n" +
+                "In each dialog, check that a page range of 2 to 3 is requested,\n" +
+                "Optionally press Print instead of Cancel, and verify that the,\n" +
+                "correct number/set of pages is printed."
+                ;
+
+        PassFailJFrame passFailJFrame = new PassFailJFrame(instruction, 10);
+        showPrintDialogs();
+        passFailJFrame.awaitAndCheck();
+    }
+
     public int print(Graphics g, PageFormat pf, int pi)
-                     throws PrinterException  {
+                     throws PrinterException {
 
         System.out.println("pi="+pi);
         if (pi >= 5) {


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

Adapted the syntax of the """ string literal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8285687](https://bugs.openjdk.org/browse/JDK-8285687) needs maintainer approval

### Issue
 * [JDK-8285687](https://bugs.openjdk.org/browse/JDK-8285687): Remove jtreg tag manual=yesno for java/awt/print/PrinterJob/PageRangesDlgTest.java (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2251/head:pull/2251` \
`$ git checkout pull/2251`

Update a local copy of the PR: \
`$ git checkout pull/2251` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2251`

View PR using the GUI difftool: \
`$ git pr show -t 2251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2251.diff">https://git.openjdk.org/jdk11u-dev/pull/2251.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2251#issuecomment-1794660346)