### PR TITLE
8230435: Replace wildcard address with loopback or local host in tests - part 22

### DIFF
--- a/test/jdk/java/net/Authenticator/B4678055.java
+++ b/test/jdk/java/net/Authenticator/B4678055.java
@@ -36,8 +36,8 @@ import java.net.*;
 
 public class B4678055 implements HttpCallback {
 
-    static int count = 0;
-    static String authstring;
+    static volatile int count = 0;
+    static volatile String authstring;
 
     void errorReply (HttpTransaction req, String reply) throws IOException {
         req.addResponseHeader ("Connection", "close");
@@ -54,6 +54,7 @@ public class B4678055 implements HttpCallback {
 
     public void request (HttpTransaction req) {
         try {
+            System.out.println("Server handling case: "+ count);
             authstring = req.getRequestHeader ("Authorization");
             System.out.println (authstring);
             switch (count) {
@@ -93,6 +94,7 @@ public class B4678055 implements HttpCallback {
             }
             count ++;
         } catch (IOException e) {
+            System.err.println("Unexpected exception for case " + count + ": " + e);
             e.printStackTrace();
         }
     }
@@ -132,6 +134,8 @@ public class B4678055 implements HttpCallback {
             client ("http://localhost:"+server.getLocalPort()+"/d2/foo.html");
             client ("http://localhost:"+server.getLocalPort()+"/d2/foo.html");
         } catch (Exception e) {
+            System.out.println("Client got exception: " + e);
+            System.out.println("Terminating server");
             if (server != null) {
                 server.terminate();
             }
@@ -145,10 +149,13 @@ public class B4678055 implements HttpCallback {
         if (!checkFinalAuth()) {
             except ("Wrong authorization string received from client");
         }
+        System.out.println("Terminating server");
         server.terminate();
     }
 
     public static void except (String s) {
+        System.out.println("Check failed: " + s);
+        System.out.println("Terminating server");
         server.terminate();
         throw new RuntimeException (s);
     }
@@ -158,7 +165,7 @@ public class B4678055 implements HttpCallback {
             super ();
         }
 
-        int count = 0;
+        volatile int count = 0;
 
         public PasswordAuthentication getPasswordAuthentication () {
             PasswordAuthentication pw;

--- a/test/jdk/java/net/DatagramSocket/PortUnreachable.java
+++ b/test/jdk/java/net/DatagramSocket/PortUnreachable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,9 +29,10 @@
  *           exception on Windows 2000.
  */
 import java.net.BindException;
-import java.net.InetAddress;
-import java.net.DatagramSocket;
 import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 
 public class PortUnreachable {
 
@@ -67,7 +68,7 @@ public class PortUnreachable {
                 serverPort);
         while (serverSocket == null) {
             try {
-                serverSocket = new DatagramSocket(serverPort);
+                serverSocket = new DatagramSocket(serverPort, InetAddress.getLocalHost());
             } catch (BindException bEx) {
                 if (retryCount++ < 5) {
                     Thread.sleep(500);
@@ -84,8 +85,7 @@ public class PortUnreachable {
     }
 
     PortUnreachable() throws Exception {
-
-        clientSock = new DatagramSocket();
+        clientSock = new DatagramSocket(new InetSocketAddress(InetAddress.getLocalHost(), 0));
         clientPort = clientSock.getLocalPort();
 
     }
@@ -93,7 +93,7 @@ public class PortUnreachable {
     void execute () throws Exception{
 
         // pick a port for the server
-        DatagramSocket sock2 = new DatagramSocket();
+        DatagramSocket sock2 = new DatagramSocket(new InetSocketAddress(InetAddress.getLocalHost(), 0));
         serverPort = sock2.getLocalPort();
 
         // send a burst of packets to the unbound port - we should get back

--- a/test/jdk/java/net/DatagramSocket/PortUnreachable.java
+++ b/test/jdk/java/net/DatagramSocket/PortUnreachable.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 4361783
+ * @key intermittent
  * @summary  Test to see if ICMP Port Unreachable on non-connected
  *           DatagramSocket causes a SocketException "socket closed"
  *           exception on Windows 2000.
@@ -43,7 +44,7 @@ public class PortUnreachable {
     public void serverSend() {
         try {
             InetAddress addr = InetAddress.getLocalHost();
-            Thread.currentThread().sleep(1000);
+            Thread.sleep(1000);
             // send a delayed packet which should mean a delayed icmp
             // port unreachable
             byte b[] = "A late msg".getBytes();
@@ -64,24 +65,68 @@ public class PortUnreachable {
     DatagramSocket recreateServerSocket (int serverPort) throws Exception {
         DatagramSocket serverSocket = null;
         int retryCount = 0;
+        long sleeptime = 0;
         System.out.println("Attempting to recreate server socket with port: " +
                 serverPort);
+        // it's possible that this method intermittently fails, if some other
+        // process running on the machine grabs the port we want before us,
+        // and doesn't release it before the 5 * 500 ms are elapsed...
         while (serverSocket == null) {
             try {
                 serverSocket = new DatagramSocket(serverPort, InetAddress.getLocalHost());
             } catch (BindException bEx) {
                 if (retryCount++ < 5) {
-                    Thread.sleep(500);
+                   sleeptime += sleepAtLeast(500);
                 } else {
-                    System.out.println("Give up after 5 retries");
+                    System.out.println("Give up after 5 retries and " + sleeptime(sleeptime));
+                    System.out.println("Has some other process grabbed port " + serverPort + "?");
                     throw bEx;
                 }
             }
         }
 
         System.out.println("PortUnreachableTest.recreateServerSocket: returning socket == "
-                + serverSocket.getLocalAddress() + ":" + serverSocket.getLocalPort());
+                + serverSocket.getLocalAddress() + ":" + serverSocket.getLocalPort()
+                + " obtained at " + attempt(retryCount) + " attempt with " + sleeptime(sleeptime));
         return serverSocket;
+    }
+
+    long sleepAtLeast(long millis) throws Exception {
+        long start = System.nanoTime();
+        long ms = millis;
+        while (ms > 0) {
+            assert ms < Long.MAX_VALUE/1000_000L;
+            Thread.sleep(ms);
+            long elapsedms = (System.nanoTime() - start)/1000_000L;
+            ms = millis - elapsedms;
+        }
+        return millis - ms;
+    }
+
+    String attempt(int retry) {
+        switch (retry) {
+            case 0: return "first";
+            case 1: return "second";
+            case 2: return "third";
+            default: return retry + "th";
+        }
+    }
+
+    String sleeptime(long millis) {
+        if (millis == 0) return "no sleep";
+        long sec = millis / 1000L;
+        long ms =  millis % 1000L;
+        String sleeptime = "";
+        if (millis > 0) {
+           if (sec > 0) {
+               sleeptime = "" + sec + " s" +
+                   (ms > 0 ? " " : "");
+            }
+            if (ms > 0 ) {
+                sleeptime += ms + " ms";
+            }
+        } else sleeptime = millis + " ms"; // should not happen
+        return sleeptime + " of sleep time";
     }
 
     PortUnreachable() throws Exception {
@@ -126,4 +171,3 @@ public class PortUnreachable {
     }
 
 }
-

--- a/test/jdk/java/net/URLConnection/Responses.java
+++ b/test/jdk/java/net/URLConnection/Responses.java
@@ -56,7 +56,8 @@ public class Responses {
      * "HTTP/1.1 404 "
      */
     static class HttpServer implements Runnable {
-        ServerSocket ss;
+        final ServerSocket ss;
+        volatile boolean shutdown;
 
         public HttpServer() {
             try {
@@ -83,6 +84,7 @@ public class Responses {
         }
 
         public void shutdown() throws IOException {
+            shutdown = true;
             ss.close();
         }
 
@@ -90,7 +92,7 @@ public class Responses {
             Object[][] tests = getTests();
 
             try {
-                for (;;) {
+                while(!shutdown) {
                     Socket s = ss.accept();
 
                     BufferedReader in = new BufferedReader(
@@ -101,6 +103,7 @@ public class Responses {
                     int pos2 = req.indexOf(' ', pos1+1);
 
                     int i = Integer.parseInt(req.substring(pos1+2, pos2));
+                    System.out.println("Server replying to >" + tests[i][0] + "<");
 
                     PrintStream out = new PrintStream(
                                         new BufferedOutputStream(
@@ -117,6 +120,9 @@ public class Responses {
                     s.close();
                 }
             } catch (Exception e) {
+                if (!shutdown) {
+                    e.printStackTrace();
+                }
             }
         }
     }
@@ -170,6 +176,7 @@ public class Responses {
                         actualPhrase + ", expected: " + expectedPhrase);
                 }
             } catch (IOException e) {
+                System.err.println("Test failed for >" + tests[i][0] + "<: " + e);
                 e.printStackTrace();
                 failures++;
             }

--- a/test/jdk/sun/net/InetAddress/nameservice/simple/DefaultCaching.java
+++ b/test/jdk/sun/net/InetAddress/nameservice/simple/DefaultCaching.java
@@ -101,8 +101,22 @@ public class DefaultCaching {
 
     static void sleep(int seconds) {
         try {
-            Thread.sleep(seconds * 1000);
-        } catch (InterruptedException e) {}
+            sleepms(seconds * 1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    static long sleepms(long millis) throws InterruptedException {
+        long start = System.nanoTime();
+        long ms = millis;
+        while (ms > 0) {
+            assert ms < Long.MAX_VALUE/1000_000L;
+            Thread.sleep(ms);
+            long elapsedms = (System.nanoTime() - start)/1000_000L;
+            ms = millis - elapsedms;
+        }
+        return millis - ms;
     }
 
     static void test(String host, String address, boolean shouldSucceed) {
@@ -114,7 +128,7 @@ public class DefaultCaching {
                                            + addr + ")");
             }
             if (!address.equals(addr.getHostAddress())) {
-                throw new RuntimeException(host+":"+address+": compare failed (found "
+                throw new RuntimeException(host+"/"+address+": compare failed (found "
                                            + addr + ")");
             }
             System.out.println("test: " + host + "/" + address

--- a/test/jdk/sun/net/www/AuthHeaderTest.java
+++ b/test/jdk/sun/net/www/AuthHeaderTest.java
@@ -85,7 +85,7 @@ public class AuthHeaderTest implements HttpCallback {
     static void client (String u) throws Exception {
         URL url = new URL (u);
         System.out.println ("client opening connection to: " + u);
-        URLConnection urlc = url.openConnection ();
+        URLConnection urlc = url.openConnection (Proxy.NO_PROXY);
         InputStream is = urlc.getInputStream ();
         read (is);
         is.close();

--- a/test/jdk/sun/net/www/http/HttpClient/RetryPost.java
+++ b/test/jdk/sun/net/www/http/HttpClient/RetryPost.java
@@ -84,13 +84,17 @@ public class RetryPost
             throw new RuntimeException("Failed: POST request being retried");
 
         } catch (SocketException se) {
+            System.out.println("Got expected exception: " + se);
             // this is what we expect to happen and is OK.
-            if (shouldRetry && httpHandler.getCallCount() != 2)
+            if (shouldRetry && httpHandler.getCallCount() != 2) {
+                se.printStackTrace(System.out);
                 throw new RuntimeException("Failed: Handler should have been called twice. " +
                                            "It was called "+ httpHandler.getCallCount() + " times");
-            else if (!shouldRetry && httpHandler.getCallCount() != 1)
+            } else if (!shouldRetry && httpHandler.getCallCount() != 1) {
+                se.printStackTrace(System.out);
                 throw new RuntimeException("Failed: Handler should have only been called once" +
                                            "It was called "+ httpHandler.getCallCount() + " times");
+            }
         } finally {
             httpServer.stop(1);
             executorService.shutdown();

--- a/test/jdk/sun/net/www/protocol/https/HttpsClient/ProxyTunnelServer.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsClient/ProxyTunnelServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,9 +61,14 @@ public class ProxyTunnelServer extends Thread {
     static boolean needAuth = false;
 
     public ProxyTunnelServer() throws IOException {
+        this(null); // use wildcard
+    }
+
+    public ProxyTunnelServer(InetAddress proxyAddress) throws IOException {
         if (ss == null) {
-          ss = (ServerSocket) ServerSocketFactory.getDefault().
-          createServerSocket(0);
+            ss = (ServerSocket) ServerSocketFactory.getDefault().
+                createServerSocket();
+            ss.bind(new InetSocketAddress(proxyAddress, 0));
         }
         setDaemon(true);
     }
@@ -274,14 +279,18 @@ public class ProxyTunnelServer extends Thread {
             serverName = connectInfo.substring(0, endi);
             serverPort = Integer.parseInt(connectInfo.substring(endi+1));
         } catch (Exception e) {
-            throw new IOException("Proxy recieved a request: "
-                                        + connectStr);
-          }
+            throw new IOException("Proxy received a request: "
+                                  + connectStr, e);
+        }
         serverInetAddr = InetAddress.getByName(serverName);
     }
 
     public int getPort() {
         return ss.getLocalPort();
+    }
+
+    public InetAddress getInetAddress() {
+        return ss.getInetAddress();
     }
 
     /*

--- a/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/B6226610.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/B6226610.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,12 +47,14 @@ public class B6226610 {
         proxy = new HeaderCheckerProxyTunnelServer();
         proxy.start();
 
-        String hostname = InetAddress.getLocalHost().getHostName();
+        InetAddress localHost = InetAddress.getLocalHost();
+        String hostname = localHost.getHostName();
+        String hostAddress = localHost.getHostAddress();
 
         try {
            URL u = new URL("https://" + hostname + "/");
            System.out.println("Connecting to " + u);
-           InetSocketAddress proxyAddr = new InetSocketAddress(hostname, proxy.getLocalPort());
+           InetSocketAddress proxyAddr = InetSocketAddress.createUnresolved(hostAddress, proxy.getLocalPort());
            java.net.URLConnection c = u.openConnection(new Proxy(Proxy.Type.HTTP, proxyAddr));
 
            /* I want this header to go to the destination server only, protected
@@ -96,7 +98,8 @@ class HeaderCheckerProxyTunnelServer extends Thread
     public HeaderCheckerProxyTunnelServer() throws IOException
     {
        if (ss == null) {
-          ss = new ServerSocket(0);
+           ss = new ServerSocket();
+           ss.bind(new InetSocketAddress(InetAddress.getLocalHost(), 0));
        }
     }
 
@@ -143,16 +146,16 @@ class HeaderCheckerProxyTunnelServer extends Thread
            retrieveConnectInfo(statusLine);
 
            if (mheader.findValue("X-TestHeader") != null) {
-             System.out.println("Proxy should not receive user defined headers for tunneled requests");
-             failed = true;
+               System.out.println("Proxy should not receive user defined headers for tunneled requests");
+               failed = true;
            }
 
            // 6973030
            String value;
            if ((value = mheader.findValue("Proxy-Connection")) == null ||
                 !value.equals("keep-alive")) {
-             System.out.println("Proxy-Connection:keep-alive not being sent");
-             failed = true;
+               System.out.println("Proxy-Connection:keep-alive not being sent");
+               failed = true;
            }
 
            //This will allow the main thread to terminate without trying to perform the SSL handshake.
@@ -206,8 +209,8 @@ class HeaderCheckerProxyTunnelServer extends Thread
             serverPort = Integer.parseInt(connectInfo.substring(endi+1));
         } catch (Exception e) {
             throw new IOException("Proxy recieved a request: "
-                                        + connectStr);
-          }
+                                  + connectStr, e);
+        }
         serverInetAddr = InetAddress.getByName(serverName);
     }
 }

--- a/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/TunnelProxy.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/TunnelProxy.java
@@ -96,8 +96,29 @@ public class TunnelProxy {
 
     public TunnelProxy (int threads, int cperthread, int port)
         throws IOException {
+        this(threads, cperthread, null, 0);
+    }
+
+    /**
+     * Create a <code>TunnelProxy<code> instance with the specified number
+     * of threads and maximum number of connections per thread and running on
+     * the specified port. The specified number of threads are created to
+     * handle incoming requests, and each thread is allowed
+     * to handle a number of simultaneous TCP connections.
+     * @param cb the callback object which is invoked to handle
+     *  each incoming request
+     * @param threads the number of threads to create to handle
+     *  requests in parallel
+     * @param cperthread the number of simultaneous TCP connections
+     *  to handle per thread
+     * @param address the address to bind to. null means all addresses.
+     * @param port the port number to bind the server to. <code>Zero</code>
+     *  means choose any free port.
+     */
+    public TunnelProxy (int threads, int cperthread, InetAddress address, int port)
+        throws IOException {
         schan = ServerSocketChannel.open ();
-        InetSocketAddress addr = new InetSocketAddress (port);
+        InetSocketAddress addr = new InetSocketAddress (address, port);
         schan.socket().bind (addr);
         this.threads = threads;
         this.cperthread = cperthread;


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

test/jdk/com/sun/net/httpserver/bugs/8199849/BasicAuthenticatorCharset.java
This test was only added in 14 by "8199849 Add support for UTF-8 encoded credentials in HTTP Basic Authentication". Skipped.

PortUnreachable.java depends on part 3. As that change of this series is hard to backport,
I just include the respective parts in this change. See extra commit. They apply clean.

test/jdk/sun/net/www/protocol/https/HttpsURLConnection/B6216082.java
Backport of later "8268464: Remove dependancy of TestHttpsServer, HttpTransaction, HttpC..." makes these
changes pointless. Skipped.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8230435](https://bugs.openjdk.org/browse/JDK-8230435) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8230435](https://bugs.openjdk.org/browse/JDK-8230435): Replace wildcard address with loopback or local host in tests - part 22 (**Sub-task** - P3 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2252/head:pull/2252` \
`$ git checkout pull/2252`

Update a local copy of the PR: \
`$ git checkout pull/2252` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2252`

View PR using the GUI difftool: \
`$ git pr show -t 2252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2252.diff">https://git.openjdk.org/jdk11u-dev/pull/2252.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2252#issuecomment-1794811877)