### PR TITLE
8232135: Add diagnostic output to test java/util/ProcessBuilder/Basic.java

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -2188,6 +2188,19 @@ public class Basic {
                                 case 2: r = s.read(bytes); break;
                                 default: throw new Error();
                             }
+                            if (r >= 0) {
+                                // The child sent unexpected output; print it to diagnose
+                                System.out.println("Unexpected child output:");
+                                if ((action & 0x2) == 0) {
+                                    System.out.write(r);    // Single character
+
+                                } else {
+                                    System.out.write(bytes, 0, r);
+                                }
+                                for (int c = s.read(); c >= 0; c = s.read())
+                                    System.out.write(c);
+                                System.out.println("\nEND Child output.");
+                            }
                             equal(-1, r);
                         } catch (IOException ioe) {
                             if (!ioe.getMessage().equals("Stream closed")) {


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8232135](https://bugs.openjdk.org/browse/JDK-8232135) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8232135](https://bugs.openjdk.org/browse/JDK-8232135): Add diagnostic output to test java/util/ProcessBuilder/Basic.java (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2253/head:pull/2253` \
`$ git checkout pull/2253`

Update a local copy of the PR: \
`$ git checkout pull/2253` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2253`

View PR using the GUI difftool: \
`$ git pr show -t 2253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2253.diff">https://git.openjdk.org/jdk11u-dev/pull/2253.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2253#issuecomment-1795021971)