### PR TITLE
6381945: (cal) Japanese calendar unit test system should avoid multiple static imports

### DIFF
--- a/test/jdk/java/util/Calendar/CalendarTestScripts/Symbol.java
+++ b/test/jdk/java/util/Calendar/CalendarTestScripts/Symbol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import static java.util.Calendar.*;
 import static java.util.GregorianCalendar.*;
 
 public class Symbol {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [f79b3d42](https://github.com/openjdk/jdk/commit/f79b3d42f07b703f0e3b9fc67c92dee260b0e602) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Justin Lu on 9 Jan 2023 and was reviewed by Lance Andersen, Iris Clark and Naoto Sato.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-6381945](https://bugs.openjdk.org/browse/JDK-6381945) needs maintainer approval

### Issue
 * [JDK-6381945](https://bugs.openjdk.org/browse/JDK-6381945): (cal) Japanese calendar unit test system should avoid multiple static imports (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2256/head:pull/2256` \
`$ git checkout pull/2256`

Update a local copy of the PR: \
`$ git checkout pull/2256` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2256`

View PR using the GUI difftool: \
`$ git pr show -t 2256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2256.diff">https://git.openjdk.org/jdk11u-dev/pull/2256.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2256#issuecomment-1795518593)