### PR TITLE
8211045: [Testbug] Fix for 8144279 didn't define a test case!

### DIFF
--- a/test/hotspot/jtreg/runtime/jsig/Testjsig.java
+++ b/test/hotspot/jtreg/runtime/jsig/Testjsig.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test Testjsig.java
+ * @bug 8017498
+ * @bug 8020791
+ * @bug 8021296
+ * @bug 8022301
+ * @bug 8025519
+ * @summary sigaction(sig) results in process hang/timed-out if sig is much greater than SIGRTMAX
+ * @requires (os.family == "linux")
+ * @library /test/lib
+ * @compile TestJNI.java
+ * @run driver Testjsig
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class Testjsig {
+
+    public static void main(String[] args) throws Throwable {
+
+        // Get the JDK, library and class path properties
+        String libpath = System.getProperty("java.library.path");
+
+        // Create a new java process for the TestJNI Java/JNI test
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-Djava.library.path=" + libpath + ":.",
+            "TestJNI",
+            "100");
+
+        // Start the process and check the output
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldContain("old handler");
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [bc6fb26d](https://github.com/openjdk/jdk/commit/bc6fb26d02791f1f8ed9d60a0535d2066dbb3601) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by David Holmes on 24 Sep 2018 and was reviewed by Aleksey Shipilev and Severin Gehwolf.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8211045](https://bugs.openjdk.org/browse/JDK-8211045) needs maintainer approval

### Issue
 * [JDK-8211045](https://bugs.openjdk.org/browse/JDK-8211045): [Testbug] Fix for 8144279 didn't define a test case! (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2259/head:pull/2259` \
`$ git checkout pull/2259`

Update a local copy of the PR: \
`$ git checkout pull/2259` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2259`

View PR using the GUI difftool: \
`$ git pr show -t 2259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2259.diff">https://git.openjdk.org/jdk11u-dev/pull/2259.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2259#issuecomment-1795800677)