### PR TITLE
8185531: [TESTBUG] Improve test configuration for shared strings

### DIFF
--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/ExerciseGC.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/ExerciseGC.java
@@ -33,6 +33,8 @@
  * @build HelloStringGC sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main ExerciseGC
+ * @run main/othervm -XX:+UseStringDeduplication ExerciseGC
+ * @run main/othervm -XX:-CompactStrings ExerciseGC
  */
 public class ExerciseGC {
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/IncompatibleOptions.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/IncompatibleOptions.java
@@ -36,6 +36,8 @@
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox sun.hotspot.WhiteBox$WhiteBoxPermission
  * @build HelloString
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. IncompatibleOptions
+ * @run main/othervm -XX:+UseStringDeduplication -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. IncompatibleOptions
+ * @run main/othervm -XX:-CompactStrings -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. IncompatibleOptions
  */
 
 import jdk.test.lib.Asserts;

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/InternSharedString.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/InternSharedString.java
@@ -34,6 +34,8 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main InternSharedString
+ * @run main/othervm -XX:+UseStringDeduplication InternSharedString
+ * @run main/othervm -XX:-CompactStrings InternSharedString
  */
 
 public class InternSharedString {

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/InvalidFileFormat.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/InvalidFileFormat.java
@@ -32,6 +32,8 @@
  *          jdk.jartool/sun.tools.jar
  * @build HelloString
  * @run main InvalidFileFormat
+ * @run main/othervm -XX:+UseStringDeduplication InvalidFileFormat
+ * @run main/othervm -XX:-CompactStrings InvalidFileFormat
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/LargePages.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/LargePages.java
@@ -32,6 +32,8 @@
  *          jdk.jartool/sun.tools.jar
  * @build HelloString
  * @run main LargePages
+ * @run main/othervm -XX:+UseStringDeduplication LargePages
+ * @run main/othervm -XX:-CompactStrings LargePages
  */
 public class LargePages {
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/LockSharedStrings.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/LockSharedStrings.java
@@ -34,6 +34,8 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main LockSharedStrings
+ * @run main/othervm -XX:+UseStringDeduplication LockSharedStrings
+ * @run main/othervm -XX:-CompactStrings LockSharedStrings
  */
 
 public class LockSharedStrings {

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasic.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasic.java
@@ -32,6 +32,8 @@
  *          jdk.jartool/sun.tools.jar
  * @build HelloString
  * @run main SharedStringsBasic
+ * @run main/othervm -XX:+UseStringDeduplication SharedStringsBasic
+ * @run main/othervm -XX:-CompactStrings SharedStringsBasic
  */
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasicPlus.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasicPlus.java
@@ -33,6 +33,8 @@
  * @build HelloStringPlus sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main SharedStringsBasicPlus
+ * @run main/othervm -XX:+UseStringDeduplication SharedStringsBasicPlus
+ * @run main/othervm -XX:-CompactStrings SharedStringsBasicPlus
  */
 
 public class SharedStringsBasicPlus {

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsStress.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsStress.java
@@ -30,6 +30,8 @@
  * @modules jdk.jartool/sun.tools.jar
  * @build HelloString
  * @run main SharedStringsStress
+ * @run main/othervm -XX:+UseStringDeduplication SharedStringsStress
+ * @run main/othervm -XX:-CompactStrings SharedStringsStress
  */
 import java.io.File;
 import java.io.FileOutputStream;

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsWbTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsWbTest.java
@@ -33,6 +33,8 @@
  * @build sun.hotspot.WhiteBox SharedStringsWb
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @run main SharedStringsWbTest
+ * @run main/othervm -XX:+UseStringDeduplication SharedStringsWbTest
+ * @run main/othervm -XX:-CompactStrings SharedStringsWbTest
  */
 
 import java.io.*;

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SysDictCrash.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SysDictCrash.java
@@ -32,6 +32,8 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.management
  * @run main SysDictCrash
+ * @run main/othervm -XX:+UseStringDeduplication SysDictCrash
+ * @run main/othervm -XX:-CompactStrings SysDictCrash
  */
 
 import jdk.test.lib.process.OutputAnalyzer;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [8a5467b9](https://github.com/openjdk/jdk/commit/8a5467b9c22f80a22aa12d45694e8432e6c6e47d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Mikhailo Seledtsov on 2 Aug 2018 and was reviewed by Ioi Lam and Gerard Ziemski.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8185531](https://bugs.openjdk.org/browse/JDK-8185531) needs maintainer approval

### Issue
 * [JDK-8185531](https://bugs.openjdk.org/browse/JDK-8185531): [TESTBUG] Improve test configuration for shared strings (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2260/head:pull/2260` \
`$ git checkout pull/2260`

Update a local copy of the PR: \
`$ git checkout pull/2260` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2260`

View PR using the GUI difftool: \
`$ git pr show -t 2260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2260.diff">https://git.openjdk.org/jdk11u-dev/pull/2260.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2260#issuecomment-1795847671)