### PR TITLE
8210265: Crash in HSpaceCounters::update_used()

### DIFF
--- a/test/hotspot/jtreg/gc/TestNoPerfCounter.java
+++ b/test/hotspot/jtreg/gc/TestNoPerfCounter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test TestNoPerfCounter
+ * @bug 8210265
+ * @requires vm.gc=="null"
+ * @library /test/lib /
+ * @summary Tests that disabling perf counters does not crash the VM
+ * @run main/othervm -XX:-UsePerfData TestNoPerfCounter
+ */
+
+public class TestNoPerfCounter {
+    public static void main(String[] args) throws Exception {
+        // Nothing to do
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
'_from_space_counters->update_used(0);' is backported by JDK-8209062, so no need to backport this file

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8210265](https://bugs.openjdk.org/browse/JDK-8210265) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210265](https://bugs.openjdk.org/browse/JDK-8210265): Crash in HSpaceCounters::update_used() (**Bug** - P2 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2263/head:pull/2263` \
`$ git checkout pull/2263`

Update a local copy of the PR: \
`$ git checkout pull/2263` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2263`

View PR using the GUI difftool: \
`$ git pr show -t 2263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2263.diff">https://git.openjdk.org/jdk11u-dev/pull/2263.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2263#issuecomment-1797872394)