### PR TITLE
8275329: ZGC: vmTestbase/gc/gctests/SoftReference/soft004/soft004.java fails with assert(_phases->length() <= 1000) failed: Too many recored phases?

### DIFF
--- a/src/hotspot/share/gc/shared/gcTimer.cpp
+++ b/src/hotspot/share/gc/shared/gcTimer.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "gc/shared/gcTimer.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "utilities/growableArray.hpp"
 
 // the "time" parameter for most functions
@@ -129,7 +130,7 @@ void TimePartitions::clear() {
 }
 
 void TimePartitions::report_gc_phase_start(const char* name, const Ticks& time, GCPhase::PhaseType type) {
-  assert(_phases->length() <= 1000, "Too many recored phases?");
+  assert(UseZGC || _phases->length() <= 1000, "Too many recorded phases? (count: %d)", _phases->length());
 
   int level = _active_phases.count();
 


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8275329](https://bugs.openjdk.org/browse/JDK-8275329) needs maintainer approval
- [ ] [JDK-8275333](https://bugs.openjdk.org/browse/JDK-8275333) needs maintainer approval

### Issues
 * [JDK-8275329](https://bugs.openjdk.org/browse/JDK-8275329): ZGC: vmTestbase/gc/gctests/SoftReference/soft004/soft004.java fails with assert(_phases-&gt;length() &lt;= 1000) failed: Too many recored phases? (**Bug** - P2)
 * [JDK-8275333](https://bugs.openjdk.org/browse/JDK-8275333): Print count in "Too many recored phases?" assert (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2266/head:pull/2266` \
`$ git checkout pull/2266`

Update a local copy of the PR: \
`$ git checkout pull/2266` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2266`

View PR using the GUI difftool: \
`$ git pr show -t 2266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2266.diff">https://git.openjdk.org/jdk11u-dev/pull/2266.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2266#issuecomment-1797977201)