### PR TITLE
8230858: Replace wildcard address with loopback or local host in tests - part 23

### DIFF
--- a/test/jdk/java/net/CookieHandler/CookieManagerTest.java
+++ b/test/jdk/java/net/CookieHandler/CookieManagerTest.java
@@ -26,13 +26,16 @@
  * @summary Unit test for java.net.CookieManager
  * @bug 6244040 7150552 7051862
  * @modules jdk.httpserver
- * @run main/othervm -ea CookieManagerTest
+ *          java.logging
+ * @run main/othervm -ea -esa CookieManagerTest
  * @author Edward Wang
  */
 
 import com.sun.net.httpserver.*;
 import java.io.IOException;
 import java.net.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import static java.net.Proxy.NO_PROXY;
 
 public class CookieManagerTest {
@@ -59,6 +62,11 @@ public class CookieManagerTest {
     }
 
     public static void main(String[] args) throws Exception {
+        // logs everything...
+        Logger root = Logger.getLogger("");
+        root.setLevel(Level.ALL);
+        root.getHandlers()[0].setLevel(Level.ALL);
+
         startHttpServer();
         makeHttpCall();
 

--- a/test/jdk/java/net/Socket/HttpProxy.java
+++ b/test/jdk/java/net/Socket/HttpProxy.java
@@ -132,6 +132,7 @@ public class HttpProxy {
             public void run() {
                 try { simpleWrite(os, start); }
                 catch (Exception e) {unexpected(e); }
+                finally { out.println(threadName + ": done"); }
             }}, threadName)).start();
     }
 
@@ -142,6 +143,7 @@ public class HttpProxy {
             b[1] = (byte) (i % 256);
             os.write(b);
         }
+        out.println("Wrote " + start + " -> " + (start + 100));
     }
 
     void simpleRead(InputStream is, int start) throws Exception {
@@ -156,6 +158,7 @@ public class HttpProxy {
             if (r != i)
                 throw new Exception("read " + r + " expected " +i);
         }
+        out.println("Read " + start + " -> " + (start + 100));
     }
 
     int bytes(byte b1, byte b2) {
@@ -207,6 +210,7 @@ public class HttpProxy {
 
             // retrieve the host and port info from the status-line
             InetSocketAddress serverAddr = getConnectInfo(statusLine);
+            out.println("Proxy serving CONNECT request to " + serverAddr);
 
             //open socket to the server
             try (Socket serverSocket = new Socket(serverAddr.getAddress(),

--- a/test/jdk/java/net/Socket/NullHost.java
+++ b/test/jdk/java/net/Socket/NullHost.java
@@ -46,8 +46,10 @@ public class NullHost {
             return svr.getLocalPort();
         }
 
+        volatile boolean done;
         public void shutdown() {
             try {
+                done = true;
                 svr.close();
             } catch (IOException e) {
             }
@@ -56,11 +58,12 @@ public class NullHost {
         public void run() {
             Socket s;
             try {
-                while (true) {
+                while (!done) {
                     s = svr.accept();
                     s.close();
                 }
             } catch (IOException e) {
+                if (!done) e.printStackTrace();
             }
         }
     }
@@ -74,13 +77,9 @@ public class NullHost {
         int port = s.getPort();
         s.start();
         try {
-            Socket sock = new Socket((String)null, port);
-            sock.close();
-            sock = new Socket((String)null, port, true);
-            sock.close();
-            sock = new Socket((String)null, port, null, 0);
-            sock.close();
-
+            try (var sock = new Socket((String)null, port)) {}
+            try (var sock = new Socket((String)null, port, true)) {}
+            try (var sock = new Socket((String)null, port, null, 0)) {}
         } catch (NullPointerException e) {
             throw new RuntimeException("Got a NPE");
         } finally {

--- a/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public class B5045306
     public static void startHttpServer() {
         try {
             httpTrans = new SimpleHttpTransaction();
-            server = new TestHttpServer(httpTrans, 1, 10, 0);
+            server = new TestHttpServer(httpTrans, 1, 10, InetAddress.getLocalHost(), 0);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -71,13 +71,14 @@ public class B5045306
     public static void clientHttpCalls() {
         try {
             System.out.println("http server listen on: " + server.getLocalPort());
-            String baseURLStr = "http://" + InetAddress.getLocalHost().getHostAddress() + ":" +
-                                  server.getLocalPort() + "/";
+            String hostAddr =  InetAddress.getLocalHost().getHostAddress();
+            if (hostAddr.indexOf(':') > -1) hostAddr = "[" + hostAddr + "]";
+            String baseURLStr = "http://" + hostAddr + ":" + server.getLocalPort() + "/";
 
             URL bigDataURL = new URL (baseURLStr + "firstCall");
             URL smallDataURL = new URL (baseURLStr + "secondCall");
 
-            HttpURLConnection uc = (HttpURLConnection)bigDataURL.openConnection();
+            HttpURLConnection uc = (HttpURLConnection)bigDataURL.openConnection(Proxy.NO_PROXY);
 
             //Only read 1 byte of response data and close the stream
             InputStream is = uc.getInputStream();
@@ -88,7 +89,7 @@ public class B5045306
             // Allow the KeepAliveStreamCleaner thread to read the data left behind and cache the connection.
             try { Thread.sleep(2000); } catch (Exception e) {}
 
-            uc = (HttpURLConnection)smallDataURL.openConnection();
+            uc = (HttpURLConnection)smallDataURL.openConnection(Proxy.NO_PROXY);
             uc.getResponseCode();
 
             if (SimpleHttpTransaction.failed)
@@ -96,7 +97,7 @@ public class B5045306
 
             // Part 2
             URL part2Url = new URL (baseURLStr + "part2");
-            uc = (HttpURLConnection)part2Url.openConnection();
+            uc = (HttpURLConnection)part2Url.openConnection(Proxy.NO_PROXY);
             is = uc.getInputStream();
             is.close();
 

--- a/test/jdk/sun/net/www/protocol/https/HttpsClient/ServerIdentityTest.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsClient/ServerIdentityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,10 @@ import java.io.InputStream;
 import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.Proxy;
 import java.net.URL;
+import java.net.UnknownHostException;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -62,6 +65,10 @@ public final class ServerIdentityTest extends SSLSocketTemplate {
         initialize(args);
 
         (new ServerIdentityTest()).run();
+    }
+
+    ServerIdentityTest() throws UnknownHostException {
+        serverAddress = InetAddress.getByName(hostname);
     }
 
     @Override
@@ -88,7 +95,7 @@ public final class ServerIdentityTest extends SSLSocketTemplate {
         HttpURLConnection urlc = null;
         InputStream is = null;
         try {
-            urlc = (HttpURLConnection)url.openConnection();
+            urlc = (HttpURLConnection)url.openConnection(Proxy.NO_PROXY);
             is = urlc.getInputStream();
         } finally {
             if (is != null) {

--- a/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/DNSIdentities.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/DNSIdentities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -651,8 +651,13 @@ public class DNSIdentities {
             serverModulus, serverPrivateExponent, passphrase);
         SSLServerSocketFactory sslssf = context.getServerSocketFactory();
 
+        // doClientSide() connects to "localhost"
+        InetAddress localHost = InetAddress.getByName("localhost");
+        InetSocketAddress address = new InetSocketAddress(localHost, serverPort);
+
         sslServerSocket =
-            (SSLServerSocket) sslssf.createServerSocket(serverPort);
+            (SSLServerSocket) sslssf.createServerSocket();
+        sslServerSocket.bind(address);
         serverPort = sslServerSocket.getLocalPort();
 
         /*
@@ -717,7 +722,7 @@ public class DNSIdentities {
             System.out.println("url is "+url.toString());
 
             try {
-                http = (HttpsURLConnection)url.openConnection();
+                http = (HttpsURLConnection)url.openConnection(Proxy.NO_PROXY);
 
                 int respCode = http.getResponseCode();
                 System.out.println("respCode = "+respCode);

--- a/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/IPAddressDNSIdentities.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/IPAddressDNSIdentities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -650,8 +650,13 @@ public class IPAddressDNSIdentities {
             serverModulus, serverPrivateExponent, passphrase);
         SSLServerSocketFactory sslssf = context.getServerSocketFactory();
 
+        // doClientSide() connects to the loopback address
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        InetSocketAddress address = new InetSocketAddress(loopback, serverPort);
+
         sslServerSocket =
-            (SSLServerSocket) sslssf.createServerSocket(serverPort);
+            (SSLServerSocket) sslssf.createServerSocket();
+        sslServerSocket.bind(address);
         serverPort = sslServerSocket.getLocalPort();
 
         /*
@@ -721,7 +726,7 @@ public class IPAddressDNSIdentities {
             System.out.println("url is "+url.toString());
 
             try {
-                http = (HttpsURLConnection)url.openConnection();
+                http = (HttpsURLConnection)url.openConnection(Proxy.NO_PROXY);
 
                 int respCode = http.getResponseCode();
                 System.out.println("respCode = " + respCode);

--- a/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/IPAddressIPIdentities.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/IPAddressIPIdentities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -654,8 +654,13 @@ public class IPAddressIPIdentities {
             serverModulus, serverPrivateExponent, passphrase);
         SSLServerSocketFactory sslssf = context.getServerSocketFactory();
 
+        // doClientSide() connects to the loopback address
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        InetSocketAddress address = new InetSocketAddress(loopback, serverPort);
+
         sslServerSocket =
-            (SSLServerSocket) sslssf.createServerSocket(serverPort);
+            (SSLServerSocket) sslssf.createServerSocket();
+        sslServerSocket.bind(address);
         serverPort = sslServerSocket.getLocalPort();
 
         /*
@@ -725,7 +730,7 @@ public class IPAddressIPIdentities {
             System.out.println("url is "+url.toString());
 
             try {
-                http = (HttpsURLConnection)url.openConnection();
+                http = (HttpsURLConnection)url.openConnection(Proxy.NO_PROXY);
 
                 int respCode = http.getResponseCode();
                 System.out.println("respCode = "+respCode);

--- a/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/Identities.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/Identities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -651,8 +651,13 @@ public class Identities {
             serverModulus, serverPrivateExponent, passphrase);
         SSLServerSocketFactory sslssf = context.getServerSocketFactory();
 
+        // doClientSide() connects to "localhost"
+        InetAddress localHost = InetAddress.getByName("localhost");
+        InetSocketAddress address = new InetSocketAddress(localHost, serverPort);
+
         sslServerSocket =
-            (SSLServerSocket) sslssf.createServerSocket(serverPort);
+            (SSLServerSocket) sslssf.createServerSocket();
+        sslServerSocket.bind(address);
         serverPort = sslServerSocket.getLocalPort();
 
         /*
@@ -717,7 +722,7 @@ public class Identities {
             System.out.println("url is "+url.toString());
 
             try {
-                http = (HttpsURLConnection)url.openConnection();
+                http = (HttpsURLConnection)url.openConnection(Proxy.NO_PROXY);
 
                 int respCode = http.getResponseCode();
                 System.out.println("respCode = "+respCode);

--- a/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsURLConnection/ImpactOnSNI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,6 +95,16 @@ public class ImpactOnSNI {
      * smart about it....
      */
 
+    private SSLServerSocket createServerSocket(SSLServerSocketFactory sslssf)
+        throws Exception {
+        SSLServerSocket sslServerSocket =
+            (SSLServerSocket)sslssf.createServerSocket();
+        InetAddress localHost = InetAddress.getLocalHost();
+        InetSocketAddress address = new InetSocketAddress(localHost, serverPort);
+        sslServerSocket.bind(address);
+        return sslServerSocket;
+    }
+
     /*
      * Define the server side of the test.
      *
@@ -104,8 +114,7 @@ public class ImpactOnSNI {
     private void doServerSide() throws Exception {
         SSLServerSocketFactory sslssf =
             (SSLServerSocketFactory)SSLServerSocketFactory.getDefault();
-        try (SSLServerSocket sslServerSocket =
-                (SSLServerSocket)sslssf.createServerSocket(serverPort)) {
+        try (SSLServerSocket sslServerSocket = createServerSocket(sslssf)) {
 
             serverPort = sslServerSocket.getLocalPort();
 

--- a/test/jdk/sun/net/www/protocol/https/NewImpl/JavaxHostnameVerifier.java
+++ b/test/jdk/sun/net/www/protocol/https/NewImpl/JavaxHostnameVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,8 +135,14 @@ public class JavaxHostnameVerifier {
 
         SSLServerSocketFactory sslssf =
           (SSLServerSocketFactory) SSLServerSocketFactory.getDefault();
+
+        // doClientSide() connects to "localhost"
+        InetAddress localHost = InetAddress.getByName("localhost");
+        InetSocketAddress address = new InetSocketAddress(localHost, serverPort);
+
         SSLServerSocket sslServerSocket =
-            (SSLServerSocket) sslssf.createServerSocket(serverPort);
+            (SSLServerSocket) sslssf.createServerSocket();
+        sslServerSocket.bind(address);
         serverPort = sslServerSocket.getLocalPort();
 
         String ciphers[]= { "SSL_DH_anon_WITH_3DES_EDE_CBC_SHA" };
@@ -205,7 +211,7 @@ public class JavaxHostnameVerifier {
 
         URL url = new URL("https://" + "localhost:" + serverPort +
                                 "/etc/hosts");
-        URLConnection urlc = url.openConnection();
+        URLConnection urlc = url.openConnection(Proxy.NO_PROXY);
 
         if (!(urlc instanceof javax.net.ssl.HttpsURLConnection)) {
             throw new Exception(

--- a/test/jdk/sun/net/www/protocol/jar/B4957695.java
+++ b/test/jdk/sun/net/www/protocol/jar/B4957695.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,10 @@ public class B4957695 {
     public static void main (String[] args) throws Exception {
         String tmpdir = System.getProperty("java.io.tmpdir");
         String[] list1 = listTmpFiles(tmpdir);
-        ServerSocket serverSocket = new ServerSocket(0);
+        InetAddress localHost = InetAddress.getByName("localhost");
+        InetSocketAddress address = new InetSocketAddress(localHost, 0);
+        ServerSocket serverSocket = new ServerSocket();
+        serverSocket.bind(address);
         server = new Server(serverSocket);
         server.start();
         int port = serverSocket.getLocalPort();
@@ -108,7 +111,9 @@ public class B4957695 {
             read (is);
             is.close();
         } catch (IOException e) {
-            System.out.println ("Received IOException as expected");
+            System.out.println ("Received IOException as expected: " + e);
+        } finally {
+            try {serverSocket.close();} catch (IOException x) {}
         }
         String[] list2 = listTmpFiles(tmpdir);
         if (!sameList (list1, list2)) {


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8230858](https://bugs.openjdk.org/browse/JDK-8230858) needs maintainer approval

### Issue
 * [JDK-8230858](https://bugs.openjdk.org/browse/JDK-8230858): Replace wildcard address with loopback or local host in tests - part 23 (**Sub-task** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2269/head:pull/2269` \
`$ git checkout pull/2269`

Update a local copy of the PR: \
`$ git checkout pull/2269` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2269`

View PR using the GUI difftool: \
`$ git pr show -t 2269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2269.diff">https://git.openjdk.org/jdk11u-dev/pull/2269.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2269#issuecomment-1798300364)