### PR TITLE
8292683: Remove BadKeyUsageTest.java from Problem List

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -612,8 +612,6 @@ sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8161536 generic-
 
 sun/security/tools/keytool/ListKeychainStore.sh                 8156889 macosx-all
 
-sun/security/tools/jarsigner/warnings/BadKeyUsageTest.java      8026393 generic-all
-
 javax/net/ssl/DTLS/PacketLossRetransmission.java                8169086 macosx-x64
 javax/net/ssl/DTLS/RespondToRetransmit.java                     8169086 macosx-all
 javax/net/ssl/DTLS/CipherSuite.java                             8202059 macosx-x64


### PR DESCRIPTION
I backport this for parity with 11.0.21-oracle.

I had to resolve ProblemList, probably recognized clean, else will mark as such.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8292683](https://bugs.openjdk.org/browse/JDK-8292683) needs maintainer approval

### Issue
 * [JDK-8292683](https://bugs.openjdk.org/browse/JDK-8292683): Remove BadKeyUsageTest.java from Problem List (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2270/head:pull/2270` \
`$ git checkout pull/2270`

Update a local copy of the PR: \
`$ git checkout pull/2270` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2270`

View PR using the GUI difftool: \
`$ git pr show -t 2270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2270.diff">https://git.openjdk.org/jdk11u-dev/pull/2270.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2270#issuecomment-1798322337)