### PR TITLE
8231556: Wrong font ligatures used when 2 versions of same font used

### DIFF
--- a/src/java.desktop/share/classes/sun/font/PhysicalFont.java
+++ b/src/java.desktop/share/classes/sun/font/PhysicalFont.java
@@ -41,12 +41,19 @@ public abstract class PhysicalFont extends Font2D {
     protected Object nativeNames;
 
     public boolean equals(Object o) {
-        return (o != null && o.getClass() == this.getClass() &&
-                ((Font2D)o).fullName.equals(this.fullName));
+        if (o == null || o.getClass() != this.getClass()) {
+            return false;
+        }
+        PhysicalFont other = (PhysicalFont)o;
+        return
+           (this.fullName.equals(other.fullName)) &&
+            ((this.platName == null && other.platName == null) ||
+             (this.platName != null && this.platName.equals(other.platName)));
     }
 
     public int hashCode() {
-        return fullName.hashCode();
+        return fullName.hashCode() +
+               (platName != null ? platName.hashCode() : 0);
     }
 
     /**


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d86eb1de](https://github.com/openjdk/jdk/commit/d86eb1de69c2f5e3e9388c61ed6c5d928dc17d20) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Phil Race on 19 Dec 2019 and was reviewed by Sergey Bylokhov and Kevin Rushforth.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8231556](https://bugs.openjdk.org/browse/JDK-8231556) needs maintainer approval

### Issue
 * [JDK-8231556](https://bugs.openjdk.org/browse/JDK-8231556): Wrong font ligatures used when 2 versions of same font used (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2271/head:pull/2271` \
`$ git checkout pull/2271`

Update a local copy of the PR: \
`$ git checkout pull/2271` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2271`

View PR using the GUI difftool: \
`$ git pr show -t 2271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2271.diff">https://git.openjdk.org/jdk11u-dev/pull/2271.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2271#issuecomment-1799305079)