### PR TITLE
8258914: javax/net/ssl/DTLS/RespondToRetransmit.java timed out

### DIFF
--- a/test/jdk/javax/net/ssl/DTLS/RespondToRetransmit.java
+++ b/test/jdk/javax/net/ssl/DTLS/RespondToRetransmit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,8 @@
 
 /*
  * @test
- * @bug 8161086
+ * @bug 8161086 8258914
+ * @key intermittent
  * @summary DTLS handshaking fails if some messages were lost
  * @modules java.base/sun.security.util
  * @library /test/lib


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8258914](https://bugs.openjdk.org/browse/JDK-8258914) needs maintainer approval

### Issue
 * [JDK-8258914](https://bugs.openjdk.org/browse/JDK-8258914): javax/net/ssl/DTLS/RespondToRetransmit.java timed out (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2277/head:pull/2277` \
`$ git checkout pull/2277`

Update a local copy of the PR: \
`$ git checkout pull/2277` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2277`

View PR using the GUI difftool: \
`$ git pr show -t 2277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2277.diff">https://git.openjdk.org/jdk11u-dev/pull/2277.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2277#issuecomment-1805300425)