### PR TITLE
8207200: Committed > max memory usage when getting MemoryUsage

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1133,7 +1133,7 @@ bool G1CollectedHeap::do_full_collection(bool explicit_gc,
   const bool do_clear_all_soft_refs = clear_all_soft_refs ||
       soft_ref_policy()->should_clear_all_soft_refs();
 
-  G1FullCollector collector(this, &_full_gc_memory_manager, explicit_gc, do_clear_all_soft_refs);
+  G1FullCollector collector(this, explicit_gc, do_clear_all_soft_refs);
   GCTraceTime(Info, gc) tm("Pause Full", NULL, gc_cause(), true);
 
   collector.prepare_collection();
@@ -1421,11 +1421,6 @@ G1CollectedHeap::G1CollectedHeap(G1CollectorPolicy* collector_policy) :
   _collector_policy(collector_policy),
   _soft_ref_policy(),
   _card_table(NULL),
-  _memory_manager("G1 Young Generation", "end of minor GC"),
-  _full_gc_memory_manager("G1 Old Generation", "end of major GC"),
-  _eden_pool(NULL),
-  _survivor_pool(NULL),
-  _old_pool(NULL),
   _gc_timer_stw(new (ResourceObj::C_HEAP, mtGC) STWGCTimer()),
   _gc_tracer_stw(new (ResourceObj::C_HEAP, mtGC) G1NewTracer()),
   _g1_policy(new G1Policy(_gc_timer_stw)),
@@ -1732,20 +1727,6 @@ jint G1CollectedHeap::initialize() {
   _collection_set.initialize(max_regions());
 
   return JNI_OK;
-}
-
-void G1CollectedHeap::initialize_serviceability() {
-  _eden_pool = new G1EdenPool(this);
-  _survivor_pool = new G1SurvivorPool(this);
-  _old_pool = new G1OldGenPool(this);
-
-  _full_gc_memory_manager.add_pool(_eden_pool);
-  _full_gc_memory_manager.add_pool(_survivor_pool);
-  _full_gc_memory_manager.add_pool(_old_pool);
-
-  _memory_manager.add_pool(_eden_pool);
-  _memory_manager.add_pool(_survivor_pool);
-  _memory_manager.add_pool(_old_pool, false /* always_affected_by_gc */);
 }
 
 void G1CollectedHeap::stop() {
@@ -2877,9 +2858,9 @@ G1CollectedHeap::do_collection_pause_at_safepoint(double target_pause_time_ms) {
     active_workers = workers()->update_active_workers(active_workers);
     log_info(gc,task)("Using %u workers of %u for evacuation", active_workers, workers()->total_workers());
 
-    TraceCollectorStats tcs(g1mm()->incremental_collection_counters());
-    TraceMemoryManagerStats tms(&_memory_manager, gc_cause(),
-                                collector_state()->yc_type() == Mixed /* allMemoryPoolsAffected */);
+    G1MonitoringScope ms(g1mm(),
+                         false /* full_gc */,
+                         collector_state()->yc_type() == Mixed /* all_memory_pools_affected */);
 
     G1HeapTransition heap_transition(this);
     size_t heap_used_bytes_before_gc = used();
@@ -4876,7 +4857,7 @@ void G1CollectedHeap::retire_mutator_alloc_region(HeapRegion* alloc_region,
   _hr_printer.retire(alloc_region);
   // We update the eden sizes here, when the region is retired,
   // instead of when it's allocated, since this is the point that its
-  // used space has been recored in _summary_bytes_used.
+  // used space has been recorded in _summary_bytes_used.
   g1mm()->update_eden_size();
 }
 
@@ -5052,17 +5033,18 @@ void G1CollectedHeap::rebuild_strong_code_roots() {
   CodeCache::blobs_do(&blob_cl);
 }
 
+void G1CollectedHeap::initialize_serviceability() {
+  _g1mm->initialize_serviceability();
+}
+
+MemoryUsage G1CollectedHeap::memory_usage() {
+  return _g1mm->memory_usage();
+}
+
 GrowableArray<GCMemoryManager*> G1CollectedHeap::memory_managers() {
-  GrowableArray<GCMemoryManager*> memory_managers(2);
-  memory_managers.append(&_memory_manager);
-  memory_managers.append(&_full_gc_memory_manager);
-  return memory_managers;
+  return _g1mm->memory_managers();
 }
 
 GrowableArray<MemoryPool*> G1CollectedHeap::memory_pools() {
-  GrowableArray<MemoryPool*> memory_pools(3);
-  memory_pools.append(_eden_pool);
-  memory_pools.append(_survivor_pool);
-  memory_pools.append(_old_pool);
-  return memory_pools;
+  return _g1mm->memory_pools();
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -51,7 +51,6 @@
 #include "gc/shared/preservedMarks.hpp"
 #include "gc/shared/softRefPolicy.hpp"
 #include "memory/memRegion.hpp"
-#include "services/memoryManager.hpp"
 #include "utilities/stack.hpp"
 
 // A "G1CollectedHeap" is an implementation of a java heap for HotSpot.
@@ -67,6 +66,7 @@ class G1ParScanThreadState;
 class G1ParScanThreadStateSet;
 class G1ParScanThreadState;
 class MemoryPool;
+class MemoryManager;
 class ObjectClosure;
 class SpaceClosure;
 class CompactibleSpaceClosure;
@@ -160,13 +160,6 @@ private:
 
   SoftRefPolicy      _soft_ref_policy;
 
-  GCMemoryManager _memory_manager;
-  GCMemoryManager _full_gc_memory_manager;
-
-  MemoryPool* _eden_pool;
-  MemoryPool* _survivor_pool;
-  MemoryPool* _old_pool;
-
   static size_t _humongous_object_threshold_in_words;
 
   // It keeps track of the old regions.
@@ -174,8 +167,6 @@ private:
 
   // It keeps track of the humongous regions.
   HeapRegionSet _humongous_set;
-
-  virtual void initialize_serviceability();
 
   void eagerly_reclaim_humongous_regions();
   // Start a new incremental collection set for the next pause.
@@ -973,6 +964,8 @@ public:
 
   virtual SoftRefPolicy* soft_ref_policy();
 
+  virtual void initialize_serviceability();
+  virtual MemoryUsage memory_usage();
   virtual GrowableArray<GCMemoryManager*> memory_managers();
   virtual GrowableArray<MemoryPool*> memory_pools();
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -103,9 +103,9 @@ uint G1FullCollector::calc_active_workers() {
   return worker_count;
 }
 
-G1FullCollector::G1FullCollector(G1CollectedHeap* heap, GCMemoryManager* memory_manager, bool explicit_gc, bool clear_soft_refs) :
+G1FullCollector::G1FullCollector(G1CollectedHeap* heap, bool explicit_gc, bool clear_soft_refs) :
     _heap(heap),
-    _scope(memory_manager, explicit_gc, clear_soft_refs),
+    _scope(heap->g1mm(), explicit_gc, clear_soft_refs),
     _num_workers(calc_active_workers()),
     _oop_queue_set(_num_workers),
     _array_queue_set(_num_workers),

--- a/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -72,7 +72,7 @@ class G1FullCollector : StackObj {
   ReferenceProcessorSubjectToDiscoveryMutator _is_subject_mutator;
 
 public:
-  G1FullCollector(G1CollectedHeap* heap, GCMemoryManager* memory_manager, bool explicit_gc, bool clear_soft_refs);
+  G1FullCollector(G1CollectedHeap* heap, bool explicit_gc, bool clear_soft_refs);
   ~G1FullCollector();
 
   void prepare_collection();

--- a/src/hotspot/share/gc/g1/g1FullGCScope.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 #include "precompiled.hpp"
 #include "gc/g1/g1FullGCScope.hpp"
 
-G1FullGCScope::G1FullGCScope(GCMemoryManager* memory_manager, bool explicit_gc, bool clear_soft) :
+G1FullGCScope::G1FullGCScope(G1MonitoringSupport* monitoring_support, bool explicit_gc, bool clear_soft) :
     _rm(),
     _explicit_gc(explicit_gc),
     _g1h(G1CollectedHeap::heap()),
@@ -36,8 +36,7 @@ G1FullGCScope::G1FullGCScope(GCMemoryManager* memory_manager, bool explicit_gc, 
     _active(),
     _cpu_time(),
     _soft_refs(clear_soft, _g1h->soft_ref_policy()),
-    _memory_stats(memory_manager, _g1h->gc_cause()),
-    _collector_stats(_g1h->g1mm()->full_collection_counters()),
+    _monitoring_scope(monitoring_support, true /* full_gc */, true /* all_memory_pools_affected */),
     _heap_transition(_g1h) {
   _timer.register_gc_start();
   _tracer.report_gc_start(_g1h->gc_cause(), _timer.gc_start());

--- a/src/hotspot/share/gc/g1/g1FullGCScope.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@
 
 #include "gc/g1/g1CollectedHeap.hpp"
 #include "gc/g1/g1HeapTransition.hpp"
-#include "gc/shared/collectorCounters.hpp"
 #include "gc/shared/gcId.hpp"
 #include "gc/shared/gcTrace.hpp"
 #include "gc/shared/gcTraceTime.hpp"
@@ -51,12 +50,11 @@ class G1FullGCScope : public StackObj {
   IsGCActiveMark          _active;
   GCTraceCPUTime          _cpu_time;
   ClearedAllSoftRefs      _soft_refs;
-  TraceCollectorStats     _collector_stats;
-  TraceMemoryManagerStats _memory_stats;
+  G1MonitoringScope       _monitoring_scope;
   G1HeapTransition        _heap_transition;
 
 public:
-  G1FullGCScope(GCMemoryManager* memory_manager, bool explicit_gc, bool clear_soft);
+  G1FullGCScope(G1MonitoringSupport* monitoring_support, bool explicit_gc, bool clear_soft);
   ~G1FullGCScope();
 
   bool is_explicit_gc();

--- a/src/hotspot/share/gc/g1/g1MemoryPool.cpp
+++ b/src/hotspot/share/gc/g1/g1MemoryPool.cpp
@@ -39,50 +39,35 @@ G1MemoryPoolSuper::G1MemoryPoolSuper(G1CollectedHeap* g1h,
   assert(UseG1GC, "sanity");
 }
 
-G1EdenPool::G1EdenPool(G1CollectedHeap* g1h) :
+G1EdenPool::G1EdenPool(G1CollectedHeap* g1h, size_t initial_size) :
   G1MemoryPoolSuper(g1h,
                     "G1 Eden Space",
-                    g1h->g1mm()->eden_space_committed(), /* init_size */
-                    _undefined_max,
+                    initial_size,
+                    MemoryUsage::undefined_size(),
                     false /* support_usage_threshold */) { }
 
 MemoryUsage G1EdenPool::get_memory_usage() {
-  size_t initial_sz = initial_size();
-  size_t max_sz     = max_size();
-  size_t used       = used_in_bytes();
-  size_t committed  = _g1mm->eden_space_committed();
-
-  return MemoryUsage(initial_sz, used, committed, max_sz);
+  return _g1mm->eden_space_memory_usage(initial_size(), max_size());
 }
 
-G1SurvivorPool::G1SurvivorPool(G1CollectedHeap* g1h) :
+G1SurvivorPool::G1SurvivorPool(G1CollectedHeap* g1h, size_t initial_size) :
   G1MemoryPoolSuper(g1h,
                     "G1 Survivor Space",
-                    g1h->g1mm()->survivor_space_committed(), /* init_size */
-                    _undefined_max,
+                    initial_size,
+                    MemoryUsage::undefined_size(),
                     false /* support_usage_threshold */) { }
 
 MemoryUsage G1SurvivorPool::get_memory_usage() {
-  size_t initial_sz = initial_size();
-  size_t max_sz     = max_size();
-  size_t used       = used_in_bytes();
-  size_t committed  = _g1mm->survivor_space_committed();
-
-  return MemoryUsage(initial_sz, used, committed, max_sz);
+  return _g1mm->survivor_space_memory_usage(initial_size(), max_size());
 }
 
-G1OldGenPool::G1OldGenPool(G1CollectedHeap* g1h) :
+G1OldGenPool::G1OldGenPool(G1CollectedHeap* g1h, size_t initial_size, size_t max_size) :
   G1MemoryPoolSuper(g1h,
                     "G1 Old Gen",
-                    g1h->g1mm()->old_space_committed(), /* init_size */
-                    g1h->g1mm()->old_gen_max(),
+                    initial_size,
+                    max_size,
                     true /* support_usage_threshold */) { }
 
 MemoryUsage G1OldGenPool::get_memory_usage() {
-  size_t initial_sz = initial_size();
-  size_t max_sz     = max_size();
-  size_t used       = used_in_bytes();
-  size_t committed  = _g1mm->old_space_committed();
-
-  return MemoryUsage(initial_sz, used, committed, max_sz);
+  return _g1mm->old_gen_memory_usage(initial_size(), max_size());
 }

--- a/src/hotspot/share/gc/g1/g1MemoryPool.hpp
+++ b/src/hotspot/share/gc/g1/g1MemoryPool.hpp
@@ -53,7 +53,6 @@ class G1CollectedHeap;
 // (G1EdenPool, G1SurvivorPool, G1OldGenPool).
 class G1MemoryPoolSuper : public CollectedMemoryPool {
 protected:
-  const static size_t _undefined_max = (size_t) -1;
   G1MonitoringSupport* _g1mm;
 
   // Would only be called from subclasses.
@@ -67,42 +66,30 @@ protected:
 // Memory pool that represents the G1 eden.
 class G1EdenPool : public G1MemoryPoolSuper {
 public:
-  G1EdenPool(G1CollectedHeap* g1h);
+  G1EdenPool(G1CollectedHeap* g1h, size_t initial_size);
 
-  size_t used_in_bytes() {
-    return _g1mm->eden_space_used();
-  }
-  size_t max_size() const {
-    return _undefined_max;
-  }
+  size_t used_in_bytes() { return _g1mm->eden_space_used(); }
+
   MemoryUsage get_memory_usage();
 };
 
 // Memory pool that represents the G1 survivor.
 class G1SurvivorPool : public G1MemoryPoolSuper {
 public:
-  G1SurvivorPool(G1CollectedHeap* g1h);
+  G1SurvivorPool(G1CollectedHeap* g1h, size_t initial_size);
 
-  size_t used_in_bytes() {
-    return _g1mm->survivor_space_used();
-  }
-  size_t max_size() const {
-    return _undefined_max;
-  }
+  size_t used_in_bytes() { return _g1mm->survivor_space_used(); }
+
   MemoryUsage get_memory_usage();
 };
 
 // Memory pool that represents the G1 old gen.
 class G1OldGenPool : public G1MemoryPoolSuper {
 public:
-  G1OldGenPool(G1CollectedHeap* g1h);
+  G1OldGenPool(G1CollectedHeap* g1h, size_t initial_size, size_t max_size);
 
-  size_t used_in_bytes() {
-    return _g1mm->old_space_used();
-  }
-  size_t max_size() const {
-    return _g1mm->old_gen_max();
-  }
+  size_t used_in_bytes() { return _g1mm->old_gen_used(); }
+
   MemoryUsage get_memory_usage();
 };
 

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -26,79 +26,95 @@
 #include "gc/g1/g1CollectedHeap.inline.hpp"
 #include "gc/g1/g1MonitoringSupport.hpp"
 #include "gc/g1/g1Policy.hpp"
-#include "gc/shared/collectorCounters.hpp"
+#include "gc/g1/g1MemoryPool.hpp"
 #include "gc/shared/hSpaceCounters.hpp"
 #include "memory/metaspaceCounters.hpp"
+#include "services/memoryPool.hpp"
 
-G1GenerationCounters::G1GenerationCounters(G1MonitoringSupport* g1mm,
-                                           const char* name,
-                                           int ordinal, int spaces,
-                                           size_t min_capacity,
-                                           size_t max_capacity,
-                                           size_t curr_capacity)
+class G1GenerationCounters : public GenerationCounters {
+protected:
+  G1MonitoringSupport* _g1mm;
+
+public:
+  G1GenerationCounters(G1MonitoringSupport* g1mm,
+                       const char* name, int ordinal, int spaces,
+                       size_t min_capacity, size_t max_capacity,
+                       size_t curr_capacity)
   : GenerationCounters(name, ordinal, spaces, min_capacity,
                        max_capacity, curr_capacity), _g1mm(g1mm) { }
+};
 
-// We pad the capacity three times given that the young generation
-// contains three spaces (eden and two survivors).
-G1YoungGenerationCounters::G1YoungGenerationCounters(G1MonitoringSupport* g1mm,
-                                                     const char* name)
+class G1YoungGenerationCounters : public G1GenerationCounters {
+public:
+  // We pad the capacity three times given that the young generation
+  // contains three spaces (eden and two survivors).
+  G1YoungGenerationCounters(G1MonitoringSupport* g1mm, const char* name, size_t max_size)
   : G1GenerationCounters(g1mm, name, 0 /* ordinal */, 3 /* spaces */,
-               G1MonitoringSupport::pad_capacity(0, 3) /* min_capacity */,
-               G1MonitoringSupport::pad_capacity(g1mm->young_gen_max(), 3),
-               G1MonitoringSupport::pad_capacity(0, 3) /* curr_capacity */) {
-  if (UsePerfData) {
-    update_all();
+                         G1MonitoringSupport::pad_capacity(0, 3) /* min_capacity */,
+                         G1MonitoringSupport::pad_capacity(max_size, 3),
+                         G1MonitoringSupport::pad_capacity(0, 3) /* curr_capacity */) {
+    if (UsePerfData) {
+      update_all();
+    }
   }
-}
 
-G1OldGenerationCounters::G1OldGenerationCounters(G1MonitoringSupport* g1mm,
-                                                 const char* name)
+  virtual void update_all() {
+    size_t committed =
+              G1MonitoringSupport::pad_capacity(_g1mm->young_gen_committed(), 3);
+    _current_size->set_value(committed);
+  }
+};
+
+class G1OldGenerationCounters : public G1GenerationCounters {
+public:
+  G1OldGenerationCounters(G1MonitoringSupport* g1mm, const char* name, size_t max_size)
   : G1GenerationCounters(g1mm, name, 1 /* ordinal */, 1 /* spaces */,
-               G1MonitoringSupport::pad_capacity(0) /* min_capacity */,
-               G1MonitoringSupport::pad_capacity(g1mm->old_gen_max()),
-               G1MonitoringSupport::pad_capacity(0) /* curr_capacity */) {
-  if (UsePerfData) {
-    update_all();
+                         G1MonitoringSupport::pad_capacity(0) /* min_capacity */,
+                         G1MonitoringSupport::pad_capacity(max_size),
+                         G1MonitoringSupport::pad_capacity(0) /* curr_capacity */) {
+    if (UsePerfData) {
+      update_all();
+    }
   }
-}
 
-void G1YoungGenerationCounters::update_all() {
-  size_t committed =
-            G1MonitoringSupport::pad_capacity(_g1mm->young_gen_committed(), 3);
-  _current_size->set_value(committed);
-}
-
-void G1OldGenerationCounters::update_all() {
-  size_t committed =
-            G1MonitoringSupport::pad_capacity(_g1mm->old_gen_committed());
-  _current_size->set_value(committed);
-}
+  virtual void update_all() {
+    size_t committed =
+              G1MonitoringSupport::pad_capacity(_g1mm->old_gen_committed());
+    _current_size->set_value(committed);
+  }
+};
 
 G1MonitoringSupport::G1MonitoringSupport(G1CollectedHeap* g1h) :
   _g1h(g1h),
+  _incremental_memory_manager("G1 Young Generation", "end of minor GC"),
+  _full_gc_memory_manager("G1 Old Generation", "end of major GC"),
+  _eden_space_pool(NULL),
+  _survivor_space_pool(NULL),
+  _old_gen_pool(NULL),
   _incremental_collection_counters(NULL),
   _full_collection_counters(NULL),
   _conc_collection_counters(NULL),
-  _old_collection_counters(NULL),
+  _young_gen_counters(NULL),
+  _old_gen_counters(NULL),
   _old_space_counters(NULL),
-  _young_collection_counters(NULL),
-  _eden_counters(NULL),
-  _from_counters(NULL),
-  _to_counters(NULL),
+  _eden_space_counters(NULL),
+  _from_space_counters(NULL),
+  _to_space_counters(NULL),
 
-  _overall_reserved(0),
-  _overall_committed(0),    _overall_used(0),
-  _young_region_num(0),
+  _overall_committed(0),
+  _overall_used(0),
   _young_gen_committed(0),
-  _eden_committed(0),       _eden_used(0),
-  _survivor_committed(0),   _survivor_used(0),
-  _old_committed(0),        _old_used(0) {
+  _old_gen_committed(0),
 
-  _overall_reserved = g1h->max_capacity();
+  _eden_space_committed(0),
+  _eden_space_used(0),
+  _survivor_space_committed(0),
+  _survivor_space_used(0),
+  _old_gen_used(0) {
+
   recalculate_sizes();
 
-  // Counters for GC collections
+  // Counters for garbage collections
   //
   //  name "collector.0".  In a generational collector this would be the
   // young generation collection.
@@ -113,77 +129,102 @@ G1MonitoringSupport::G1MonitoringSupport(G1CollectedHeap* g1h) :
   _conc_collection_counters =
     new CollectorCounters("G1 stop-the-world phases", 2);
 
-  // timer sampling for all counters supporting sampling only update the
-  // used value.  See the take_sample() method.  G1 requires both used and
-  // capacity updated so sampling is not currently used.  It might
-  // be sufficient to update all counters in take_sample() even though
-  // take_sample() only returns "used".  When sampling was used, there
-  // were some anomolous values emitted which may have been the consequence
-  // of not updating all values simultaneously (i.e., see the calculation done
-  // in eden_space_used(), is it possible that the values used to
-  // calculate either eden_used or survivor_used are being updated by
-  // the collector when the sample is being done?).
-  const bool sampled = false;
-
   // "Generation" and "Space" counters.
   //
   //  name "generation.1" This is logically the old generation in
   // generational GC terms.  The "1, 1" parameters are for
   // the n-th generation (=1) with 1 space.
   // Counters are created from minCapacity, maxCapacity, and capacity
-  _old_collection_counters = new G1OldGenerationCounters(this, "old");
+  _old_gen_counters = new G1OldGenerationCounters(this, "old", _g1h->max_capacity());
 
   //  name  "generation.1.space.0"
   // Counters are created from maxCapacity, capacity, initCapacity,
   // and used.
-  _old_space_counters = new HSpaceCounters(_old_collection_counters->name_space(),
+  _old_space_counters = new HSpaceCounters(_old_gen_counters->name_space(),
     "space", 0 /* ordinal */,
-    pad_capacity(overall_reserved()) /* max_capacity */,
-    pad_capacity(old_space_committed()) /* init_capacity */);
+    pad_capacity(g1h->max_capacity()) /* max_capacity */,
+    pad_capacity(_old_gen_committed) /* init_capacity */);
 
   //   Young collection set
   //  name "generation.0".  This is logically the young generation.
   //  The "0, 3" are parameters for the n-th generation (=0) with 3 spaces.
   // See  _old_collection_counters for additional counters
-  _young_collection_counters = new G1YoungGenerationCounters(this, "young");
+  _young_gen_counters = new G1YoungGenerationCounters(this, "young", _g1h->max_capacity());
 
-  const char* young_collection_name_space = _young_collection_counters->name_space();
+  const char* young_collection_name_space = _young_gen_counters->name_space();
 
   //  name "generation.0.space.0"
   // See _old_space_counters for additional counters
-  _eden_counters = new HSpaceCounters(young_collection_name_space,
+  _eden_space_counters = new HSpaceCounters(young_collection_name_space,
     "eden", 0 /* ordinal */,
-    pad_capacity(overall_reserved()) /* max_capacity */,
-    pad_capacity(eden_space_committed()) /* init_capacity */);
+    pad_capacity(g1h->max_capacity()) /* max_capacity */,
+    pad_capacity(_eden_space_committed) /* init_capacity */);
 
   //  name "generation.0.space.1"
   // See _old_space_counters for additional counters
   // Set the arguments to indicate that this survivor space is not used.
-  _from_counters = new HSpaceCounters(young_collection_name_space,
+  _from_space_counters = new HSpaceCounters(young_collection_name_space,
     "s0", 1 /* ordinal */,
     pad_capacity(0) /* max_capacity */,
     pad_capacity(0) /* init_capacity */);
+  // Given that this survivor space is not used, we update it here
+  // once to reflect that its used space is 0 so that we don't have to
+  // worry about updating it again later.
+  _from_space_counters->update_used(0);
 
   //  name "generation.0.space.2"
   // See _old_space_counters for additional counters
-  _to_counters = new HSpaceCounters(young_collection_name_space,
+  _to_space_counters = new HSpaceCounters(young_collection_name_space,
     "s1", 2 /* ordinal */,
-    pad_capacity(overall_reserved()) /* max_capacity */,
-    pad_capacity(survivor_space_committed()) /* init_capacity */);
+    pad_capacity(g1h->max_capacity()) /* max_capacity */,
+    pad_capacity(_survivor_space_committed) /* init_capacity */);
+}
 
-  if (UsePerfData) {
-    // Given that this survivor space is not used, we update it here
-    // once to reflect that its used space is 0 so that we don't have to
-    // worry about updating it again later.
-    _from_counters->update_used(0);
-  }
+G1MonitoringSupport::~G1MonitoringSupport() {
+  delete _eden_space_pool;
+  delete _survivor_space_pool;
+  delete _old_gen_pool;
+}
+
+void G1MonitoringSupport::initialize_serviceability() {
+  _eden_space_pool = new G1EdenPool(_g1h, _eden_space_committed);
+  _survivor_space_pool = new G1SurvivorPool(_g1h, _survivor_space_committed);
+  _old_gen_pool = new G1OldGenPool(_g1h, _old_gen_committed, _g1h->max_capacity());
+
+  _full_gc_memory_manager.add_pool(_eden_space_pool);
+  _full_gc_memory_manager.add_pool(_survivor_space_pool);
+  _full_gc_memory_manager.add_pool(_old_gen_pool);
+
+  _incremental_memory_manager.add_pool(_eden_space_pool);
+  _incremental_memory_manager.add_pool(_survivor_space_pool);
+  _incremental_memory_manager.add_pool(_old_gen_pool, false /* always_affected_by_gc */);
+}
+
+MemoryUsage G1MonitoringSupport::memory_usage() {
+  MutexLockerEx x(MonitoringSupport_lock, Mutex::_no_safepoint_check_flag);
+  return MemoryUsage(InitialHeapSize, _overall_used, _overall_committed, _g1h->max_capacity());
+}
+
+GrowableArray<GCMemoryManager*> G1MonitoringSupport::memory_managers() {
+  GrowableArray<GCMemoryManager*> memory_managers(2);
+  memory_managers.append(&_incremental_memory_manager);
+  memory_managers.append(&_full_gc_memory_manager);
+  return memory_managers;
+}
+
+GrowableArray<MemoryPool*> G1MonitoringSupport::memory_pools() {
+  GrowableArray<MemoryPool*> memory_pools(3);
+  memory_pools.append(_eden_space_pool);
+  memory_pools.append(_survivor_space_pool);
+  memory_pools.append(_old_gen_pool);
+  return memory_pools;
 }
 
 void G1MonitoringSupport::recalculate_sizes() {
-  // Recalculate all the sizes from scratch. We assume that this is
-  // called at a point where no concurrent updates to the various
-  // values we read here are possible (i.e., at a STW phase at the end
-  // of a GC).
+  assert_heap_locked_or_at_safepoint(true);
+
+  MutexLockerEx x(MonitoringSupport_lock, Mutex::_no_safepoint_check_flag);
+  // Recalculate all the sizes from scratch.
 
   uint young_list_length = _g1h->young_regions_count();
   uint survivor_list_length = _g1h->survivor_regions_count();
@@ -196,14 +237,13 @@ void G1MonitoringSupport::recalculate_sizes() {
   uint eden_list_max_length = young_list_max_length - survivor_list_length;
 
   _overall_used = _g1h->used_unlocked();
-  _eden_used = (size_t) eden_list_length * HeapRegion::GrainBytes;
-  _survivor_used = (size_t) survivor_list_length * HeapRegion::GrainBytes;
-  _young_region_num = young_list_length;
-  _old_used = subtract_up_to_zero(_overall_used, _eden_used + _survivor_used);
+  _eden_space_used = (size_t) eden_list_length * HeapRegion::GrainBytes;
+  _survivor_space_used = (size_t) survivor_list_length * HeapRegion::GrainBytes;
+  _old_gen_used = subtract_up_to_zero(_overall_used, _eden_space_used + _survivor_space_used);
 
   // First calculate the committed sizes that can be calculated independently.
-  _survivor_committed = _survivor_used;
-  _old_committed = HeapRegion::align_up_to_region_byte_size(_old_used);
+  _survivor_space_committed = _survivor_space_used;
+  _old_gen_committed = HeapRegion::align_up_to_region_byte_size(_old_gen_used);
 
   // Next, start with the overall committed size.
   _overall_committed = _g1h->capacity();
@@ -211,70 +251,92 @@ void G1MonitoringSupport::recalculate_sizes() {
 
   // Remove the committed size we have calculated so far (for the
   // survivor and old space).
-  assert(committed >= (_survivor_committed + _old_committed), "sanity");
-  committed -= _survivor_committed + _old_committed;
+  assert(committed >= (_survivor_space_committed + _old_gen_committed), "sanity");
+  committed -= _survivor_space_committed + _old_gen_committed;
 
   // Next, calculate and remove the committed size for the eden.
-  _eden_committed = (size_t) eden_list_max_length * HeapRegion::GrainBytes;
+  _eden_space_committed = (size_t) eden_list_max_length * HeapRegion::GrainBytes;
   // Somewhat defensive: be robust in case there are inaccuracies in
   // the calculations
-  _eden_committed = MIN2(_eden_committed, committed);
-  committed -= _eden_committed;
+  _eden_space_committed = MIN2(_eden_space_committed, committed);
+  committed -= _eden_space_committed;
 
   // Finally, give the rest to the old space...
-  _old_committed += committed;
+  _old_gen_committed += committed;
   // ..and calculate the young gen committed.
-  _young_gen_committed = _eden_committed + _survivor_committed;
+  _young_gen_committed = _eden_space_committed + _survivor_space_committed;
 
   assert(_overall_committed ==
-         (_eden_committed + _survivor_committed + _old_committed),
+         (_eden_space_committed + _survivor_space_committed + _old_gen_committed),
          "the committed sizes should add up");
   // Somewhat defensive: cap the eden used size to make sure it
   // never exceeds the committed size.
-  _eden_used = MIN2(_eden_used, _eden_committed);
+  _eden_space_used = MIN2(_eden_space_used, _eden_space_committed);
   // _survivor_committed and _old_committed are calculated in terms of
   // the corresponding _*_used value, so the next two conditions
   // should hold.
-  assert(_survivor_used <= _survivor_committed, "post-condition");
-  assert(_old_used <= _old_committed, "post-condition");
-}
-
-void G1MonitoringSupport::recalculate_eden_size() {
-  // When a new eden region is allocated, only the eden_used size is
-  // affected (since we have recalculated everything else at the last GC).
-
-  uint young_region_num = _g1h->young_regions_count();
-  if (young_region_num > _young_region_num) {
-    uint diff = young_region_num - _young_region_num;
-    _eden_used += (size_t) diff * HeapRegion::GrainBytes;
-    // Somewhat defensive: cap the eden used size to make sure it
-    // never exceeds the committed size.
-    _eden_used = MIN2(_eden_used, _eden_committed);
-    _young_region_num = young_region_num;
-  }
+  assert(_survivor_space_used <= _survivor_space_committed, "post-condition");
+  assert(_old_gen_used <= _old_gen_committed, "post-condition");
 }
 
 void G1MonitoringSupport::update_sizes() {
   recalculate_sizes();
   if (UsePerfData) {
-    eden_counters()->update_capacity(pad_capacity(eden_space_committed()));
-    eden_counters()->update_used(eden_space_used());
-    // only the to survivor space (s1) is active, so we don't need to
-    // update the counters for the from survivor space (s0)
-    to_counters()->update_capacity(pad_capacity(survivor_space_committed()));
-    to_counters()->update_used(survivor_space_used());
-    old_space_counters()->update_capacity(pad_capacity(old_space_committed()));
-    old_space_counters()->update_used(old_space_used());
-    old_collection_counters()->update_all();
-    young_collection_counters()->update_all();
+    _eden_space_counters->update_capacity(pad_capacity(_eden_space_committed));
+    _eden_space_counters->update_used(_eden_space_used);
+   // only the "to" survivor space is active, so we don't need to
+    // update the counters for the "from" survivor space
+    _to_space_counters->update_capacity(pad_capacity(_survivor_space_committed));
+    _to_space_counters->update_used(_survivor_space_used);
+    _old_space_counters->update_capacity(pad_capacity(_old_gen_committed));
+    _old_space_counters->update_used(_old_gen_used);
+
+    _young_gen_counters->update_all();
+    _old_gen_counters->update_all();
+
     MetaspaceCounters::update_performance_counters();
     CompressedClassSpaceCounters::update_performance_counters();
   }
 }
 
 void G1MonitoringSupport::update_eden_size() {
-  recalculate_eden_size();
+  // Recalculate everything - this should be fast enough and we are sure that we do not
+  // miss anything.
+  recalculate_sizes();
   if (UsePerfData) {
-    eden_counters()->update_used(eden_space_used());
+    _eden_space_counters->update_used(_eden_space_used);
   }
+}
+
+MemoryUsage G1MonitoringSupport::eden_space_memory_usage(size_t initial_size, size_t max_size) {
+  MutexLockerEx x(MonitoringSupport_lock, Mutex::_no_safepoint_check_flag);
+
+  return MemoryUsage(initial_size,
+                     _eden_space_used,
+                     _eden_space_committed,
+                     max_size);
+}
+
+MemoryUsage G1MonitoringSupport::survivor_space_memory_usage(size_t initial_size, size_t max_size) {
+  MutexLockerEx x(MonitoringSupport_lock, Mutex::_no_safepoint_check_flag);
+
+  return MemoryUsage(initial_size,
+                     _survivor_space_used,
+                     _survivor_space_committed,
+                     max_size);
+}
+
+MemoryUsage G1MonitoringSupport::old_gen_memory_usage(size_t initial_size, size_t max_size) {
+  MutexLockerEx x(MonitoringSupport_lock, Mutex::_no_safepoint_check_flag);
+
+  return MemoryUsage(initial_size,
+                     _old_gen_used,
+                     _old_gen_committed,
+                     max_size);
+}
+
+G1MonitoringScope::G1MonitoringScope(G1MonitoringSupport* g1mm, bool full_gc, bool all_memory_pools_affected) :
+  _tcs(full_gc ? g1mm->_full_collection_counters : g1mm->_incremental_collection_counters),
+  _tms(full_gc ? &g1mm->_full_gc_memory_manager : &g1mm->_incremental_memory_manager,
+       G1CollectedHeap::heap()->gc_cause(), all_memory_pools_affected) {
 }

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
@@ -25,11 +25,16 @@
 #ifndef SHARE_VM_GC_G1_G1MONITORINGSUPPORT_HPP
 #define SHARE_VM_GC_G1_G1MONITORINGSUPPORT_HPP
 
+#include "gc/shared/collectorCounters.hpp"
 #include "gc/shared/generationCounters.hpp"
+#include "services/memoryManager.hpp"
+#include "services/memoryService.hpp"
+#include "runtime/mutex.hpp"
 
 class CollectorCounters;
 class G1CollectedHeap;
 class HSpaceCounters;
+class MemoryPool;
 
 // Class for monitoring logical spaces in G1. It provides data for
 // both G1's jstat counters as well as G1's memory pools.
@@ -116,8 +121,17 @@ class HSpaceCounters;
 
 class G1MonitoringSupport : public CHeapObj<mtGC> {
   friend class VMStructs;
+  friend class G1MonitoringScope;
 
   G1CollectedHeap* _g1h;
+
+  // java.lang.management MemoryManager and MemoryPool support
+  GCMemoryManager _incremental_memory_manager;
+  GCMemoryManager _full_gc_memory_manager;
+
+  MemoryPool* _eden_space_pool;
+  MemoryPool* _survivor_space_pool;
+  MemoryPool* _old_gen_pool;
 
   // jstat performance counters
   //  incremental collections both young and mixed
@@ -129,37 +143,36 @@ class G1MonitoringSupport : public CHeapObj<mtGC> {
   //  young collection set counters.  The _eden_counters,
   // _from_counters, and _to_counters are associated with
   // this "generational" counter.
-  GenerationCounters*  _young_collection_counters;
+  GenerationCounters*  _young_gen_counters;
   //  old collection set counters. The _old_space_counters
   // below are associated with this "generational" counter.
-  GenerationCounters*  _old_collection_counters;
+  GenerationCounters*  _old_gen_counters;
   // Counters for the capacity and used for
   //   the whole heap
   HSpaceCounters*      _old_space_counters;
   //   the young collection
-  HSpaceCounters*      _eden_counters;
+  HSpaceCounters*      _eden_space_counters;
   //   the survivor collection (only one, _to_counters, is actively used)
-  HSpaceCounters*      _from_counters;
-  HSpaceCounters*      _to_counters;
+  HSpaceCounters*      _from_space_counters;
+  HSpaceCounters*      _to_space_counters;
 
   // When it's appropriate to recalculate the various sizes (at the
   // end of a GC, when a new eden region is allocated, etc.) we store
   // them here so that we can easily report them when needed and not
   // have to recalculate them every time.
 
-  size_t _overall_reserved;
   size_t _overall_committed;
   size_t _overall_used;
 
-  uint   _young_region_num;
   size_t _young_gen_committed;
-  size_t _eden_committed;
-  size_t _eden_used;
-  size_t _survivor_committed;
-  size_t _survivor_used;
+  size_t _old_gen_committed;
 
-  size_t _old_committed;
-  size_t _old_used;
+  size_t _eden_space_committed;
+  size_t _eden_space_used;
+  size_t _survivor_space_committed;
+  size_t _survivor_space_used;
+
+  size_t _old_gen_used;
 
   // It returns x - y if x > y, 0 otherwise.
   // As described in the comment above, some of the inputs to the
@@ -178,11 +191,18 @@ class G1MonitoringSupport : public CHeapObj<mtGC> {
 
   // Recalculate all the sizes.
   void recalculate_sizes();
-  // Recalculate only what's necessary when a new eden region is allocated.
+
   void recalculate_eden_size();
 
- public:
+public:
   G1MonitoringSupport(G1CollectedHeap* g1h);
+  ~G1MonitoringSupport();
+
+  void initialize_serviceability();
+
+  MemoryUsage memory_usage();
+  GrowableArray<GCMemoryManager*> memory_managers();
+  GrowableArray<MemoryPool*> memory_pools();
 
   // Unfortunately, the jstat tool assumes that no space has 0
   // capacity. In our case, given that each space is logical, it's
@@ -202,73 +222,41 @@ class G1MonitoringSupport : public CHeapObj<mtGC> {
   // Recalculate all the sizes from scratch and update all the jstat
   // counters accordingly.
   void update_sizes();
-  // Recalculate only what's necessary when a new eden region is
-  // allocated and update any jstat counters that need to be updated.
+
   void update_eden_size();
 
-  CollectorCounters* incremental_collection_counters() {
-    return _incremental_collection_counters;
-  }
-  CollectorCounters* full_collection_counters() {
-    return _full_collection_counters;
-  }
   CollectorCounters* conc_collection_counters() {
     return _conc_collection_counters;
   }
-  GenerationCounters* young_collection_counters() {
-    return _young_collection_counters;
-  }
-  GenerationCounters* old_collection_counters() {
-    return _old_collection_counters;
-  }
-  HSpaceCounters*      old_space_counters() { return _old_space_counters; }
-  HSpaceCounters*      eden_counters() { return _eden_counters; }
-  HSpaceCounters*      from_counters() { return _from_counters; }
-  HSpaceCounters*      to_counters() { return _to_counters; }
 
   // Monitoring support used by
   //   MemoryService
   //   jstat counters
   //   Tracing
+  // Values may not be consistent wrt to each other.
 
-  size_t overall_reserved()           { return _overall_reserved;     }
-  size_t overall_committed()          { return _overall_committed;    }
-  size_t overall_used()               { return _overall_used;         }
+  size_t young_gen_committed()        { return _young_gen_committed; }
 
-  size_t young_gen_committed()        { return _young_gen_committed;  }
-  size_t young_gen_max()              { return overall_reserved();    }
-  size_t eden_space_committed()       { return _eden_committed;       }
-  size_t eden_space_used()            { return _eden_used;            }
-  size_t survivor_space_committed()   { return _survivor_committed;   }
-  size_t survivor_space_used()        { return _survivor_used;        }
+  size_t eden_space_used()            { return _eden_space_used; }
+  size_t survivor_space_used()        { return _survivor_space_used; }
 
-  size_t old_gen_committed()          { return old_space_committed(); }
-  size_t old_gen_max()                { return overall_reserved();    }
-  size_t old_space_committed()        { return _old_committed;        }
-  size_t old_space_used()             { return _old_used;             }
+  size_t old_gen_committed()          { return _old_gen_committed; }
+  size_t old_gen_used()               { return _old_gen_used; }
+
+  // Monitoring support for MemoryPools. Values in the returned MemoryUsage are
+  // guaranteed to be consistent with each other.
+  MemoryUsage eden_space_memory_usage(size_t initial_size, size_t max_size);
+  MemoryUsage survivor_space_memory_usage(size_t initial_size, size_t max_size);
+
+  MemoryUsage old_gen_memory_usage(size_t initial_size, size_t max_size);
 };
 
-class G1GenerationCounters: public GenerationCounters {
-protected:
-  G1MonitoringSupport* _g1mm;
-
+// Scope object for java.lang.management support.
+class G1MonitoringScope : public StackObj {
+  TraceCollectorStats _tcs;
+  TraceMemoryManagerStats _tms;
 public:
-  G1GenerationCounters(G1MonitoringSupport* g1mm,
-                       const char* name, int ordinal, int spaces,
-                       size_t min_capacity, size_t max_capacity,
-                       size_t curr_capacity);
-};
-
-class G1YoungGenerationCounters: public G1GenerationCounters {
-public:
-  G1YoungGenerationCounters(G1MonitoringSupport* g1mm, const char* name);
-  virtual void update_all();
-};
-
-class G1OldGenerationCounters: public G1GenerationCounters {
-public:
-  G1OldGenerationCounters(G1MonitoringSupport* g1mm, const char* name);
-  virtual void update_all();
+  G1MonitoringScope(G1MonitoringSupport* g1mm, bool full_gc, bool all_memory_pools_affected);
 };
 
 #endif // SHARE_VM_GC_G1_G1MONITORINGSUPPORT_HPP

--- a/src/hotspot/share/gc/g1/vmStructs_g1.hpp
+++ b/src/hotspot/share/gc/g1/vmStructs_g1.hpp
@@ -58,12 +58,12 @@
   nonstatic_field(G1CollectedHeap, _old_set,            HeapRegionSetBase)    \
   nonstatic_field(G1CollectedHeap, _humongous_set,      HeapRegionSetBase)    \
                                                                               \
-  nonstatic_field(G1MonitoringSupport, _eden_committed,     size_t)           \
-  nonstatic_field(G1MonitoringSupport, _eden_used,          size_t)           \
-  nonstatic_field(G1MonitoringSupport, _survivor_committed, size_t)           \
-  nonstatic_field(G1MonitoringSupport, _survivor_used,      size_t)           \
-  nonstatic_field(G1MonitoringSupport, _old_committed,      size_t)           \
-  nonstatic_field(G1MonitoringSupport, _old_used,           size_t)           \
+  nonstatic_field(G1MonitoringSupport, _eden_space_committed,     size_t)     \
+  nonstatic_field(G1MonitoringSupport, _eden_space_used,          size_t)     \
+  nonstatic_field(G1MonitoringSupport, _survivor_space_committed, size_t)     \
+  nonstatic_field(G1MonitoringSupport, _survivor_space_used,      size_t)     \
+  nonstatic_field(G1MonitoringSupport, _old_gen_committed,        size_t)     \
+  nonstatic_field(G1MonitoringSupport, _old_gen_used,             size_t)     \
                                                                               \
   nonstatic_field(HeapRegionSetBase,   _length,         uint)                 \
                                                                               \

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -328,6 +328,11 @@ MetaWord* CollectedHeap::satisfy_failed_metadata_allocation(ClassLoaderData* loa
   } while (true);  // Until a GC is done
 }
 
+MemoryUsage CollectedHeap::memory_usage() {
+  return MemoryUsage(InitialHeapSize, used(), capacity(), max_capacity());
+}
+
+
 #ifndef PRODUCT
 void CollectedHeap::check_for_non_bad_heap_word_value(HeapWord* addr, size_t size) {
   if (CheckMemoryInitialization && ZapUnusedHeapArea) {

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -32,6 +32,7 @@
 #include "runtime/handles.hpp"
 #include "runtime/perfData.hpp"
 #include "runtime/safepoint.hpp"
+#include "services/memoryUsage.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/events.hpp"
 #include "utilities/formatBuffer.hpp"
@@ -436,6 +437,7 @@ class CollectedHeap : public CHeapObj<mtGC> {
   // Return the SoftRefPolicy for the heap;
   virtual SoftRefPolicy* soft_ref_policy() = 0;
 
+  virtual MemoryUsage memory_usage();
   virtual GrowableArray<GCMemoryManager*> memory_managers() = 0;
   virtual GrowableArray<MemoryPool*> memory_pools() = 0;
 

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -88,6 +88,7 @@ Monitor* DirtyCardQ_CBL_mon           = NULL;
 Mutex*   Shared_DirtyCardQ_lock       = NULL;
 Mutex*   MarkStackFreeList_lock       = NULL;
 Mutex*   MarkStackChunkList_lock      = NULL;
+Mutex*   MonitoringSupport_lock       = NULL;
 Mutex*   ParGCRareEvent_lock          = NULL;
 Mutex*   DerivedPointerTableGC_lock   = NULL;
 Monitor* CGCPhaseManager_lock         = NULL;
@@ -224,6 +225,8 @@ void mutex_init() {
 
     def(MarkStackFreeList_lock     , PaddedMutex  , leaf     ,   true,  Monitor::_safepoint_check_never);
     def(MarkStackChunkList_lock    , PaddedMutex  , leaf     ,   true,  Monitor::_safepoint_check_never);
+
+    def(MonitoringSupport_lock     , PaddedMutex  , native   ,   true,  Monitor::_safepoint_check_never);      // used for serviceability monitoring support
   }
 #if INCLUDE_SHENANDOAHGC
   if (UseShenandoahGC) {

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -94,6 +94,7 @@ extern Mutex*   Shared_DirtyCardQ_lock;          // Lock protecting dirty card
                                                  // non-Java threads.
 extern Mutex*   MarkStackFreeList_lock;          // Protects access to the global mark stack free list.
 extern Mutex*   MarkStackChunkList_lock;         // Protects access to the global mark stack chunk list.
+extern Mutex*   MonitoringSupport_lock;          // Protects updates to the serviceability memory pools.
 extern Mutex*   ParGCRareEvent_lock;             // Synchronizes various (rare) parallel GC ops.
 extern Mutex*   Compile_lock;                    // a lock held when Compilation is updating code (used to block CodeCache traversal, CHA updates, etc)
 extern Monitor* MethodCompileQueue_lock;         // a lock held when method compilations are enqueued, dequeued

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -709,50 +709,53 @@ JVM_END
 JVM_ENTRY(jobject, jmm_GetMemoryUsage(JNIEnv* env, jboolean heap))
   ResourceMark rm(THREAD);
 
-  // Calculate the memory usage
-  size_t total_init = 0;
-  size_t total_used = 0;
-  size_t total_committed = 0;
-  size_t total_max = 0;
-  bool   has_undefined_init_size = false;
-  bool   has_undefined_max_size = false;
+  MemoryUsage usage;
 
-  for (int i = 0; i < MemoryService::num_memory_pools(); i++) {
-    MemoryPool* pool = MemoryService::get_memory_pool(i);
-    if ((heap && pool->is_heap()) || (!heap && pool->is_non_heap())) {
-      MemoryUsage u = pool->get_memory_usage();
-      total_used += u.used();
-      total_committed += u.committed();
+  if (heap) {
+    usage = Universe::heap()->memory_usage();
+  } else {
+    // Calculate the memory usage by summing up the pools.
+    size_t total_init = 0;
+    size_t total_used = 0;
+    size_t total_committed = 0;
+    size_t total_max = 0;
+    bool   has_undefined_init_size = false;
+    bool   has_undefined_max_size = false;
 
-      if (u.init_size() == (size_t)-1) {
-        has_undefined_init_size = true;
-      }
-      if (!has_undefined_init_size) {
-        total_init += u.init_size();
-      }
+    for (int i = 0; i < MemoryService::num_memory_pools(); i++) {
+      MemoryPool* pool = MemoryService::get_memory_pool(i);
+      if (pool->is_non_heap()) {
+        MemoryUsage u = pool->get_memory_usage();
+        total_used += u.used();
+        total_committed += u.committed();
 
-      if (u.max_size() == (size_t)-1) {
-        has_undefined_max_size = true;
-      }
-      if (!has_undefined_max_size) {
-        total_max += u.max_size();
+        if (u.init_size() == MemoryUsage::undefined_size()) {
+          has_undefined_init_size = true;
+        }
+        if (!has_undefined_init_size) {
+          total_init += u.init_size();
+        }
+
+        if (u.max_size() == MemoryUsage::undefined_size()) {
+          has_undefined_max_size = true;
+        }
+        if (!has_undefined_max_size) {
+          total_max += u.max_size();
+        }
       }
     }
-  }
 
-  // if any one of the memory pool has undefined init_size or max_size,
-  // set it to -1
-  if (has_undefined_init_size) {
-    total_init = (size_t)-1;
-  }
-  if (has_undefined_max_size) {
-    total_max = (size_t)-1;
-  }
+    // if any one of the memory pool has undefined init_size or max_size,
+    // set it to MemoryUsage::undefined_size()
+    if (has_undefined_init_size) {
+      total_init = MemoryUsage::undefined_size();
+    }
+    if (has_undefined_max_size) {
+      total_max = MemoryUsage::undefined_size();
+    }
 
-  MemoryUsage usage((heap ? InitialHeapSize : total_init),
-                    total_used,
-                    total_committed,
-                    (heap ? Universe::heap()->max_capacity() : total_max));
+    usage = MemoryUsage(total_init, total_used, total_committed, total_max);
+  }
 
   Handle obj = MemoryService::create_MemoryUsage_obj(usage, CHECK_NULL);
   return JNIHandles::make_local(env, obj());

--- a/src/hotspot/share/services/memoryPool.hpp
+++ b/src/hotspot/share/services/memoryPool.hpp
@@ -85,6 +85,8 @@ class MemoryPool : public CHeapObj<mtInternal> {
              bool support_usage_threshold,
              bool support_gc_threshold);
 
+  virtual ~MemoryPool() { }
+
   const char* name()                       { return _name; }
   bool        is_heap()                    { return _type == Heap; }
   bool        is_non_heap()                { return _type == NonHeap; }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/G1MonitoringSupport.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/G1MonitoringSupport.java
@@ -37,18 +37,18 @@ import sun.jvm.hotspot.types.TypeDataBase;
 // Mirror class for G1MonitoringSupport.
 
 public class G1MonitoringSupport extends VMObject {
-    // size_t _eden_committed;
-    static private CIntegerField edenCommittedField;
-    // size_t _eden_used;
-    static private CIntegerField edenUsedField;
-    // size_t _survivor_committed;
-    static private CIntegerField survivorCommittedField;
-    // size_t _survivor_used;
-    static private CIntegerField survivorUsedField;
-    // size_t _old_committed;
-    static private CIntegerField oldCommittedField;
-    // size_t _old_used;
-    static private CIntegerField oldUsedField;
+    // size_t _eden_space_committed;
+    static private CIntegerField edenSpaceCommittedField;
+    // size_t _eden_space_used;
+    static private CIntegerField edenSpaceUsedField;
+    // size_t _survivor_space_committed;
+    static private CIntegerField survivorSpaceCommittedField;
+    // size_t _survivor_space_used;
+    static private CIntegerField survivorSpaceUsedField;
+    // size_t _old_gen_committed;
+    static private CIntegerField oldGenCommittedField;
+    // size_t _old_gen_used;
+    static private CIntegerField oldGenUsedField;
 
     static {
         VM.registerVMInitializedObserver(new Observer() {
@@ -61,44 +61,44 @@ public class G1MonitoringSupport extends VMObject {
     static private synchronized void initialize(TypeDataBase db) {
         Type type = db.lookupType("G1MonitoringSupport");
 
-        edenCommittedField = type.getCIntegerField("_eden_committed");
-        edenUsedField = type.getCIntegerField("_eden_used");
-        survivorCommittedField = type.getCIntegerField("_survivor_committed");
-        survivorUsedField = type.getCIntegerField("_survivor_used");
-        oldCommittedField = type.getCIntegerField("_old_committed");
-        oldUsedField = type.getCIntegerField("_old_used");
+        edenSpaceCommittedField = type.getCIntegerField("_eden_space_committed");
+        edenSpaceUsedField = type.getCIntegerField("_eden_space_used");
+        survivorSpaceCommittedField = type.getCIntegerField("_survivor_space_committed");
+        survivorSpaceUsedField = type.getCIntegerField("_survivor_space_used");
+        oldGenCommittedField = type.getCIntegerField("_old_gen_committed");
+        oldGenUsedField = type.getCIntegerField("_old_gen_used");
     }
 
-    public long edenCommitted() {
-        return edenCommittedField.getValue(addr);
+    public long edenSpaceCommitted() {
+        return edenSpaceCommittedField.getValue(addr);
     }
 
-    public long edenUsed() {
-        return edenUsedField.getValue(addr);
+    public long edenSpaceUsed() {
+        return edenSpaceUsedField.getValue(addr);
     }
 
-    public long edenRegionNum() {
-        return edenUsed() / HeapRegion.grainBytes();
+    public long edenSpaceRegionNum() {
+        return edenSpaceUsed() / HeapRegion.grainBytes();
     }
 
-    public long survivorCommitted() {
-        return survivorCommittedField.getValue(addr);
+    public long survivorSpaceCommitted() {
+        return survivorSpaceCommittedField.getValue(addr);
     }
 
-    public long survivorUsed() {
-        return survivorUsedField.getValue(addr);
+    public long survivorSpaceUsed() {
+        return survivorSpaceUsedField.getValue(addr);
     }
 
-    public long survivorRegionNum() {
-        return survivorUsed() / HeapRegion.grainBytes();
+    public long survivorSpaceRegionNum() {
+        return survivorSpaceUsed() / HeapRegion.grainBytes();
     }
 
-    public long oldCommitted() {
-        return oldCommittedField.getValue(addr);
+    public long oldGenCommitted() {
+        return oldGenCommittedField.getValue(addr);
     }
 
-    public long oldUsed() {
-        return oldUsedField.getValue(addr);
+    public long oldGenUsed() {
+        return oldGenUsedField.getValue(addr);
     }
 
     public G1MonitoringSupport(Address addr) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
@@ -246,20 +246,20 @@ public class HeapSummary extends Tool {
 
    public void printG1HeapSummary(G1CollectedHeap g1h) {
       G1MonitoringSupport g1mm = g1h.g1mm();
-      long edenRegionNum = g1mm.edenRegionNum();
-      long survivorRegionNum = g1mm.survivorRegionNum();
+      long edenSpaceRegionNum = g1mm.edenSpaceRegionNum();
+      long survivorSpaceRegionNum = g1mm.survivorSpaceRegionNum();
       HeapRegionSetBase oldSet = g1h.oldSet();
       HeapRegionSetBase humongousSet = g1h.humongousSet();
-      long oldRegionNum = oldSet.length() + humongousSet.length();
+      long oldGenRegionNum = oldSet.length() + humongousSet.length();
       printG1Space("G1 Heap:", g1h.n_regions(),
                    g1h.used(), g1h.capacity());
       System.out.println("G1 Young Generation:");
-      printG1Space("Eden Space:", edenRegionNum,
-                   g1mm.edenUsed(), g1mm.edenCommitted());
-      printG1Space("Survivor Space:", survivorRegionNum,
-                   g1mm.survivorUsed(), g1mm.survivorCommitted());
-      printG1Space("G1 Old Generation:", oldRegionNum,
-                   g1mm.oldUsed(), g1mm.oldCommitted());
+      printG1Space("Eden Space:", edenSpaceRegionNum,
+              g1mm.edenSpaceUsed(), g1mm.edenSpaceCommitted());
+      printG1Space("Survivor Space:", survivorSpaceRegionNum,
+              g1mm.survivorSpaceUsed(), g1mm.survivorSpaceCommitted());
+      printG1Space("G1 Old Generation:", oldGenRegionNum,
+              g1mm.oldGenUsed(), g1mm.oldGenCommitted());
    }
 
    private void printG1Space(String spaceName, long regionNum,


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8207200](https://bugs.openjdk.org/browse/JDK-8207200) needs maintainer approval
- [ ] [JDK-8209061](https://bugs.openjdk.org/browse/JDK-8209061) needs maintainer approval
- [ ] [JDK-8209062](https://bugs.openjdk.org/browse/JDK-8209062) needs maintainer approval

### Issues
 * [JDK-8207200](https://bugs.openjdk.org/browse/JDK-8207200): Committed &gt; max memory usage when getting MemoryUsage (**Bug** - P3)
 * [JDK-8209061](https://bugs.openjdk.org/browse/JDK-8209061): Move G1 serviceability functionality to G1MonitoringSupport (**Enhancement** - P4)
 * [JDK-8209062](https://bugs.openjdk.org/browse/JDK-8209062): Clean up G1MonitoringSupport (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2281/head:pull/2281` \
`$ git checkout pull/2281`

Update a local copy of the PR: \
`$ git checkout pull/2281` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2281`

View PR using the GUI difftool: \
`$ git pr show -t 2281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2281.diff">https://git.openjdk.org/jdk11u-dev/pull/2281.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2281#issuecomment-1818291310)