### PR TITLE
8214694: cleanup rawtypes warnings in open jndi tests

### DIFF
--- a/test/jdk/com/sun/jndi/dns/CheckAccess.java
+++ b/test/jdk/com/sun/jndi/dns/CheckAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import java.lang.reflect.Modifier;
 public class CheckAccess {
     public static final void main(String[] args) throws Exception {
         try {
-            Class clazz = Class.forName("com.sun.jndi.dns.DnsContext");
+            Class<?> clazz = Class.forName("com.sun.jndi.dns.DnsContext");
             Field field = clazz.getField("debug");
             if (Modifier.isPublic(field.getModifiers())) {
                 throw new Exception(

--- a/test/jdk/com/sun/jndi/dns/EnvTests/AddInherited.java
+++ b/test/jdk/com/sun/jndi/dns/EnvTests/AddInherited.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,8 +55,8 @@ public class AddInherited extends EnvTestBase {
 
         Context child = (Context) context().lookup(getKey());
 
-        Hashtable envParent = context().getEnvironment();
-        Hashtable envChild = child.getEnvironment();
+        Hashtable<?,?> envParent = context().getEnvironment();
+        Hashtable<?,?> envChild = child.getEnvironment();
 
         DNSTestUtils.debug(child);
         DNSTestUtils.debug("Parent env: " + envParent);

--- a/test/jdk/com/sun/jndi/dns/EnvTests/GetEnv.java
+++ b/test/jdk/com/sun/jndi/dns/EnvTests/GetEnv.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,8 +53,8 @@ public class GetEnv extends EnvTestBase {
 
         Context child = (Context) context().lookup(getKey());
 
-        Hashtable envParent = context().getEnvironment();
-        Hashtable envChild = child.getEnvironment();
+        Hashtable<?,?> envParent = context().getEnvironment();
+        Hashtable<?,?> envChild = child.getEnvironment();
 
         DNSTestUtils.debug(child);
         DNSTestUtils.debug("Parent env: " + envParent);

--- a/test/jdk/com/sun/jndi/dns/EnvTests/RemoveInherited.java
+++ b/test/jdk/com/sun/jndi/dns/EnvTests/RemoveInherited.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,8 +67,8 @@ public class RemoveInherited extends EnvTestBase {
 
         Context child = (Context) context().lookup(getKey());
 
-        Hashtable envParent = context().getEnvironment();
-        Hashtable envChild = child.getEnvironment();
+        Hashtable<?,?> envParent = context().getEnvironment();
+        Hashtable<?,?> envChild = child.getEnvironment();
 
         DNSTestUtils.debug(child);
         DNSTestUtils.debug("Parent env: " + envParent);

--- a/test/jdk/com/sun/jndi/dns/EnvTests/SubcontextAdd.java
+++ b/test/jdk/com/sun/jndi/dns/EnvTests/SubcontextAdd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,8 +57,8 @@ public class SubcontextAdd extends EnvTestBase {
         addToEnvAndVerifyOldValIsNull(child, "some.irrelevant.property",
                 "somevalue");
 
-        Hashtable envParent = context().getEnvironment();
-        Hashtable envChild = child.getEnvironment();
+        Hashtable<?,?> envParent = context().getEnvironment();
+        Hashtable<?,?> envChild = child.getEnvironment();
 
         DNSTestUtils.debug(child);
         DNSTestUtils.debug("Parent env: " + envParent);

--- a/test/jdk/com/sun/jndi/dns/EnvTests/SubcontextRemove.java
+++ b/test/jdk/com/sun/jndi/dns/EnvTests/SubcontextRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,8 +62,8 @@ public class SubcontextRemove extends EnvTestBase {
                             + val);
         }
 
-        Hashtable envParent = context().getEnvironment();
-        Hashtable envChild = child.getEnvironment();
+        Hashtable<?,?> envParent = context().getEnvironment();
+        Hashtable<?,?> envChild = child.getEnvironment();
 
         DNSTestUtils.debug(child);
         DNSTestUtils.debug("Parent env: " + envParent);

--- a/test/jdk/com/sun/jndi/dns/FactoryTests/TestDnsObject.java
+++ b/test/jdk/com/sun/jndi/dns/FactoryTests/TestDnsObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ public class TestDnsObject {
     public TestDnsObject(Attribute attr) {
         StringBuilder buf = new StringBuilder();
         try {
-            NamingEnumeration enumObj = attr.getAll();
+            NamingEnumeration<?> enumObj = attr.getAll();
             while (enumObj.hasMore()) {
                 buf.append(enumObj.next());
             }

--- a/test/jdk/com/sun/jndi/dns/FedTests/ListFedBase.java
+++ b/test/jdk/com/sun/jndi/dns/FedTests/ListFedBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ abstract class ListFedBase extends DNSTestBase {
      * @param expectedCount given expected count
      * @throws NamingException
      */
-    public void verifyNamingEnumeration(NamingEnumeration enumObj,
+    public void verifyNamingEnumeration(NamingEnumeration<Binding> enumObj,
             int expectedCount) throws NamingException {
         DNSTestUtils.debug("Enum is: " + enumObj);
 
@@ -54,7 +54,7 @@ abstract class ListFedBase extends DNSTestBase {
         Binding res;
 
         while (enumObj.hasMore()) {
-            res = (Binding) enumObj.next();
+            res = enumObj.next();
             DNSTestUtils.debug(res);
             ++count;
         }

--- a/test/jdk/com/sun/jndi/dns/FedTests/ListNns.java
+++ b/test/jdk/com/sun/jndi/dns/FedTests/ListNns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import javax.naming.Binding;
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
 import javax.naming.directory.InitialDirContext;
@@ -52,7 +53,7 @@ public class ListNns extends ListFedBase {
         env().put(Context.OBJECT_FACTORIES, "FedObjectFactory");
         setContext(new InitialDirContext(env()));
 
-        NamingEnumeration enumObj = context().listBindings(getKey() + "/");
+        NamingEnumeration<Binding> enumObj = context().listBindings(getKey() + "/");
         verifyNamingEnumeration(enumObj, COUNT_LIMIT);
     }
 }

--- a/test/jdk/com/sun/jndi/dns/FedTests/ListSubInterior.java
+++ b/test/jdk/com/sun/jndi/dns/FedTests/ListSubInterior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import javax.naming.Binding;
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
 import javax.naming.directory.InitialDirContext;
@@ -54,7 +55,7 @@ public class ListSubInterior extends ListFedBase {
         env().put(Context.OBJECT_FACTORIES, "FedObjectFactory");
         setContext(new InitialDirContext(env()));
 
-        NamingEnumeration enumObj = context().listBindings(getKey() + "/a/b");
+        NamingEnumeration<Binding> enumObj = context().listBindings(getKey() + "/a/b");
         verifyNamingEnumeration(enumObj, COUNT_LIMIT);
     }
 }

--- a/test/jdk/com/sun/jndi/dns/FedTests/ListSubLeaf.java
+++ b/test/jdk/com/sun/jndi/dns/FedTests/ListSubLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import javax.naming.Binding;
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
 import javax.naming.directory.InitialDirContext;
@@ -54,7 +55,7 @@ public class ListSubLeaf extends ListFedBase {
         env().put(Context.OBJECT_FACTORIES, "FedObjectFactory");
         setContext(new InitialDirContext(env()));
 
-        NamingEnumeration enumObj = context().listBindings(getKey() + "/a/b/c");
+        NamingEnumeration<Binding> enumObj = context().listBindings(getKey() + "/a/b/c");
         verifyNamingEnumeration(enumObj, COUNT_LIMIT);
     }
 }

--- a/test/jdk/com/sun/jndi/dns/ListTests/ListBindingsInteriorNotFound.java
+++ b/test/jdk/com/sun/jndi/dns/ListTests/ListBindingsInteriorNotFound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import javax.naming.Binding;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingEnumeration;
 import javax.naming.directory.InitialDirContext;
@@ -52,7 +53,7 @@ public class ListBindingsInteriorNotFound extends ListTestBase {
     @Override
     public void runTest() throws Exception {
         setContext(new InitialDirContext(env()));
-        NamingEnumeration enumObj = context().listBindings(getKey());
+        NamingEnumeration<Binding> enumObj = context().listBindings(getKey());
 
         DNSTestUtils.debug("Enum is: " + enumObj);
         throw new RuntimeException("Failed: expecting NameNotFoundException");

--- a/test/jdk/com/sun/jndi/dns/ListTests/ListBindingsLeafNotFound.java
+++ b/test/jdk/com/sun/jndi/dns/ListTests/ListBindingsLeafNotFound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import javax.naming.Binding;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingEnumeration;
 import javax.naming.directory.InitialDirContext;
@@ -52,7 +53,7 @@ public class ListBindingsLeafNotFound extends ListTestBase {
     @Override
     public void runTest() throws Exception {
         setContext(new InitialDirContext(env()));
-        NamingEnumeration enumObj = context().listBindings(getKey());
+        NamingEnumeration<Binding> enumObj = context().listBindings(getKey());
 
         DNSTestUtils.debug("Enum is: " + enumObj);
         throw new RuntimeException("Failed: expecting NameNotFoundException");

--- a/test/jdk/com/sun/jndi/dns/ListTests/ListInteriorNotFound.java
+++ b/test/jdk/com/sun/jndi/dns/ListTests/ListInteriorNotFound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import javax.naming.NameClassPair;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingEnumeration;
 import javax.naming.directory.InitialDirContext;
@@ -52,7 +53,7 @@ public class ListInteriorNotFound extends ListTestBase {
     @Override
     public void runTest() throws Exception {
         setContext(new InitialDirContext(env()));
-        NamingEnumeration enumObj = context().list(getKey());
+        NamingEnumeration<NameClassPair> enumObj = context().list(getKey());
 
         DNSTestUtils.debug("Enum is: " + enumObj);
         throw new RuntimeException("Failed: expecting NameNotFoundException");

--- a/test/jdk/com/sun/jndi/dns/ListTests/ListLeafNotFound.java
+++ b/test/jdk/com/sun/jndi/dns/ListTests/ListLeafNotFound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import javax.naming.NameClassPair;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingEnumeration;
 import javax.naming.directory.InitialDirContext;
@@ -52,7 +53,7 @@ public class ListLeafNotFound extends ListTestBase {
     @Override
     public void runTest() throws Exception {
         setContext(new InitialDirContext(env()));
-        NamingEnumeration enumObj = context().list(getKey());
+        NamingEnumeration<NameClassPair> enumObj = context().list(getKey());
 
         DNSTestUtils.debug("Enum is: " + enumObj);
         throw new RuntimeException("Failed: expecting NameNotFoundException");

--- a/test/jdk/com/sun/jndi/ldap/BalancedParentheses.java
+++ b/test/jdk/com/sun/jndi/ldap/BalancedParentheses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,7 +103,7 @@ public class BalancedParentheses {
         }
 
         // set up the environment for creating the initial context
-        Hashtable<Object, Object> env = new Hashtable<Object, Object>();
+        Hashtable<Object, Object> env = new Hashtable<>();
         env.put(Context.INITIAL_CONTEXT_FACTORY,
                                 "com.sun.jndi.ldap.LdapCtxFactory");
         env.put(Context.PROVIDER_URL, "ldap://localhost:" + serverPort);
@@ -121,7 +121,7 @@ public class BalancedParentheses {
         scs.setSearchScope(SearchControls.SUBTREE_SCOPE);
 
         try {
-            NamingEnumeration answer = context.search(
+            NamingEnumeration<SearchResult> answer = context.search(
                                         "o=sun,c=us", "(&(cn=Bob)))", scs);
         } catch (InvalidSearchFilterException isfe) {
             // ignore, it is the expected filter exception.
@@ -132,7 +132,7 @@ public class BalancedParentheses {
         }
 
         try {
-            NamingEnumeration answer = context.search(
+            NamingEnumeration<SearchResult> answer = context.search(
                                         "o=sun,c=us", ")(&(cn=Bob)", scs);
         } catch (InvalidSearchFilterException isfe) {
             // ignore, it is the expected filter exception.
@@ -143,7 +143,7 @@ public class BalancedParentheses {
         }
 
         try {
-            NamingEnumeration answer = context.search(
+            NamingEnumeration<SearchResult> answer = context.search(
                                         "o=sun,c=us", "(&(cn=Bob))", scs);
         } catch (InvalidSearchFilterException isfe) {
             // ignore, it is the expected filter exception.

--- a/test/jdk/com/sun/jndi/ldap/Base64Test.java
+++ b/test/jdk/com/sun/jndi/ldap/Base64Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,7 +180,7 @@ public class Base64Test {
      * in an LDAP directory.
      */
     private static void storeObjectInLDAP() {
-        Hashtable env = new Hashtable();
+        Hashtable<Object, Object> env = new Hashtable<>();
         env.put(Context.REFERRAL, "follow"); // omit an LDAP control
         env.put("java.naming.ldap.version", "3"); // omit LDAP bind operation
         env.put("com.sun.jndi.ldap.trace.ber", System.err); // dump protocol

--- a/test/jdk/com/sun/jndi/ldap/DeadSSLLdapTimeoutTest.java
+++ b/test/jdk/com/sun/jndi/ldap/DeadSSLLdapTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,14 +52,14 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 
-class DeadServerTimeoutSSLTest implements Callable {
+class DeadServerTimeoutSSLTest implements Callable<Boolean> {
 
-    Hashtable env;
+    Hashtable<Object, Object> env;
     DeadSSLServer server;
     boolean passed = false;
     private int HANGING_TEST_TIMEOUT = 20_000;
 
-    public DeadServerTimeoutSSLTest(Hashtable env) throws IOException {
+    public DeadServerTimeoutSSLTest(Hashtable<Object, Object> env) throws IOException {
         this.server = new DeadSSLServer();
         this.env = env;
     }
@@ -106,7 +106,7 @@ class DeadServerTimeoutSSLTest implements Callable {
 
     public Boolean call() {
         InitialContext ctx = null;
-        ScheduledFuture killer = null;
+        ScheduledFuture<?> killer = null;
         long start = System.nanoTime();
 
         try {
@@ -174,8 +174,8 @@ class DeadSSLServer extends Thread {
 
 public class DeadSSLLdapTimeoutTest {
 
-    static Hashtable createEnv() {
-        Hashtable env = new Hashtable(11);
+    static Hashtable<Object, Object> createEnv() {
+        Hashtable<Object, Object> env = new Hashtable<>(11);
         env.put(Context.INITIAL_CONTEXT_FACTORY,
             "com.sun.jndi.ldap.LdapCtxFactory");
         return env;
@@ -194,7 +194,7 @@ public class DeadSSLLdapTimeoutTest {
         // this should exit with a SocketTimeoutException as the root cause
         // it should also use the connect timeout instead of the read timeout
         System.out.println("Running connect timeout test with 10ms connect timeout, 3000ms read timeout & SSL");
-        Hashtable sslenv = createEnv();
+        Hashtable<Object, Object> sslenv = createEnv();
         sslenv.put("com.sun.jndi.ldap.connect.timeout", "10");
         sslenv.put("com.sun.jndi.ldap.read.timeout", "3000");
         sslenv.put(Context.SECURITY_PROTOCOL, "ssl");

--- a/test/jdk/com/sun/jndi/ldap/InvalidLdapFilters.java
+++ b/test/jdk/com/sun/jndi/ldap/InvalidLdapFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -192,7 +192,7 @@ public class InvalidLdapFilters {
         scs.setSearchScope(SearchControls.SUBTREE_SCOPE);
 
         try {
-            NamingEnumeration answer =
+            NamingEnumeration<SearchResult> answer =
                     context.search("o=sun,c=us", searchFilter, scs);
         } catch (InvalidSearchFilterException isfe) {
             if (filterIsValid) {

--- a/test/jdk/com/sun/jndi/ldap/LdapName/EmptyNameSearch.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapName/EmptyNameSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ public class EmptyNameSearch {
         Thread.sleep(3000);
 
         // Setup JNDI parameters
-        Hashtable env = new Hashtable();
+        Hashtable<Object, Object> env = new Hashtable<>();
         env.put(Context.INITIAL_CONTEXT_FACTORY,
             "com.sun.jndi.ldap.LdapCtxFactory");
         env.put(Context.PROVIDER_URL, URIBuilder.newBuilder()
@@ -86,7 +86,7 @@ public class EmptyNameSearch {
             DirContext ctx = new InitialDirContext(env);
 
             System.out.println("Client: performing search...");
-            ctx.search(new LdapName(Collections.EMPTY_LIST), "cn=*", null);
+            ctx.search(new LdapName(Collections.emptyList()), "cn=*", null);
             ctx.close();
 
             // Exit

--- a/test/jdk/com/sun/jndi/ldap/NoWaitForReplyTest.java
+++ b/test/jdk/com/sun/jndi/ldap/NoWaitForReplyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public class NoWaitForReplyTest {
         var ldapServer = new BaseLdapServer().start();
 
         // Set up the environment for creating the initial context
-        Hashtable env = new Hashtable(11);
+        Hashtable<Object, Object> env = new Hashtable<>(11);
         env.put(Context.PROVIDER_URL, URIBuilder.newBuilder()
                 .scheme("ldap")
                 .loopback()
@@ -71,7 +71,7 @@ public class NoWaitForReplyTest {
             SearchControls scl = new SearchControls();
             scl.setSearchScope(SearchControls.SUBTREE_SCOPE);
             System.out.println("Client: performing search");
-            NamingEnumeration answer =
+            NamingEnumeration<SearchResult> answer =
             ctx.search("ou=People,o=JNDITutorial", "(objectClass=*)", scl);
 
             // Server will never reply: either we waited in the call above until

--- a/test/jdk/com/sun/jndi/ldap/blits/AddTests/AddNewEntry.java
+++ b/test/jdk/com/sun/jndi/ldap/blits/AddTests/AddNewEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ import javax.naming.directory.BasicAttributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
 import java.net.ServerSocket;
 import java.util.Hashtable;
 
@@ -99,7 +100,7 @@ public class AddNewEntry {
             SearchControls constraints = new SearchControls();
             constraints.setSearchScope(SearchControls.OBJECT_SCOPE);
 
-            NamingEnumeration results = ctx
+            NamingEnumeration<SearchResult> results = ctx
                     .search(entryDN, "(objectclass=*)", constraints);
 
             int found = LDAPTestUtils.checkResult(results, expect);

--- a/test/jdk/javax/naming/InitialContext/EnvClone.java
+++ b/test/jdk/javax/naming/InitialContext/EnvClone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import javax.naming.*;
 
 public class EnvClone extends InitialContext {
 
-    EnvClone(Hashtable env) throws NamingException{
+    EnvClone(Hashtable<Object, Object> env) throws NamingException{
         super(env);
     }
 
@@ -44,7 +44,7 @@ public class EnvClone extends InitialContext {
 
     public static void main(String[] args) throws Exception {
 
-        Hashtable env = new Hashtable(5);
+        Hashtable<Object, Object> env = new Hashtable<>(5);
         EnvClone ctx = new EnvClone(env);
 
         if (env == ctx.myProps) {

--- a/test/jdk/javax/naming/ldap/LdapName/CompareToEqualsTests.java
+++ b/test/jdk/javax/naming/ldap/LdapName/CompareToEqualsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,12 +74,12 @@ public class CompareToEqualsTests {
 
                 byte[] value = "abcxyz".getBytes();
                 Rdn rdn1 = new Rdn("binary", value);
-                ArrayList rdns1 = new ArrayList();
+                ArrayList<Rdn> rdns1 = new ArrayList<>();
                 rdns1.add(rdn1);
                 LdapName l1 = new LdapName(rdns1);
 
                 Rdn rdn2 = new Rdn("binary", value);
-                ArrayList rdns2 = new ArrayList();
+                ArrayList<Rdn> rdns2 = new ArrayList<>();
                 rdns2.add(rdn2);
                 LdapName l2 = new LdapName(rdns2);
                 checkResults(l1, l2, 0);

--- a/test/jdk/javax/naming/ldap/LdapName/LdapNameConstruction.java
+++ b/test/jdk/javax/naming/ldap/LdapName/LdapNameConstruction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public class LdapNameConstruction {
         /**
          * LdapName creation tests
          */
-        List rdns = new ArrayList();
+        List<Rdn> rdns = new ArrayList<>();
         rdns.add(new Rdn("o=Food"));
         rdns.add(new Rdn("ou=Fruits"));
         rdns.add(rdn3);
@@ -82,7 +82,7 @@ public class LdapNameConstruction {
         }
         System.out.println("ldapname1 and ldapname2 are equal");
 
-        LdapName name = new LdapName(new ArrayList());
+        LdapName name = new LdapName(new ArrayList<>());
         System.out.println("Empty ldapname:" + name);
     }
 }

--- a/test/jdk/javax/naming/ldap/LdapName/NameTests.java
+++ b/test/jdk/javax/naming/ldap/LdapName/NameTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,25 +42,25 @@ public class NameTests {
 
         String[] rdnStr = new String[] {"one=voilet"};
 
-        ArrayList rdnList = new ArrayList();
+        ArrayList<Rdn> rdnList = new ArrayList<>();
 
         for (int i = 0; i < rdnStr.length; i++) {
             rdnList.add(i, new Rdn(rdnStr[i]));
         }
         LdapName dn = new LdapName(rdnList);
 
-        Collection rdns = dn.getRdns();
+        Collection<Rdn> rdns = dn.getRdns();
         System.out.println("size is :" + dn.size());
         System.out.println("isEmpty :" + dn.isEmpty());
         System.out.println("************Printing as Rdns*********");
-        Iterator iter = rdns.iterator();
+        Iterator<Rdn> iter = rdns.iterator();
         while (iter.hasNext()) {
             System.out.println(iter.next());
         }
 
         System.out.println();
         System.out.println("************Printing the Enumeration*********");
-        Enumeration dnEnum = dn.getAll();
+        Enumeration<String> dnEnum = dn.getAll();
         while (dnEnum.hasMoreElements()) {
             System.out.println(dnEnum.nextElement());
         }
@@ -70,7 +70,7 @@ public class NameTests {
         LdapName nameSuffix = new LdapName("two=Indigo");
         System.out.println("addAll():" + dn.addAll(nameSuffix));
 
-        ArrayList list = new ArrayList();
+        ArrayList<Rdn> list = new ArrayList<>();
         list.add(new Rdn("five=Yellow"));
         System.out.println("Rdn- addAll():" + dn.addAll(list));
 
@@ -79,7 +79,7 @@ public class NameTests {
         System.out.println("addAll at pos = 2");
         System.out.println("addAll():" + dn.addAll(2, nameSuffix));
 
-        list = new ArrayList();
+        list = new ArrayList<>();
         list.add(new Rdn("four=Green"));
         System.out.println();
         System.out.println("addAll at pos = 3");
@@ -146,12 +146,12 @@ public class NameTests {
                         rdnStr[0] + "): " + dn.startsWith(
                                         new CompositeName(rdnStr[0])));
 
-        java.util.List prefixList = (dn.getRdns()).subList(0, size /2);
+        List<Rdn> prefixList = (dn.getRdns()).subList(0, size /2);
         System.out.println("Rdn - startsWith(" + prefixList + "):" +
                                 dn.startsWith(prefixList));
 
         System.out.println("Rdn - startsWith() - empty RDN list:" +
-                                dn.startsWith(new ArrayList()));
+                                dn.startsWith(new ArrayList<>()));
 
         System.out.println();
         System.out.println("endsWith(" + rdnStr[0] + "):" +
@@ -167,7 +167,7 @@ public class NameTests {
                                 dn.endsWith(prefixList));
 
         System.out.println("Rdn - endsWith() empty RDN list:" +
-                                dn.endsWith(new ArrayList()));
+                                dn.endsWith(new ArrayList<>()));
 
         // test clone
         System.out.println();

--- a/test/jdk/javax/naming/spi/DirectoryManager/DummyContext.java
+++ b/test/jdk/javax/naming/spi/DirectoryManager/DummyContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,13 +31,13 @@ import java.util.Hashtable;
 
 public class DummyContext extends InitialContext {
 
-    private Hashtable env;
+    private Hashtable<?,?> env;
 
-    DummyContext(Hashtable env) throws NamingException {
+    DummyContext(Hashtable<?,?> env) throws NamingException {
         this.env = env;
     }
 
-    public Hashtable getEnvironment() throws NamingException {
+    public Hashtable<?,?> getEnvironment() throws NamingException {
         return env;
     }
 }

--- a/test/jdk/javax/naming/spi/DirectoryManager/GetContDirCtx.java
+++ b/test/jdk/javax/naming/spi/DirectoryManager/GetContDirCtx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ public class GetContDirCtx {
     public static void main(String[] args) throws Exception {
 
         CannotProceedException cpe = new CannotProceedException();
-        Hashtable env = new Hashtable(1);
+        Hashtable<Object, Object> env = new Hashtable<>(1);
         cpe.setEnvironment(env);
 
         Reference ref = new Reference("java.lang.Object",
@@ -52,7 +52,7 @@ public class GetContDirCtx {
         } catch (CannotProceedException e) {
         }
 
-        Hashtable contEnv = contCtx.getEnvironment();
+        Hashtable<?,?> contEnv = contCtx.getEnvironment();
         if (contEnv.get(NamingManager.CPE) != cpe) {
             throw new Exception("Test failed: CPE property not set" +
                         " in the continuation context");

--- a/test/jdk/javax/naming/spi/DummyContextFactory.java
+++ b/test/jdk/javax/naming/spi/DummyContextFactory.java
@@ -126,13 +126,13 @@ public class DummyContextFactory implements InitialContextFactory {
 
     public class DummyContext extends InitialContext {
 
-        private Hashtable env;
+        private Hashtable<?, ?> env;
 
-        DummyContext(Hashtable env) throws NamingException {
+        DummyContext(Hashtable<?, ?> env) throws NamingException {
             this.env = env;
         }
 
-        public Hashtable getEnvironment() {
+        public Hashtable<?, ?> getEnvironment() {
             return env;
         }
     }

--- a/test/jdk/javax/naming/spi/DummyContextFactory2.java
+++ b/test/jdk/javax/naming/spi/DummyContextFactory2.java
@@ -42,13 +42,13 @@ public class DummyContextFactory2 implements InitialContextFactory {
 
     public class DummyContext extends InitialContext {
 
-        private Hashtable env;
+        private Hashtable<?, ?> env;
 
-        DummyContext(Hashtable env) throws NamingException {
+        DummyContext(Hashtable<?, ?> env) throws NamingException {
             this.env = env;
         }
 
-        public Hashtable getEnvironment() {
+        public Hashtable<?, ?> getEnvironment() {
             return env;
         }
     }


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

test/jdk/com/sun/jndi/ldap/InvalidLdapFilters.java
Copyright
test/jdk/com/sun/jndi/ldap/NoWaitForReplyTest.java
Resolved due to context

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8214694](https://bugs.openjdk.org/browse/JDK-8214694) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8214694](https://bugs.openjdk.org/browse/JDK-8214694): cleanup rawtypes warnings in open jndi tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2282/head:pull/2282` \
`$ git checkout pull/2282`

Update a local copy of the PR: \
`$ git checkout pull/2282` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2282`

View PR using the GUI difftool: \
`$ git pr show -t 2282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2282.diff">https://git.openjdk.org/jdk11u-dev/pull/2282.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2282#issuecomment-1818428324)