### PR TITLE
8238740: java/net/httpclient/whitebox/FlowTestDriver.java should not specify a TLS protocol

### DIFF
--- a/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/FlowTest.java
+++ b/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/FlowTest.java
@@ -90,7 +90,6 @@ public class FlowTest extends AbstractRandomTest {
         SSLEngine engineClient = ctx.createSSLEngine();
         SSLParameters params = ctx.getSupportedSSLParameters();
         params.setApplicationProtocols(new String[]{"proto1", "proto2"}); // server will choose proto2
-        params.setProtocols(new String[]{"TLSv1.2"}); // TODO: This is essential. Needs to be protocol impl
         engineClient.setSSLParameters(params);
         engineClient.setUseClientMode(true);
         completion = new CompletableFuture<>();


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8238740](https://bugs.openjdk.org/browse/JDK-8238740) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8238740](https://bugs.openjdk.org/browse/JDK-8238740): java/net/httpclient/whitebox/FlowTestDriver.java should not specify a TLS protocol (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2283/head:pull/2283` \
`$ git checkout pull/2283`

Update a local copy of the PR: \
`$ git checkout pull/2283` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2283`

View PR using the GUI difftool: \
`$ git pr show -t 2283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2283.diff">https://git.openjdk.org/jdk11u-dev/pull/2283.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2283#issuecomment-1818495102)