### PR TITLE
8249812: java/net/DatagramSocket/PortUnreachable.java still fails intermittently with SocketTimeoutException

### DIFF
--- a/test/jdk/java/net/DatagramSocket/PortUnreachable.java
+++ b/test/jdk/java/net/DatagramSocket/PortUnreachable.java
@@ -25,10 +25,12 @@
  * @test
  * @bug 4361783
  * @key intermittent
- * @summary  Test to see if ICMP Port Unreachable on non-connected
- *           DatagramSocket causes a SocketException "socket closed"
- *           exception on Windows 2000.
+ * @summary Test to see if ICMP Port Unreachable on non-connected
+ *          DatagramSocket causes a SocketException "socket closed"
+ *          exception on Windows 2000.
+ * @run main/othervm PortUnreachable
  */
+
 import java.net.BindException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
@@ -41,25 +43,22 @@ public class PortUnreachable {
     int serverPort;
     int clientPort;
 
-    public void serverSend() {
-        try {
-            InetAddress addr = InetAddress.getLocalHost();
-            Thread.sleep(1000);
-            // send a delayed packet which should mean a delayed icmp
-            // port unreachable
-            byte b[] = "A late msg".getBytes();
-            DatagramPacket packet = new DatagramPacket(b, b.length, addr,
-                                                       serverPort);
-            clientSock.send(packet);
+    public void serverSend() throws Exception {
+        InetAddress addr = InetAddress.getLocalHost();
+        Thread.sleep(1000);
+        // send a delayed packet which should mean a delayed icmp
+        // port unreachable
+        byte b[] = "A late msg".getBytes();
+        DatagramPacket packet = new DatagramPacket(b, b.length, addr,
+                serverPort);
+        clientSock.send(packet);
 
-            DatagramSocket sock = recreateServerSocket(serverPort);
-            b = "Greetings from the server".getBytes();
-            packet = new DatagramPacket(b, b.length, addr, clientPort);
-            sock.send(packet);
-            sock.close();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        DatagramSocket sock = recreateServerSocket(serverPort);
+        b = "Greetings from the server".getBytes();
+        packet = new DatagramPacket(b, b.length, addr, clientPort);
+        sock.send(packet);
+        Thread.sleep(500);  // give time to the kernel to send packet
+        sock.close();
     }
 
     DatagramSocket recreateServerSocket (int serverPort) throws Exception {
@@ -70,15 +69,15 @@ public class PortUnreachable {
                 serverPort);
         // it's possible that this method intermittently fails, if some other
         // process running on the machine grabs the port we want before us,
-        // and doesn't release it before the 5 * 500 ms are elapsed...
+        // and doesn't release it before the 10 * 500 ms are elapsed...
         while (serverSocket == null) {
             try {
                 serverSocket = new DatagramSocket(serverPort, InetAddress.getLocalHost());
             } catch (BindException bEx) {
-                if (retryCount++ < 5) {
-                   sleeptime += sleepAtLeast(500);
+                if (retryCount++ < 10) {
+                    sleeptime += sleepAtLeast(500);
                 } else {
-                    System.out.println("Give up after 5 retries and " + sleeptime(sleeptime));
+                    System.out.println("Give up after 10 retries and " + sleeptime(sleeptime));
                     System.out.println("Has some other process grabbed port " + serverPort + "?");
                     throw bEx;
                 }
@@ -154,6 +153,7 @@ public class PortUnreachable {
             clientSock.send(packet);
 
         serverSend();
+
         // try to receive
         b = new byte[25];
         packet = new DatagramPacket(b, b.length, addr, serverPort);
@@ -166,8 +166,23 @@ public class PortUnreachable {
     }
 
     public static void main(String[] args) throws Exception {
-        PortUnreachable test = new PortUnreachable();
-        test.execute();
-    }
+        // A BindException might be thrown intermittently. In that case retry
+        // 3 times before propagating the exception to finish execution.
+        int catchCount = 0;
 
+        while (true) {
+            try {
+                PortUnreachable test = new PortUnreachable();
+                test.execute();
+                return;
+            } catch (BindException bEx) {
+                System.out.println("Failed to bind server: " + bEx);
+                if (++catchCount > 3) {
+                    System.out.printf("Max retry count exceeded (%d)%n", catchCount);
+                    throw bEx;
+                }
+                System.out.printf("Retrying; retry count: %d%n", catchCount);
+            }
+        }
+    }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle. 
Also backport for JDK-8232513. Clean backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8232513](https://bugs.openjdk.org/browse/JDK-8232513) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8249812](https://bugs.openjdk.org/browse/JDK-8249812) needs maintainer approval
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8249812](https://bugs.openjdk.org/browse/JDK-8249812): java/net/DatagramSocket/PortUnreachable.java still fails intermittently with SocketTimeoutException (**Bug** - P4 - Approved)
 * [JDK-8232513](https://bugs.openjdk.org/browse/JDK-8232513): java/net/DatagramSocket/PortUnreachable.java still fails intermittently with BindException (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2285/head:pull/2285` \
`$ git checkout pull/2285`

Update a local copy of the PR: \
`$ git checkout pull/2285` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2285`

View PR using the GUI difftool: \
`$ git pr show -t 2285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2285.diff">https://git.openjdk.org/jdk11u-dev/pull/2285.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2285#issuecomment-1820279498)