### PR TITLE
8315692: Parallelize gc/stress/TestStressRSetCoarsening.java test

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
@@ -27,13 +27,12 @@ import java.util.concurrent.TimeoutException;
 import sun.hotspot.WhiteBox;
 
 /*
- * @test TestStressRSetCoarsening.java
+ * @test
  * @key stress
  * @bug 8146984 8147087
  * @requires vm.gc.G1
  * @requires os.maxMemory > 3G
  * @requires vm.opt.MaxGCPauseMillis == "null"
- *
  * @summary Stress G1 Remembered Set by creating a lot of cross region links
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -43,27 +42,87 @@ import sun.hotspot.WhiteBox;
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening  1  0 300
+ *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 1 0 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx500m -XX:G1HeapRegionSize=8m gc.stress.TestStressRSetCoarsening  1 10 300
+ *     -Xmx500m -XX:G1HeapRegionSize=8m gc.stress.TestStressRSetCoarsening 1 10 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
  *     -Xmx500m -XX:G1HeapRegionSize=32m gc.stress.TestStressRSetCoarsening 42 10 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening  2 0 300
+ *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 2 0 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm/timeout=1800
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 500 0  1800
+ *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 500 0 1800
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *                              sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm/timeout=1800
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 10  10 1800
+ *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 10 10 1800
  */
 
 /**
@@ -96,7 +155,7 @@ public class TestStressRSetCoarsening {
         }
         int objectsPerRegion = Integer.parseInt(args[0]); // 1 means humongous
         int regsToRefresh = Integer.parseInt(args[1]);  // 0 means no regions to refresh at the end of cycle
-        int timeout = Integer.parseInt(args[2]); // in seconds, test should stop working eariler
+        int timeout = Integer.parseInt(args[2]); // in seconds, test should stop working earlier
         new TestStressRSetCoarsening(objectsPerRegion, regsToRefresh, timeout).go();
     }
 


### PR DESCRIPTION
The commit includes backporting a564d436c722f14041231158f21c4ad3a2f6a3a5 from upstream to jdk11u-dev. The hunks were not applied cleanly due to the WhiteBox path being different in JDK11(sun.hotspot.WhiteBox) from JDK17 and JDK21(jdk.test.whitebox.WhiteBox). Below are the results upon running in AL2_x86_64:

* before_release: 1345.83s user 96.37s system 507% cpu 4:44.44 total
* before_debug: 6899.97s user 176.88s system 1452% cpu 8:07.25 total
* after_release: 1362.16s user 85.15s system 901% cpu 2:40.53 total
* after_debug: 8678.08s user 90.59s system 3287% cpu 4:26.70 total

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8315692](https://bugs.openjdk.org/browse/JDK-8315692) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315692](https://bugs.openjdk.org/browse/JDK-8315692): Parallelize gc/stress/TestStressRSetCoarsening.java test (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2293/head:pull/2293` \
`$ git checkout pull/2293`

Update a local copy of the PR: \
`$ git checkout pull/2293` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2293`

View PR using the GUI difftool: \
`$ git pr show -t 2293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2293.diff">https://git.openjdk.org/jdk11u-dev/pull/2293.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2293#issuecomment-1824695149)