### PR TITLE
8067250: [mlvm] vm/mlvm/mixed/stress/regression/b6969574 fails and perf regression

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,7 @@
  * @bug 6969574
  *
  * @summary converted from VM Testbase vm/mlvm/mixed/stress/regression/b6969574.
- * VM Testbase keywords: [feature_mlvm, nonconcurrent, quarantine]
- * VM Testbase comments: 8079650
+ * VM Testbase keywords: [feature_mlvm, nonconcurrent]
  *
  * @library /vmTestbase
  *          /test/lib
@@ -313,10 +312,8 @@ public class INDIFY_Test extends MlvmTest {
     private final static int REFLECTION_CALL = 1;
     private final static int INVOKE_EXACT = 2;
     private final static int INVOKE = 3;
-    private final static int INVOKE_WITHARG = 4;
-    private final static int INVOKE_WITHARG_TYPECONV = 5;
-    private final static int INDY = 6;
-    private final static int BENCHMARK_COUNT = 7;
+    private final static int INDY = 4;
+    private final static int BENCHMARK_COUNT = 5;
 
     //
     // Test body
@@ -353,18 +350,6 @@ public class INDIFY_Test extends MlvmTest {
         benchmarks[INVOKE] = new Benchmark("MH.invoke()", new T() {
                     public void run() throws Throwable {
                         mhTestee.invokeExact(testData, TESTEE_ARG2, TESTEE_ARG3);
-                    }
-                });
-
-        benchmarks[INVOKE_WITHARG] = new Benchmark("MH.invokeWithArguments(), exact types", new T() {
-                    public void run() throws Throwable {
-                        mhTestee.invokeWithArguments(testData, TESTEE_ARG2, TESTEE_ARG3);
-                    }
-                });
-
-        benchmarks[INVOKE_WITHARG_TYPECONV] = new Benchmark("MH.invokeWithArguments() + type conv.", new T() {
-                    public void run() throws Throwable {
-                        mhTestee.invokeWithArguments((Object) testData, null, (Short) Short.MAX_VALUE);
                     }
                 });
 
@@ -415,8 +400,6 @@ public class INDIFY_Test extends MlvmTest {
         verifyTimeOrder(results[REFLECTION_CALL],         results[INVOKE_EXACT]);
         verifyTimeOrder(results[INVOKE_EXACT],            results[DIRECT_CALL]);
         verifyTimeOrder(results[INVOKE],                  results[DIRECT_CALL]);
-        verifyTimeOrder(results[INVOKE_WITHARG],          results[INVOKE_EXACT]);
-        verifyTimeOrder(results[INVOKE_WITHARG_TYPECONV], results[INVOKE_EXACT]);
         verifyTimeOrder(results[INVOKE_EXACT],            results[INDY]);
 
         return true;


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8067250](https://bugs.openjdk.org/browse/JDK-8067250) needs maintainer approval

### Issue
 * [JDK-8067250](https://bugs.openjdk.org/browse/JDK-8067250): [mlvm] vm/mlvm/mixed/stress/regression/b6969574 fails and perf regression (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2294/head:pull/2294` \
`$ git checkout pull/2294`

Update a local copy of the PR: \
`$ git checkout pull/2294` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2294`

View PR using the GUI difftool: \
`$ git pr show -t 2294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2294.diff">https://git.openjdk.org/jdk11u-dev/pull/2294.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2294#issuecomment-1825106437)