### PR TITLE
8214908: add ctw tests for jdk.jfr and jdk.management.jfr modules

### DIFF
--- a/test/hotspot/jtreg/applications/ctw/modules/jdk_jfr.java
+++ b/test/hotspot/jtreg/applications/ctw/modules/jdk_jfr.java
@@ -26,7 +26,8 @@
  * @summary run CTW for all classes from jdk.jfr module
  *
  * @library /test/lib / /testlibrary/ctw/src
- * @modules java.base/jdk.internal.jimage
+ * @modules java.base/jdk.internal.access
+ *          java.base/jdk.internal.jimage
  *          java.base/jdk.internal.misc
  *          java.base/jdk.internal.reflect
  * @modules jdk.jfr

--- a/test/hotspot/jtreg/applications/ctw/modules/jdk_management_jfr.java
+++ b/test/hotspot/jtreg/applications/ctw/modules/jdk_management_jfr.java
@@ -26,7 +26,8 @@
  * @summary run CTW for all classes from jdk.management.jfr module
  *
  * @library /test/lib / /testlibrary/ctw/src
- * @modules java.base/jdk.internal.jimage
+ * @modules java.base/jdk.internal.access
+ *          java.base/jdk.internal.jimage
  *          java.base/jdk.internal.misc
  *          java.base/jdk.internal.reflect
  * @modules jdk.management.jfr


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.
This two files already exist, only add new module "java.base/jdk.internal.access"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8214908](https://bugs.openjdk.org/browse/JDK-8214908) needs maintainer approval

### Issue
 * [JDK-8214908](https://bugs.openjdk.org/browse/JDK-8214908): add ctw tests for jdk.jfr and jdk.management.jfr modules (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2295/head:pull/2295` \
`$ git checkout pull/2295`

Update a local copy of the PR: \
`$ git checkout pull/2295` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2295`

View PR using the GUI difftool: \
`$ git pr show -t 2295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2295.diff">https://git.openjdk.org/jdk11u-dev/pull/2295.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2295#issuecomment-1825174561)