### PR TITLE
8214915: CtwRunner misses export for jdk.internal.access

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -272,6 +272,7 @@ public class CtwRunner {
                 "--add-exports", "java.base/jdk.internal.jimage=ALL-UNNAMED",
                 "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
                 "--add-exports", "java.base/jdk.internal.reflect=ALL-UNNAMED",
+                "--add-exports", "java.base/jdk.internal.access=ALL-UNNAMED",
                 // enable diagnostic logging
                 "-XX:+LogCompilation",
                 // use phase specific log, hs_err and ciReplay files


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8214915](https://bugs.openjdk.org/browse/JDK-8214915) needs maintainer approval

### Issue
 * [JDK-8214915](https://bugs.openjdk.org/browse/JDK-8214915): CtwRunner misses export for jdk.internal.access (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2296/head:pull/2296` \
`$ git checkout pull/2296`

Update a local copy of the PR: \
`$ git checkout pull/2296` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2296`

View PR using the GUI difftool: \
`$ git pr show -t 2296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2296.diff">https://git.openjdk.org/jdk11u-dev/pull/2296.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2296#issuecomment-1825177912)