### PR TITLE
8218178: vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java fails with -Xcomp

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java
@@ -412,7 +412,7 @@ public class INDIFY_Test extends MlvmTest {
         // TODO: exclude GC time, compilation time (optionally) from measurements
 
         print("Comparing invocation time orders");
-        verifyTimeOrder(results[REFLECTION_CALL],         results[INVOKE_EXACT]);
+        verifyTimeOrder(results[INDY],                    results[REFLECTION_CALL]);
         verifyTimeOrder(results[INVOKE_EXACT],            results[DIRECT_CALL]);
         verifyTimeOrder(results[INVOKE],                  results[DIRECT_CALL]);
         verifyTimeOrder(results[INVOKE_WITHARG],          results[INVOKE_EXACT]);


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8218178](https://bugs.openjdk.org/browse/JDK-8218178) needs maintainer approval

### Issue
 * [JDK-8218178](https://bugs.openjdk.org/browse/JDK-8218178): vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java fails with -Xcomp (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2297/head:pull/2297` \
`$ git checkout pull/2297`

Update a local copy of the PR: \
`$ git checkout pull/2297` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2297`

View PR using the GUI difftool: \
`$ git pr show -t 2297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2297.diff">https://git.openjdk.org/jdk11u-dev/pull/2297.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2297#issuecomment-1825195212)