### PR TITLE
8224035: Replace wildcard address with loopback or local host in tests - part 9

### DIFF
--- a/test/jdk/java/net/ServerSocket/ThreadStop.java
+++ b/test/jdk/java/net/ServerSocket/ThreadStop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,8 @@ public class ThreadStop {
         ServerSocket ss;
 
         Server() throws IOException {
-            ss = new ServerSocket(0);
+            ss = new ServerSocket();
+            ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         }
 
         public int localPort() {
@@ -81,7 +82,7 @@ public class ThreadStop {
         // still in accept() so we connect to server which causes
         // it to unblock and do JNI-stuff with a pending exception
 
-        try (Socket s = new Socket("localhost", svr.localPort())) {
+        try (Socket s = new Socket(svr.ss.getInetAddress(), svr.localPort())) {
         } catch (IOException ioe) {
         }
         thr.join();

--- a/test/jdk/java/net/Socket/asyncClose/Race.java
+++ b/test/jdk/java/net/Socket/asyncClose/Race.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@
  */
 
 import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.ConnectException;
@@ -40,12 +42,14 @@ public class Race {
     final static int THREADS = 100;
 
     public static void main(String[] args) throws Exception {
-        try (ServerSocket ss = new ServerSocket(0)) {
+        try (ServerSocket ss = new ServerSocket()) {
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            ss.bind(new InetSocketAddress(loopback, 0));
             final int port = ss.getLocalPort();
             final Phaser phaser = new Phaser(THREADS + 1);
             for (int i=0; i<100; i++) {
                 try {
-                    final Socket s = new Socket("localhost", port);
+                    final Socket s = new Socket(loopback, port);
                     s.setSoLinger(false, 0);
                     try (Socket sa = ss.accept()) {
                         sa.setSoLinger(false, 0);

--- a/test/jdk/java/net/URLClassLoader/HttpTest.java
+++ b/test/jdk/java/net/URLClassLoader/HttpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,15 @@
 /**
  * @test
  * @bug 4636331
+ * @library /test/lib
  * @summary Check that URLClassLoader doesn't create excessive http
  *          connections
  */
 import java.net.*;
 import java.io.*;
 import java.util.*;
+
+import jdk.test.lib.net.URIBuilder;
 
 public class HttpTest {
 
@@ -119,7 +122,8 @@ public class HttpTest {
         }
 
         HttpServer() throws Exception {
-            ss = new ServerSocket(0);
+            ss = new ServerSocket();
+            ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         }
 
         public void run() {
@@ -200,9 +204,12 @@ public class HttpTest {
         HttpServer svr = HttpServer.create();
 
         // create class loader
-        URL urls[] =
-            { new URL("http://localhost:" + svr.port() + "/dir1/"),
-              new URL("http://localhost:" + svr.port() + "/dir2/") };
+        URL urls[] = {
+                URIBuilder.newBuilder().scheme("http").loopback().port(svr.port())
+                        .path("/dir1/").toURL(),
+                URIBuilder.newBuilder().scheme("http").loopback().port(svr.port())
+                        .path("/dir2/").toURL(),
+        };
         URLClassLoader cl = new URLClassLoader(urls);
 
         // Test 1 - check that getResource does single HEAD request

--- a/test/jdk/java/net/URLConnection/TimeoutTest.java
+++ b/test/jdk/java/net/URLConnection/TimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,8 @@ public class TimeoutTest {
     }
 
     public void test() throws Exception {
-        ServerSocket ss = new ServerSocket(0);
+        ServerSocket ss = new ServerSocket();
+        ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         Server s = new Server (ss);
         try{
             URL url = URIBuilder.newBuilder()

--- a/test/jdk/sun/net/www/http/HttpClient/CookieHttpClientTest.java
+++ b/test/jdk/sun/net/www/http/HttpClient/CookieHttpClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 7129083
+ * @library /test/lib
  * @summary Cookiemanager does not store cookies if url is read
  *          before setting cookiemanager
  */
@@ -31,11 +32,15 @@
 import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URL;
 import java.io.InputStream;
 import java.io.IOException;
+
+import jdk.test.lib.net.URIBuilder;
 
 public class CookieHttpClientTest implements Runnable {
     final ServerSocket ss;
@@ -85,10 +90,15 @@ public class CookieHttpClientTest implements Runnable {
 
     CookieHttpClientTest() throws Exception {
         /* start the server */
-        ss = new ServerSocket(0);
+        ss = new ServerSocket();
+        ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         (new Thread(this)).start();
 
-        URL url = new URL("http://localhost:" + ss.getLocalPort() +"/");
+        URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(ss.getLocalPort())
+                .path("/").toURL();
 
         // Run without a CookieHandler first
         InputStream in = url.openConnection().getInputStream();

--- a/test/jdk/sun/net/www/protocol/http/RedirectOnPost.java
+++ b/test/jdk/sun/net/www/protocol/http/RedirectOnPost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -166,7 +166,8 @@ public class RedirectOnPost {
     private static HttpServer getHttpServer(ExecutorService execs)
         throws Exception
     {
-        InetSocketAddress inetAddress = new InetSocketAddress(0);
+        InetSocketAddress inetAddress = new InetSocketAddress(
+                InetAddress.getLoopbackAddress(), 0);
         HttpServer testServer = HttpServer.create(inetAddress, 15);
         int port = testServer.getAddress().getPort();
         testServer.setExecutor(execs);
@@ -181,7 +182,8 @@ public class RedirectOnPost {
     )
         throws Exception
     {
-        InetSocketAddress inetAddress = new InetSocketAddress(0);
+        InetSocketAddress inetAddress = new InetSocketAddress(
+                InetAddress.getLoopbackAddress(), 0);
         HttpsServer testServer = HttpsServer.create(inetAddress, 15);
         int port = testServer.getAddress().getPort();
         testServer.setExecutor(execs);

--- a/test/jdk/sun/net/www/protocol/http/SetChunkedStreamingMode.java
+++ b/test/jdk/sun/net/www/protocol/http/SetChunkedStreamingMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,8 @@ public class SetChunkedStreamingMode implements HttpCallback {
 
     public static void main (String[] args) throws Exception {
         try {
-            server = new TestHttpServer (new SetChunkedStreamingMode(), 1, 10, 0);
+            server = new TestHttpServer(new SetChunkedStreamingMode(), 1, 10,
+                    InetAddress.getLoopbackAddress(), 0);
             System.out.println ("Server: listening on port: " + server.getLocalPort());
             URL url = URIBuilder.newBuilder()
                 .scheme("http")

--- a/test/jdk/sun/net/www/protocol/http/SetIfModifiedSince.java
+++ b/test/jdk/sun/net/www/protocol/http/SetIfModifiedSince.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,15 @@
  */
 
 /* @test
-   @bug 4213164 8172253
-   @summary setIfModifiedSince mehtod in HttpURLConnection sometimes fails
-   */
+ * @bug 4213164 8172253
+ * @library /test/lib
+ * @summary setIfModifiedSince method in HttpURLConnection sometimes fails
+ */
 import java.util.*;
 import java.io.*;
 import java.net.*;
-import java.text.*;
+
+import jdk.test.lib.net.URIBuilder;
 
 public class SetIfModifiedSince implements Runnable {
 
@@ -75,7 +77,8 @@ public class SetIfModifiedSince implements Runnable {
 
   public SetIfModifiedSince() throws Exception {
 
-     serverSock = new ServerSocket(0);
+      serverSock = new ServerSocket();
+      serverSock.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
      int port = serverSock.getLocalPort();
 
      Thread thr = new Thread(this);
@@ -86,8 +89,12 @@ public class SetIfModifiedSince implements Runnable {
      HttpURLConnection con;
 
      //url = new URL(args[0]);
-     url = new URL("http://localhost:" + String.valueOf(port) +
-                   "/anything");
+      url = URIBuilder.newBuilder()
+              .scheme("http")
+              .loopback()
+              .port(port)
+              .path("/anything")
+              .toURL();
      con = (HttpURLConnection)url.openConnection(Proxy.NO_PROXY);
 
      con.setIfModifiedSince(date.getTime());


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8224035](https://bugs.openjdk.org/browse/JDK-8224035) needs maintainer approval

### Issue
 * [JDK-8224035](https://bugs.openjdk.org/browse/JDK-8224035): Replace wildcard address with loopback or local host in tests - part 9 (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2298/head:pull/2298` \
`$ git checkout pull/2298`

Update a local copy of the PR: \
`$ git checkout pull/2298` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2298`

View PR using the GUI difftool: \
`$ git pr show -t 2298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2298.diff">https://git.openjdk.org/jdk11u-dev/pull/2298.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2298#issuecomment-1825213071)