### PR TITLE
Backport 3c743cfea00692d0b938cb1cbde936084eecf369

### DIFF
--- a/src/java.naming/share/classes/sun/security/provider/certpath/ldap/LDAPCertStoreImpl.java
+++ b/src/java.naming/share/classes/sun/security/provider/certpath/ldap/LDAPCertStoreImpl.java
@@ -775,9 +775,13 @@ final class LDAPCertStoreImpl {
                 } catch (IllegalArgumentException e) {
                     continue;
                 }
-            } else {
+            } else if (nameObject instanceof String) {
                 issuerName = (String)nameObject;
+            } else {
+                throw new CertStoreException(
+                    "unrecognized issuerName: must be String or byte[]");
             }
+
             // If all we want is CA certs, try to get the (probably shorter) ARL
             Collection<X509CRL> entryCRLs = Collections.emptySet();
             if (certChecking == null || certChecking.getBasicConstraints() != -1) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [3c743cfe](https://github.com/openjdk/jdk/commit/3c743cfea00692d0b938cb1cbde936084eecf369) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sean Mullan on 15 Sep 2023 and was reviewed by Weijun Wang. It was backported to 17u on 2023-11-10.

It is a simple fix and clean backport for a regression introduced by [JDK-8297955](https://bugs.openjdk.org/browse/JDK-8297955) which was backported in 11.0.21. The new code in JDK-8297955 failed to catch a null  IssuerName, allowing a NullPointerException to be thrown instead of the specified CertStoreException.

Thanks.