### PR TITLE
8227438: [TESTLIB] Determine if file exists by Files.exists in function FileUtils.deleteFileIfExistsWithRetry

### DIFF
--- a/test/lib/jdk/test/lib/util/FileUtils.java
+++ b/test/lib/jdk/test/lib/util/FileUtils.java
@@ -97,7 +97,7 @@ public final class FileUtils {
      */
     public static void deleteFileIfExistsWithRetry(Path path) throws IOException {
         try {
-            if (Files.exists(path)) {
+            if (!Files.notExists(path)) {
                 deleteFileWithRetry0(path);
             }
         } catch (InterruptedException x) {


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8227438](https://bugs.openjdk.org/browse/JDK-8227438) needs maintainer approval

### Issue
 * [JDK-8227438](https://bugs.openjdk.org/browse/JDK-8227438): [TESTLIB] Determine if file exists by Files.exists in function FileUtils.deleteFileIfExistsWithRetry (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2300/head:pull/2300` \
`$ git checkout pull/2300`

Update a local copy of the PR: \
`$ git checkout pull/2300` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2300`

View PR using the GUI difftool: \
`$ git pr show -t 2300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2300.diff">https://git.openjdk.org/jdk11u-dev/pull/2300.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2300#issuecomment-1827053238)