### PR TITLE
8208699: remove unneeded imports from runtime tests

### DIFF
--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/CdsSameObjectAlignment.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/CdsSameObjectAlignment.java
@@ -36,7 +36,6 @@
 import jdk.test.lib.Platform;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
-import jtreg.SkippedException;
 
 public class CdsSameObjectAlignment {
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/runtime/XCheckJniJsig/XCheckJSig.java
+++ b/test/hotspot/jtreg/runtime/XCheckJniJsig/XCheckJSig.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Platform;
-import jtreg.SkippedException;
 
 public class XCheckJSig {
     public static void main(String args[]) throws Throwable {


### PR DESCRIPTION
Backport of [JDK-8208699](https://bugs.openjdk.org/browse/JDK-8208699)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8208699](https://bugs.openjdk.org/browse/JDK-8208699) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8208699](https://bugs.openjdk.org/browse/JDK-8208699): remove unneeded imports from runtime tests (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2303/head:pull/2303` \
`$ git checkout pull/2303`

Update a local copy of the PR: \
`$ git checkout pull/2303` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2303`

View PR using the GUI difftool: \
`$ git pr show -t 2303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2303.diff">https://git.openjdk.org/jdk11u-dev/pull/2303.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2303#issuecomment-1831536709)