### PR TITLE
8202282: [TESTBUG] appcds TestCommon.makeCommandLineForAppCDS() can be removed

### DIFF
--- a/test/hotspot/jtreg/runtime/appcds/GraalWithLimitedMetaspace.java
+++ b/test/hotspot/jtreg/runtime/appcds/GraalWithLimitedMetaspace.java
@@ -87,7 +87,6 @@ public class GraalWithLimitedMetaspace {
 
     static void dumpLoadedClasses(String[] expectedClasses) throws Exception {
         ProcessBuilder pb = ProcessTools.createTestJvm(
-          TestCommon.makeCommandLineForAppCDS(
             "-XX:DumpLoadedClassList=" + CLASSLIST_FILE,
             // trigger JVMCI runtime init so that JVMCI classes will be
             // included in the classlist
@@ -97,7 +96,7 @@ public class GraalWithLimitedMetaspace {
             "-cp",
             TESTJAR,
             TESTNAME,
-            TEST_OUT));
+            TEST_OUT);
 
         OutputAnalyzer output = TestCommon.executeAndLog(pb, "dump-loaded-classes")
             .shouldHaveExitValue(0)
@@ -115,7 +114,6 @@ public class GraalWithLimitedMetaspace {
 
     static void dumpArchive() throws Exception {
         ProcessBuilder pb = ProcessTools.createTestJvm(
-          TestCommon.makeCommandLineForAppCDS(
             "-cp",
             TESTJAR,
             "-XX:SharedClassListFile=" + CLASSLIST_FILE,
@@ -123,7 +121,7 @@ public class GraalWithLimitedMetaspace {
             "-Xlog:cds",
             "-Xshare:dump",
             "-XX:MetaspaceSize=12M",
-            "-XX:MaxMetaspaceSize=12M"));
+            "-XX:MaxMetaspaceSize=12M");
 
         OutputAnalyzer output = TestCommon.executeAndLog(pb, "dump-archive");
         int exitValue = output.getExitValue();

--- a/test/hotspot/jtreg/runtime/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/appcds/TestCommon.java
@@ -114,10 +114,6 @@ public class TestCommon extends CDSTestUtils {
         return createArchive(opts);
     }
 
-    public static String[] makeCommandLineForAppCDS(String... args) throws Exception {
-        return args;
-    }
-
     // Create AppCDS archive using appcds options
     public static OutputAnalyzer createArchive(AppCDSOptions opts)
         throws Exception {

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasic.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasic.java
@@ -49,24 +49,22 @@ public class SharedStringsBasic {
             TestCommon.getSourceFile("SharedStringsBasic.txt").toString();
 
         ProcessBuilder dumpPb = ProcessTools.createTestJvm(
-          TestCommon.makeCommandLineForAppCDS(
             "-cp", appJar,
             "-XX:SharedArchiveConfigFile=" + sharedArchiveConfigFile,
             "-XX:SharedArchiveFile=./SharedStringsBasic.jsa",
             "-Xshare:dump",
-            "-Xlog:cds,cds+hashtables"));
+            "-Xlog:cds,cds+hashtables");
 
         TestCommon.executeAndLog(dumpPb, "dump")
             .shouldContain("Shared string table stats")
             .shouldHaveExitValue(0);
 
         ProcessBuilder runPb = ProcessTools.createTestJvm(
-          TestCommon.makeCommandLineForAppCDS(
             "-cp", appJar,
             "-XX:SharedArchiveFile=./SharedStringsBasic.jsa",
             "-Xshare:auto",
             "-showversion",
-            "HelloString"));
+            "HelloString");
 
         TestCommon.executeAndLog(runPb, "run").shouldHaveExitValue(0);
     }

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SysDictCrash.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SysDictCrash.java
@@ -44,21 +44,19 @@ public class SysDictCrash {
         // SharedBaseAddress=0 puts the archive at a very high address on solaris,
         // which provokes the crash.
         ProcessBuilder dumpPb = ProcessTools.createTestJvm(
-          TestCommon.makeCommandLineForAppCDS(
             "-XX:+UseG1GC", "-XX:MaxRAMPercentage=12.5",
             "-cp", ".",
             "-XX:SharedBaseAddress=0", "-XX:SharedArchiveFile=./SysDictCrash.jsa",
             "-Xshare:dump",
-            "-showversion", "-Xlog:cds,cds+hashtables"));
+            "-showversion", "-Xlog:cds,cds+hashtables");
 
         TestCommon.checkDump(TestCommon.executeAndLog(dumpPb, "dump"));
 
         ProcessBuilder runPb = ProcessTools.createTestJvm(
-          TestCommon.makeCommandLineForAppCDS(
             "-XX:+UseG1GC", "-XX:MaxRAMPercentage=12.5",
             "-XX:SharedArchiveFile=./SysDictCrash.jsa",
             "-Xshare:on",
-            "-version"));
+            "-version");
 
         TestCommon.checkExec(TestCommon.executeAndLog(runPb, "exec"));
     }


### PR DESCRIPTION
Backport of [JDK-8202282](https://bugs.openjdk.org/browse/JDK-8202282)

Note.
- The diff file of the [original commit](https://github.com/openjdk/jdk/commit/5108d2e1dd0c89f45aa508d17fb3706e81afb7e1) cannot be applied, because the baseline code are different
- Manually merged the file.
- So this is an `unclean` backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8202282](https://bugs.openjdk.org/browse/JDK-8202282) needs maintainer approval

### Issue
 * [JDK-8202282](https://bugs.openjdk.org/browse/JDK-8202282): [TESTBUG] appcds TestCommon.makeCommandLineForAppCDS() can be removed (**Enhancement** - P3 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2313/head:pull/2313` \
`$ git checkout pull/2313`

Update a local copy of the PR: \
`$ git checkout pull/2313` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2313`

View PR using the GUI difftool: \
`$ git pr show -t 2313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2313.diff">https://git.openjdk.org/jdk11u-dev/pull/2313.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2313#issuecomment-1833125654)