### PR TITLE
8208623: [TESTBUG] runtime/LoadClass/LongBCP.java fails in AUFS file system

### DIFF
--- a/test/hotspot/jtreg/runtime/LoadClass/LongBCP.java
+++ b/test/hotspot/jtreg/runtime/LoadClass/LongBCP.java
@@ -34,6 +34,8 @@
  */
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.FileStore;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -103,8 +105,15 @@ public class LongBCP {
         // We currently cannot handle relative path specified in the
         // -Xbootclasspath/a on windows.
         //
-        // relative path length within the 256 limit
-        char[] chars = new char[255];
+        // relative path length within the file system limit
+        int fn_max_length = 255;
+        // In AUFS file system, the maximal file name length is 242
+        FileStore store = Files.getFileStore(new File(".").toPath());
+        String fs_type = store.type();
+        if ("aufs".equals(fs_type)) {
+            fn_max_length = 242;
+        }
+        char[] chars = new char[fn_max_length];
         Arrays.fill(chars, 'y');
         String subPath = new String(chars);
         destDir = Paths.get(".", subPath);


### PR DESCRIPTION
Backport of [JDK-8208623](https://bugs.openjdk.org/browse/JDK-8208623)

Note.
- The diff of the [original commit](https://github.com/openjdk/jdk/commit/03d6ab3b09eaa0bc4860fb530d648270149dcfe0) cannot be applied, because the baseline code is different
- The only issue is `import java.io.File;` already exists in [jdk11u-dev](https://github.com/openjdk/jdk11u-dev), so we ignored this line when doing manual merge
- This change can be **considered as clean** backport because the Semantics is exactly the same

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8208623](https://bugs.openjdk.org/browse/JDK-8208623) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8208623](https://bugs.openjdk.org/browse/JDK-8208623): [TESTBUG] runtime/LoadClass/LongBCP.java fails in AUFS file system (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2315/head:pull/2315` \
`$ git checkout pull/2315`

Update a local copy of the PR: \
`$ git checkout pull/2315` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2315`

View PR using the GUI difftool: \
`$ git pr show -t 2315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2315.diff">https://git.openjdk.org/jdk11u-dev/pull/2315.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2315#issuecomment-1833201135)