### PR TITLE
8208705: [TESTBUG] The -Xlog:cds,cds+hashtables vm option is not always required for appcds tests

### DIFF
--- a/test/hotspot/jtreg/runtime/appcds/ExtraSymbols.java
+++ b/test/hotspot/jtreg/runtime/appcds/ExtraSymbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,17 +38,19 @@ import java.io.*;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class ExtraSymbols {
+    static final String CDS_LOGGING = "-Xlog:cds,cds+hashtables";
     public static void main(String[] args) throws Exception {
         String appJar = JarBuilder.getOrCreateHelloJar();
 
         // 1. Dump without extra symbols.
-        OutputAnalyzer output = TestCommon.dump(appJar, TestCommon.list("Hello"));
+        OutputAnalyzer output = TestCommon.dump(appJar, TestCommon.list("Hello"),
+                                                CDS_LOGGING);
         checkOutput(output);
         int numEntries1 = numOfEntries(output);
 
         // 2. Dump an archive with extra symbols. All symbols in
         // ExtraSymbols.symbols.txt are valid. Dumping should succeed.
-        output = TestCommon.dump(appJar, TestCommon.list("Hello"),
+        output = TestCommon.dump(appJar, TestCommon.list("Hello"), CDS_LOGGING,
             "-XX:SharedArchiveConfigFile=" + TestCommon.getSourceFile("ExtraSymbols.symbols.txt"));
         checkOutput(output);
         int numEntries2 = numOfEntries(output);

--- a/test/hotspot/jtreg/runtime/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/appcds/TestCommon.java
@@ -137,7 +137,6 @@ public class TestCommon extends CDSTestUtils {
         }
 
         cmd.add("-Xshare:dump");
-        cmd.add("-Xlog:cds,cds+hashtables");
         cmd.add("-XX:ExtraSharedClassListFile=" + classList.getPath());
 
         if (opts.archiveName == null)

--- a/test/hotspot/jtreg/runtime/appcds/VerifierTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/VerifierTest.java
@@ -48,6 +48,7 @@ public class VerifierTest implements Opcodes {
     static final String PASS_RESULT = "Hi, how are you?";
     static final String VFY_INFO_MESSAGE =
         "All non-system classes will be verified (-Xverify:remote) during CDS dump time.";
+    static final String CDS_LOGGING = "-Xlog:cds,cds+hashtables";
 
     enum Testset1Part {
         A, B
@@ -104,6 +105,7 @@ public class VerifierTest implements Opcodes {
         // Dumping should fail if the IgnoreUnverifiableClassesDuringDump
         // option is not enabled.
         OutputAnalyzer output = TestCommon.dump(jar, appClasses,
+                            CDS_LOGGING,
                             "-XX:+UnlockDiagnosticVMOptions",
                             "-XX:-IgnoreUnverifiableClassesDuringDump");
         output.shouldContain("Please remove the unverifiable classes");
@@ -186,6 +188,7 @@ public class VerifierTest implements Opcodes {
             if (!dump_setting.equals(prev_dump_setting)) {
                 OutputAnalyzer dumpOutput = TestCommon.dump(
                                                             jar, dump_list, dump_setting,
+                                                            CDS_LOGGING,
                                                             // FIXME: the following options are for working around a GC
                                                             // issue - assert failure when dumping archive with the -Xverify:all
                                                             "-Xms256m",
@@ -243,6 +246,7 @@ public class VerifierTest implements Opcodes {
             if (!dump_setting.equals(prev_dump_setting)) {
                 OutputAnalyzer dumpOutput = TestCommon.dump(
                                                             jar, appClasses, dump_setting,
+                                                            CDS_LOGGING,
                                                             // FIXME: the following options are for working around a GC
                                                             // issue - assert failure when dumping archive with the -Xverify:all
                                                             "-Xms256m",

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatBase.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class ClassListFormatBase {
         System.out.println("------------------------------");
 
         try {
-            OutputAnalyzer output = TestCommon.dump(appJar, appClasses);
+            OutputAnalyzer output = TestCommon.dump(appJar, appClasses, "-Xlog:cds");
             output.shouldHaveExitValue(0);
             output.shouldContain("Dumping");
             for (String s : expected_msgs) {

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/ExerciseGC.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/ExerciseGC.java
@@ -41,7 +41,7 @@ public class ExerciseGC {
         SharedStringsUtils.buildJarAndWhiteBox("HelloStringGC");
 
         SharedStringsUtils.dumpWithWhiteBox(TestCommon.list("HelloStringGC"),
-            "SharedStringsBasic.txt");
+            "SharedStringsBasic.txt", "-Xlog:cds,cds+hashtables");
 
         SharedStringsUtils.runWithArchiveAndWhiteBox("HelloStringGC",
             "-XX:+UnlockDiagnosticVMOptions", "-XX:+VerifyBeforeGC");

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/FlagCombo.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/FlagCombo.java
@@ -55,7 +55,7 @@ public class FlagCombo {
         SharedStringsUtils.buildJar("HelloString");
 
         SharedStringsUtils.dump(TestCommon.list("HelloString"),
-            "SharedStringsBasic.txt");
+            "SharedStringsBasic.txt", "-Xlog:cds,cds+hashtables");
 
         SharedStringsUtils.runWithArchive("HelloString", "-XX:+UseG1GC");
 

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/IncompatibleOptions.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/IncompatibleOptions.java
@@ -120,6 +120,7 @@ public class IncompatibleOptions {
             "-XX:+UseCompressedOops",
             collectorOption,
             "-XX:SharedArchiveConfigFile=" + TestCommon.getSourceFile("SharedStringsBasic.txt"),
+            "-Xlog:cds,cds+hashtables",
             extraOption);
 
         if (expectedWarning != null)

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/InternSharedString.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/InternSharedString.java
@@ -43,7 +43,7 @@ public class InternSharedString {
         SharedStringsUtils.buildJarAndWhiteBox("InternStringTest");
 
         SharedStringsUtils.dumpWithWhiteBox(TestCommon.list("InternStringTest"),
-            "ExtraSharedInput.txt");
+            "ExtraSharedInput.txt", "-Xlog:cds,cds+hashtables");
 
         String[] extraMatches = new String[]   {
             InternStringTest.passed_output1,

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/LargePages.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/LargePages.java
@@ -36,15 +36,16 @@
  * @run main/othervm -XX:-CompactStrings LargePages
  */
 public class LargePages {
+    static final String CDS_LOGGING = "-Xlog:cds,cds+hashtables";
     public static void main(String[] args) throws Exception {
         SharedStringsUtils.buildJar("HelloString");
 
         SharedStringsUtils.dump(TestCommon.list("HelloString"),
-            "SharedStringsBasic.txt", "-XX:+UseLargePages");
+            "SharedStringsBasic.txt", "-XX:+UseLargePages", CDS_LOGGING);
         SharedStringsUtils.runWithArchive("HelloString", "-XX:+UseLargePages");
 
         SharedStringsUtils.dump(TestCommon.list("HelloString"),
-            "SharedStringsBasic.txt",
+            "SharedStringsBasic.txt", CDS_LOGGING,
             "-XX:+UseLargePages", "-XX:+UseLargePagesInMetaspace");
         SharedStringsUtils.runWithArchive("HelloString",
             "-XX:+UseLargePages", "-XX:+UseLargePagesInMetaspace");

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/LockSharedStrings.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/LockSharedStrings.java
@@ -44,7 +44,7 @@ public class LockSharedStrings {
 
         SharedStringsUtils.dumpWithWhiteBox(
             TestCommon.list("LockStringTest", "LockStringValueTest"),
-            "ExtraSharedInput.txt");
+            "ExtraSharedInput.txt", "-Xlog:cds,cds+hashtables");
 
         String[] extraMatch = new String[] {"LockStringTest: PASS"};
         SharedStringsUtils.runWithArchiveAndWhiteBox(extraMatch, "LockStringTest");

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasicPlus.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasicPlus.java
@@ -42,7 +42,7 @@ public class SharedStringsBasicPlus {
         SharedStringsUtils.buildJarAndWhiteBox("HelloStringPlus");
 
         SharedStringsUtils.dumpWithWhiteBox( TestCommon.list("HelloStringPlus"),
-            "SharedStringsBasic.txt");
+            "SharedStringsBasic.txt", "-Xlog:cds,cds+hashtables");
 
         SharedStringsUtils.runWithArchiveAndWhiteBox("HelloStringPlus");
     }

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsWbTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsWbTest.java
@@ -45,7 +45,7 @@ public class SharedStringsWbTest {
         SharedStringsUtils.buildJarAndWhiteBox("SharedStringsWb");
 
         SharedStringsUtils.dumpWithWhiteBox(TestCommon.list("SharedStringsWb"),
-            "SharedStringsBasic.txt");
+            "SharedStringsBasic.txt", "-Xlog:cds,cds+hashtables");
 
         SharedStringsUtils.runWithArchiveAndWhiteBox("SharedStringsWb");
     }


### PR DESCRIPTION
Backport of [JDK-8208705](https://bugs.openjdk.org/browse/JDK-8208705)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8208705](https://bugs.openjdk.org/browse/JDK-8208705) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8208705](https://bugs.openjdk.org/browse/JDK-8208705): [TESTBUG] The -Xlog:cds,cds+hashtables vm option is not always required for appcds tests (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2316/head:pull/2316` \
`$ git checkout pull/2316`

Update a local copy of the PR: \
`$ git checkout pull/2316` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2316`

View PR using the GUI difftool: \
`$ git pr show -t 2316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2316.diff">https://git.openjdk.org/jdk11u-dev/pull/2316.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2316#issuecomment-1833222494)