### PR TITLE
8209549: remove VMPropsExt from TEST.ROOT

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -40,10 +40,10 @@ groups=TEST.groups
 # Source files for classes that will be used at the beginning of each test suite run,
 # to determine additional characteristics of the system for use with the @requires tag.
 # Note: compiled bootlibs code will be located in the folder 'bootClasses'
-requires.extraPropDefns = ../../test/jtreg-ext/requires/VMProps.java [../../closed/test/jtreg-ext/requires/VMPropsExt.java]
-requires.extraPropDefns.bootlibs = ../../test/lib/sun \
-    ../../test/lib/jdk/test/lib/Platform.java \
-    ../../test/lib/jdk/test/lib/Container.java
+requires.extraPropDefns = ../jtreg-ext/requires/VMProps.java
+requires.extraPropDefns.bootlibs = ../lib/sun \
+    ../lib/jdk/test/lib/Platform.java \
+    ../lib/jdk/test/lib/Container.java
 requires.extraPropDefns.vmOpts = -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:bootClasses
 requires.properties= \
     sun.arch.data.model \


### PR DESCRIPTION
Backport of [JDK-8209549](https://bugs.openjdk.org/browse/JDK-8209549)

Note.
- The diff file of [original commit](https://github.com/openjdk/jdk/commit/610dfb22d3eab9bd92a733c06b1d54888d28e446) be applied, because the baseline code are different
- Manually merged the diff file based on the `original commit`
- So this is an `unclean` backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8209549](https://bugs.openjdk.org/browse/JDK-8209549) needs maintainer approval

### Issue
 * [JDK-8209549](https://bugs.openjdk.org/browse/JDK-8209549): remove VMPropsExt from TEST.ROOT (**Enhancement** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2317/head:pull/2317` \
`$ git checkout pull/2317`

Update a local copy of the PR: \
`$ git checkout pull/2317` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2317`

View PR using the GUI difftool: \
`$ git pr show -t 2317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2317.diff">https://git.openjdk.org/jdk11u-dev/pull/2317.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2317#issuecomment-1833240062)