### PR TITLE
8209946: [TESTBUG] CDS tests should use "@run driver"

### DIFF
--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/ArchiveDoesNotExist.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/ArchiveDoesNotExist.java
@@ -31,7 +31,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main ArchiveDoesNotExist
+ * @run driver ArchiveDoesNotExist
  */
 
 import jdk.test.lib.cds.CDSOptions;

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/CdsDifferentObjectAlignment.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/CdsDifferentObjectAlignment.java
@@ -34,7 +34,7 @@
  * @bug 8025642
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main CdsDifferentObjectAlignment
+ * @run driver CdsDifferentObjectAlignment
  */
 
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/CdsSameObjectAlignment.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/CdsSameObjectAlignment.java
@@ -30,7 +30,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main CdsSameObjectAlignment
+ * @run driver CdsSameObjectAlignment
  */
 
 import jdk.test.lib.Platform;

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/DumpSharedDictionary.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/DumpSharedDictionary.java
@@ -28,7 +28,7 @@
  * @requires vm.cds
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run main DumpSharedDictionary
+ * @run driver DumpSharedDictionary
  */
 
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/NonBootLoaderClasses.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/NonBootLoaderClasses.java
@@ -28,7 +28,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main NonBootLoaderClasses
+ * @run driver NonBootLoaderClasses
  */
 
 import jdk.test.lib.cds.CDSOptions;

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedBaseAddress.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedBaseAddress.java
@@ -29,7 +29,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main SharedBaseAddress
+ * @run driver SharedBaseAddress
  */
 
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedStrings.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedStrings.java
@@ -31,7 +31,7 @@
  *          java.management
  * @build SharedStringsWb sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller -jar whitebox.jar sun.hotspot.WhiteBox
- * @run main SharedStrings
+ * @run driver SharedStrings
  */
 
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedStringsDedup.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedStringsDedup.java
@@ -28,7 +28,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main SharedStringsDedup
+ * @run driver SharedStringsDedup
  */
 
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedStringsRunAuto.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedStringsRunAuto.java
@@ -28,7 +28,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main SharedStringsRunAuto
+ * @run driver SharedStringsRunAuto
  */
 
 import jdk.test.lib.cds.CDSTestUtils;

--- a/test/hotspot/jtreg/runtime/appcds/AppendClasspath.java
+++ b/test/hotspot/jtreg/runtime/appcds/AppendClasspath.java
@@ -32,7 +32,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java
  * @compile test-classes/HelloMore.java
- * @run main AppendClasspath
+ * @run driver AppendClasspath
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/BootClassPathMismatch.java
+++ b/test/hotspot/jtreg/runtime/appcds/BootClassPathMismatch.java
@@ -31,7 +31,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java
- * @run main BootClassPathMismatch
+ * @run driver BootClassPathMismatch
  */
 
 import jdk.test.lib.cds.CDSOptions;

--- a/test/hotspot/jtreg/runtime/appcds/CDSandJFR.java
+++ b/test/hotspot/jtreg/runtime/appcds/CDSandJFR.java
@@ -30,7 +30,7 @@
  * @modules jdk.jfr
  * @build Hello GetFlightRecorder
  * @run driver ClassFileInstaller -jar CDSandJFR.jar Hello GetFlightRecorder GetFlightRecorder$TestEvent GetFlightRecorder$SimpleEvent
- * @run main CDSandJFR
+ * @run driver CDSandJFR
  */
 
 import jdk.test.lib.BuildHelper;

--- a/test/hotspot/jtreg/runtime/appcds/CaseSensitiveClassPath.java
+++ b/test/hotspot/jtreg/runtime/appcds/CaseSensitiveClassPath.java
@@ -34,7 +34,7 @@
  *          jdk.jartool/sun.tools.jar
  * @requires os.family != "mac"
  * @compile test-classes/Hello.java
- * @run main CaseSensitiveClassPath
+ * @run driver CaseSensitiveClassPath
  */
 
 import java.nio.file.FileAlreadyExistsException;

--- a/test/hotspot/jtreg/runtime/appcds/ClassLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/ClassLoaderTest.java
@@ -36,7 +36,7 @@
  * @compile test-classes/BootClassPathAppendHelper.java
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main ClassLoaderTest
+ * @run driver ClassLoaderTest
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/ClassPathAttr.java
+++ b/test/hotspot/jtreg/runtime/appcds/ClassPathAttr.java
@@ -30,7 +30,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  *          jdk.jartool/sun.tools.jar
- * @run main ClassPathAttr
+ * @run driver ClassPathAttr
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/CommandLineFlagComboNegative.java
+++ b/test/hotspot/jtreg/runtime/appcds/CommandLineFlagComboNegative.java
@@ -34,7 +34,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java
- * @run main CommandLineFlagComboNegative
+ * @run driver CommandLineFlagComboNegative
  */
 
 import java.util.ArrayList;

--- a/test/hotspot/jtreg/runtime/appcds/DirClasspathTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/DirClasspathTest.java
@@ -28,7 +28,7 @@
  * @requires vm.cds
  * @library /test/lib
  * @compile test-classes/Hello.java
- * @run main DirClasspathTest
+ * @run driver DirClasspathTest
  */
 
 import jdk.test.lib.Platform;

--- a/test/hotspot/jtreg/runtime/appcds/DumpClassList.java
+++ b/test/hotspot/jtreg/runtime/appcds/DumpClassList.java
@@ -31,7 +31,7 @@
  * @modules java.base/jdk.internal.misc
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/ArrayListTest.java
- * @run main DumpClassList
+ * @run driver DumpClassList
  */
 
 import jdk.test.lib.compiler.InMemoryJavaCompiler;

--- a/test/hotspot/jtreg/runtime/appcds/ExtraSymbols.java
+++ b/test/hotspot/jtreg/runtime/appcds/ExtraSymbols.java
@@ -31,7 +31,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java
- * @run main ExtraSymbols
+ * @run driver ExtraSymbols
  */
 
 import java.io.*;

--- a/test/hotspot/jtreg/runtime/appcds/FieldAnnotationsTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/FieldAnnotationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/FieldAnnotationsApp.java test-classes/MyAnnotation.java
- * @run main FieldAnnotationsTest
+ * @run driver FieldAnnotationsTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/FreeUnusedMetadata.java
+++ b/test/hotspot/jtreg/runtime/appcds/FreeUnusedMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  * @library /test/lib
  * @modules jdk.jartool/sun.tools.jar
  * @compile test-classes/MethodNoReturn.jasm test-classes/Hello.java
- * @run main FreeUnusedMetadata
+ * @run driver FreeUnusedMetadata
  */
 
 import java.nio.file.Files;

--- a/test/hotspot/jtreg/runtime/appcds/HelloExtTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/HelloExtTest.java
@@ -35,7 +35,7 @@
  * @compile test-classes/HelloExt.java
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main HelloExtTest
+ * @run driver HelloExtTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/HelloTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/HelloTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java
- * @run main HelloTest
+ * @run driver HelloTest
  */
 
 public class HelloTest {

--- a/test/hotspot/jtreg/runtime/appcds/IgnoreEmptyClassPaths.java
+++ b/test/hotspot/jtreg/runtime/appcds/IgnoreEmptyClassPaths.java
@@ -32,7 +32,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java
  * @compile test-classes/HelloMore.java
- * @run main IgnoreEmptyClassPaths
+ * @run driver IgnoreEmptyClassPaths
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/JvmtiAddPath.java
+++ b/test/hotspot/jtreg/runtime/appcds/JvmtiAddPath.java
@@ -35,7 +35,7 @@
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @compile test-classes/Hello.java
  * @compile test-classes/JvmtiApp.java
- * @run main JvmtiAddPath
+ * @run driver JvmtiAddPath
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/MissingSuperTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/MissingSuperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/MissingSuper.java
- * @run main MissingSuperTest
+ * @run driver MissingSuperTest
  */
 
 public class MissingSuperTest {

--- a/test/hotspot/jtreg/runtime/appcds/MoveJDKTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/MoveJDKTest.java
@@ -34,7 +34,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java
- * @run main MoveJDKTest
+ * @run driver MoveJDKTest
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/MultiProcessSharing.java
+++ b/test/hotspot/jtreg/runtime/appcds/MultiProcessSharing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @compile test-classes/MultiProcClass.java
- * @run main MultiProcessSharing
+ * @run driver MultiProcessSharing
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/OldClassTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/OldClassTest.java
@@ -33,7 +33,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java
  * @run build TestCommon JarBuilder
- * @run main OldClassTest
+ * @run driver OldClassTest
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/PackageSealing.java
+++ b/test/hotspot/jtreg/runtime/appcds/PackageSealing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  * @compile test-classes/C1.java
  * @compile test-classes/C2.java
  * @compile test-classes/PackageSealingTest.java
- * @run main PackageSealing
+ * @run driver PackageSealing
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/ParallelLoad2.java
+++ b/test/hotspot/jtreg/runtime/appcds/ParallelLoad2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/ParallelLoad.java
  * @compile test-classes/ParallelClasses.java
- * @run main ParallelLoad2
+ * @run driver ParallelLoad2
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/ParallelLoadTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/ParallelLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/ParallelLoad.java
  * @compile test-classes/ParallelClasses.java
- * @run main ParallelLoadTest
+ * @run driver ParallelLoadTest
  */
 
 public class ParallelLoadTest {

--- a/test/hotspot/jtreg/runtime/appcds/ProhibitedPackage.java
+++ b/test/hotspot/jtreg/runtime/appcds/ProhibitedPackage.java
@@ -31,7 +31,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/ProhibitedHelper.java test-classes/Prohibited.jasm
- * @run main ProhibitedPackage
+ * @run driver ProhibitedPackage
  */
 
 import jdk.test.lib.cds.CDSOptions;

--- a/test/hotspot/jtreg/runtime/appcds/ProtectionDomain.java
+++ b/test/hotspot/jtreg/runtime/appcds/ProtectionDomain.java
@@ -33,7 +33,7 @@
  * @compile test-classes/ProtDomain.java
  * @compile test-classes/ProtDomainB.java
  * @compile test-classes/JimageClassProtDomain.java
- * @run main ProtectionDomain
+ * @run driver ProtectionDomain
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/RewriteBytecodesTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/RewriteBytecodesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  * @compile test-classes/RewriteBytecodes.java test-classes/Util.java test-classes/Super.java test-classes/Child.java
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main RewriteBytecodesTest
+ * @run driver RewriteBytecodesTest
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/SharedPackages.java
+++ b/test/hotspot/jtreg/runtime/appcds/SharedPackages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/PackageTest.java
  * @compile test-classes/JimageClassPackage.java
- * @run main SharedPackages
+ * @run driver SharedPackages
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/SignedJar.java
+++ b/test/hotspot/jtreg/runtime/appcds/SignedJar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java
- * @run main SignedJar
+ * @run driver SignedJar
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/SpecifySysLoaderProp.java
+++ b/test/hotspot/jtreg/runtime/appcds/SpecifySysLoaderProp.java
@@ -32,7 +32,7 @@
  * @compile test-classes/TestClassLoader.java
  * @compile test-classes/ReportMyLoader.java
  * @compile test-classes/TrySwitchMyLoader.java
- * @run main SpecifySysLoaderProp
+ * @run driver SpecifySysLoaderProp
  */
 
 import java.io.*;

--- a/test/hotspot/jtreg/runtime/appcds/TestWithProfiler.java
+++ b/test/hotspot/jtreg/runtime/appcds/TestWithProfiler.java
@@ -36,7 +36,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/MyThread.java
  * @compile test-classes/TestWithProfilerHelper.java
- * @run main TestWithProfiler
+ * @run driver TestWithProfiler
  */
 
 import jdk.test.lib.BuildHelper;

--- a/test/hotspot/jtreg/runtime/appcds/TraceLongClasspath.java
+++ b/test/hotspot/jtreg/runtime/appcds/TraceLongClasspath.java
@@ -31,7 +31,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java
- * @run main TraceLongClasspath
+ * @run driver TraceLongClasspath
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/WideIloadTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/WideIloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Iloadw.jasm
  * @compile test-classes/IloadwMain.java
- * @run main WideIloadTest
+ * @run driver WideIloadTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/WrongClasspath.java
+++ b/test/hotspot/jtreg/runtime/appcds/WrongClasspath.java
@@ -31,7 +31,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java
- * @run main WrongClasspath
+ * @run driver WrongClasspath
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/XShareAutoWithChangedJar.java
+++ b/test/hotspot/jtreg/runtime/appcds/XShareAutoWithChangedJar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java
- * @run main XShareAutoWithChangedJar
+ * @run driver XShareAutoWithChangedJar
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedIntegerCacheTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedIntegerCacheTest.java
@@ -34,7 +34,7 @@
  * @compile CheckIntegerCacheApp.java
  * @run driver ClassFileInstaller -jar integer.jar CheckIntegerCacheApp
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
- * @run main ArchivedIntegerCacheTest
+ * @run driver ArchivedIntegerCacheTest
  */
 
 import java.nio.file.Files;

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedModuleComboTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedModuleComboTest.java
@@ -34,7 +34,7 @@
  * @compile CheckArchivedModuleApp.java
  * @run driver ClassFileInstaller -jar app.jar CheckArchivedModuleApp
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
- * @run main ArchivedModuleComboTest
+ * @run driver ArchivedModuleComboTest
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedModuleCompareTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedModuleCompareTest.java
@@ -32,7 +32,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile PrintSystemModulesApp.java
  * @run driver ClassFileInstaller -jar app.jar PrintSystemModulesApp
- * @run main ArchivedModuleCompareTest
+ * @run driver ArchivedModuleCompareTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
@@ -34,7 +34,7 @@
  * @compile CheckArchivedModuleApp.java
  * @run driver ClassFileInstaller -jar app.jar CheckArchivedModuleApp
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
- * @run main ArchivedModuleWithCustomImageTest
+ * @run driver ArchivedModuleWithCustomImageTest
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/CheckCachedMirrorTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/CheckCachedMirrorTest.java
@@ -37,7 +37,7 @@
  * @run driver ClassFileInstaller -jar app.jar CheckCachedMirrorApp
  * @run driver ClassFileInstaller -jar hello.jar Hello
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
- * @run main CheckCachedMirrorTest
+ * @run driver CheckCachedMirrorTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/CheckCachedResolvedReferences.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/CheckCachedResolvedReferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@
  * @run driver ClassFileInstaller -jar app.jar CheckCachedResolvedReferencesApp
  * @run driver ClassFileInstaller -jar hello.jar Hello
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
- * @run main CheckCachedResolvedReferences
+ * @run driver CheckCachedResolvedReferences
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/DifferentHeapSizes.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/DifferentHeapSizes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/DumpTimeVerifyFailure.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/DumpTimeVerifyFailure.java
@@ -32,7 +32,7 @@
  * @modules java.management
  *          jdk.jartool/sun.tools.jar
  * @compile MyOuter.java MyException.java
- * @run main DumpTimeVerifyFailure
+ * @run driver DumpTimeVerifyFailure
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/GCStressTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/GCStressTest.java
@@ -35,7 +35,7 @@
  * @compile GCStressApp.java
  * @run driver ClassFileInstaller -jar gcstress.jar GCStressApp jdk.test.lib.Utils
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
- * @run main GCStressTest
+ * @run driver GCStressTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/MirrorWithReferenceFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/MirrorWithReferenceFieldsTest.java
@@ -34,7 +34,7 @@
  * @compile MirrorWithReferenceFieldsApp.java
  * @run driver ClassFileInstaller -jar app.jar MirrorWithReferenceFieldsApp
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
- * @run main MirrorWithReferenceFieldsTest
+ * @run driver MirrorWithReferenceFieldsTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/OpenArchiveRegion.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/OpenArchiveRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  * @modules java.management
  *          jdk.jartool/sun.tools.jar
  * @compile ../test-classes/Hello.java
- * @run main OpenArchiveRegion
+ * @run driver OpenArchiveRegion
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/PrimitiveTypesTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/PrimitiveTypesTest.java
@@ -34,7 +34,7 @@
  * @compile PrimitiveTypesApp.java
  * @run driver ClassFileInstaller -jar app.jar PrimitiveTypesApp FieldsTest
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
- * @run main PrimitiveTypesTest
+ * @run driver PrimitiveTypesTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/RedefineClassTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/RedefineClassTest.java
@@ -34,7 +34,7 @@
  *        RedefineClassApp
  *        InstrumentationClassFileTransformer
  *        InstrumentationRegisterClassFileTransformer
- * @run main/othervm RedefineClassTest
+ * @run driver RedefineClassTest
  */
 
 import com.sun.tools.attach.VirtualMachine;

--- a/test/hotspot/jtreg/runtime/appcds/condy/CondyHelloTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/condy/CondyHelloTest.java
@@ -31,7 +31,7 @@
  * @build sun.hotspot.WhiteBox CondyHelloTest CondyHelloApp
  * @run driver ClassFileInstaller -jar condy_hello.jar CondyHello CondyHelloApp
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
- * @run main CondyHelloTest
+ * @run driver CondyHelloTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatA.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java test-classes/CustomLoadee.java test-classes/CustomLoadee2.java
  *          test-classes/CustomInterface2_ia.java test-classes/CustomInterface2_ib.java
- * @run main ClassListFormatA
+ * @run driver ClassListFormatA
  */
 
 public class ClassListFormatA extends ClassListFormatBase {

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatB.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java test-classes/CustomLoadee.java test-classes/CustomLoadee2.java
  *          test-classes/CustomInterface2_ia.java test-classes/CustomInterface2_ib.java
- * @run main ClassListFormatB
+ * @run driver ClassListFormatB
  */
 
 public class ClassListFormatB extends ClassListFormatBase {

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatC.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java test-classes/CustomLoadee.java test-classes/CustomLoadee2.java
  *          test-classes/CustomInterface2_ia.java test-classes/CustomInterface2_ib.java
- * @run main ClassListFormatC
+ * @run driver ClassListFormatC
  */
 
 public class ClassListFormatC extends ClassListFormatBase {

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatD.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java test-classes/CustomLoadee.java test-classes/CustomLoadee2.java
  *          test-classes/CustomInterface2_ia.java test-classes/CustomInterface2_ib.java
- * @run main ClassListFormatD
+ * @run driver ClassListFormatD
  */
 
 public class ClassListFormatD extends ClassListFormatBase {

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatE.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/Hello.java test-classes/CustomLoadee.java test-classes/CustomLoadee2.java
  *          test-classes/CustomInterface2_ia.java test-classes/CustomInterface2_ib.java
- * @run main ClassListFormatE
+ * @run driver ClassListFormatE
  */
 
 public class ClassListFormatE extends ClassListFormatBase {

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/HelloCustom.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/HelloCustom.java
@@ -33,7 +33,7 @@
  * @run driver ClassFileInstaller -jar hello.jar Hello
  * @run driver ClassFileInstaller -jar hello_custom.jar CustomLoadee
  * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
- * @run main HelloCustom
+ * @run driver HelloCustom
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/LoaderSegregationTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/LoaderSegregationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@
  *          ../test-classes/Util.java
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main LoaderSegregationTest
+ * @run driver LoaderSegregationTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/ParallelTestMultiFP.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/ParallelTestMultiFP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile ../test-classes/ParallelLoad.java ../test-classes/ParallelClasses.java
- * @run main ParallelTestMultiFP
+ * @run driver ParallelTestMultiFP
  */
 
 public class ParallelTestMultiFP extends ParallelTestBase {

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/ParallelTestSingleFP.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/ParallelTestSingleFP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile ../test-classes/ParallelLoad.java ../test-classes/ParallelClasses.java
- * @run main ParallelTestSingleFP
+ * @run driver ParallelTestSingleFP
  */
 
 public class ParallelTestSingleFP extends ParallelTestBase {

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/ProhibitedPackageNamesTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/ProhibitedPackageNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile ClassListFormatBase.java test-classes/Hello.java test-classes/InProhibitedPkg.java
- * @run main ProhibitedPackageNamesTest
+ * @run driver ProhibitedPackageNamesTest
  */
 
 public class ProhibitedPackageNamesTest extends ClassListFormatBase {

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/ProtectionDomain.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/ProtectionDomain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/ProtDomain.java
- * @run main ProtectionDomain
+ * @run driver ProtectionDomain
  */
 
 public class ProtectionDomain {

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/SameNameInTwoLoadersTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/SameNameInTwoLoadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@
  *     test-classes/SameNameUnrelatedLoaders.java
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main SameNameInTwoLoadersTest
+ * @run driver SameNameInTwoLoadersTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/UnintendedLoadersTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/UnintendedLoadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  * @compile test-classes/UnintendedLoaders.java test-classes/CustomLoadee.java
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main UnintendedLoadersTest
+ * @run driver UnintendedLoadersTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/UnloadUnregisteredLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/UnloadUnregisteredLoaderTest.java
@@ -39,7 +39,7 @@
  * @run driver ClassFileInstaller ClassUnloadCommon
  * @run driver ClassFileInstaller ClassUnloadCommon$1
  * @run driver ClassFileInstaller ClassUnloadCommon$TestFailure
- * @run main UnloadUnregisteredLoaderTest
+ * @run driver UnloadUnregisteredLoaderTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/UnsupportedPlatforms.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/UnsupportedPlatforms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @compile test-classes/SimpleHello.java
- * @run main UnsupportedPlatforms
+ * @run driver UnsupportedPlatforms
  */
 
 import jdk.test.lib.Platform;

--- a/test/hotspot/jtreg/runtime/appcds/javaldr/ArrayTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/javaldr/ArrayTest.java
@@ -31,7 +31,7 @@
  * @compile ArrayTestHelper.java
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main ArrayTest
+ * @run driver ArrayTest
  */
 
 import java.util.List;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/CheckUnsupportedDumpingOptions.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/CheckUnsupportedDumpingOptions.java
@@ -32,7 +32,7 @@
  *          jdk.jartool/sun.tools.jar
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @compile ../test-classes/Hello.java
- * @run main CheckUnsupportedDumpingOptions
+ * @run driver CheckUnsupportedDumpingOptions
  */
 
 import jdk.test.lib.compiler.InMemoryJavaCompiler;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/JigsawOptionsCombo.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/JigsawOptionsCombo.java
@@ -33,7 +33,7 @@
  *          jdk.jartool/sun.tools.jar
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @compile ../test-classes/Hello.java ../test-classes/HelloMore.java
- * @run main JigsawOptionsCombo
+ * @run driver JigsawOptionsCombo
  */
 import jdk.test.lib.compiler.InMemoryJavaCompiler;
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/AppClassInCP.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/AppClassInCP.java
@@ -34,7 +34,7 @@
  * @modules java.base/jdk.internal.misc
  *          jdk.jartool/sun.tools.jar
  * @build PatchMain
- * @run main AppClassInCP
+ * @run driver AppClassInCP
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/CustomPackage.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/CustomPackage.java
@@ -34,7 +34,7 @@
  * @modules java.base/jdk.internal.misc
  *          jdk.jartool/sun.tools.jar
  * @build PatchMain
- * @run main CustomPackage
+ * @run driver CustomPackage
  */
 
 import jdk.test.lib.compiler.InMemoryJavaCompiler;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/MismatchedPatchModule.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/MismatchedPatchModule.java
@@ -34,7 +34,7 @@
  * @modules java.base/jdk.internal.misc
  *          jdk.jartool/sun.tools.jar
  * @build PatchMain
- * @run main MismatchedPatchModule
+ * @run driver MismatchedPatchModule
  */
 
 import jdk.test.lib.compiler.InMemoryJavaCompiler;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/PatchDir.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/PatchDir.java
@@ -33,7 +33,7 @@
  * @modules java.base/jdk.internal.misc
  *          jdk.jartool/sun.tools.jar
  * @build PatchMain
- * @run main PatchDir
+ * @run driver PatchDir
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/PatchJavaBase.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/PatchJavaBase.java
@@ -32,7 +32,7 @@
  * @modules java.base/jdk.internal.misc
  *          jdk.jartool/sun.tools.jar
  * @build PatchMain
- * @run main PatchJavaBase
+ * @run driver PatchJavaBase
  */
 
 import jdk.test.lib.compiler.InMemoryJavaCompiler;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/Simple.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/Simple.java
@@ -32,7 +32,7 @@
  * @modules java.base/jdk.internal.misc
  *          jdk.jartool/sun.tools.jar
  * @build PatchMain
- * @run main Simple
+ * @run driver Simple
  */
 
 import jdk.test.lib.compiler.InMemoryJavaCompiler;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/SubClassOfPatchedClass.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/SubClassOfPatchedClass.java
@@ -33,7 +33,7 @@
  * @modules java.base/jdk.internal.misc
  *          jdk.jartool/sun.tools.jar
  * @build PatchMain
- * @run main SubClassOfPatchedClass
+ * @run driver SubClassOfPatchedClass
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/TwoJars.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/PatchModule/TwoJars.java
@@ -32,7 +32,7 @@
  * @modules java.base/jdk.internal.misc
  *          jdk.jartool/sun.tools.jar
  * @build PatchMain
- * @run main TwoJars
+ * @run driver TwoJars
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/classpathtests/BootAppendTests.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/classpathtests/BootAppendTests.java
@@ -35,7 +35,7 @@
  * @compile src/com/sun/tools/javac/MyMain.jasm
  * @compile src/sun/nio/cs/ext/MyClass.java
  * @compile src/sun/nio/cs/ext1/MyClass.java
- * @run main BootAppendTests
+ * @run driver BootAppendTests
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/classpathtests/ClassPathTests.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/classpathtests/ClassPathTests.java
@@ -34,7 +34,7 @@
  * @compile src/com/sun/tools/javac/Main.jasm
  * @compile src/com/sun/tools/javac/MyMain.jasm
  * @compile ../../../SharedArchiveFile/javax/annotation/processing/FilerException.jasm
- * @run main ClassPathTests
+ * @run driver ClassPathTests
  * @summary AppCDS tests for testing classpath/package conflicts
  */
 

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/classpathtests/DummyClassesInBootClassPath.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/classpathtests/DummyClassesInBootClassPath.java
@@ -34,7 +34,7 @@
  * @compile ../../../SharedArchiveFile/javax/annotation/processing/FilerException.jasm
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main DummyClassesInBootClassPath
+ * @run driver DummyClassesInBootClassPath
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/classpathtests/EmptyClassInBootClassPath.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/classpathtests/EmptyClassInBootClassPath.java
@@ -37,7 +37,7 @@
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @compile ../../test-classes/EmptyClassHelper.java
  * @compile ../../test-classes/com/sun/tools/javac/Main.jasm
- * @run main EmptyClassInBootClassPath
+ * @run driver EmptyClassInBootClassPath
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/AddModules.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/AddModules.java
@@ -29,7 +29,7 @@
  * @modules jdk.compiler
  *          jdk.jartool/sun.tools.jar
  *          jdk.jlink
- * @run main AddModules
+ * @run driver AddModules
  * @summary sanity test the --add-modules option
  */
 

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/AddOpens.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/AddOpens.java
@@ -29,7 +29,7 @@
  * @modules jdk.compiler
  *          jdk.jartool/sun.tools.jar
  *          jdk.jlink
- * @run main AddOpens
+ * @run driver AddOpens
  * @summary sanity test the --add-opens option
  */
 

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/AddReads.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/AddReads.java
@@ -29,7 +29,7 @@
  * @modules jdk.compiler
  *          jdk.jartool/sun.tools.jar
  *          jdk.jlink
- * @run main AddReads
+ * @run driver AddReads
  * @summary sanity test the --add-reads option
  */
 

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/ExportModule.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/ExportModule.java
@@ -29,7 +29,7 @@
  * @modules jdk.compiler
  *          jdk.jartool/sun.tools.jar
  *          jdk.jlink
- * @run main ExportModule
+ * @run driver ExportModule
  * @summary Tests involve exporting a module from the module path to a jar in the -cp.
  */
 

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/JvmtiAddPath.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/JvmtiAddPath.java
@@ -33,7 +33,7 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  * @compile ../../test-classes/JvmtiApp.java
- * @run main JvmtiAddPath
+ * @run driver JvmtiAddPath
  */
 
 import java.io.File;

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/MainModuleOnly.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/MainModuleOnly.java
@@ -29,7 +29,7 @@
  * @modules jdk.compiler
  *          jdk.jartool/sun.tools.jar
  *          jdk.jlink
- * @run main MainModuleOnly
+ * @run driver MainModuleOnly
  * @summary Test some scenarios with a main modular jar specified in the --module-path and -cp options in the command line.
  */
 

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/ModulePathAndCP.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/ModulePathAndCP.java
@@ -29,7 +29,7 @@
  * @modules jdk.compiler
  *          jdk.jartool/sun.tools.jar
  *          jdk.jlink
- * @run main ModulePathAndCP
+ * @run driver ModulePathAndCP
  * @summary 2 sets of tests: one with only --module-path in the command line;
  *          another with both -cp and --module-path in the command line.
  */

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/overridetests/OverrideTests.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/overridetests/OverrideTests.java
@@ -28,7 +28,7 @@
  * @modules java.base/jdk.internal.misc
  * @library ../..
  * @library /test/lib
- * @run main OverrideTests
+ * @run driver OverrideTests
  * @summary AppCDS tests for overriding archived classes with -p and --upgrade-module-path
  */
 

--- a/test/hotspot/jtreg/runtime/appcds/jvmti/parallelLoad/ParallelLoadAndTransformTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/jvmti/parallelLoad/ParallelLoadAndTransformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@
  *          jdk.jartool/sun.tools.jar
  *          java.instrument
  * @build TransformUtil TransformerAgent ParallelLoad
- * @run main ParallelLoadAndTransformTest
+ * @run driver ParallelLoadAndTransformTest
  */
 import java.util.List;
 import java.util.stream.Collectors;

--- a/test/hotspot/jtreg/runtime/appcds/redefineClass/RedefineBasicTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/redefineClass/RedefineBasicTest.java
@@ -33,9 +33,9 @@
  *          jdk.jartool/sun.tools.jar
  *          java.base/jdk.internal.misc
  *          java.management
- * @run main RedefineClassHelper
+ * @run driver RedefineClassHelper
  * @build sun.hotspot.WhiteBox RedefineBasic
- * @run main RedefineBasicTest
+ * @run driver RedefineBasicTest
  */
 
 import jdk.test.lib.process.OutputAnalyzer;
@@ -63,7 +63,7 @@ public class RedefineBasicTest {
         OutputAnalyzer output;
         TestCommon.testDump(appJar, sharedClasses, useWb);
 
-        // redefineagent.jar is created by executing "@run main RedefineClassHelper"
+        // redefineagent.jar is created by executing "@run driver RedefineClassHelper"
         // which should be called before executing RedefineBasicTest
         output = TestCommon.exec(appJar, useWb,
                                  "-XX:+UnlockDiagnosticVMOptions",

--- a/test/hotspot/jtreg/runtime/appcds/redefineClass/RedefineRunningMethods_Shared.java
+++ b/test/hotspot/jtreg/runtime/appcds/redefineClass/RedefineRunningMethods_Shared.java
@@ -32,9 +32,9 @@
  * @modules java.compiler
  *          java.instrument
  *          jdk.jartool/sun.tools.jar
- * @run main RedefineClassHelper
+ * @run driver RedefineClassHelper
  * @build sun.hotspot.WhiteBox RedefineRunningMethods_SharedHelper
- * @run main RedefineRunningMethods_Shared
+ * @run driver RedefineRunningMethods_Shared
  */
 
 import jdk.test.lib.process.OutputAnalyzer;

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/ExerciseGC.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/ExerciseGC.java
@@ -32,7 +32,7 @@
  *          jdk.jartool/sun.tools.jar
  * @build HelloStringGC sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main ExerciseGC
+ * @run driver ExerciseGC
  * @run main/othervm -XX:+UseStringDeduplication ExerciseGC
  * @run main/othervm -XX:-CompactStrings ExerciseGC
  */

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/FlagCombo.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/FlagCombo.java
@@ -31,7 +31,7 @@
  * @modules java.management
  *          jdk.jartool/sun.tools.jar
  * @build HelloString
- * @run main FlagCombo
+ * @run driver FlagCombo
  */
 
 /**
@@ -44,7 +44,7 @@
  * @modules java.management
  *          jdk.jartool/sun.tools.jar
  * @build HelloString
- * @run main FlagCombo noJfr
+ * @run driver FlagCombo noJfr
  */
 
 import jdk.test.lib.BuildHelper;

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/InternSharedString.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/InternSharedString.java
@@ -33,7 +33,7 @@
  * @compile InternStringTest.java
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main InternSharedString
+ * @run driver InternSharedString
  * @run main/othervm -XX:+UseStringDeduplication InternSharedString
  * @run main/othervm -XX:-CompactStrings InternSharedString
  */

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/InvalidFileFormat.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/InvalidFileFormat.java
@@ -31,7 +31,7 @@
  * @modules java.management
  *          jdk.jartool/sun.tools.jar
  * @build HelloString
- * @run main InvalidFileFormat
+ * @run driver InvalidFileFormat
  * @run main/othervm -XX:+UseStringDeduplication InvalidFileFormat
  * @run main/othervm -XX:-CompactStrings InvalidFileFormat
  */

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/LargePages.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/LargePages.java
@@ -31,7 +31,7 @@
  * @modules java.management
  *          jdk.jartool/sun.tools.jar
  * @build HelloString
- * @run main LargePages
+ * @run driver LargePages
  * @run main/othervm -XX:+UseStringDeduplication LargePages
  * @run main/othervm -XX:-CompactStrings LargePages
  */

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/LockSharedStrings.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/LockSharedStrings.java
@@ -33,7 +33,7 @@
  * @compile LockStringTest.java LockStringValueTest.java
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main LockSharedStrings
+ * @run driver LockSharedStrings
  * @run main/othervm -XX:+UseStringDeduplication LockSharedStrings
  * @run main/othervm -XX:-CompactStrings LockSharedStrings
  */

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasic.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasic.java
@@ -31,7 +31,7 @@
  * @modules java.management
  *          jdk.jartool/sun.tools.jar
  * @build HelloString
- * @run main SharedStringsBasic
+ * @run driver SharedStringsBasic
  * @run main/othervm -XX:+UseStringDeduplication SharedStringsBasic
  * @run main/othervm -XX:-CompactStrings SharedStringsBasic
  */

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasicPlus.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsBasicPlus.java
@@ -32,7 +32,7 @@
  *          jdk.jartool/sun.tools.jar
  * @build HelloStringPlus sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main SharedStringsBasicPlus
+ * @run driver SharedStringsBasicPlus
  * @run main/othervm -XX:+UseStringDeduplication SharedStringsBasicPlus
  * @run main/othervm -XX:-CompactStrings SharedStringsBasicPlus
  */

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsStress.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsStress.java
@@ -29,7 +29,7 @@
  * @library /test/hotspot/jtreg/runtime/appcds /test/lib
  * @modules jdk.jartool/sun.tools.jar
  * @build HelloString
- * @run main SharedStringsStress
+ * @run driver SharedStringsStress
  * @run main/othervm -XX:+UseStringDeduplication SharedStringsStress
  * @run main/othervm -XX:-CompactStrings SharedStringsStress
  */

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsWbTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SharedStringsWbTest.java
@@ -32,7 +32,7 @@
  *          jdk.jartool/sun.tools.jar
  * @build sun.hotspot.WhiteBox SharedStringsWb
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
- * @run main SharedStringsWbTest
+ * @run driver SharedStringsWbTest
  * @run main/othervm -XX:+UseStringDeduplication SharedStringsWbTest
  * @run main/othervm -XX:-CompactStrings SharedStringsWbTest
  */

--- a/test/hotspot/jtreg/runtime/appcds/sharedStrings/SysDictCrash.java
+++ b/test/hotspot/jtreg/runtime/appcds/sharedStrings/SysDictCrash.java
@@ -31,7 +31,7 @@
  * @library /test/lib /test/hotspot/jtreg/runtime/appcds
  * @modules java.base/jdk.internal.misc
  * @modules java.management
- * @run main SysDictCrash
+ * @run driver SysDictCrash
  * @run main/othervm -XX:+UseStringDeduplication SysDictCrash
  * @run main/othervm -XX:-CompactStrings SysDictCrash
  */


### PR DESCRIPTION
Backport of [JDK-8209946](https://bugs.openjdk.org/browse/JDK-8209946)
Notes
- Comparing to the original commit, the following files has been changed and no need to change in current PR
  - `test/hotspot/jtreg/runtime/SharedArchiveFile/TestInterpreterMethodEntries.java` No need
  - `test/hotspot/jtreg/runtime/appcds/cacheObject/GCStressTest.java` No need
  - `test/hotspot/jtreg/runtime/appcds/customLoader/HelloCustom.java` No need
- The following file the base line content is different, so I manually changed the file based on the original commit
  - `test/hotspot/jtreg/runtime/appcds/cacheObject/RedefineClassTest.java` Base version is different, so manually edit

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8209946](https://bugs.openjdk.org/browse/JDK-8209946) needs maintainer approval

### Issue
 * [JDK-8209946](https://bugs.openjdk.org/browse/JDK-8209946): [TESTBUG] CDS tests should use "@<!---->run driver" (**Enhancement** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2318/head:pull/2318` \
`$ git checkout pull/2318`

Update a local copy of the PR: \
`$ git checkout pull/2318` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2318`

View PR using the GUI difftool: \
`$ git pr show -t 2318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2318.diff">https://git.openjdk.org/jdk11u-dev/pull/2318.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2318#issuecomment-1833354240)