### PR TITLE
8211438: [Testbug] runtime/XCheckJniJsig/XCheckJSig.java looks for libjsig in wrong location

### DIFF
--- a/test/hotspot/jtreg/runtime/XCheckJniJsig/XCheckJSig.java
+++ b/test/hotspot/jtreg/runtime/XCheckJniJsig/XCheckJSig.java
@@ -45,29 +45,21 @@ public class XCheckJSig {
         System.out.println("Regression test for bugs 7051189 and 8023393");
 
         String jdk_path = System.getProperty("test.jdk");
-        String os_arch = Platform.getOsArch();
         String libjsig;
         String env_var;
         if (Platform.isOSX()) {
             env_var = "DYLD_INSERT_LIBRARIES";
-            libjsig = jdk_path + "/jre/lib/libjsig.dylib"; // jdk location
-            if (!(new File(libjsig).exists())) {
-                libjsig = jdk_path + "/lib/libjsig.dylib"; // jre location
-            }
+            libjsig = jdk_path + "/lib/libjsig.dylib"; // jre location
         } else {
             env_var = "LD_PRELOAD";
-            libjsig = jdk_path + "/jre/lib/" + os_arch + "/libjsig.so"; // jdk location
-            if (!(new File(libjsig).exists())) {
-                libjsig = jdk_path + "/lib/" + os_arch + "/libjsig.so"; // jre location
-            }
+            libjsig = jdk_path + "/lib/libjsig.so"; // jre location
         }
         // If this test fails, these might be useful to know.
         System.out.println("libjsig: " + libjsig);
-        System.out.println("osArch: " + os_arch);
 
         // Make sure the libjsig file exists.
         if (!(new File(libjsig).exists())) {
-            throw new jtreg.SkippedException("File " + libjsig + " not found");
+            throw new RuntimeException("File libjsig not found, path: " + libjsig);
         }
 
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xcheck:jni", "-version");


### PR DESCRIPTION
Backport of [JDK-8211438](https://bugs.openjdk.org/browse/JDK-8211438)

Note. 
- `test/hotspot/jtreg/ProblemList.txt` No need to change because the line has been removed already
- `src/java.base/unix/native/libjsig/jsig.c` Add include section to fix compile error; the include was originally added by [JDK-8200609](https://bugs.openjdk.org/browse/JDK-8200609)

So this is `unclean` backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8211438](https://bugs.openjdk.org/browse/JDK-8211438) needs maintainer approval

### Issue
 * [JDK-8211438](https://bugs.openjdk.org/browse/JDK-8211438): [Testbug] runtime/XCheckJniJsig/XCheckJSig.java looks for libjsig in wrong location (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2319/head:pull/2319` \
`$ git checkout pull/2319`

Update a local copy of the PR: \
`$ git checkout pull/2319` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2319`

View PR using the GUI difftool: \
`$ git pr show -t 2319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2319.diff">https://git.openjdk.org/jdk11u-dev/pull/2319.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2319#issuecomment-1833403357)