### PR TITLE
8213926: WB_EnqueueInitializerForCompilation requests compilation for NULL

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -949,7 +949,11 @@ WB_END
 
 WB_ENTRY(jboolean, WB_EnqueueInitializerForCompilation(JNIEnv* env, jobject o, jclass klass, jint comp_level))
   InstanceKlass* ik = InstanceKlass::cast(java_lang_Class::as_Klass(JNIHandles::resolve(klass)));
-  return WhiteBox::compile_method(ik->class_initializer(), comp_level, InvocationEntryBci, THREAD);
+  Method* clinit = ik->class_initializer();
+  if (clinit == NULL) {
+    return false;
+  }
+  return WhiteBox::compile_method(clinit, comp_level, InvocationEntryBci, THREAD);
 WB_END
 
 WB_ENTRY(jboolean, WB_ShouldPrintAssembly(JNIEnv* env, jobject o, jobject method, jint comp_level))


### PR DESCRIPTION
Backport of [JDK-8213926](https://bugs.openjdk.org/browse/JDK-8213926)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8213926](https://bugs.openjdk.org/browse/JDK-8213926) needs maintainer approval

### Issue
 * [JDK-8213926](https://bugs.openjdk.org/browse/JDK-8213926): WB_EnqueueInitializerForCompilation requests compilation for NULL (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2320/head:pull/2320` \
`$ git checkout pull/2320`

Update a local copy of the PR: \
`$ git checkout pull/2320` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2320`

View PR using the GUI difftool: \
`$ git pr show -t 2320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2320.diff">https://git.openjdk.org/jdk11u-dev/pull/2320.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2320#issuecomment-1833433908)