### PR TITLE
8218754: JDK-8068225 regression in JDIBreakpointTest

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/jdi/JDIBreakpointTest.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/jdi/JDIBreakpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@ import com.sun.jdi.StackFrame;
 import com.sun.jdi.ThreadReference;
 import com.sun.jdi.Value;
 import com.sun.jdi.VirtualMachine;
+import com.sun.jdi.VMDisconnectedException;
 import com.sun.jdi.event.BreakpointEvent;
 import com.sun.jdi.event.ClassPrepareEvent;
 import com.sun.jdi.event.Event;
@@ -358,8 +359,12 @@ public abstract class JDIBreakpointTest extends MlvmTest {
             }
         }.go();
 
-        if (!debuggee.terminated())
-            debuggee.endDebugee();
+        if (!debuggee.terminated()) {
+            try {
+                debuggee.dispose();
+            } catch (VMDisconnectedException ignore) {
+            }
+        }
 
         debuggee.waitFor();
         return true;


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8218754](https://bugs.openjdk.org/browse/JDK-8218754) needs maintainer approval

### Issue
 * [JDK-8218754](https://bugs.openjdk.org/browse/JDK-8218754): JDK-8068225 regression in JDIBreakpointTest (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2326/head:pull/2326` \
`$ git checkout pull/2326`

Update a local copy of the PR: \
`$ git checkout pull/2326` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2326`

View PR using the GUI difftool: \
`$ git pr show -t 2326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2326.diff">https://git.openjdk.org/jdk11u-dev/pull/2326.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2326#issuecomment-1837891613)