### PR TITLE
8219612: [TESTBUG] compiler.codecache.stress.Helper.TestCaseImpl can't be defined in different runtime package as its nest host

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/stress/Helper.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/Helper.java
@@ -37,7 +37,7 @@ public final class Helper {
     public static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
 
     private static final long THRESHOLD = WHITE_BOX.getIntxVMFlag("CompileThreshold");
-    private static final String TEST_CASE_IMPL_CLASS_NAME = "compiler.codecache.stress.Helper$TestCaseImpl";
+    private static final String TEST_CASE_IMPL_CLASS_NAME = "compiler.codecache.stress.TestCaseImpl";
     private static byte[] CLASS_DATA;
     static {
         try {
@@ -106,34 +106,4 @@ public final class Helper {
         int method();
         int expectedValue();
     }
-
-    public static class TestCaseImpl implements TestCase {
-        private static final int RETURN_VALUE = 42;
-        private static final int RECURSION_DEPTH = 10;
-        private volatile int i;
-
-        @Override
-        public Callable<Integer> getCallable() {
-            return () -> {
-                i = 0;
-                return method();
-            };
-        }
-
-        @Override
-        public int method() {
-            ++i;
-            int result = RETURN_VALUE;
-            if (i < RECURSION_DEPTH) {
-                return result + method();
-            }
-            return result;
-        }
-
-        @Override
-        public int expectedValue() {
-            return RETURN_VALUE * RECURSION_DEPTH;
-        }
-    }
-
 }

--- a/test/hotspot/jtreg/compiler/codecache/stress/RandomAllocationTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/RandomAllocationTest.java
@@ -29,7 +29,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  *
- * @build sun.hotspot.WhiteBox
+ * @build sun.hotspot.WhiteBox compiler.codecache.stress.Helper compiler.codecache.stress.TestCaseImpl
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/compiler/codecache/stress/ReturnBlobToWrongHeapTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/ReturnBlobToWrongHeapTest.java
@@ -29,7 +29,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  *
- * @build sun.hotspot.WhiteBox
+ * @build sun.hotspot.WhiteBox compiler.codecache.stress.Helper compiler.codecache.stress.TestCaseImpl
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions

--- a/test/hotspot/jtreg/compiler/codecache/stress/TestCaseImpl.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/TestCaseImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.codecache.stress;
+
+import java.util.concurrent.Callable;
+
+public class TestCaseImpl implements Helper.TestCase {
+    private static final int RETURN_VALUE = 42;
+    private static final int RECURSION_DEPTH = 10;
+    private volatile int i;
+
+    @Override
+    public Callable<Integer> getCallable() {
+        return () -> {
+            i = 0;
+            return method();
+        };
+    }
+
+    @Override
+    public int method() {
+        ++i;
+        int result = RETURN_VALUE;
+        if (i < RECURSION_DEPTH) {
+            return result + method();
+        }
+        return result;
+    }
+
+    @Override
+    public int expectedValue() {
+        return RETURN_VALUE * RECURSION_DEPTH;
+    }
+}

--- a/test/hotspot/jtreg/compiler/codecache/stress/UnexpectedDeoptimizationTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/UnexpectedDeoptimizationTest.java
@@ -29,7 +29,7 @@
  * @modules java.base/jdk.internal.misc
  *          java.management
  *
- * @build sun.hotspot.WhiteBox
+ * @build sun.hotspot.WhiteBox compiler.codecache.stress.Helper compiler.codecache.stress.TestCaseImpl
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8219612](https://bugs.openjdk.org/browse/JDK-8219612) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8219612](https://bugs.openjdk.org/browse/JDK-8219612): [TESTBUG] compiler.codecache.stress.Helper.TestCaseImpl can't be defined in different runtime package as its nest host (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2328/head:pull/2328` \
`$ git checkout pull/2328`

Update a local copy of the PR: \
`$ git checkout pull/2328` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2328`

View PR using the GUI difftool: \
`$ git pr show -t 2328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2328.diff">https://git.openjdk.org/jdk11u-dev/pull/2328.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2328#issuecomment-1837960048)