### PR TITLE
8234309: LFGarbageCollectedTest.java fails with parse Exception

### DIFF
--- a/test/jdk/java/lang/invoke/LFCaching/LFGarbageCollectedTest.java
+++ b/test/jdk/java/lang/invoke/LFCaching/LFGarbageCollectedTest.java
@@ -25,10 +25,10 @@
  * @test LFGarbageCollectedTest
  * @bug 8046703
  * @key randomness
+ * @library /lib/testlibrary /java/lang/invoke/common
  * @ignore 8078602
  * @summary Test verifies that lambda forms are garbage collected
  * @author kshefov
- * @library /lib/testlibrary /java/lang/invoke/common
  * @build jdk.test.lib.TimeLimitedRunner
  * @build TestMethods
  * @build LambdaFormTestCase


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8234309](https://bugs.openjdk.org/browse/JDK-8234309) needs maintainer approval

### Issue
 * [JDK-8234309](https://bugs.openjdk.org/browse/JDK-8234309): LFGarbageCollectedTest.java fails with parse Exception (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2329/head:pull/2329` \
`$ git checkout pull/2329`

Update a local copy of the PR: \
`$ git checkout pull/2329` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2329`

View PR using the GUI difftool: \
`$ git pr show -t 2329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2329.diff">https://git.openjdk.org/jdk11u-dev/pull/2329.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2329#issuecomment-1838021297)