### PR TITLE
8314883: Java_java_util_prefs_FileSystemPreferences_lockFile0 write result errno in missing case

### DIFF
--- a/src/java.prefs/unix/native/libprefs/FileSystemPreferences.c
+++ b/src/java.prefs/unix/native/libprefs/FileSystemPreferences.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ Java_java_util_prefs_FileSystemPreferences_lockFile0(JNIEnv *env,
     jclass thisclass, jstring java_fname, jint permission, jboolean shared) {
     const char *fname = JNU_GetStringPlatformChars(env, java_fname, NULL);
     int fd, rc;
-    int result[2];
+    int result[2] = {0, 0};
     jintArray javaResult = NULL;
     int old_umask;
     FLOCK fl;
@@ -90,6 +90,7 @@ Java_java_util_prefs_FileSystemPreferences_lockFile0(JNIEnv *env,
 
     if (shared == JNI_TRUE) {
         fd = open(fname, O_RDONLY, 0);
+        result[1] = errno;
     } else {
         old_umask = umask(0);
         fd = open(fname, O_WRONLY|O_CREAT, permission);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8314883](https://bugs.openjdk.org/browse/JDK-8314883) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314883](https://bugs.openjdk.org/browse/JDK-8314883): Java_java_util_prefs_FileSystemPreferences_lockFile0 write result errno in missing case (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2331/head:pull/2331` \
`$ git checkout pull/2331`

Update a local copy of the PR: \
`$ git checkout pull/2331` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2331`

View PR using the GUI difftool: \
`$ git pr show -t 2331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2331.diff">https://git.openjdk.org/jdk11u-dev/pull/2331.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2331#issuecomment-1838771366)