### PR TITLE
8226905: unproblem list applications/ctw/modules/* tests on windows

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -110,10 +110,6 @@ compiler/types/correctness/OffTest.java 8225620 solaris-sparcv9
 
 compiler/c2/Test6852078.java 8194310 generic-all
 
-applications/ctw/modules/java_desktop.java 8189604 windows-all
-applications/ctw/modules/java_desktop_2.java 8189604,8204842 generic-all
-applications/ctw/modules/jdk_jconsole.java 8189604 windows-all
-
 compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all
 
 compiler/runtime/Test8168712.java 8211769,8211771 generic-ppc64,generic-ppc64le,linux-s390x


### PR DESCRIPTION
Backport of [JDK-8226905](https://bugs.openjdk.org/browse/JDK-8226905)

Note the diff file for `test/hotspot/jtreg/ProblemList.txt` cannot be applied automatically
- Because in [jdk commit](https://github.com/openjdk/jdk/commit/cac96b1b587d3c0203a252cca10bc7aa4530d274) the ticket was `8205016`
- While in current jdk11u-dev repo it is [JDK-8189604](https://bugs.openjdk.org/browse/JDK-8189604) and [JDK-8204842](https://bugs.openjdk.org/browse/JDK-8204842)
- The file  `test/hotspot/jtreg/ProblemList.txt` has been handled manually
- So this change can be considered as `clean`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8226905](https://bugs.openjdk.org/browse/JDK-8226905) needs maintainer approval

### Issue
 * [JDK-8226905](https://bugs.openjdk.org/browse/JDK-8226905): unproblem list applications/ctw/modules/* tests on windows (**Bug** - P4 - Approved)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2333/head:pull/2333` \
`$ git checkout pull/2333`

Update a local copy of the PR: \
`$ git checkout pull/2333` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2333`

View PR using the GUI difftool: \
`$ git pr show -t 2333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2333.diff">https://git.openjdk.org/jdk11u-dev/pull/2333.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2333#issuecomment-1839947409)