### PR TITLE
Backport 7ca053de218bf76ea06bbeed860d142db381ca53

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/BTreeTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/BTreeTest.java
@@ -59,7 +59,7 @@ public class BTreeTest extends SysDictTest {
         }
         try {
             // Load FatsInfo with URLClassLoader btree.jar & fats.jar should not
-            // present in classpath
+            // be present in classpath
             Class info;
             if (useFats) {
                 info = createJarLoader().loadClass(PACKAGE_PREFIX + "FatsInfo");
@@ -76,7 +76,7 @@ public class BTreeTest extends SysDictTest {
             }
 
             if (level >= height) {
-                throw new Failure("Icorrect level : " + level + " .Should be less then " + height);
+                throw new Failure("Incorrect level : " + level + " should be less than " + height);
             }
 
             // generate names for all nodes at the given level:

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/SysDictTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/SysDictTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public abstract class SysDictTest extends ThreadedGCTest {
             if (args[i].equals("-useSingleLoader")) {
                 this.useSingleLoader = false;
             }
-            // jar path is in useal classpath format
+            // jar path is in usual classpath format
             if (args[i].equals("-jarpath")) {
                 String[] files = args[i + 1].split(File.pathSeparator);
                 jars = new URL[files.length];
@@ -148,11 +148,8 @@ public abstract class SysDictTest extends ThreadedGCTest {
                     // set name into public variable just to be sure
                     // that class is loaded
                     tmp = clz.getName();
-                } catch (ClassNotFoundException cnfe) {
-                    throw new TestFailure(cnfe);
-                } catch (OutOfMemoryError oome) {
+                } catch (OutOfMemoryError | ClassNotFoundException e) {
                     // just ignore
-                    // we do not check memory leaks in PermGen in this tests
                 } catch (StackOverflowError soe) {
                     // just ignore, chains could be too large
                     // StackOverflowError could be in some sparcs
@@ -163,6 +160,7 @@ public abstract class SysDictTest extends ThreadedGCTest {
             }
         }
     }
+
 
     @Override
     protected Runnable createRunnable(int i) {


### PR DESCRIPTION
Backport of [JDK-8251904](https://bugs.openjdk.org/browse/JDK-8251904)

Note the diff for file `test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/SysDictTest.java` cannot be applied automatically
- Because the baseline of `Copyright (c) year` section are different
- This line has been merged manually
- So the change can be considered `clear`
