### PR TITLE
8316461: Fix: make test outputs TEST SUCCESS after unsuccessful exit

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -735,8 +735,9 @@ define SetupRunJtregTestBody
     $1_JTREG_BASIC_OPTIONS += -vmoptions:"$$($1_AOT_OPTIONS)"
   endif
 
-  clean-workdir-$1:
+  clean-outputdirs-$1:
 	$$(RM) -r $$($1_TEST_SUPPORT_DIR)
+	$$(RM) -r $$($1_TEST_RESULTS_DIR)
 
   $1_COMMAND_LINE := \
       $$(JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \
@@ -780,7 +781,7 @@ define SetupRunJtregTestBody
         done
   endif
 
-  run-test-$1: clean-workdir-$1 $$($1_AOT_TARGETS)
+  run-test-$1: clean-outputdirs-$1 $$($1_AOT_TARGETS)
 	$$(call LogWarn)
 	$$(call LogWarn, Running test '$$($1_TEST)')
 	$$(call MakeDir, $$($1_TEST_RESULTS_DIR) $$($1_TEST_SUPPORT_DIR) \


### PR DESCRIPTION
Backport of [JDK-8316461](https://bugs.openjdk.org/browse/JDK-8316461)

Note. The diff for file `make/RunTests.gmk` cannot be applied as the [original commit](https://github.com/openjdk/jdk/commit/e30e3564420c631f08ac3d613ab91c93227a00b3)
- manually merged the code change
  - Ignored the lines which does not exist in [jdk11u-dev](https://github.com/openjdk/jdk11u-dev)
- This is unclean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316461](https://bugs.openjdk.org/browse/JDK-8316461) needs maintainer approval

### Issue
 * [JDK-8316461](https://bugs.openjdk.org/browse/JDK-8316461): Fix: make test outputs TEST SUCCESS after unsuccessful exit (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2335/head:pull/2335` \
`$ git checkout pull/2335`

Update a local copy of the PR: \
`$ git checkout pull/2335` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2335`

View PR using the GUI difftool: \
`$ git pr show -t 2335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2335.diff">https://git.openjdk.org/jdk11u-dev/pull/2335.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2335#issuecomment-1840011208)