### PR TITLE
8292946: GC lock/jni/jnilock001 test failed "assert(gch->gc_cause() == GCCause::_scavenge_alot || !gch->incremental_collection_failed()) failed: Twice in a row"

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -887,10 +887,6 @@ void DefNewGeneration::gc_epilogue(bool full) {
     } else if (seen_incremental_collection_failed) {
       log_trace(gc)("DefNewEpilogue: cause(%s), not full, seen_failed, will_clear_seen_failed",
                             GCCause::to_string(gch->gc_cause()));
-      assert(gch->gc_cause() == GCCause::_scavenge_alot ||
-             (GCCause::is_user_requested_gc(gch->gc_cause()) && UseConcMarkSweepGC && ExplicitGCInvokesConcurrent) ||
-             !gch->incremental_collection_failed(),
-             "Twice in a row");
       seen_incremental_collection_failed = false;
     }
 #endif // ASSERT


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

this is not in problemList, only remove the assert.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8292946](https://bugs.openjdk.org/browse/JDK-8292946) needs maintainer approval

### Issue
 * [JDK-8292946](https://bugs.openjdk.org/browse/JDK-8292946): GC lock/jni/jnilock001 test failed "assert(gch-&gt;gc_cause() == GCCause::_scavenge_alot || !gch-&gt;incremental_collection_failed()) failed: Twice in a row" (**Bug** - P1 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2338/head:pull/2338` \
`$ git checkout pull/2338`

Update a local copy of the PR: \
`$ git checkout pull/2338` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2338`

View PR using the GUI difftool: \
`$ git pr show -t 2338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2338.diff">https://git.openjdk.org/jdk11u-dev/pull/2338.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2338#issuecomment-1840059320)