### PR TITLE
8217475: Unexpected StackOverflowError in "process reaper" thread

### DIFF
--- a/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
@@ -87,8 +87,12 @@ final class ProcessHandleImpl implements ProcessHandle {
                 ThreadGroup tg = Thread.currentThread().getThreadGroup();
                 while (tg.getParent() != null) tg = tg.getParent();
                 ThreadGroup systemThreadGroup = tg;
+
+                // For a debug build, the stack shadow zone is larger;
+                // Increase the total stack size to avoid potential stack overflow.
+                int debugDelta = "release".equals(System.getProperty("jdk.debug")) ? 0 : (4*4096);
                 final long stackSize = Boolean.getBoolean("jdk.lang.processReaperUseDefaultStackSize")
-                        ? 0 : REAPER_DEFAULT_STACKSIZE;
+                        ? 0 : REAPER_DEFAULT_STACKSIZE + debugDelta;
 
                 ThreadFactory threadFactory = grimReaper -> {
                     Thread t = new Thread(systemThreadGroup, grimReaper,


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8217475](https://bugs.openjdk.org/browse/JDK-8217475) needs maintainer approval

### Issue
 * [JDK-8217475](https://bugs.openjdk.org/browse/JDK-8217475): Unexpected StackOverflowError in "process reaper" thread (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2341/head:pull/2341` \
`$ git checkout pull/2341`

Update a local copy of the PR: \
`$ git checkout pull/2341` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2341`

View PR using the GUI difftool: \
`$ git pr show -t 2341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2341.diff">https://git.openjdk.org/jdk11u-dev/pull/2341.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2341#issuecomment-1842554314)