### PR TITLE
8310106: sun.security.ssl.SSLHandshake.getHandshakeProducer() incorrectly checks handshakeConsumers

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLHandshake.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLHandshake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -442,7 +442,7 @@ enum SSLHandshake implements SSLConsumer, HandshakeProducer {
 
     private HandshakeProducer getHandshakeProducer(
             ConnectionContext context) {
-        if (handshakeConsumers.length == 0) {
+        if (handshakeProducers.length == 0) {
             return null;
         }
 


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

Resolved Copyright, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8310106](https://bugs.openjdk.org/browse/JDK-8310106) needs maintainer approval

### Issue
 * [JDK-8310106](https://bugs.openjdk.org/browse/JDK-8310106): sun.security.ssl.SSLHandshake.getHandshakeProducer() incorrectly checks handshakeConsumers (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2344/head:pull/2344` \
`$ git checkout pull/2344`

Update a local copy of the PR: \
`$ git checkout pull/2344` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2344`

View PR using the GUI difftool: \
`$ git pr show -t 2344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2344.diff">https://git.openjdk.org/jdk11u-dev/pull/2344.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2344#issuecomment-1846480333)