### PR TITLE
8054572: [macosx] JComboBox paints the border incorrectly

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -454,6 +454,31 @@ public class AquaComboBoxUI extends BasicComboBoxUI implements Sizeable {
     }
 
     class AquaComboBoxLayoutManager extends BasicComboBoxUI.ComboBoxLayoutManager {
+        protected Rectangle rectangleForCurrentValue() {
+            int width = comboBox.getWidth();
+            int height = 22;
+            Insets insets = getInsets();
+            int buttonSize = height - (insets.top + insets.bottom);
+            if ( arrowButton != null )  {
+                buttonSize = arrowButton.getWidth();
+            }
+            int midHeight = (comboBox.getHeight() - height - (insets.top + insets.bottom)) / 2 - 1;
+            if (midHeight < 0) {
+                midHeight = 0;
+            }
+
+            if (comboBox.getComponentOrientation().isLeftToRight()) {
+                return new Rectangle(insets.left, insets.top + midHeight,
+                        width - (insets.left + insets.right + buttonSize) + 4,
+                        height - (insets.top + insets.bottom));
+            }
+            else {
+                return new Rectangle(insets.left + buttonSize, insets.top + midHeight,
+                        width - (insets.left + insets.right + buttonSize) + 4,
+                        height - (insets.top + insets.bottom));
+            }
+        }
+
         public void layoutContainer(final Container parent) {
             if (arrowButton != null && !comboBox.isEditable()) {
                 final Insets insets = comboBox.getInsets();
@@ -477,8 +502,6 @@ public class AquaComboBoxUI extends BasicComboBoxUI implements Sizeable {
 
             if (editor != null) {
                 final Rectangle editorRect = rectangleForCurrentValue();
-                editorRect.width += 4;
-                editorRect.height += 1;
                 editor.setBounds(editorRect);
             }
         }

--- a/test/jdk/javax/swing/JComboBox/JComboBoxBorderTest.java
+++ b/test/jdk/javax/swing/JComboBox/JComboBoxBorderTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8054572
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Tests if JComboBox displays correctly when editable/non-editable
+ * @run main/manual JComboBoxBorderTest
+ */
+
+import java.awt.FlowLayout;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class JComboBoxBorderTest {
+    private static final String instructionsText = "Pass if you can see both " +
+            "an editable and non-editable JComboBox and if they display " +
+            "reasonably. Fail if they do not appear or are misaligned.";
+
+    private static JFrame frame;
+
+    public static void createAndShowGUI() throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+
+            JLabel label = new JLabel("Editable combo box:");
+            JLabel label2 = new JLabel("Non-editable combo box:");
+
+            JComboBox<String> comboBox = new JComboBox<>(new String[]
+                    { "Item 1", "Item 2", "Item 3" });
+            JComboBox<String> comboBox2 = new JComboBox<>(new String[]
+                    { "Item 1", "Item 2", "Item 3" });
+            comboBox.setEditable(true);
+
+            FlowLayout layout = new FlowLayout(FlowLayout.LEADING);
+            JPanel panel = new JPanel(layout);
+            panel.add(label);
+            panel.add(comboBox);
+
+            panel.add(label2);
+            panel.add(comboBox2);
+
+            frame = new JFrame();
+            frame.getContentPane().add(panel);
+            frame.pack();
+            frame.setLocationRelativeTo(null);
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(frame,
+                    PassFailJFrame.Position.HORIZONTAL);
+
+            frame.setVisible(true);
+        });
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        UIManager.setLookAndFeel("com.apple.laf.AquaLookAndFeel");
+
+        PassFailJFrame pfjFrame = new PassFailJFrame("JScrollPane "
+                + "Test Instructions", instructionsText, 5);
+
+        createAndShowGUI();
+
+        pfjFrame.awaitAndCheck();
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

Resolved the copyright, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8054572](https://bugs.openjdk.org/browse/JDK-8054572) needs maintainer approval

### Issue
 * [JDK-8054572](https://bugs.openjdk.org/browse/JDK-8054572): [macosx] JComboBox paints the border incorrectly (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2346/head:pull/2346` \
`$ git checkout pull/2346`

Update a local copy of the PR: \
`$ git checkout pull/2346` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2346`

View PR using the GUI difftool: \
`$ git pr show -t 2346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2346.diff">https://git.openjdk.org/jdk11u-dev/pull/2346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2346#issuecomment-1846589312)