### PR TITLE
7132796: [macosx] closed/javax/swing/JComboBox/4517214/bug4517214.java fails on MacOS

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
@@ -620,13 +620,6 @@ public class AquaComboBoxUI extends BasicComboBoxUI implements Sizeable {
             size = super.getMinimumSize(c);
         }
 
-        final Border border = c.getBorder();
-        if (border != null) {
-            final Insets insets = border.getBorderInsets(c);
-            size.height += insets.top + insets.bottom;
-            size.width += insets.left + insets.right;
-        }
-
         cachedMinimumSize.setSize(size.width, size.height);
         isMinimumSizeDirty = false;
 

--- a/test/jdk/javax/swing/JComboBox/TestComboBoxHeight.java
+++ b/test/jdk/javax/swing/JComboBox/TestComboBoxHeight.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 4517214
+ * @summary Tests that comboBox is not doubleheight if editable and has TitledBorder
+*/
+
+import javax.swing.BorderFactory;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Robot;
+
+public class TestComboBoxHeight {
+    private static String[] data = { "Ten", "Twenty", "Forty-three" };
+    private static JFrame jframe;
+    private static int heightCombo1, heightCombo2;
+    private static JComboBox combo1, combo2;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            SwingUtilities.invokeAndWait(() -> {
+                jframe = new JFrame();
+
+                GridBagLayout gridBag = new GridBagLayout();
+                GridBagConstraints c = new GridBagConstraints();
+                JPanel p = new JPanel(gridBag);
+                c.fill = GridBagConstraints.NONE;
+
+                // fine-looking combo
+                combo1 = new JComboBox(data);
+                combo1.setEditable(true);
+                gridBag.setConstraints(combo1, c);
+                p.add(combo1);
+
+                // combo has border
+                combo2 = new JComboBox(data);
+                combo2.setEditable(true);
+                combo2.setBorder(BorderFactory.
+                        createTitledBorder("Combo Border"));
+                gridBag.setConstraints(combo2, c);
+                p.add(combo2);
+
+                jframe.setContentPane(p);
+                jframe.setLocationRelativeTo(null);
+                jframe.setSize(400, 200);
+                jframe.setDefaultCloseOperation(
+                        WindowConstants.DISPOSE_ON_CLOSE);
+                jframe.setVisible(true);
+            });
+
+            robot.delay(1000);
+            robot.waitForIdle();
+            SwingUtilities.invokeAndWait(() -> {
+                heightCombo1 = combo1.getHeight();
+                heightCombo2 = combo2.getHeight();
+            });
+
+            if (heightCombo2 >= heightCombo1 * 2) {
+                throw new RuntimeException("combo boxes with border " +
+                 " should not have double height compared to normal combobox");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (jframe != null) {
+                    jframe.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-7132796](https://bugs.openjdk.org/browse/JDK-7132796) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7132796](https://bugs.openjdk.org/browse/JDK-7132796): [macosx] closed/javax/swing/JComboBox/4517214/bug4517214.java fails on MacOS (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2348/head:pull/2348` \
`$ git checkout pull/2348`

Update a local copy of the PR: \
`$ git checkout pull/2348` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2348`

View PR using the GUI difftool: \
`$ git pr show -t 2348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2348.diff">https://git.openjdk.org/jdk11u-dev/pull/2348.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2348#issuecomment-1846621328)