### PR TITLE
8213927: G1 ignores AlwaysPreTouch when UseTransparentHugePages is enabled

### DIFF
--- a/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
+++ b/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
@@ -232,14 +232,19 @@ private:
   char* volatile _cur_addr;
   char* const _start_addr;
   char* const _end_addr;
-  size_t const _page_size;
+  size_t _page_size;
 public:
   G1PretouchTask(char* start_address, char* end_address, size_t page_size) :
     AbstractGangTask("G1 PreTouch"),
     _cur_addr(start_address),
     _start_addr(start_address),
     _end_addr(end_address),
-    _page_size(page_size) {
+    _page_size(0) {
+#ifdef LINUX
+    _page_size = UseTransparentHugePages ? (size_t)os::vm_page_size(): page_size;
+#else
+    _page_size = page_size;
+#endif
   }
 
   virtual void work(uint worker_id) {


### PR DESCRIPTION
Backport of [JDK-8213927](https://bugs.openjdk.org/browse/JDK-8213927)
- Clean backport
- PR Test - All checks have passed
- SAP nightlies passed on 2023-12-14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8213927](https://bugs.openjdk.org/browse/JDK-8213927) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8213927](https://bugs.openjdk.org/browse/JDK-8213927): G1 ignores AlwaysPreTouch when UseTransparentHugePages is enabled (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2355/head:pull/2355` \
`$ git checkout pull/2355`

Update a local copy of the PR: \
`$ git checkout pull/2355` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2355`

View PR using the GUI difftool: \
`$ git pr show -t 2355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2355.diff">https://git.openjdk.org/jdk11u-dev/pull/2355.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2355#issuecomment-1851604453)