### PR TITLE
8216408: XMLStreamWriter setDefaultNamespace(null) throws NullPointerException

### DIFF
--- a/src/java.xml/share/classes/com/sun/xml/internal/stream/writers/XMLStreamWriterImpl.java
+++ b/src/java.xml/share/classes/com/sun/xml/internal/stream/writers/XMLStreamWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import javax.xml.XMLConstants;
@@ -1729,12 +1730,7 @@ public final class XMLStreamWriterImpl extends AbstractMap<Object, Object>
      */
     private boolean isDefaultNamespace(String uri) {
         String defaultNamespace = fInternalNamespaceContext.getURI(DEFAULT_PREFIX);
-
-        if (uri.equals(defaultNamespace)) {
-            return true;
-        }
-
-        return false;
+        return Objects.equals(uri, defaultNamespace);
     }
 
     /**

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/XMLStreamWriterTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamWriterTest/XMLStreamWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,11 +42,11 @@ import org.w3c.dom.Document;
 
 /*
  * @test
- * @bug 6347190 8139584
+ * @bug 6347190 8139584 8216408
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @run testng/othervm -DrunSecMngr=true stream.XMLStreamWriterTest.XMLStreamWriterTest
  * @run testng/othervm stream.XMLStreamWriterTest.XMLStreamWriterTest
- * @summary Test StAX Writer won't insert comment into element inside.
+ * @summary Tests XMLStreamWriter.
  */
 @Listeners({jaxp.library.BasePolicy.class})
 public class XMLStreamWriterTest {
@@ -94,12 +94,14 @@ public class XMLStreamWriterTest {
     }
 
     /**
-     * Test of main method, of class TestXMLStreamWriter.
+     * Verifies that the StAX Writer won't insert comment into the element tag.
      */
     @Test
     public void testWriteComment() {
         try {
-            String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><a:html href=\"http://java.sun.com\"><!--This is comment-->java.sun.com</a:html>";
+            String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                    + "<a:html href=\"http://java.sun.com\">"
+                    + "<!--This is comment-->java.sun.com</a:html>";
             XMLOutputFactory f = XMLOutputFactory.newInstance();
             // f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES,
             // Boolean.TRUE);
@@ -122,4 +124,18 @@ public class XMLStreamWriterTest {
         }
     }
 
+    /**
+     * @bug 8216408
+     * Verifies that setDefaultNamespace accepts null.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSetDefaultNamespace() throws Exception {
+        XMLOutputFactory f = XMLOutputFactory.newFactory();
+        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, true);
+        StringWriter sw = new StringWriter();
+        XMLStreamWriter xsw = f.createXMLStreamWriter(sw);
+        xsw.setDefaultNamespace(null);
+    }
 }


### PR DESCRIPTION
Backport of [JDK-8216408](https://bugs.openjdk.org/browse/JDK-8216408)
- Clean backport
- PR Test - All checks have passed
- SAP nightlies passed on 2023-12-14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8216408](https://bugs.openjdk.org/browse/JDK-8216408) needs maintainer approval

### Issue
 * [JDK-8216408](https://bugs.openjdk.org/browse/JDK-8216408): XMLStreamWriter setDefaultNamespace(null) throws NullPointerException (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2356/head:pull/2356` \
`$ git checkout pull/2356`

Update a local copy of the PR: \
`$ git checkout pull/2356` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2356`

View PR using the GUI difftool: \
`$ git pr show -t 2356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2356.diff">https://git.openjdk.org/jdk11u-dev/pull/2356.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2356#issuecomment-1851695210)