### PR TITLE
8231585: java/lang/management/ThreadMXBean/MaxDepthForThreadInfoTest.java fails with java.lang.NullPointerException

### DIFF
--- a/test/jdk/java/lang/management/ThreadMXBean/MaxDepthForThreadInfoTest.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/MaxDepthForThreadInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class MaxDepthForThreadInfoTest {
 
         ThreadInfo[] tinfos = tmxb.getThreadInfo(threadIds, true, true, 0);
         for (ThreadInfo ti : tinfos) {
-            if (ti.getStackTrace().length > 0) {
+            if (ti != null && ti.getStackTrace().length > 0) {
                 ThreadDump.printThreadInfo(ti);
                 throw new RuntimeException("more than requested " +
                         "number of frames dumped");
@@ -56,7 +56,7 @@ public class MaxDepthForThreadInfoTest {
 
         tinfos = tmxb.getThreadInfo(threadIds, true, true, 3);
         for (ThreadInfo ti : tinfos) {
-            if (ti.getStackTrace().length > 3) {
+            if (ti != null && ti.getStackTrace().length > 3) {
                 ThreadDump.printThreadInfo(ti);
                 throw new RuntimeException("more than requested " +
                         "number of frames dumped");


### PR DESCRIPTION
Backport of [JDK-8231585](https://bugs.openjdk.org/browse/JDK-8231585)
- Clean Backport
- Test Succeeded in local Dev Apple M1 Laptop
- PR - All checks have passed
- SAP nightlies passed on 2023-12-14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8231585](https://bugs.openjdk.org/browse/JDK-8231585) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8231585](https://bugs.openjdk.org/browse/JDK-8231585): java/lang/management/ThreadMXBean/MaxDepthForThreadInfoTest.java fails with java.lang.NullPointerException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2357/head:pull/2357` \
`$ git checkout pull/2357`

Update a local copy of the PR: \
`$ git checkout pull/2357` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2357`

View PR using the GUI difftool: \
`$ git pr show -t 2357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2357.diff">https://git.openjdk.org/jdk11u-dev/pull/2357.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2357#issuecomment-1853045676)