### PR TITLE
8251349: Add TestCaseImpl to OverloadCompileQueueTest.java's build dependencies

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/stress/Helper.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/Helper.java
@@ -37,7 +37,7 @@ public final class Helper {
     public static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
 
     private static final long THRESHOLD = WHITE_BOX.getIntxVMFlag("CompileThreshold");
-    private static final String TEST_CASE_IMPL_CLASS_NAME = "compiler.codecache.stress.TestCaseImpl";
+    private static final String TEST_CASE_IMPL_CLASS_NAME = TestCaseImpl.class.getName();
     private static byte[] CLASS_DATA;
     static {
         try {


### PR DESCRIPTION
Backport of [JDK-8251349](https://bugs.openjdk.org/browse/JDK-8251349)
- Clean Backport
- Test Succeeded in local Dev Apple M1 Laptop
- PR - All checks have passed
- SAP nightlies passed on 2023-12-14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8251349](https://bugs.openjdk.org/browse/JDK-8251349) needs maintainer approval

### Issue
 * [JDK-8251349](https://bugs.openjdk.org/browse/JDK-8251349): Add TestCaseImpl to OverloadCompileQueueTest.java's build dependencies (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2358/head:pull/2358` \
`$ git checkout pull/2358`

Update a local copy of the PR: \
`$ git checkout pull/2358` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2358`

View PR using the GUI difftool: \
`$ git pr show -t 2358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2358.diff">https://git.openjdk.org/jdk11u-dev/pull/2358.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2358#issuecomment-1853146572)