### PR TITLE
8285785: CheckCleanerBound test fails with PasswordCallback object is not released

### DIFF
--- a/test/jdk/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
+++ b/test/jdk/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
@@ -47,6 +47,7 @@ public final class CheckCleanerBound {
         // Wait to trigger the cleanup.
         for (int i = 0; i < 10 && weakHashMap.size() != 0; i++) {
             System.gc();
+            Thread.sleep(100);
         }
 
         // Check if the object has been collected.  The collection will not


### PR DESCRIPTION
Backport of [JDK-8285785](https://bugs.openjdk.org/browse/JDK-8285785)
- Clean Backport
- Test Succeeded in local Dev Apple M1 Laptop
- PR - All checks have passed
- SAP nightlies passed on 2023-12-14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8285785](https://bugs.openjdk.org/browse/JDK-8285785) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285785](https://bugs.openjdk.org/browse/JDK-8285785): CheckCleanerBound test fails with PasswordCallback object is not released (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2359/head:pull/2359` \
`$ git checkout pull/2359`

Update a local copy of the PR: \
`$ git checkout pull/2359` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2359`

View PR using the GUI difftool: \
`$ git pr show -t 2359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2359.diff">https://git.openjdk.org/jdk11u-dev/pull/2359.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2359#issuecomment-1853180172)