### PR TITLE
8296384: [TESTBUG] sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java intermittently timeout

### DIFF
--- a/test/jdk/java/security/SecureRandom/NoSync.java
+++ b/test/jdk/java/security/SecureRandom/NoSync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /*
  * @test
  * @bug 7004967
- * @run main/othervm NoSync
+ * @run main/othervm -Djava.security.egd=file:/dev/urandom NoSync
  * @summary SecureRandom should be more explicit about threading
  */
 public class NoSync {

--- a/test/jdk/sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java
+++ b/test/jdk/sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @bug 8051408 8157308 8130181
  * @modules java.base/sun.security.provider
  * @build java.base/sun.security.provider.S
- * @run main SpecTest
+ * @run main/othervm -Djava.security.egd=file:/dev/urandom SpecTest
  * @summary check the AbstractDrbg API etc
  */
 


### PR DESCRIPTION
git commit -m "Backport 82561de722b9ca580c0c1a53050c711b64611352" && git push
Backport of [JDK-8296384](https://bugs.openjdk.org/browse/JDK-8296384)
- Clean Backport
- Test Succeeded in local Dev Apple M1 Laptop
- PR - All checks have passed
- SAP nightlies passed on 2023-12-14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8296384](https://bugs.openjdk.org/browse/JDK-8296384) needs maintainer approval

### Issue
 * [JDK-8296384](https://bugs.openjdk.org/browse/JDK-8296384): [TESTBUG] sun/security/provider/SecureRandom/AbstractDrbg/SpecTest.java intermittently timeout (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2363/head:pull/2363` \
`$ git checkout pull/2363`

Update a local copy of the PR: \
`$ git checkout pull/2363` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2363`

View PR using the GUI difftool: \
`$ git pr show -t 2363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2363.diff">https://git.openjdk.org/jdk11u-dev/pull/2363.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2363#issuecomment-1853246796)