### PR TITLE
8302149: Speed up compiler/jsr292/methodHandleExceptions/TestAMEnotNPE.java

### DIFF
--- a/test/hotspot/jtreg/compiler/jsr292/methodHandleExceptions/TestAMEnotNPE.java
+++ b/test/hotspot/jtreg/compiler/jsr292/methodHandleExceptions/TestAMEnotNPE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,12 @@
  *
  * @build p.*
  * @run main/othervm compiler.jsr292.methodHandleExceptions.TestAMEnotNPE
- * @run main/othervm -Xint compiler.jsr292.methodHandleExceptions.TestAMEnotNPE
- * @run main/othervm -Xcomp compiler.jsr292.methodHandleExceptions.TestAMEnotNPE
+ * @run main/othervm -Xint
+ *                   compiler.jsr292.methodHandleExceptions.TestAMEnotNPE
+ * @run main/othervm -Xcomp
+ *                   -XX:CompileCommand=compileonly,p.*::*
+ *                   -XX:CompileCommand=compileonly,q.*::*
+ *                   compiler.jsr292.methodHandleExceptions.TestAMEnotNPE
  */
 
 // Since this test was written the specification for interface method selection has been


### PR DESCRIPTION
Backport of [JDK-8302149](https://bugs.openjdk.org/browse/JDK-8302149)
- Clean Backport
- Test Succeeded in local Dev Apple M1 Laptop
- PR - All checks have passed
- SAP nightlies passed on 2023-12-14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8302149](https://bugs.openjdk.org/browse/JDK-8302149) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302149](https://bugs.openjdk.org/browse/JDK-8302149): Speed up compiler/jsr292/methodHandleExceptions/TestAMEnotNPE.java (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2366/head:pull/2366` \
`$ git checkout pull/2366`

Update a local copy of the PR: \
`$ git checkout pull/2366` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2366`

View PR using the GUI difftool: \
`$ git pr show -t 2366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2366.diff">https://git.openjdk.org/jdk11u-dev/pull/2366.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2366#issuecomment-1853285067)