### PR TITLE
8305505: NPE in javazic compiler

### DIFF
--- a/test/jdk/sun/util/calendar/zi/GenDoc.java
+++ b/test/jdk/sun/util/calendar/zi/GenDoc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,10 +154,10 @@ class GenDoc extends BackEnd {
             outD.mkdirs();
 
             /* If mapfile is available, add a link to the appropriate map */
-            if ((mapList == null) && (Main.getMapFile() != null)) {
+            if (mapList == null && Main.getMapFile() != null) {
+                mapList = new HashMap<String, LatitudeAndLongitude>();
                 FileReader fr = new FileReader(Main.getMapFile());
                 BufferedReader in = new BufferedReader(fr);
-                mapList = new HashMap<String,LatitudeAndLongitude>();
                 String line;
                 while ((line = in.readLine()) != null) {
                     // skip blank and comment lines
@@ -180,7 +180,7 @@ class GenDoc extends BackEnd {
 
             out.write(header1 + new Date() + header3 + zonename + header4);
             out.write(body1 + "<FONT size=\"+2\"><B>" + zonename + "</B></FONT>");
-            LatitudeAndLongitude location = mapList.get(zonename);
+            LatitudeAndLongitude location = (mapList != null ? mapList.get(zonename) : null);
             if (location != null) {
                 int deg, min, sec;
 


### PR DESCRIPTION
Backport of [JDK-8305505](https://bugs.openjdk.org/browse/JDK-8305505)
- Clean Backport
- PR - All checks have passed
- SAP nightlies passed on 2023-12-14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8305505](https://bugs.openjdk.org/browse/JDK-8305505) needs maintainer approval

### Issue
 * [JDK-8305505](https://bugs.openjdk.org/browse/JDK-8305505): NPE in javazic compiler (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2367/head:pull/2367` \
`$ git checkout pull/2367`

Update a local copy of the PR: \
`$ git checkout pull/2367` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2367`

View PR using the GUI difftool: \
`$ git pr show -t 2367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2367.diff">https://git.openjdk.org/jdk11u-dev/pull/2367.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2367#issuecomment-1853292801)