### PR TITLE
8307311: Timeouts on one macOS 12.6.1 host of two Swing JTableHeader tests

### DIFF
--- a/test/jdk/javax/swing/JTableHeader/6889007/bug6889007.java
+++ b/test/jdk/javax/swing/JTableHeader/6889007/bug6889007.java
@@ -53,7 +53,6 @@ public class bug6889007 {
     public static void main(String[] args) throws Exception {
         try {
             robot = new Robot();
-            robot.setAutoDelay(100);
 
             SwingUtilities.invokeAndWait(() -> {
                 frame = new JFrame();
@@ -69,6 +68,7 @@ public class bug6889007 {
                 frame.add(th);
                 frame.pack();
                 frame.setLocationRelativeTo(null);
+                frame.setAlwaysOnTop(true);
                 frame.setVisible(true);
             });
             robot.waitForIdle();
@@ -83,7 +83,7 @@ public class bug6889007 {
             int y = point.y + height/2;
             for(int i = -shift; i < width + 2*shift; i++) {
                 robot.mouseMove(x++, y);
-                robot.waitForIdle();
+                robot.delay(100);
             }
             robot.waitForIdle();
             // 9 is a magic test number
@@ -109,6 +109,8 @@ public class bug6889007 {
             Cursor cursor = Cursor.getPredefinedCursor(Cursor.E_RESIZE_CURSOR);
             if (oldColumn != -1 && newColumn != -1 &&
                     header.getCursor() != cursor) {
+                System.out.println("oldColumn " + oldColumn + " newColumn " + newColumn +
+                        "header.getCursor " + header.getCursor() + " cursor " + cursor);
                 try {
                     Dimension screenSize =
                                Toolkit.getDefaultToolkit().getScreenSize();


### PR DESCRIPTION
Backport of [JDK-8307311](https://bugs.openjdk.org/browse/JDK-8307311)
- Clean Backport
- Test Succeeded in local Dev Apple M1 Laptop
- PR - All checks have passed
- SAP nightlies passed on 2023-12-14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8307311](https://bugs.openjdk.org/browse/JDK-8307311) needs maintainer approval

### Issue
 * [JDK-8307311](https://bugs.openjdk.org/browse/JDK-8307311): Timeouts on one macOS 12.6.1 host of two Swing JTableHeader tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2371/head:pull/2371` \
`$ git checkout pull/2371`

Update a local copy of the PR: \
`$ git checkout pull/2371` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2371`

View PR using the GUI difftool: \
`$ git pr show -t 2371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2371.diff">https://git.openjdk.org/jdk11u-dev/pull/2371.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2371#issuecomment-1853340662)