### PR TITLE
8318951: Additional negative value check in JPEG decoding

### DIFF
--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -1132,6 +1132,10 @@ imageio_skip_input_data(j_decompress_ptr cinfo, long num_bytes)
         return;
     }
     num_bytes += sb->remaining_skip;
+    // Check for overflow if remaining_skip value is too large
+    if (num_bytes < 0) {
+        return;
+    }
     sb->remaining_skip = 0;
 
     /* First the easy case where we are skipping <= the current contents. */

--- a/src/java.desktop/share/native/libjavajpeg/jpegdecoder.c
+++ b/src/java.desktop/share/native/libjavajpeg/jpegdecoder.c
@@ -406,6 +406,10 @@ sun_jpeg_skip_input_data(j_decompress_ptr cinfo, long num_bytes)
         return;
     }
     num_bytes += src->remaining_skip;
+    // Check for overflow if remaining_skip value is too large
+    if (num_bytes < 0) {
+        return;
+    }
     src->remaining_skip = 0;
     ret = (int)src->pub.bytes_in_buffer; /* this conversion is safe, because capacity of the buffer is limited by jnit */
     if (ret >= num_bytes) {


### PR DESCRIPTION
Backport of [JDK-8318951](https://bugs.openjdk.org/browse/JDK-8318951)
- Clean Backport
- PR - All checks have passed
- SAP nightlies passed on 2023-12-14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8318951](https://bugs.openjdk.org/browse/JDK-8318951) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318951](https://bugs.openjdk.org/browse/JDK-8318951): Additional negative value check in JPEG decoding (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2372/head:pull/2372` \
`$ git checkout pull/2372`

Update a local copy of the PR: \
`$ git checkout pull/2372` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2372`

View PR using the GUI difftool: \
`$ git pr show -t 2372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2372.diff">https://git.openjdk.org/jdk11u-dev/pull/2372.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2372#issuecomment-1853341193)