### PR TITLE
8067651: LevelTransitionTest.java, fix trivial methods levels logic

### DIFF
--- a/test/hotspot/jtreg/compiler/tiered/ConstantGettersTransitionsTest.java
+++ b/test/hotspot/jtreg/compiler/tiered/ConstantGettersTransitionsTest.java
@@ -106,8 +106,8 @@ public class ConstantGettersTransitionsTest extends LevelTransitionTest {
 
         private ConstantGettersTestCase() {
             String name = "make" + this.name();
-            this.executable = LevelTransitionTest.Helper.getMethod(TrivialMethods.class, name);
-            this.callable = LevelTransitionTest.Helper.getCallable(new TrivialMethods(), name);
+            this.executable = MethodHelper.getMethod(TrivialMethods.class, name);
+            this.callable = MethodHelper.getCallable(new TrivialMethods(), name);
         }
 
         /**

--- a/test/hotspot/jtreg/compiler/tiered/LevelTransitionTest.java
+++ b/test/hotspot/jtreg/compiler/tiered/LevelTransitionTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test LevelTransitionTest
+ * @requires vm.compMode != "Xcomp"
  * @summary Test the correctness of compilation level transitions for different methods
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
@@ -34,6 +35,7 @@
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm/timeout=240 -Xmixed -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -XX:+TieredCompilation -XX:-UseCounterDecay
+ *                   -XX:-BackgroundCompilation
  *                   -XX:CompileCommand=compileonly,compiler.whitebox.SimpleTestCaseHelper::*
  *                   -XX:CompileCommand=compileonly,compiler.tiered.LevelTransitionTest$ExtendedTestCase$CompileMethodHolder::*
  *                   compiler.tiered.LevelTransitionTest
@@ -43,11 +45,11 @@ package compiler.tiered;
 
 import compiler.whitebox.CompilerWhiteBoxTest;
 import compiler.whitebox.SimpleTestCase;
+import jdk.test.lib.Platform;
 import jtreg.SkippedException;
 
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
-import java.util.Objects;
 import java.util.concurrent.Callable;
 
 public class LevelTransitionTest extends TieredLevelsTest {
@@ -99,6 +101,7 @@ public class LevelTransitionTest extends TieredLevelsTest {
             int newLevel;
             int current = getCompLevel();
             int expected = getNextLevel(current);
+            System.out.println("Levels, current: " + current + ", expected: " + expected);
             if (current == expected) {
                 // if we are on expected level, just execute it more
                 // to ensure that the level won't change
@@ -108,9 +111,10 @@ public class LevelTransitionTest extends TieredLevelsTest {
                 finish = true;
             } else {
                 newLevel = changeCompLevel();
+                System.out.printf("Method %s has been compiled to level %d. Expected level is %d%n",
+                        method, newLevel, expected);
                 finish = false;
             }
-            System.out.printf("Method %s is compiled on level %d. Expected level is %d%n", method, newLevel, expected);
             checkLevel(expected, newLevel);
             printInfo();
         }
@@ -127,8 +131,9 @@ public class LevelTransitionTest extends TieredLevelsTest {
         int nextLevel = currentLevel;
         switch (currentLevel) {
             case CompilerWhiteBoxTest.COMP_LEVEL_NONE:
-                nextLevel = isMethodProfiled ? CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION
-                        : CompilerWhiteBoxTest.COMP_LEVEL_FULL_PROFILE;
+                nextLevel = isTrivial() ? CompilerWhiteBoxTest.COMP_LEVEL_SIMPLE :
+                            isMethodProfiled ? CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION :
+                            CompilerWhiteBoxTest.COMP_LEVEL_FULL_PROFILE;
                 break;
             case CompilerWhiteBoxTest.COMP_LEVEL_LIMITED_PROFILE:
             case CompilerWhiteBoxTest.COMP_LEVEL_FULL_PROFILE:
@@ -149,7 +154,7 @@ public class LevelTransitionTest extends TieredLevelsTest {
         return testCase == ExtendedTestCase.ACCESSOR_TEST
                 || testCase == SimpleTestCase.METHOD_TEST
                 || testCase == SimpleTestCase.STATIC_TEST
-                || (testCase == ExtendedTestCase.TRIVIAL_CODE_TEST && isMethodProfiled);
+                || testCase == ExtendedTestCase.TRIVIAL_CODE_TEST;
     }
 
     /**
@@ -169,42 +174,6 @@ public class LevelTransitionTest extends TieredLevelsTest {
             }
         }
         return newLevel;
-    }
-
-    protected static class Helper {
-        /**
-         * Gets method from a specified class using its name
-         *
-         * @param aClass type method belongs to
-         * @param name   the name of the method
-         * @return {@link Method} that represents corresponding class method
-         */
-        public static Method getMethod(Class<?> aClass, String name) {
-            Method method;
-            try {
-                method = aClass.getDeclaredMethod(name);
-            } catch (NoSuchMethodException e) {
-                throw new Error("TESTBUG: Unable to get method " + name, e);
-            }
-            return method;
-        }
-
-        /**
-         * Gets {@link Callable} that invokes given method from the given object
-         *
-         * @param object the object the specified method is invoked from
-         * @param name   the name of the method
-         */
-        public static Callable<Integer> getCallable(Object object, String name) {
-            Method method = getMethod(object.getClass(), name);
-            return () -> {
-                try {
-                    return Objects.hashCode(method.invoke(object));
-                } catch (ReflectiveOperationException e) {
-                    throw new Error("TESTBUG: Invocation failure", e);
-                }
-            };
-        }
     }
 
     private static enum ExtendedTestCase implements CompilerWhiteBoxTest.TestCase {
@@ -231,8 +200,8 @@ public class LevelTransitionTest extends TieredLevelsTest {
         }
 
         private ExtendedTestCase(String methodName) {
-            this.executable = LevelTransitionTest.Helper.getMethod(CompileMethodHolder.class, methodName);
-            this.callable = LevelTransitionTest.Helper.getCallable(new CompileMethodHolder(), methodName);
+            this.executable = MethodHelper.getMethod(CompileMethodHolder.class, methodName);
+            this.callable = MethodHelper.getCallable(new CompileMethodHolder(), methodName);
         }
 
         private static class CompileMethodHolder {
@@ -258,12 +227,10 @@ public class LevelTransitionTest extends TieredLevelsTest {
             }
 
             /**
-             * Method considered as trivial by amount of code
+             * Method considered as trivial by type (constant getter)
              */
             public int trivialCode() {
-                int var = 0xBAAD_C0DE;
-                var *= field;
-                return var;
+                return 0x42;
             }
         }
     }

--- a/test/hotspot/jtreg/compiler/tiered/MethodHelper.java
+++ b/test/hotspot/jtreg/compiler/tiered/MethodHelper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.tiered;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+public class MethodHelper {
+    /**
+     * Gets method from a specified class using its name
+     *
+     * @param aClass type method belongs to
+     * @param name   the name of the method
+     * @return {@link Method} that represents corresponding class method
+     */
+    public static Method getMethod(Class<?> aClass, String name) {
+        Method method;
+        try {
+            method = aClass.getDeclaredMethod(name);
+        } catch (NoSuchMethodException e) {
+            throw new Error("TESTBUG: Unable to get method " + name, e);
+        }
+        return method;
+    }
+
+    /**
+     * Gets {@link Callable} that invokes given method from the given object
+     *
+     * @param object the object the specified method is invoked from
+     * @param name   the name of the method
+     */
+    public static Callable<Integer> getCallable(Object object, String name) {
+        Method method = getMethod(object.getClass(), name);
+        return () -> {
+            try {
+                return Objects.hashCode(method.invoke(object));
+            } catch (ReflectiveOperationException e) {
+                throw new Error("TESTBUG: Invocation failure", e);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8067651](https://bugs.openjdk.org/browse/JDK-8067651)
- Clean Backport
- Test Succeeded in local Dev Apple M1 Laptop
- PR: All checks have passed
- SAP nightlies passed on 2023-12-19

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8067651](https://bugs.openjdk.org/browse/JDK-8067651) needs maintainer approval

### Issue
 * [JDK-8067651](https://bugs.openjdk.org/browse/JDK-8067651): LevelTransitionTest.java, fix trivial methods levels logic (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2373/head:pull/2373` \
`$ git checkout pull/2373`

Update a local copy of the PR: \
`$ git checkout pull/2373` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2373`

View PR using the GUI difftool: \
`$ git pr show -t 2373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2373.diff">https://git.openjdk.org/jdk11u-dev/pull/2373.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2373#issuecomment-1854464356)