### PR TITLE
8193543: Regression automated test '/open/test/jdk/java/awt/TrayIcon/SystemTrayInstance/SystemTrayInstanceTest.java' fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -182,7 +182,6 @@ java/awt/TrayIcon/ModalityTest/ModalityTest.java 8150540 windows-all,macosx-all
 java/awt/TrayIcon/MouseEventMask/MouseEventMaskTest.java 8150540 windows-all
 java/awt/TrayIcon/MouseMovedTest/MouseMovedTest.java 8150540 windows-all
 java/awt/TrayIcon/SecurityCheck/FunctionalityCheck/FunctionalityCheck.java 8150540 windows-all
-java/awt/TrayIcon/SystemTrayInstance/SystemTrayInstanceTest.java 8193543 linux-all
 java/awt/TrayIcon/TrayIconEventModifiers/TrayIconEventModifiersTest.java 8150540 windows-all
 java/awt/TrayIcon/TrayIconEvents/TrayIconEventsTest.java 8150540 windows-all
 java/awt/TrayIcon/TrayIconMouseTest/TrayIconMouseTest.java 8150540 windows-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -182,6 +182,7 @@ java/awt/TrayIcon/ModalityTest/ModalityTest.java 8150540 windows-all,macosx-all
 java/awt/TrayIcon/MouseEventMask/MouseEventMaskTest.java 8150540 windows-all
 java/awt/TrayIcon/MouseMovedTest/MouseMovedTest.java 8150540 windows-all
 java/awt/TrayIcon/SecurityCheck/FunctionalityCheck/FunctionalityCheck.java 8150540 windows-all
+java/awt/TrayIcon/SystemTrayInstance/SystemTrayInstanceTest.java 8193543 linux-all
 java/awt/TrayIcon/TrayIconEventModifiers/TrayIconEventModifiersTest.java 8150540 windows-all
 java/awt/TrayIcon/TrayIconEvents/TrayIconEventsTest.java 8150540 windows-all
 java/awt/TrayIcon/TrayIconMouseTest/TrayIconMouseTest.java 8150540 windows-all

--- a/test/jdk/java/awt/TrayIcon/SystemTrayInstance/SystemTrayInstanceTest.java
+++ b/test/jdk/java/awt/TrayIcon/SystemTrayInstance/SystemTrayInstanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-import java.awt.*;
+import java.awt.SystemTray;
 
 /*
  * @test
@@ -30,12 +30,20 @@ import java.awt.*;
  *          a proper instance is returned in supported platforms and a proper
  *          exception is thrown in unsupported platforms
  * @author Dmitriy Ermashov (dmitriy.ermashov@oracle.com)
+ * @requires (os.family != "linux")
  * @run main/othervm -DSystemTraySupport=TRUE SystemTrayInstanceTest
+ */
+
+/*
+ * @test
+ * @key headful
+ * @requires (os.family == "linux")
+ * @run main/othervm -DSystemTraySupport=MAYBE SystemTrayInstanceTest
  */
 
 public class SystemTrayInstanceTest {
 
-    private static boolean supported = false;
+    private static boolean shouldSupport = false;
 
     public static void main(String[] args) throws Exception {
         String sysTraySupport = System.getProperty("SystemTraySupport");
@@ -43,29 +51,34 @@ public class SystemTrayInstanceTest {
             throw new RuntimeException("SystemTray support status unknown!");
 
         if ("TRUE".equals(sysTraySupport)) {
-            System.out.println("System tray is supported on the platform under test");
-            supported = true;
+            System.out.println("System tray should be supported on this platform.");
+            shouldSupport = true;
         }
 
         new SystemTrayInstanceTest().doTest();
     }
 
-    private void doTest() throws Exception {
-        boolean flag = SystemTray.isSupported();
-        if (supported != flag)
-            throw new RuntimeException("FAIL: isSupported did not return the correct value"+
-                    (supported ?
-                            "SystemTray is supported on the platform under test" :
-                            "SystemTray is not supported on the platform under test") +
-                    "SystemTray.isSupported() method returned " + flag);
+    private void doTest() {
+        boolean systemSupported = SystemTray.isSupported();
+        if (shouldSupport && !systemSupported) {
+            throw new RuntimeException(
+                    "FAIL: SystemTray is not supported on the platform under test, while it should."
+            );
+        }
 
-        if (supported) {
+        if (shouldSupport || systemSupported) {
             SystemTray tray = SystemTray.getSystemTray();
+            System.out.println("SystemTray instance received");
         } else {
+            boolean exceptionThrown = false;
             try {
                 SystemTray tray = SystemTray.getSystemTray();
             } catch (UnsupportedOperationException uoe) {
+                exceptionThrown = true;
                 System.out.println("UnsupportedOperationException thrown correctly");
+            }
+            if (!exceptionThrown) {
+                throw new RuntimeException("UnsupportedOperationException is not thrown");
             }
         }
     }


### PR DESCRIPTION
Backport of [JDK-8193543](https://bugs.openjdk.org/browse/JDK-8193543)
UnClean Backport
- The `ProblemList.txt` change is not needed in Java 11, because this line does not exist

Tests
- Test Succeeded in local Dev Apple M1 Laptop
- PR: All checks have passed
- SAP nightlies passed on `2023-12-23,24`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8193543](https://bugs.openjdk.org/browse/JDK-8193543) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8193543](https://bugs.openjdk.org/browse/JDK-8193543): Regression automated test '/open/test/jdk/java/awt/TrayIcon/SystemTrayInstance/SystemTrayInstanceTest.java' fails (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2374/head:pull/2374` \
`$ git checkout pull/2374`

Update a local copy of the PR: \
`$ git checkout pull/2374` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2374`

View PR using the GUI difftool: \
`$ git pr show -t 2374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2374.diff">https://git.openjdk.org/jdk11u-dev/pull/2374.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2374#issuecomment-1854521094)