### PR TITLE
8232839: JDI AfterThreadDeathTest.java failed due to "FAILED: Did not get expected IllegalThreadStateException on a StepRequest.enable()"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -782,8 +782,6 @@ com/sun/jdi/NashornPopFrameTest.java                            8187143 generic-
 
 com/sun/jdi/InvokeHangTest.java                                 8218463 linux-all
 
-com/sun/jdi/AfterThreadDeathTest.java                           8232839 linux-all
-
 ############################################################################
 
 # jdk_time

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -782,6 +782,8 @@ com/sun/jdi/NashornPopFrameTest.java                            8187143 generic-
 
 com/sun/jdi/InvokeHangTest.java                                 8218463 linux-all
 
+com/sun/jdi/AfterThreadDeathTest.java                           8232839 linux-all
+
 ############################################################################
 
 # jdk_time


### PR DESCRIPTION
Backport of [JDK-8232839](https://bugs.openjdk.org/browse/JDK-8232839)

Unclean backport
- The [original PR](https://github.com/openjdk/jdk/commit/84184f947342fd1adbe4e3f2230ce3de4ae6007e) was removing 2 lines from `test/jdk/ProblemList.txt` file
- While in Java 11 these lines does not exist, so no need to touch this file

Teses
- PR: All checks have passed
- SAP nightlies passed on `2023-12-23,24`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8232839](https://bugs.openjdk.org/browse/JDK-8232839) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8232839](https://bugs.openjdk.org/browse/JDK-8232839): JDI AfterThreadDeathTest.java failed due to "FAILED: Did not get expected IllegalThreadStateException on a StepRequest.enable()" (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2376/head:pull/2376` \
`$ git checkout pull/2376`

Update a local copy of the PR: \
`$ git checkout pull/2376` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2376`

View PR using the GUI difftool: \
`$ git pr show -t 2376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2376.diff">https://git.openjdk.org/jdk11u-dev/pull/2376.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2376#issuecomment-1854670678)