### PR TITLE
8207211: [TESTBUG] Remove excessive output from CDS/AppCDS tests

### DIFF
--- a/test/hotspot/jtreg/runtime/appcds/HelloExtTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/HelloExtTest.java
@@ -52,7 +52,7 @@ public class HelloExtTest {
 
     TestCommon.dump(appJar,
         TestCommon.list("javax/annotation/processing/FilerException", "[Ljava/lang/Comparable;"),
-        bootClassPath, "-verbose:class");
+        bootClassPath);
 
     String prefix = ".class.load. ";
     String class_pattern = ".*LambdaForm[$]MH[/][0123456789].*";
@@ -60,12 +60,12 @@ public class HelloExtTest {
     String pattern = prefix + class_pattern + suffix;
 
     TestCommon.run("-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI",
-            "-cp", appJar, bootClassPath, "-verbose:class", "HelloExt")
+            "-cp", appJar, bootClassPath, "-Xlog:class+load", "HelloExt")
         .assertNormalExit(output -> output.shouldNotMatch(pattern));
 
 
     TestCommon.run("-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI",
-            "-cp", appJar, bootClassPath, "-verbose:class",
+            "-cp", appJar, bootClassPath, "-Xlog:class+load",
             "-XX:+PrintSharedArchiveAndExit", "-XX:+PrintSharedDictionary",
             "HelloExt")
         .assertNormalExit(output ->  output.shouldNotMatch(class_pattern));

--- a/test/hotspot/jtreg/runtime/appcds/OldClassTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/OldClassTest.java
@@ -67,7 +67,6 @@ public class OldClassTest implements Opcodes {
 
     TestCommon.run(
         "-cp", jar,
-        "-verbose:class",
         "Hello")
       .assertNormalExit("Hello Unicode world (Old)");
 
@@ -79,7 +78,6 @@ public class OldClassTest implements Opcodes {
 
     TestCommon.run(
         "-cp", classpath,
-        "-verbose:class",
         "Hello")
       .assertNormalExit("Hello Unicode world (Old)");
   }

--- a/test/hotspot/jtreg/runtime/appcds/ProhibitedPackage.java
+++ b/test/hotspot/jtreg/runtime/appcds/ProhibitedPackage.java
@@ -79,20 +79,20 @@ public class ProhibitedPackage {
         // -Xshare:on
         TestCommon.run(
             "-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI",
-            "-cp", appJar, "-Xlog:class+load=info", "ProhibitedHelper")
+            "-cp", appJar, "ProhibitedHelper")
           .assertNormalExit("Prohibited package name: java.lang");
 
         // -Xshare:auto
         output = TestCommon.execAuto(
             "-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI",
-            "-cp", appJar, "-Xlog:class+load=info", "ProhibitedHelper");
+            "-cp", appJar, "ProhibitedHelper");
         CDSOptions opts = (new CDSOptions()).setXShareMode("auto");
         TestCommon.checkExec(output, opts, "Prohibited package name: java.lang");
 
         // -Xshare:off
         output = TestCommon.execOff(
             "-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI",
-            "-cp", appJar, "-Xlog:class+load=info", "ProhibitedHelper");
+            "-cp", appJar, "ProhibitedHelper");
         output.shouldContain("Prohibited package name: java.lang");
     }
 }

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/RedefineClassTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/RedefineClassTest.java
@@ -34,7 +34,7 @@
  *        RedefineClassApp
  *        InstrumentationClassFileTransformer
  *        InstrumentationRegisterClassFileTransformer
- * @run main/othervm RedefineClassTest
+ * @run main RedefineClassTest
  */
 
 import com.sun.tools.attach.VirtualMachine;
@@ -89,7 +89,7 @@ public class RedefineClassTest {
                 bootCP,
                 "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:+WhiteBoxAPI",
-                "-Xlog:gc+region=trace,cds=info",
+                "-Xlog:cds=info",
                 agentCmdArg,
                "RedefineClassApp", bootJar, appJar);
         out.reportDiagnosticSummary();

--- a/test/hotspot/jtreg/runtime/appcds/javaldr/ArrayTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/javaldr/ArrayTest.java
@@ -57,7 +57,7 @@ public class ArrayTest {
         String bootClassPath = "-Xbootclasspath/a:" + whiteBoxJar;
 
         // create an archive containing array classes
-        OutputAnalyzer output = TestCommon.dump(appJar, TestCommon.list(arrayClasses), bootClassPath, "-verbose:class");
+        OutputAnalyzer output = TestCommon.dump(appJar, TestCommon.list(arrayClasses), bootClassPath);
         // we currently don't support array classes during CDS dump
         output.shouldContain("Preload Warning: Cannot find [Ljava/lang/Comparable;")
               .shouldContain("Preload Warning: Cannot find [I")
@@ -70,7 +70,6 @@ public class ArrayTest {
         argsList.add("-cp");
         argsList.add(appJar);
         argsList.add(bootClassPath);
-        argsList.add("-verbose:class");
         argsList.add("ArrayTestHelper");
         // the following are input args to the ArrayTestHelper.
         // skip checking array classes during run time

--- a/test/hotspot/jtreg/runtime/appcds/javaldr/GCDuringDump.java
+++ b/test/hotspot/jtreg/runtime/appcds/javaldr/GCDuringDump.java
@@ -56,7 +56,8 @@ public class GCDuringDump {
         String appJar =
             ClassFileInstaller.writeJar("GCDuringDumpApp.jar", appClasses);
 
-        String gcLog = "-Xlog:gc*=info,gc+region=trace,gc+alloc+region=debug";
+        String gcLog = Boolean.getBoolean("test.cds.verbose.gc") ?
+            "-Xlog:gc*=info,gc+region=trace,gc+alloc+region=debug" : "-showversion";
 
         for (int i=0; i<2; i++) {
             // i = 0 -- run without agent = no extra GCs

--- a/test/hotspot/jtreg/runtime/appcds/javaldr/GCDuringDumpTransformer.java
+++ b/test/hotspot/jtreg/runtime/appcds/javaldr/GCDuringDumpTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,13 +28,8 @@ import java.lang.instrument.IllegalClassFormatException;
 import java.security.ProtectionDomain;
 
 public class GCDuringDumpTransformer implements ClassFileTransformer {
-    static int n = 0;
     public byte[] transform(ClassLoader loader, String name, Class<?> classBeingRedefined,
                             ProtectionDomain pd, byte[] buffer) throws IllegalClassFormatException {
-        n++;
-
-        System.out.println("dump time loading: " + name + " in loader: " + loader);
-        System.out.println("making garbage: " + n);
         try {
             makeGarbage();
         } catch (Throwable t) {
@@ -43,7 +38,6 @@ public class GCDuringDumpTransformer implements ClassFileTransformer {
                 Thread.sleep(200); // let GC to have a chance to run
             } catch (Throwable t2) {}
         }
-        System.out.println("making garbage: done");
 
         return null;
     }

--- a/test/hotspot/jtreg/runtime/appcds/javaldr/GCSharedStringsDuringDump.java
+++ b/test/hotspot/jtreg/runtime/appcds/javaldr/GCSharedStringsDuringDump.java
@@ -62,7 +62,8 @@ public class GCSharedStringsDuringDump {
         String appJar =
             ClassFileInstaller.writeJar("GCSharedStringsDuringDumpApp.jar", appClasses);
 
-        String gcLog = "-Xlog:gc*=info,gc+region=trace,gc+alloc+region=debug";
+        String gcLog = Boolean.getBoolean("test.cds.verbose.gc") ?
+            "-Xlog:gc*=info,gc+region=trace,gc+alloc+region=debug" : "-showversion";
 
         String sharedArchiveCfgFile =
             System.getProperty("user.dir") + File.separator + "GCSharedStringDuringDump_gen.txt";

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/AddOpens.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/AddOpens.java
@@ -86,7 +86,6 @@ public class AddOpens {
         // the class in the modular jar in the -cp won't be archived.
         OutputAnalyzer output = TestCommon.createArchive(
                                         destJar.toString(), appClasses,
-                                        "-Xlog:class+load=trace",
                                         "--module-path", moduleDir.toString(),
                                         "-m", TEST_MODULE1);
         TestCommon.checkDump(output);

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/ExportModule.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/ExportModule.java
@@ -117,7 +117,6 @@ public class ExportModule {
         // the module in the --module-path
         OutputAnalyzer output = TestCommon.createArchive(
                                         appJar.toString(), appClasses,
-                                        "-Xlog:class+load=trace",
                                         "--module-path", moduleDir.toString(),
                                         "--add-modules", TEST_MODULE2, MAIN_CLASS);
         TestCommon.checkDump(output);
@@ -141,7 +140,6 @@ public class ExportModule {
         // unnmaed.
         output = TestCommon.createArchive(
                                         appJar2.toString(), appClasses2,
-                                        "-Xlog:class+load=trace",
                                         "--module-path", moduleDir.toString(),
                                         "--add-modules", TEST_MODULE2,
                                         "--add-exports", "org.astro/org.astro=ALL-UNNAMED",

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/JvmtiAddPath.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/JvmtiAddPath.java
@@ -113,7 +113,6 @@ public class JvmtiAddPath {
                                     appJar,
                                     TestCommon.list("JvmtiApp", "ExtraClass", MAIN_CLASS),
                                     use_whitebox_jar,
-                                    "-Xlog:class+load=trace",
                                     modulePath);
         TestCommon.checkDump(output);
 
@@ -143,7 +142,6 @@ public class JvmtiAddPath {
         output = TestCommon.createArchive(
                      appJar, TestCommon.list("JvmtiApp", "ExtraClass"),
                      use_whitebox_jar,
-                     "-Xlog:class+load=trace",
                      modulePath);
         TestCommon.checkDump(output);
         run(twoAppJars, modulePath,

--- a/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/MainModuleOnly.java
+++ b/test/hotspot/jtreg/runtime/appcds/jigsaw/modulepath/MainModuleOnly.java
@@ -89,7 +89,6 @@ public class MainModuleOnly {
         // the class in the modular jar in the -cp won't be archived.
         OutputAnalyzer output = TestCommon.createArchive(
                                         destJar.toString(), appClasses,
-                                        "-Xlog:class+load=trace",
                                         "--module-path", moduleDir.toString(),
                                         "-m", TEST_MODULE1);
         TestCommon.checkDump(output);
@@ -168,8 +167,7 @@ public class MainModuleOnly {
         // run with the archive and the jar with modified timestamp.
         // It should fail due to timestamp of the jar doesn't match the one
         // used during dump time.
-        TestCommon.run("-Xlog:class+load=trace",
-                       "-cp", destJar.toString(),
+        TestCommon.run("-cp", destJar.toString(),
                        "--module-path", moduleDir.toString(),
                        "-m", TEST_MODULE1)
             .assertAbnormalExit(

--- a/test/hotspot/jtreg/runtime/appcds/jvmti/transformRelatedClasses/TransformRelatedClassesAppCDS.java
+++ b/test/hotspot/jtreg/runtime/appcds/jvmti/transformRelatedClasses/TransformRelatedClassesAppCDS.java
@@ -188,7 +188,6 @@ public class TransformRelatedClassesAppCDS extends TransformRelatedClasses {
 
         TestCommon.run("-Xlog:class+load=info",
                        "-cp", appJar,
-                       "--add-opens=java.base/java.security=ALL-UNNAMED",
                        agentParam,
                        "CustomLoaderApp",
                        customJar, loaderType, child)

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -220,11 +220,19 @@ public class CDSTestUtils {
         }
     }
 
-    // Specify this property to copy sdandard output of the child test process to
-    // the parent/main stdout of the test.
-    // By default such output is logged into a file, and is copied into the main stdout.
-    public static final boolean CopyChildStdoutToMainStdout =
-        Boolean.valueOf(System.getProperty("test.cds.copy.child.stdout", "true"));
+    // A number to be included in the filename of the stdout and the stderr output file.
+    static int logCounter = 0;
+
+    private static int getNextLogCounter() {
+        return logCounter++;
+    }
+
+    // By default, stdout of child processes are logged in files such as
+    // <testname>-0000-exec.stdout. If you want to also include the stdout
+    // inside jtr files, you can override this in the jtreg command line like
+    // "jtreg -Dtest.cds.copy.child.stdout=true ...."
+    public static final boolean copyChildStdoutToMainStdout =
+        Boolean.getBoolean("test.cds.copy.child.stdout");
 
     // This property is passed to child test processes
     public static final String TestTimeoutFactor = System.getProperty("test.timeout.factor", "1.0");
@@ -564,13 +572,17 @@ public class CDSTestUtils {
     public static OutputAnalyzer executeAndLog(Process process, String logName) throws Exception {
         long started = System.currentTimeMillis();
         OutputAnalyzer output = new OutputAnalyzer(process);
+        String outputFileNamePrefix =
+            testName + "-" + String.format("%04d", getNextLogCounter()) + "-" + logName;
 
-        writeFile(getOutputFile(logName + ".stdout"), output.getStdout());
-        writeFile(getOutputFile(logName + ".stderr"), output.getStderr());
+        writeFile(getOutputFile(outputFileNamePrefix + ".stdout"), output.getStdout());
+        writeFile(getOutputFile(outputFileNamePrefix + ".stderr"), output.getStderr());
         System.out.println("[ELAPSED: " + (System.currentTimeMillis() - started) + " ms]");
+        System.out.println("[logging stdout to " + outputFileNamePrefix + ".stdout]");
+        System.out.println("[logging stderr to " + outputFileNamePrefix + ".stderr]");
         System.out.println("[STDERR]\n" + output.getStderr());
 
-        if (CopyChildStdoutToMainStdout)
+        if (copyChildStdoutToMainStdout)
             System.out.println("[STDOUT]\n" + output.getStdout());
 
         return output;


### PR DESCRIPTION
Backport of [JDK-8207211](https://bugs.openjdk.org/browse/JDK-8207211)
Unclean Backport. We have the following differences from the original commit:
- `test/hotspot/jtreg/runtime/appcds/ProtectionDomain.java` is not needed to change, because
  - `Copyright year` line do not need to change, because current year is more recent
  - The `"-verbose:class"` parameter does not exist any more
- `test/lib/jdk/test/lib/cds/CDSTestUtils.java` has manual modification
  - In the original commit `c3adb5f87d6af6345bf9cd047d2c378ecdd7ede7` a method named `getTestName()` is called
  - This method was added by [JDK-8177728](https://bugs.openjdk.org/browse/JDK-8177728) on `Apr 18, 2017` and removed by [JDK-8246387](https://bugs.openjdk.org/browse/JDK-8246387) later on `Jun 10, 2020`
  - So this method does not exit any more in current code base
  - We respect the current (newer) code base so use the `testName` variable instead

Tests
- PR All checks have passed
- SAP nightlies passed on 2023-12-19

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8207211](https://bugs.openjdk.org/browse/JDK-8207211) needs maintainer approval

### Issue
 * [JDK-8207211](https://bugs.openjdk.org/browse/JDK-8207211): [TESTBUG] Remove excessive output from CDS/AppCDS tests (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to [771aae3c](https://git.openjdk.org/jdk11u-dev/pull/2380/files/771aae3ca0bb7e2cd9408234af450ba6111e9da8)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2380/head:pull/2380` \
`$ git checkout pull/2380`

Update a local copy of the PR: \
`$ git checkout pull/2380` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2380`

View PR using the GUI difftool: \
`$ git pr show -t 2380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2380.diff">https://git.openjdk.org/jdk11u-dev/pull/2380.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2380#issuecomment-1854864158)