### PR TITLE
8294254: [macOS] javax/swing/plaf/aqua/CustomComboBoxFocusTest.java failure

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
@@ -470,12 +470,12 @@ public class AquaComboBoxUI extends BasicComboBoxUI implements Sizeable {
 
             if (comboBox.getComponentOrientation().isLeftToRight()) {
                 return new Rectangle(insets.left, insets.top + midHeight,
-                        width - (insets.left + insets.right + buttonSize) + 4,
+                        width - (insets.left + insets.right + buttonSize) + 3,
                         height - (insets.top + insets.bottom));
             }
             else {
                 return new Rectangle(insets.left + buttonSize, insets.top + midHeight,
-                        width - (insets.left + insets.right + buttonSize) + 4,
+                        width - (insets.left + insets.right + buttonSize) + 3,
                         height - (insets.top + insets.bottom));
             }
         }

--- a/test/jdk/javax/swing/plaf/aqua/CustomComboBoxFocusTest.java
+++ b/test/jdk/javax/swing/plaf/aqua/CustomComboBoxFocusTest.java
@@ -28,12 +28,12 @@
  * @requires (os.family == "mac")
  * @summary Test verifies that combo box with custom editor renders
  *          focus ring around arrow button correctly.
- * @run     main CustomComboBoxFocusTest
+ * @run     main/othervm -Dsun.java2d.uiScale=1 CustomComboBoxFocusTest
  */
 
 import java.awt.AWTException;
-import java.awt.Component;
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.GridLayout;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -44,8 +44,8 @@ import java.awt.event.FocusListener;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.CountDownLatch;
+
 import javax.imageio.ImageIO;
 import javax.swing.ComboBoxEditor;
 import javax.swing.JComboBox;


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.
Skipped change to ProblemList as the test is not listed in 17. Will mark clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8294254](https://bugs.openjdk.org/browse/JDK-8294254) needs maintainer approval

### Issue
 * [JDK-8294254](https://bugs.openjdk.org/browse/JDK-8294254): [macOS] javax/swing/plaf/aqua/CustomComboBoxFocusTest.java failure (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2386/head:pull/2386` \
`$ git checkout pull/2386`

Update a local copy of the PR: \
`$ git checkout pull/2386` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2386`

View PR using the GUI difftool: \
`$ git pr show -t 2386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2386.diff">https://git.openjdk.org/jdk11u-dev/pull/2386.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2386#issuecomment-1855249179)