### PR TITLE
8226910: make it possible to use jtreg's -match via run-test framework

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -296,6 +296,7 @@
 </tr>
 </tbody>
 </table>
+<p>All compilers are expected to be able to compile to the C99 language standard, as some C99 features are used in the source code. Microsoft Visual Studio doesn't fully support C99 so in practice shared code is limited to using C99 features that it does support.</p>
 <h3 id="gcc">gcc</h3>
 <p>The minimum accepted version of gcc is 4.8. Older versions will generate a warning by <code>configure</code> and are unlikely to work.</p>
 <p>The JDK is currently known to be able to compile with at least version 7.4 of gcc.</p>

--- a/doc/testing.html
+++ b/doc/testing.html
@@ -147,6 +147,9 @@ TEST FAILURE</code></pre>
 <p>Use additional problem lists file or files, in addition to the default ProblemList.txt located at the JTReg test roots.</p>
 <p>If multiple file names are specified, they should be separated by space (or, to help avoid quoting issues, the special value <code>%20</code>).</p>
 <p>The file names should be either absolute, or relative to the JTReg test root of the tests to be run.</p>
+<h4 id="run_problem_lists">RUN_PROBLEM_LISTS</h4>
+<p>Use the problem lists to select tests instead of excluding them.</p>
+<p>Set to <code>true</code> or <code>false</code>. If <code>true</code>, JTReg will use <code>-match:</code> option, otherwise <code>-exclude:</code> will be used. Default is <code>false</code>.</p>
 <h4 id="options">OPTIONS</h4>
 <p>Additional options to the JTReg test framework.</p>
 <p>Use <code>JTREG=&quot;OPTIONS=--help all&quot;</code> to see all available JTReg options.</p>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -297,6 +297,14 @@ help avoid quoting issues, the special value `%20`).
 The file names should be either absolute, or relative to the JTReg test root of
 the tests to be run.
 
+#### RUN_PROBLEM_LISTS
+
+Use the problem lists to select tests instead of excluding them.
+
+Set to `true` or `false`.
+If `true`, JTReg will use `-match:` option, otherwise `-exclude:` will be used.
+Default is `false`.
+
 
 #### OPTIONS
 Additional options to the JTReg test framework.

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -264,7 +264,7 @@ $(eval $(call SetTestOpt,TIMEOUT_FACTOR,JTREG))
 
 $(eval $(call ParseKeywordVariable, JTREG, \
     SINGLE_KEYWORDS := JOBS TIMEOUT_FACTOR TEST_MODE ASSERT VERBOSE RETAIN \
-        MAX_MEM RETRY_COUNT REPEAT_COUNT, \
+        MAX_MEM RUN_PROBLEM_LISTS RETRY_COUNT REPEAT_COUNT, \
     STRING_KEYWORDS := OPTIONS JAVA_OPTIONS VM_OPTIONS KEYWORDS \
         EXTRA_PROBLEM_LISTS AOT_MODULES, \
 ))
@@ -639,6 +639,7 @@ define SetupRunJtregTestBody
   endif
   JTREG_VERBOSE ?= fail,error,summary
   JTREG_RETAIN ?= fail,error
+  JTREG_RUN_PROBLEM_LISTS ?= false
   JTREG_RETRY_COUNT ?= 0
   JTREG_REPEAT_COUNT ?= 0
 
@@ -690,13 +691,19 @@ define SetupRunJtregTestBody
     $1_JTREG_BASIC_OPTIONS += -nativepath:$$($1_JTREG_NATIVEPATH)
   endif
 
+  ifeq ($$(JTREG_RUN_PROBLEM_LISTS), true)
+    JTREG_PROBLEM_LIST_PREFIX := -match:
+  else
+    JTREG_PROBLEM_LIST_PREFIX := -exclude:
+  endif
+
   ifneq ($$($1_JTREG_PROBLEM_LIST), )
-    $1_JTREG_BASIC_OPTIONS += $$(addprefix -exclude:, $$($1_JTREG_PROBLEM_LIST))
+    $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$($1_JTREG_PROBLEM_LIST))
   endif
 
   ifneq ($$(JTREG_EXTRA_PROBLEM_LISTS), )
     # Accept both absolute paths as well as relative to the current test root.
-    $1_JTREG_BASIC_OPTIONS += $$(addprefix -exclude:, $$(wildcard \
+    $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$(wildcard \
         $$(JTREG_EXTRA_PROBLEM_LISTS) \
         $$(addprefix $$($1_TEST_ROOT)/, $$(JTREG_EXTRA_PROBLEM_LISTS)) \
     ))


### PR DESCRIPTION
Backport of [JDK-8226910](https://bugs.openjdk.org/browse/JDK-8226910)

Unclean Backport:
- `doc/building.html`
  - Manually merged with exaclty the conent
  - So this file can be considered `Clean backport`
- `make/RunTests.gmk`
  - `RUN_PROBLEM_LISTS` manualy merged based on [current latest code](https://github.com/openjdk/jdk/blob/bd02cfd96f80abd1559ea3531a21c28c1f670f5d/make/RunTests.gmk#L207)
  - `JTREG_RUN_PROBLEM_LISTS ?= false` manualy merged with exaclty the same code
  - Functionally this file can be considered `Clean backport`

Tests
- PR: All checks have passed
- SAP nightlies passed on `2023-12-23,24`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8226910](https://bugs.openjdk.org/browse/JDK-8226910) needs maintainer approval

### Issue
 * [JDK-8226910](https://bugs.openjdk.org/browse/JDK-8226910): make it possible to use jtreg's -match via run-test framework (**Enhancement** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2387/head:pull/2387` \
`$ git checkout pull/2387`

Update a local copy of the PR: \
`$ git checkout pull/2387` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2387`

View PR using the GUI difftool: \
`$ git pr show -t 2387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2387.diff">https://git.openjdk.org/jdk11u-dev/pull/2387.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2387#issuecomment-1855264740)