### PR TITLE
8272291: mark hotspot runtime/logging tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassInitializationTest.java
@@ -25,6 +25,7 @@
 /*
  * @test ClassInitializationTest
  * @bug 8142976
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile BadMap50.jasm

--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -25,7 +25,7 @@
 /*
  * @test ClassLoadUnloadTest
  * @bug 8142506
- * @requires vm.opt.final.ClassUnloading
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /runtime/testlibrary
  * @library classes
@@ -76,6 +76,7 @@ public class ClassLoadUnloadTest {
         Collections.addAll(argsList, args);
         Collections.addAll(argsList, "-Xmn8m");
         Collections.addAll(argsList, "-Dtest.class.path=" + System.getProperty("test.class.path", "."));
+        Collections.addAll(argsList, "-XX:+ClassUnloading");
         Collections.addAll(argsList, ClassUnloadTestMain.class.getName());
         return ProcessTools.createJavaProcessBuilder(argsList);
     }

--- a/test/hotspot/jtreg/runtime/logging/ClassResolutionTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassResolutionTest.java
@@ -25,6 +25,7 @@
 /*
  * @test ClassResolutionTest
  * @bug 8144874
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver ClassResolutionTest

--- a/test/hotspot/jtreg/runtime/logging/CompressedOopsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/CompressedOopsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,8 @@
 /*
  * @test
  * @bug 8149991
- * @requires vm.bits == 64 & vm.opt.final.UseCompressedOops == true
+ * @requires vm.bits == 64
+ * @requires vm.flagless
  * @summary -Xlog:gc+heap+coops=info should have output from the code
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/logging/DefaultMethodsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/DefaultMethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8139564 8203960
  * @summary defaultmethods=debug should have logging from each of the statements in the code
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/ExceptionsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ExceptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8141211 8147477
  * @summary exceptions=info output should have an exception message for interpreter methods
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/ItablesTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ItablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8141564
  * @summary itables=trace should have logging from each of the statements
  *          in the code
+ * @requires vm.flagless
  * @library /test/lib
  * @compile ClassB.java
  *          ItablesVtableTest.java

--- a/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
@@ -25,6 +25,7 @@
 /*
  * @test LoaderConstraintsTest
  * @bug 8149996
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /runtime/testlibrary classes
  * @run driver LoaderConstraintsTest

--- a/test/hotspot/jtreg/runtime/logging/ModulesTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ModulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary -Xlog:module should emit logging output
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/MonitorInflationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/MonitorInflationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8133885
  * @summary monitorinflation=debug should have logging from each of the statements in the code
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/MonitorMismatchTest.java
+++ b/test/hotspot/jtreg/runtime/logging/MonitorMismatchTest.java
@@ -25,6 +25,7 @@
 /*
  * @test MonitorMismatchTest
  * @bug 8150084
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile MonitorMismatchHelper.jasm

--- a/test/hotspot/jtreg/runtime/logging/OsCpuLoggingTest.java
+++ b/test/hotspot/jtreg/runtime/logging/OsCpuLoggingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8151939
  * @summary os+cpu output should contain some os,cpu information
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/ProtectionDomainVerificationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ProtectionDomainVerificationTest.java
@@ -24,6 +24,7 @@
 /*
  * @test ProtectionDomainVerificationTest
  * @bug 8149064
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver ProtectionDomainVerificationTest

--- a/test/hotspot/jtreg/runtime/logging/SafepointCleanupTest.java
+++ b/test/hotspot/jtreg/runtime/logging/SafepointCleanupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8149991
  * @summary safepoint+cleanup=info should have output from the code
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/SafepointTest.java
+++ b/test/hotspot/jtreg/runtime/logging/SafepointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8140348
  * @summary safepoint=trace should have output from each log statement in the code
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/StackWalkTest.java
+++ b/test/hotspot/jtreg/runtime/logging/StackWalkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @test StackWalkTest
  * @bug 8160064
  * @summary -Xlog:stackwalk should produce logging from the source code
+ * @requires vm.flagless
  * @library /test/lib
  * @run driver StackWalkTest
  */

--- a/test/hotspot/jtreg/runtime/logging/StartupTimeTest.java
+++ b/test/hotspot/jtreg/runtime/logging/StartupTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8148630
  * @summary -Xlog:startuptime should produce logging from the source code
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/ThreadLoggingTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ThreadLoggingTest.java
@@ -26,6 +26,7 @@
  * @test
  * @bug 8149036 8150619
  * @summary os+thread output should contain logging calls for thread start stop attaches detaches
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/VMOperationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/VMOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8143157
  * @summary vmoperation=debug should have logging output
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/VerificationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/VerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8150083
  * @summary verification=info output should have output from the code
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/logging/VtablesTest.java
+++ b/test/hotspot/jtreg/runtime/logging/VtablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8141564
  * @summary vtables=trace should have logging from each of the statements in the code
  * @library /test/lib
+ * @requires vm.flagless
  * @compile ClassB.java
  *          p1/A.java
  *          p2/B.jcod


### PR DESCRIPTION
Backport of [JDK-8272291](https://bugs.openjdk.org/browse/JDK-8272291)

Unclean Backport:
- `test/hotspot/jtreg/runtime/logging/CondyIndyTest.java`
  - This file has been skipped since it does not exist yet
  - This file was added via [JDK-8210012](https://bugs.openjdk.org/browse/JDK-8210012) since Java `15`
- `test/hotspot/jtreg/runtime/logging/ExceptionsTest.java`
  - The only difference is the `Copyright year` part. Manually merged.
  - This file can be considered as `Clean backport`
- `test/hotspot/jtreg/runtime/logging/ItablesTest.java`
  - The base line are different, so auto merge not succeed
  - Manually mereged, with exaclty the same coding logic
  - This file can be considered as `Clean backport`
- `test/hotspot/jtreg/runtime/logging/ModulesTest.java`
  - The only difference is the `Copyright year` part. Manually merged.
  - This file can be considered as `Clean backport`
- `test/hotspot/jtreg/runtime/logging/MonitorInflationTest.java`
  - The base line are different, so auto merge not succeed
  - Manually mereged, with exaclty the same coding logic
  - This file can be considered as `Clean backport`
- `test/hotspot/jtreg/runtime/logging/SafepointCleanupTest.java`
  - The only difference is the `Copyright year` part. Manually merged.
  - This file can be considered as `Clean backport`
- `test/hotspot/jtreg/runtime/logging/SafepointTest.java`
  - The only difference is the `Copyright year` part. Manually merged.
  - This file can be considered as `Clean backport`
- `test/hotspot/jtreg/runtime/logging/VerificationTest.java`
  - The base line are different, so auto merge not succeed
  - Manually mereged, with exaclty the same coding logic
  - This file can be considered as `Clean backport`
- `test/hotspot/jtreg/runtime/logging/VtablesTest.java`
  - The base line are different, so auto merge not succeed
  - Manually mereged, with exaclty the same coding logic
  - This file can be considered as `Clean backport`
- `test/hotspot/jtreg/runtime/logging/loadLibraryTest/LoadLibraryTest.java`
  - This file has been skipped since it does not exist yet
  - This file was added via [JDK-8187305](https://bugs.openjdk.org/browse/JDK-8187305) since Java `15`

Tests
- Test Succeeded in local Dev Apple M1 Laptop
- PR: All checks have passed
- SAP nightlies passed on `2023-12-23,24`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8272291](https://bugs.openjdk.org/browse/JDK-8272291) needs maintainer approval

### Issue
 * [JDK-8272291](https://bugs.openjdk.org/browse/JDK-8272291): mark hotspot runtime/logging tests which ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2388/head:pull/2388` \
`$ git checkout pull/2388`

Update a local copy of the PR: \
`$ git checkout pull/2388` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2388`

View PR using the GUI difftool: \
`$ git pr show -t 2388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2388.diff">https://git.openjdk.org/jdk11u-dev/pull/2388.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2388#issuecomment-1855375497)