### PR TITLE
8301377: adjust timeout for JLI GetObjectSizeIntrinsicsTest.java subtest again

### DIFF
--- a/test/hotspot/jtreg/compiler/jsr292/ContinuousCallSiteTargetChange.java
+++ b/test/hotspot/jtreg/compiler/jsr292/ContinuousCallSiteTargetChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission
- * @run driver compiler.jsr292.ContinuousCallSiteTargetChange
+ * @run driver/timeout=180 compiler.jsr292.ContinuousCallSiteTargetChange
  */
 
 package compiler.jsr292;

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load007/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@
  * @run driver jdk.test.lib.FileInstaller . .
  * @comment generate and compile LoadableClassXXX classes
  * @run driver nsk.monitoring.stress.classload.GenClassesBuilder
- * @run main/othervm
+ * @run main/othervm/timeout=180
  *      -XX:-UseGCOverheadLimit
  *      nsk.monitoring.stress.classload.load001
  *      classes

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load011/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load011/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@
  * @run driver jdk.test.lib.FileInstaller . .
  * @comment generate and compile LoadableClassXXX classes
  * @run driver nsk.monitoring.stress.classload.GenClassesBuilder
- * @run main/othervm
+ * @run main/othervm/timeout=180
  *      -XX:-UseGCOverheadLimit
  *      nsk.monitoring.stress.classload.load001
  *      classes

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load012/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load012/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@
  * @run driver jdk.test.lib.FileInstaller . .
  * @comment generate and compile LoadableClassXXX classes
  * @run driver nsk.monitoring.stress.classload.GenClassesBuilder
- * @run main/othervm
+ * @run main/othervm/timeout=180
  *      -XX:-UseGCOverheadLimit
  *      nsk.monitoring.stress.classload.load001
  *      classes


### PR DESCRIPTION
Backport of [JDK-8301377](https://bugs.openjdk.org/browse/JDK-8301377). 
This same fix also fixed the following two tickets
- [JDK-8302607](https://bugs.openjdk.org/browse/JDK-8302607)
- [JDK-8305502](https://bugs.openjdk.org/browse/JDK-8305502)

Unclean Backport:
- `test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java`
  - This file has been ignored, because it does not exist in Java 11
  - Based on [current history](https://github.com/openjdk/jdk/commits/4b23bef51df9c1a5bc8f43748a8d6c8d99995656/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java) This file was added by [JDK-8253525](https://bugs.openjdk.org/browse/JDK-8253525) on Java 16
- `test/hotspot/jtreg/compiler/jsr292/ContinuousCallSiteTargetChange.java`
  - `Copyright year` line manually merged.
  - `driver/timeout=180` line manually merged
  - The change is exactly the same as the original [commit](https://github.com/openjdk/jdk/commit/4b23bef51df9c1a5bc8f43748a8d6c8d99995656)
  - So the change to this file can be considered as `Clean`
- `test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load007/TestDescription.java`
- `test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load011/TestDescription.java`
- `test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load012/TestDescription.java`
  - For the 3 files above, the only difference is the `Copyright year` line.
  - Manually merged this line
  - These 3 files can be considered as `Clean`


Tests
- Test Succeeded in local Dev Apple M1 Laptop
- PR: All checks have passed
- SAP nightlies passed on `2023-12-23,24`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8301377](https://bugs.openjdk.org/browse/JDK-8301377) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8305502](https://bugs.openjdk.org/browse/JDK-8305502) needs maintainer approval
- [x] [JDK-8302607](https://bugs.openjdk.org/browse/JDK-8302607) needs maintainer approval

### Issues
 * [JDK-8301377](https://bugs.openjdk.org/browse/JDK-8301377): adjust timeout for JLI GetObjectSizeIntrinsicsTest.java subtest again (**Bug** - P4 - Approved)
 * [JDK-8302607](https://bugs.openjdk.org/browse/JDK-8302607): increase timeout for ContinuousCallSiteTargetChange.java (**Bug** - P5 - Approved)
 * [JDK-8305502](https://bugs.openjdk.org/browse/JDK-8305502): adjust timeouts in three more M&amp;M tests (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2392/head:pull/2392` \
`$ git checkout pull/2392`

Update a local copy of the PR: \
`$ git checkout pull/2392` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2392`

View PR using the GUI difftool: \
`$ git pr show -t 2392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2392.diff">https://git.openjdk.org/jdk11u-dev/pull/2392.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2392#issuecomment-1857336465)