### PR TITLE
8308043: Deadlock in TestCSLocker.java due to blocking GC while allocating

### DIFF
--- a/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
+++ b/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
@@ -46,10 +46,13 @@ public class TestCSLocker extends Thread
         // start CS locker thread
         CSLocker csLocker = new CSLocker();
         csLocker.start();
+        // After the CSLocker thread has started, any operation such as an allocation,
+        // which could rely on the GC to make progress, will cause a deadlock that will
+        // make the test time out. That includes printing. Please don't use any such
+        // code until unlock() is called below.
 
         // check timeout to success deadlocking
-        while(System.currentTimeMillis() < startTime + timeout) {
-            System.out.println("sleeping...");
+        while (System.currentTimeMillis() < startTime + timeout) {
             sleep(1000);
         }
 


### PR DESCRIPTION
Backport of [JDK-8308043](https://bugs.openjdk.org/browse/JDK-8308043)

Unclean Backport:
- `test/hotspot/jtreg/ProblemList-Xcomp.txt`
  - The changes of this file has been ignored, because the line `TestCSLocker.java` does not exist

Tests
- Test Succeeded in local Dev Apple M1 Laptop
- PR: All checks have passed
- SAP nightlies passed on `2023-12-21,22,23,24`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8308043](https://bugs.openjdk.org/browse/JDK-8308043) needs maintainer approval

### Issue
 * [JDK-8308043](https://bugs.openjdk.org/browse/JDK-8308043): Deadlock in TestCSLocker.java due to blocking GC while allocating (**Bug** - P2 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2394/head:pull/2394` \
`$ git checkout pull/2394`

Update a local copy of the PR: \
`$ git checkout pull/2394` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2394`

View PR using the GUI difftool: \
`$ git pr show -t 2394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2394.diff">https://git.openjdk.org/jdk11u-dev/pull/2394.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2394#issuecomment-1857367948)