### PR TITLE
8308223: failure handler missed jcmd.vm.info command

### DIFF
--- a/test/failure_handler/src/share/conf/common.properties
+++ b/test/failure_handler/src/share/conf/common.properties
@@ -33,7 +33,7 @@ onTimeout=\
         jcmd.compiler.queue \
   jcmd.vm.classloader_stats jcmd.vm.stringtable \
         jcmd.vm.symboltable jcmd.vm.uptime jcmd.vm.dynlibs \
-        jcmd.vm.system_properties \
+        jcmd.vm.system_properties jcmd.vm.info \
   jcmd.gc.heap_info jcmd.gc.class_histogram jcmd.gc.finalizer_info \
   jstack
 


### PR DESCRIPTION
Backport of [JDK-8308223](https://bugs.openjdk.org/browse/JDK-8308223)

Unclean Backport:
- `test/failure_handler/src/share/conf/common.properties`
  - This file is merged manually; the change is exactly the same as the [original commit](https://github.com/openjdk/jdk/commit/563152f32dd2c8617c0e0955d55c5bbce23627fb)
  - This file can be considered as `Clean`

Tests
- PR: All checks have passed
- SAP nightlies passed on `2023-12-21,22`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8308223](https://bugs.openjdk.org/browse/JDK-8308223) needs maintainer approval

### Issue
 * [JDK-8308223](https://bugs.openjdk.org/browse/JDK-8308223): failure handler missed jcmd.vm.info command (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2396/head:pull/2396` \
`$ git checkout pull/2396`

Update a local copy of the PR: \
`$ git checkout pull/2396` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2396`

View PR using the GUI difftool: \
`$ git pr show -t 2396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2396.diff">https://git.openjdk.org/jdk11u-dev/pull/2396.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2396#issuecomment-1857388764)