### PR TITLE
8308232: nsk/jdb tests don't pass -verbose flag to the debuggee

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
@@ -217,6 +217,10 @@ public class Launcher extends DebugeeBinder {
                     }
                 }
                 String cmdline = classToExecute + " " + ArgumentHandler.joinArguments(argumentHandler.getArguments(), " ");
+                cmdline += " -waittime " + argumentHandler.getWaitTime();
+                if (argumentHandler.verbose()) {
+                    cmdline += " -verbose";
+                }
                 connect.append(",main=" + cmdline.trim());
 
             }


### PR DESCRIPTION
Backport of [JDK-8308232](https://bugs.openjdk.org/browse/JDK-8308232)

Unclean Backport:
- `test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java`
  - Auto diff apply failed.
  - Manually merged the code; the code change is exactly the same as the [original commit](https://github.com/openjdk/jdk/commit/c6f20db945c6217aea84cebd6c97dbf8b93c48a4)
  - This file can be considered as `Clean`

Test
- PR: All checks have passed
- SAP nightlies passed on `2023-12-21,22`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8308232](https://bugs.openjdk.org/browse/JDK-8308232) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308232](https://bugs.openjdk.org/browse/JDK-8308232): nsk/jdb tests don't pass -verbose flag to the debuggee (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2397/head:pull/2397` \
`$ git checkout pull/2397`

Update a local copy of the PR: \
`$ git checkout pull/2397` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2397`

View PR using the GUI difftool: \
`$ git pr show -t 2397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2397.diff">https://git.openjdk.org/jdk11u-dev/pull/2397.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2397#issuecomment-1857424781)