### PR TITLE
8320798: Console read line with zero out should zero out underlying buffer

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -426,6 +426,10 @@ public final class Console implements Flushable
             System.arraycopy(rcb, 0, b, 0, len);
             if (zeroOut) {
                 Arrays.fill(rcb, 0, len, ' ');
+                if (reader instanceof LineReader) {
+                    LineReader lr = (LineReader)reader;
+                    lr.zeroOut();
+                }
             }
         }
         return b;
@@ -449,6 +453,12 @@ public final class Console implements Flushable
             cb = new char[1024];
             nextChar = nChars = 0;
             leftoverLF = false;
+        }
+        public void zeroOut() throws IOException {
+            if (in instanceof StreamDecoder) {
+                StreamDecoder sd = (StreamDecoder)in;
+                sd.fillZeroToPosition();
+            }
         }
         public void close () {}
         public boolean ready() throws IOException {

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -32,6 +32,7 @@ import java.io.*;
 import java.nio.*;
 import java.nio.channels.*;
 import java.nio.charset.*;
+import java.util.Arrays;
 
 public class StreamDecoder extends Reader
 {
@@ -199,6 +200,16 @@ public class StreamDecoder extends Reader
         return !closed;
     }
 
+    public void fillZeroToPosition() throws IOException {
+        Object lock = this.lock;
+        synchronized (lock) {
+            lockedFillZeroToPosition();
+        }
+    }
+
+    private void lockedFillZeroToPosition() {
+        Arrays.fill(bb.array(), bb.arrayOffset(), bb.arrayOffset() + bb.position(), (byte)0);
+    }
 
     // -- Charset-based stream decoder impl --
 


### PR DESCRIPTION
A fix we should have in 11., backported from 17.
Basically the same change, but I had to adapt the instanceof statements to syntax of 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320798](https://bugs.openjdk.org/browse/JDK-8320798) needs maintainer approval

### Issue
 * [JDK-8320798](https://bugs.openjdk.org/browse/JDK-8320798): Console read line with zero out should zero out underlying buffer (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2400/head:pull/2400` \
`$ git checkout pull/2400`

Update a local copy of the PR: \
`$ git checkout pull/2400` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2400`

View PR using the GUI difftool: \
`$ git pr show -t 2400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2400.diff">https://git.openjdk.org/jdk11u-dev/pull/2400.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2400#issuecomment-1858789767)