### PR TITLE
8257505: nsk/share/test/StressOptions stressTime is scaled in getter but not when printed

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/test/StressOptions.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/test/StressOptions.java
@@ -210,10 +210,10 @@ public class StressOptions {
      * @param out output stream
      */
     public void printInfo(PrintStream out) {
-        out.println("Stress time: " + time + " seconds");
-        out.println("Stress iterations factor: " + iterationsFactor);
-        out.println("Stress threads factor: " + threadsFactor);
-        out.println("Stress runs factor: " + runsFactor);
+        out.println("Stress time: " + getTime() + " seconds");
+        out.println("Stress iterations factor: " + getIterationsFactor());
+        out.println("Stress threads factor: " + getThreadsFactor());
+        out.println("Stress runs factor: " + getRunsFactor());
     }
 
     private void error(String msg) {


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8257505](https://bugs.openjdk.org/browse/JDK-8257505) needs maintainer approval

### Issue
 * [JDK-8257505](https://bugs.openjdk.org/browse/JDK-8257505): nsk/share/test/StressOptions stressTime is scaled in getter but not when printed (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2401/head:pull/2401` \
`$ git checkout pull/2401`

Update a local copy of the PR: \
`$ git checkout pull/2401` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2401`

View PR using the GUI difftool: \
`$ git pr show -t 2401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2401.diff">https://git.openjdk.org/jdk11u-dev/pull/2401.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2401#issuecomment-1859599059)