### PR TITLE
8255743: Relax SIGFPE match in in runtime/ErrorHandling/SecondaryErrorTest.java

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
@@ -68,7 +68,7 @@ public class SecondaryErrorTest {
 
     // we should have crashed with a SIGFPE
     output_detail.shouldMatch("# A fatal error has been detected by the Java Runtime Environment:.*");
-    output_detail.shouldMatch("# +SIGFPE.*");
+    output_detail.shouldMatch("#.+SIGFPE.*");
 
     // extract hs-err file
     String hs_err_file = output_detail.firstMatch("# *(\\S*hs_err_pid\\d+\\.log)", 1);


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8255743](https://bugs.openjdk.org/browse/JDK-8255743) needs maintainer approval

### Issue
 * [JDK-8255743](https://bugs.openjdk.org/browse/JDK-8255743): Relax SIGFPE match in in runtime/ErrorHandling/SecondaryErrorTest.java (**Bug** - P4 - Approved)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2402/head:pull/2402` \
`$ git checkout pull/2402`

Update a local copy of the PR: \
`$ git checkout pull/2402` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2402`

View PR using the GUI difftool: \
`$ git pr show -t 2402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2402.diff">https://git.openjdk.org/jdk11u-dev/pull/2402.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2402#issuecomment-1859608589)