### PR TITLE
8233453: MLVM deoptimize stress test timed out

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
@@ -43,7 +43,7 @@
  * @build vm.mlvm.meth.stress.compiler.deoptimize.Test
  * @run driver vm.mlvm.share.IndifiedClassesBuilder
  *
- * @run main/othervm
+ * @run main/othervm/timeout=300
  *      -XX:ReservedCodeCacheSize=100m
  *      vm.mlvm.meth.stress.compiler.deoptimize.Test
  *      -threadsPerCpu 4


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8233453](https://bugs.openjdk.org/browse/JDK-8233453) needs maintainer approval

### Issue
 * [JDK-8233453](https://bugs.openjdk.org/browse/JDK-8233453): MLVM deoptimize stress test timed out (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2405/head:pull/2405` \
`$ git checkout pull/2405`

Update a local copy of the PR: \
`$ git checkout pull/2405` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2405`

View PR using the GUI difftool: \
`$ git pr show -t 2405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2405.diff">https://git.openjdk.org/jdk11u-dev/pull/2405.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2405#issuecomment-1859698652)