### PR TITLE
8166554: Avoid compilation blocking in OverloadCompileQueueTest.java

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/stress/OverloadCompileQueueTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/OverloadCompileQueueTest.java
@@ -30,6 +30,7 @@
  *          java.management
  *
  * @build sun.hotspot.WhiteBox
+ *        compiler.codecache.stress.TestCaseImpl
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
@@ -53,8 +54,34 @@ import java.lang.reflect.Method;
 import java.util.stream.IntStream;
 import java.util.Random;
 
-public class OverloadCompileQueueTest implements Runnable {
+class LockUnlockThread extends Thread {
     private static final int MAX_SLEEP = 10000;
+    private static final int DELAY_BETWEEN_LOCKS = 100;
+    private final Random rng = Utils.getRandomInstance();
+
+    public volatile boolean isActive = true;
+
+    @Override
+    public void run() {
+        try {
+            while (isActive) {
+                int timeInLockedState = rng.nextInt(MAX_SLEEP);
+                Helper.WHITE_BOX.lockCompilation();
+                Thread.sleep(timeInLockedState);
+                Helper.WHITE_BOX.unlockCompilation();
+                Thread.sleep(DELAY_BETWEEN_LOCKS);
+            }
+        } catch (InterruptedException e) {
+            if (isActive) {
+                throw new Error("TESTBUG: LockUnlockThread was unexpectedly interrupted", e);
+            }
+        } finally {
+            Helper.WHITE_BOX.unlockCompilation();
+        }
+    }
+}
+
+public class OverloadCompileQueueTest implements Runnable {
     private static final String METHOD_TO_ENQUEUE = "method";
     private static final int LEVEL_SIMPLE = 1;
     private static final int LEVEL_FULL_OPTIMIZATION = 4;
@@ -63,7 +90,6 @@ public class OverloadCompileQueueTest implements Runnable {
     private static final int TIERED_STOP_AT_LEVEL
             = Helper.WHITE_BOX.getIntxVMFlag("TieredStopAtLevel").intValue();
     private static final int[] AVAILABLE_LEVELS;
-    private final Random rng = Utils.getRandomInstance();
     static {
         if (TIERED_COMPILATION) {
             AVAILABLE_LEVELS = IntStream
@@ -78,15 +104,18 @@ public class OverloadCompileQueueTest implements Runnable {
         }
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws InterruptedException {
+        LockUnlockThread lockUnlockThread = new LockUnlockThread();
+        lockUnlockThread.start();
+
         if (Platform.isInt()) {
             throw new Error("TESTBUG: test can not be run in interpreter");
         }
         new CodeCacheStressRunner(new OverloadCompileQueueTest()).runTest();
-    }
 
-    public OverloadCompileQueueTest() {
-        Helper.startInfiniteLoopThread(this::lockUnlock, 100L);
+        lockUnlockThread.isActive = false;
+        lockUnlockThread.interrupt();
+        lockUnlockThread.join();
     }
 
     @Override
@@ -103,18 +132,6 @@ public class OverloadCompileQueueTest implements Runnable {
         }
         for (int compLevel : AVAILABLE_LEVELS) {
             Helper.WHITE_BOX.enqueueMethodForCompilation(mEnqueue, compLevel);
-        }
-    }
-
-    private void lockUnlock() {
-        try {
-            int sleep = rng.nextInt(MAX_SLEEP);
-            Helper.WHITE_BOX.lockCompilation();
-            Thread.sleep(sleep);
-        } catch (InterruptedException e) {
-            throw new Error("TESTBUG: lockUnlocker thread was unexpectedly interrupted", e);
-        } finally {
-            Helper.WHITE_BOX.unlockCompilation();
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8166554](https://bugs.openjdk.org/browse/JDK-8166554) needs maintainer approval

### Issue
 * [JDK-8166554](https://bugs.openjdk.org/browse/JDK-8166554): Avoid compilation blocking in OverloadCompileQueueTest.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2406/head:pull/2406` \
`$ git checkout pull/2406`

Update a local copy of the PR: \
`$ git checkout pull/2406` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2406`

View PR using the GUI difftool: \
`$ git pr show -t 2406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2406.diff">https://git.openjdk.org/jdk11u-dev/pull/2406.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2406#issuecomment-1859707981)