### PR TITLE
8166275: vm/mlvm/meth/stress/compiler/deoptimize keeps timeouting

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,12 +43,36 @@
  * @build vm.mlvm.meth.stress.compiler.deoptimize.Test
  * @run driver vm.mlvm.share.IndifiedClassesBuilder
  *
+ * @requires vm.debug != true
+ *
  * @run main/othervm
  *      -XX:ReservedCodeCacheSize=100m
  *      vm.mlvm.meth.stress.compiler.deoptimize.Test
  *      -threadsPerCpu 4
  *      -threadsExtra 2
  */
+
+
+/*
+ * @test
+ *
+ * @library /vmTestbase
+ *          /test/lib
+ * @run driver jdk.test.lib.FileInstaller . .
+ *
+ * @comment build test class and indify classes
+ * @build vm.mlvm.meth.stress.compiler.deoptimize.Test
+ * @run driver vm.mlvm.share.IndifiedClassesBuilder
+ *
+ * @requires vm.debug == true
+ *
+ * @run main/othervm
+ *      -XX:ReservedCodeCacheSize=100m
+ *      vm.mlvm.meth.stress.compiler.deoptimize.Test
+ *      -threadsPerCpu 2
+ *      -threadsExtra 2
+ */
+
 
 package vm.mlvm.meth.stress.compiler.deoptimize;
 

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java
@@ -45,7 +45,7 @@
  *
  * @requires vm.debug != true
  *
- * @run main/othervm
+ * @run main/othervm/timeout=300
  *      -XX:ReservedCodeCacheSize=100m
  *      vm.mlvm.meth.stress.compiler.deoptimize.Test
  *      -threadsPerCpu 4
@@ -66,7 +66,7 @@
  *
  * @requires vm.debug == true
  *
- * @run main/othervm
+ * @run main/othervm/timeout=300
  *      -XX:ReservedCodeCacheSize=100m
  *      vm.mlvm.meth.stress.compiler.deoptimize.Test
  *      -threadsPerCpu 2


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.
backport for JDK-8233453 and JDK-8166275.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8166275](https://bugs.openjdk.org/browse/JDK-8166275) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8233453](https://bugs.openjdk.org/browse/JDK-8233453) needs maintainer approval

### Issues
 * [JDK-8166275](https://bugs.openjdk.org/browse/JDK-8166275): vm/mlvm/meth/stress/compiler/deoptimize keeps timeouting (**Bug** - P3 - Approved)
 * [JDK-8233453](https://bugs.openjdk.org/browse/JDK-8233453): MLVM deoptimize stress test timed out (**Bug** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2407/head:pull/2407` \
`$ git checkout pull/2407`

Update a local copy of the PR: \
`$ git checkout pull/2407` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2407`

View PR using the GUI difftool: \
`$ git pr show -t 2407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2407.diff">https://git.openjdk.org/jdk11u-dev/pull/2407.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2407#issuecomment-1859724615)