### PR TITLE
8272552: mark hotspot runtime/cds tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedStrings.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedStrings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,17 +26,17 @@
  * @summary Check to make sure that shared strings in the bootstrap CDS archive
  *          are actually shared
  * @requires vm.cds.archived.java.heap
+ * @requires vm.flagless
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.management
  * @build SharedStringsWb sun.hotspot.WhiteBox
- * @run driver ClassFileInstaller -jar whitebox.jar sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar sun.hotspot.WhiteBox
  * @run driver SharedStrings
  */
 
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.helpers.ClassFileInstaller;
 
 public class SharedStrings {
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/runtime/appcds/VerifyWithDefaultArchive.java
+++ b/test/hotspot/jtreg/runtime/appcds/VerifyWithDefaultArchive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -19,40 +19,27 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
+ *
  */
 
-/**
+/*
  * @test
- * @requires vm.cds
+ * @bug 8264337
+ * @summary test default cds archive when turning on VerifySharedSpaces
  * @requires vm.flagless
- * @bug 8067187 8200078
- * @summary Testing CDS dumping with the -XX:MaxMetaspaceSize=<size> option
+ * @requires vm.cds
  * @library /test/lib
- * @modules java.base/jdk.internal.misc
- *          java.management
- * @run driver MaxMetaspaceSize
+ * @run driver VerifyWithDefaultArchive
  */
 
-import java.util.ArrayList;
-
-import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.Platform;
+import jdk.test.lib.process.OutputAnalyzer;
 
-public class MaxMetaspaceSize {
-  public static void main(String[] args) throws Exception {
-    ArrayList<String> processArgs = new ArrayList<>();
-    processArgs.add("-Xshare:dump");
-
-    if (Platform.is64bit()) {
-      processArgs.add("-XX:MaxMetaspaceSize=3m");
-      processArgs.add("-XX:CompressedClassSpaceSize=1m");
-    } else {
-      processArgs.add("-XX:MaxMetaspaceSize=1m");
+public class VerifyWithDefaultArchive {
+    public static void main(String... args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xlog:cds", "-XX:+VerifySharedSpaces", "-version");
+        OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        out.shouldNotContain("relocation bitmap CRC error");
+        out.shouldHaveExitValue(0);
     }
-
-    String msg = "OutOfMemoryError: Metaspace";
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(processArgs);
-    CDSTestUtils.executeAndLog(pb, "dump").shouldContain(msg).shouldHaveExitValue(1);
-  }
 }

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
@@ -1,5 +1,5 @@
-/**
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+/*
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,12 @@
  * @test
  * @summary Test archived module graph with custom runtime image
  * @requires vm.cds.archived.java.heap
- * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/appcds
- * @modules java.base/jdk.internal.module
- *          java.management
- *          jdk.jlink
- *          jdk.compiler
+ * @requires vm.flagless
+ * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build sun.hotspot.WhiteBox
  * @compile CheckArchivedModuleApp.java
- * @run driver ClassFileInstaller -jar app.jar CheckArchivedModuleApp
- * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar CheckArchivedModuleApp
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
  * @run driver ArchivedModuleWithCustomImageTest
  */
 
@@ -45,6 +42,7 @@ import java.nio.file.Paths;
 import jdk.test.lib.compiler.CompilerUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.helpers.ClassFileInstaller;
 
 public class ArchivedModuleWithCustomImageTest {
     private static final String JAVA_HOME = System.getProperty("java.home");
@@ -110,7 +108,7 @@ public class ArchivedModuleWithCustomImageTest {
         String[] dumpCmd = {
             customJava.toString(),
             "-XX:SharedArchiveFile=./ArchivedModuleWithCustomImageTest.jsa",
-            "-Xshare:dump"};
+            "-Xshare:dump", "-Xlog:cds"};
         printCommand(dumpCmd);
         ProcessBuilder pbDump = new ProcessBuilder();
         pbDump.command(dumpCmd);

--- a/test/hotspot/jtreg/runtime/appcds/jcmd/JCmdTestDynamicDump.java
+++ b/test/hotspot/jtreg/runtime/appcds/jcmd/JCmdTestDynamicDump.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8259070
+ * @summary Test jcmd to dump dynamic shared archive.
+ * @requires vm.cds
+ * @requires vm.flagless
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @modules jdk.jcmd/sun.tools.common:+open
+ * @compile ../test-classes/Hello.java JCmdTestDumpBase.java
+ * @build sun.hotspot.WhiteBox
+ * @build JCmdTestLingeredApp JCmdTestDynamicDump
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm/timeout=480 -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI JCmdTestDynamicDump
+ */
+
+import java.io.File;
+
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.JDKToolFinder;
+
+public class JCmdTestDynamicDump extends JCmdTestDumpBase {
+    static final String DYNAMIC_DUMP_FILE   = "mydynamic";
+    static final String[] DYNAMIC_MESSAGES  = {"JCmdTestLingeredApp source: shared objects file (top)",
+                                               "LingeredApp source: shared objects file (top)",
+                                               "Hello source: shared objects file (top)"};
+    static void test() throws Exception {
+        setIsStatic(false);
+        buildJars();
+
+        LingeredApp app  = null;
+        long pid;
+
+        int  test_count = 1;
+        // Test dynamic dump with -XX:+RecordDynamicDumpInfo.
+        print2ln(test_count++ + " Test dynamic dump with -XX:+RecordDynamicDumpInfo.");
+        app = createLingeredApp("-cp", allJars, "-XX:+RecordDynamicDumpInfo");
+        pid = app.getPid();
+        test(DYNAMIC_DUMP_FILE + "01.jsa", pid, noBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
+
+        // Test dynamic dump twice to same process.
+        print2ln(test_count++ + " Test dynamic dump second time to the same process.");
+        test("02.jsa", pid, noBoot,  EXPECT_PASS);
+        app.stopApp();
+
+        // Test dynamic dump with -XX:-RecordDynamicDumpInfo.
+        print2ln(test_count++ + " Test dynamic dump with -XX:-RecordDynamicDumpInfo.");
+        app = createLingeredApp("-cp", allJars);
+        pid = app.getPid();
+        test("01.jsa", pid, noBoot, EXPECT_FAIL);
+        app.stopApp();
+
+        // Test dynamic dump with default archive name (null).
+        print2ln(test_count++ + " Test dynamic dump with default archive name (null).");
+        app = createLingeredApp("-cp", allJars, "-XX:+RecordDynamicDumpInfo");
+        pid = app.getPid();
+        test(null, pid, noBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
+        app.stopApp();
+
+        // Test dynamic dump with flags -XX:+RecordDynamicDumpInfo -XX:-DynamicDumpSharedSpaces.
+        print2ln(test_count++ + " Test dynamic dump with flags -XX:+RecordDynamicDumpInfo -XX:-DynamicDumpSharedSpaces.");
+        app = createLingeredApp("-cp", allJars, "-XX:+RecordDynamicDumpInfo", "-XX:-DynamicDumpSharedSpaces");
+        pid = app.getPid();
+        test(null, pid, noBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
+        app.stopApp();
+
+        // Test dynamic dump with flags -XX:-DynamicDumpSharedSpaces -XX:+RecordDynamicDumpInfo.
+        print2ln(test_count++ + " Test dynamic dump with flags -XX:-DynamicDumpSharedSpaces -XX:+RecordDynamicDumpInfo.");
+        app = createLingeredApp("-cp", allJars, "-XX:-DynamicDumpSharedSpaces", "-XX:+RecordDynamicDumpInfo");
+        pid = app.getPid();
+        test(null, pid, noBoot,  EXPECT_PASS, DYNAMIC_MESSAGES);
+        app.stopApp();
+
+        // Test dynamic with -Xbootclasspath/a:boot.jar
+        print2ln(test_count++ + " Test dynamic with -Xbootclasspath/a:boot.jar");
+        app = createLingeredApp("-cp", testJar, "-Xbootclasspath/a:" + bootJar, "-XX:+RecordDynamicDumpInfo");
+        pid = app.getPid();
+        test(null, pid, useBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
+        app.stopApp();
+
+        // Test -XX:+RecordDynamicDump -XX:SharedArchiveFile=test_static.jsa
+        print2ln(test_count++ + " Test -XX:+RecordDynamicDumpInfo -XX:SharedArchiveFile=test_static.jsa");
+        // Dump a static archive as base (here do not use the default classes.jsa)
+        String archiveFile = "test_static.jsa";
+        dumpStaticArchive(archiveFile);
+        app = createLingeredApp("-cp", allJars, "-XX:+RecordDynamicDumpInfo",
+                                "-XX:SharedArchiveFile=" + archiveFile);
+        pid = app.getPid();
+        test(null, pid, noBoot, EXPECT_PASS, DYNAMIC_MESSAGES);
+        app.stopApp();
+
+        // Test dynamic dump with -XX:ArchiveClassAtExit will fail.
+        print2ln(test_count++ + " Test dynamic dump with -XX:ArchiveClassAtExit will fail.");
+        app = createLingeredApp("-cp", allJars,
+                                "-Xshare:auto",
+                                "-XX:+RecordDynamicDumpInfo",
+                                "-XX:ArchiveClassesAtExit=AnyName.jsa");
+        if (app != null) {
+            if (app.getProcess().isAlive()) {
+                throw new RuntimeException("The JCmdTestLingeredApp should not start up!");
+            }
+        }
+    }
+
+    // Dump a static archive, not using TestCommon.dump(...), we do not take jtreg args.
+    private static void dumpStaticArchive(String archiveFile) throws Exception {
+        String javapath = JDKToolFinder.getJDKTool("java");
+        String cmd[] = {javapath, "-Xshare:dump",  "-XX:SharedArchiveFile=" + archiveFile};
+        // Do not use ProcessTools.createTestJvm(cmd) here, it copies jtreg env.
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        CDSTestUtils.executeAndLog(pb, "dump")
+            .shouldHaveExitValue(0);
+        File file = new File(archiveFile);
+        if (!file.exists()) {
+            throw new RuntimeException("Cannot dump classes to archive file " + archiveFile);
+        }
+    }
+
+    public static void main(String... args) throws Exception {
+        runTest(JCmdTestDynamicDump::test);
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8123456](https://bugs.openjdk.org/browse/JDK-8123456)
- This is a complex change, because in the latest code base the code has been refactored to `test/hotspot/jtreg/runtime/cds/` folder, while in Java 11 they are in different folders

This is an `Unclean` backport, because of
- The [original commit](https://github.com/openjdk/jdk/commit/989f39f8106a22498053a4ca5f2becf8df5f2420) was changing the files in the folder `test/hotspot/jtreg/runtime/cds/`, while this folder does not exist in Java 11. Where
  1. file `test/hotspot/jtreg/runtime/cds/MaxMetaspaceSize.java` match to `test/hotspot/jtreg/runtime/SharedArchiveFile/MaxMetaspaceSize.java` in Java 11
  1. file `test/hotspot/jtreg/runtime/cds/SharedStrings.java` match to `test/hotspot/jtreg/runtime/SharedArchiveFile/SharedStrings.java` in Java 11
  1. file `test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java` match to `test/hotspot/jtreg/runtime/appcds/MoveJDKTest.java` in Java 11
  1. file `test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java` matche to `test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java` in Java 11
  1. file `test/hotspot/jtreg/runtime/cds/appcds/VerifyWithDefaultArchive.java` `does not exist` in Java 11, it was added by [JDK-8264337](https://bugs.openjdk.org/browse/JDK-8264337) on Java 17
  1. file `test/hotspot/jtreg/runtime/cds/appcds/jcmd/JCmdTestDynamicDump.java` `does not exist` in Java 11, it was added by [JDK-8265393](https://bugs.openjdk.org/browse/JDK-8265393) on Java 17
- So For those four (4) moved files
  1. we applied the change in the original commit
  1. and also all the missing commits in between
- For those two (2) missing files
  - which were added in Java 17, and does not exist in Java 11
  - we simply add them

Tests
- Test Succeeded in local laptop of MacOS M1 CPU Machine
- PR: Issue found, under investigation
- Test Machine: (to run)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8272552](https://bugs.openjdk.org/browse/JDK-8272552) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272552](https://bugs.openjdk.org/browse/JDK-8272552): mark hotspot runtime/cds tests which ignore external VM flags (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2408/head:pull/2408` \
`$ git checkout pull/2408`

Update a local copy of the PR: \
`$ git checkout pull/2408` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2408`

View PR using the GUI difftool: \
`$ git pr show -t 2408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2408.diff">https://git.openjdk.org/jdk11u-dev/pull/2408.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2408#issuecomment-1861769064)