### PR TITLE
8271890: mark hotspot runtime/Dictionary tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/Dictionary/ProtectionDomainCacheTest.java
+++ b/test/hotspot/jtreg/runtime/Dictionary/ProtectionDomainCacheTest.java
@@ -26,6 +26,7 @@
  * @bug 8151486 8218266
  * @summary Call Class.forName() on the system classloader from a class loaded
  *          from a custom classloader, using the current class's protection domain.
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @build jdk.test.lib.Utils


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.
CleanProtectionDomain.java, this test has not been added to jdk11u-dev, so ignore the backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271890](https://bugs.openjdk.org/browse/JDK-8271890) needs maintainer approval

### Issue
 * [JDK-8271890](https://bugs.openjdk.org/browse/JDK-8271890): mark hotspot runtime/Dictionary tests which ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2415/head:pull/2415` \
`$ git checkout pull/2415`

Update a local copy of the PR: \
`$ git checkout pull/2415` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2415`

View PR using the GUI difftool: \
`$ git pr show -t 2415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2415.diff">https://git.openjdk.org/jdk11u-dev/pull/2415.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2415#issuecomment-1869315814)