### PR TITLE
8271828: mark hotspot runtime/classFileParserBug tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/classFileParserBug/ClassFileParserBug.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/ClassFileParserBug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8040018
  * @library /test/lib
  * @summary Check for exception instead of assert.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @run main ClassFileParserBug

--- a/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
@@ -26,6 +26,7 @@
  * @bug 8041918
  * @library /test/lib
  * @summary Test empty bootstrap_methods table within BootstrapMethods attribute
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @compile TestEmptyBootstrapMethodsAttr.java


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.
test/hotspot/jtreg/runtime/classFileParserBug/ClassFileParserBug.java
test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
Copyright.

test/hotspot/jtreg/runtime/classFileParserBug/TestBadPackageWithInterface.java
this test has not been added to jdk11u-dev, so ignore the backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271828](https://bugs.openjdk.org/browse/JDK-8271828) needs maintainer approval

### Issue
 * [JDK-8271828](https://bugs.openjdk.org/browse/JDK-8271828): mark hotspot runtime/classFileParserBug tests which ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2416/head:pull/2416` \
`$ git checkout pull/2416`

Update a local copy of the PR: \
`$ git checkout pull/2416` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2416`

View PR using the GUI difftool: \
`$ git pr show -t 2416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2416.diff">https://git.openjdk.org/jdk11u-dev/pull/2416.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2416#issuecomment-1869330584)