### PR TITLE
8271224: runtime/EnclosingMethodAttr/EnclMethodAttr.java doesn't check exit code

### DIFF
--- a/test/hotspot/jtreg/runtime/EnclosingMethodAttr/EnclMethodAttr.java
+++ b/test/hotspot/jtreg/runtime/EnclosingMethodAttr/EnclMethodAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ public class EnclMethodAttr {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-jar", testsrc + File.separator + "enclMethodAttr.jar");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldNotHaveExitValue(0);
         output.shouldContain("java.lang.ClassFormatError: Wrong EnclosingMethod");
     }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.
test/hotspot/jtreg/runtime/EnclosingMethodAttr/EnclMethodAttr.java
Copyright.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271224](https://bugs.openjdk.org/browse/JDK-8271224) needs maintainer approval

### Issue
 * [JDK-8271224](https://bugs.openjdk.org/browse/JDK-8271224): runtime/EnclosingMethodAttr/EnclMethodAttr.java doesn't check exit code (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2417/head:pull/2417` \
`$ git checkout pull/2417`

Update a local copy of the PR: \
`$ git checkout pull/2417` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2417`

View PR using the GUI difftool: \
`$ git pr show -t 2417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2417.diff">https://git.openjdk.org/jdk11u-dev/pull/2417.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2417#issuecomment-1869335454)