### PR TITLE
8271094: runtime/duplAttributes/DuplAttributesTest.java doesn't check exit code

### DIFF
--- a/test/hotspot/jtreg/runtime/duplAttributes/DuplAttributesTest.java
+++ b/test/hotspot/jtreg/runtime/duplAttributes/DuplAttributesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ public class DuplAttributesTest {
             "-cp", testsrc + File.separator + "test.jar", test);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("java.lang.ClassFormatError: Multiple " + result);
+        output.shouldNotHaveExitValue(0);
     }
 
     public static void main(String args[]) throws Throwable {


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.
test/hotspot/jtreg/runtime/duplAttributes/DuplAttributesTest.java
Copyright.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271094](https://bugs.openjdk.org/browse/JDK-8271094) needs maintainer approval

### Issue
 * [JDK-8271094](https://bugs.openjdk.org/browse/JDK-8271094): runtime/duplAttributes/DuplAttributesTest.java doesn't check exit code (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2418/head:pull/2418` \
`$ git checkout pull/2418`

Update a local copy of the PR: \
`$ git checkout pull/2418` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2418`

View PR using the GUI difftool: \
`$ git pr show -t 2418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2418.diff">https://git.openjdk.org/jdk11u-dev/pull/2418.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2418#issuecomment-1869341263)