### PR TITLE
8058176: [mlvm] tests should not allow code cache exhaustion

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -274,7 +274,7 @@ vmTestbase/vm/mlvm/meth/stress/compiler/i2c_c2i/Test.java 8208255 generic-all
 vmTestbase/vm/mlvm/meth/stress/compiler/sequences/Test.java 8208255 generic-all
 vmTestbase/vm/mlvm/meth/stress/gc/callSequencesDuringGC/Test.java 8208255 generic-all
 vmTestbase/vm/mlvm/meth/stress/java/sequences/Test.java 8208255 generic-all
-vmTestbase/vm/mlvm/meth/stress/jdi/breakpointInCompiledCode/Test.java 8208255 generic-all
+vmTestbase/vm/mlvm/meth/stress/jdi/breakpointInCompiledCode/Test.java 8257761 generic-all
 vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8079650 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2none_a/TestDescription.java 8013267 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_b/TestDescription.java 8013267 generic-all

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/share/MHTransformationGen.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/share/MHTransformationGen.java
@@ -25,10 +25,15 @@ package vm.mlvm.meth.share;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
+import java.lang.management.MemoryUsage;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.ManagementFactory;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
 
 import nsk.share.test.LazyIntArrayToString;
 import nsk.share.test.TestUtils;
@@ -65,8 +70,45 @@ public class MHTransformationGen {
     private static final boolean USE_SAM = false; // Disabled in JDK7
     private static final boolean USE_THROW_CATCH = false; // Test bugs
 
+    private static final Optional<MemoryPoolMXBean> NON_SEGMENTED_CODE_CACHE_POOL;
+    private static final Optional<MemoryPoolMXBean> NON_NMETHODS_POOL;
+    private static final Optional<MemoryPoolMXBean> PROFILED_NMETHODS_POOL;
+    private static final Optional<MemoryPoolMXBean> NON_PROFILED_NMETHODS_POOL ;
+
+    // Limit numbers are arbitrary, feel free to change if arguably necessary
+    private static final int NON_SEGMENTED_CACHE_ALLOWANCE = 2_000_000;
+    private static final int SEGMENTED_CACHE_ALLOWANCE = 1_000_000;
+
+    static {
+        var pools = ManagementFactory.getMemoryPoolMXBeans();
+        NON_SEGMENTED_CODE_CACHE_POOL = pools.stream()
+            .filter(pool -> pool.getName().equals("CodeCache")).findFirst();
+        NON_NMETHODS_POOL = pools.stream()
+            .filter(pool -> pool.getName().equals("CodeHeap 'non-nmethods'")).findFirst();
+        PROFILED_NMETHODS_POOL = pools.stream()
+            .filter(pool -> pool.getName().equals("CodeHeap 'profiled nmethods'")).findFirst();
+        NON_PROFILED_NMETHODS_POOL = pools.stream()
+            .filter(pool -> pool.getName().equals("CodeHeap 'non-profiled nmethods'")).findFirst();
+    }
+
     public static class ThrowCatchTestException extends Throwable {
         private static final long serialVersionUID = -6749961303738648241L;
+    }
+
+    private static final boolean isCodeCacheEffectivelyFull() {
+        var result = new Object() { boolean value = false; };
+
+        BiConsumer<MemoryPoolMXBean, Integer> check = (pool, limit) -> {
+            var usage = pool.getUsage();
+            result.value |= usage.getMax() - usage.getUsed() < limit;
+        };
+
+        NON_SEGMENTED_CODE_CACHE_POOL.ifPresent(pool -> check.accept(pool, NON_SEGMENTED_CACHE_ALLOWANCE));
+        NON_NMETHODS_POOL.ifPresent(pool -> check.accept(pool, SEGMENTED_CACHE_ALLOWANCE));
+        PROFILED_NMETHODS_POOL.ifPresent(pool -> check.accept(pool, SEGMENTED_CACHE_ALLOWANCE));
+        NON_PROFILED_NMETHODS_POOL.ifPresent(pool -> check.accept(pool, SEGMENTED_CACHE_ALLOWANCE));
+
+        return result.value;
     }
 
     @SuppressWarnings("unused")
@@ -89,7 +131,14 @@ public class MHTransformationGen {
 
         List<MHTFPair> pendingPWTFs = new LinkedList<MHTFPair>();
 
-        for ( int i = nextInt(MAX_CYCLES); i > 0; i-- ) {
+        final int cyclesToBuild = nextInt(MAX_CYCLES);
+        for ( int i = 0; i < cyclesToBuild; i++) {
+            if (isCodeCacheEffectivelyFull()) {
+                Env.traceNormal("Not enought code cache to build up MH sequences anymore. " +
+                        " Has only been able to achieve " + i + " out of " + cyclesToBuild);
+                break;
+            }
+
             MHCall lastCall = graph.computeInboundCall();
             Argument[] lastArgs = lastCall.getArgs();
             MethodType type = lastCall.getTargetMH().type();


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

test/hotspot/jtreg/ProblemList.txt
the removed tests are not in ProblemList.txt, 
"vmTestbase/vm/mlvm/meth/stress/jdi/breakpointInCompiledCode/Test.java 8208255 generic-all"
JDK-8208255 is duplicated with JDK-8058176, so change to 8058176

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8058176](https://bugs.openjdk.org/browse/JDK-8058176) needs maintainer approval

### Issue
 * [JDK-8058176](https://bugs.openjdk.org/browse/JDK-8058176): [mlvm] tests should not allow code cache exhaustion (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2419/head:pull/2419` \
`$ git checkout pull/2419`

Update a local copy of the PR: \
`$ git checkout pull/2419` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2419`

View PR using the GUI difftool: \
`$ git pr show -t 2419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2419.diff">https://git.openjdk.org/jdk11u-dev/pull/2419.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2419#issuecomment-1869911839)