### PR TITLE
8264135: UnsafeGetStableArrayElement should account for different JIT implementation details

### DIFF
--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeGetStableArrayElement.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeGetStableArrayElement.java
@@ -25,15 +25,17 @@
  * @test
  * @summary tests on constant folding of unsafe get operations from stable arrays
  * @library /test/lib
- *
+ * @build sun.hotspot.WhiteBox
  * @requires vm.flavor == "server" & !vm.emulatedClient
  *
  * @modules java.base/jdk.internal.vm.annotation
  *          java.base/jdk.internal.misc
-
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ *
  * @run main/bootclasspath/othervm -XX:+UnlockDiagnosticVMOptions
  *                   -Xbatch -XX:-TieredCompilation
  *                   -XX:+FoldStableValues
+ *                   -XX:+WhiteBoxAPI
  *                   -XX:CompileCommand=dontinline,*Test::test*
  *                   compiler.unsafe.UnsafeGetStableArrayElement
  */
@@ -49,6 +51,8 @@ import java.util.concurrent.Callable;
 import static jdk.internal.misc.Unsafe.*;
 import static jdk.test.lib.Asserts.assertEQ;
 import static jdk.test.lib.Asserts.assertNE;
+
+import sun.hotspot.code.Compiler;
 
 public class UnsafeGetStableArrayElement {
     @Stable static final boolean[] STABLE_BOOLEAN_ARRAY = new boolean[16];
@@ -220,7 +224,16 @@ public class UnsafeGetStableArrayElement {
     }
 
     static void testMismatched(Callable<?> c, Runnable setDefaultAction) throws Exception {
-        run(c, null, setDefaultAction);
+        testMismatched(c, setDefaultAction, false);
+    }
+
+    static void testMismatched(Callable<?> c, Runnable setDefaultAction, boolean objectArray) throws Exception {
+        if (Compiler.isGraalEnabled() && !objectArray) {
+            // Graal will constant fold mismatched reads from primitive stable arrays
+            run(c, setDefaultAction, null);
+        } else {
+            run(c, null, setDefaultAction);
+        }
         Setter.reset();
     }
 
@@ -306,8 +319,8 @@ public class UnsafeGetStableArrayElement {
         testMatched(   Test::testD_D, Test::changeD);
 
         // Object[], aligned accesses
-        testMismatched(Test::testL_J, Test::changeL); // long & double are always as large as an OOP
-        testMismatched(Test::testL_D, Test::changeL);
+        testMismatched(Test::testL_J, Test::changeL, true); // long & double are always as large as an OOP
+        testMismatched(Test::testL_D, Test::changeL, true);
         testMatched(   Test::testL_L, Test::changeL);
 
         // Unaligned accesses


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

“ClassFileInstaller” path is modified as can't find jdk.test.lib.helpers.ClassFileInstaller, then local test pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8264135](https://bugs.openjdk.org/browse/JDK-8264135) needs maintainer approval

### Issue
 * [JDK-8264135](https://bugs.openjdk.org/browse/JDK-8264135): UnsafeGetStableArrayElement should account for different JIT implementation details (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2420/head:pull/2420` \
`$ git checkout pull/2420`

Update a local copy of the PR: \
`$ git checkout pull/2420` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2420`

View PR using the GUI difftool: \
`$ git pr show -t 2420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2420.diff">https://git.openjdk.org/jdk11u-dev/pull/2420.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2420#issuecomment-1869966202)