### PR TITLE
8269025: jsig/Testjsig.java doesn't check exit code

### DIFF
--- a/test/hotspot/jtreg/runtime/jsig/Testjsig.java
+++ b/test/hotspot/jtreg/runtime/jsig/Testjsig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,7 @@ public class Testjsig {
 
         // Start the process and check the output
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
         output.shouldContain("old handler");
     }
 }


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.
no local.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8269025](https://bugs.openjdk.org/browse/JDK-8269025) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269025](https://bugs.openjdk.org/browse/JDK-8269025): jsig/Testjsig.java doesn't check exit code (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2421/head:pull/2421` \
`$ git checkout pull/2421`

Update a local copy of the PR: \
`$ git checkout pull/2421` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2421`

View PR using the GUI difftool: \
`$ git pr show -t 2421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2421.diff">https://git.openjdk.org/jdk11u-dev/pull/2421.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2421#issuecomment-1869971800)