### PR TITLE
8271829: mark hotspot runtime/Throwable tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/Throwable/StackTraceLogging.java
+++ b/test/hotspot/jtreg/runtime/Throwable/StackTraceLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8150778
  * @summary check stacktrace logging
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/Throwable/TestMaxJavaStackTraceDepth.java
+++ b/test/hotspot/jtreg/runtime/Throwable/TestMaxJavaStackTraceDepth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 7179701
  * @summary MaxJavaStackTraceDepth of zero is not handled correctly/consistently in the VM
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  * @library /test/lib


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

test/hotspot/jtreg/runtime/Throwable/TestCatchThrowableOOM.java
this test has not been added to jdk11u-dev, so ignore the backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271829](https://bugs.openjdk.org/browse/JDK-8271829) needs maintainer approval

### Issue
 * [JDK-8271829](https://bugs.openjdk.org/browse/JDK-8271829): mark hotspot runtime/Throwable tests which ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2422/head:pull/2422` \
`$ git checkout pull/2422`

Update a local copy of the PR: \
`$ git checkout pull/2422` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2422`

View PR using the GUI difftool: \
`$ git pr show -t 2422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2422.diff">https://git.openjdk.org/jdk11u-dev/pull/2422.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2422#issuecomment-1870035244)