### PR TITLE
8280007: Enable Neoverse N1 optimizations for Arm Neoverse V1 & N2

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -149,8 +149,10 @@ void VM_Version::initialize() {
     }
   }
 
-  // Neoverse N1
-  if (_cpu == CPU_ARM && (_model == 0xd0c || _model2 == 0xd0c)) {
+  // Neoverse N1, N2 and V1
+  if (_cpu == CPU_ARM && ((_model == 0xd0c || _model2 == 0xd0c)
+                          || (_model == 0xd49 || _model2 == 0xd49)
+                          || (_model == 0xd40 || _model2 == 0xd40))) {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }


### PR DESCRIPTION
Backport of JDK-8280007. The change should be enabled in JDK11 better performance on Neoverse V1/N1/N2. It is quite safe for existing in upstream and 17u for years.

Additional testing: aarch64 server ARM Neoverse N2 release/fastdebug tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8280007](https://bugs.openjdk.org/browse/JDK-8280007) needs maintainer approval

### Issue
 * [JDK-8280007](https://bugs.openjdk.org/browse/JDK-8280007): Enable Neoverse N1 optimizations for Arm Neoverse V1 &amp; N2 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2425/head:pull/2425` \
`$ git checkout pull/2425`

Update a local copy of the PR: \
`$ git checkout pull/2425` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2425`

View PR using the GUI difftool: \
`$ git pr show -t 2425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2425.diff">https://git.openjdk.org/jdk11u-dev/pull/2425.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2425#issuecomment-1873581571)