### PR TITLE
8321215: Incorrect x86 instruction encoding for VSIB addressing mode

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -346,7 +346,7 @@ class Address {
   }
 
   bool xmmindex_needs_rex() const {
-    return _xmmindex != xnoreg && _xmmindex->encoding() >= 8;
+    return _xmmindex != xnoreg && ((_xmmindex->encoding() & 8) == 8);
   }
 
   relocInfo::relocType reloc() const { return _rspec.type(); }


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

I had to resolve due to context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321215](https://bugs.openjdk.org/browse/JDK-8321215) needs maintainer approval

### Issue
 * [JDK-8321215](https://bugs.openjdk.org/browse/JDK-8321215): Incorrect x86 instruction encoding for VSIB addressing mode (**Bug** - P3 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2427/head:pull/2427` \
`$ git checkout pull/2427`

Update a local copy of the PR: \
`$ git checkout pull/2427` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2427`

View PR using the GUI difftool: \
`$ git pr show -t 2427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2427.diff">https://git.openjdk.org/jdk11u-dev/pull/2427.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2427#issuecomment-1875288532)