### PR TITLE
8239801: [macos] java/awt/Focus/UnaccessibleChoice/AccessibleChoiceTest.java fails

### DIFF
--- a/test/jdk/java/awt/Focus/UnaccessibleChoice/AccessibleChoiceTest.java
+++ b/test/jdk/java/awt/Focus/UnaccessibleChoice/AccessibleChoiceTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Choice;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Window;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.imageio.ImageIO;
+
+/**
+ * @test
+ * @bug 4478780
+ * @key headful
+ * @summary Tests that Choice can be accessed and controlled by keyboard.
+ */
+public class AccessibleChoiceTest {
+    //Declare things used in the test, like buttons and labels here
+    Frame frame = new Frame("window owner");
+    Window win = new Window(frame);
+    Choice choice = new Choice();
+    Button def = new Button("default owner");
+    CountDownLatch go = new CountDownLatch(1);
+
+    public static void main(final String[] args) throws IOException {
+        AccessibleChoiceTest app = new AccessibleChoiceTest();
+        app.test();
+    }
+
+    private void test() throws IOException {
+        try {
+            init();
+            start();
+        } finally {
+            if (frame != null) frame.dispose();
+            if (win != null) win.dispose();
+        }
+    }
+
+    public void init() {
+        win.setLayout (new FlowLayout ());
+        win.add(def);
+        def.addFocusListener(new FocusAdapter() {
+                public void focusGained(FocusEvent e) {
+                    go.countDown();
+                }
+            });
+        choice.add("One");
+        choice.add("Two");
+        win.add(choice);
+    }
+
+    public void start () throws IOException {
+        frame.setVisible(true);
+        win.pack();
+        win.setLocation(100, 200);
+        win.setVisible(true);
+
+        Robot robot = null;
+        try {
+            robot = new Robot();
+        } catch (Exception ex) {
+            throw new RuntimeException("Can't create robot");
+        }
+        robot.waitForIdle();
+        robot.delay(1000);
+        robot.setAutoDelay(150);
+        robot.setAutoWaitForIdle(true);
+
+        // Focus default button and wait till it gets focus
+        Point loc = def.getLocationOnScreen();
+        robot.mouseMove(loc.x+2, loc.y+2);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+        try {
+            go.await(1, TimeUnit.SECONDS);
+        } catch (InterruptedException ie) {
+            throw new RuntimeException("Interrupted !!!");
+        }
+
+        if (!def.isFocusOwner()) {
+            throw new RuntimeException("Button doesn't have focus");
+        }
+
+        // Press Tab key to move focus to Choice
+        robot.keyPress(KeyEvent.VK_TAB);
+        robot.keyRelease(KeyEvent.VK_TAB);
+
+        robot.delay(500);
+
+        // Press Down key to select next item in the choice(Motif 2.1)
+        // If bug exists we won't be able to do so
+        robot.keyPress(KeyEvent.VK_DOWN);
+        robot.keyRelease(KeyEvent.VK_DOWN);
+
+        robot.delay(500);
+
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (osName.startsWith("mac")) {
+            robot.keyPress(KeyEvent.VK_DOWN);
+            robot.keyRelease(KeyEvent.VK_DOWN);
+            robot.delay(500);
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+        }
+
+        robot.delay(1000);
+
+        // On success second item should be selected
+        if (choice.getSelectedItem() != choice.getItem(1)) {
+            // Print out os name to check if mac conditional is relevant
+            System.err.println("Failed on os: " + osName);
+
+            // Save image to better debug the status of test when failing
+            GraphicsConfiguration ge = GraphicsEnvironment
+                    .getLocalGraphicsEnvironment().getDefaultScreenDevice()
+                    .getDefaultConfiguration();
+            BufferedImage failImage = robot.createScreenCapture(ge.getBounds());
+            ImageIO.write(failImage, "png", new File("failImage.png"));
+
+            throw new RuntimeException("Choice can't be controlled by keyboard");
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.
Also backport for JDK-8237222, both clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8237222](https://bugs.openjdk.org/browse/JDK-8237222) needs maintainer approval
- [x] [JDK-8239801](https://bugs.openjdk.org/browse/JDK-8239801) needs maintainer approval

### Issues
 * [JDK-8239801](https://bugs.openjdk.org/browse/JDK-8239801): [macos] java/awt/Focus/UnaccessibleChoice/AccessibleChoiceTest.java fails (**Bug** - P4 - Approved)
 * [JDK-8237222](https://bugs.openjdk.org/browse/JDK-8237222): [macos] java/awt/Focus/UnaccessibleChoice/AccessibleChoiceTest.java fails (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2432/head:pull/2432` \
`$ git checkout pull/2432`

Update a local copy of the PR: \
`$ git checkout pull/2432` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2432`

View PR using the GUI difftool: \
`$ git pr show -t 2432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2432.diff">https://git.openjdk.org/jdk11u-dev/pull/2432.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2432#issuecomment-1876409695)