### PR TITLE
8202931: [macos] java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -449,7 +449,6 @@ java/awt/datatransfer/ConstructFlavoredObjectTest/ConstructFlavoredObjectTest.ja
 java/awt/dnd/DisposeFrameOnDragCrash/DisposeFrameOnDragTest.java 8202790 macosx-all,linux-all
 java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882 linux-all
 java/awt/Frame/FramesGC/FramesGC.java 8079069 macosx-all
-java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java 8202931 macosx-all,linux-all
 java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.java 7124275 macosx-all
 java/awt/Focus/TranserFocusToWindow/TranserFocusToWindow.java 6848810 macosx-all
 java/awt/Component/NativeInLightShow/NativeInLightShow.java 8202932 linux-all

--- a/test/jdk/java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java
+++ b/test/jdk/java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,10 @@ import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.Toolkit;
 import java.awt.event.InputEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+
+import javax.imageio.ImageIO;
 
 /**
  * @test
@@ -44,6 +48,7 @@ public final class ChoicePopupLocation {
 
     private static final int SIZE = 350;
     private static int frameWidth;
+    private static Rectangle bounds;
 
     public static void main(final String[] args) throws Exception {
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
@@ -52,7 +57,7 @@ public final class ChoicePopupLocation {
         Point right = null;
         for (GraphicsDevice sd : sds) {
             GraphicsConfiguration gc = sd.getDefaultConfiguration();
-            Rectangle bounds = gc.getBounds();
+            bounds = gc.getBounds();
             if (left == null || left.x > bounds.x) {
                 left = new Point(bounds.x, bounds.y + bounds.height / 2);
             }
@@ -120,6 +125,8 @@ public final class ChoicePopupLocation {
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
         if (choice.getSelectedIndex() == 0) {
+            BufferedImage failImage = robot.createScreenCapture(bounds);
+            ImageIO.write(failImage, "png", new File("failImage.png"));
             throw new RuntimeException();
         }
     }


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8202931](https://bugs.openjdk.org/browse/JDK-8202931) needs maintainer approval

### Issue
 * [JDK-8202931](https://bugs.openjdk.org/browse/JDK-8202931): [macos] java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java fails (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2433/head:pull/2433` \
`$ git checkout pull/2433`

Update a local copy of the PR: \
`$ git checkout pull/2433` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2433`

View PR using the GUI difftool: \
`$ git pr show -t 2433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2433.diff">https://git.openjdk.org/jdk11u-dev/pull/2433.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2433#issuecomment-1876437454)