### PR TITLE
8276796: gc/TestSystemGC.java large pages subtest fails with ZGC

### DIFF
--- a/test/hotspot/jtreg/gc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/TestSystemGC.java
@@ -24,35 +24,37 @@
 package gc;
 
 /*
- * @test TestSystemGCSerial
+ * @test id=Serial
  * @key gc
  * @requires vm.gc.Serial
  * @summary Runs System.gc() with different flags.
  * @run main/othervm -XX:+UseSerialGC gc.TestSystemGC
+ * @run main/othervm -XX:+UseSerialGC -XX:+UseLargePages gc.TestSystemGC
  */
 
 /*
- * @test TestSystemGCParallel
+ * @test id=Parallel
  * @key gc
  * @requires vm.gc.Parallel
  * @summary Runs System.gc() with different flags.
  * @run main/othervm -XX:+UseParallelGC gc.TestSystemGC
  * @run main/othervm -XX:+UseParallelGC -XX:-UseParallelOldGC gc.TestSystemGC
+ * @run main/othervm -XX:+UseParallelGC -XX:+UseLargePages gc.TestSystemGC
  */
 
 /*
- * @test TestSystemGCG1
+ * @test id=G1
  * @key gc
  * @requires vm.gc.G1
  * @summary Runs System.gc() with different flags.
  * @run main/othervm -XX:+UseG1GC gc.TestSystemGC
  * @run main/othervm -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
- * @run main/othervm -XX:+UseLargePages gc.TestSystemGC
  * @run main/othervm -XX:+UseLargePages -XX:+UseLargePagesInMetaspace gc.TestSystemGC
+ * @run main/othervm -XX:+UseG1GC -XX:+UseLargePages gc.TestSystemGC
  */
 
 /*
- * @test TestSystemGCCMS
+ * @test id=CMS
  * @key gc
  * @comment Graal does not support CMS
  * @requires vm.gc.ConcMarkSweep & !vm.graal.enabled
@@ -61,13 +63,24 @@ package gc;
  */
 
 /*
- * @test TestSystemGCShenandoah
+ * @test id=Shenandoah
  * @key gc
  * @requires vm.gc.Shenandoah & !vm.graal.enabled
  * @summary Runs System.gc() with different flags.
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC gc.TestSystemGC
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
+ * @run main/othervm -XX:+UseShenandoahGC gc.TestSystemGC
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages gc.TestSystemGC
  */
+
+/*
+ * @test id=Z
+ * @requires vm.gc.Z
+ * @comment ZGC will not start when LargePages cannot be allocated, therefore
+ *          we do not run such configuration.
+ * @summary Runs System.gc() with different flags.
+ * @run main/othervm -XX:+UseZGC gc.TestSystemGC
+ */
+
 public class TestSystemGC {
   public static void main(String args[]) throws Exception {
     System.gc();

--- a/test/hotspot/jtreg/gc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/TestSystemGC.java
@@ -78,7 +78,7 @@ package gc;
  * @comment ZGC will not start when LargePages cannot be allocated, therefore
  *          we do not run such configuration.
  * @summary Runs System.gc() with different flags.
- * @run main/othervm -XX:+UseZGC gc.TestSystemGC
+ * @run main/othervm -XX:+UseZGC -XX:+UnlockExperimentalVMOptions gc.TestSystemGC
  */
 
 public class TestSystemGC {

--- a/test/hotspot/jtreg/gc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/TestSystemGC.java
@@ -78,7 +78,7 @@ package gc;
  * @comment ZGC will not start when LargePages cannot be allocated, therefore
  *          we do not run such configuration.
  * @summary Runs System.gc() with different flags.
- * @run main/othervm -XX:+UseZGC -XX:+UnlockExperimentalVMOptions gc.TestSystemGC
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseZGC gc.TestSystemGC
  */
 
 public class TestSystemGC {


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.
Backport for JDK-8269077 and JDK-8276796,
For JDK-8269077, it's clean, as CMS test is remain in this file, only modify the '@test id=CMS', other added parts are clean. Local test pass.
For ZGC test, add '-XX:+UnlockExperimentalVMOptions', pass on sap nightly test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8276796](https://bugs.openjdk.org/browse/JDK-8276796) needs maintainer approval
- [x] [JDK-8269077](https://bugs.openjdk.org/browse/JDK-8269077) needs maintainer approval

### Issues
 * [JDK-8276796](https://bugs.openjdk.org/browse/JDK-8276796): gc/TestSystemGC.java large pages subtest fails with ZGC (**Bug** - P3 - Approved)
 * [JDK-8269077](https://bugs.openjdk.org/browse/JDK-8269077): TestSystemGC uses "require vm.gc.G1" for large pages subtest (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2442/head:pull/2442` \
`$ git checkout pull/2442`

Update a local copy of the PR: \
`$ git checkout pull/2442` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2442`

View PR using the GUI difftool: \
`$ git pr show -t 2442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2442.diff">https://git.openjdk.org/jdk11u-dev/pull/2442.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2442#issuecomment-1882485429)