### PR TITLE
8322772: Clean up code after JDK-8322417

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -335,7 +335,7 @@ public final class Console implements Flushable
                             ioe.addSuppressed(x);
                     }
                     if (ioe != null) {
-                        java.util.Arrays.fill(passwd, ' ');
+                        Arrays.fill(passwd, ' ');
                         try {
                             if (reader instanceof LineReader) {
                                 LineReader lr = (LineReader)reader;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8322772](https://bugs.openjdk.org/browse/JDK-8322772), commit [bfd23aea](https://github.com/openjdk/jdk17u-dev/commit/bfd23aeae1566b86c20bdcbecff58f216947612a) from the [openjdk/jdk17u-dev](https://git.openjdk.org/jdk17u-dev) repository.

The commit being backported was authored by Christoph Langer on 9 Jan 2024 and was reviewed by Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322772](https://bugs.openjdk.org/browse/JDK-8322772) needs maintainer approval

### Issue
 * [JDK-8322772](https://bugs.openjdk.org/browse/JDK-8322772): Clean up code after JDK-8322417 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2443/head:pull/2443` \
`$ git checkout pull/2443`

Update a local copy of the PR: \
`$ git checkout pull/2443` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2443`

View PR using the GUI difftool: \
`$ git pr show -t 2443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2443.diff">https://git.openjdk.org/jdk11u-dev/pull/2443.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2443#issuecomment-1882484575)