### PR TITLE
8307381: Open Source JFrame, JIF related Swing Tests

### DIFF
--- a/test/jdk/javax/swing/JFrame/bug4101444.java
+++ b/test/jdk/javax/swing/JFrame/bug4101444.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JFrame;
+import static javax.swing.SwingUtilities.invokeAndWait;
+
+/*
+ * @test
+ * @bug 4101444
+ * @key headful
+ * @summary Tests JFrame supports EXIT_ON_CLOSE
+ */
+
+public class bug4101444 {
+    private static JFrame jFrame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            invokeAndWait(() -> {
+                jFrame = new JFrame("bug4101444 - Test EXIT_ON_CLOSE");
+                jFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                if (jFrame.getDefaultCloseOperation() != JFrame.EXIT_ON_CLOSE) {
+                    throw new RuntimeException("EXIT_ON_CLOSE wasn't set" +
+                            " correctly in setDefaultCloseOperation()...");
+                }
+            });
+        } finally {
+            invokeAndWait(() -> {
+                if (jFrame != null) {
+                    jFrame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JFrame/bug4208018.java
+++ b/test/jdk/javax/swing/JFrame/bug4208018.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JMenuBar;
+
+import static javax.swing.SwingUtilities.invokeAndWait;
+
+/*
+ * @test
+ * @bug 4208018
+ * @key headful
+ * @summary Tests if calling JFrame.dispose() when menubar is set, cause Exception.
+ */
+
+public class bug4208018 {
+    private static JFrame jFrame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            invokeAndWait(() -> {
+                jFrame = new JFrame("bug4208018 - Test dispose");
+                JMenuBar menubar = new JMenuBar();
+                jFrame.setJMenuBar(menubar);
+                jFrame.dispose();
+            });
+        } catch (Exception e) {
+            throw new RuntimeException("Test failed!" +
+                    " Calling dispose on JFrame caused exception", e);
+        }
+    }
+}

--- a/test/jdk/javax/swing/JInternalFrame/bug4308938.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4308938.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JInternalFrame;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+/*
+ * @test
+ * @bug 4308938
+ * @summary Tests if Serializing JInternalFrame throws Error
+ */
+
+public class bug4308938 {
+    private static JInternalFrame jif =
+            new JInternalFrame("Serializable",true,true,true,true);
+
+    public static void main(String[] args) throws Exception {
+        try {
+            jif.setLocation(100,100);
+            jif.setSize(100,100);
+            ByteArrayOutputStream s = new ByteArrayOutputStream();
+            ObjectOutputStream o = new ObjectOutputStream(s);
+            o.writeObject(jif);
+            o.close();
+            o = new ObjectOutputStream(s);
+            o.writeObject(jif);
+            o.close();
+        } catch (Exception e) {
+            throw new RuntimeException("Serializing JInternalFrame throws Error");
+        } finally {
+            if (jif != null) {
+                jif.dispose();
+            }
+        }
+    }
+}

--- a/test/jdk/javax/swing/JInternalFrame/bug4320889.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4320889.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+
+import static javax.swing.SwingUtilities.invokeAndWait;
+
+/*
+ * @test
+ * @bug 4320889
+ * @key headful
+ * @summary Tests if default background color is set correctly for JInternalFrame
+*/
+
+public class bug4320889 {
+    private static JFrame jFrame;
+
+    private static final int FRAME_SIZE = 200;
+    private static final int JIF_SIZE = 100;
+
+    public static void main(String[] args) throws Exception {
+        invokeAndWait(() -> {
+            try {
+                jFrame = new JFrame("bug4320889 - JFrame b/g color");
+                JDesktopPane desktop = new JDesktopPane();
+                jFrame.setSize(FRAME_SIZE, FRAME_SIZE);
+                jFrame.setContentPane(desktop);
+
+                JInternalFrame jif = new JInternalFrame();
+                jif.setSize(JIF_SIZE, JIF_SIZE);
+                jif.setLocation(5, 5);
+                desktop.add(jif);
+                jif.setVisible(true);
+                jFrame.setVisible(true);
+
+                if ((jif.getBackground()).equals(desktop.getBackground())) {
+                    throw new RuntimeException("Test failed: default background color" +
+                            " is not set correctly for JInternalFrame");
+                }
+            } finally {
+                if (jFrame != null) {
+                    jFrame.dispose();
+                }
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JTextField/bug4300552.java
+++ b/test/jdk/javax/swing/JTextField/bug4300552.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JTextField;
+import java.awt.ComponentOrientation;
+import java.awt.font.TextAttribute;
+
+/*
+ * @test
+ * @bug 4300552
+ * @summary A JTextComponent's RUN_DIRECTION document property was not being
+ *          initialized.
+ */
+
+public class bug4300552 {
+    private static JTextField textField;
+
+    public static void main(String[] args) throws Exception {
+        textField = new JTextField("\u0633\u0644\u0627\u0645 Peace");
+        testCompOrientation();
+
+        textField.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+        testCompOrientation();
+
+        textField.setComponentOrientation(ComponentOrientation.LEFT_TO_RIGHT);
+        testCompOrientation();
+    }
+
+    private static void testCompOrientation() {
+        Object runDir = textField.getDocument().getProperty(TextAttribute.RUN_DIRECTION);
+        if (runDir == null) {
+            throw new RuntimeException("Document's run direction property should be set");
+        }
+
+        Boolean runDirFlag = (Boolean) runDir;
+        ComponentOrientation o = textField.getComponentOrientation();
+        if ((TextAttribute.RUN_DIRECTION_LTR == runDirFlag) != o.isLeftToRight()) {
+            throw new RuntimeException("Document's run direction property("
+                    + (TextAttribute.RUN_DIRECTION_LTR == runDirFlag ? "LTR" : "RTL")
+                    + ") doesn't match component orientation ("
+                    + (o.isLeftToRight() ? "LTR" : "RTL") + ")");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JToggleButton/bug4277049.java
+++ b/test/jdk/javax/swing/JToggleButton/bug4277049.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import javax.swing.JCheckBox;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+
+/*
+ * @test
+ * @bug 4277049
+ * @summary Tests that ToggleButtonModel doesn't fire extra ChangeEvents
+ */
+
+public class bug4277049 implements ItemListener {
+
+    public static void main(String[] args) throws Exception {
+        JCheckBox box = new JCheckBox();
+        box.setSelected(false);
+        box.addItemListener(e -> fail());
+        box.setSelected(false);
+
+        if (failed()) {
+            throw new RuntimeException("Failed: extra ChangeEvent was fired");
+        }
+    }
+
+    private static boolean failed_flag = false;
+    synchronized static void fail() {
+        failed_flag = true;
+    }
+    synchronized static boolean failed() { return failed_flag; }
+
+    @Override
+    public void itemStateChanged(ItemEvent e) {
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8307381](https://bugs.openjdk.org/browse/JDK-8307381) needs maintainer approval

### Issue
 * [JDK-8307381](https://bugs.openjdk.org/browse/JDK-8307381): Open Source JFrame, JIF related Swing Tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2449/head:pull/2449` \
`$ git checkout pull/2449`

Update a local copy of the PR: \
`$ git checkout pull/2449` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2449`

View PR using the GUI difftool: \
`$ git pr show -t 2449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2449.diff">https://git.openjdk.org/jdk11u-dev/pull/2449.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2449#issuecomment-1882634103)