### PR TITLE
8318955: Add ReleaseIntArrayElements in Java_sun_awt_X11_XlibWrapper_SetBitmapShape XlbWrapper.c to early return

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/xawt/XlibWrapper.c
+++ b/src/java.desktop/unix/native/libawt_xawt/xawt/XlibWrapper.c
@@ -2300,6 +2300,7 @@ Java_sun_awt_X11_XlibWrapper_SetBitmapShape
 
     pRect = (RECT_T *)SAFE_SIZE_ARRAY_ALLOC(malloc, worstBufferSize, sizeof(RECT_T));
     if (!pRect) {
+        (*env)->ReleaseIntArrayElements(env, bitmap, values, JNI_ABORT);
         return;
     }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318955](https://bugs.openjdk.org/browse/JDK-8318955) needs maintainer approval

### Issue
 * [JDK-8318955](https://bugs.openjdk.org/browse/JDK-8318955): Add ReleaseIntArrayElements in Java_sun_awt_X11_XlibWrapper_SetBitmapShape XlbWrapper.c to early return (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2462/head:pull/2462` \
`$ git checkout pull/2462`

Update a local copy of the PR: \
`$ git checkout pull/2462` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2462`

View PR using the GUI difftool: \
`$ git pr show -t 2462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2462.diff">https://git.openjdk.org/jdk11u-dev/pull/2462.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2462#issuecomment-1895761104)