### PR TITLE
8272335: runtime/cds/appcds/MoveJDKTest.java doesn't check exit codes

### DIFF
--- a/test/hotspot/jtreg/runtime/appcds/MoveJDKTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/MoveJDKTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,8 @@ public class MoveJDKTest {
         String jsaOpt = "-XX:SharedArchiveFile=" + jsaFile;
         {
             ProcessBuilder pb = makeBuilder(java_home_src + "/bin/java", "-Xshare:dump", jsaOpt);
-            TestCommon.executeAndLog(pb, "dump");
+            TestCommon.executeAndLog(pb, "dump")
+                      .shouldHaveExitValue(0);
         }
         {
             ProcessBuilder pb = makeBuilder(java_home_src + "/bin/java",
@@ -63,6 +64,7 @@ public class MoveJDKTest {
                                             "-Xlog:class+path=info",
                                             "-version");
             OutputAnalyzer out = TestCommon.executeAndLog(pb, "exec-src");
+            out.shouldHaveExitValue(0);
             out.shouldNotContain("shared class paths mismatch");
             out.shouldNotContain("BOOT classpath mismatch");
         }
@@ -78,6 +80,7 @@ public class MoveJDKTest {
                                             "-Xlog:class+path=info",
                                             "-version");
             OutputAnalyzer out = TestCommon.executeAndLog(pb, "exec-dst");
+            out.shouldHaveExitValue(0);
             out.shouldNotContain("shared class paths mismatch");
             out.shouldNotContain("BOOT classpath mismatch");
         }
@@ -91,7 +94,8 @@ public class MoveJDKTest {
                                             "-Xshare:dump",
                                             dumptimeBootAppendOpt,
                                             jsaOpt);
-            TestCommon.executeAndLog(pb, "dump");
+            TestCommon.executeAndLog(pb, "dump")
+                      .shouldHaveExitValue(0);
         }
         {
             String runtimeBootAppendOpt = dumptimeBootAppendOpt + System.getProperty("path.separator") + helloJar;
@@ -102,6 +106,7 @@ public class MoveJDKTest {
                                             "-Xlog:class+path=info",
                                             "-version");
             OutputAnalyzer out = TestCommon.executeAndLog(pb, "exec-dst");
+            out.shouldHaveExitValue(0);
             out.shouldNotContain("shared class paths mismatch");
             out.shouldNotContain("BOOT classpath mismatch");
         }


### PR DESCRIPTION
Backport of [JDK-8272335](https://bugs.openjdk.org/browse/JDK-8272335)
- The file `test/hotspot/jtreg/runtime/cds/appcds/MoveJDKTest.java` match to `test/hotspot/jtreg/runtime/appcds/MoveJDKTest.java` in Java 11
- The `diff` file patched successfully, except the `Copyright year` line
- So this change can be considered as `Clean` although technically not clean


Testing
- Local: not aplicable - `no tests selected`
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-01-25,26`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8272335](https://bugs.openjdk.org/browse/JDK-8272335) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272335](https://bugs.openjdk.org/browse/JDK-8272335): runtime/cds/appcds/MoveJDKTest.java doesn't check exit codes (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2467/head:pull/2467` \
`$ git checkout pull/2467`

Update a local copy of the PR: \
`$ git checkout pull/2467` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2467`

View PR using the GUI difftool: \
`$ git pr show -t 2467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2467.diff">https://git.openjdk.org/jdk11u-dev/pull/2467.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2467#issuecomment-1903497180)