### PR TITLE
Backport 989f39f8106a22498053a4ca5f2becf8df5f2420

### DIFF
--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/MaxMetaspaceSize.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/MaxMetaspaceSize.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @requires vm.cds
+ * @requires vm.flagless
  * @bug 8067187 8200078
  * @summary Testing CDS dumping with the -XX:MaxMetaspaceSize=<size> option
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedStrings.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/SharedStrings.java
@@ -26,6 +26,7 @@
  * @summary Check to make sure that shared strings in the bootstrap CDS archive
  *          are actually shared
  * @requires vm.cds.archived.java.heap
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/appcds/MoveJDKTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/MoveJDKTest.java
@@ -27,6 +27,7 @@
  * @summary Test that CDS still works when the JDK is moved to a new directory
  * @bug 8272345
  * @requires vm.cds
+ * @requires vm.flagless
  * @comment This test doesn't work on Windows because it depends on symlinks
  * @requires os.family != "windows"
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
@@ -25,6 +25,7 @@
  * @test
  * @summary Test archived module graph with custom runtime image
  * @requires vm.cds.archived.java.heap
+ * @requires vm.flagless
  * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/appcds
  * @modules java.base/jdk.internal.module
  *          java.management


### PR DESCRIPTION
Backport of [JDK-8272335](https://bugs.openjdk.org/browse/JDK-8272335)
- The original commit contains 6 files, well this PR only contains 4 of them, because the following 2 files do not exist
- `VerifyWithDefaultArchive.java` does not exist in Java 11, it was added by [JDK-8264337](https://bugs.openjdk.org/browse/JDK-8264337) since Java 17
- `JCmdTestDynamicDump.java` does not exist in Java 11, it was added by [JDK-8265393](https://bugs.openjdk.org/browse/JDK-8265393) since Java 17
- So this is unclean backport

Testing
- Local: not aplicable - `no tests selected`
  - `MaxMetaspaceSize.java` - Test results: no tests selected
  - `SharedStrings.java` - Test results: no tests selected
  - `MoveJDKTest.java` - Test results: no tests selected
  - `ArchivedModuleWithCustomImageTest.java` - Test results: no tests selected
  - `test/hotspot/jtreg/runtime/SharedArchiveFile` folder - Test results: passed: 1
- Pipeline: 
- Testing Machine: 
