### PR TITLE
8324307: [11u] hotspot fails to build with GCC 12 and newer (non-static data member initializers)

### DIFF
--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -105,11 +105,11 @@ class CgroupV1Subsystem: public CgroupSubsystem {
 
   private:
     /* controllers */
-    CachingCgroupController* _memory = NULL;
-    CgroupV1Controller* _cpuset = NULL;
-    CachingCgroupController* _cpu = NULL;
-    CgroupV1Controller* _cpuacct = NULL;
-    CgroupV1Controller* _pids = NULL;
+    CachingCgroupController* _memory;
+    CgroupV1Controller* _cpuset;
+    CachingCgroupController* _cpu;
+    CgroupV1Controller* _cpuacct;
+    CgroupV1Controller* _pids;
 
     char * pids_max_val();
 

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
@@ -51,10 +51,10 @@ class CgroupV2Controller: public CgroupController {
 class CgroupV2Subsystem: public CgroupSubsystem {
   private:
     /* One unified controller */
-    CgroupController* _unified = NULL;
+    CgroupController* _unified;
     /* Caching wrappers for cpu/memory metrics */
-    CachingCgroupController* _memory = NULL;
-    CachingCgroupController* _cpu = NULL;
+    CachingCgroupController* _memory;
+    CachingCgroupController* _cpu;
 
     char *mem_limit_val();
     char *mem_swp_limit_val();


### PR DESCRIPTION
GCC 12 and newer warn about non-static data member initialisers when operating under -std=gnu++98 (jdk11u-dev's C++ standards version). These warnings are promoted to errors by default.

This is an issue for jdk11u-dev which uses the C++ standard version '-std=gnu++98'. It is not an issue for later JDK versions which have moved to newer standards (JEP 347 moved JDK16 to -std=c++14): therefore an 11u-specific fix is required.

The approach used in this PR is to remove the initialisers, in common with what we did when backporting the same code to jdk8u-dev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324307](https://bugs.openjdk.org/browse/JDK-8324307) needs maintainer approval

### Issue
 * [JDK-8324307](https://bugs.openjdk.org/browse/JDK-8324307): [11u] hotspot fails to build with GCC 12 and newer (non-static data member initializers) (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2470/head:pull/2470` \
`$ git checkout pull/2470`

Update a local copy of the PR: \
`$ git checkout pull/2470` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2470`

View PR using the GUI difftool: \
`$ git pr show -t 2470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2470.diff">https://git.openjdk.org/jdk11u-dev/pull/2470.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2470#issuecomment-1903901399)