### PR TITLE
8244679: JVM/TI GetCurrentContendedMonitor/contmon001 failed due to "(IsSameObject#3) unexpected monitor object: 0x000000562336DBA8"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetCurrentContendedMonitor/contmon002.java
@@ -23,7 +23,6 @@
 
 package nsk.jvmti.GetCurrentContendedMonitor;
 
-import nsk.share.Wicket;
 import java.io.PrintStream;
 
 public class contmon002 {
@@ -42,7 +41,7 @@ public class contmon002 {
         }
     }
 
-    public static Wicket startingBarrier;
+    public static boolean startingBarrier = true;
 
     public static void main(String[] args) {
         args = nsk.share.jvmti.JVMTITest.commonInit(args);
@@ -50,13 +49,22 @@ public class contmon002 {
         System.exit(run(args, System.out) + 95/*STATUS_TEMP*/);
     }
 
+    public static void doSleep() {
+        try {
+            Thread.sleep(10);
+        } catch (Exception e) {
+            throw new Error("Unexpected " + e);
+        }
+    }
+
     public static int run(String argv[], PrintStream ref) {
         checkMon(1, Thread.currentThread());
 
         contmon002a thr = new contmon002a();
-        startingBarrier = new Wicket();
         thr.start();
-        startingBarrier.waitFor();
+        while (startingBarrier) {
+            doSleep();
+        }
         checkMon(2, thr);
         thr.letItGo();
         try {
@@ -73,7 +81,7 @@ class contmon002a extends Thread {
     private volatile boolean flag = true;
 
     private synchronized void meth() {
-        contmon002.startingBarrier.unlock();
+        contmon002.startingBarrier = false;
         int i = 0;
         int n = 1000;
         while (flag) {


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8244679](https://bugs.openjdk.org/browse/JDK-8244679) needs maintainer approval

### Issue
 * [JDK-8244679](https://bugs.openjdk.org/browse/JDK-8244679): JVM/TI GetCurrentContendedMonitor/contmon001 failed due to "(IsSameObject#3) unexpected monitor object: 0x000000562336DBA8" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2472/head:pull/2472` \
`$ git checkout pull/2472`

Update a local copy of the PR: \
`$ git checkout pull/2472` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2472`

View PR using the GUI difftool: \
`$ git pr show -t 2472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2472.diff">https://git.openjdk.org/jdk11u-dev/pull/2472.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2472#issuecomment-1904751223)