### PR TITLE
8246222: Rename javac test T6395981.java to be more informative

### DIFF
--- a/test/langtools/tools/javac/api/TestGetSourceVersions.java
+++ b/test/langtools/tools/javac/api/TestGetSourceVersions.java
@@ -28,10 +28,12 @@
  * @author  Peter von der Ah\u00e9
  * @modules java.compiler
  *          jdk.compiler
- * @run main/fail T6395981
- * @run main/fail T6395981 RELEASE_3 RELEASE_5 RELEASE_6
- * @run main/fail T6395981 RELEASE_0 RELEASE_1 RELEASE_2 RELEASE_3 RELEASE_4 RELEASE_5 RELEASE_6
- * @run main T6395981 RELEASE_3 RELEASE_4 RELEASE_5 RELEASE_6 RELEASE_7 RELEASE_8 RELEASE_9 RELEASE_10 RELEASE_11
+ * @run main/fail TestGetSourceVersions
+ * @run main/fail TestGetSourceVersions RELEASE_3  RELEASE_5  RELEASE_6
+ * @run main/fail TestGetSourceVersions RELEASE_0  RELEASE_1  RELEASE_2  RELEASE_3  RELEASE_4
+ *                                      RELEASE_5  RELEASE_6
+ * @run main TestGetSourceVersions      RELEASE_3  RELEASE_4  RELEASE_5  RELEASE_6  RELEASE_7
+ *                                      RELEASE_8  RELEASE_9  RELEASE_10 RELEASE_11
  */
 
 import java.util.EnumSet;
@@ -41,7 +43,7 @@ import javax.tools.Tool;
 import javax.tools.ToolProvider;
 import static javax.lang.model.SourceVersion.*;
 
-public class T6395981 {
+public class TestGetSourceVersions {
     public static void main(String... args) {
         Tool compiler = ToolProvider.getSystemJavaCompiler();
         Set<SourceVersion> expected = EnumSet.noneOf(SourceVersion.class);


### PR DESCRIPTION
Backport of [JDK-8246222](https://bugs.openjdk.org/browse/JDK-8246222)
- The only differences between current PR and the original commit is, we removed `RELEASE_12` to `RELEASE_16`
- Because the original commit was on Java `16`, and current repo is Java `11`
- So current PR is `unclean`
- The following is the original PR diff part: it contains `RELEASE_12` to `RELEASE_16`

```diff
- * @run main/fail T6395981
- * @run main/fail T6395981 RELEASE_3  RELEASE_5  RELEASE_6
- * @run main/fail T6395981 RELEASE_0  RELEASE_1  RELEASE_2  RELEASE_3  RELEASE_4
- *                         RELEASE_5  RELEASE_6
- * @run main T6395981      RELEASE_3  RELEASE_4  RELEASE_5  RELEASE_6  RELEASE_7
- *                         RELEASE_8  RELEASE_9  RELEASE_10 RELEASE_11 RELEASE_12
- *                         RELEASE_13 RELEASE_14 RELEASE_15 RELEASE_16
+ * @run main/fail TestGetSourceVersions
+ * @run main/fail TestGetSourceVersions RELEASE_3  RELEASE_5  RELEASE_6
+ * @run main/fail TestGetSourceVersions RELEASE_0  RELEASE_1  RELEASE_2  RELEASE_3  RELEASE_4
+ *                                      RELEASE_5  RELEASE_6
+ * @run main TestGetSourceVersions      RELEASE_3  RELEASE_4  RELEASE_5  RELEASE_6  RELEASE_7
+ *                                      RELEASE_8  RELEASE_9  RELEASE_10 RELEASE_11 RELEASE_12
+ *                                      RELEASE_13 RELEASE_14 RELEASE_15 RELEASE_16
```

Testing
- Local: Test passed
  - `TestGetSourceVersions.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-01-25,26`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8246222](https://bugs.openjdk.org/browse/JDK-8246222) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8246222](https://bugs.openjdk.org/browse/JDK-8246222): Rename javac test T6395981.java to be more informative (**Enhancement** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2476/head:pull/2476` \
`$ git checkout pull/2476`

Update a local copy of the PR: \
`$ git checkout pull/2476` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2476`

View PR using the GUI difftool: \
`$ git pr show -t 2476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2476.diff">https://git.openjdk.org/jdk11u-dev/pull/2476.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2476#issuecomment-1905414964)