### PR TITLE
8315986: [macos14] javax/swing/JMenuItem/4654927/bug4654927.java: component must be showing on the screen to determine its location

### DIFF
--- a/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
+++ b/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,15 +26,20 @@
  * @key headful
  * @bug 4654927
  * @summary Clicking on Greyed Menuitems closes the Menubar Dropdown
- * @author Alexander Potochkin
  * @library ../../regtesthelpers
  * @build Util
  * @run main bug4654927
  */
 
-import javax.swing.*;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 
-import java.awt.*;
+import java.awt.Point;
+import java.awt.Robot;
 import java.awt.event.InputEvent;
 import java.util.concurrent.Callable;
 
@@ -48,78 +53,65 @@ public class bug4654927 {
         try {
             String systemLAF = UIManager.getSystemLookAndFeelClassName();
             // the test is not applicable to Motif L&F
-            if(systemLAF.endsWith("MotifLookAndFeel")){
+            if (systemLAF.endsWith("MotifLookAndFeel")) {
                 return;
             }
 
             UIManager.setLookAndFeel(systemLAF);
             Robot robot = new Robot();
-            robot.setAutoDelay(10);
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(100);
 
-            SwingUtilities.invokeAndWait(new Runnable() {
+            SwingUtilities.invokeAndWait(() -> createAndShowUI());
 
-                public void run() {
-                    createAndShowUI();
-                }
-            });
             robot.waitForIdle();
+            robot.delay(1000);
 
             // test mouse press
-            Point point = Util.getCenterPoint(menu);
-            robot.mouseMove(point.x, point.y);
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            Point menuLocation = Util.getCenterPoint(menu);
+            System.out.println("Menu Location " + menuLocation);
+            robot.mouseMove(menuLocation.x, menuLocation.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
+            robot.delay(250);
 
-            point = Util.getCenterPoint(menuItem);
-            robot.mouseMove(point.x, point.y);
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            Point itemLocation = Util.getCenterPoint(menuItem);
+            System.out.println("MenuItem Location " + itemLocation);
+            robot.mouseMove(itemLocation.x, itemLocation.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
+            robot.delay(250);
 
             if (!isMenuItemShowing()) {
                 throw new RuntimeException("Popup is unexpectedly closed");
             }
 
-            // test mouse drag
-            point = Util.getCenterPoint(menu);
-            robot.mouseMove(point.x, point.y);
-            Point menuLocation = Util.invokeOnEDT(new Callable<Point>() {
-
-                @Override
-                public Point call() throws Exception {
-                    return menu.getLocationOnScreen();
-                }
-            });
-
-            Point itemLocation = Util.invokeOnEDT(new Callable<Point>() {
-
-                @Override
-                public Point call() throws Exception {
-                    return menuItem.getLocationOnScreen();
-                }
-            });
-
-            int x0 = menuLocation.x + 10;
-            int y0 = menuLocation.y + 10;
-            int x1 = itemLocation.x + 10;
-            int y1 = itemLocation.y + 10;
-
             // close menu
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mouseMove(menuLocation.x, menuLocation.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
+            robot.delay(250);
 
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            Util.glide(robot, x0, y0, x1, y1);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            // test mouse drag
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(250);
+            Util.glide(robot, menuLocation.x, menuLocation.y,
+                              itemLocation.x, itemLocation.y);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
 
             if (!isMenuItemShowing()) {
                 throw new RuntimeException("Popup is unexpectedly closed");
             }
         } finally {
-            if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 
@@ -151,6 +143,6 @@ public class bug4654927 {
         frame.setSize(200, 200);
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
-
     }
 }
+


### PR DESCRIPTION
Backport of [JDK-8315986](https://bugs.openjdk.org/browse/JDK-8315986)

Testing
- Local: Test passed on MacOS M1 Laptop
  - bug4654927.java - Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-01-25,26`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315986](https://bugs.openjdk.org/browse/JDK-8315986) needs maintainer approval

### Issue
 * [JDK-8315986](https://bugs.openjdk.org/browse/JDK-8315986): [macos14] javax/swing/JMenuItem/4654927/bug4654927.java: component must be showing on the screen to determine its location (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2481/head:pull/2481` \
`$ git checkout pull/2481`

Update a local copy of the PR: \
`$ git checkout pull/2481` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2481/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2481`

View PR using the GUI difftool: \
`$ git pr show -t 2481`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2481.diff">https://git.openjdk.org/jdk11u-dev/pull/2481.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2481#issuecomment-1905687618)