### PR TITLE
8316106: Open source few swing JInternalFrame and JMenuBar tests

### DIFF
--- a/test/jdk/javax/swing/JInternalFrame/bug4268949.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4268949.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4268949
+ * @summary Tests if JInternalFrame can do setBackground()
+ * @run main bug4268949
+ */
+
+import java.awt.Color;
+import javax.swing.JInternalFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4268949 {
+
+    static Color c1;
+    static Color c2;
+    static Color c3;
+
+    public static void main(String[] argv) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            JInternalFrame if1, if2, if3;
+            if1 = new JInternalFrame("Frame 1");
+            if2 = new JInternalFrame("Frame 2");
+            if3 = new JInternalFrame("Frame 3");
+            if1.setBounds(20, 20, 95, 95);
+            if2.setBounds(120, 20, 95, 95);
+            if3.setBounds(220, 20, 95, 95);
+            if1.setBackground(Color.red);
+            if2.setBackground(Color.blue);
+            if3.setBackground(Color.green);
+            c1 = if1.getContentPane().getBackground();
+            c2 = if2.getContentPane().getBackground();
+            c3 = if3.getContentPane().getBackground();
+        });
+        if (!(c1.equals(Color.red)) || !(c2.equals(Color.blue))
+                || !(c3.equals(Color.green))) {
+            throw new RuntimeException("Test failed: JInternalFrame " +
+                    "cannot do setBackground()");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JInternalFrame/bug4309079.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4309079.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4309079
+ * @summary Tests that when a JInternalFrame is activated,
+            focused JTextField shows cursor.
+ * @key headful
+ * @run main bug4309079
+ */
+
+import java.awt.FlowLayout;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import javax.swing.JFrame;
+import javax.swing.JDesktopPane;
+import javax.swing.JInternalFrame;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+
+public class bug4309079 {
+
+    private static JFrame f;
+    private static JTextField tf;
+    private static JDesktopPane desktop;
+    private static JInternalFrame f1;
+    private static JInternalFrame f2;
+    private static volatile boolean passed = true;
+    private static volatile Point p;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            SwingUtilities.invokeAndWait(() -> {
+                f = new JFrame();
+                f.setSize(500, 300);
+                tf = new JTextField(10);
+                tf.addFocusListener(new FocusListener() {
+                    public void focusGained(FocusEvent e) {
+                        passed = tf.getCaret().isVisible();
+                    }
+                    public void focusLost(FocusEvent e) {
+                    }
+                });
+                tf.requestFocus();
+                f1 = AddFrame(new JTextField(10));
+                f2 = AddFrame(tf);
+                f.getContentPane().add(desktop);
+                f.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(500);
+
+            SwingUtilities.invokeAndWait(() -> {
+                f1.toFront();
+                f2.toFront();
+                p = tf.getLocationOnScreen();
+            });
+            robot.mouseMove(p.x, p.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK );
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK );
+
+            if (!passed) {
+                throw new RuntimeException("Test failed.");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    private static JInternalFrame AddFrame(JTextField tf) {
+        JInternalFrame frame = new JInternalFrame();
+        desktop = new JDesktopPane();
+        desktop.add(frame);
+        frame.getContentPane().setLayout(new FlowLayout());
+        frame.getContentPane().add(tf);
+        frame.setSize(300, 200);
+        frame.setVisible(true);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JInternalFrame/bug4732229.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4732229.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4732229
+ * @summary Ctrl+Space, bringing up System menu on a JIF errors using Win LAF
+ * @key headful
+ * @run main bug4732229
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JDesktopPane;
+import javax.swing.JInternalFrame;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import java.awt.Robot;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyEvent;
+
+public class bug4732229 {
+
+    JFrame frame;
+    JDesktopPane desktop;
+    JInternalFrame jif;
+    JTextArea ta;
+    Robot robot;
+    volatile boolean keyTyped = false;
+
+    public static void main(String[] args) throws Exception {
+        bug4732229 b = new bug4732229();
+        b.init();
+    }
+
+    public void init() throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("bug4732229");
+                desktop = new JDesktopPane();
+                frame.getContentPane().add(desktop);
+
+                ta = new JTextArea();
+                ta.addFocusListener(new FocusAdapter() {
+                    public void focusGained(FocusEvent e) {
+                        synchronized (bug4732229.this) {
+                            keyTyped = true;
+                            bug4732229.this.notifyAll();
+                        }
+                    }
+                });
+                frame.setSize(200, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+                jif = new JInternalFrame("Internal Frame", true, false, true,
+                        true);
+                jif.setBounds(10, 10, 100, 100);
+                jif.getContentPane().add(ta);
+                jif.setVisible(true);
+                desktop.add(jif);
+                try {
+                    jif.setSelected(true);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+
+            });
+            synchronized (this) {
+                while (!keyTyped) {
+                    bug4732229.this.wait();
+                }
+            }
+            robot.waitForIdle();
+            robot.delay(200);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.keyPress(KeyEvent.VK_SPACE);
+            robot.keyRelease(KeyEvent.VK_SPACE);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+            robot.waitForIdle();
+            robot.delay(200);
+            SwingUtilities.invokeAndWait(() -> {
+                try {
+                    jif.setSelected(false);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                jif.setVisible(false);
+                desktop.remove(jif);
+                try {
+                    UIManager.setLookAndFeel(
+                            UIManager.getSystemLookAndFeelClassName());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                desktop.updateUI();
+
+                jif = new JInternalFrame("Internal Frame", true, false, true,
+                        true);
+                jif.setBounds(10, 10, 100, 100);
+                jif.getContentPane().add(ta);
+                jif.setVisible(true);
+                desktop.add(jif);
+                try {
+                    jif.setSelected(true);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            synchronized (this) {
+                while (!keyTyped) {
+                    bug4732229.this.wait();
+                }
+            }
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.keyPress(KeyEvent.VK_SPACE);
+            robot.keyRelease(KeyEvent.VK_SPACE);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+            robot.waitForIdle();
+            robot.delay(200);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JInternalFrame/bug5009724.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug5009724.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5009724
+ * @requires (os.family == "linux")
+ * @summary JInternalFrame not serializable in GTK L&F
+ * @key headful
+ * @run main bug5009724
+ */
+
+import java.awt.event.ActionEvent;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import javax.swing.AbstractAction;
+import javax.swing.JInternalFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class bug5009724 {
+
+    public static void main(String []args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        SwingUtilities.invokeAndWait(() -> {
+            JInternalFrame frame = new JInternalFrame();
+            ObjectOutputStream out = null;
+            ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+            try {
+                out = new ObjectOutputStream(byteStream);
+            } catch (IOException e) {
+
+            }
+            if (out != null) {
+                System.out.println("Testing...");
+                try {
+                    out.writeObject(frame);
+                } catch (Exception e) {
+                    System.out.println(e);
+                    throw new RuntimeException("Serialization exception. Test failed.");
+                }
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JMenuBar/bug4191374.java
+++ b/test/jdk/javax/swing/JMenuBar/bug4191374.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4191374
+ * @summary Verify if JMenuBar.getSubElements returns an array
+            with null values
+ * @run main bug4191374
+ */
+
+import javax.swing.Box;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.MenuElement;
+import javax.swing.SwingUtilities;
+
+public class bug4191374 {
+    static JMenuBar mb;
+    static volatile boolean pass = true;
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            mb = new JMenuBar();
+            newMenu(mb);
+            newMenu(mb);
+            mb.add(Box.createGlue());
+            mb.add(new JMenu("Help"));
+            MenuElement[] me = mb.getSubElements();
+            for (int i = 0; i < me.length; i++) {
+                if (me[i] == null)
+                    pass = false;
+            }
+        });
+        if (!pass) {
+            throw new RuntimeException("Bug 4191374 FAILED");
+        }
+    }
+
+    public static void newMenu(JMenuBar mb) {
+        JMenu m = (JMenu) mb.add(new JMenu("File"));
+        m.add("Menu item");
+        m.add("Menu item");
+        m.add("Menu item");
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8316106](https://bugs.openjdk.org/browse/JDK-8316106)

Testing
- Local: Test passed on MacOS M1 Laptop
  - bug4268949.java - Test results: passed: 1
  - bug4309079.java - Test results: passed: 1
  - bug4732229.java - Test results: passed: 1
  - bug5009724.java - Test results: no tests selected
  - bug4191374.java - Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-01-25,26`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316106](https://bugs.openjdk.org/browse/JDK-8316106) needs maintainer approval

### Issue
 * [JDK-8316106](https://bugs.openjdk.org/browse/JDK-8316106): Open source few swing JInternalFrame and JMenuBar tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2482/head:pull/2482` \
`$ git checkout pull/2482`

Update a local copy of the PR: \
`$ git checkout pull/2482` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2482`

View PR using the GUI difftool: \
`$ git pr show -t 2482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2482.diff">https://git.openjdk.org/jdk11u-dev/pull/2482.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2482#issuecomment-1905714770)