### PR TITLE
8318971: Better Error Handling for Jar Tool When Processing Non-existent Files

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
@@ -283,6 +283,9 @@ public class Main {
                     }
                 }
                 expand();
+                if (!ok) {
+                    return false;
+                }
                 if (!moduleInfos.isEmpty()) {
                     // All actual file entries (excl manifest and module-info.class)
                     Set<String> jentries = new HashSet<>();
@@ -357,6 +360,9 @@ public class Main {
                     tmpFile = createTemporaryFile("tmpjar", ".jar");
                 }
                 expand();
+                if (!ok) {
+                    return false;
+                }
                 try (FileInputStream in = (fname != null) ? new FileInputStream(inputFile)
                         : new FileInputStream(FileDescriptor.in);
                      FileOutputStream out = new FileOutputStream(tmpFile);

--- a/test/jdk/tools/jar/InputFilesTest.java
+++ b/test/jdk/tools/jar/InputFilesTest.java
@@ -181,11 +181,11 @@ public class InputFilesTest {
     public void testNonExistentFileInputClassList() throws IOException {
         touch("existingTestFile.txt");
         touch("classes.list");
-        Files.writeString(Path.of("classes.list"), """
-                existingTestFile.txt
-                nonExistentTestFile.txt
-                nonExistentDirectory
-                 """);
+        Files.writeString(Path.of("classes.list"),
+                "existingTestFile.txt\n" +
+                "nonExistentTestFile.txt\n" +
+                "nonExistentDirectory\n"
+                );
         onCompletion = () -> rm("existingTestFile.txt classes.list");
         try {
             jar("cf test.jar @classes.list");
@@ -210,11 +210,11 @@ public class InputFilesTest {
         touch("existingTestFileUpdate.txt");
         touch("existingTestFileUpdate2.txt");
         touch("classesUpdate.list");
-        Files.writeString(Path.of("classesUpdate.list"), """
-                existingTestFileUpdate2.txt
-                nonExistentTestFileUpdate.txt
-                nonExistentDirectoryUpdate
-                 """);
+        Files.writeString(Path.of("classesUpdate.list"),
+                "existingTestFileUpdate2.txt\n" +
+                "nonExistentTestFileUpdate.txt\n" +
+                "nonExistentDirectoryUpdate\n"
+                 );
         onCompletion = () -> rm("existingTestFileUpdate.txt existingTestFileUpdate2.txt " +
                 "classesUpdate.list testUpdate.jar");
         try {


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8318971](https://bugs.openjdk.org/browse/JDK-8318971) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318971](https://bugs.openjdk.org/browse/JDK-8318971): Better Error Handling for Jar Tool When Processing Non-existent Files (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2484/head:pull/2484` \
`$ git checkout pull/2484`

Update a local copy of the PR: \
`$ git checkout pull/2484` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2484`

View PR using the GUI difftool: \
`$ git pr show -t 2484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2484.diff">https://git.openjdk.org/jdk11u-dev/pull/2484.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2484#issuecomment-1908094652)