### PR TITLE
8253739: java/awt/image/MultiResolutionImage/MultiResolutionImageObserverTest.java fails

### DIFF
--- a/test/jdk/java/awt/image/MultiResolutionImage/MultiResolutionImageObserverTest.java
+++ b/test/jdk/java/awt/image/MultiResolutionImage/MultiResolutionImageObserverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import javax.imageio.ImageIO;
 
 public class MultiResolutionImageObserverTest {
 
-    private static final int TIMEOUT = 500;
+    private static final int TIMEOUT = 2000;
 
     public static void main(String[] args) throws Exception {
 
@@ -70,7 +70,7 @@ public class MultiResolutionImageObserverTest {
         long endTime = System.currentTimeMillis() + TIMEOUT;
 
         while (!observer.loaded && System.currentTimeMillis() < endTime) {
-            Thread.sleep(TIMEOUT / 10);
+            Thread.sleep(TIMEOUT / 100);
         }
 
         if (!observer.loaded) {
@@ -101,7 +101,7 @@ public class MultiResolutionImageObserverTest {
     private static class LoadImageObserver implements ImageObserver {
 
         private final int infoflags;
-        private boolean loaded;
+        private volatile boolean loaded;
 
         public LoadImageObserver(int flags) {
             this.infoflags = flags;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8253739](https://bugs.openjdk.java.net/browse/JDK-8253739), commit [928da494](https://github.com/openjdk/jdk/commit/928da494a853c164452c96d01318c94d115ca946) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jayathirth D V on 1 Oct 2020 and was reviewed by Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8253739](https://bugs.openjdk.org/browse/JDK-8253739) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253739](https://bugs.openjdk.org/browse/JDK-8253739): java/awt/image/MultiResolutionImage/MultiResolutionImageObserverTest.java fails (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2485/head:pull/2485` \
`$ git checkout pull/2485`

Update a local copy of the PR: \
`$ git checkout pull/2485` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2485`

View PR using the GUI difftool: \
`$ git pr show -t 2485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2485.diff">https://git.openjdk.org/jdk11u-dev/pull/2485.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2485#issuecomment-1908375839)