### PR TITLE
8324184: Windows VS2010 build failed with "error C2275: 'int64_t'"

### DIFF
--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -1693,12 +1693,13 @@ static int instruction_length(unsigned char *iptr, unsigned char *end)
     switch (instruction) {
         case JVM_OPC_tableswitch: {
             int *lpc = (int *)UCALIGN(iptr + 1);
+            int64_t low, high, index;
             if (lpc + 2 >= (int *)end) {
                 return -1; /* do not read pass the end */
             }
-            int64_t low  = _ck_ntohl(lpc[1]);
-            int64_t high = _ck_ntohl(lpc[2]);
-            int64_t index = high - low;
+            low  = _ck_ntohl(lpc[1]);
+            high = _ck_ntohl(lpc[2]);
+            index = high - low;
             // The value of low must be less than or equal to high - i.e. index >= 0
             if ((index < 0) || (index > 65535)) {
                 return -1;      /* illegal */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4d078930](https://github.com/openjdk/jdk21u/commit/4d078930eecfacb28a7c8324f233080eaf649334) from the [openjdk/jdk21u](https://git.openjdk.org/jdk21u) repository & the clean backport commit [4f80edf](https://github.com/openjdk/jdk17u-dev/commit/4f80edfae10e83f2709f297a553d2128712e4b51) from 17u. A new bug ID, JDK-8324184, had to be created as JDK-8317331, the original bug, is private.

The commit being backported was authored by Coleen Phillimore on 2 Oct 2023 and had no reviewers.

We hit this issue in 8u, where the VS2010 build seems to be broken because of the placing of the declarations of `low`, `high` and `index` in JDK-8314295; see https://github.com/gnu-andrew/jdk8u-dev/actions/runs/7549766959/job/20554342418. The name of the private bug fix, JDK-8317331: `Solaris build failed with "declaration can not follow a statement (E_DECLARATION_IN_CODE)"`, suggests it is also an issue on Solaris which is still supported by 8u & 11u.

Backport was clean and built fine on GNU/Linux with GCC 13.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8324184](https://bugs.openjdk.org/browse/JDK-8324184) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324184](https://bugs.openjdk.org/browse/JDK-8324184): Windows VS2010 build failed with "error C2275: 'int64_t'" (**Bug** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2486/head:pull/2486` \
`$ git checkout pull/2486`

Update a local copy of the PR: \
`$ git checkout pull/2486` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2486`

View PR using the GUI difftool: \
`$ git pr show -t 2486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2486.diff">https://git.openjdk.org/jdk11u-dev/pull/2486.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2486#issuecomment-1911285517)