### PR TITLE
8315761: Open source few swing JList and JMenuBar tests

### DIFF
--- a/test/jdk/javax/swing/JList/bug4300224.java
+++ b/test/jdk/javax/swing/JList/bug4300224.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4300224
+ * @summary BasicListUI.ListDataHandler improperly updates list selection on insertion
+ * @run main bug4300224
+ */
+
+import javax.swing.JList;
+import javax.swing.DefaultListModel;
+
+public class bug4300224 {
+
+    public static void main(String[] args) throws Exception {
+        DefaultListModel<String> model = new DefaultListModel<>();
+        JList<String> list = new JList<>(model);
+
+        model.addElement("List Item 1");
+        model.addElement("List Item 2");
+        model.addElement("List Item 3");
+        model.addElement("List Item 4");
+        list.setSelectedIndex(2);
+        model.insertElementAt("Inserted Item", 0);
+        if (list.getSelectedIndex() != 3) {
+            throw new RuntimeException("Inserted element improperly updates list selection");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JList/bug4487689.java
+++ b/test/jdk/javax/swing/JList/bug4487689.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4487689
+ * @summary JList.setSelectedValue() throws ArrayIndexOutOfBoundsException on empty list.
+ * @run main bug4487689
+ */
+
+import java.util.Vector;
+import javax.swing.JList;
+
+public class bug4487689 {
+
+    public static void main(String[] args) throws Exception {
+        JList<String> list = new JList<>(new Vector<String>());
+
+        list.setSelectedIndex(0);
+        list.getSelectedValue();
+
+        int[] indices = {0,1};
+        list.setSelectedIndices(indices);
+        list.getSelectedValues();
+    }
+}

--- a/test/jdk/javax/swing/JList/bug4832765.java
+++ b/test/jdk/javax/swing/JList/bug4832765.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4832765
+ * @summary JList vertical scrolling doesn't work properly.
+ * @run main bug4832765
+ */
+
+import java.awt.Dimension;
+import java.awt.Rectangle;
+import javax.swing.JFrame;
+import javax.swing.JList;
+import javax.swing.JScrollPane;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+
+public class bug4832765 {
+
+    public static void main(String[] argv) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            String[] data = {"One", "Two", "Three", "Four",
+                    "Five", "Six ", "Seven", "Eight",
+                    "Nine", "Ten", "Eleven", "Twelv"};
+            JList<String> list = new JList<>(data);
+            list.setLayoutOrientation(JList.HORIZONTAL_WRAP);
+
+            JScrollPane jsp = new JScrollPane(list);
+            Rectangle rect = list.getCellBounds(5, 5);
+            Dimension d = new Dimension(200, rect.height);
+            jsp.setPreferredSize(d);
+            jsp.setMinimumSize(d);
+
+            list.scrollRectToVisible(rect);
+
+            int unit = list.getScrollableUnitIncrement(rect,
+                    SwingConstants.VERTICAL,
+                    -1);
+            if (unit <= 0) {
+                throw new RuntimeException("JList scrollable unit increment" +
+                        " should be greate than 0.");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JMenuBar/bug4802656.java
+++ b/test/jdk/javax/swing/JMenuBar/bug4802656.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4802656
+ * @summary Problem with keyboard navigation in JMenus JMenuItems if setVisible(false)
+ * @key headful
+ * @run main bug4802656
+ */
+
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.SwingUtilities;
+
+public class bug4802656 {
+
+    public static JFrame mainFrame;
+    public static JMenu menu2;
+    public static volatile boolean menu2Selected = true;
+
+    public static void main(String[] args) throws Exception {
+        Robot robo = new Robot();
+        robo.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                mainFrame = new JFrame("Bug4802656");
+                JMenuBar menuBar = new JMenuBar();
+                JMenu menu1 = new JMenu("File");
+                menu2 = new JMenu("Hidden");
+                JMenu menu3 = new JMenu("Help");
+                menuBar.add(menu1);
+                menuBar.add(menu2);
+                menuBar.add(menu3);
+                menu2.setVisible(false);
+                mainFrame.setJMenuBar(menuBar);
+                mainFrame.setSize(200, 200);
+                mainFrame.setLocationRelativeTo(null);
+                mainFrame.setVisible(true);
+            });
+            robo.waitForIdle();
+            robo.delay(1000);
+            robo.keyPress(KeyEvent.VK_F10);
+            robo.keyRelease(KeyEvent.VK_F10);
+            robo.keyPress(KeyEvent.VK_RIGHT);
+            robo.keyRelease(KeyEvent.VK_RIGHT);
+            robo.delay(500);
+
+            SwingUtilities.invokeAndWait(() -> {
+                menu2Selected = menu2.isSelected();
+            });
+
+            if (menu2Selected) {
+                throw new RuntimeException("Test failed");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (mainFrame != null) {
+                    mainFrame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315761](https://bugs.openjdk.org/browse/JDK-8315761) needs maintainer approval

### Issue
 * [JDK-8315761](https://bugs.openjdk.org/browse/JDK-8315761): Open source few swing JList and JMenuBar tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2487/head:pull/2487` \
`$ git checkout pull/2487`

Update a local copy of the PR: \
`$ git checkout pull/2487` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2487`

View PR using the GUI difftool: \
`$ git pr show -t 2487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2487.diff">https://git.openjdk.org/jdk11u-dev/pull/2487.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2487#issuecomment-1911717994)