### PR TITLE
8315034: File.mkdirs() occasionally fails to create folders on Windows shared folder

### DIFF
--- a/src/java.base/windows/native/libjava/canonicalize_md.c
+++ b/src/java.base/windows/native/libjava/canonicalize_md.c
@@ -215,7 +215,8 @@ lastErrorReportable()
         || (errval == ERROR_BAD_NET_NAME)
         || (errval == ERROR_ACCESS_DENIED)
         || (errval == ERROR_NETWORK_UNREACHABLE)
-        || (errval == ERROR_NETWORK_ACCESS_DENIED)) {
+        || (errval == ERROR_NETWORK_ACCESS_DENIED)
+        || (errval == ERROR_NO_MORE_FILES)) {
         return 0;
     }
 


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315034](https://bugs.openjdk.org/browse/JDK-8315034) needs maintainer approval

### Issue
 * [JDK-8315034](https://bugs.openjdk.org/browse/JDK-8315034): File.mkdirs() occasionally fails to create folders on Windows shared folder (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2489/head:pull/2489` \
`$ git checkout pull/2489`

Update a local copy of the PR: \
`$ git checkout pull/2489` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2489`

View PR using the GUI difftool: \
`$ git pr show -t 2489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2489.diff">https://git.openjdk.org/jdk11u-dev/pull/2489.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2489#issuecomment-1911742396)