### PR TITLE
8309104: [JVMCI] compiler/unsafe/UnsafeGetStableArrayElement test asserts wrong values with Graal

### DIFF
--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeGetStableArrayElement.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeGetStableArrayElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -224,12 +224,12 @@ public class UnsafeGetStableArrayElement {
     }
 
     static void testMismatched(Callable<?> c, Runnable setDefaultAction) throws Exception {
-        testMismatched(c, setDefaultAction, false);
+        testMismatched(c, setDefaultAction, false, true);
     }
 
-    static void testMismatched(Callable<?> c, Runnable setDefaultAction, boolean objectArray) throws Exception {
-        if (Compiler.isGraalEnabled() && !objectArray) {
-            // Graal will constant fold mismatched reads from primitive stable arrays
+    static void testMismatched(Callable<?> c, Runnable setDefaultAction, boolean objectArray, boolean aligned) throws Exception {
+        if (Compiler.isGraalEnabled() && !objectArray && aligned) {
+            // Graal will constant fold mismatched reads from primitive stable arrays, except unaligned ones
             run(c, setDefaultAction, null);
         } else {
             run(c, null, setDefaultAction);
@@ -319,15 +319,15 @@ public class UnsafeGetStableArrayElement {
         testMatched(   Test::testD_D, Test::changeD);
 
         // Object[], aligned accesses
-        testMismatched(Test::testL_J, Test::changeL, true); // long & double are always as large as an OOP
-        testMismatched(Test::testL_D, Test::changeL, true);
+        testMismatched(Test::testL_J, Test::changeL, true, true); // long & double are always as large as an OOP
+        testMismatched(Test::testL_D, Test::changeL, true, true);
         testMatched(   Test::testL_L, Test::changeL);
 
         // Unaligned accesses
-        testMismatched(Test::testS_U, Test::changeS);
-        testMismatched(Test::testC_U, Test::changeC);
-        testMismatched(Test::testI_U, Test::changeI);
-        testMismatched(Test::testJ_U, Test::changeJ);
+        testMismatched(Test::testS_U, Test::changeS, false, false);
+        testMismatched(Test::testC_U, Test::changeC, false, false);
+        testMismatched(Test::testI_U, Test::changeI, false, false);
+        testMismatched(Test::testJ_U, Test::changeJ, true, false);
 
         // No way to reliably check the expected behavior:
         //   (1) OOPs change during GC;


### PR DESCRIPTION
Backport of [JDK-8309104](https://bugs.openjdk.org/browse/JDK-8309104)
- `test/hotspot/jtreg/compiler/unsafe/UnsafeGetStableArrayElement.java`
  - `Copyright year` line manually merged (`unclean`), all other code changes are `clean`

Testing
- Local: `Passed`
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-01-29,31`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309104](https://bugs.openjdk.org/browse/JDK-8309104) needs maintainer approval

### Issue
 * [JDK-8309104](https://bugs.openjdk.org/browse/JDK-8309104): [JVMCI] compiler/unsafe/UnsafeGetStableArrayElement test asserts wrong values with Graal (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2491/head:pull/2491` \
`$ git checkout pull/2491`

Update a local copy of the PR: \
`$ git checkout pull/2491` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2491`

View PR using the GUI difftool: \
`$ git pr show -t 2491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2491.diff">https://git.openjdk.org/jdk11u-dev/pull/2491.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2491#issuecomment-1913474370)