### PR TITLE
8309870: Using -proc:full should be considered requesting explicit annotation processing

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1290,7 +1290,10 @@ public class JavaCompiler {
             options.isSet(PROCESSOR_PATH) ||
             options.isSet(PROCESSOR_MODULE_PATH) ||
             options.isSet(PROC, "only") ||
+            options.isSet(PROC, "full") ||
+            options.isSet(A) ||
             options.isSet(XPRINT);
+        // Skipping -XprintRounds and -XprintProcessorInfo
     }
 
     public void setDeferredDiagnosticHandler(Log.DeferredDiagnosticHandler deferredDiagnosticHandler) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Option.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Option.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,6 +80,11 @@ import static com.sun.tools.javac.main.Option.OptionKind.*;
  * whether an argument is needed and where to find it;
  * {@code handleOption} then calls {@link #process process} providing a suitable
  * {@link OptionHelper} to provide access the compiler state.
+ *
+ *
+ * <p>Maintenance note: when adding new annotation processing related
+ * options, the list of options regarded as requesting explicit
+ * annotation processing in JavaCompiler should be updated.
  *
  * <p><b>This is NOT part of any supported API.
  * If you write code that depends on this, you do so at your own


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309870](https://bugs.openjdk.org/browse/JDK-8309870) needs maintainer approval

### Issue
 * [JDK-8309870](https://bugs.openjdk.org/browse/JDK-8309870): Using -proc:full should be considered requesting explicit annotation processing (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2493/head:pull/2493` \
`$ git checkout pull/2493`

Update a local copy of the PR: \
`$ git checkout pull/2493` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2493`

View PR using the GUI difftool: \
`$ git pr show -t 2493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2493.diff">https://git.openjdk.org/jdk11u-dev/pull/2493.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2493#issuecomment-1913895678)