### PR TITLE
8314144: gc/g1/ihop/TestIHOPStatic.java fails due to extra concurrent mark with -Xcomp

### DIFF
--- a/test/hotspot/jtreg/gc/g1/ihop/TestIHOPErgo.java
+++ b/test/hotspot/jtreg/gc/g1/ihop/TestIHOPErgo.java
@@ -30,6 +30,7 @@
  * @requires !vm.flightRecorder
  * @requires vm.opt.ExplicitGCInvokesConcurrent != true
  * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @requires vm.compMode != "Xcomp"
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  * @modules java.management

--- a/test/hotspot/jtreg/gc/g1/ihop/TestIHOPStatic.java
+++ b/test/hotspot/jtreg/gc/g1/ihop/TestIHOPStatic.java
@@ -28,6 +28,8 @@
  * @requires vm.gc.G1
  * @requires !vm.flightRecorder
  * @requires vm.opt.ExplicitGCInvokesConcurrent != true
+ * @requires !vm.graal.enabled
+ * @requires vm.compMode != "Xcomp"
  * @requires os.maxMemory > 1G
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.
Only add the '@requires', make it clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8314144](https://bugs.openjdk.org/browse/JDK-8314144) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314144](https://bugs.openjdk.org/browse/JDK-8314144): gc/g1/ihop/TestIHOPStatic.java fails due to extra concurrent mark with -Xcomp (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2494/head:pull/2494` \
`$ git checkout pull/2494`

Update a local copy of the PR: \
`$ git checkout pull/2494` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2494`

View PR using the GUI difftool: \
`$ git pr show -t 2494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2494.diff">https://git.openjdk.org/jdk11u-dev/pull/2494.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2494#issuecomment-1914026415)