### PR TITLE
8309778: java/nio/file/Files/CopyAndMove.java fails when using second test directory

### DIFF
--- a/test/jdk/java/nio/file/Files/CopyAndMove.java
+++ b/test/jdk/java/nio/file/Files/CopyAndMove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -892,7 +892,7 @@ public class CopyAndMove {
         if (supportsLinks) {
             source = createSourceFile(dir1);
             link = dir1.resolve("link");
-            createSymbolicLink(link, source);
+            createSymbolicLink(link, source.getFileName());
             target = getTargetFile(dir2);
             copyAndVerify(link, target);
             delete(link);


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309778](https://bugs.openjdk.org/browse/JDK-8309778) needs maintainer approval

### Issue
 * [JDK-8309778](https://bugs.openjdk.org/browse/JDK-8309778): java/nio/file/Files/CopyAndMove.java fails when using second test directory (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2495/head:pull/2495` \
`$ git checkout pull/2495`

Update a local copy of the PR: \
`$ git checkout pull/2495` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2495`

View PR using the GUI difftool: \
`$ git pr show -t 2495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2495.diff">https://git.openjdk.org/jdk11u-dev/pull/2495.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2495#issuecomment-1914041934)