### PR TITLE
8324754: WB_IsIntrinsicAvailable failed with "compiler not available" with option -Xint

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -709,7 +709,15 @@ static jmethodID reflected_method_to_jmid(JavaThread* thread, JNIEnv* env, jobje
 }
 
 static CompLevel highestCompLevel() {
-  return TieredCompilation ? MIN2((CompLevel) TieredStopAtLevel, CompLevel_highest_tier) : CompLevel_highest_tier;
+  CompLevel level = CompLevel_none;
+  if (!Arguments::is_interpreter_only()) {
+    if (TieredCompilation) {
+      level = MIN2((CompLevel) TieredStopAtLevel, CompLevel_highest_tier);
+    } else {
+      level = CompLevel_highest_tier;
+    }
+  }
+  return level;
 }
 
 // Deoptimizes all compiled frames and makes nmethods not entrant if it's requested

--- a/test/hotspot/jtreg/compiler/codegen/aes/CTR_Wraparound.java
+++ b/test/hotspot/jtreg/compiler/codegen/aes/CTR_Wraparound.java
@@ -34,6 +34,9 @@
  * @run main/othervm -Xbatch
  * -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  * compiler.codegen.aes.CTR_Wraparound 32
+ * @run main/othervm -Xint
+ * -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ * compiler.codegen.aes.CTR_Wraparound 32
  * @run main/othervm -Xbatch
  * -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  * compiler.codegen.aes.CTR_Wraparound 1009

--- a/test/hotspot/jtreg/compiler/codegen/aes/Test8292158.java
+++ b/test/hotspot/jtreg/compiler/codegen/aes/Test8292158.java
@@ -33,6 +33,9 @@
  * @run main/othervm -Xbatch
  * -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  * compiler.codegen.aes.Test8292158
+ * @run main/othervm -Xint
+ * -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ * compiler.codegen.aes.Test8292158
  */
 
 package compiler.codegen.aes;

--- a/test/hotspot/jtreg/compiler/codegen/aes/TestAESMain.java
+++ b/test/hotspot/jtreg/compiler/codegen/aes/TestAESMain.java
@@ -36,6 +36,9 @@
  * @run main/othervm/timeout=600 -Xbatch -DcheckOutput=true -Dmode=CBC
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *      compiler.codegen.aes.TestAESMain
+ * @run main/othervm/timeout=600 -Xint -DcheckOutput=true -Dmode=CBC
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *      compiler.codegen.aes.TestAESMain
  * @run main/othervm/timeout=600 -Xbatch -DcheckOutput=true -Dmode=CBC -DencInputOffset=1
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *      compiler.codegen.aes.TestAESMain
@@ -56,6 +59,9 @@
  *      compiler.codegen.aes.TestAESMain
  *
  * @run main/othervm/timeout=600 -Xbatch -DcheckOutput=true -Dmode=ECB
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *      compiler.codegen.aes.TestAESMain
+ * @run main/othervm/timeout=600 -Xint -DcheckOutput=true -Dmode=ECB
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *      compiler.codegen.aes.TestAESMain
  * @run main/othervm/timeout=600 -Xbatch -DcheckOutput=true -Dmode=ECB -DencInputOffset=1
@@ -80,6 +86,9 @@
  * @run main/othervm/timeout=600 -Xbatch -DcheckOutput=true -Dmode=GCM
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *      compiler.codegen.aes.TestAESMain
+ * @run main/othervm/timeout=600 -Xint -DcheckOutput=true -Dmode=GCM
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *      compiler.codegen.aes.TestAESMain
  * @run main/othervm/timeout=600 -Xbatch -DcheckOutput=true -Dmode=GCM -DencInputOffset=1
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *      compiler.codegen.aes.TestAESMain
@@ -100,6 +109,9 @@
  *      compiler.codegen.aes.TestAESMain
  *
  * @run main/othervm/timeout=600 -Xbatch -DcheckOutput=true -Dmode=CTR
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *      compiler.codegen.aes.TestAESMain
+ * @run main/othervm/timeout=600 -Xint -DcheckOutput=true -Dmode=CTR
  *      -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *      compiler.codegen.aes.TestAESMain
  * @run main/othervm/timeout=600 -Xbatch -DcheckOutput=true -Dmode=CTR -DencInputOffset=1

--- a/test/hotspot/jtreg/compiler/codegen/aes/TestCipherBlockChainingEncrypt.java
+++ b/test/hotspot/jtreg/compiler/codegen/aes/TestCipherBlockChainingEncrypt.java
@@ -33,6 +33,9 @@
  * @run main/othervm -Xbatch
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *      compiler.codegen.aes.TestCipherBlockChainingEncrypt
+ * @run main/othervm -Xint
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *      compiler.codegen.aes.TestCipherBlockChainingEncrypt
  */
 
 package compiler.codegen.aes;

--- a/test/hotspot/jtreg/compiler/intrinsics/IntrinsicAvailableTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/IntrinsicAvailableTest.java
@@ -40,6 +40,12 @@
  *                   -XX:+WhiteBoxAPI
  *                   -XX:-UseCRC32Intrinsics
  *                   compiler.intrinsics.IntrinsicAvailableTest
+ * @run main/othervm -Xbootclasspath/a:.
+ *                   -Xint
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI
+ *                   -XX:-UseCRC32Intrinsics
+ *                   compiler.intrinsics.IntrinsicAvailableTest
  */
 
 
@@ -47,6 +53,7 @@ package compiler.intrinsics;
 
 import compiler.whitebox.CompilerWhiteBoxTest;
 import jdk.test.lib.Platform;
+import jtreg.SkippedException;
 
 import java.lang.reflect.Executable;
 import java.util.concurrent.Callable;
@@ -113,6 +120,9 @@ public class IntrinsicAvailableTest extends CompilerWhiteBoxTest {
     }
 
     public void test() throws Exception {
+        if (Platform.isInt()) {
+            throw new SkippedException("Compiler not available with -Xint");
+        }
         Executable intrinsicMethod = testCase.getExecutable();
         if (Platform.isServer() && !Platform.isEmulatedClient() && (TIERED_STOP_AT_LEVEL == COMP_LEVEL_FULL_OPTIMIZATION)) {
             if (TIERED_COMPILATION) {

--- a/test/hotspot/jtreg/compiler/intrinsics/IntrinsicDisabledTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/IntrinsicDisabledTest.java
@@ -32,6 +32,11 @@
  * @build sun.hotspot.WhiteBox
  * @run driver ClassFileInstaller sun.hotspot.WhiteBox
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission
+ * @run main/othervm -Xint
+ *                   -Xbootclasspath/a:.
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI
+ *                   compiler.intrinsics.IntrinsicDisabledTest
  * @run main/othervm -Xbootclasspath/a:.
  *                   -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI
@@ -47,6 +52,7 @@ package compiler.intrinsics;
 import jdk.test.lib.Platform;
 import sun.hotspot.WhiteBox;
 import compiler.whitebox.CompilerWhiteBoxTest;
+import jtreg.SkippedException;
 
 import java.lang.reflect.Executable;
 import java.util.Objects;
@@ -199,7 +205,9 @@ public class IntrinsicDisabledTest {
     }
 
     public static void main(String args[]) {
-        if (Platform.isServer() && !Platform.isEmulatedClient() &&
+        if (Platform.isInt()) {
+            throw new SkippedException("Compiler not available with -Xint");
+        } else if (Platform.isServer() && !Platform.isEmulatedClient() &&
                                    (TIERED_STOP_AT_LEVEL == CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION)) {
             if (TIERED_COMPILATION) {
                 test(CompilerWhiteBoxTest.COMP_LEVEL_SIMPLE);

--- a/test/hotspot/jtreg/compiler/intrinsics/base64/TestBase64.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/base64/TestBase64.java
@@ -32,6 +32,9 @@
  * @run main/othervm/timeout=600 -Xbatch -DcheckOutput=true
  *       -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *      compiler.intrinsics.base64.TestBase64
+ * @run main/othervm/timeout=600 -Xint -DcheckOutput=true
+ *       -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *      compiler.intrinsics.base64.TestBase64
  */
 
 package compiler.intrinsics.base64;

--- a/test/hotspot/jtreg/compiler/intrinsics/bigInteger/MontgomeryMultiplyTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/bigInteger/MontgomeryMultiplyTest.java
@@ -36,6 +36,8 @@
  *                                sun.hotspot.WhiteBox$WhiteBoxPermission
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *      compiler.intrinsics.bigInteger.MontgomeryMultiplyTest
+ * @run main/othervm -Xint -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      compiler.intrinsics.bigInteger.MontgomeryMultiplyTest
  */
 
 package compiler.intrinsics.bigInteger;


### PR DESCRIPTION
If interpreter mode is enabled, the highest compile level should be none. Therefore, WB_IsIntrinsicAvailable will return false directly rather than check intrinsic availability with non-existent compiler.
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8324754](https://bugs.openjdk.org/browse/JDK-8324754) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324754](https://bugs.openjdk.org/browse/JDK-8324754): WB_IsIntrinsicAvailable failed with "compiler not available" with option -Xint (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2497/head:pull/2497` \
`$ git checkout pull/2497`

Update a local copy of the PR: \
`$ git checkout pull/2497` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2497`

View PR using the GUI difftool: \
`$ git pr show -t 2497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2497.diff">https://git.openjdk.org/jdk11u-dev/pull/2497.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2497#issuecomment-1914315821)