### PR TITLE
8314220: Configurable InlineCacheBuffer size

### DIFF
--- a/src/hotspot/share/code/icBuffer.cpp
+++ b/src/hotspot/share/code/icBuffer.cpp
@@ -111,7 +111,7 @@ void InlineCacheBuffer::init_next_stub() {
 
 void InlineCacheBuffer::initialize() {
   if (_buffer != NULL) return; // already initialized
-  _buffer = new StubQueue(new ICStubInterface, 10*K, InlineCacheBuffer_lock, "InlineCacheBuffer");
+  _buffer = new StubQueue(new ICStubInterface, checked_cast<int>(InlineCacheBufferSize), InlineCacheBuffer_lock, "InlineCacheBuffer");
   assert (_buffer != NULL, "cannot allocate InlineCacheBuffer");
   init_next_stub();
 }

--- a/src/hotspot/share/code/stubs.cpp
+++ b/src/hotspot/share/code/stubs.cpp
@@ -214,8 +214,6 @@ void StubQueue::verify() {
   guarantee(0 <= _queue_begin  && _queue_begin  <  _buffer_limit, "_queue_begin out of bounds");
   guarantee(0 <= _queue_end    && _queue_end    <= _buffer_limit, "_queue_end   out of bounds");
   // verify alignment
-  guarantee(_buffer_size  % CodeEntryAlignment == 0, "_buffer_size  not aligned");
-  guarantee(_buffer_limit % CodeEntryAlignment == 0, "_buffer_limit not aligned");
   guarantee(_queue_begin  % CodeEntryAlignment == 0, "_queue_begin  not aligned");
   guarantee(_queue_end    % CodeEntryAlignment == 0, "_queue_end    not aligned");
   // verify buffer limit/size relationship

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -313,6 +313,11 @@ bool CompilerConfig::check_args_consistency(bool status) {
                 "Invalid NonNMethodCodeHeapSize=%dK. Must be at least %uK.\n", NonNMethodCodeHeapSize/K,
                 min_code_cache_size/K);
     status = false;
+  } else if (InlineCacheBufferSize > NonNMethodCodeHeapSize / 2) {
+    jio_fprintf(defaultStream::error_stream(),
+                "Invalid InlineCacheBufferSize=" SIZE_FORMAT "K. Must be less than or equal to " SIZE_FORMAT "K.\n",
+                InlineCacheBufferSize/K, NonNMethodCodeHeapSize/2/K);
+    status = false;
   }
 
 #ifdef _LP64

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -409,6 +409,9 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
   product(bool, UseInlineCaches, true,                                      \
           "Use Inline Caches for virtual calls ")                           \
                                                                             \
+  experimental(size_t, InlineCacheBufferSize, 10*K,                         \
+          "InlineCacheBuffer size")                                         \
+                                                                            \
   diagnostic(bool, InlineArrayCopy, true,                                   \
           "Inline arraycopy native that is known to be part of "            \
           "base library DLL")                                               \


### PR DESCRIPTION
I'd like to backport JDK-8314220 to 11u.
It allows to configure IC buffer size to avoid multiple ICBufferFull safepoints and possible performance degradation.

17u patch applies almost cleanly except for:
- minor context difference in icBuffer.cpp
- different method for experimental flag declaration in globals.hpp (JDK-8243208 is not in 11u)
The changes reapplied manually.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314220](https://bugs.openjdk.org/browse/JDK-8314220) needs maintainer approval

### Issue
 * [JDK-8314220](https://bugs.openjdk.org/browse/JDK-8314220): Configurable InlineCacheBuffer size (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2498/head:pull/2498` \
`$ git checkout pull/2498`

Update a local copy of the PR: \
`$ git checkout pull/2498` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2498`

View PR using the GUI difftool: \
`$ git pr show -t 2498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2498.diff">https://git.openjdk.org/jdk11u-dev/pull/2498.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2498#issuecomment-1915573950)