### PR TITLE
8324347: Enable "maybe-uninitialized" warning for FreeType 2.13.1

### DIFF
--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -516,7 +516,6 @@ else
     LIBFREETYPE_LIBS := -lfreetype
   endif
 
-  # gcc_ftobjs.c := maybe-uninitialized required for GCC 7 builds.
   $(eval $(call SetupJdkLibrary, BUILD_LIBFREETYPE, \
       NAME := freetype, \
       OPTIMIZATION := HIGHEST, \
@@ -529,7 +528,6 @@ else
       DISABLED_WARNINGS_microsoft := 4018 4267 4244 4312 4819, \
       DISABLED_WARNINGS_gcc := implicit-fallthrough cast-function-type bad-function-cast, \
       DISABLED_WARNINGS_clang := missing-declarations, \
-      DISABLED_WARNINGS_gcc_ftobjs.c := maybe-uninitialized, \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \
   ))


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [781f368d](https://github.com/openjdk/jdk/commit/781f368d421a94857929e4168974f43e890637d8) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 26 Jan 2024 and was reviewed by Erik Joelsson, Alexander Zvegintsev, Julian Waters and Alexey Ivanov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324347](https://bugs.openjdk.org/browse/JDK-8324347) needs maintainer approval

### Issue
 * [JDK-8324347](https://bugs.openjdk.org/browse/JDK-8324347): Enable "maybe-uninitialized" warning for FreeType 2.13.1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2499/head:pull/2499` \
`$ git checkout pull/2499`

Update a local copy of the PR: \
`$ git checkout pull/2499` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2499`

View PR using the GUI difftool: \
`$ git pr show -t 2499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2499.diff">https://git.openjdk.org/jdk11u-dev/pull/2499.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2499#issuecomment-1915987020)