### PR TITLE
8276125: RunThese24H.java SIGSEGV in JfrThreadGroup::thread_group_id

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrThreadGroup.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrThreadGroup.cpp
@@ -150,8 +150,12 @@ int JfrThreadGroupsHelper::populate_thread_group_hierarchy(const JavaThread* jt,
   assert(current != NULL, "invariant");
   assert(_thread_group_hierarchy != NULL, "invariant");
 
+  oop thread_oop = jt->threadObj();
+  if (thread_oop == NULL) {
+    return 0;
+  }
   // immediate thread group
-  Handle thread_group_handle(current, java_lang_Thread::threadGroup(jt->threadObj()));
+  Handle thread_group_handle(current, java_lang_Thread::threadGroup(thread_oop));
   if (thread_group_handle == NULL) {
     return 0;
   }


### PR DESCRIPTION
It isn't a clean backport for two reasons.
1. jdk11 cannot use nullptr, so it should use NULL instead.
2. `parent_thread_group_handle != NULL` will cause a compile error without a type cast. 

This backport prevents a JFR operation from accessing an illegal address which has not be filled before the initialization of a JavaThread, which is created from a JNI interface.

The risk is very low since it only adds a null pointer check. Besides, This backport has be accepted in [jdk17-dev](https://github.com/openjdk/jdk17u-dev/pull/2179).  

Additional testing:
- [x] Linux aarch64 server fastdebug, test/jdk/jdk/jfr passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8276125](https://bugs.openjdk.org/browse/JDK-8276125) needs maintainer approval

### Issue
 * [JDK-8276125](https://bugs.openjdk.org/browse/JDK-8276125): RunThese24H.java SIGSEGV in JfrThreadGroup::thread_group_id (**Bug** - P3 - Approved)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2501/head:pull/2501` \
`$ git checkout pull/2501`

Update a local copy of the PR: \
`$ git checkout pull/2501` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2501`

View PR using the GUI difftool: \
`$ git pr show -t 2501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2501.diff">https://git.openjdk.org/jdk11u-dev/pull/2501.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2501#issuecomment-1916428485)