### PR TITLE
8287113: JFR: Periodic task thread uses period for method sampling events

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -80,7 +80,7 @@ public final class MetadataRepository {
                 // annotations, such as Period and Threshold.
                 if (pEventType.hasPeriod()) {
                     pEventType.setEventHook(true);
-                    if (!(Type.EVENT_NAME_PREFIX + "ExecutionSample").equals(type.getName())) {
+                    if (!pEventType.isMethodSampling()) {
                         requestHooks.add(new RequestHook(pEventType));
                     }
                 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformEventType.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformEventType.java
@@ -278,4 +278,8 @@ public final class PlatformEventType extends Type {
     public int getStackTraceOffset() {
         return stackTraceOffset;
     }
+
+    public boolean isMethodSampling() {
+        return isMethodSampling;
+    }
 }


### PR DESCRIPTION
Backport of [JDK-8287113](https://bugs.openjdk.org/browse/JDK-8287113)
- `PlatformEventType.java` The line number changed are different from the original commit, well the contents are exactly the same, so this change can be considered as `clean`

Testing
- Local: `Passed` on MacOS M1 Laptop
  - `test/hotspot/jtreg/gc/stress/jfr` - Test results: passed: 10
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-02-02`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8287113](https://bugs.openjdk.org/browse/JDK-8287113) needs maintainer approval

### Issue
 * [JDK-8287113](https://bugs.openjdk.org/browse/JDK-8287113): JFR: Periodic task thread uses period for method sampling events (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2502/head:pull/2502` \
`$ git checkout pull/2502`

Update a local copy of the PR: \
`$ git checkout pull/2502` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2502`

View PR using the GUI difftool: \
`$ git pr show -t 2502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2502.diff">https://git.openjdk.org/jdk11u-dev/pull/2502.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2502#issuecomment-1920287966)