### PR TITLE
8315415: OutputAnalyzer.shouldMatchByLine() fails in some cases

### DIFF
--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -607,15 +607,15 @@ public final class OutputAnalyzer {
     /**
      * @see #shouldMatchByLine(String, String, String)
      */
-    public OutputAnalyzer shouldMatchByLineFrom(String from, String pattern) {
-        return shouldMatchByLine(from, null, pattern);
+    public OutputAnalyzer shouldMatchByLineFrom(String fromPattern, String pattern) {
+        return shouldMatchByLine(fromPattern, null, pattern);
     }
 
     /**
      * @see #shouldMatchByLine(String, String, String)
      */
-    public OutputAnalyzer shouldMatchByLineTo(String to, String pattern) {
-        return shouldMatchByLine(null, to, pattern);
+    public OutputAnalyzer shouldMatchByLineTo(String toPattern, String pattern) {
+        return shouldMatchByLine(null, toPattern, pattern);
     }
 
     /**
@@ -623,17 +623,17 @@ public final class OutputAnalyzer {
      * {@code pattern} line by line. The whole output could be matched or
      * just a subset of it.
      *
-     * @param from
-     *            The line (excluded) from where output will be matched.
-     *            Set {@code from} to null for matching from the first line.
-     * @param to
-     *            The line (excluded) until where output will be matched.
-     *            Set {@code to} to null for matching until the last line.
+     * @param fromPattern
+     *            The pattern of line (excluded) from where output will be matched.
+     *            Set {@code fromPattern} to null for matching from the first line.
+     * @param toPattern
+     *            The pattern of line (excluded) until where output will be matched.
+     *            Set {@code toPattern} to null for matching until the last line.
      * @param pattern
      *            Matching pattern
      */
-    public OutputAnalyzer shouldMatchByLine(String from, String to, String pattern) {
-        return shouldMatchByLine(getOutput(), from, to, pattern);
+    public OutputAnalyzer shouldMatchByLine(String fromPattern, String toPattern, String pattern) {
+        return shouldMatchByLine(getOutput(), fromPattern, toPattern, pattern);
     }
 
     /**
@@ -641,34 +641,34 @@ public final class OutputAnalyzer {
      * {@code pattern} line by line. The whole stdout could be matched or
      * just a subset of it.
      *
-     * @param from
-     *            The line (excluded) from where stdout will be matched.
-     *            Set {@code from} to null for matching from the first line.
-     * @param to
-     *            The line (excluded) until where stdout will be matched.
-     *            Set {@code to} to null for matching until the last line.
+     * @param fromPattern
+     *            The pattern of line (excluded) from where stdout will be matched.
+     *            Set {@code fromPattern} to null for matching from the first line.
+     * @param toPattern
+     *            The pattern of line (excluded) until where stdout will be matched.
+     *            Set {@code toPattern} to null for matching until the last line.
      * @param pattern
      *            Matching pattern
      */
-    public OutputAnalyzer stdoutShouldMatchByLine(String from, String to, String pattern) {
-        return shouldMatchByLine(getStdout(), from, to, pattern);
+    public OutputAnalyzer stdoutShouldMatchByLine(String fromPattern, String toPattern, String pattern) {
+        return shouldMatchByLine(getStdout(), fromPattern, toPattern, pattern);
     }
 
-    private OutputAnalyzer shouldMatchByLine(String buffer, String from, String to, String pattern) {
+    private OutputAnalyzer shouldMatchByLine(String buffer, String fromPattern, String toPattern, String pattern) {
         List<String> lines = asLines(buffer);
 
         int fromIndex = 0;
-        if (from != null) {
-            fromIndex = indexOf(lines, from, 0) + 1; // + 1 -> apply 'pattern' to lines after 'from' match
+        if (fromPattern != null) {
+            fromIndex = indexOf(lines, fromPattern, 0) + 1; // + 1 -> apply 'pattern' to lines after 'from' match
             Asserts.assertGreaterThan(fromIndex, 0,
-                    "The line/pattern '" + from + "' from where the output should match can not be found");
+                    "The line matched with pattern '" + fromPattern + "' from where the output should match can not be found");
         }
 
         int toIndex = lines.size();
-        if (to != null) {
-            toIndex = indexOf(lines, to, fromIndex);
+        if (toPattern != null) {
+            toIndex = indexOf(lines, toPattern, fromIndex);
             Asserts.assertGreaterThan(toIndex, fromIndex,
-                    "The line/pattern '" + to + "' until where the output should match can not be found");
+                    "The line matched with pattern '" + toPattern + "' until where the output should match can not be found");
         }
 
         List<String> subList = lines.subList(fromIndex, toIndex);


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315415](https://bugs.openjdk.org/browse/JDK-8315415) needs maintainer approval

### Issue
 * [JDK-8315415](https://bugs.openjdk.org/browse/JDK-8315415): OutputAnalyzer.shouldMatchByLine() fails in some cases (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2505/head:pull/2505` \
`$ git checkout pull/2505`

Update a local copy of the PR: \
`$ git checkout pull/2505` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2505`

View PR using the GUI difftool: \
`$ git pr show -t 2505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2505.diff">https://git.openjdk.org/jdk11u-dev/pull/2505.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2505#issuecomment-1922875189)