### PR TITLE
8318468: compiler/tiered/LevelTransitionTest.java fails with -XX:CompileThreshold=100 -XX:TieredStopAtLevel=1

### DIFF
--- a/test/hotspot/jtreg/compiler/tiered/LevelTransitionTest.java
+++ b/test/hotspot/jtreg/compiler/tiered/LevelTransitionTest.java
@@ -205,7 +205,8 @@ public class LevelTransitionTest extends TieredLevelsTest {
         }
 
         private static class CompileMethodHolder {
-            private final int iter = 10;
+            // Make sure that loop backedge is never taken to prevent unexpected OSR compilations.
+            private final int iter = 1;
             private int field = 42;
 
             /**


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318468](https://bugs.openjdk.org/browse/JDK-8318468) needs maintainer approval

### Issue
 * [JDK-8318468](https://bugs.openjdk.org/browse/JDK-8318468): compiler/tiered/LevelTransitionTest.java fails with -XX:CompileThreshold=100 -XX:TieredStopAtLevel=1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2506/head:pull/2506` \
`$ git checkout pull/2506`

Update a local copy of the PR: \
`$ git checkout pull/2506` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2506`

View PR using the GUI difftool: \
`$ git pr show -t 2506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2506.diff">https://git.openjdk.org/jdk11u-dev/pull/2506.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2506#issuecomment-1923099964)