### PR TITLE
8323243: JNI invocation of an abstract instance method corrupts the stack

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -1168,6 +1168,11 @@ static void jni_invoke_nonstatic(JNIEnv *env, JavaValue* result, jobject receive
     }
   }
 
+  if (selected_method->is_abstract()) {
+    ResourceMark rm(THREAD);
+    THROW_MSG(vmSymbols::java_lang_AbstractMethodError(), selected_method->name()->as_C_string());
+  }
+
   methodHandle method(THREAD, selected_method);
 
   // Create object to hold arguments for the JavaCall, and associate it with

--- a/test/hotspot/jtreg/runtime/jni/abstractMethod/AbstractMethodClass.jasm
+++ b/test/hotspot/jtreg/runtime/jni/abstractMethod/AbstractMethodClass.jasm
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+/*
+ *  This is a non-abstract class with an abstract method.
+ *
+ */
+super public class AbstractMethodClass
+      extends java/lang/Object
+              version 51:0  // Java 7 version
+{
+
+    public Method "<init>":"()V"
+       stack 1 locals 1
+    {
+        aload_0;
+        invokespecial Method java/lang/Object."<init>":"()V";
+        return;
+    }
+
+    public abstract Method "abstractM":"()V";
+
+}

--- a/test/hotspot/jtreg/runtime/jni/abstractMethod/TestJNIAbstractMethod.java
+++ b/test/hotspot/jtreg/runtime/jni/abstractMethod/TestJNIAbstractMethod.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8323243
+ * @summary Test that invocation of an abstract method from JNI works correctly
+ * @compile AbstractMethodClass.jasm
+ * @run main/othervm/native TestJNIAbstractMethod
+ */
+
+/**
+ * We are testing invocation of an abstract method from JNI - which should
+ * simply result in throwning AbstractMethodError. To invoke an abstract method
+ * we must have an instance method (as abstract static methods are illegal),
+ * but instantiating an abstract class is also illegal at the Java language
+ * level, so we have to use a custom jasm class that contains an abstract method
+ * declaration, but which is not itself declared as an abstract class.
+ */
+public class TestJNIAbstractMethod {
+
+    // Invokes an abstract method from JNI and throws AbstractMethodError.
+    private static native void invokeAbstractM(Class<?> AMclass,
+                                               AbstractMethodClass receiver);
+
+    static {
+        System.loadLibrary("JNIAbstractMethod");
+    }
+
+    public static void main(String[] args) {
+        AbstractMethodClass obj = new AbstractMethodClass();
+        try {
+            System.out.println("Attempting direct invocation via Java");
+            obj.abstractM();
+            throw new RuntimeException("Did not get AbstractMethodError from Java!");
+        } catch (AbstractMethodError expected) {
+            System.out.println("ok - got expected exception: " + expected);
+        }
+        try {
+            System.out.println("Attempting direct invocation via JNI");
+            invokeAbstractM(obj.getClass(), obj);
+            throw new RuntimeException("Did not get AbstractMethodError from JNI!");
+        } catch (AbstractMethodError expected) {
+            System.out.println("ok - got expected exception: " + expected);
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/jni/abstractMethod/libJNIAbstractMethod.c
+++ b/test/hotspot/jtreg/runtime/jni/abstractMethod/libJNIAbstractMethod.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+#include <jni.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+JNIEXPORT void JNICALL Java_TestJNIAbstractMethod_invokeAbstractM(JNIEnv* env,
+                                                                  jclass this_cls,
+                                                                  jclass target_cls,
+                                                                  jobject receiver) {
+
+  jmethodID mid = (*env)->GetMethodID(env, target_cls, "abstractM", "()V");
+  if (mid == NULL) {
+    fprintf(stderr, "Error looking up method abstractM\n");
+    (*env)->ExceptionDescribe(env);
+    exit(1);
+  }
+
+  printf("Invoking abstract method ...\n");
+  (*env)->CallVoidMethod(env, receiver, mid);  // Should raise exception
+
+}


### PR DESCRIPTION
I backport this for parity with 11.0.23-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323243](https://bugs.openjdk.org/browse/JDK-8323243) needs maintainer approval

### Issue
 * [JDK-8323243](https://bugs.openjdk.org/browse/JDK-8323243): JNI invocation of an abstract instance method corrupts the stack (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2507/head:pull/2507` \
`$ git checkout pull/2507`

Update a local copy of the PR: \
`$ git checkout pull/2507` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2507`

View PR using the GUI difftool: \
`$ git pr show -t 2507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2507.diff">https://git.openjdk.org/jdk11u-dev/pull/2507.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2507#issuecomment-1923168600)