### PR TITLE
8274122: java/io/File/createTempFile/SpecialTempFile.java fails in Windows 11

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -517,7 +517,6 @@ java/lang/management/MemoryMXBean/PendingAllGC.sh               8158837 generic-
 # jdk_io
 
 java/io/pathNames/GeneralWin32.java                             8180264 windows-all
-java/io/File/createTempFile/SpecialTempFile.java                8274122 windows11
 
 ############################################################################
 

--- a/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
+++ b/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8013827 8011950 8017212 8025128
+ * @modules java.base/jdk.internal.util
  * @summary Check whether File.createTempFile can handle special parameters
  * @author Dan Xu
  */
@@ -32,10 +33,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+
+import jdk.internal.util.OperatingSystem;
+import jdk.internal.util.OSVersion;
 
 public class SpecialTempFile {
-
     private static void test(String name, String[] prefix, String[] suffix,
                              boolean exceptionExpected) throws IOException
     {
@@ -48,7 +50,7 @@ public class SpecialTempFile {
         final String exceptionMsg = "Unable to create temporary file";
         String[] dirs = { null, "." };
 
-        Path testPath = Paths.get(System.getProperty("test.dir", "."));
+        Path testPath = Path.of(System.getProperty("test.dir", "."));
         for (int i = 0; i < prefix.length; i++) {
             boolean exceptionThrown = false;
             File f = null;
@@ -99,12 +101,15 @@ public class SpecialTempFile {
         test("SlashedName", slashPre, slashSuf, true);
 
         // Windows tests
-        if (!System.getProperty("os.name").startsWith("Windows"))
+        if (!OperatingSystem.isWindows())
             return;
 
         // Test JDK-8013827
         String[] resvPre = { "LPT1.package.zip", "com7.4.package.zip" };
         String[] resvSuf = { ".temp", ".temp" };
-        test("ReservedName", resvPre, resvSuf, true);
+        boolean exceptionExpected =
+            !(System.getProperty("os.name").endsWith("11") ||
+              new OSVersion(10, 0).compareTo(OSVersion.current()) > 0);
+        test("ReservedName", resvPre, resvSuf, exceptionExpected);
     }
 }

--- a/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
+++ b/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
@@ -24,8 +24,11 @@
 /*
  * @test
  * @bug 8013827 8011950 8017212 8025128
+ * @library /test/lib
  * @modules java.base/jdk.internal.util
  * @summary Check whether File.createTempFile can handle special parameters
+ * @build jdk.test.lib.OSVersion jdk.test.lib.Platform
+   @run main SpecialTempFile
  * @author Dan Xu
  */
 
@@ -34,8 +37,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import jdk.internal.util.OperatingSystem;
-import jdk.internal.util.OSVersion;
+import jdk.test.lib.Platform;
+import jdk.test.lib.OSVersion;
 
 public class SpecialTempFile {
     private static void test(String name, String[] prefix, String[] suffix,
@@ -101,7 +104,7 @@ public class SpecialTempFile {
         test("SlashedName", slashPre, slashSuf, true);
 
         // Windows tests
-        if (!OperatingSystem.isWindows())
+        if (!Platform.isWindows())
             return;
 
         // Test JDK-8013827


### PR DESCRIPTION
Backport of [JDK-8274122](https://bugs.openjdk.org/browse/JDK-8274122)
- This PR has 2 commits
  - The first commit is a clean git apply
  - The second commit is `Compile` error fix on Java 11
- Clean from `jdk17u-dev`


Testing
- Local: Test in progress
  - MacOS - `SpecialTempFile.java`: Test results: passed: 1
  - Windows - `SpecialTempFile.java`: Test results: passed: 1

```
Edition	Windows 11 Enterprise
Version	23H2
Installed on	‎5/‎10/‎2023
OS build	22631.3007
Experience	Windows Feature Experience Pack 1000.22681.1000.0
```

- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-02-11`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8274122](https://bugs.openjdk.org/browse/JDK-8274122) needs maintainer approval

### Issue
 * [JDK-8274122](https://bugs.openjdk.org/browse/JDK-8274122): java/io/File/createTempFile/SpecialTempFile.java fails in Windows 11 (**Bug** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2510/head:pull/2510` \
`$ git checkout pull/2510`

Update a local copy of the PR: \
`$ git checkout pull/2510` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2510`

View PR using the GUI difftool: \
`$ git pr show -t 2510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2510.diff">https://git.openjdk.org/jdk11u-dev/pull/2510.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2510#issuecomment-1930956660)