### PR TITLE
Backport b76f320e76f0fb58c598fdd7a5937f1b5bb1de15

### DIFF
--- a/test/langtools/tools/javac/lib/DPrinter.java
+++ b/test/langtools/tools/javac/lib/DPrinter.java
@@ -600,6 +600,7 @@ public class DPrinter {
     protected Object getField(Object o, Class<?> clazz, String name) {
         try {
             Field f = clazz.getDeclaredField(name);
+            @SuppressWarnings("deprecation")
             boolean prev = f.isAccessible();
             f.setAccessible(true);
             try {
@@ -617,6 +618,7 @@ public class DPrinter {
     protected Object callMethod(Object o, Class<?> clazz, String name) {
         try {
             Method m = clazz.getDeclaredMethod(name);
+            @SuppressWarnings("deprecation")
             boolean prev = m.isAccessible();
             m.setAccessible(true);
             try {


### PR DESCRIPTION
Backport of [8307123](https://bugs.openjdk.org/browse/JDK-8307123)

Testing
- Local: Passed, on MacOS M1
- Pipeline: 
- Testing Machine: 