### PR TITLE
8315680: java/lang/ref/ReachabilityFenceTest.java should run with -Xbatch

### DIFF
--- a/test/jdk/java/lang/ref/ReachabilityFenceTest.java
+++ b/test/jdk/java/lang/ref/ReachabilityFenceTest.java
@@ -27,11 +27,11 @@
  *
  * @requires vm.opt.DeoptimizeALot != true
  *
- * @run main/othervm -Xint                   -Dpremature=false ReachabilityFenceTest
- * @run main/othervm -XX:TieredStopAtLevel=1 -Dpremature=true  ReachabilityFenceTest
- * @run main/othervm -XX:TieredStopAtLevel=2 -Dpremature=true  ReachabilityFenceTest
- * @run main/othervm -XX:TieredStopAtLevel=3 -Dpremature=true  ReachabilityFenceTest
- * @run main/othervm -XX:TieredStopAtLevel=4 -Dpremature=true  ReachabilityFenceTest
+ * @run main/othervm -Xint                           -Dpremature=false ReachabilityFenceTest
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=1 -Dpremature=true  ReachabilityFenceTest
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=2 -Dpremature=true  ReachabilityFenceTest
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=3 -Dpremature=true  ReachabilityFenceTest
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=4 -Dpremature=true  ReachabilityFenceTest
  */
 
 import java.lang.ref.Reference;
@@ -54,7 +54,7 @@ public class ReachabilityFenceTest {
      * the object cannot be finalized. There is no sense running a positive test when premature finalization
      * is not expected. It is a job for negative test to verify that invariant.
      *
-     * The test methods should be appropriately compiled, therefore we do several iterations.
+     * The test methods should be appropriately compiled, therefore we do several iterations and run with -Xbatch.
      */
 
     // Enough to OSR and compile


### PR DESCRIPTION
Backport of [JDK-8315680](https://bugs.openjdk.org/browse/JDK-8315680)

Testing
- Local: Passed, on MacOS M1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-02-11`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315680](https://bugs.openjdk.org/browse/JDK-8315680) needs maintainer approval

### Issue
 * [JDK-8315680](https://bugs.openjdk.org/browse/JDK-8315680): java/lang/ref/ReachabilityFenceTest.java should run with -Xbatch (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2512/head:pull/2512` \
`$ git checkout pull/2512`

Update a local copy of the PR: \
`$ git checkout pull/2512` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2512`

View PR using the GUI difftool: \
`$ git pr show -t 2512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2512.diff">https://git.openjdk.org/jdk11u-dev/pull/2512.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2512#issuecomment-1931496489)