### PR TITLE
8317307: test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java fails with ConnectException: Connection timed out: no further information

### DIFF
--- a/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,7 +124,7 @@ public class LdapPoolTimeoutTest {
             // assertCompletion may wrap a CommunicationException in an RTE
             assertNotNull(msg);
             assertTrue(msg.contains("Network is unreachable")
-                        || msg.contains("No route to host"));
+                        || msg.contains("No route to host") || msg.contains("Connection timed out"));
         } catch (NamingException ex) {
             String msg = ex.getCause() == null ? ex.getMessage() : ex.getCause().getMessage();
             System.err.println("MSG: " + msg);


### PR DESCRIPTION
Backport of [JDK-8317307](https://bugs.openjdk.org/browse/JDK-8317307)

Testing
- Local: Passed, on MacOS M1 laptop
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-02-11`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317307](https://bugs.openjdk.org/browse/JDK-8317307) needs maintainer approval

### Issue
 * [JDK-8317307](https://bugs.openjdk.org/browse/JDK-8317307): test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java fails with ConnectException: Connection timed out: no further information (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2513/head:pull/2513` \
`$ git checkout pull/2513`

Update a local copy of the PR: \
`$ git checkout pull/2513` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2513`

View PR using the GUI difftool: \
`$ git pr show -t 2513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2513.diff">https://git.openjdk.org/jdk11u-dev/pull/2513.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2513#issuecomment-1931502457)