### PR TITLE
8319668: Fixup of jar filename typo in BadFactoryTest.sh

### DIFF
--- a/test/jdk/javax/script/JDK_8196959/BadFactoryTest.sh
+++ b/test/jdk/javax/script/JDK_8196959/BadFactoryTest.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -56,5 +56,5 @@ fi
 
 echo "Running test without security manager ..."
 $JAVA ${TESTVMOPTS} -classpath \
-  "${TESTCLASSES}${PS}${TESTCLASSES}/badfactoty.jar" \
+  "${TESTCLASSES}${PS}${TESTCLASSES}/badfactory.jar" \
   BadFactoryTest


### PR DESCRIPTION
Backport of [JDK-8319668](https://bugs.openjdk.org/browse/JDK-8319668)

Testing
- Local: Not applicable
  - jtreg message: Not a test or directory containing tests: `javax/script/JDK_8196959/BadFactoryTest.java`
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-02-11`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319668](https://bugs.openjdk.org/browse/JDK-8319668) needs maintainer approval

### Issue
 * [JDK-8319668](https://bugs.openjdk.org/browse/JDK-8319668): Fixup of jar filename typo in BadFactoryTest.sh (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2516/head:pull/2516` \
`$ git checkout pull/2516`

Update a local copy of the PR: \
`$ git checkout pull/2516` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2516`

View PR using the GUI difftool: \
`$ git pr show -t 2516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2516.diff">https://git.openjdk.org/jdk11u-dev/pull/2516.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2516#issuecomment-1931525218)