### PR TITLE
8161536: sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java fails with ProviderException

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -611,6 +611,8 @@ javax/net/ssl/DTLS/PacketLossRetransmission.java                8169086 macosx-x
 javax/net/ssl/DTLS/RespondToRetransmit.java                     8169086 macosx-all
 javax/net/ssl/DTLS/CipherSuite.java                             8202059 macosx-x64
 
+sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8161536 generic-all
+
 sun/security/smartcardio/TestChannel.java                       8039280 generic-all
 sun/security/smartcardio/TestConnect.java                       8039280 generic-all
 sun/security/smartcardio/TestConnectAgain.java                  8039280 generic-all

--- a/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
+++ b/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@
  * @run main/othervm -Djdk.tls.namedGroups="secp256r1,sect193r1"
  *      ClientJSSEServerJSSE
  * @run main/othervm -Djdk.tls.namedGroups="secp256r1,sect193r1"
- *      ClientJSSEServerJSSE sm policy
+ *      -Djava.security.manager=allow ClientJSSEServerJSSE sm policy
  */
 
 import java.security.Provider;

--- a/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
+++ b/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
@@ -37,7 +37,7 @@
  * @run main/othervm -Djdk.tls.namedGroups="secp256r1,sect193r1"
  *      ClientJSSEServerJSSE
  * @run main/othervm -Djdk.tls.namedGroups="secp256r1,sect193r1"
- *      -Djava.security.manager=allow ClientJSSEServerJSSE sm policy
+ *      ClientJSSEServerJSSE sm policy
  */
 
 import java.security.Provider;


### PR DESCRIPTION
Backport of [JDK-8161536](https://bugs.openjdk.org/browse/JDK-8161536)
- This PR has two commits
- Commit 1 is a clean back port of original commit
- Commit 2 is the fix for test case error `ClassNotFoundException: allow`

Testing
- Local: Passed
- Pipeline: `All checks have passed`
- Testing Machine: SAP nightlies passed on `2024-02-11` on the following environment
  - NTAMD64
  - linuxppc64le
  - linuxx86_64
  - linuxaarch64
  - darwinintel64
  - darwinaarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8161536](https://bugs.openjdk.org/browse/JDK-8161536) needs maintainer approval

### Issue
 * [JDK-8161536](https://bugs.openjdk.org/browse/JDK-8161536): sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java fails with ProviderException (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2521/head:pull/2521` \
`$ git checkout pull/2521`

Update a local copy of the PR: \
`$ git checkout pull/2521` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2521`

View PR using the GUI difftool: \
`$ git pr show -t 2521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2521.diff">https://git.openjdk.org/jdk11u-dev/pull/2521.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2521#issuecomment-1935051759)