### PR TITLE
8318603: Parallelize sun/java2d/marlin/ClipShapeTest.java

### DIFF
--- a/test/jdk/sun/java2d/marlin/ClipShapeTest.java
+++ b/test/jdk/sun/java2d/marlin/ClipShapeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,24 +52,43 @@ import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 import javax.imageio.stream.ImageOutputStream;
 
-/**
- * @test
+/*
+ * @test id=Poly
  * @bug 8191814
- * @summary Verifies that Marlin rendering generates the same
- * images with and without clipping optimization with all possible
- * stroke (cap/join) and/or dashes or fill modes (EO rules)
- * for paths made of either 9 lines, 4 quads, 2 cubics (random)
- * Note: Use the argument -slow to run more intensive tests (too much time)
- *
+ * @summary Runs the test with "-poly" option
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.MarlinRenderingEngine ClipShapeTest -poly
+ */
+
+/*
+ * @test id=PolyDoDash
+ * @bug 8191814
+ * @summary Runs the test with "-poly -doDash" options
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.MarlinRenderingEngine ClipShapeTest -poly -doDash
+ */
+
+/*
+ * @test id=Cubic
+ * @bug 8191814
+ * @summary Runs the test with "-cubic" option
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.MarlinRenderingEngine ClipShapeTest -cubic
+ */
+
+/*
+ * @test id=CubicDoDash
+ * @bug 8191814
+ * @summary Runs the test with "-cubic -doDash" options
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.MarlinRenderingEngine ClipShapeTest -cubic -doDash
- * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -poly
- * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -poly -doDash
- * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -cubic
- * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -cubic -doDash
-*/
+ */
+
+/**
+ * Verifies that Marlin rendering generates the same images with and without
+ * clipping optimization with all possible stroke (cap/join) and/or dashes or
+ * fill modes (EO rules) for paths made of either 9 lines, 4 quads, 2 cubics
+ * (random).
+ * <p>
+ * Note: Use the argument {@code -slow} to run more intensive tests (too much
+ * time).
+ */
 public final class ClipShapeTest {
 
     // test options:

--- a/test/jdk/sun/java2d/marlin/ClipShapeTest.java
+++ b/test/jdk/sun/java2d/marlin/ClipShapeTest.java
@@ -55,29 +55,57 @@ import javax.imageio.stream.ImageOutputStream;
 /*
  * @test id=Poly
  * @bug 8191814
- * @summary Runs the test with "-poly" option
+ * @summary Runs the test with "-poly" option, single-precision
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.MarlinRenderingEngine ClipShapeTest -poly
  */
 
 /*
  * @test id=PolyDoDash
  * @bug 8191814
- * @summary Runs the test with "-poly -doDash" options
+ * @summary Runs the test with "-poly -doDash" options, single-precision
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.MarlinRenderingEngine ClipShapeTest -poly -doDash
  */
 
 /*
  * @test id=Cubic
  * @bug 8191814
- * @summary Runs the test with "-cubic" option
+ * @summary Runs the test with "-cubic" option, single-precision
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.MarlinRenderingEngine ClipShapeTest -cubic
  */
 
 /*
  * @test id=CubicDoDash
  * @bug 8191814
- * @summary Runs the test with "-cubic -doDash" options
+ * @summary Runs the test with "-cubic -doDash" options, single-precision
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.MarlinRenderingEngine ClipShapeTest -cubic -doDash
+ */
+
+/*
+ * @test id=Poly
+ * @bug 8191814
+ * @summary Runs the test with "-poly" option, double-precision
+ * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -poly
+ */
+
+/*
+ * @test id=PolyDoDash
+ * @bug 8191814
+ * @summary Runs the test with "-poly -doDash" options, double-precision
+ * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -poly -doDash
+ */
+
+/*
+ * @test id=Cubic
+ * @bug 8191814
+ * @summary Runs the test with "-cubic" option, double-precision
+ * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -cubic
+ */
+
+/*
+ * @test id=CubicDoDash
+ * @bug 8191814
+ * @summary Runs the test with "-cubic -doDash" options, double-precision
+ * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -cubic -doDash
  */
 
 /**

--- a/test/jdk/sun/java2d/marlin/ClipShapeTest.java
+++ b/test/jdk/sun/java2d/marlin/ClipShapeTest.java
@@ -53,28 +53,28 @@ import javax.imageio.ImageWriter;
 import javax.imageio.stream.ImageOutputStream;
 
 /*
- * @test id=Poly
+ * @test id=PolySingle
  * @bug 8191814
  * @summary Runs the test with "-poly" option, single-precision
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.MarlinRenderingEngine ClipShapeTest -poly
  */
 
 /*
- * @test id=PolyDoDash
+ * @test id=PolyDoDashSingle
  * @bug 8191814
  * @summary Runs the test with "-poly -doDash" options, single-precision
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.MarlinRenderingEngine ClipShapeTest -poly -doDash
  */
 
 /*
- * @test id=Cubic
+ * @test id=CubicSingle
  * @bug 8191814
  * @summary Runs the test with "-cubic" option, single-precision
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.MarlinRenderingEngine ClipShapeTest -cubic
  */
 
 /*
- * @test id=CubicDoDash
+ * @test id=CubicDoDashSingle
  * @bug 8191814
  * @summary Runs the test with "-cubic -doDash" options, single-precision
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.MarlinRenderingEngine ClipShapeTest -cubic -doDash


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [6c7029ff](https://github.com/openjdk/jdk/commit/6c7029ffd48186353fc1d2a03915386b5f386ae2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 10 Feb 2024 and was reviewed by Alexey Ivanov and Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318603](https://bugs.openjdk.org/browse/JDK-8318603) needs maintainer approval

### Issue
 * [JDK-8318603](https://bugs.openjdk.org/browse/JDK-8318603): Parallelize sun/java2d/marlin/ClipShapeTest.java (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2522/head:pull/2522` \
`$ git checkout pull/2522`

Update a local copy of the PR: \
`$ git checkout pull/2522` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2522`

View PR using the GUI difftool: \
`$ git pr show -t 2522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2522.diff">https://git.openjdk.org/jdk11u-dev/pull/2522.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2522#issuecomment-1938423238)