### PR TITLE
8286705: GCC 12 reports use-after-free potential bugs

### DIFF
--- a/src/java.base/share/native/libjli/parse_manifest.c
+++ b/src/java.base/share/native/libjli/parse_manifest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -288,8 +288,8 @@ find_positions(int fd, Byte *eb, jlong* base_offset, jlong* censtart)
     for (cp = &buffer[bytes - ENDHDR]; cp >= &buffer[0]; cp--)
         if (ENDSIG_AT(cp) && (cp + ENDHDR + ENDCOM(cp) == endpos)) {
             (void) memcpy(eb, cp, ENDHDR);
-            free(buffer);
             pos = flen - (endpos - cp);
+            free(buffer);
             return find_positions64(fd, eb, pos, base_offset, censtart);
         }
     free(buffer);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [0e4bece5](https://github.com/openjdk/jdk/commit/0e4bece5b5143b8505496ea7430bbfa11e151aff) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Yasumasa Suenaga on 15 May 2022 and was reviewed by Kim Barrett.

The backport to `parse_manifest.c` applied cleanly. The patch as a whole doesn't apply cleanly as it also patches `src/jdk.jpackage/linux/native/applauncher/LinuxPackage.c` and `jpackage` is not part of 11u.

It fixes a `use-after-free` warning which prevents GCC 12+ from building 11u without `--disable-warnings-as-errors`.
   
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8286705](https://bugs.openjdk.org/browse/JDK-8286705) needs maintainer approval

### Issue
 * [JDK-8286705](https://bugs.openjdk.org/browse/JDK-8286705): GCC 12 reports use-after-free potential bugs (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2524/head:pull/2524` \
`$ git checkout pull/2524`

Update a local copy of the PR: \
`$ git checkout pull/2524` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2524`

View PR using the GUI difftool: \
`$ git pr show -t 2524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2524.diff">https://git.openjdk.org/jdk11u-dev/pull/2524.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2524#issuecomment-1950302257)