### PR TITLE
8326109: GCC 13 reports maybe-uninitialized warnings for jni.cpp with dtrace enabled

### DIFF
--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -40,6 +40,10 @@ ifeq ($(TOOLCHAIN_TYPE), gcc)
     # Need extra inlining to collapse all marking code into the hot marking loop
     BUILD_LIBJVM_shenandoahConcurrentMark.cpp_CXXFLAGS := --param inline-unit-growth=1000
   endif
+  ifeq ($(call check-jvm-feature, dtrace), true)
+    # DTRACE_PROBE macros trigger a maybe-uninitialized warning on 'ret'
+    BUILD_LIBJVM_jni.cpp_CXXFLAGS := -Wno-maybe-uninitialized
+  endif
 endif
 
 LIBJVM_FDLIBM_COPY_OPT_FLAG := $(CXX_O_FLAG_NONE)


### PR DESCRIPTION
This is a simple fix that allows newer versions of `gcc` to build OpenJDK without `--disable-warnings-as-errors` (i.e. the default)

When `dtrace` is enabled, the compilation of `jni.cpp` throws up a number of `maybe-uninitialized` warnings due to the expansion of the `DTRACE_PROBE` macros from `sdt.hpp` e.g.

~~~
In file included from /localhome/andrew/projects/openjdk/upstream/jdk11u-dev/src/hotspot/share/prims/jni.cpp:88:
In destructor 'DTraceReturnProbeMark_NewStringUTF::~DTraceReturnProbeMark_NewStringUTF()',
    inlined from '_jstring* jni_NewStringUTF(JNIEnv*, const char*)' at /localhome/andrew/projects/openjdk/upstream/jdk11u-dev/src/hotspot/share/prims/jni.cpp:2524:1:
/home/andrew/builder/11u-dev/hotspot/variant-server/gensrc/dtracefiles/hotspot_jni.h:4179:1: error: 'ret' may be used uninitialized [-Werror=maybe-uninitialized]
 4179 | DTRACE_PROBE1 (hotspot_jni, NewStringUTF__return, arg1)
      | ^~~~~~~~~~~~~
/localhome/andrew/projects/openjdk/upstream/jdk11u-dev/src/hotspot/share/utilities/dtrace.hpp:33:24: note: in definition of macro 'DTRACE_ONLY'
   33 | #define DTRACE_ONLY(x) x
      | ^
/localhome/andrew/projects/openjdk/upstream/jdk11u-dev/src/hotspot/share/prims/jni.cpp:2512:1: note: in expansion of macro 'DT_RETURN_MARK_DECL'
 2512 | DT_RETURN_MARK_DECL(NewStringUTF, jstring
      | ^~~~~~~~~~~~~~~~~~~
/localhome/andrew/projects/openjdk/upstream/jdk11u-dev/src/hotspot/share/prims/jni.cpp:2513:23: note: in expansion of macro 'HOTSPOT_JNI_NEWSTRINGUTF_RETURN'
 2513 | , HOTSPOT_JNI_NEWSTRINGUTF_RETURN(_ret_ref));
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
~~~

I don't see the same on 17u as `-Wno-maybe-uninitialized` is one of a number of warnings disabled in `CompileJvm.gmk`. This 11u only patch does the more specific fix of disabling the warning on `jni.cpp` only and only when `dtrace` is enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326109](https://bugs.openjdk.org/browse/JDK-8326109) needs maintainer approval

### Issue
 * [JDK-8326109](https://bugs.openjdk.org/browse/JDK-8326109): GCC 13 reports maybe-uninitialized warnings for jni.cpp with dtrace enabled (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2525/head:pull/2525` \
`$ git checkout pull/2525`

Update a local copy of the PR: \
`$ git checkout pull/2525` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2525`

View PR using the GUI difftool: \
`$ git pr show -t 2525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2525.diff">https://git.openjdk.org/jdk11u-dev/pull/2525.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2525#issuecomment-1950396378)