### PR TITLE
8306640: Open source several AWT TextArea related tests

### DIFF
--- a/test/jdk/java/awt/TextArea/ReplaceRangeTest.java
+++ b/test/jdk/java/awt/TextArea/ReplaceRangeTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 5025532
+  @requires (os.family == "windows")
+  @summary Tests that textarea replaces text correctly if the text contains
+   line separators
+  @key headful
+*/
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.TextArea;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class ReplaceRangeTest {
+    static Frame f;
+
+    public static void main(String[] args) throws InterruptedException, InvocationTargetException {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                f = new Frame("Test frame");
+                f.setSize(400, 400);
+                f.setLayout(new GridLayout(3, 1));
+
+                TextArea textArea1 = new TextArea(5, 80);
+                TextArea textArea2 = new TextArea(5, 80);
+                TextArea textArea3 = new TextArea(5, 80);
+                f.add(textArea1);
+                f.add(textArea2);
+                f.add(textArea3);
+                f.setVisible(true);
+
+                textArea1.setText("01234");
+                textArea1.replaceRange("X", 3, 4);
+                textArea2.setText("0\r\n234");
+                textArea2.replaceRange("X", 3, 4);
+                textArea3.setText("0\n\n34");
+                textArea3.replaceRange("X", 3, 4);
+
+                if (textArea1.getText().equals("012X4") &&
+                        textArea2.getText().equals("0\r\n2X4") &&
+                        textArea3.getText().equals("0\n\nX4")) {
+                    System.out.println("Test Pass");
+                    return;
+                } else {
+                    throw new RuntimeException("Test FAILED");
+                }
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/TextArea/TextAreaCRLFAutoDetectTest.java
+++ b/test/jdk/java/awt/TextArea/TextAreaCRLFAutoDetectTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 4800187
+  @requires (os.family == "windows")
+  @summary REGRESSION:show the wrong selection when there are \r characters in the text
+  @key headful
+*/
+
+import java.awt.Button;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.IllegalComponentStateException;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextArea;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class TextAreaCRLFAutoDetectTest {
+    Frame f;
+    TextArea ta1;
+    TextArea ta2;
+    Button b;
+    boolean passed = true;
+    boolean crlf = true;
+
+    public static void main(String[] args) throws Exception {
+        TextAreaCRLFAutoDetectTest crlfAutoDetectTest = new TextAreaCRLFAutoDetectTest();
+        crlfAutoDetectTest.init();
+        crlfAutoDetectTest.start();
+    }
+
+    public void init() throws InterruptedException, InvocationTargetException {
+        EventQueue.invokeAndWait(() -> {
+            f = new Frame("TextAreaCRLFAutoDetectTest");
+            ta1 = new TextArea(5, 20);
+            ta2 = new TextArea(5, 20);
+            b = new Button("Click Me");
+            b.addActionListener(new ActionListener() {
+                public void actionPerformed(ActionEvent evt) {
+                    ta1.setText("");
+                    ta2.setText("");
+                    System.out.println("--------------------------------");
+
+                    String eoln = (crlf) ? "\r\n" : "\n";
+                    String s = eoln + "123" + eoln + "567" + eoln + "90" + eoln;
+                    printString("            s=", s);
+                    ta1.setText(s);
+                    printString("ta1.getText()=", ta1.getText());
+
+                    s = "67" + eoln + "9";
+                    ta1.select(6, 10);
+
+                    String s1 = ta1.getSelectedText();
+                    printString("ta1.getSelectedText()=", s1);
+                    passed = passed && s.equals(s1);
+
+                    ta2.setText(s1);
+                    printString("        ta2.getText()=", s1);
+                    passed = passed && s1.equals(ta2.getText());
+
+                    crlf = false;
+                }
+            });
+
+            f.setLayout(new FlowLayout());
+            f.add(ta1);
+            f.add(ta2);
+            f.add(b);
+            f.setLocation(300, 50);
+            f.pack();
+            f.setVisible(true);
+        });
+    }
+
+    public void start() throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(50);
+            robot.waitForIdle();
+
+            Point pt = new Point(0, 0);
+
+            boolean drawn = false;
+            while (!drawn) {
+                try {
+                    pt = b.getLocationOnScreen();
+                } catch (IllegalComponentStateException icse) {
+                    Thread.sleep(50);
+                    continue;
+                }
+                drawn = true;
+            }
+
+            for (int i = 0; i < 2; i++) {
+                pt = b.getLocationOnScreen();
+                robot.mouseMove(pt.x + b.getWidth() / 2,
+                        pt.y + b.getHeight() / 2);
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+                Thread.sleep(250);
+            }
+            if (!passed) {
+                throw new RuntimeException("TextAreaCRLFAutoDetectTest FAILED.");
+            } else {
+                System.out.println("TextAreaCRLFAutoDetectTest PASSED");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("The test was not completed.\n\n" + e);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    void printString(String t, String s) {
+        byte b[] = s.getBytes();
+        String o = t;
+        for (int i = 0; i < b.length; i++) {
+            o += Byte.toString(b[i]) + " ";
+        }
+        System.out.println(o);
+    }
+}

--- a/test/jdk/java/awt/TextArea/TextLengthTest.java
+++ b/test/jdk/java/awt/TextArea/TextLengthTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4072264
+  @summary REGRESSION:Test to verify getSelectedText,
+  getSelectedStart/End in TextArea class
+  @key headful
+*/
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.TextArea;
+
+public class TextLengthTest {
+    static final int MY_SIZE = 100;
+    static final int MY_START = 13;
+    static final int MY_END = 47;
+    TextArea ta;
+    Frame f;
+    int mySize;
+    int myStart;
+    int myEnd;
+
+    public static void main(String[] args) throws Exception {
+        TextLengthTest textLengthTest = new TextLengthTest();
+        textLengthTest.init();
+        textLengthTest.start();
+    }
+
+    public void init() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            f = new Frame("TextLengthTest");
+            ta = new TextArea(15, 30);
+            f.add(ta);
+            f.setSize(400, 400);
+            f.setVisible(true);
+        });
+    }
+
+    public void start() throws Exception {
+        try {
+            Robot r = new Robot();
+            r.delay(1000);
+            r.waitForIdle();
+            EventQueue.invokeAndWait(() -> {
+                StringBuffer bigStringBuffer = new StringBuffer();
+
+                for (int i = 1; i <= 10; i++) {
+                    bigStringBuffer.append("abcdefghi\n");
+                }
+
+                ta.setText(bigStringBuffer.toString());
+
+                mySize = bigStringBuffer.toString().length();
+                System.out.println("String size = " + mySize);
+
+                if (mySize != MY_SIZE) {
+                    throw new Error("The string size is " +
+                            mySize + "but it should be " + MY_SIZE);
+                }
+
+                ta.select(MY_START, MY_END);
+
+                String str = new String(ta.getSelectedText());
+                str = str.toUpperCase();
+
+                myStart = ta.getSelectionStart();
+                myEnd = ta.getSelectionEnd();
+                System.out.println("Selected string start = " + myStart);
+                System.out.println("Selected string end = " + myEnd);
+
+                if (myStart != MY_START) {
+                    throw new Error("The selected text starts at " +
+                            mySize + "but it should start at " + MY_START);
+                }
+
+                if (myEnd != MY_END) {
+                    throw new Error("The selected text ends at " +
+                            myEnd + "but it should end at " + MY_END);
+                }
+
+                ta.replaceRange(str, myStart, myEnd);
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+        System.out.println("Test Pass");
+    }
+}

--- a/test/jdk/java/awt/TextArea/TextLimitTest.java
+++ b/test/jdk/java/awt/TextArea/TextLimitTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+  @test
+  @bug 4260109
+  @summary tests that the text limit is set to the maximum possible value
+  @key headful
+*/
+
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.TextArea;
+
+public class TextLimitTest {
+    static Frame frame;
+    static TextArea textarea;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                StringBuffer buffer = new StringBuffer();
+                frame = new Frame("Text Limit Test");
+                textarea = new TextArea(3, 10);
+                frame.setLayout(new BorderLayout());
+                frame.add(textarea);
+                frame.setSize(200, 200);
+                frame.pack();
+                frame.setVisible(true);
+
+                /*
+                 * The magic number 0xF700 was choosen because of the two reasons:
+                 *  - it shouldn't be greater since on win95 (even in native win32 apps)
+                 *    adding more than 0xF800 symbols to a textarea doesn't always work,
+                 *  - it shouldn't be less since in this case we won't run in the stack
+                 *    overflow on Win95 even if we use W2A allocating memory on the stack.
+                 */
+                for (int i = 0; i < 0xF700; i += 0x10) {
+                    buffer.append("0123456789abcdef");
+                }
+
+                textarea.setText(buffer.toString());
+                System.out.println("Text length before append: " +
+                        Integer.toString(textarea.getText().length(), 16));
+
+                textarea.append("0123456789abcdef");
+
+                int len = textarea.getText().length();
+                System.out.println("Text length after append: " +
+                        Integer.toString(len, 16));
+                if (len != 0xF710) {
+                    throw new RuntimeException("Test failed: textarea has " +
+                            "wrong text limit!");
+                }
+            });
+            System.out.println("Test pass");
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
I backport this for JDK-8306640.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8306640](https://bugs.openjdk.org/browse/JDK-8306640) needs maintainer approval

### Issue
 * [JDK-8306640](https://bugs.openjdk.org/browse/JDK-8306640): Open source several AWT TextArea related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2527/head:pull/2527` \
`$ git checkout pull/2527`

Update a local copy of the PR: \
`$ git checkout pull/2527` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2527`

View PR using the GUI difftool: \
`$ git pr show -t 2527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2527.diff">https://git.openjdk.org/jdk11u-dev/pull/2527.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2527#issuecomment-1951777078)