### PR TITLE
8306755: Open source few Swing JComponent and AbstractButton tests

### DIFF
--- a/test/jdk/javax/swing/AbstractButton/bug4143867.java
+++ b/test/jdk/javax/swing/AbstractButton/bug4143867.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4143867 4237390 4383709
+   @summary Tests set/getAction(.) and some constructors with Action argument
+   @key headful
+   @run main bug4143867
+*/
+
+import javax.swing.AbstractAction;
+import javax.swing.AbstractButton;
+import javax.swing.Action;
+import javax.swing.DefaultButtonModel;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JFrame;
+import javax.swing.JToggleButton;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JRadioButton;
+import javax.swing.JRadioButtonMenuItem;
+import javax.swing.SwingUtilities;
+import java.awt.FlowLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.beans.PropertyChangeListener;
+
+public class bug4143867 {
+    static final int TEST_MNEMONIC = KeyEvent.VK_1;
+    static JFrame fr;
+
+    public static void main(String[] argv) throws Exception {
+        bug4143867 b = new bug4143867();
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                b.doInitAndTest();
+            } finally {
+                if (fr != null) {
+                    fr.dispose();
+                }
+            }
+        });
+    }
+
+    public void doInitAndTest() {
+        fr = new JFrame("bug4143867");
+        JMenuBar mb = new JMenuBar();
+        JMenu m = mb.add(new JMenu("Menu1"));
+        fr.setJMenuBar(mb);
+        JMenuItem it1 = m.add(new JMenuItem("Item1"));
+        fr.getContentPane().setLayout(new FlowLayout());
+        JButton bt1 = new JButton("Button1");
+        fr.getContentPane().add(bt1);
+
+        final AbstractAction al = new AbstractAction() {
+            public void actionPerformed(ActionEvent e) {
+              System.out.println("Pressed...");
+            }
+        };
+        al.putValue(Action.NAME, "Action");
+        al.putValue(Action.MNEMONIC_KEY, new Integer(TEST_MNEMONIC));
+        m.add(al);
+        m.getItem(0).setAction(al);
+        bt1.setAction(al);
+        JButton bt2 = new JButton(al);
+        fr.getContentPane().add(bt2);
+        if (it1.getAction() != al || m.getItem(1).getAction() != al ||
+            bt1.getAction() != al || bt2.getAction() != al) {
+            throw new RuntimeException("Action was not set correctly.");
+        }
+
+        if (bt1.getMnemonic() != TEST_MNEMONIC) {
+            throw new RuntimeException("Failed 4383709: JButton doesn't get mnemonic from Action");
+        }
+
+        class TestProtectedOfAbstractButton extends AbstractButton {
+            public void test() {
+                PropertyChangeListener pcl = createActionPropertyChangeListener(null);
+                setModel(new DefaultButtonModel());
+                configurePropertiesFromAction(al);
+            }
+        }
+        TestProtectedOfAbstractButton tpAB = new TestProtectedOfAbstractButton();
+        tpAB.test();
+
+        //  Constructors presence test
+        JRadioButton ct1         = new JRadioButton(al);
+        JCheckBox ct2            = new JCheckBox(al);
+        JRadioButton ct3         = new JRadioButton(al);
+        JToggleButton ct4        = new JToggleButton(al);
+        JMenuItem ct5            = new JMenuItem(al);
+        JMenu ct6                = new JMenu(al);
+        JCheckBoxMenuItem ct7    = new JCheckBoxMenuItem(al);
+        JRadioButtonMenuItem ct8 = new JRadioButtonMenuItem(al);
+        if (ct1.getAction() != al) {
+            throw new RuntimeException("Constructor error in JRadioButton...");
+        }
+        if (ct2.getAction() != al) {
+            throw new RuntimeException("Constructor error in JCheckBox...");
+        }
+        if (ct3.getAction() != al) {
+            throw new RuntimeException("Constructor error in JRadioButton...");
+        }
+        if (ct4.getAction() != al) {
+            throw new RuntimeException("Constructor error in JToggleButton...");
+        }
+        if (ct5.getAction() != al) {
+            throw new RuntimeException("Constructor error in JMenuItem...");
+        }
+        if (ct6.getAction() != al) {
+            throw new RuntimeException("Constructor error in JMenu...");
+        }
+        if (ct7.getAction() != al) {
+            throw new RuntimeException("Constructor error in JCheckBoxMenuItem...");
+        }
+        if (ct8.getAction() != al) {
+            throw new RuntimeException("Constructor error in JRadioButtonMenuItem...");
+        }
+    }
+}

--- a/test/jdk/javax/swing/AbstractButton/bug4147740.java
+++ b/test/jdk/javax/swing/AbstractButton/bug4147740.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4147740
+   @summary Tests that AbstractButton does not update images it doesn't use
+   @key headful
+   @run main bug4147740
+*/
+
+import java.awt.Image;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.ImageIcon;
+import java.awt.Robot;
+import javax.swing.SwingUtilities;
+import java.awt.event.HierarchyEvent;
+import java.awt.event.HierarchyListener;
+
+public class bug4147740 {
+
+    static JButton b;
+    static JFrame frame;
+    static volatile boolean imageUpdated = false;
+    static volatile boolean shouldUpdate = true;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("bug4147740");
+                b = new AnimatedButton();
+                frame.getContentPane().add(b);
+                b.addHierarchyListener(new Listener());
+                frame.setSize(200, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    static class Listener implements HierarchyListener {
+        public void hierarchyChanged(HierarchyEvent ev) {
+            if ((ev.getChangeFlags() | HierarchyEvent.SHOWING_CHANGED) != 0 &&
+                frame.isShowing()) {
+
+                frame.repaint();
+                SwingUtilities.invokeLater(new Runnable() {
+                    public void run() {
+                        synchronized(b) {
+                            b.setEnabled(false);
+                            shouldUpdate = false;
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    static class AnimatedButton extends JButton {
+        boolean shouldNotUpdate = false;
+
+        AnimatedButton() {
+            super();
+            setIcon(new ImageIcon("animated.gif"));
+            setDisabledIcon(new ImageIcon("static.gif"));
+        }
+
+        public boolean imageUpdate(Image img, int infoflags,
+                                   int x, int y, int w, int h) {
+            boolean updated;
+            synchronized(b) {
+                updated = super.imageUpdate(img, infoflags, x, y, w, h);
+                if (!shouldUpdate && updated) {
+                    throw new RuntimeException("Failed: unused image is being updated");
+                }
+            }
+            return updated;
+        }
+    }
+}

--- a/test/jdk/javax/swing/AbstractButton/bug4246045.java
+++ b/test/jdk/javax/swing/AbstractButton/bug4246045.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4246045
+   @summary AbstractButton fires accessible PropertyChangeEvent incorrectly
+   @key headful
+   @run main bug4246045
+*/
+
+import java.awt.Container;
+import java.awt.Robot;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+import javax.swing.JToggleButton;
+import javax.swing.SwingUtilities;
+import javax.accessibility.AccessibleContext;
+import javax.accessibility.AccessibleState;
+
+public class bug4246045 {
+
+    class Listener implements PropertyChangeListener {
+        boolean state = false; // focused or not
+
+        public void propertyChange(PropertyChangeEvent e) {
+            if (e.getPropertyName().equals(
+                  AccessibleContext.ACCESSIBLE_STATE_PROPERTY)) {
+
+                boolean reported = false;
+                if (e.getNewValue() == null) {
+                    reported = false;
+                } else if (e.getNewValue().equals(AccessibleState.FOCUSED)) {
+                    reported = true;
+                } else {
+                    throw new RuntimeException("Unknown value of ACCESSIBLE_STATE_PROPERTY");
+                }
+
+                if (!state == reported) {
+                    state = reported;
+                } else {
+                    throw new RuntimeException("Bad value of ACCESSIBLE_STATE_PROPERTY");
+                }
+            }
+        }
+    }
+
+    static JFrame frame;
+    static JButton btn;
+    static JToggleButton tb;
+    static JTextField dummy;
+
+    public void init() {
+        btn = new JButton("JButton");
+        tb = new JToggleButton("JToggleButton");
+        dummy = new JTextField();
+        Container pane = frame.getContentPane();
+        pane.setLayout(new BoxLayout(pane, BoxLayout.Y_AXIS));
+        pane.add(btn);
+        pane.add(tb);
+        pane.add(dummy);
+
+        Listener bl = new Listener();
+        btn.getAccessibleContext().addPropertyChangeListener(bl);
+        Listener tbl = new Listener();
+        tb.getAccessibleContext().addPropertyChangeListener(tbl);
+    }
+
+    public void start() {
+        btn.requestFocus();
+        btn.transferFocus();
+        tb.transferFocus();
+    }
+
+    public static void main(String[] argv) throws Exception {
+        Robot robot = new Robot();
+        bug4246045 bug = new bug4246045();
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("4246045 Test");
+                bug.init();
+                frame.setSize(200, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+                bug.start();
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JComponent/bug4419219.java
+++ b/test/jdk/javax/swing/JComponent/bug4419219.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4419219
+   @summary Tests that registerKeyboardAction(null, ...) doen't throw NPE.
+   @key headful
+   @run main bug4419219
+*/
+
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import javax.swing.KeyStroke;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+
+public class bug4419219 {
+    static volatile boolean passed = true;
+    static JFrame frame;
+    static Robot robo;
+
+    public static void main(String[] args) throws Exception {
+        robo = new Robot();
+        robo.setAutoWaitForIdle(true);
+        robo.setAutoDelay(100);
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                frame = new JFrame("bug4419219 Table");
+
+                final String[] names = {"col"};
+                final Object[][] data = {{"A"}, {"B"}, {"C"}, {"D"}, {"E"}};
+
+                JTable tableView = (JTable)new TestTable(data, names);
+                // unregister ctrl-A
+                tableView.registerKeyboardAction(null,
+                     KeyStroke.getKeyStroke(KeyEvent.VK_A, ActionEvent.CTRL_MASK),
+                     JComponent.WHEN_FOCUSED);
+
+                frame.getContentPane().add(tableView);
+                frame.setSize(250,250);
+                frame.setLocationRelativeTo(null);
+                frame.addWindowListener(new TestStateListener());
+                frame.setVisible(true);
+            } finally {
+                if (frame != null) {
+                    frame.dispose();
+                }
+           }
+        });
+        if (!passed) {
+            throw new RuntimeException("Test failed.");
+        }
+    }
+
+    static class TestStateListener extends WindowAdapter {
+        public void windowOpened(WindowEvent ev) {
+            robo.delay(1000);
+            robo.mouseMove(100,100);
+            robo.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robo.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robo.keyPress(KeyEvent.VK_CONTROL);
+            robo.keyPress(KeyEvent.VK_A);
+            robo.keyRelease(KeyEvent.VK_A);
+            robo.keyRelease(KeyEvent.VK_CONTROL);
+        }
+    }
+
+    static class TestTable extends JTable {
+
+        public TestTable(Object[][] data, String[] names) {
+            super(data, names);
+        }
+
+        protected  boolean processKeyBinding(KeyStroke ks,
+                                             KeyEvent e,
+                                             int condition,
+                                             boolean pressed) {
+            try {
+                return super.processKeyBinding(ks, e, condition, pressed);
+            } catch (NullPointerException ex) {
+                passed = false;
+            }
+            return false;
+        }
+    }
+}

--- a/test/jdk/javax/swing/JComponent/bug4962718.java
+++ b/test/jdk/javax/swing/JComponent/bug4962718.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4962718
+ * @summary Propertychange Listener not fired by inheritPopupMenu and Popupmenu properties
+ * @key headful
+ * @run main bug4962718
+*/
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+public class bug4962718 {
+    static volatile boolean popupWasSet = false;
+    static volatile boolean inheritWasSet = false;
+    static JFrame frame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("bug4962718");
+                JButton button = new JButton("For test");
+                JPopupMenu popup = new JPopupMenu();
+
+                button.addPropertyChangeListener(new PropertyChangeListener() {
+                    public void propertyChange(PropertyChangeEvent evt) {
+                        if (evt.getPropertyName().equals("inheritsPopupMenu")) {
+                            inheritWasSet = true;
+                        } else if( evt.getPropertyName().
+                                  equals("componentPopupMenu")) {
+                            popupWasSet = true;
+                        }
+                    }
+                });
+
+                frame.add(button);
+                button.setInheritsPopupMenu(true);
+                button.setInheritsPopupMenu(false);
+                button.setComponentPopupMenu(popup);
+                button.setComponentPopupMenu(null);
+                frame.pack();
+                frame.setVisible(true);
+            });
+
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {}
+
+            if (!inheritWasSet) {
+                throw new RuntimeException("Test failed, inheritsPopupMenu " +
+                                   " property change listener was not called");
+            }
+            if (!popupWasSet) {
+                throw new RuntimeException("Test failed, componentPopupMenu " +
+                                    " property change listener was not called");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}
+


### PR DESCRIPTION
I backport this for JDK-8306755

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8306755](https://bugs.openjdk.org/browse/JDK-8306755) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306755](https://bugs.openjdk.org/browse/JDK-8306755): Open source few Swing JComponent and AbstractButton tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2529/head:pull/2529` \
`$ git checkout pull/2529`

Update a local copy of the PR: \
`$ git checkout pull/2529` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2529`

View PR using the GUI difftool: \
`$ git pr show -t 2529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2529.diff">https://git.openjdk.org/jdk11u-dev/pull/2529.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2529#issuecomment-1951789483)