### PR TITLE
8306408: Fix the format of several tables in building.md

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -175,26 +175,26 @@
 <table>
 <thead>
 <tr class="header">
-<th style="text-align: left;">Operating system</th>
-<th style="text-align: left;">Vendor/version used</th>
+<th>Operating system</th>
+<th>Vendor/version used</th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td style="text-align: left;">Linux</td>
-<td style="text-align: left;">Oracle Enterprise Linux 6.4 / 7.1 (using kernel 3.8.13)</td>
+<td>Linux</td>
+<td>Oracle Enterprise Linux 6.4 / 7.1 (using kernel 3.8.13)</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">Solaris</td>
-<td style="text-align: left;">Solaris 11.1 SRU 21.4.1 / 11.2 SRU 5.5</td>
+<td>Solaris</td>
+<td>Solaris 11.1 SRU 21.4.1 / 11.2 SRU 5.5</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">macOS</td>
-<td style="text-align: left;">Mac OS X 10.9 (Mavericks) / 10.10 (Yosemite)</td>
+<td>macOS</td>
+<td>Mac OS X 10.9 (Mavericks) / 10.10 (Yosemite)</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">Windows</td>
-<td style="text-align: left;">Windows Server 2012 R2</td>
+<td>Windows</td>
+<td>Windows Server 2012 R2</td>
 </tr>
 </tbody>
 </table>
@@ -296,7 +296,6 @@
 </tr>
 </tbody>
 </table>
-<p>All compilers are expected to be able to compile to the C99 language standard, as some C99 features are used in the source code. Microsoft Visual Studio doesn't fully support C99 so in practice shared code is limited to using C99 features that it does support.</p>
 <h3 id="gcc">gcc</h3>
 <p>The minimum accepted version of gcc is 4.8. Older versions will generate a warning by <code>configure</code> and are unlikely to work.</p>
 <p>The JDK is currently known to be able to compile with at least version 7.4 of gcc.</p>
@@ -320,50 +319,50 @@
 <table>
 <thead>
 <tr class="header">
-<th style="text-align: left;">Package</th>
-<th style="text-align: left;">Version</th>
+<th>Package</th>
+<th>Version</th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td style="text-align: left;">developer/solarisstudio-124/backend</td>
-<td style="text-align: left;">12.4-1.0.6.0</td>
+<td>developer/solarisstudio-124/backend</td>
+<td>12.4-1.0.6.0</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">developer/solarisstudio-124/c++</td>
-<td style="text-align: left;">12.4-1.0.10.0</td>
+<td>developer/solarisstudio-124/c++</td>
+<td>12.4-1.0.10.0</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">developer/solarisstudio-124/cc</td>
-<td style="text-align: left;">12.4-1.0.4.0</td>
+<td>developer/solarisstudio-124/cc</td>
+<td>12.4-1.0.4.0</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">developer/solarisstudio-124/library/c++-libs</td>
-<td style="text-align: left;">12.4-1.0.10.0</td>
+<td>developer/solarisstudio-124/library/c++-libs</td>
+<td>12.4-1.0.10.0</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">developer/solarisstudio-124/library/math-libs</td>
-<td style="text-align: left;">12.4-1.0.0.1</td>
+<td>developer/solarisstudio-124/library/math-libs</td>
+<td>12.4-1.0.0.1</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">developer/solarisstudio-124/library/studio-gccrt</td>
-<td style="text-align: left;">12.4-1.0.0.1</td>
+<td>developer/solarisstudio-124/library/studio-gccrt</td>
+<td>12.4-1.0.0.1</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">developer/solarisstudio-124/studio-common</td>
-<td style="text-align: left;">12.4-1.0.0.1</td>
+<td>developer/solarisstudio-124/studio-common</td>
+<td>12.4-1.0.0.1</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">developer/solarisstudio-124/studio-ja</td>
-<td style="text-align: left;">12.4-1.0.0.1</td>
+<td>developer/solarisstudio-124/studio-ja</td>
+<td>12.4-1.0.0.1</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">developer/solarisstudio-124/studio-legal</td>
-<td style="text-align: left;">12.4-1.0.0.1</td>
+<td>developer/solarisstudio-124/studio-legal</td>
+<td>12.4-1.0.0.1</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">developer/solarisstudio-124/studio-zhCN</td>
-<td style="text-align: left;">12.4-1.0.0.1</td>
+<td>developer/solarisstudio-124/studio-zhCN</td>
+<td>12.4-1.0.0.1</td>
 </tr>
 </tbody>
 </table>
@@ -747,103 +746,103 @@ ls build/linux-aarch64-normal-server-release/</code></pre></li>
 <table>
 <thead>
 <tr class="header">
-<th style="text-align: left;">Target</th>
-<th style="text-align: left;">Debian tree</th>
-<th style="text-align: left;">Debian arch</th>
-<th style="text-align: left;"><code>--openjdk-target=...</code></th>
+<th>Target</th>
+<th>Debian tree</th>
+<th>Debian arch</th>
+<th><code>--openjdk-target=...</code></th>
 <th><code>--with-jvm-variants=...</code></th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td style="text-align: left;">x86</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">i386</td>
-<td style="text-align: left;">i386-linux-gnu</td>
+<td>x86</td>
+<td>buster</td>
+<td>i386</td>
+<td>i386-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">arm</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">armhf</td>
-<td style="text-align: left;">arm-linux-gnueabihf</td>
+<td>arm</td>
+<td>buster</td>
+<td>armhf</td>
+<td>arm-linux-gnueabihf</td>
 <td>(all)</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">aarch64</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">arm64</td>
-<td style="text-align: left;">aarch64-linux-gnu</td>
+<td>aarch64</td>
+<td>buster</td>
+<td>arm64</td>
+<td>aarch64-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">ppc64le</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">ppc64el</td>
-<td style="text-align: left;">powerpc64le-linux-gnu</td>
+<td>ppc64le</td>
+<td>buster</td>
+<td>ppc64el</td>
+<td>powerpc64le-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">s390x</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">s390x</td>
-<td style="text-align: left;">s390x-linux-gnu</td>
+<td>s390x</td>
+<td>buster</td>
+<td>s390x</td>
+<td>s390x-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">mipsle</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">mipsel</td>
-<td style="text-align: left;">mipsel-linux-gnu</td>
+<td>mipsle</td>
+<td>buster</td>
+<td>mipsel</td>
+<td>mipsel-linux-gnu</td>
 <td>zero</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">mips64le</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">mips64el</td>
-<td style="text-align: left;">mips64el-linux-gnueabi64</td>
+<td>mips64le</td>
+<td>buster</td>
+<td>mips64el</td>
+<td>mips64el-linux-gnueabi64</td>
 <td>zero</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">armel</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">arm</td>
-<td style="text-align: left;">arm-linux-gnueabi</td>
+<td>armel</td>
+<td>buster</td>
+<td>arm</td>
+<td>arm-linux-gnueabi</td>
 <td>zero</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">ppc</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">powerpc</td>
-<td style="text-align: left;">powerpc-linux-gnu</td>
+<td>ppc</td>
+<td>sid</td>
+<td>powerpc</td>
+<td>powerpc-linux-gnu</td>
 <td>zero</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">ppc64be</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">ppc64</td>
-<td style="text-align: left;">powerpc64-linux-gnu</td>
+<td>ppc64be</td>
+<td>sid</td>
+<td>ppc64</td>
+<td>powerpc64-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">m68k</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">m68k</td>
-<td style="text-align: left;">m68k-linux-gnu</td>
+<td>m68k</td>
+<td>sid</td>
+<td>m68k</td>
+<td>m68k-linux-gnu</td>
 <td>zero</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">alpha</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">alpha</td>
-<td style="text-align: left;">alpha-linux-gnu</td>
+<td>alpha</td>
+<td>sid</td>
+<td>alpha</td>
+<td>alpha-linux-gnu</td>
 <td>zero</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">sh4</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">sh4</td>
-<td style="text-align: left;">sh4-linux-gnu</td>
+<td>sh4</td>
+<td>sid</td>
+<td>sh4</td>
+<td>sh4-linux-gnu</td>
 <td>zero</td>
 </tr>
 </tbody>

--- a/doc/building.md
+++ b/doc/building.md
@@ -151,12 +151,12 @@ This table lists the OS versions used by Oracle when building the JDK. Such
 information is always subject to change, but this table is up to date at the
 time of writing.
 
- Operating system   Vendor/version used
- -----------------  -------------------------------------------------------
- Linux              Oracle Enterprise Linux 6.4 / 7.1 (using kernel 3.8.13)
- Solaris            Solaris 11.1 SRU 21.4.1 / 11.2 SRU 5.5
- macOS              Mac OS X 10.9 (Mavericks) / 10.10 (Yosemite)
- Windows            Windows Server 2012 R2
+| Operating system  | Vendor/version used                                     |
+| ----------------- | ------------------------------------------------------- |
+| Linux             | Oracle Enterprise Linux 6.4 / 7.1 (using kernel 3.8.13) |
+| Solaris           | Solaris 11.1 SRU 21.4.1 / 11.2 SRU 5.5                  |
+| macOS             | Mac OS X 10.9 (Mavericks) / 10.10 (Yosemite)            |
+| Windows           | Windows Server 2012 R2                                  |
 
 The double version numbers for Linux, Solaris and macOS is due to the hybrid
 model used at Oracle, where header files and external libraries from an older
@@ -363,18 +363,18 @@ configure.
 
 The Solaris Studio installation should contain at least these packages:
 
- Package                                            Version
- -------------------------------------------------- -------------
- developer/solarisstudio-124/backend                12.4-1.0.6.0
- developer/solarisstudio-124/c++                    12.4-1.0.10.0
- developer/solarisstudio-124/cc                     12.4-1.0.4.0
- developer/solarisstudio-124/library/c++-libs       12.4-1.0.10.0
- developer/solarisstudio-124/library/math-libs      12.4-1.0.0.1
- developer/solarisstudio-124/library/studio-gccrt   12.4-1.0.0.1
- developer/solarisstudio-124/studio-common          12.4-1.0.0.1
- developer/solarisstudio-124/studio-ja              12.4-1.0.0.1
- developer/solarisstudio-124/studio-legal           12.4-1.0.0.1
- developer/solarisstudio-124/studio-zhCN            12.4-1.0.0.1
+| Package                                            | Version       |
+| -------------------------------------------------- | ------------- |
+| developer/solarisstudio-124/backend                | 12.4-1.0.6.0  |
+| developer/solarisstudio-124/c++                    | 12.4-1.0.10.0 |
+| developer/solarisstudio-124/cc                     | 12.4-1.0.4.0  |
+| developer/solarisstudio-124/library/c++-libs       | 12.4-1.0.10.0 |
+| developer/solarisstudio-124/library/math-libs      | 12.4-1.0.0.1  |
+| developer/solarisstudio-124/library/studio-gccrt   | 12.4-1.0.0.1  |
+| developer/solarisstudio-124/studio-common          | 12.4-1.0.0.1  |
+| developer/solarisstudio-124/studio-ja              | 12.4-1.0.0.1  |
+| developer/solarisstudio-124/studio-legal           | 12.4-1.0.0.1  |
+| developer/solarisstudio-124/studio-zhCN            | 12.4-1.0.0.1  |
 
 Compiling with Solaris Studio can sometimes be finicky. This is the exact
 version used by Oracle, which worked correctly at the time of writing:
@@ -965,14 +965,14 @@ https://sourceware.org/autobook/autobook/autobook_17.html). If no
 targets are given, a native toolchain for the current platform will be
 created. Currently, at least the following targets are known to work:
 
- Supported devkit targets
- ------------------------
- x86_64-linux-gnu
- aarch64-linux-gnu
- arm-linux-gnueabihf
- ppc64-linux-gnu
- ppc64le-linux-gnu
- s390x-linux-gnu
+| Supported devkit targets |
+| ------------------------ |
+| x86_64-linux-gnu         |
+| aarch64-linux-gnu        |
+| arm-linux-gnueabihf      |
+| ppc64-linux-gnu          |
+| ppc64le-linux-gnu        |
+| s390x-linux-gnu          |
 
 `BASE_OS` must be one of "OEL6" for Oracle Enterprise Linux 6 or
 "Fedora" (if not specified "OEL6" will be the default). If the base OS
@@ -1199,21 +1199,21 @@ it might require a little nudge with:
 
 Architectures that are known to successfully cross-compile like this are:
 
-  Target        Debian tree  Debian arch   `--openjdk-target=...`   `--with-jvm-variants=...`
-  ------------  ------------ ------------- ------------------------ --------------
-  x86           buster       i386          i386-linux-gnu           (all)
-  arm           buster       armhf         arm-linux-gnueabihf      (all)
-  aarch64       buster       arm64         aarch64-linux-gnu        (all)
-  ppc64le       buster       ppc64el       powerpc64le-linux-gnu    (all)
-  s390x         buster       s390x         s390x-linux-gnu          (all)
-  mipsle        buster       mipsel        mipsel-linux-gnu         zero
-  mips64le      buster       mips64el      mips64el-linux-gnueabi64 zero
-  armel         buster       arm           arm-linux-gnueabi        zero
-  ppc           sid          powerpc       powerpc-linux-gnu        zero
-  ppc64be       sid          ppc64         powerpc64-linux-gnu      (all)
-  m68k          sid          m68k          m68k-linux-gnu           zero
-  alpha         sid          alpha         alpha-linux-gnu          zero
-  sh4           sid          sh4           sh4-linux-gnu            zero
+| Target       | Debian tree  | Debian arch   | `--openjdk-target=...`   | `--with-jvm-variants=...` |
+| ------------ | ------------ | ------------- | ------------------------ | ------------------------- |
+| x86          | buster       | i386          | i386-linux-gnu           | (all)                     |
+| arm          | buster       | armhf         | arm-linux-gnueabihf      | (all)                     |
+| aarch64      | buster       | arm64         | aarch64-linux-gnu        | (all)                     |
+| ppc64le      | buster       | ppc64el       | powerpc64le-linux-gnu    | (all)                     |
+| s390x        | buster       | s390x         | s390x-linux-gnu          | (all)                     |
+| mipsle       | buster       | mipsel        | mipsel-linux-gnu         | zero                      |
+| mips64le     | buster       | mips64el      | mips64el-linux-gnueabi64 | zero                      |
+| armel        | buster       | arm           | arm-linux-gnueabi        | zero                      |
+| ppc          | sid          | powerpc       | powerpc-linux-gnu        | zero                      |
+| ppc64be      | sid          | ppc64         | powerpc64-linux-gnu      | (all)                     |
+| m68k         | sid          | m68k          | m68k-linux-gnu           | zero                      |
+| alpha        | sid          | alpha         | alpha-linux-gnu          | zero                      |
+| sh4          | sid          | sh4           | sh4-linux-gnu            | zero                      |
 
 ### Building for ARM/aarch64
 


### PR DESCRIPTION
Backport fixing several tables in `doc/building.md`, so they would display correctly in GitHub. Changes to `doc/building.html` were done manually, as there are some differences to table contents. Also table in `Oracle Solaris Studio` section was fixed, which is missing in newer jdks.

File `doc/building.html` was regenerated (pandoc used was one [created by current jdk17u devkit](https://github.com/openjdk/jdk17u-dev/blob/3285292597efd34176465df0b0394cc4a99605eb/make/devkit/createPandocBundle.sh), as this one seems to have be used previously -> no unrelated format changes).

Interestingly update of `doc/building.html` also removed one paragraph (about C99 standard). However, it turns out, this was accidentally included in [JDK-8226910](https://bugs.openjdk.org/browse/JDK-8226910) backport to jdk11u-dev. Paragraph is from [JDK-8224087](https://bugs.openjdk.org/browse/JDK-8224087), which has not been backported to jdk11u-dev. (So paragraph should never been there in first place.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8306408](https://bugs.openjdk.org/browse/JDK-8306408) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306408](https://bugs.openjdk.org/browse/JDK-8306408): Fix the format of several tables in building.md (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2533/head:pull/2533` \
`$ git checkout pull/2533`

Update a local copy of the PR: \
`$ git checkout pull/2533` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2533`

View PR using the GUI difftool: \
`$ git pr show -t 2533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2533.diff">https://git.openjdk.org/jdk11u-dev/pull/2533.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2533#issuecomment-1954484364)
</details>
