### PR TITLE
8322750: Test "api/java_awt/interactive/SystemTrayTests.html" failed because A blue ball icon is added outside of the system tray

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,12 @@ package sun.awt;
 
 import java.awt.RenderingHints;
 import static java.awt.RenderingHints.*;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import java.awt.color.ColorSpace;
 import java.awt.image.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
@@ -192,6 +196,72 @@ public abstract class UNIXToolkit extends SunToolkit
             setDesktopProperty(longname, img);
         }
         return img;
+    }
+
+    private static volatile Boolean shouldDisableSystemTray = null;
+
+    /**
+     * There is an issue displaying the xembed icons in appIndicators
+     * area with certain Gnome Shell versions.
+     * To avoid any loss of quality of service, we are disabling
+     * SystemTray support in such cases.
+     *
+     * @return true if system tray should be disabled
+     */
+    public boolean shouldDisableSystemTray() {
+        Boolean result = shouldDisableSystemTray;
+        if (result == null) {
+            synchronized (GTK_LOCK) {
+                result = shouldDisableSystemTray;
+                if (result == null) {
+                    if ("gnome".equals(getDesktop())) {
+                        @SuppressWarnings("removal")
+                        Integer gnomeShellMajorVersion =
+                                AccessController
+                                        .doPrivileged((PrivilegedAction<Integer>)
+                                                this::getGnomeShellMajorVersion);
+
+                        if (gnomeShellMajorVersion == null
+                                || gnomeShellMajorVersion < 45) {
+
+                            return shouldDisableSystemTray = true;
+                        }
+                    }
+                    shouldDisableSystemTray = result = false;
+                }
+            }
+        }
+        return result;
+    }
+
+    private Integer getGnomeShellMajorVersion() {
+        try {
+            Process process =
+                new ProcessBuilder("/usr/bin/gnome-shell", "--version")
+                        .start();
+            try (InputStreamReader isr = new InputStreamReader(process.getInputStream());
+                 BufferedReader reader = new BufferedReader(isr)) {
+
+                if (process.waitFor(2, SECONDS) &&  process.exitValue() == 0) {
+                    String line = reader.readLine();
+                    if (line != null) {
+                        String[] versionComponents = line
+                                .replaceAll("[^\\d.]", "")
+                                .split("\\.");
+
+                        if (versionComponents.length >= 1) {
+                            return Integer.parseInt(versionComponents[0]);
+                        }
+                    }
+                }
+            }
+        } catch (IOException
+                 | InterruptedException
+                 | IllegalThreadStateException
+                 | NumberFormatException ignored) {
+        }
+
+        return null;
     }
 
     /**

--- a/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
@@ -214,7 +214,9 @@ public abstract class UNIXToolkit extends SunToolkit
             synchronized (GTK_LOCK) {
                 result = shouldDisableSystemTray;
                 if (result == null) {
-                    if ("gnome".equals(getDesktop())) {
+                    String desktop = AccessController.doPrivileged(
+                            new GetPropertyAction("sun.desktop"));
+                    if ("gnome".equals(desktop)) {
                         @SuppressWarnings("removal")
                         Integer gnomeShellMajorVersion =
                                 AccessController

--- a/src/java.desktop/unix/classes/sun/awt/X11/XSystemTrayPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XSystemTrayPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.awt.peer.SystemTrayPeer;
 import sun.awt.SunToolkit;
 import sun.awt.AppContext;
 import sun.awt.AWTAccessor;
+import sun.awt.UNIXToolkit;
 import sun.util.logging.PlatformLogger;
 
 public class XSystemTrayPeer implements SystemTrayPeer, XMSelectionListener {
@@ -48,22 +49,32 @@ public class XSystemTrayPeer implements SystemTrayPeer, XMSelectionListener {
     private static final XAtom _NET_SYSTEM_TRAY_OPCODE = XAtom.get("_NET_SYSTEM_TRAY_OPCODE");
     private static final XAtom _NET_WM_ICON = XAtom.get("_NET_WM_ICON");
     private static final long SYSTEM_TRAY_REQUEST_DOCK = 0;
+    private final boolean shouldDisableSystemTray;
 
     XSystemTrayPeer(SystemTray target) {
         this.target = target;
         peerInstance = this;
 
-        selection.addSelectionListener(this);
+        UNIXToolkit tk = (UNIXToolkit)Toolkit.getDefaultToolkit();
+        shouldDisableSystemTray = tk.shouldDisableSystemTray();
 
-        long selection_owner = selection.getOwner(SCREEN);
-        available = (selection_owner != XConstants.None);
+        if (!shouldDisableSystemTray) {
+            selection.addSelectionListener(this);
 
-        if (log.isLoggable(PlatformLogger.Level.FINE)) {
-            log.fine(" check if system tray is available. selection owner: " + selection_owner);
+            long selection_owner = selection.getOwner(SCREEN);
+            available = (selection_owner != XConstants.None);
+
+            if (log.isLoggable(PlatformLogger.Level.FINE)) {
+                log.fine(" check if system tray is available. selection owner: " + selection_owner);
+            }
         }
     }
 
     public void ownerChanged(int screen, XMSelection sel, long newOwner, long data, long timestamp) {
+        if (shouldDisableSystemTray) {
+            return;
+        }
+
         if (screen != SCREEN) {
             return;
         }
@@ -77,6 +88,10 @@ public class XSystemTrayPeer implements SystemTrayPeer, XMSelectionListener {
     }
 
     public void ownerDeath(int screen, XMSelection sel, long deadOwner) {
+        if (shouldDisableSystemTray) {
+            return;
+        }
+
         if (screen != SCREEN) {
             return;
         }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [5a988a50](https://github.com/openjdk/jdk/commit/5a988a5087d0afbb577c6715fd5e1e44564888cb) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alexander Zvegintsev on 15 Feb 2024 and was reviewed by Jayathirth D V, Alexander Zuev, Prasanta Sadhukhan and Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8322750](https://bugs.openjdk.org/browse/JDK-8322750) needs maintainer approval

### Issue
 * [JDK-8322750](https://bugs.openjdk.org/browse/JDK-8322750): Test "api/java_awt/interactive/SystemTrayTests.html" failed because A blue ball icon is added outside of the system tray (**Bug** - P1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-dev.git pull/2534/head:pull/2534` \
`$ git checkout pull/2534`

Update a local copy of the PR: \
`$ git checkout pull/2534` \
`$ git pull https://git.openjdk.org/jdk11u-dev.git pull/2534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2534`

View PR using the GUI difftool: \
`$ git pr show -t 2534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-dev/pull/2534.diff">https://git.openjdk.org/jdk11u-dev/pull/2534.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-dev/pull/2534#issuecomment-1963852134)